### PR TITLE
Add RAM-tiered local AI presets

### DIFF
--- a/app/src/components/settings/panels/LocalModelPanel.tsx
+++ b/app/src/components/settings/panels/LocalModelPanel.tsx
@@ -456,7 +456,11 @@ const LocalModelPanel = () => {
                     </div>
                     <div className="text-xs text-stone-400 mt-1">{preset.description}</div>
                     <div className="text-[10px] text-stone-500 mt-1">
-                      Chat: {preset.chat_model_id} &middot; Min RAM: {preset.min_ram_gb} GB
+                      Chat: {preset.chat_model_id} &middot; Vision:{' '}
+                      {preset.vision_mode === 'disabled'
+                        ? 'disabled'
+                        : preset.vision_model_id || preset.vision_mode}{' '}
+                      &middot; Target RAM: {preset.target_ram_gb} GB
                     </div>
                   </button>
                 );

--- a/app/src/utils/tauriCommands/localAi.ts
+++ b/app/src/utils/tauriCommands/localAi.ts
@@ -14,6 +14,7 @@ export interface LocalAiStatus {
   tts_voice_id: string;
   quantization: string;
   vision_state: string;
+  vision_mode: string;
   embedding_state: string;
   stt_state: string;
   tts_state: string;
@@ -170,6 +171,9 @@ export interface ModelPresetResult {
   vision_model_id: string;
   embedding_model_id: string;
   quantization: string;
+  vision_mode: string;
+  supports_screen_summary: boolean;
+  target_ram_gb: number;
   min_ram_gb: number;
   approx_download_gb: number;
 }
@@ -188,11 +192,13 @@ export interface ApplyPresetResult {
   vision_model_id: string;
   embedding_model_id: string;
   quantization: string;
+  vision_mode?: string;
 }
 
 export interface LocalAiDiagnostics {
   ollama_running: boolean;
   ollama_binary_path: string | null;
+  vision_mode?: string;
   installed_models: Array<{ name: string; size?: number | null; modified_at?: string | null }>;
   expected: {
     chat_model: string;

--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -665,7 +665,7 @@ impl Config {
                 } else {
                     tracing::warn!(
                         tier = %tier_str,
-                        "ignoring invalid OPENHUMAN_LOCAL_AI_TIER (valid: low, medium, high)"
+                        "ignoring invalid OPENHUMAN_LOCAL_AI_TIER (valid: ram_1gb, ram_2_4gb, ram_4_8gb, ram_8_16gb, ram_16_plus_gb)"
                     );
                 }
             }

--- a/src/openhuman/local_ai/mod.rs
+++ b/src/openhuman/local_ai/mod.rs
@@ -21,7 +21,7 @@ pub use device::DeviceProfile;
 pub use gif_decision::{GifDecision, TenorGifResult, TenorSearchResult};
 pub use ops as rpc;
 pub use ops::*;
-pub use presets::{ModelPreset, ModelTier};
+pub use presets::{ModelPreset, ModelTier, VisionMode};
 pub use schemas::{
     all_controller_schemas as all_local_ai_controller_schemas,
     all_registered_controllers as all_local_ai_registered_controllers,

--- a/src/openhuman/local_ai/model_ids.rs
+++ b/src/openhuman/local_ai/model_ids.rs
@@ -4,6 +4,7 @@ use crate::openhuman::config::Config;
 
 pub(crate) const DEFAULT_OLLAMA_MODEL: &str = "gemma3:4b-it-qat";
 pub(crate) const DEFAULT_OLLAMA_VISION_MODEL: &str = "gemma3:4b-it-qat";
+pub(crate) const DEFAULT_LOW_VISION_MODEL: &str = "moondream:1.8b-v2-q4_K_S";
 pub(crate) const DEFAULT_OLLAMA_EMBED_MODEL: &str = "nomic-embed-text:latest";
 
 pub(crate) fn effective_chat_model_id(config: &Config) -> String {
@@ -29,11 +30,11 @@ pub(crate) fn effective_chat_model_id(config: &Config) -> String {
 pub(crate) fn effective_vision_model_id(config: &Config) -> String {
     let raw = config.local_ai.vision_model_id.trim();
     if raw.is_empty() {
-        return DEFAULT_OLLAMA_VISION_MODEL.to_string();
+        return String::new();
     }
     let lower = raw.to_ascii_lowercase();
     if lower == "moondream:1.8b" || lower == "moondream" {
-        return DEFAULT_OLLAMA_VISION_MODEL.to_string();
+        return DEFAULT_LOW_VISION_MODEL.to_string();
     }
     raw.to_string()
 }
@@ -107,16 +108,13 @@ mod tests {
     #[test]
     fn vision_model_normalizes_legacy_moondream_values() {
         let mut config = test_config();
+        config.local_ai.vision_model_id = String::new();
+        assert_eq!(effective_vision_model_id(&config), "");
+
         config.local_ai.vision_model_id = "moondream".to_string();
-        assert_eq!(
-            effective_vision_model_id(&config),
-            DEFAULT_OLLAMA_VISION_MODEL
-        );
+        assert_eq!(effective_vision_model_id(&config), DEFAULT_LOW_VISION_MODEL);
         config.local_ai.vision_model_id = "moondream:1.8b".to_string();
-        assert_eq!(
-            effective_vision_model_id(&config),
-            DEFAULT_OLLAMA_VISION_MODEL
-        );
+        assert_eq!(effective_vision_model_id(&config), DEFAULT_LOW_VISION_MODEL);
     }
 
     #[test]

--- a/src/openhuman/local_ai/presets.rs
+++ b/src/openhuman/local_ai/presets.rs
@@ -1,23 +1,8 @@
 //! Tiered model presets and recommendation logic for local AI.
 //!
-//! # Tier → Model ID Mapping
-//!
-//! | Tier   | Chat / Vision Model       | Embedding Model            | Min RAM | ~Download |
-//! |--------|---------------------------|----------------------------|---------|-----------|
-//! | Low    | `gemma3:1b-it-q4_0`       | `nomic-embed-text:latest`  | 4 GB    | ~1 GB     |
-//! | Medium | `gemma3:4b-it-qat`        | `nomic-embed-text:latest`  | 8 GB    | ~3 GB     |
-//! | High   | `gemma3:12b-it-q4_K_M`    | `nomic-embed-text:latest`  | 16 GB   | ~8 GB     |
-//!
-//! # Changing defaults for a release
-//!
-//! Edit [`all_presets()`] below. Each `ModelPreset` defines:
-//! - `chat_model_id` / `vision_model_id` — Ollama tag for the chat and vision models.
-//! - `embedding_model_id` — Ollama tag for the embedding model.
-//! - `quantization` — quantization label shown in the UI.
-//! - `min_ram_gb` / `approx_download_gb` — user-facing guidance.
-//!
-//! After changing model tags, verify they exist in the Ollama library and update
-//! the `OPENHUMAN_LOCAL_AI_TIER` env var docs in `.env.example` if tier names change.
+//! Text generation is always the primary summarizer. Vision is a secondary
+//! scene-description sidecar whose output can be merged with OCR by the text
+//! model when a tier supports it.
 
 use serde::{Deserialize, Serialize};
 
@@ -27,33 +12,52 @@ use super::device::DeviceProfile;
 
 /// Performance tier for local AI model selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum ModelTier {
-    Low,
-    Medium,
-    High,
+    #[serde(rename = "ram_1gb")]
+    Ram1Gb,
+    #[serde(rename = "ram_2_4gb")]
+    Ram2To4Gb,
+    #[serde(rename = "ram_4_8gb")]
+    Ram4To8Gb,
+    #[serde(rename = "ram_8_16gb")]
+    Ram8To16Gb,
+    #[serde(rename = "ram_16_plus_gb")]
+    Ram16PlusGb,
+    #[serde(rename = "custom")]
     Custom,
 }
 
 impl ModelTier {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Low => "low",
-            Self::Medium => "medium",
-            Self::High => "high",
+            Self::Ram1Gb => "ram_1gb",
+            Self::Ram2To4Gb => "ram_2_4gb",
+            Self::Ram4To8Gb => "ram_4_8gb",
+            Self::Ram8To16Gb => "ram_8_16gb",
+            Self::Ram16PlusGb => "ram_16_plus_gb",
             Self::Custom => "custom",
         }
     }
 
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
-            "low" => Some(Self::Low),
-            "medium" => Some(Self::Medium),
-            "high" => Some(Self::High),
+            "ram_1gb" | "tier_1gb" | "1gb" => Some(Self::Ram1Gb),
+            "ram_2_4gb" | "tier_2_4gb" | "2_4gb" | "low" => Some(Self::Ram2To4Gb),
+            "ram_4_8gb" | "tier_4_8gb" | "4_8gb" => Some(Self::Ram4To8Gb),
+            "ram_8_16gb" | "tier_8_16gb" | "8_16gb" | "medium" => Some(Self::Ram8To16Gb),
+            "ram_16_plus_gb" | "tier_16_plus_gb" | "16_plus_gb" | "high" => Some(Self::Ram16PlusGb),
             "custom" => Some(Self::Custom),
             _ => None,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VisionMode {
+    Disabled,
+    Ondemand,
+    Bundled,
 }
 
 /// A concrete model preset tied to a performance tier.
@@ -66,70 +70,138 @@ pub struct ModelPreset {
     pub vision_model_id: &'static str,
     pub embedding_model_id: &'static str,
     pub quantization: &'static str,
+    pub vision_mode: VisionMode,
+    pub supports_screen_summary: bool,
+    pub target_ram_gb: u64,
     pub min_ram_gb: u64,
     pub approx_download_gb: f32,
 }
 
-/// Return all built-in presets (Low, Medium, High).
+/// Return all built-in presets.
 pub fn all_presets() -> Vec<ModelPreset> {
     vec![
         ModelPreset {
-            tier: ModelTier::Low,
-            label: "Lightweight",
-            description: "Smallest footprint. Works on machines with 4 GB+ RAM.",
-            chat_model_id: "gemma3:1b-it-q4_0",
-            vision_model_id: "gemma3:1b-it-q4_0",
-            embedding_model_id: "nomic-embed-text:latest",
-            quantization: "q4_0",
-            min_ram_gb: 4,
-            approx_download_gb: 1.0,
+            tier: ModelTier::Ram1Gb,
+            label: "1 GB",
+            description: "Fastest chat-only tier for ultra-low-memory devices. OCR + text only.",
+            chat_model_id: "gemma3:270m-it-qat",
+            vision_model_id: "",
+            embedding_model_id: "all-minilm:latest",
+            quantization: "qat",
+            vision_mode: VisionMode::Disabled,
+            supports_screen_summary: false,
+            target_ram_gb: 1,
+            min_ram_gb: 1,
+            approx_download_gb: 0.3,
         },
         ModelPreset {
-            tier: ModelTier::Medium,
-            label: "Balanced",
-            description: "Good quality with moderate resource use. Requires 8 GB+ RAM.",
+            tier: ModelTier::Ram2To4Gb,
+            label: "2-4 GB",
+            description: "Speed-first Gemma tier for low-memory devices. Vision disabled.",
+            chat_model_id: "gemma3:1b-it-qat",
+            vision_model_id: "",
+            embedding_model_id: "all-minilm:latest",
+            quantization: "qat",
+            vision_mode: VisionMode::Disabled,
+            supports_screen_summary: false,
+            target_ram_gb: 2,
+            min_ram_gb: 2,
+            approx_download_gb: 1.1,
+        },
+        ModelPreset {
+            tier: ModelTier::Ram4To8Gb,
+            label: "4-8 GB",
+            description: "Light Gemma chat with on-demand vision summaries via Moondream.",
+            chat_model_id: "gemma3:1b-it-qat",
+            vision_model_id: "moondream:1.8b-v2-q4_K_S",
+            embedding_model_id: "all-minilm:latest",
+            quantization: "qat",
+            vision_mode: VisionMode::Ondemand,
+            supports_screen_summary: true,
+            target_ram_gb: 4,
+            min_ram_gb: 4,
+            approx_download_gb: 2.8,
+        },
+        ModelPreset {
+            tier: ModelTier::Ram8To16Gb,
+            label: "8-16 GB",
+            description: "Balanced Gemma multimodal preset with bundled vision support.",
             chat_model_id: "gemma3:4b-it-qat",
             vision_model_id: "gemma3:4b-it-qat",
             embedding_model_id: "nomic-embed-text:latest",
-            quantization: "q4",
+            quantization: "qat",
+            vision_mode: VisionMode::Bundled,
+            supports_screen_summary: true,
+            target_ram_gb: 8,
             min_ram_gb: 8,
-            approx_download_gb: 3.0,
+            approx_download_gb: 4.3,
         },
         ModelPreset {
-            tier: ModelTier::High,
-            label: "Performance",
-            description: "Best quality. Requires 16 GB+ RAM and a capable GPU.",
-            chat_model_id: "gemma3:12b-it-q4_K_M",
-            vision_model_id: "gemma3:12b-it-q4_K_M",
+            tier: ModelTier::Ram16PlusGb,
+            label: "16 GB+",
+            description: "Best local quality with Gemma 4 on higher-end devices.",
+            chat_model_id: "gemma4:e4b",
+            vision_model_id: "gemma4:e4b",
             embedding_model_id: "nomic-embed-text:latest",
-            quantization: "q4_K_M",
+            quantization: "qat",
+            vision_mode: VisionMode::Bundled,
+            supports_screen_summary: true,
+            target_ram_gb: 16,
             min_ram_gb: 16,
-            approx_download_gb: 8.0,
+            approx_download_gb: 9.9,
         },
     ]
 }
 
 /// Return the preset for a specific tier, or `None` for `Custom`.
 pub fn preset_for_tier(tier: ModelTier) -> Option<ModelPreset> {
-    all_presets().into_iter().find(|p| p.tier == tier)
+    all_presets().into_iter().find(|preset| preset.tier == tier)
 }
 
 /// Recommend a tier based on device capabilities.
-///
-/// * < 8 GB RAM  -> Low
-/// * 8 - 15 GB   -> Medium
-/// * >= 16 GB    -> High
 pub fn recommend_tier(device: &DeviceProfile) -> ModelTier {
     let ram_gb = device.total_ram_gb();
     let tier = if ram_gb >= 16 {
-        ModelTier::High
+        ModelTier::Ram16PlusGb
     } else if ram_gb >= 8 {
-        ModelTier::Medium
+        ModelTier::Ram8To16Gb
+    } else if ram_gb >= 4 {
+        ModelTier::Ram4To8Gb
+    } else if ram_gb >= 2 {
+        ModelTier::Ram2To4Gb
     } else {
-        ModelTier::Low
+        ModelTier::Ram1Gb
     };
-    tracing::debug!(ram_gb, ?tier, "recommended model tier");
+    tracing::debug!(ram_gb, ?tier, "[local_ai] recommended model tier");
     tier
+}
+
+pub fn vision_mode_for_tier(tier: ModelTier) -> VisionMode {
+    match tier {
+        ModelTier::Ram1Gb | ModelTier::Ram2To4Gb => VisionMode::Disabled,
+        ModelTier::Ram4To8Gb => VisionMode::Ondemand,
+        ModelTier::Ram8To16Gb | ModelTier::Ram16PlusGb => VisionMode::Bundled,
+        ModelTier::Custom => VisionMode::Bundled,
+    }
+}
+
+pub fn vision_mode_for_config(config: &LocalAiConfig) -> VisionMode {
+    match current_tier_from_config(config) {
+        ModelTier::Custom => {
+            if config.vision_model_id.trim().is_empty() {
+                VisionMode::Disabled
+            } else if config.preload_vision_model {
+                VisionMode::Bundled
+            } else {
+                VisionMode::Ondemand
+            }
+        }
+        tier => vision_mode_for_tier(tier),
+    }
+}
+
+pub fn supports_screen_summary(config: &LocalAiConfig) -> bool {
+    !matches!(vision_mode_for_config(config), VisionMode::Disabled)
 }
 
 /// Apply a preset to a [`LocalAiConfig`], overwriting model IDs, quantization,
@@ -139,32 +211,38 @@ pub fn apply_preset_to_config(config: &mut LocalAiConfig, tier: ModelTier) {
         tracing::debug!(
             ?tier,
             chat = preset.chat_model_id,
-            "applying preset to config"
+            vision_mode = ?preset.vision_mode,
+            "[local_ai] applying preset to config"
         );
         config.model_id = preset.chat_model_id.to_string();
         config.chat_model_id = preset.chat_model_id.to_string();
         config.vision_model_id = preset.vision_model_id.to_string();
         config.embedding_model_id = preset.embedding_model_id.to_string();
         config.quantization = preset.quantization.to_string();
+        config.preload_vision_model = matches!(preset.vision_mode, VisionMode::Bundled);
+        config.preload_embedding_model = true;
         config.selected_tier = Some(tier.as_str().to_string());
     } else {
-        tracing::debug!("apply_preset_to_config called for Custom tier; no-op");
+        tracing::debug!("[local_ai] apply_preset_to_config called for custom tier; no-op");
     }
 }
 
 /// Reverse-lookup the current tier from config. Returns `Custom` if none of the
 /// built-in presets match the current model IDs.
 pub fn current_tier_from_config(config: &LocalAiConfig) -> ModelTier {
-    // If a tier is explicitly stored, try to match it first.
     if let Some(ref stored) = config.selected_tier {
         if let Some(tier) = ModelTier::from_str_opt(stored) {
             if tier == ModelTier::Custom {
                 return ModelTier::Custom;
             }
-            // Verify the stored tier still matches the actual model IDs.
             if let Some(preset) = preset_for_tier(tier) {
+                let vision_matches = if matches!(preset.vision_mode, VisionMode::Disabled) {
+                    config.vision_model_id.trim().is_empty()
+                } else {
+                    config.vision_model_id == preset.vision_model_id
+                };
                 if config.chat_model_id == preset.chat_model_id
-                    && config.vision_model_id == preset.vision_model_id
+                    && vision_matches
                     && config.embedding_model_id == preset.embedding_model_id
                 {
                     return tier;
@@ -173,10 +251,14 @@ pub fn current_tier_from_config(config: &LocalAiConfig) -> ModelTier {
         }
     }
 
-    // Fallback: match by model IDs.
     for preset in all_presets() {
+        let vision_matches = if matches!(preset.vision_mode, VisionMode::Disabled) {
+            config.vision_model_id.trim().is_empty()
+        } else {
+            config.vision_model_id == preset.vision_model_id
+        };
         if config.chat_model_id == preset.chat_model_id
-            && config.vision_model_id == preset.vision_model_id
+            && vision_matches
             && config.embedding_model_id == preset.embedding_model_id
         {
             return preset.tier;
@@ -190,39 +272,36 @@ pub fn current_tier_from_config(config: &LocalAiConfig) -> ModelTier {
 mod tests {
     use super::*;
 
-    #[test]
-    fn recommend_tier_by_ram() {
-        let low_device = DeviceProfile {
-            total_ram_bytes: 4 * 1024 * 1024 * 1024, // 4 GB
+    fn test_device(total_ram_gb: u64) -> DeviceProfile {
+        DeviceProfile {
+            total_ram_bytes: total_ram_gb * 1024 * 1024 * 1024,
             cpu_count: 4,
             cpu_brand: String::new(),
             os_name: String::new(),
             os_version: String::new(),
             has_gpu: false,
             gpu_description: None,
-        };
-        assert_eq!(recommend_tier(&low_device), ModelTier::Low);
+        }
+    }
 
-        let medium_device = DeviceProfile {
-            total_ram_bytes: 8 * 1024 * 1024 * 1024, // 8 GB
-            ..low_device.clone()
-        };
-        assert_eq!(recommend_tier(&medium_device), ModelTier::Medium);
-
-        let high_device = DeviceProfile {
-            total_ram_bytes: 32 * 1024 * 1024 * 1024_u64, // 32 GB
-            ..low_device.clone()
-        };
-        assert_eq!(recommend_tier(&high_device), ModelTier::High);
+    #[test]
+    fn recommend_tier_by_ram() {
+        assert_eq!(recommend_tier(&test_device(1)), ModelTier::Ram1Gb);
+        assert_eq!(recommend_tier(&test_device(3)), ModelTier::Ram2To4Gb);
+        assert_eq!(recommend_tier(&test_device(4)), ModelTier::Ram4To8Gb);
+        assert_eq!(recommend_tier(&test_device(8)), ModelTier::Ram8To16Gb);
+        assert_eq!(recommend_tier(&test_device(32)), ModelTier::Ram16PlusGb);
     }
 
     #[test]
     fn preset_application_and_round_trip() {
         let mut config = LocalAiConfig::default();
-        apply_preset_to_config(&mut config, ModelTier::Low);
-        assert_eq!(config.chat_model_id, "gemma3:1b-it-q4_0");
-        assert_eq!(config.selected_tier, Some("low".to_string()));
-        assert_eq!(current_tier_from_config(&config), ModelTier::Low);
+        apply_preset_to_config(&mut config, ModelTier::Ram1Gb);
+        assert_eq!(config.chat_model_id, "gemma3:270m-it-qat");
+        assert_eq!(config.selected_tier, Some("ram_1gb".to_string()));
+        assert_eq!(current_tier_from_config(&config), ModelTier::Ram1Gb);
+        assert!(!config.preload_vision_model);
+        assert_eq!(vision_mode_for_config(&config), VisionMode::Disabled);
     }
 
     #[test]
@@ -234,18 +313,35 @@ mod tests {
     }
 
     #[test]
-    fn all_presets_returns_three_tiers() {
+    fn all_presets_returns_five_tiers() {
         let presets = all_presets();
-        assert_eq!(presets.len(), 3);
-        assert_eq!(presets[0].tier, ModelTier::Low);
-        assert_eq!(presets[1].tier, ModelTier::Medium);
-        assert_eq!(presets[2].tier, ModelTier::High);
+        assert_eq!(presets.len(), 5);
+        assert_eq!(presets[0].tier, ModelTier::Ram1Gb);
+        assert_eq!(presets[1].tier, ModelTier::Ram2To4Gb);
+        assert_eq!(presets[2].tier, ModelTier::Ram4To8Gb);
+        assert_eq!(presets[3].tier, ModelTier::Ram8To16Gb);
+        assert_eq!(presets[4].tier, ModelTier::Ram16PlusGb);
     }
 
     #[test]
-    fn default_config_maps_to_medium() {
+    fn default_config_maps_to_balanced_tier() {
         let config = LocalAiConfig::default();
-        // Default config uses gemma3:4b-it-qat which is the Medium preset.
-        assert_eq!(current_tier_from_config(&config), ModelTier::Medium);
+        assert_eq!(current_tier_from_config(&config), ModelTier::Ram8To16Gb);
+        assert_eq!(vision_mode_for_config(&config), VisionMode::Bundled);
+    }
+
+    #[test]
+    fn built_in_vision_modes_match_expectations() {
+        let mut config = LocalAiConfig::default();
+        apply_preset_to_config(&mut config, ModelTier::Ram2To4Gb);
+        assert_eq!(vision_mode_for_config(&config), VisionMode::Disabled);
+        assert!(!supports_screen_summary(&config));
+
+        apply_preset_to_config(&mut config, ModelTier::Ram4To8Gb);
+        assert_eq!(vision_mode_for_config(&config), VisionMode::Ondemand);
+        assert!(supports_screen_summary(&config));
+
+        apply_preset_to_config(&mut config, ModelTier::Ram16PlusGb);
+        assert_eq!(vision_mode_for_config(&config), VisionMode::Bundled);
     }
 }

--- a/src/openhuman/local_ai/schemas.rs
+++ b/src/openhuman/local_ai/schemas.rs
@@ -499,7 +499,10 @@ pub fn schemas(function: &str) -> ControllerSchema {
             namespace: "local_ai",
             function: "apply_preset",
             description: "Apply a model tier preset to local AI config and persist.",
-            inputs: vec![required_string("tier", "Tier to apply: low, medium, high.")],
+            inputs: vec![required_string(
+                "tier",
+                "Tier to apply: ram_1gb, ram_2_4gb, ram_4_8gb, ram_8_16gb, ram_16_plus_gb.",
+            )],
             outputs: vec![json_output("result", "Applied tier status.")],
         },
         "local_ai_diagnostics" => ControllerSchema {
@@ -829,12 +832,12 @@ fn handle_local_ai_presets(_params: Map<String, Value>) -> ControllerFuture {
         let recommended = crate::openhuman::local_ai::presets::recommend_tier(&device);
         let current =
             crate::openhuman::local_ai::presets::current_tier_from_config(&config.local_ai);
-        let selected_tier = config
-            .local_ai
-            .selected_tier
-            .as_ref()
-            .map(|value| value.trim().to_ascii_lowercase())
-            .filter(|value| !value.is_empty());
+        let selected_tier = config.local_ai.selected_tier.as_ref().and_then(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            crate::openhuman::local_ai::presets::ModelTier::from_str_opt(&normalized)
+                .map(|tier| tier.as_str().to_string())
+                .or_else(|| (!normalized.is_empty()).then_some(normalized))
+        });
         let presets = crate::openhuman::local_ai::presets::all_presets();
         tracing::debug!(
             ?recommended,
@@ -863,7 +866,7 @@ fn handle_local_ai_apply_preset(params: Map<String, Value>) -> ControllerFuture 
         let tier = crate::openhuman::local_ai::presets::ModelTier::from_str_opt(&tier_str)
             .ok_or_else(|| {
                 format!(
-                    "invalid tier '{}': expected one of low, medium, high",
+                    "invalid tier '{}': expected one of ram_1gb, ram_2_4gb, ram_4_8gb, ram_8_16gb, ram_16_plus_gb",
                     tier_str
                 )
             })?;
@@ -886,6 +889,7 @@ fn handle_local_ai_apply_preset(params: Map<String, Value>) -> ControllerFuture 
             "vision_model_id": config.local_ai.vision_model_id,
             "embedding_model_id": config.local_ai.embedding_model_id,
             "quantization": config.local_ai.quantization,
+            "vision_mode": crate::openhuman::local_ai::presets::vision_mode_for_config(&config.local_ai),
         }))
     })
 }

--- a/src/openhuman/local_ai/service/assets.rs
+++ b/src/openhuman/local_ai/service/assets.rs
@@ -7,6 +7,7 @@ use crate::openhuman::local_ai::model_ids;
 use crate::openhuman::local_ai::paths::{
     resolve_stt_model_path, resolve_tts_voice_path, stt_model_target_path, tts_model_target_path,
 };
+use crate::openhuman::local_ai::presets::{self, VisionMode};
 use crate::openhuman::local_ai::types::{
     LocalAiAssetStatus, LocalAiAssetsStatus, LocalAiDownloadProgressItem, LocalAiDownloadsProgress,
 };
@@ -27,6 +28,7 @@ impl LocalAiService {
         let stt_path = resolve_stt_model_path(config).ok();
         let tts_path = resolve_tts_voice_path(config).ok();
 
+        let vision_mode = presets::vision_mode_for_config(&config.local_ai);
         Ok(LocalAiAssetsStatus {
             chat: LocalAiAssetStatus {
                 state: if chat_ready { "ready" } else { "missing" }.to_string(),
@@ -36,11 +38,26 @@ impl LocalAiService {
                 warning: None,
             },
             vision: LocalAiAssetStatus {
-                state: if vision_ready { "ready" } else { "missing" }.to_string(),
+                state: match vision_mode {
+                    VisionMode::Disabled => "disabled",
+                    VisionMode::Ondemand if vision_ready => "ready",
+                    VisionMode::Ondemand => "ondemand",
+                    VisionMode::Bundled if vision_ready => "ready",
+                    VisionMode::Bundled => "missing",
+                }
+                .to_string(),
                 id: vision_model,
                 provider: "ollama".to_string(),
                 path: None,
-                warning: None,
+                warning: match vision_mode {
+                    VisionMode::Disabled => {
+                        Some("Vision is disabled for this RAM tier.".to_string())
+                    }
+                    VisionMode::Ondemand if !vision_ready => {
+                        Some("Vision model will download on first vision request.".to_string())
+                    }
+                    _ => None,
+                },
             },
             embedding: LocalAiAssetStatus {
                 state: if embedding_ready { "ready" } else { "missing" }.to_string(),
@@ -201,11 +218,16 @@ impl LocalAiService {
 
         self.ensure_ollama_server(config).await?;
 
-        let steps = vec![
+        let mut steps = vec![
             ("chat", model_ids::effective_chat_model_id(config)),
-            ("vision", model_ids::effective_vision_model_id(config)),
             ("embedding", model_ids::effective_embedding_model_id(config)),
         ];
+        if matches!(
+            presets::vision_mode_for_config(&config.local_ai),
+            VisionMode::Bundled
+        ) {
+            steps.insert(1, ("vision", model_ids::effective_vision_model_id(config)));
+        }
 
         let total = steps.len();
         for (index, (label, model_id)) in steps.into_iter().enumerate() {
@@ -243,6 +265,11 @@ impl LocalAiService {
         {
             let mut status = self.status.lock();
             status.state = "ready".to_string();
+            status.vision_state = match presets::vision_mode_for_config(&config.local_ai) {
+                VisionMode::Disabled => "disabled".to_string(),
+                VisionMode::Ondemand => "idle".to_string(),
+                VisionMode::Bundled => "ready".to_string(),
+            };
             status.download_progress = Some(1.0);
             status.downloaded_bytes = None;
             status.total_bytes = None;
@@ -277,6 +304,15 @@ impl LocalAiService {
                 self.ensure_ollama_model_available(&model, "chat").await?;
             }
             "vision" => {
+                if matches!(
+                    presets::vision_mode_for_config(&config.local_ai),
+                    VisionMode::Disabled
+                ) {
+                    return Err(
+                        "Vision is disabled for this RAM tier. Switch to the 4-8 GB tier or above to enable it."
+                            .to_string(),
+                    );
+                }
                 self.ensure_ollama_server(config).await?;
                 let model = model_ids::effective_vision_model_id(config);
                 self.ensure_ollama_model_available(&model, "vision").await?;

--- a/src/openhuman/local_ai/service/bootstrap.rs
+++ b/src/openhuman/local_ai/service/bootstrap.rs
@@ -1,6 +1,7 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::local_ai::device::DeviceProfile;
 use crate::openhuman::local_ai::model_ids;
+use crate::openhuman::local_ai::presets::{self, VisionMode};
 use crate::openhuman::local_ai::types::LocalAiStatus;
 
 use super::LocalAiService;
@@ -10,6 +11,7 @@ impl LocalAiService {
         let model_id = model_ids::effective_chat_model_id(config);
         let vision_model_id = model_ids::effective_vision_model_id(config);
         let embedding_model_id = model_ids::effective_embedding_model_id(config);
+        let vision_mode = vision_mode_str(config);
         Self {
             whisper: super::whisper_engine::new_handle(),
             status: parking_lot::Mutex::new(LocalAiStatus {
@@ -21,7 +23,8 @@ impl LocalAiService {
                 stt_model_id: model_ids::effective_stt_model_id(config),
                 tts_voice_id: model_ids::effective_tts_voice_id(config),
                 quantization: model_ids::effective_quantization(config),
-                vision_state: "idle".to_string(),
+                vision_state: initial_vision_state(config),
+                vision_mode,
                 embedding_state: "idle".to_string(),
                 stt_state: "idle".to_string(),
                 tts_state: "idle".to_string(),
@@ -62,6 +65,7 @@ impl LocalAiService {
 
     pub fn reset_to_idle(&self, config: &Config) {
         let model_id = model_ids::effective_chat_model_id(config);
+        let vision_mode = vision_mode_str(config);
         let mut status = self.status.lock();
         status.state = "idle".to_string();
         status.model_id = model_id.clone();
@@ -71,7 +75,8 @@ impl LocalAiService {
         status.stt_model_id = model_ids::effective_stt_model_id(config);
         status.tts_voice_id = model_ids::effective_tts_voice_id(config);
         status.quantization = model_ids::effective_quantization(config);
-        status.vision_state = "idle".to_string();
+        status.vision_state = initial_vision_state(config);
+        status.vision_mode = vision_mode;
         status.embedding_state = "idle".to_string();
         status.stt_state = "idle".to_string();
         status.tts_state = "idle".to_string();
@@ -126,6 +131,7 @@ impl LocalAiService {
             status.tts_voice_id = model_ids::effective_tts_voice_id(&effective_config);
             status.quantization = model_ids::effective_quantization(&effective_config);
             status.state = "loading".to_string();
+            status.vision_mode = vision_mode_str(&effective_config);
             status.warning = Some("Connecting to local Ollama runtime".to_string());
             status.download_progress = None;
             status.downloaded_bytes = None;
@@ -207,10 +213,10 @@ impl LocalAiService {
 
         let mut status = self.status.lock();
         status.state = "ready".to_string();
-        status.vision_state = if effective_config.local_ai.preload_vision_model {
-            "ready".to_string()
-        } else {
-            "idle".to_string()
+        status.vision_state = match presets::vision_mode_for_config(&effective_config.local_ai) {
+            VisionMode::Disabled => "disabled".to_string(),
+            VisionMode::Bundled => "ready".to_string(),
+            VisionMode::Ondemand => "idle".to_string(),
         };
         status.embedding_state = if effective_config.local_ai.preload_embedding_model {
             "ready".to_string()
@@ -267,9 +273,11 @@ fn config_with_recommended_tier_if_unselected(config: &Config, device: &DevicePr
     if selected_tier.is_some()
         || matches!(
             current_tier,
-            crate::openhuman::local_ai::presets::ModelTier::Low
-                | crate::openhuman::local_ai::presets::ModelTier::Medium
-                | crate::openhuman::local_ai::presets::ModelTier::High
+            crate::openhuman::local_ai::presets::ModelTier::Ram1Gb
+                | crate::openhuman::local_ai::presets::ModelTier::Ram2To4Gb
+                | crate::openhuman::local_ai::presets::ModelTier::Ram4To8Gb
+                | crate::openhuman::local_ai::presets::ModelTier::Ram8To16Gb
+                | crate::openhuman::local_ai::presets::ModelTier::Ram16PlusGb
         )
     {
         return config.clone();
@@ -288,24 +296,38 @@ fn config_with_recommended_tier_if_unselected(config: &Config, device: &DevicePr
     effective_config
 }
 
-/// Append a tier step-down hint when the current tier is Medium or High.
 fn format_degraded_warning(err: &str, config: &Config) -> String {
     let current = crate::openhuman::local_ai::presets::current_tier_from_config(&config.local_ai);
     match current {
-        crate::openhuman::local_ai::presets::ModelTier::High => {
+        crate::openhuman::local_ai::presets::ModelTier::Ram16PlusGb => {
             format!(
-                "{err}. Hint: your device may not support the High tier model. \
-                 Try switching to Medium or Low in Settings > Local AI Model."
+                "{err}. Hint: your device may not support the 16 GB+ tier model. \
+                 Try switching to the 8-16 GB or 4-8 GB tier in Settings > Local AI Model."
             )
         }
-        crate::openhuman::local_ai::presets::ModelTier::Medium => {
+        crate::openhuman::local_ai::presets::ModelTier::Ram8To16Gb => {
             format!(
-                "{err}. Hint: your device may not support the Medium tier model. \
-                 Try switching to Low in Settings > Local AI Model."
+                "{err}. Hint: your device may not support the 8-16 GB tier model. \
+                 Try switching to the 4-8 GB or 2-4 GB tier in Settings > Local AI Model."
             )
         }
+        crate::openhuman::local_ai::presets::ModelTier::Ram4To8Gb => format!(
+            "{err}. Hint: your device may not support the 4-8 GB tier vision sidecar. \
+             Try switching to the 2-4 GB tier for text-only local AI."
+        ),
         _ => err.to_string(),
     }
+}
+
+fn initial_vision_state(config: &Config) -> String {
+    match presets::vision_mode_for_config(&config.local_ai) {
+        VisionMode::Disabled => "disabled".to_string(),
+        VisionMode::Ondemand | VisionMode::Bundled => "idle".to_string(),
+    }
+}
+
+fn vision_mode_str(config: &Config) -> String {
+    format!("{:?}", presets::vision_mode_for_config(&config.local_ai)).to_ascii_lowercase()
 }
 
 #[cfg(test)]

--- a/src/openhuman/local_ai/service/ollama_admin.rs
+++ b/src/openhuman/local_ai/service/ollama_admin.rs
@@ -10,6 +10,7 @@ use crate::openhuman::local_ai::ollama_api::{
     OLLAMA_BASE_URL,
 };
 use crate::openhuman::local_ai::paths::{find_workspace_ollama_binary, workspace_ollama_binary};
+use crate::openhuman::local_ai::presets::{self, VisionMode};
 
 use super::LocalAiService;
 
@@ -253,11 +254,19 @@ impl LocalAiService {
         self.ensure_ollama_model_available(&chat_model, "chat")
             .await?;
 
-        let vision_model = model_ids::effective_vision_model_id(config);
-        if config.local_ai.preload_vision_model {
-            self.ensure_ollama_model_available(&vision_model, "vision")
-                .await?;
-            self.status.lock().vision_state = "ready".to_string();
+        match presets::vision_mode_for_config(&config.local_ai) {
+            VisionMode::Disabled => {
+                self.status.lock().vision_state = "disabled".to_string();
+            }
+            VisionMode::Ondemand => {
+                self.status.lock().vision_state = "idle".to_string();
+            }
+            VisionMode::Bundled => {
+                let vision_model = model_ids::effective_vision_model_id(config);
+                self.ensure_ollama_model_available(&vision_model, "vision")
+                    .await?;
+                self.status.lock().vision_state = "ready".to_string();
+            }
         }
 
         let embedding_model = model_ids::effective_embedding_model_id(config);
@@ -588,7 +597,13 @@ impl LocalAiService {
                 expected_embedding
             ));
         }
-        if healthy && config.local_ai.preload_vision_model && !vision_found {
+        if healthy
+            && matches!(
+                presets::vision_mode_for_config(&config.local_ai),
+                VisionMode::Bundled
+            )
+            && !vision_found
+        {
             issues.push(format!(
                 "Vision model `{}` is not installed",
                 expected_vision
@@ -609,6 +624,7 @@ impl LocalAiService {
             "ollama_running": healthy,
             "ollama_binary_path": binary_path,
             "installed_models": models,
+            "vision_mode": presets::vision_mode_for_config(&config.local_ai),
             "expected": {
                 "chat_model": expected_chat,
                 "chat_found": chat_found,

--- a/src/openhuman/local_ai/service/vision_embed.rs
+++ b/src/openhuman/local_ai/service/vision_embed.rs
@@ -5,6 +5,7 @@ use crate::openhuman::local_ai::ollama_api::{
     OllamaEmbedRequest, OllamaEmbedResponse, OllamaGenerateOptions, OllamaGenerateRequest,
     OLLAMA_BASE_URL,
 };
+use crate::openhuman::local_ai::presets::{self, VisionMode};
 use crate::openhuman::local_ai::types::LocalAiEmbeddingResult;
 
 use super::LocalAiService;
@@ -22,6 +23,16 @@ impl LocalAiService {
         }
         if image_refs.is_empty() {
             return Err("vision prompt requires at least one image reference".to_string());
+        }
+        if matches!(
+            presets::vision_mode_for_config(&config.local_ai),
+            VisionMode::Disabled
+        ) {
+            self.status.lock().vision_state = "disabled".to_string();
+            return Err(
+                "vision summaries are unavailable for this RAM tier. Use OCR-only summarization or switch to a higher local AI tier."
+                    .to_string(),
+            );
         }
         self.bootstrap(config).await;
         let vision_model = model_ids::effective_vision_model_id(config);

--- a/src/openhuman/local_ai/types.rs
+++ b/src/openhuman/local_ai/types.rs
@@ -4,6 +4,7 @@ use crate::openhuman::config::Config;
 use serde::{Deserialize, Serialize};
 
 use super::model_ids;
+use super::presets;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalAiStatus {
@@ -16,6 +17,7 @@ pub struct LocalAiStatus {
     pub tts_voice_id: String,
     pub quantization: String,
     pub vision_state: String,
+    pub vision_mode: String,
     pub embedding_state: String,
     pub stt_state: String,
     pub tts_state: String,
@@ -40,6 +42,7 @@ pub struct LocalAiStatus {
 
 impl LocalAiStatus {
     pub(crate) fn disabled(config: &Config) -> Self {
+        let vision_mode = presets::vision_mode_for_config(&config.local_ai);
         Self {
             state: "disabled".to_string(),
             model_id: model_ids::effective_chat_model_id(config),
@@ -50,6 +53,7 @@ impl LocalAiStatus {
             tts_voice_id: model_ids::effective_tts_voice_id(config),
             quantization: model_ids::effective_quantization(config),
             vision_state: "disabled".to_string(),
+            vision_mode: format!("{vision_mode:?}").to_ascii_lowercase(),
             embedding_state: "disabled".to_string(),
             stt_state: "disabled".to_string(),
             tts_state: "disabled".to_string(),
@@ -162,5 +166,16 @@ mod tests {
         assert_eq!(status.tts_state, "disabled");
         assert_eq!(status.provider, "ollama");
         assert_eq!(status.active_backend, "ollama");
+    }
+
+    #[test]
+    fn disabled_status_uses_config_vision_mode() {
+        let mut config = Config::default();
+        config.local_ai.chat_model_id = "gemma3:1b-it-qat".to_string();
+        config.local_ai.vision_model_id.clear();
+        config.local_ai.embedding_model_id = "all-minilm:latest".to_string();
+
+        let status = LocalAiStatus::disabled(&config);
+        assert_eq!(status.vision_mode, "disabled");
     }
 }

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -1774,14 +1774,21 @@ async fn json_rpc_local_ai_device_profile_and_presets() {
         .get("presets")
         .and_then(Value::as_array)
         .expect("presets should be an array");
-    assert_eq!(presets_arr.len(), 3, "expected 3 presets: {presets_result}");
+    assert_eq!(presets_arr.len(), 5, "expected 5 presets: {presets_result}");
 
     let recommended = presets_result
         .get("recommended_tier")
         .and_then(Value::as_str)
         .expect("should have recommended_tier");
     assert!(
-        ["low", "medium", "high"].contains(&recommended),
+        [
+            "ram_1gb",
+            "ram_2_4gb",
+            "ram_4_8gb",
+            "ram_8_16gb",
+            "ram_16_plus_gb",
+        ]
+        .contains(&recommended),
         "unexpected recommended_tier: {recommended}"
     );
 
@@ -1789,25 +1796,32 @@ async fn json_rpc_local_ai_device_profile_and_presets() {
         .get("current_tier")
         .and_then(Value::as_str)
         .expect("should have current_tier");
-    // Default config uses gemma3:4b-it-qat which matches Medium
-    assert_eq!(current, "medium", "default config should be medium tier");
+    // Default config uses gemma3:4b-it-qat which now maps to the 8-16 GB tier.
+    assert_eq!(
+        current, "ram_8_16gb",
+        "default config should be the 8-16 GB tier"
+    );
 
-    // --- apply_preset (switch to Low) ---
+    // --- apply_preset (switch to 2-4 GB) ---
     let apply = post_json_rpc(
         &rpc_base,
         32,
         "openhuman.local_ai_apply_preset",
-        json!({"tier": "low"}),
+        json!({"tier": "ram_2_4gb"}),
     )
     .await;
     let apply_result = assert_no_jsonrpc_error(&apply, "apply_preset");
     assert_eq!(
         apply_result.get("applied_tier").and_then(Value::as_str),
-        Some("low")
+        Some("ram_2_4gb")
     );
     assert_eq!(
         apply_result.get("chat_model_id").and_then(Value::as_str),
-        Some("gemma3:1b-it-q4_0")
+        Some("gemma3:1b-it-qat")
+    );
+    assert_eq!(
+        apply_result.get("vision_mode").and_then(Value::as_str),
+        Some("disabled")
     );
 
     // --- verify presets reflects the change ---
@@ -1817,8 +1831,8 @@ async fn json_rpc_local_ai_device_profile_and_presets() {
         presets_after_result
             .get("current_tier")
             .and_then(Value::as_str),
-        Some("low"),
-        "current tier should now be low after apply"
+        Some("ram_2_4gb"),
+        "current tier should now be 2-4 GB after apply"
     );
 
     // --- apply_preset with invalid tier should error ---


### PR DESCRIPTION
## Summary

- replace the old 3-tier local AI presets with 5 RAM-based presets tuned for speed-first local inference
- keep Gemma as the primary text model family, reserve `gemma4:e4b` for 16 GB+ devices, and start local vision at the 4-8 GB tier
- make vision tier-aware at runtime so 1-4 GB devices stay text-only, 4-8 GB uses on-demand Moondream summaries, and 8 GB+ keeps bundled multimodal behavior
- extend local AI preset/status payloads with vision mode metadata and update the Settings UI to show vision availability per tier
- update JSON-RPC and local AI tests to the new 5-tier contract

## Problem

- The existing local AI preset system only exposed `low`, `medium`, and `high`, which was too coarse for very small devices and did not reflect the desired RAM-specific deployment strategy.
- Vision bootstrap behavior was effectively all-or-nothing. Low-memory devices could still fall back into vision model resolution and download paths that did not match the intended product behavior.
- The JSON-RPC/UI contract still assumed the old preset model, so device recommendations and preset application were not aligned with the new local-LLM strategy.

## Solution

- Introduced five explicit RAM-tier presets in `src/openhuman/local_ai/presets.rs` with concrete chat, vision, and embedding model mappings.
- Added tier-derived vision modes (`disabled`, `ondemand`, `bundled`) and used them in bootstrap, asset download, diagnostics, and vision inference paths.
- Changed low-memory tiers to clear `vision_model_id` and taught runtime helpers not to silently fall back to a default vision model when vision is intentionally disabled.
- Extended preset/apply RPC payloads and TypeScript types so the frontend can render the new tier metadata and vision behavior.
- Updated the JSON-RPC E2E test and targeted app tests to match the 5-tier preset system.

## Submission Checklist

- [x] **Unit tests** — Vitest (`app/`) and/or `cargo test` (core) for logic you add or change
- [x] **E2E / integration** — Where behavior is user-visible or crosses UI → Tauri → sidecar → JSON-RPC; use existing harnesses (`app/test/e2e`, mock backend, `tests/json_rpc_e2e.rs` as appropriate)
- [ ] **N/A** — If truly not applicable, say why (e.g. change is documentation-only)
- [x] **Doc comments** — `///` / `//!` (Rust), JSDoc or brief file/module headers (TS) on public APIs and non-obvious modules
- [ ] **Inline comments** — Where logic, invariants, or edge cases aren’t clear from names alone (keep them grep-friendly; avoid restating the code)

## Impact

- Desktop local-AI runtime only; no mobile-specific behavior added.
- Low-memory devices now avoid unnecessary vision downloads and use smaller embedding models, which should improve first-run performance and reduce storage pressure.
- Existing users on old stored tier names remain compatible through tier alias parsing, but the public preset contract now reports the new RAM-tier identifiers.
- Pre-push checks passed for this change; repo-wide lint still reports pre-existing warnings in unrelated frontend files.

## Related

- Issue(s): none linked
- Follow-up PR(s)/TODOs: update any user-facing docs or env examples that still mention `low` / `medium` / `high` local AI tiers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded local AI tier system: new RAM-based configuration with 5 options for improved device compatibility
  * Added flexible vision model capability modes with multiple configuration choices
  * Updated settings UI to display vision capability status and target RAM requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->