### PR TITLE
fix(e2e): rewrite performFullLogin and extend walkOnboarding for 6-st…

### DIFF
--- a/app/test/e2e/helpers/shared-flows.ts
+++ b/app/test/e2e/helpers/shared-flows.ts
@@ -260,6 +260,10 @@ export const ONBOARDING_OVERLAY_TEXTS = [
   'Screen & Accessibility',
   'Enable Tools',
   'Install Skills',
+  'Lastly, your Recovery Phrase',
+  'Your Recovery Phrase',
+  'Import Recovery Phrase',
+  'Finish Setup',
 ] as const;
 
 /** True when the full-screen onboarding overlay is likely visible. */
@@ -270,10 +274,45 @@ async function onboardingOverlayLikelyVisible(): Promise<boolean> {
   return false;
 }
 
+async function completeMnemonicStep(logPrefix: string): Promise<boolean> {
+  const mnemonicVisible =
+    (await textExists('Lastly, your Recovery Phrase')) ||
+    (await textExists('Your Recovery Phrase')) ||
+    (await textExists('Import Recovery Phrase'));
+
+  if (!mnemonicVisible) {
+    return false;
+  }
+
+  console.log(`${logPrefix} MnemonicStep visible`);
+
+  try {
+    const checked = await browser.execute(() => {
+      const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement | null;
+      if (!checkbox) return false;
+      if (!checkbox.checked) {
+        checkbox.click();
+      }
+      return checkbox.checked;
+    });
+    console.log(`${logPrefix} MnemonicStep checkbox checked=${checked}`);
+  } catch (err) {
+    console.log(`${logPrefix} MnemonicStep checkbox interaction failed:`, err);
+  }
+
+  const clicked = await clickFirstMatch(['Finish Setup', 'Continue'], 12_000);
+  if (clicked) {
+    console.log(`${logPrefix} MnemonicStep: clicked ${clicked}`);
+    await browser.pause(4_000);
+    return true;
+  }
+
+  return false;
+}
+
 /**
- * Walk through onboarding: Welcome → Local AI → Screen & Accessibility → Tools → Skills.
- * Each step uses the shared primary button label "Continue" (see OnboardingNextButton).
- * Completing the last step dismisses the overlay.
+ * Walk through onboarding. Supports both the legacy 5-step flow and the
+ * newer 6-step variant that ends with a recovery phrase confirmation.
  */
 export async function walkOnboarding(logPrefix = '[E2E]') {
   let visible = false;
@@ -291,29 +330,41 @@ export async function walkOnboarding(logPrefix = '[E2E]') {
     return;
   }
 
-  // Up to 6 "Continue" clicks — covers 5 steps plus one retry if the list is still loading.
-  for (let step = 0; step < 6; step++) {
+  // Up to 7 passes covers the 6-step flow plus one retry while async content settles.
+  for (let step = 0; step < 7; step++) {
     if (!(await onboardingOverlayLikelyVisible())) {
       console.log(`${logPrefix} Onboarding dismissed after step ${step}`);
       return;
     }
 
-    const clicked = await clickFirstMatch(['Continue'], 12_000);
+    if (await completeMnemonicStep(logPrefix)) {
+      continue;
+    }
+
+    const clicked = await clickFirstMatch(['Continue', 'Finish Setup'], 12_000);
     if (clicked) {
-      console.log(`${logPrefix} Onboarding step ${step}: clicked Continue`);
-      await browser.pause(step >= 4 ? 4_000 : 2_000);
+      console.log(`${logPrefix} Onboarding step ${step}: clicked ${clicked}`);
+      await browser.pause(clicked === 'Finish Setup' || step >= 4 ? 4_000 : 2_000);
     } else {
       const installSkillsLabel = ONBOARDING_OVERLAY_TEXTS[ONBOARDING_OVERLAY_TEXTS.length - 1]!;
-      if (await textExists(installSkillsLabel)) {
+      if (
+        (await textExists('Install Skills')) ||
+        (await textExists('Finish Setup')) ||
+        (await textExists(installSkillsLabel))
+      ) {
         await browser.pause(2_500);
-        const retry = await clickFirstMatch(['Continue'], 10_000);
+        if (await completeMnemonicStep(logPrefix)) {
+          continue;
+        }
+        const retry = await clickFirstMatch(['Continue', 'Finish Setup'], 10_000);
         if (retry) {
-          console.log(
-            `${logPrefix} Onboarding step ${step}: retry Continue on ${installSkillsLabel}`
-          );
+          console.log(`${logPrefix} Onboarding step ${step}: retry ${retry}`);
           await browser.pause(4_000);
+          continue;
         }
       }
+      const tree = await dumpAccessibilityTree();
+      console.log(`${logPrefix} Onboarding stalled at step ${step}. Tree:\n`, tree.slice(0, 4000));
       break;
     }
   }

--- a/app/test/e2e/specs/auth-access-control.spec.ts
+++ b/app/test/e2e/specs/auth-access-control.spec.ts
@@ -14,9 +14,9 @@
  *   1.3    Logout via Settings menu
  *   1.3.1  Revoked session auto-logout
  *
- * Onboarding steps (Onboarding.tsx — 5 steps, indices 0–4):
- *   Welcome → Local AI → Screen & Accessibility → Enable Tools → Install Skills
- *   (each step: primary "Continue"; final step completes onboarding)
+ * Onboarding steps:
+ *   Shared helper walks the current onboarding overlay and supports both the
+ *   legacy 5-step flow and the newer 6-step flow with recovery phrase setup.
  *
  * The mock server runs on http://127.0.0.1:18473 and the .app bundle must
  * have been built with VITE_BACKEND_URL pointing there.
@@ -37,8 +37,9 @@ import {
   navigateToBilling,
   navigateToHome,
   navigateToSettings,
+  performFullLogin,
   waitForHomePage,
-  walkOnboarding,
+  waitForRequest as waitForSharedRequest,
 } from '../helpers/shared-flows';
 import {
   clearRequestLog,
@@ -75,51 +76,6 @@ async function waitForRequest(method, urlFragment, timeout = 15_000) {
   return undefined;
 }
 
-// walkOnboarding, waitForHomePage imported from shared-flows
-
-/**
- * Perform full login via deep link. Walks onboarding. Leaves app on Home page.
- */
-async function performFullLogin(token = 'e2e-test-token') {
-  await triggerAuthDeepLink(token);
-
-  await waitForWindowVisible(25_000);
-  await waitForWebView(15_000);
-  await waitForAppReady(15_000);
-  await waitForAuthBootstrap(15_000);
-
-  const consumeCall = await waitForRequest('POST', '/telegram/login-tokens/', 20_000);
-  if (!consumeCall) {
-    console.log(
-      '[AuthAccess] Missing consume call. Request log:',
-      JSON.stringify(getRequestLog(), null, 2)
-    );
-    throw new Error('Auth consume call missing in performFullLogin');
-  }
-  // The app may call /telegram/me or /settings for user profile
-  const meCall =
-    (await waitForRequest('GET', '/telegram/me', 10_000)) ||
-    (await waitForRequest('GET', '/settings', 10_000));
-  if (!meCall) {
-    console.log(
-      '[AuthAccess] Missing user profile call. Request log:',
-      JSON.stringify(getRequestLog(), null, 2)
-    );
-    console.log('[AuthAccess] Continuing without user profile call confirmation');
-  }
-
-  // Walk real onboarding steps
-  await walkOnboarding('[AuthAccess]');
-
-  const homeText = await waitForHomePage(15_000);
-  if (!homeText) {
-    const tree = await dumpAccessibilityTree();
-    console.log('[AuthAccess] Home page not reached after login. Tree:\n', tree.slice(0, 4000));
-    throw new Error('Full login did not reach Home page');
-  }
-  console.log(`[AuthAccess] Home page confirmed: found "${homeText}"`);
-}
-
 // ===========================================================================
 // Test suite
 // ===========================================================================
@@ -141,7 +97,32 @@ describe('Auth & Access Control', () => {
   // -------------------------------------------------------------------------
 
   it('new user registers via deep link and reaches home', async () => {
-    await performFullLogin('e2e-auth-token');
+    await performFullLogin('e2e-auth-token', '[AuthAccess]', async () => {
+      const consumeCall = await waitForSharedRequest(
+        getRequestLog,
+        'POST',
+        '/telegram/login-tokens/',
+        20_000
+      );
+      if (!consumeCall) {
+        console.log(
+          '[AuthAccess] Missing consume call. Request log:',
+          JSON.stringify(getRequestLog(), null, 2)
+        );
+        throw new Error('Auth consume call missing in performFullLogin');
+      }
+
+      const meCall =
+        (await waitForSharedRequest(getRequestLog, 'GET', '/telegram/me', 10_000)) ||
+        (await waitForSharedRequest(getRequestLog, 'GET', '/settings', 10_000));
+      if (!meCall) {
+        console.log(
+          '[AuthAccess] Missing user profile call. Request log:',
+          JSON.stringify(getRequestLog(), null, 2)
+        );
+        console.log('[AuthAccess] Continuing without user profile call confirmation');
+      }
+    });
   });
 
   it('re-authenticating with a new token for the same user returns to home', async () => {


### PR DESCRIPTION
## Summary

- Rewrites `performFullLogin()` to use the current 6-step onboarding flow, replacing the legacy 5-step helper that referenced UI labels no longer in the app.
- Extracts `performFullLogin` to `app/test/e2e/helpers/shared-flows.ts` so all specs can import it rather than duplicating login logic per file.
- Extends `walkOnboarding` with `completeMnemonicStep` to handle the recovery-phrase step (checkbox tick + `Finish Setup` click) introduced in the 6-step flow.
- Adds mnemonic screen labels to `ONBOARDING_OVERLAY_TEXTS` so overlay detection works for all onboarding screens.

## Problem

`auth-access-control.spec.ts` had a local `performFullLogin()` that clicked through legacy step names (`Enable Tools`, `Install Skills` as the final step via `Continue`) that no longer exist as the last step in the app. The current onboarding ends with a recovery-phrase confirmation screen (`Finish Setup`). This caused every auth test case that relied on the helper — registration, revoked session — to stall at the mnemonic step and fail.

The helper was also private to the spec, so any new spec needing full login had to duplicate the logic.

## Solution

- `completeMnemonicStep(logPrefix)`: detects the recovery-phrase screen by checking for any of its three possible heading texts, ticks the acknowledgement checkbox via `browser.execute`, then clicks `Finish Setup` or `Continue`. Returns `true` if it handled the step so `walkOnboarding` can `continue` without consuming a regular `Continue` click.
- `walkOnboarding` loop cap raised from 6 → 7 to cover the 6-step flow plus one async-settle retry. `completeMnemonicStep` is attempted at the start of each pass and in the stall-recovery path.
- `performFullLogin(token, logPrefix, postLoginVerifier?)` in `shared-flows.ts`: drives deep link → bootstrap → `walkOnboarding` → Home assertion. Optional `postLoginVerifier` callback runs after Home is confirmed, letting callers assert side-effects (consume call, profile fetch) without those assertions being baked into the helper itself.
- Local `performFullLogin` removed from `auth-access-control.spec.ts`; consume/me assertions moved into the first test's verifier callback.
- File-level doc comment updated to reflect the current 6-step flow description.

## Submission Checklist

- [x] **Unit tests** — N/A: change is E2E harness only, no product logic changed.
- [x] **E2E / integration** — Directly modifies the E2E harness. `walkOnboarding` is exercised by every spec that calls `performFullLogin` or `completeOnboardingIfVisible`.
- [x] **Doc comments** — JSDoc updated on `walkOnboarding`, `completeOnboardingIfVisible`, and `performFullLogin` in `shared-flows.ts`.
- [x] **Inline comments** — Loop cap comment updated; stall path logs `dumpAccessibilityTree` for diagnosis.

## Impact

- E2E only. No product code, Rust core, or runtime behaviour changed.
- All 9 test cases in `auth-access-control.spec.ts` are covered by the updated helper.
- `performFullLogin` is now importable by any future spec — no duplication needed.

## Merge order note

> **Merge this PR (`fix/200`) before `fix/202` (logout/re-login overlay spec).**
>
> Both PRs add code immediately after `onboardingOverlayLikelyVisible()` in `shared-flows.ts`.
> If `fix/202` is merged second, a one-hunk conflict will appear at that insertion point.
> Resolution: keep both sets in order — public overlay lifecycle exports (fix/202) first,
> then the private `completeMnemonicStep` function (fix/200) immediately below.

## Related

- Issue(s): #200
- Follow-up PR(s)/TODOs: Merge before #202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced e2e test helpers to support recovery phrase verification during onboarding
  * Improved test coverage for multiple onboarding flow variants
  * Added enhanced diagnostics for test debugging and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->