### PR TITLE
Update webhook routes for backend contract

### DIFF
--- a/app/src/components/settings/panels/WebhooksDebugPanel.tsx
+++ b/app/src/components/settings/panels/WebhooksDebugPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getCoreHttpBaseUrl } from '../../../services/coreRpcClient';
+import { tunnelsApi } from '../../../services/api/tunnelsApi';
 import { BACKEND_URL } from '../../../utils/config';
 import {
   openhumanWebhooksClearLogs,
@@ -241,7 +242,7 @@ const WebhooksDebugPanel = () => {
                     <div>
                       Target URL:{' '}
                       <span className="font-mono text-stone-900">
-                        {fallbackBackendUrl}/webhooks/{registration.tunnel_uuid}
+                        {tunnelsApi.ingressUrl(fallbackBackendUrl, registration.tunnel_uuid)}
                       </span>
                     </div>
                     {registration.backend_tunnel_id && (

--- a/app/src/components/webhooks/TunnelList.tsx
+++ b/app/src/components/webhooks/TunnelList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import type { Tunnel } from '../../services/api/tunnelsApi';
+import { tunnelsApi } from '../../services/api/tunnelsApi';
 import type { TunnelRegistration } from '../../store/webhooksSlice';
 import { BACKEND_URL } from '../../utils/config';
 
@@ -54,7 +55,7 @@ export default function TunnelList({
   const getRegistration = (uuid: string) => registrations.find(r => r.tunnel_uuid === uuid);
 
   const webhookUrl = (uuid: string) =>
-    `${BACKEND_URL || 'https://api.tinyhumans.ai'}/webhooks/${uuid}`;
+    tunnelsApi.ingressUrl(BACKEND_URL || 'https://api.tinyhumans.ai', uuid);
 
   return (
     <div className="space-y-4">

--- a/app/src/services/api/tunnelsApi.ts
+++ b/app/src/services/api/tunnelsApi.ts
@@ -1,10 +1,13 @@
 import type { ApiResponse } from '../../types/api';
 import { apiClient } from '../apiClient';
 
+const WEBHOOKS_CORE_BASE = '/webhooks/core';
+const WEBHOOKS_INGRESS_BASE = '/webhooks/ingress';
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface Tunnel {
-  /** Internal backend ID (used for CRUD endpoints: GET/PATCH/DELETE /tunnels/:id). */
+  /** Internal backend ID (used for CRUD endpoints: GET/PATCH/DELETE /webhooks/core/:id). */
   id: string;
   /** External UUID used for webhook routing (appears in webhook URLs and local registrations). */
   uuid: string;
@@ -16,10 +19,7 @@ export interface Tunnel {
 }
 
 export interface TunnelBandwidthUsage {
-  usedBytes: number;
-  limitBytes: number;
-  cycleStartDate: string;
-  cycleEndDate: string;
+  remainingBudgetUsd: number;
 }
 
 export interface CreateTunnelRequest {
@@ -36,38 +36,46 @@ export interface UpdateTunnelRequest {
 // ── API ───────────────────────────────────────────────────────────────────────
 
 export const tunnelsApi = {
-  /** POST /tunnels — create a new webhook tunnel */
+  /** POST /webhooks/core — create a new webhook tunnel */
   createTunnel: async (body: CreateTunnelRequest): Promise<Tunnel> => {
-    const response = await apiClient.post<ApiResponse<Tunnel>>('/tunnels', body);
+    const response = await apiClient.post<ApiResponse<Tunnel>>(WEBHOOKS_CORE_BASE, body);
     return response.data;
   },
 
-  /** GET /tunnels — list user's webhook tunnels */
+  /** GET /webhooks/core — list user's webhook tunnels */
   getTunnels: async (): Promise<Tunnel[]> => {
-    const response = await apiClient.get<ApiResponse<Tunnel[]>>('/tunnels');
+    const response = await apiClient.get<ApiResponse<Tunnel[]>>(WEBHOOKS_CORE_BASE);
     return response.data;
   },
 
-  /** GET /tunnels/bandwidth — get bandwidth usage for current billing cycle */
+  /** GET /webhooks/core/bandwidth — get remaining webhook budget for the current cycle */
   getBandwidthUsage: async (): Promise<TunnelBandwidthUsage> => {
-    const response = await apiClient.get<ApiResponse<TunnelBandwidthUsage>>('/tunnels/bandwidth');
+    const response = await apiClient.get<ApiResponse<TunnelBandwidthUsage>>(
+      `${WEBHOOKS_CORE_BASE}/bandwidth`
+    );
     return response.data;
   },
 
-  /** GET /tunnels/:tunnelId — get a specific webhook tunnel by its internal ID. */
+  /** GET /webhooks/core/:tunnelId — get a specific webhook tunnel by its internal ID. */
   getTunnel: async (tunnelId: string): Promise<Tunnel> => {
-    const response = await apiClient.get<ApiResponse<Tunnel>>(`/tunnels/${tunnelId}`);
+    const response = await apiClient.get<ApiResponse<Tunnel>>(`${WEBHOOKS_CORE_BASE}/${tunnelId}`);
     return response.data;
   },
 
-  /** PATCH /tunnels/:tunnelId — update a webhook tunnel by its internal ID. */
+  /** PATCH /webhooks/core/:tunnelId — update a webhook tunnel by its internal ID. */
   updateTunnel: async (tunnelId: string, body: UpdateTunnelRequest): Promise<Tunnel> => {
-    const response = await apiClient.patch<ApiResponse<Tunnel>>(`/tunnels/${tunnelId}`, body);
+    const response = await apiClient.patch<ApiResponse<Tunnel>>(
+      `${WEBHOOKS_CORE_BASE}/${tunnelId}`,
+      body
+    );
     return response.data;
   },
 
-  /** DELETE /tunnels/:tunnelId — delete a webhook tunnel by its internal ID. */
+  /** DELETE /webhooks/core/:tunnelId — delete a webhook tunnel by its internal ID. */
   deleteTunnel: async (tunnelId: string): Promise<void> => {
-    await apiClient.delete<ApiResponse<unknown>>(`/tunnels/${tunnelId}`);
+    await apiClient.delete<ApiResponse<unknown>>(`${WEBHOOKS_CORE_BASE}/${tunnelId}`);
   },
+
+  ingressUrl: (backendUrl: string, tunnelUuid: string): string =>
+    `${backendUrl.replace(/\/$/, '')}${WEBHOOKS_INGRESS_BASE}/${tunnelUuid}`,
 };

--- a/scripts/mock-api-core.mjs
+++ b/scripts/mock-api-core.mjs
@@ -8,6 +8,7 @@ let requestLog = [];
 let mockBehavior = {};
 let server = null;
 const openSockets = new Set();
+let mockTunnels = [];
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -109,6 +110,10 @@ function clearRequestLog() {
   requestLog = [];
 }
 
+function resetMockTunnels() {
+  mockTunnels = [];
+}
+
 function setMockBehavior(key, value) {
   mockBehavior[key] = String(value);
 }
@@ -156,6 +161,19 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function createMockTunnel(payload = {}) {
+  const now = new Date().toISOString();
+  return {
+    id: crypto.randomUUID(),
+    uuid: crypto.randomUUID(),
+    name: String(payload.name || "Mock Tunnel").trim(),
+    description: String(payload.description || "").trim(),
+    isActive: payload.isActive ?? true,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 async function handleRequest(req, res) {
   const method = req.method ?? "GET";
   const url = req.url ?? "/";
@@ -189,6 +207,7 @@ async function handleRequest(req, res) {
     const keepRequests = parsedBody?.keepRequests === true;
     if (!keepBehavior) resetMockBehavior();
     if (!keepRequests) clearRequestLog();
+    resetMockTunnels();
     json(res, 200, {
       success: true,
       data: {
@@ -301,6 +320,57 @@ async function handleRequest(req, res) {
   if (method === "GET" && /^\/auth\/integrations\/?(\?.*)?$/.test(url)) {
     json(res, 200, { success: true, data: [] });
     return;
+  }
+
+  if (method === "POST" && /^\/webhooks\/core\/?$/.test(url)) {
+    const tunnel = createMockTunnel(parsedBody || {});
+    mockTunnels.unshift(tunnel);
+    json(res, 200, { success: true, data: tunnel });
+    return;
+  }
+
+  if (method === "GET" && /^\/webhooks\/core\/?(\?.*)?$/.test(url)) {
+    json(res, 200, { success: true, data: mockTunnels });
+    return;
+  }
+
+  if (method === "GET" && /^\/webhooks\/core\/bandwidth\/?(\?.*)?$/.test(url)) {
+    json(res, 200, { success: true, data: { remainingBudgetUsd: 10 } });
+    return;
+  }
+
+  const webhookCoreMatch = url.match(/^\/webhooks\/core\/([^/?]+)\/?(\?.*)?$/);
+  if (webhookCoreMatch) {
+    const [, tunnelId] = webhookCoreMatch;
+    const tunnelIndex = mockTunnels.findIndex((entry) => entry.id === tunnelId);
+    const tunnel = tunnelIndex >= 0 ? mockTunnels[tunnelIndex] : null;
+
+    if (!tunnel) {
+      json(res, 404, { success: false, error: "Tunnel not found" });
+      return;
+    }
+
+    if (method === "GET") {
+      json(res, 200, { success: true, data: tunnel });
+      return;
+    }
+
+    if (method === "PATCH") {
+      const updated = {
+        ...tunnel,
+        ...(parsedBody || {}),
+        updatedAt: new Date().toISOString(),
+      };
+      mockTunnels[tunnelIndex] = updated;
+      json(res, 200, { success: true, data: updated });
+      return;
+    }
+
+    if (method === "DELETE") {
+      mockTunnels.splice(tunnelIndex, 1);
+      json(res, 200, { success: true, data: tunnel });
+      return;
+    }
   }
 
   // --- Payments / Credits / Billing ---

--- a/scripts/test-webhook-flow.sh
+++ b/scripts/test-webhook-flow.sh
@@ -30,7 +30,7 @@ deletes the tunnel unless told to keep it.
 Options:
   --keep                 Keep the backend tunnel and local echo registration
   --name <name>          Tunnel name override
-  --path <path>          Request path suffix to send after /webhooks/<uuid>
+  --path <path>          Request path suffix to send after /webhooks/ingress/<uuid>
   --method <method>      HTTP method to send (default: POST)
   --payload <json>       Raw JSON payload string to send
   -h, --help             Show this help
@@ -118,7 +118,7 @@ echo "Tunnel name: $TUNNEL_NAME"
 
 CREATE_BODY="$(jq -n --arg name "$TUNNEL_NAME" '{name: $name, description: "Live webhook echo flow test"}')"
 CREATE_RESP="$(
-  curl -fsS "${BACKEND_URL%/}/tunnels" \
+  curl -fsS "${BACKEND_URL%/}/webhooks/core" \
     -H 'Content-Type: application/json' \
     -H "Authorization: Bearer $SESSION_TOKEN" \
     -d "$CREATE_BODY"
@@ -145,7 +145,7 @@ cleanup() {
     "$(jq -n --arg tunnel_uuid "$TUNNEL_UUID" '{tunnel_uuid: $tunnel_uuid}')" >/dev/null || true
 
   echo "Deleting backend tunnel..."
-  curl -fsS -X DELETE "${BACKEND_URL%/}/tunnels/${TUNNEL_ID}" \
+  curl -fsS -X DELETE "${BACKEND_URL%/}/webhooks/core/${TUNNEL_ID}" \
     -H "Authorization: Bearer $SESSION_TOKEN" >/dev/null || true
 }
 
@@ -162,7 +162,7 @@ REGISTER_PARAMS="$(
 )"
 rpc_call "openhuman.webhooks_register_echo" "$REGISTER_PARAMS" >/dev/null
 
-WEBHOOK_URL="${BACKEND_URL%/}/webhooks/${TUNNEL_UUID}${HOOK_PATH}"
+WEBHOOK_URL="${BACKEND_URL%/}/webhooks/ingress/${TUNNEL_UUID}${HOOK_PATH}"
 echo "Triggering: ${HOOK_METHOD} ${WEBHOOK_URL}"
 
 RESPONSE_BODY_FILE="$(mktemp)"

--- a/src/openhuman/skills/quickjs_libs/bootstrap.js
+++ b/src/openhuman/skills/quickjs_libs/bootstrap.js
@@ -1065,7 +1065,7 @@ globalThis.webhook = {
     var backendUrl = __platform.env('BACKEND_URL') || 'https://api.tinyhumans.ai';
     var jwtToken = __ops.get_session_token() || '';
 
-    var result = await net.fetch(backendUrl + '/tunnels', {
+    var result = await net.fetch(backendUrl + '/webhooks/core', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1080,7 +1080,7 @@ globalThis.webhook = {
       throw new Error('Failed to create tunnel: ' + parsed.status + ' ' + parsed.body);
     }
     var data = JSON.parse(parsed.body);
-    var tunnel = data.tunnel || data;
+    var tunnel = data.data || data.tunnel || data;
 
     // Auto-register this tunnel to the calling skill
     if (tunnel.uuid) {
@@ -1088,7 +1088,7 @@ globalThis.webhook = {
     }
 
     // Build webhook URL for the caller
-    tunnel.webhookUrl = backendUrl + '/webhooks/' + tunnel.uuid;
+    tunnel.webhookUrl = backendUrl.replace(/\/$/, '') + '/webhooks/ingress/' + tunnel.uuid;
 
     console.log('[webhook] Created tunnel: ' + name + ' → ' + tunnel.webhookUrl);
     return tunnel;
@@ -1108,19 +1108,26 @@ globalThis.webhook = {
    * @param {string} tunnelUuid - The tunnel UUID to delete
    */
   deleteTunnel: async function (tunnelUuid) {
-    // Verify ownership locally first (will throw if not owned), but don't
-    // unregister yet — we need the backend DELETE to succeed first so we
-    // don't orphan tunnels if the network call fails.
+    var registration = null;
     webhook.list().forEach(function (reg) {
-      // webhook.list() only returns this skill's registrations, so if the
-      // tunnelUuid isn't among them the skill doesn't own it.
+      if (reg.tunnel_uuid === tunnelUuid) {
+        registration = reg;
+      }
     });
+    if (!registration) {
+      throw new Error('[webhook] Tunnel is not registered to this skill: ' + tunnelUuid);
+    }
+    if (!registration.backend_tunnel_id) {
+      throw new Error(
+        '[webhook] Missing backend tunnel id for deleteTunnel; re-create or re-register this tunnel'
+      );
+    }
 
     // Delete from backend first
     var backendUrl = __platform.env('BACKEND_URL') || 'https://api.tinyhumans.ai';
     var jwtToken = __ops.get_session_token() || '';
 
-    var result = await net.fetch(backendUrl + '/tunnels/' + tunnelUuid, {
+    var result = await net.fetch(backendUrl + '/webhooks/core/' + registration.backend_tunnel_id, {
       method: 'DELETE',
       headers: { Authorization: 'Bearer ' + jwtToken },
       timeout: 10000,


### PR DESCRIPTION
## Summary

- Update frontend webhook tunnel CRUD calls from `/tunnels` to `/webhooks/core`.
- Update displayed and generated webhook ingress URLs from `/webhooks/:uuid` to `/webhooks/ingress/:uuid`.
- Align the QuickJS webhook helper with the backend's `{ success, data }` response envelope and backend tunnel-id deletes.
- Update local webhook verification tooling and mock API routes to match the new backend contract.

## Problem

- The backend webhook tunnel API moved from the legacy `/tunnels` and `/webhooks/:uuid` routes to `/webhooks/core` and `/webhooks/ingress/:uuid`.
- The desktop app, developer debug UI, QuickJS webhook helper, and local verification scripts were still targeting the old endpoints.
- That left webhook tunnel creation, deletion, and copied ingress URLs stale against the current backend implementation.

## Solution

- Centralize the new webhook route constants in the frontend tunnel API client and expose a shared ingress URL helper.
- Repoint the webhooks UI and debug panel to use that shared ingress URL builder so displayed URLs stay consistent.
- Update the QuickJS bootstrap webhook helper to call the new backend routes, unwrap the backend `data` envelope, and delete tunnels by backend tunnel id.
- Add `/webhooks/core` CRUD support to the mock API and update the webhook flow script so local verification continues to exercise the current contract.

## Submission Checklist

- [x] **Unit tests** — Vitest (`app/`) and/or `cargo test` (core) for logic you add or change
- [ ] **E2E / integration** — Where behavior is user-visible or crosses UI → Tauri → sidecar → JSON-RPC; use existing harnesses (`app/test/e2e`, mock backend, `tests/json_rpc_e2e.rs` as appropriate)
- [x] **N/A** — No dedicated E2E coverage was added because this change updates existing backend route wiring and local verification tooling rather than introducing a new user flow.
- [ ] **Doc comments** — `///` / `//!` (Rust), JSDoc or brief file/module headers (TS) on public APIs and non-obvious modules
- [x] **Inline comments** — Where logic, invariants, or edge cases aren’t clear from names alone (keep them grep-friendly; avoid restating the code)

## Impact

- Desktop app webhook tunnel management now matches the current backend contract.
- QuickJS skills that create or delete webhook tunnels now call the live backend routes correctly.
- Local mock and manual webhook flow tooling stay compatible with the backend route migration.
- No schema migration or platform-specific behavior change beyond webhook route compatibility.

## Related

- Issue(s):
- Follow-up PR(s)/TODOs:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored webhook tunnel management infrastructure and request handling.
  * Updated bandwidth reporting format to display remaining budget allocation in USD.
  * Enhanced mock API server with extended webhook endpoints for improved testing.
  * Improved webhook integration flow validation scripts and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->