### PR TITLE
feat(scripts): add core:stage script and improve dev code-signing setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "yarn workspace openhuman-app build",
     "compile": "yarn workspace openhuman-app compile",
+    "core:stage": "yarn workspace openhuman-app core:stage",
     "dev": "yarn workspace openhuman-app dev",
     "dev:app": "yarn workspace openhuman-app dev:app",
     "format": "yarn workspace openhuman-app format",

--- a/scripts/setup-dev-codesign.sh
+++ b/scripts/setup-dev-codesign.sh
@@ -39,6 +39,21 @@ fi
 echo "[setup-dev-codesign] Creating self-signed code-signing certificate: \"$IDENTITY\""
 
 # ── Generate key + self-signed certificate ───────────────────────────────────
+cat > "$TMPDIR_CERT/openssl.conf" <<EOF
+[ req ]
+distinguished_name = req_distinguished_name
+prompt = no
+x509_extensions = v3_ca
+
+[ req_distinguished_name ]
+CN = $IDENTITY
+
+[ v3_ca ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment
+extendedKeyUsage = codeSigning
+EOF
+
 openssl req \
   -newkey rsa:2048 \
   -nodes \
@@ -46,7 +61,7 @@ openssl req \
   -x509 \
   -days 3650 \
   -out "$CERT" \
-  -subj "/CN=$IDENTITY" \
+  -config "$TMPDIR_CERT/openssl.conf" \
   2>/dev/null
 
 # ── Bundle to PKCS12 ─────────────────────────────────────────────────────────
@@ -66,9 +81,10 @@ security import "$P12" \
   -T /usr/bin/security
 
 # ── Trust for code signing ───────────────────────────────────────────────────
+# Note: we add both basic and codeSign trust.
 security add-trusted-cert \
-  -d \
   -r trustRoot \
+  -p basic \
   -p codeSign \
   -k "$KEYCHAIN" \
   "$CERT"


### PR DESCRIPTION
## Summary

- add a root `core:stage` script entry to simplify staging the `openhuman-app` sidecar flow
- improve `scripts/setup-dev-codesign.sh` to generate a self-signed code-signing certificate with a custom OpenSSL config
- tighten the generated certificate attributes so local development signing behaves more like a real code-signing cert

## Problem

- local development workflows needed a simpler entrypoint for staging the core binary from the repo root
- the existing dev code-signing certificate generation was too minimal and could produce certificates with weaker or incomplete code-signing metadata

## Solution

- add `core:stage` to the root `package.json` so staging can be invoked consistently from the repository root
- update the dev code-signing setup script to emit a custom OpenSSL configuration and generate a better-formed self-signed certificate for code signing
- keep the change scoped to developer tooling so no runtime product behavior changes outside local setup flows

## Submission Checklist

- [ ] **Unit tests** — Vitest (`app/`) and/or `cargo test` (core) for logic you add or change
- [ ] **E2E / integration** — Where behavior is user-visible or crosses UI → Tauri → sidecar → JSON-RPC; use existing harnesses (`app/test/e2e`, mock backend, `tests/json_rpc_e2e.rs` as appropriate)
- [x] **N/A** — Dev tooling/script change only; no applicable automated test coverage was added
- [ ] **Doc comments** — `///` / `//!` (Rust), JSDoc or brief file/module headers (TS) on public APIs and non-obvious modules
- [ ] **Inline comments** — Where logic, invariants, or edge cases aren’t clear from names alone (keep them grep-friendly; avoid restating the code)

## Impact

- affects developer setup and local desktop signing workflows
- no production runtime, migration, or compatibility impact expected

## Related

- Issue(s):
- Follow-up PR(s)/TODOs:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new npm script for staging operations in workspace configuration.
  * Updated development certificate generation and macOS keychain trust setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->