### PR TITLE
Fix test.yml: build + stage sidecar before Tauri shell tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,15 @@ jobs:
       - name: Test core crate (openhuman)
         run: cargo test -p openhuman
 
+      - name: Build sidecar core binary
+        run: cargo build --manifest-path Cargo.toml --release --target x86_64-unknown-linux-gnu --bin openhuman
+
+      - name: Stage sidecar for Tauri shell tests
+        run: |
+          mkdir -p app/src-tauri/binaries
+          cp target/x86_64-unknown-linux-gnu/release/openhuman app/src-tauri/binaries/openhuman-x86_64-unknown-linux-gnu
+          chmod +x app/src-tauri/binaries/openhuman-x86_64-unknown-linux-gnu
+
       - name: Test Tauri shell (OpenHuman)
         run: cargo test --manifest-path app/src-tauri/Cargo.toml
 


### PR DESCRIPTION
## Summary
- Build and stage the `openhuman` sidecar binary before running `cargo test` on the Tauri shell
- The Tauri build script validates sidecar resource paths even during tests, so the binary must exist at `app/src-tauri/binaries/openhuman-x86_64-unknown-linux-gnu`
- This catches real shell/sidecar integration issues in CI rather than skipping the Tauri shell tests entirely

## Test plan
- [ ] Verify `Rust Tests + Quality` job passes (including Tauri shell tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)