### PR TITLE
Fix Ollama download retries and progress reporting

### DIFF
--- a/src/openhuman/local_ai/ollama_api.rs
+++ b/src/openhuman/local_ai/ollama_api.rs
@@ -14,9 +14,84 @@ pub(crate) struct OllamaPullRequest {
 pub(crate) struct OllamaPullEvent {
     #[allow(dead_code)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub digest: Option<String>,
     pub total: Option<u64>,
     pub completed: Option<u64>,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct OllamaPullProgress {
+    layers: std::collections::BTreeMap<String, OllamaPullLayerProgress>,
+    fallback_total: Option<u64>,
+    fallback_completed: u64,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct OllamaPullLayerProgress {
+    total: Option<u64>,
+    completed: u64,
+}
+
+impl OllamaPullProgress {
+    pub(crate) fn observe(&mut self, event: &OllamaPullEvent) {
+        if let Some(digest) = event
+            .digest
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            let layer = self.layers.entry(digest.clone()).or_default();
+            if let Some(total) = event.total {
+                layer.total = Some(layer.total.unwrap_or(0).max(total));
+                layer.completed = layer.completed.min(layer.total.unwrap_or(total));
+            }
+            if let Some(completed) = event.completed {
+                let capped = layer
+                    .total
+                    .map(|total| completed.min(total))
+                    .unwrap_or(completed);
+                layer.completed = layer.completed.max(capped);
+            }
+            return;
+        }
+
+        if let Some(total) = event.total {
+            self.fallback_total = Some(self.fallback_total.unwrap_or(0).max(total));
+            self.fallback_completed = self
+                .fallback_completed
+                .min(self.fallback_total.unwrap_or(total));
+        }
+        if let Some(completed) = event.completed {
+            let capped = self
+                .fallback_total
+                .map(|total| completed.min(total))
+                .unwrap_or(completed);
+            self.fallback_completed = self.fallback_completed.max(capped);
+        }
+    }
+
+    pub(crate) fn aggregate_downloaded(&self) -> u64 {
+        if !self.layers.is_empty() {
+            return self.layers.values().map(|layer| layer.completed).sum();
+        }
+        self.fallback_completed
+    }
+
+    pub(crate) fn aggregate_total(&self) -> Option<u64> {
+        if !self.layers.is_empty() {
+            let mut total = 0_u64;
+            let mut has_any = false;
+            for layer in self.layers.values() {
+                if let Some(layer_total) = layer.total {
+                    total = total.saturating_add(layer_total);
+                    has_any = true;
+                }
+            }
+            return has_any.then_some(total);
+        }
+        self.fallback_total
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -112,5 +187,63 @@ pub(crate) fn ns_to_tps(tokens: f32, duration_ns: u64) -> Option<f32> {
         None
     } else {
         Some(tokens / seconds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pull_progress_aggregates_layered_download_events() {
+        let mut progress = OllamaPullProgress::default();
+
+        progress.observe(&OllamaPullEvent {
+            status: Some("pulling".to_string()),
+            digest: Some("sha256:layer-a".to_string()),
+            total: Some(100),
+            completed: Some(20),
+            error: None,
+        });
+        progress.observe(&OllamaPullEvent {
+            status: Some("pulling".to_string()),
+            digest: Some("sha256:layer-b".to_string()),
+            total: Some(200),
+            completed: Some(50),
+            error: None,
+        });
+        progress.observe(&OllamaPullEvent {
+            status: Some("pulling".to_string()),
+            digest: Some("sha256:layer-a".to_string()),
+            total: Some(100),
+            completed: Some(100),
+            error: None,
+        });
+
+        assert_eq!(progress.aggregate_downloaded(), 150);
+        assert_eq!(progress.aggregate_total(), Some(300));
+    }
+
+    #[test]
+    fn pull_progress_falls_back_when_digest_is_missing() {
+        let mut progress = OllamaPullProgress::default();
+
+        progress.observe(&OllamaPullEvent {
+            status: Some("pulling manifest".to_string()),
+            digest: None,
+            total: Some(120),
+            completed: Some(30),
+            error: None,
+        });
+        progress.observe(&OllamaPullEvent {
+            status: Some("pulling manifest".to_string()),
+            digest: None,
+            total: Some(120),
+            completed: Some(80),
+            error: None,
+        });
+
+        assert_eq!(progress.aggregate_downloaded(), 80);
+        assert_eq!(progress.aggregate_total(), Some(120));
     }
 }

--- a/src/openhuman/local_ai/service/ollama_admin.rs
+++ b/src/openhuman/local_ai/service/ollama_admin.rs
@@ -6,7 +6,8 @@ use crate::openhuman::config::Config;
 use crate::openhuman::local_ai::install::{find_system_ollama_binary, run_ollama_install_script};
 use crate::openhuman::local_ai::model_ids;
 use crate::openhuman::local_ai::ollama_api::{
-    OllamaModelTag, OllamaPullEvent, OllamaPullRequest, OllamaTagsResponse, OLLAMA_BASE_URL,
+    OllamaModelTag, OllamaPullEvent, OllamaPullProgress, OllamaPullRequest, OllamaTagsResponse,
+    OLLAMA_BASE_URL,
 };
 use crate::openhuman::local_ai::paths::{find_workspace_ollama_binary, workspace_ollama_binary};
 
@@ -375,6 +376,7 @@ impl LocalAiService {
             let mut pending = String::new();
             let mut stream_error: Option<String> = None;
             let started_at = std::time::Instant::now();
+            let mut progress = OllamaPullProgress::default();
             let mut observed_bytes = false;
             while let Some(item) = stream.next().await {
                 let chunk = match item {
@@ -399,8 +401,9 @@ impl LocalAiService {
                         return Err(format!("ollama pull error: {err}"));
                     }
 
-                    let completed = event.completed.unwrap_or(0);
-                    let total = event.total;
+                    progress.observe(&event);
+                    let completed = progress.aggregate_downloaded();
+                    let total = progress.aggregate_total();
                     let elapsed = started_at.elapsed().as_secs_f64().max(0.001);
                     let speed_bps = (completed as f64 / elapsed).round().max(0.0) as u64;
                     let eta_seconds = total.and_then(|t| {


### PR DESCRIPTION
## Summary

- stop `ollama pull` from immediately restarting after a stream interruption once bytes have already been observed
- add a settle window that waits for the in-flight Ollama download to finish before issuing another retry request
- aggregate streamed Ollama pull progress across layer digests instead of overwriting progress with the current layer only
- keep existing fallback handling for pull events that do not include a digest
- add focused Rust regression tests for interrupted-pull waiting and layered progress aggregation

## Problem

- Local AI model downloads could get stuck in a retry loop when the pull stream disconnected mid-download.
- Ollama reports progress per layer during `/api/pull`, but the app treated each event as whole-model progress, so the UI showed progress for the current part instead of the entire model.
- Together these made large Ollama downloads look unstable and misleading in the Local AI surfaces.

## Solution

- Track whether a pull has already transferred bytes and, on interruption, wait briefly for Ollama to finish the existing background pull before retrying.
- Preserve grep-friendly warning/log messages so interrupted downloads are diagnosable without logging sensitive data.
- Extend the pull event parser with optional `digest` support and aggregate totals/completed bytes across layers when digests are present.
- Fall back to the previous single-stream accounting when digest metadata is absent.

## Submission Checklist

- [x] **Unit tests** — `cargo test --manifest-path Cargo.toml interrupted_pull_waits_when_bytes_were_observed`; `cargo test --manifest-path Cargo.toml pull_progress_aggregates_layered_download_events`; `cargo test --manifest-path Cargo.toml pull_progress_falls_back_when_digest_is_missing`
- [ ] **E2E / integration** — Not run; this change stays inside the core Ollama pull state handling and adds focused Rust regression coverage only
- [x] **N/A** — E2E not run in this pass; targeted Rust tests covered the changed logic
- [x] **Doc comments** — Existing module/file headers already cover the touched internal modules; no new public API added
- [x] **Inline comments** — Existing and added comments cover the non-obvious retry behavior

## Impact

- Affects desktop Local AI downloads that go through the Rust core + Ollama runtime.
- Reduces redundant pull retries after mid-stream disconnects.
- Makes progress bars and byte counters reflect whole-model download progress more accurately when Ollama emits per-layer updates.
- No config or migration changes.

## Related

- Issue(s): n/a
- Follow-up PR(s)/TODOs: Consider adding a JSON-RPC or desktop E2E harness around mocked Ollama pull streams if we want higher-level coverage for these status transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of model downloads by adding automatic recovery when pulls are interrupted or fail to complete.

* **Improvements**
  * Enhanced progress tracking during model downloads for more accurate status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->