### PR TITLE
feat(memory): timestamp-prefixed document IDs

### DIFF
--- a/src/openhuman/memory/store/unified/documents.rs
+++ b/src/openhuman/memory/store/unified/documents.rs
@@ -27,7 +27,11 @@ impl UnifiedMemory {
         let document_id = input
             .document_id
             .or(existing_document_id)
-            .unwrap_or_else(|| Uuid::new_v4().to_string());
+            .unwrap_or_else(|| {
+                let ts = Self::now_ts() as u64;
+                let short = &Uuid::new_v4().to_string()[..8];
+                format!("{ts}_{short}")
+            });
         let now = Self::now_ts();
         let created_at = {
             let conn = self.conn.lock();


### PR DESCRIPTION
## Summary
- Replace random UUID document IDs with `{unix_seconds}_{8char_hex}` format (e.g. `1743955200_a1b2c3de`)
- Memory documents now sort chronologically by filename and ID
- Existing UUID-based documents are unaffected (upsert by namespace+key still works)

## Test plan
- [ ] Ingest a new memory document and verify the `document_id` starts with a Unix timestamp
- [ ] Confirm markdown files under `memory/namespaces/*/docs/` sort chronologically by name
- [ ] Verify chunk IDs inherit the new format (`{ts}_{hex}:0`, `{ts}_{hex}:1`, etc.)
- [ ] Confirm existing documents with UUID IDs are still retrievable and upsertable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal document identifier generation for better uniqueness and ordering characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->