### PR TITLE
feat(nav): enable Home tab in bottom toolbar

### DIFF
--- a/app/src/components/BottomTabBar.tsx
+++ b/app/src/components/BottomTabBar.tsx
@@ -4,21 +4,21 @@ import { useCoreState } from '../providers/CoreStateProvider';
 import { useAppSelector } from '../store/hooks';
 
 const tabs = [
-  // {
-  //   id: 'home',
-  //   label: 'Home',
-  //   path: '/home',
-  //   icon: (
-  //     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-  //       <path
-  //         strokeLinecap="round"
-  //         strokeLinejoin="round"
-  //         strokeWidth={1.8}
-  //         d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a2 2 0 01-2-2v-4a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z"
-  //       />
-  //     </svg>
-  //   ),
-  // },
+  {
+    id: 'home',
+    label: 'Home',
+    path: '/home',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.8}
+          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a2 2 0 01-2-2v-4a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z"
+        />
+      </svg>
+    ),
+  },
   {
     id: 'chat',
     label: 'Chat',


### PR DESCRIPTION
## Summary
- Enables the Home tab in the bottom toolbar navigation (`BottomTabBar.tsx`)
- The tab was already fully defined but commented out — this uncomments it so it renders as the first (leftmost) tab
- Route (`/home`), active-state logic, and `Home.tsx` page component were already wired

## Test plan
- [ ] Home tab appears as the first item in the bottom toolbar
- [ ] Tapping Home navigates to `/home` (dashboard)
- [ ] Active-state styling (white bg, semibold text) matches other tabs
- [ ] Other tabs continue to work as before

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-enabled the Home tab in the bottom navigation bar, making it accessible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->