### PR TITLE
refactor: update memory recall methods to return context as JSON values

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -535,12 +535,9 @@ async fn chat_send_inner(
                 log::info!(
                     "[chat] Conversation memory recall: has_data={}, len={}",
                     ctx.is_some(),
-                    ctx.as_deref().map(|s| s.len()).unwrap_or(0)
+                    ctx.as_ref().map(|ctx| ctx.to_string().len()).unwrap_or(0)
                 );
-                if let Some(ref data) = ctx {
-                    log::debug!("[chat] Conversation memory content:\n{}", data);
-                }
-                ctx
+                ctx.map(|ctx| ctx.to_string())
             }
             Err(e) => {
                 log::warn!("[chat] Conversation memory recall failed: {}", e);
@@ -567,10 +564,6 @@ async fn chat_send_inner(
             log::info!("[chat] Recalling memory for skill={sid}");
             match mem.recall_skill_context(sid, sid, 10).await {
                 Ok(Some(ctx)) => {
-                    log::info!(
-                        "[chat] Skill memory recall ok: skill={sid}, len={}",
-                        ctx.len()
-                    );
                     log::debug!("[chat] Skill memory content (skill={sid}):\n{}", ctx);
                     skill_contexts.push(format!(
                         "[{}_CONTEXT]\n{}\n[/{}_CONTEXT]",

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -122,7 +122,7 @@ pub async fn recall_memory(
                 ),
                 Err(e) => log::warn!("[memory] recall_memory: exit — error: {e}"),
             }
-            result
+            result.map(|ctx| ctx.map(|ctx| ctx.to_string()))
         }
         None => {
             log::warn!("[memory] recall_memory: exit — client not initialised (no JWT set)");

--- a/src-tauri/src/memory/mod.rs
+++ b/src-tauri/src/memory/mod.rs
@@ -214,7 +214,7 @@ impl MemoryClient {
         skill_id: &str,
         _integration_id: &str,
         max_chunks: u32,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<Option<serde_json::Value>, String> {
         let namespace = skill_id.to_string();
         log::info!(
             "[memory] recall_skill_context: entry (namespace={namespace}, max_chunks={max_chunks})"
@@ -230,7 +230,8 @@ impl MemoryClient {
                 log::warn!("[memory] recall_skill_context: exit — error (namespace={namespace}): {e}");
                 format!("Memory recall failed: {e}")
             })?;
-        let response = res.data.response;
+        log::info!("[memory] recall_skill_context: response: {res:?}");
+        let response = res.data.context;
         log::info!(
             "[memory] recall_skill_context: exit — ok (namespace={namespace}, has_response={})",
             response.is_some()


### PR DESCRIPTION
- Changed the return type of `recall_skill_context` to `Option<serde_json::Value>` for better flexibility.
- Updated logging to provide clearer insights during memory recall operations.
- Simplified context handling in `chat_send_inner` and `recall_memory` functions to improve readability.