### PR TITLE
Fix build.yml: Ubuntu-only build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,19 +55,9 @@ jobs:
         run: cargo clippy -p openhuman
 
   build:
-    name: Build Tauri App (${{ matrix.settings.label }})
+    name: Build Tauri App (Linux x86_64)
     needs: rust-quality
-    runs-on: ${{ matrix.settings.platform }}
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - platform: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            label: Linux x86_64
-          - platform: macos-latest
-            target: aarch64-apple-darwin
-            label: macOS ARM64
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -84,10 +74,9 @@ jobs:
       - name: Install Rust (rust-toolchain.toml)
         uses: dtolnay/rust-toolchain@1.93.0
         with:
-          targets: ${{ matrix.settings.target }}
+          targets: x86_64-unknown-linux-gnu
 
-      - name: Install Tauri dependencies (Linux)
-        if: matrix.settings.platform == 'ubuntu-22.04'
+      - name: Install Tauri dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -123,19 +112,18 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build sidecar core binary
-        run: cargo build --manifest-path Cargo.toml --release --target ${{ matrix.settings.target }} --bin openhuman
+        run: cargo build --manifest-path Cargo.toml --release --target x86_64-unknown-linux-gnu --bin openhuman
 
       - name: Stage sidecar for Tauri bundler
-        shell: bash
         run: |
           mkdir -p app/src-tauri/binaries
-          cp target/${{ matrix.settings.target }}/release/openhuman app/src-tauri/binaries/openhuman-${{ matrix.settings.target }}
-          chmod +x app/src-tauri/binaries/openhuman-${{ matrix.settings.target }}
+          cp target/x86_64-unknown-linux-gnu/release/openhuman app/src-tauri/binaries/openhuman-x86_64-unknown-linux-gnu
+          chmod +x app/src-tauri/binaries/openhuman-x86_64-unknown-linux-gnu
 
       - name: Build Tauri app
         working-directory: app
         run: |
           TAURI_CONFIG_OVERRIDE='{"bundle":{"createUpdaterArtifacts":"never"},"plugins":{"updater":{"active":false}}}'
-          yarn tauri build -c "$TAURI_CONFIG_OVERRIDE" --bundles none --target ${{ matrix.settings.target }} -- -- --bin OpenHuman
+          yarn tauri build -c "$TAURI_CONFIG_OVERRIDE" --bundles none -- -- --bin OpenHuman
         env:
           NODE_ENV: production


### PR DESCRIPTION
## Summary
- Simplify build workflow to Ubuntu x86_64 only (remove macOS matrix for now)
- Remove `--target` flag from `tauri build` (not needed for single-platform)
- Keeps rust-quality gate (fmt + clippy) and updater-disabled config

## Test plan
- [ ] Verify Build workflow passes on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)