### PR TITLE
Fix Ollama workspace install flow

### DIFF
--- a/src/openhuman/local_ai/install.rs
+++ b/src/openhuman/local_ai/install.rs
@@ -1,6 +1,6 @@
 //! Automatic Ollama installer and system binary discovery.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Captured output from the Ollama install script.
 pub(crate) struct InstallResult {
@@ -9,9 +9,9 @@ pub(crate) struct InstallResult {
     pub stderr: String,
 }
 
-/// Run the platform-specific Ollama install and capture stdout/stderr.
-pub(crate) async fn run_ollama_install_script() -> Result<InstallResult, String> {
-    let mut cmd = build_install_command()?;
+/// Run the platform-specific Ollama install into the workspace and capture stdout/stderr.
+pub(crate) async fn run_ollama_install_script(install_dir: &Path) -> Result<InstallResult, String> {
+    let mut cmd = build_install_command(install_dir)?;
 
     let output = cmd
         .output()
@@ -19,7 +19,8 @@ pub(crate) async fn run_ollama_install_script() -> Result<InstallResult, String>
         .map_err(|e| format!("failed to execute Ollama installer: {e}"))?;
 
     log::debug!(
-        "[local_ai] Ollama install script finished (exit={}) stdout={} stderr={}",
+        "[local_ai] Ollama install script finished (dir={} exit={}) stdout={} stderr={}",
+        install_dir.display(),
         output.status,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
@@ -32,16 +33,32 @@ pub(crate) async fn run_ollama_install_script() -> Result<InstallResult, String>
     })
 }
 
-fn build_install_command() -> Result<tokio::process::Command, String> {
+fn build_install_command(install_dir: &Path) -> Result<tokio::process::Command, String> {
     #[cfg(target_os = "windows")]
     {
         let mut cmd = tokio::process::Command::new("powershell");
+        cmd.env("OPENHUMAN_OLLAMA_INSTALL_DIR", install_dir);
         cmd.args([
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            "irm https://ollama.com/install.ps1 | iex",
+            r#"
+            $ErrorActionPreference = "Stop"
+            $ProgressPreference = "SilentlyContinue"
+            $installDir = $env:OPENHUMAN_OLLAMA_INSTALL_DIR
+            New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+            $installerUrl = "https://ollama.com/download/OllamaSetup.exe"
+            $tempInstaller = Join-Path $env:TEMP "OllamaSetup.exe"
+            Invoke-WebRequest -UseBasicParsing -Uri $installerUrl -OutFile $tempInstaller
+            $args = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES /CURRENTUSER /DIR=""$installDir"""
+            $proc = Start-Process -FilePath $tempInstaller -ArgumentList $args -PassThru
+            $proc.WaitForExit()
+            if ($proc.ExitCode -ne 0) {
+                throw "Installation failed with exit code $($proc.ExitCode)"
+            }
+            Remove-Item $tempInstaller -Force -ErrorAction SilentlyContinue
+            "#,
         ]);
         return Ok(cmd);
     }
@@ -49,16 +66,61 @@ fn build_install_command() -> Result<tokio::process::Command, String> {
     #[cfg(target_os = "macos")]
     {
         let mut cmd = tokio::process::Command::new("sh");
+        cmd.env("OPENHUMAN_OLLAMA_INSTALL_DIR", install_dir);
         cmd.arg("-lc")
-            .arg("curl -fsSL https://ollama.com/install.sh | sh");
+            .arg(
+                r#"
+                set -eu
+                for tool in curl unzip mktemp rm cp chmod mkdir; do
+                  command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+                done
+                dest="$OPENHUMAN_OLLAMA_INSTALL_DIR"
+                tmp_dir="$(mktemp -d)"
+                cleanup() { rm -rf "$tmp_dir"; }
+                trap cleanup EXIT
+                archive="$tmp_dir/Ollama-darwin.zip"
+                echo ">>> Downloading Ollama for macOS into $dest" >&2
+                curl --fail --show-error --location --progress-bar -o "$archive" "https://ollama.com/download/Ollama-darwin.zip"
+                unzip -q "$archive" -d "$tmp_dir"
+                rm -rf "$dest"
+                mkdir -p "$dest"
+                cp -R "$tmp_dir/Ollama.app/Contents/Resources/." "$dest/"
+                chmod 755 "$dest/ollama"
+                "#,
+            );
         return Ok(cmd);
     }
 
     #[cfg(target_os = "linux")]
     {
         let mut cmd = tokio::process::Command::new("sh");
+        cmd.env("OPENHUMAN_OLLAMA_INSTALL_DIR", install_dir);
         cmd.arg("-lc")
-            .arg("curl -fsSL https://ollama.com/install.sh | sh");
+            .arg(
+                r#"
+                set -eu
+                for tool in curl tar uname rm mkdir; do
+                  command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+                done
+                arch="$(uname -m)"
+                case "$arch" in
+                  x86_64) arch="amd64" ;;
+                  aarch64|arm64) arch="arm64" ;;
+                  *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+                esac
+                dest="$OPENHUMAN_OLLAMA_INSTALL_DIR"
+                archive_url="https://ollama.com/download/ollama-linux-${arch}.tar.zst"
+                if ! command -v unzstd >/dev/null 2>&1; then
+                  echo "missing required tool: unzstd (zstd package)" >&2
+                  exit 1
+                fi
+                rm -rf "$dest"
+                mkdir -p "$dest"
+                echo ">>> Downloading Ollama for Linux into $dest" >&2
+                curl --fail --show-error --location --progress-bar "$archive_url" | tar --use-compress-program=unzstd -xf - -C "$dest"
+                chmod 755 "$dest/bin/ollama"
+                "#,
+            );
         return Ok(cmd);
     }
 

--- a/src/openhuman/local_ai/paths.rs
+++ b/src/openhuman/local_ai/paths.rs
@@ -19,12 +19,44 @@ pub(crate) fn workspace_ollama_dir(config: &Config) -> PathBuf {
 }
 
 pub(crate) fn workspace_ollama_binary(config: &Config) -> PathBuf {
+    if cfg!(target_os = "linux") {
+        return workspace_ollama_dir(config).join("bin").join("ollama");
+    }
+
     let name = if cfg!(windows) {
         "ollama.exe"
     } else {
         "ollama"
     };
     workspace_ollama_dir(config).join(name)
+}
+
+pub(crate) fn workspace_ollama_binary_candidates(config: &Config) -> Vec<PathBuf> {
+    let dir = workspace_ollama_dir(config);
+    let binary_name = if cfg!(windows) {
+        "ollama.exe"
+    } else {
+        "ollama"
+    };
+
+    let mut candidates = Vec::new();
+    if cfg!(target_os = "linux") {
+        candidates.push(dir.join("bin").join(binary_name));
+    }
+    candidates.push(dir.join(binary_name));
+    candidates.push(
+        dir.join("Ollama.app")
+            .join("Contents")
+            .join("Resources")
+            .join(binary_name),
+    );
+    candidates
+}
+
+pub(crate) fn find_workspace_ollama_binary(config: &Config) -> Option<PathBuf> {
+    workspace_ollama_binary_candidates(config)
+        .into_iter()
+        .find(|candidate| candidate.is_file())
 }
 
 pub(crate) fn workspace_local_models_dir(config: &Config) -> PathBuf {
@@ -196,5 +228,39 @@ mod tests {
             tts_model_target_path(&config),
             PathBuf::from("/tmp/voice.onnx")
         );
+    }
+
+    #[test]
+    fn workspace_ollama_binary_matches_platform_layout() {
+        let (_tmp, config) = temp_config();
+        let root = config_root_dir(&config).join("bin").join("ollama");
+
+        if cfg!(target_os = "linux") {
+            assert_eq!(
+                workspace_ollama_binary(&config),
+                root.join("bin").join("ollama")
+            );
+        } else if cfg!(windows) {
+            assert_eq!(workspace_ollama_binary(&config), root.join("ollama.exe"));
+        } else {
+            assert_eq!(workspace_ollama_binary(&config), root.join("ollama"));
+        }
+    }
+
+    #[test]
+    fn find_workspace_ollama_binary_supports_legacy_flat_layout() {
+        let (_tmp, config) = temp_config();
+        let dir = workspace_ollama_dir(&config);
+        std::fs::create_dir_all(&dir).expect("create workspace ollama dir");
+
+        let legacy = dir.join(if cfg!(windows) {
+            "ollama.exe"
+        } else {
+            "ollama"
+        });
+        std::fs::write(&legacy, b"stub").expect("write legacy binary");
+
+        let found = find_workspace_ollama_binary(&config).expect("find workspace binary");
+        assert_eq!(found, legacy);
     }
 }

--- a/src/openhuman/local_ai/service/ollama_admin.rs
+++ b/src/openhuman/local_ai/service/ollama_admin.rs
@@ -8,7 +8,7 @@ use crate::openhuman::local_ai::model_ids;
 use crate::openhuman::local_ai::ollama_api::{
     OllamaModelTag, OllamaPullEvent, OllamaPullRequest, OllamaTagsResponse, OLLAMA_BASE_URL,
 };
-use crate::openhuman::local_ai::paths::workspace_ollama_binary;
+use crate::openhuman::local_ai::paths::{find_workspace_ollama_binary, workspace_ollama_binary};
 
 use super::LocalAiService;
 
@@ -41,14 +41,13 @@ impl LocalAiService {
         // Force a fresh download regardless of existing binaries.
         self.download_and_install_ollama(config).await?;
 
-        let ollama_cmd = workspace_ollama_binary(config);
-        if !ollama_cmd.is_file() {
+        let Some(ollama_cmd) = find_workspace_ollama_binary(config) else {
             // Also check system path after install.
             let system_bin = find_system_ollama_binary()
                 .ok_or_else(|| "Ollama installed but binary not found on system".to_string())?;
             // Try to use the system binary directly.
             return self.start_and_wait_for_server(&system_bin).await;
-        }
+        };
 
         self.start_and_wait_for_server(&ollama_cmd).await
     }
@@ -115,9 +114,18 @@ impl LocalAiService {
             }
         }
 
-        let workspace_bin = workspace_ollama_binary(config);
-        if workspace_bin.is_file() {
-            return Ok(workspace_bin);
+        if let Some(workspace_bin) = find_workspace_ollama_binary(config) {
+            if self.command_works(&workspace_bin).await {
+                log::debug!(
+                    "[local_ai] using workspace-managed ollama binary: {}",
+                    workspace_bin.display()
+                );
+                return Ok(workspace_bin);
+            }
+            log::warn!(
+                "[local_ai] workspace-managed ollama binary is present but not executable, reinstalling: {}",
+                workspace_bin.display()
+            );
         }
 
         if self.command_works(Path::new("ollama")).await {
@@ -125,8 +133,7 @@ impl LocalAiService {
         }
 
         self.download_and_install_ollama(config).await?;
-        let installed = workspace_ollama_binary(config);
-        if installed.is_file() {
+        if let Some(installed) = find_workspace_ollama_binary(config) {
             Ok(installed)
         } else {
             Err("Ollama download completed but executable is missing.".to_string())
@@ -163,7 +170,7 @@ impl LocalAiService {
             status.error_category = None;
         }
 
-        let result = run_ollama_install_script().await?;
+        let result = run_ollama_install_script(&install_dir).await?;
         if !result.exit_status.success() {
             let stderr_tail: String = result
                 .stderr
@@ -211,18 +218,13 @@ impl LocalAiService {
             result.stdout.chars().take(500).collect::<String>(),
         );
 
-        let installed = find_system_ollama_binary()
+        let installed = find_workspace_ollama_binary(config)
+            .or_else(find_system_ollama_binary)
             .ok_or_else(|| "Ollama installer finished but binary was not found".to_string())?;
-        let dest = workspace_ollama_binary(config);
-        tokio::fs::copy(&installed, &dest)
-            .await
-            .map_err(|e| format!("failed to copy Ollama binary into workspace: {e}"))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
-                .map_err(|e| format!("failed to set Ollama binary permissions: {e}"))?;
-        }
+        log::debug!(
+            "[local_ai] Ollama install finished with binary at {}",
+            installed.display()
+        );
 
         {
             let mut status = self.status.lock();


### PR DESCRIPTION
## Summary

- replace the Ollama bootstrap path that piped the upstream install script and relied on privileged global install behavior
- install Ollama directly into the OpenHuman workspace-managed directory on macOS, Linux, and Windows
- resolve workspace Ollama binaries across both the new extracted layouts and the legacy flat binary layout
- keep the local AI bootstrap flow using an existing configured or system Ollama when available, and otherwise fall back to the workspace-managed install
- add targeted path-resolution tests for the workspace Ollama layouts

## Problem

- the previous local AI install flow executed the upstream Ollama installer and then copied the resulting binary back into the workspace
- on macOS and Linux, the upstream installer tries to write into common system locations and may invoke `sudo`, which is not usable from the desktop app flow
- that made first-run Ollama bootstrap unreliable in the environment where OpenHuman actually needs to self-manage the runtime

## Solution

- move the installer logic into the core Ollama install helper so it downloads and extracts/installers into the workspace-managed directory directly
- update runtime path resolution so the service can find the binary in the Linux extracted layout, the macOS app-resource layout, and the previous flat copied layout
- keep the existing resolution order for configured paths and system installs, but make the automatic install path fully workspace-local so no privileged move step is required

## Submission Checklist

- [x] **Unit tests** — `cargo test --manifest-path Cargo.toml workspace_ollama_binary -- --nocapture`
- [ ] **E2E / integration** — Not run; this change needs a live local-AI bootstrap validation in the desktop app to exercise the real Ollama download/start flow
- [ ] **N/A** — If truly not applicable, say why (e.g. change is documentation-only)
- [x] **Doc comments** — `//!`/existing module comments remain in place for the touched Rust modules
- [x] **Inline comments** — Existing flow comments retained; no extra non-obvious inline comments were required beyond the current resolver/install flow

## Impact

- affects desktop local-AI bootstrap in the Rust core
- removes dependence on privileged global Ollama installation during automatic setup
- preserves compatibility with existing workspace-managed Ollama binaries and system-wide Ollama installs
- Linux workspace installs now expect `unzstd` to be available because upstream Ollama currently ships the Linux artifact as `.tar.zst`

## Related

- Issue(s):
- Follow-up PR(s)/TODOs: run a live desktop validation of first-run Ollama install/start on macOS and Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Ollama installation process with improved platform-specific handling and workspace configuration.
  * Improved binary detection and validation for more reliable Ollama management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->