### PR TITLE
fix: patch whisper-rs-sys for Windows MSVC static CRT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8600,8 +8600,7 @@ dependencies = [
 [[package]]
 name = "whisper-rs-sys"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+source = "git+https://github.com/tinyhumansai/whisper-rs-sys.git?branch=main#229cb4c97e41ca302d3f13b1fa7e93a9b417a5f9"
 dependencies = [
  "bindgen",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,13 @@ probe = ["dep:probe-rs"]
 rag-pdf = ["dep:pdf-extract"]
 whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-proto", "dep:wa-rs-ureq-http", "dep:wa-rs-tokio-transport", "serde-big-array"]
 
+# Fix whisper-rs-sys CRT mismatch on Windows MSVC (LNK2038).
+# Upstream cmake build defaults to /MD but Rust uses /MT.
+# This fork adds config.static_crt(true) to the build script.
+# See: https://github.com/tinyhumansai/openhuman/issues/273
+[patch.crates-io]
+whisper-rs-sys = { git = "https://github.com/tinyhumansai/whisper-rs-sys.git", branch = "main" }
+
 # Fast CI builds: trade runtime perf for compile speed
 [profile.ci]
 inherits = "release"


### PR DESCRIPTION
## Summary

- Patch `whisper-rs-sys` from [tinyhumansai/whisper-rs-sys](https://github.com/tinyhumansai/whisper-rs-sys) fork to fix Windows MSVC build failure

## Problem

- `whisper-rs-sys` builds `whisper.cpp` via CMake which defaults to `/MD` (dynamic CRT)
- All other C dependencies and Rust itself use `/MT` (static CRT) on Windows MSVC
- Linker fails with `LNK2038: mismatch detected for 'RuntimeLibrary'` and `LNK1169: multiply defined symbols`
- Blocks all Windows development and testing on `main`

## Solution

- Fork `whisper-rs-sys` to `tinyhumansai/whisper-rs-sys` with one change: call `config.static_crt(true)` in `build.rs` and override all per-config CMake flags (`Debug/Release/MinSizeRel/RelWithDebInfo`) from `/MD` to `/MT`
- Add `[patch.crates-io]` in `Cargo.toml` pointing to the fork

## Submission Checklist

- [x] **Unit tests** — N/A (build fix only, no code changes)
- [x] **E2E / integration** — Verified: `cargo build --bin openhuman-core` succeeds on Windows MSVC where it previously failed
- [x] **Doc comments** — Comment in Cargo.toml explaining the patch
- [x] **Inline comments** — N/A

## Impact

- **Windows**: Build unblocked. No runtime behavior change — same whisper.cpp, just linked with `/MT` instead of `/MD`
- **Linux/macOS**: No effect — the `static_crt` call is gated behind `#[cfg(target_env = "msvc")]`

## Related

- Issue(s): #273
- Follow-up: Submit fix upstream to `whisper-rs` crate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to use an alternative source for a core library component, enabling access to the latest development version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->