### PR TITLE
fix: unwrap API envelope in memory tauriCommands and fix file path scope

### DIFF
--- a/app/src/utils/tauriCommands.ts
+++ b/app/src/utils/tauriCommands.ts
@@ -217,17 +217,30 @@ export async function memoryListDocuments(namespace?: string): Promise<unknown> 
   if (!isTauri()) {
     throw new Error('Not running in Tauri');
   }
-  return await callCoreRpc<unknown>({
+  const resp = await callCoreRpc<unknown>({
     method: 'openhuman.memory_list_documents',
     params: { namespace },
   });
+  // Unwrap envelope: registry returns { data: { documents: [...] }, meta: {...} }
+  if (resp && typeof resp === 'object' && !Array.isArray(resp) && 'data' in resp) {
+    return (resp as Record<string, unknown>).data;
+  }
+  return resp;
 }
 
 export async function memoryListNamespaces(): Promise<string[]> {
   if (!isTauri()) {
     throw new Error('Not running in Tauri');
   }
-  return await callCoreRpc<string[]>({ method: 'openhuman.memory_list_namespaces' });
+  const resp = await callCoreRpc<{ data?: { namespaces?: string[] }; namespaces?: string[] }>({
+    method: 'openhuman.memory_list_namespaces',
+  });
+  if (resp && typeof resp === 'object') {
+    if (Array.isArray(resp)) return resp;
+    const ns = resp.data?.namespaces ?? resp.namespaces;
+    if (Array.isArray(ns)) return ns;
+  }
+  return [];
 }
 
 export async function memoryDeleteDocument(
@@ -325,20 +338,32 @@ export async function aiListMemoryFiles(relativeDir = 'memory'): Promise<string[
   if (!isTauri()) {
     throw new Error('Not running in Tauri');
   }
-  return await callCoreRpc<string[]>({
+  const resp = await callCoreRpc<{ data?: { files?: string[] }; files?: string[] }>({
     method: 'openhuman.memory_list_files',
     params: { relative_dir: relativeDir },
   });
+  // Unwrap envelope: registry returns { data: { files: [...] } }
+  if (resp && typeof resp === 'object') {
+    if (Array.isArray(resp)) return resp;
+    const files = resp.data?.files ?? resp.files;
+    if (Array.isArray(files)) return files;
+  }
+  return [];
 }
 
 export async function aiReadMemoryFile(relativePath: string): Promise<string> {
   if (!isTauri()) {
     throw new Error('Not running in Tauri');
   }
-  return await callCoreRpc<string>({
+  const resp = await callCoreRpc<{ data?: { content?: string }; content?: string } | string>({
     method: 'openhuman.memory_read_file',
     params: { relative_path: relativePath },
   });
+  if (typeof resp === 'string') return resp;
+  if (resp && typeof resp === 'object') {
+    return resp.data?.content ?? resp.content ?? '';
+  }
+  return '';
 }
 
 export async function aiWriteMemoryFile(relativePath: string, content: string): Promise<void> {

--- a/src/openhuman/memory/ops.rs
+++ b/src/openhuman/memory/ops.rs
@@ -335,27 +335,27 @@ async fn resolve_memory_root() -> Result<PathBuf, String> {
 
 async fn resolve_existing_memory_path(relative_path: &str) -> Result<PathBuf, String> {
     validate_memory_relative_path(relative_path)?;
-    let memory_root = resolve_memory_root().await?;
-    let workspace_root = memory_root
-        .parent()
-        .ok_or_else(|| "memory root is missing a parent workspace".to_string())?;
-    let full_path = workspace_root.join(relative_path);
+    let workspace_dir = current_workspace_dir().await?;
+    let canonical_workspace = workspace_dir
+        .canonicalize()
+        .map_err(|e| format!("resolve workspace dir {}: {e}", workspace_dir.display()))?;
+    let full_path = workspace_dir.join(relative_path);
     let resolved = full_path
         .canonicalize()
         .map_err(|e| format!("resolve memory path {}: {e}", full_path.display()))?;
-    if !resolved.starts_with(&memory_root) {
-        return Err("memory path escapes the memory directory".to_string());
+    if !resolved.starts_with(&canonical_workspace) {
+        return Err("memory path escapes the workspace directory".to_string());
     }
     Ok(resolved)
 }
 
 async fn resolve_writable_memory_path(relative_path: &str) -> Result<PathBuf, String> {
     validate_memory_relative_path(relative_path)?;
-    let memory_root = resolve_memory_root().await?;
-    let workspace_root = memory_root
-        .parent()
-        .ok_or_else(|| "memory root is missing a parent workspace".to_string())?;
-    let full_path = workspace_root.join(relative_path);
+    let workspace_dir = current_workspace_dir().await?;
+    let canonical_workspace = workspace_dir
+        .canonicalize()
+        .map_err(|e| format!("resolve workspace dir {}: {e}", workspace_dir.display()))?;
+    let full_path = workspace_dir.join(relative_path);
     let parent = full_path
         .parent()
         .ok_or_else(|| "memory path must include a file name".to_string())?;
@@ -364,8 +364,8 @@ async fn resolve_writable_memory_path(relative_path: &str) -> Result<PathBuf, St
     let resolved_parent = parent
         .canonicalize()
         .map_err(|e| format!("resolve memory parent {}: {e}", parent.display()))?;
-    if !resolved_parent.starts_with(&memory_root) {
-        return Err("memory path escapes the memory directory".to_string());
+    if !resolved_parent.starts_with(&canonical_workspace) {
+        return Err("memory path escapes the workspace directory".to_string());
     }
     let file_name = full_path
         .file_name()


### PR DESCRIPTION
## Summary

- Unwrap `ApiEnvelope` responses in memory `tauriCommands.ts` functions so the UI receives flat data
- Fix workspace file path scope in `ops.rs` to allow reading files at workspace root

## Problem

- After #138 (controller registry migration), memory methods return `ApiEnvelope` (`{ data: { ... }, meta: { ... } }`) but frontend expects flat arrays/strings — causes `map is not a function` crashes on the Intelligence page
- `resolve_existing_memory_path` scoped to `workspace/memory/` but workspace files (`MEMORY.md`, `SOUL.md`) live at `workspace/` root — reading them was rejected with "memory path escapes the memory directory"

## Solution

- **`tauriCommands.ts`**: Unwrap envelope in `memoryListDocuments`, `memoryListNamespaces`, `aiListMemoryFiles`, `aiReadMemoryFile` with defensive checks for both envelope and flat formats
- **`ops.rs`**: Change `resolve_existing_memory_path` and `resolve_writable_memory_path` to scope against workspace root instead of `memory/` subdirectory. Path traversal still blocked by `validate_memory_relative_path`

## Submission Checklist

- [x] **Unit tests** — `cargo check` + `cargo fmt` + `yarn typecheck` pass
- [ ] **E2E / integration** — Manually verified: Memory Workspace loads namespaces, documents, files on Intelligence page
- [x] **Doc comments** — N/A (no new public APIs)
- [x] **Inline comments** — Envelope unwrap comments in tauriCommands.ts

## Impact

- **Desktop**: Memory Workspace on Intelligence page now loads real data from Rust core

## Related

- Issue(s): #170
- Follow-up PR(s)/TODOs: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory operations for document listing, namespace queries, and file access to handle and properly unwrap multiple API response formats and envelope structures.
  * Improved workspace path resolution and validation for memory operations with enhanced error reporting that better indicates the workspace directory context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->