### PR TITLE
feat(voice): sync overlay orb with chat voice button state (#487)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,7 +5120,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.52.0"
+version = "0.52.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src/overlay/OverlayApp.tsx
+++ b/app/src/overlay/OverlayApp.tsx
@@ -405,7 +405,7 @@ export default function OverlayApp() {
         <div className="relative">
           <button
             type="button"
-            aria-label="Overlay orb"
+            aria-label={mode === 'stt' ? 'Recording speech' : mode === 'attention' ? 'Attention message' : 'OpenHuman overlay'}
             onClick={goIdle}
             onMouseEnter={() => {
               setIsHovered(true);

--- a/app/src/overlay/OverlayApp.tsx
+++ b/app/src/overlay/OverlayApp.tsx
@@ -405,7 +405,13 @@ export default function OverlayApp() {
         <div className="relative">
           <button
             type="button"
-            aria-label={mode === 'stt' ? 'Recording speech' : mode === 'attention' ? 'Attention message' : 'OpenHuman overlay'}
+            aria-label={
+              mode === 'stt'
+                ? 'Voice input active'
+                : mode === 'attention'
+                  ? 'Attention message'
+                  : 'OpenHuman overlay'
+            }
             onClick={goIdle}
             onMouseEnter={() => {
               setIsHovered(true);

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -42,6 +42,7 @@ import {
   openhumanVoiceStatus,
   openhumanVoiceTranscribeBytes,
   openhumanVoiceTts,
+  notifyOverlaySttState,
 } from '../utils/tauriCommands';
 
 const DEFAULT_THREAD_ID = 'default-thread';
@@ -762,6 +763,7 @@ const Conversations = () => {
     const chunks = audioChunksRef.current;
     audioChunksRef.current = [];
     if (chunks.length === 0) {
+      notifyOverlaySttState('cancelled');
       setVoiceStatus('No audio captured. Try again.');
       return;
     }
@@ -784,13 +786,16 @@ const Conversations = () => {
       const transcript = result.text.trim();
 
       if (!transcript) {
+        notifyOverlaySttState('cancelled');
         setVoiceStatus('No speech detected. Try again.');
         return;
       }
 
+      notifyOverlaySttState('transcription_done', transcript);
       setVoiceStatus(`Heard: ${transcript}`);
       await handleSendMessage(transcript);
     } catch (err) {
+      notifyOverlaySttState('error');
       const message = err instanceof Error ? err.message : String(err);
       setSendError(chatSendError('voice_transcription', `Voice transcription failed: ${message}`));
       setVoiceStatus(null);
@@ -839,6 +844,7 @@ const Conversations = () => {
         }
       };
       recorder.onerror = () => {
+        notifyOverlaySttState('error');
         setIsRecording(false);
         mediaStreamRef.current?.getTracks().forEach(track => track.stop());
         mediaStreamRef.current = null;
@@ -853,7 +859,9 @@ const Conversations = () => {
       setSendError(null);
       setIsRecording(true);
       recorder.start();
+      notifyOverlaySttState('recording_started');
     } catch (err) {
+      notifyOverlaySttState('error');
       const message = err instanceof Error ? err.message : String(err);
       setSendError(chatSendError('microphone_access', `Microphone access failed: ${message}`));
       setVoiceStatus(null);

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -34,6 +34,7 @@ import {
 import type { ThreadMessage } from '../types/thread';
 import {
   isTauri,
+  notifyOverlaySttState,
   openhumanAutocompleteAccept,
   openhumanAutocompleteCurrent,
   openhumanLocalAiAnalyzeSentiment,
@@ -42,7 +43,6 @@ import {
   openhumanVoiceStatus,
   openhumanVoiceTranscribeBytes,
   openhumanVoiceTts,
-  notifyOverlaySttState,
 } from '../utils/tauriCommands';
 
 const DEFAULT_THREAD_ID = 'default-thread';

--- a/app/src/utils/tauriCommands/voice.ts
+++ b/app/src/utils/tauriCommands/voice.ts
@@ -172,6 +172,19 @@ export async function registerDictationHotkey(shortcut: string): Promise<void> {
 }
 
 /**
+ * Notify the overlay of a voice/STT state change from the chat prompt button.
+ * Fire-and-forget — errors are logged but never propagated.
+ */
+export function notifyOverlaySttState(
+  state: 'recording_started' | 'transcription_done' | 'cancelled' | 'error',
+  text?: string,
+): void {
+  callCoreRpc({ method: 'openhuman.overlay_stt_notify', params: { state, text } }).catch(
+    (err: unknown) => console.debug('[overlay_stt_notify] fire-and-forget error:', err),
+  );
+}
+
+/**
  * Unregister the global dictation hotkey if one is active.
  */
 export async function unregisterDictationHotkey(): Promise<void> {

--- a/app/src/utils/tauriCommands/voice.ts
+++ b/app/src/utils/tauriCommands/voice.ts
@@ -175,14 +175,18 @@ export async function registerDictationHotkey(shortcut: string): Promise<void> {
  * Notify the overlay of a voice/STT state change from the chat prompt button.
  * Fire-and-forget — errors are logged but never propagated.
  */
-export function notifyOverlaySttState(
+export const notifyOverlaySttState = (
   state: 'recording_started' | 'transcription_done' | 'cancelled' | 'error',
-  text?: string,
-): void {
-  callCoreRpc({ method: 'openhuman.overlay_stt_notify', params: { state, text } }).catch(
-    (err: unknown) => console.debug('[overlay_stt_notify] fire-and-forget error:', err),
-  );
-}
+  text?: string
+): void => {
+  void (async () => {
+    try {
+      await callCoreRpc({ method: 'openhuman.overlay_stt_notify', params: { state, text } });
+    } catch (err: unknown) {
+      console.debug('[overlay_stt_notify] fire-and-forget error:', err);
+    }
+  })();
+};
 
 /**
  * Unregister the global dictation hotkey if one is active.

--- a/src/openhuman/voice/dictation_listener.rs
+++ b/src/openhuman/voice/dictation_listener.rs
@@ -199,4 +199,25 @@ mod tests {
     fn subscribe_returns_receiver() {
         let _rx = subscribe_dictation_events();
     }
+
+    #[test]
+    fn publish_dictation_event_reaches_subscriber() {
+        let mut rx = subscribe_dictation_events();
+        publish_dictation_event(DictationEvent {
+            event_type: "pressed".to_string(),
+            hotkey: "chat_button".to_string(),
+            activation_mode: "toggle".to_string(),
+        });
+        let evt = rx.try_recv().expect("should receive dictation event");
+        assert_eq!(evt.event_type, "pressed");
+        assert_eq!(evt.hotkey, "chat_button");
+    }
+
+    #[test]
+    fn publish_transcription_reaches_subscriber() {
+        let mut rx = subscribe_transcription_results();
+        publish_transcription("hello world".to_string());
+        let text = rx.try_recv().expect("should receive transcription");
+        assert_eq!(text, "hello world");
+    }
 }

--- a/src/openhuman/voice/schemas.rs
+++ b/src/openhuman/voice/schemas.rs
@@ -44,6 +44,15 @@ struct TtsParams {
     output_path: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct OverlaySttNotifyParams {
+    /// Voice state transition: "recording_started", "transcription_done", "cancelled", "error".
+    state: String,
+    /// Transcribed text (required when state is "transcription_done").
+    #[serde(default)]
+    text: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Schema + registry exports
 // ---------------------------------------------------------------------------
@@ -57,6 +66,7 @@ pub fn all_voice_controller_schemas() -> Vec<ControllerSchema> {
         voice_schemas("voice_server_start"),
         voice_schemas("voice_server_stop"),
         voice_schemas("voice_server_status"),
+        voice_schemas("overlay_stt_notify"),
     ]
 }
 
@@ -89,6 +99,10 @@ pub fn all_voice_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: voice_schemas("voice_server_status"),
             handler: handle_voice_server_status,
+        },
+        RegisteredController {
+            schema: voice_schemas("overlay_stt_notify"),
+            handler: handle_overlay_stt_notify,
         },
     ]
 }
@@ -182,6 +196,20 @@ pub fn voice_schemas(function: &str) -> ControllerSchema {
             description: "Get the current voice dictation server status.",
             inputs: vec![],
             outputs: vec![json_output("status", "Current voice server status.")],
+        },
+        "overlay_stt_notify" => ControllerSchema {
+            namespace: "voice",
+            function: "overlay_stt_notify",
+            description:
+                "Notify the overlay of a voice/STT state change from the chat prompt button.",
+            inputs: vec![
+                required_string(
+                    "state",
+                    "State transition: recording_started, transcription_done, cancelled, error.",
+                ),
+                optional_string("text", "Transcribed text (when state is transcription_done)."),
+            ],
+            outputs: vec![json_output("result", "Notification acknowledgement.")],
         },
         _ => ControllerSchema {
             namespace: "voice",
@@ -375,6 +403,53 @@ fn handle_voice_server_status(_params: Map<String, Value>) -> ControllerFuture {
     })
 }
 
+fn handle_overlay_stt_notify(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let p = deserialize_params::<OverlaySttNotifyParams>(params)?;
+        log::debug!(
+            "[overlay_stt_notify] state={}, text={}",
+            p.state,
+            p.text.as_deref().unwrap_or("<none>")
+        );
+
+        use crate::openhuman::voice::dictation_listener::{
+            publish_dictation_event, publish_transcription, DictationEvent,
+        };
+
+        match p.state.as_str() {
+            "recording_started" => {
+                publish_dictation_event(DictationEvent {
+                    event_type: "pressed".to_string(),
+                    hotkey: "chat_button".to_string(),
+                    activation_mode: "toggle".to_string(),
+                });
+            }
+            "transcription_done" => {
+                if let Some(text) = p.text {
+                    publish_transcription(text);
+                }
+                publish_dictation_event(DictationEvent {
+                    event_type: "released".to_string(),
+                    hotkey: "chat_button".to_string(),
+                    activation_mode: "toggle".to_string(),
+                });
+            }
+            "cancelled" | "error" => {
+                publish_dictation_event(DictationEvent {
+                    event_type: "released".to_string(),
+                    hotkey: "chat_button".to_string(),
+                    activation_mode: "toggle".to_string(),
+                });
+            }
+            other => {
+                log::warn!("[overlay_stt_notify] unknown state: {other}");
+            }
+        }
+
+        Ok(serde_json::json!({ "ok": true }))
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -446,6 +521,10 @@ mod tests {
         let s = voice_schemas("voice_tts");
         assert_eq!(s.namespace, "voice");
         assert_eq!(s.function, "tts");
+
+        let s = voice_schemas("overlay_stt_notify");
+        assert_eq!(s.namespace, "voice");
+        assert_eq!(s.function, "overlay_stt_notify");
     }
 
     #[test]

--- a/src/openhuman/voice/schemas.rs
+++ b/src/openhuman/voice/schemas.rs
@@ -45,9 +45,18 @@ struct TtsParams {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OverlaySttState {
+    RecordingStarted,
+    TranscriptionDone,
+    Cancelled,
+    Error,
+}
+
+#[derive(Debug, Deserialize)]
 struct OverlaySttNotifyParams {
-    /// Voice state transition: "recording_started", "transcription_done", "cancelled", "error".
-    state: String,
+    /// Voice state transition.
+    state: OverlaySttState,
     /// Transcribed text (required when state is "transcription_done").
     #[serde(default)]
     text: Option<String>,
@@ -207,7 +216,10 @@ pub fn voice_schemas(function: &str) -> ControllerSchema {
                     "state",
                     "State transition: recording_started, transcription_done, cancelled, error.",
                 ),
-                optional_string("text", "Transcribed text (when state is transcription_done)."),
+                optional_string(
+                    "text",
+                    "Transcribed text (when state is transcription_done).",
+                ),
             ],
             outputs: vec![json_output("result", "Notification acknowledgement.")],
         },
@@ -407,42 +419,41 @@ fn handle_overlay_stt_notify(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let p = deserialize_params::<OverlaySttNotifyParams>(params)?;
         log::debug!(
-            "[overlay_stt_notify] state={}, text={}",
+            "[overlay_stt_notify] state={:?}, has_text={}, text_len={}",
             p.state,
-            p.text.as_deref().unwrap_or("<none>")
+            p.text.is_some(),
+            p.text.as_deref().map_or(0, |t| t.len())
         );
 
         use crate::openhuman::voice::dictation_listener::{
             publish_dictation_event, publish_transcription, DictationEvent,
         };
 
-        match p.state.as_str() {
-            "recording_started" => {
+        match p.state {
+            OverlaySttState::RecordingStarted => {
                 publish_dictation_event(DictationEvent {
                     event_type: "pressed".to_string(),
                     hotkey: "chat_button".to_string(),
                     activation_mode: "toggle".to_string(),
                 });
             }
-            "transcription_done" => {
-                if let Some(text) = p.text {
-                    publish_transcription(text);
-                }
+            OverlaySttState::TranscriptionDone => {
+                let text = p.text.ok_or_else(|| {
+                    "invalid params: `text` is required for transcription_done".to_string()
+                })?;
+                publish_transcription(text);
                 publish_dictation_event(DictationEvent {
                     event_type: "released".to_string(),
                     hotkey: "chat_button".to_string(),
                     activation_mode: "toggle".to_string(),
                 });
             }
-            "cancelled" | "error" => {
+            OverlaySttState::Cancelled | OverlaySttState::Error => {
                 publish_dictation_event(DictationEvent {
                     event_type: "released".to_string(),
                     hotkey: "chat_button".to_string(),
                     activation_mode: "toggle".to_string(),
                 });
-            }
-            other => {
-                log::warn!("[overlay_stt_notify] unknown state: {other}");
             }
         }
 


### PR DESCRIPTION
## Summary

- Add new RPC method `openhuman.overlay_stt_notify` so the chat voice button can signal the overlay orb
- Chat "Start Talking" button now emits recording/transcription/cancel/error state transitions through the existing broadcast infrastructure
- Overlay orb activates (blue, "Listening...") when recording from the chat prompt, not just from the global hotkey
- Dynamic accessibility labels on the overlay orb reflect current mode

## Problem

- The overlay orb reacts to hotkey-based dictation via `DICTATION_BUS`/`TRANSCRIPTION_BUS` → Socket.IO events, but the chat prompt's "Start Talking" button uses browser `MediaRecorder` with local React state only
- Since the overlay is a separate Tauri window, it cannot share React state with the main window — the orb stays idle when recording via the chat button
- Closes #487

## Solution

- **New Rust RPC handler** (`overlay_stt_notify` in `src/openhuman/voice/schemas.rs`): accepts `{ state, text? }` and calls the existing `publish_dictation_event()` / `publish_transcription()` functions — reusing 100% of existing broadcast infrastructure
- **Frontend wrapper** (`notifyOverlaySttState` in `app/src/utils/tauriCommands/voice.ts`): fire-and-forget RPC call at each voice state transition
- **7 call sites** in `Conversations.tsx`: `recording_started`, `transcription_done`, 2× `cancelled`, 3× `error`
- **No changes** to `socketio.rs` (existing bridge forwards broadcasts) or `OverlayApp.tsx` event handlers (already handle `dictation:toggle` + `dictation:transcription`)
- Minor: dynamic `aria-label` on overlay orb button reflects current mode (stt/attention/idle)

## Submission Checklist

- [x] **Unit tests** — 2 new broadcast tests in `dictation_listener.rs` + schema stability test updated in `schemas.rs`; all 59 voice tests pass
- [ ] **E2E / integration** — Manual verification required: click "Start Talking" → overlay activates; stop → overlay shows transcript then dismisses; hotkey path still works
- [x] **Doc comments** — Handler and wrapper functions documented
- [x] **Inline comments** — State values documented in param struct

## Impact

- **Desktop only** — overlay window and core RPC are desktop-only features; no mobile impact
- **No performance concern** — fire-and-forget RPC calls with tokio broadcast (sub-microsecond)
- **No breaking changes** — additive only; existing hotkey path unchanged

## Related

- Issue(s): #487
- Follow-up PR(s)/TODOs: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overlay orb now exposes dynamic, context-aware accessibility labels: "Voice input active", "Attention message", or "OpenHuman overlay" depending on mode.
  * Overlay receives real-time voice transcription state updates (recording started, transcription done, cancelled, error) to improve UI responsiveness.

* **Tests**
  * Added unit tests validating voice event and transcription broadcast delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->