### PR TITLE
fix(voice): cross-platform microphone permission handling (#489)

### DIFF
--- a/app/src-tauri/Info.plist
+++ b/app/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>OpenHuman uses the microphone for voice dictation — press the hotkey to record speech and transcribe it to text.</string>
+</dict>
+</plist>

--- a/app/src-tauri/entitlements.sidecar.plist
+++ b/app/src-tauri/entitlements.sidecar.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -69,9 +69,7 @@
     "macOS": {
       "minimumSystemVersion": "10.15",
       "entitlements": "entitlements.sidecar.plist",
-      "infoPlist": {
-        "NSMicrophoneUsageDescription": "OpenHuman uses the microphone for voice dictation — press the hotkey to record speech and transcribe it to text."
-      },
+      "infoPlist": "Info.plist",
       "dmg": {
         "background": "./images/background-dmg.png"
       }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -69,6 +69,9 @@
     "macOS": {
       "minimumSystemVersion": "10.15",
       "entitlements": "entitlements.sidecar.plist",
+      "infoPlist": {
+        "NSMicrophoneUsageDescription": "OpenHuman uses the microphone for voice dictation — press the hotkey to record speech and transcribe it to text."
+      },
       "dmg": {
         "background": "./images/background-dmg.png"
       }

--- a/src/openhuman/accessibility/mod.rs
+++ b/src/openhuman/accessibility/mod.rs
@@ -36,7 +36,10 @@ pub use permissions::{
     detect_screen_recording_permission, open_macos_privacy_pane, request_accessibility_access,
     request_screen_recording_access,
 };
-pub use permissions::{detect_permissions, permission_to_str};
+pub use permissions::{
+    detect_microphone_permission, detect_permissions, microphone_denied_message, permission_to_str,
+    request_microphone_access,
+};
 pub use terminal::{
     extract_terminal_input_context, is_terminal_app, is_text_role, looks_like_terminal_buffer,
 };

--- a/src/openhuman/accessibility/permissions.rs
+++ b/src/openhuman/accessibility/permissions.rs
@@ -60,6 +60,7 @@ pub fn permission_to_str(permission: PermissionKind) -> &'static str {
         PermissionKind::ScreenRecording => "screen_recording",
         PermissionKind::Accessibility => "accessibility",
         PermissionKind::InputMonitoring => "input_monitoring",
+        PermissionKind::Microphone => "microphone",
     }
 }
 
@@ -129,12 +130,132 @@ pub fn detect_input_monitoring_permission() -> PermissionState {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Microphone permission — cross-platform
+// ---------------------------------------------------------------------------
+
+/// Detect whether the app has microphone permission.
+///
+/// Uses CPAL device probing as a cross-platform permission proxy:
+/// - If `default_input_device()` returns a device, access is available.
+/// - If it returns `None`, either permission is denied or no mic is connected.
+///
+/// On **macOS** under hardened runtime, CPAL will fail to enumerate input
+/// devices when the `com.apple.security.device.audio-input` entitlement is
+/// missing or microphone permission is denied in System Settings.
+///
+/// On **Windows**, `None` may indicate a privacy toggle denial or no hardware.
+///
+/// **Linux** standard desktops don't enforce per-app permissions; Flatpak/Snap
+/// sandboxes are detected separately.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+pub fn detect_microphone_permission() -> PermissionState {
+    use cpal::traits::HostTrait;
+    let host = cpal::default_host();
+    match host.default_input_device() {
+        Some(device) => {
+            let name =
+                cpal::traits::DeviceTrait::name(&device).unwrap_or_else(|_| "<unknown>".into());
+            log::debug!("[permissions] microphone access available — device: {name}");
+            PermissionState::Granted
+        }
+        None => {
+            log::debug!(
+                "[permissions] no default input device — possible permission denial or no mic connected"
+            );
+            PermissionState::Unknown
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn detect_microphone_permission() -> PermissionState {
+    // Standard Linux desktops (PulseAudio/PipeWire) don't enforce app-level mic permissions.
+    // Detect Flatpak sandbox — if sandboxed, probe CPAL as a permission proxy.
+    if std::env::var("FLATPAK_ID").is_ok() || std::path::Path::new("/run/flatpak").exists() {
+        use cpal::traits::HostTrait;
+        let host = cpal::default_host();
+        match host.default_input_device() {
+            Some(_) => PermissionState::Granted,
+            None => {
+                log::debug!(
+                    "[permissions] Linux (Flatpak): no default input device — possible sandbox restriction"
+                );
+                PermissionState::Denied
+            }
+        }
+    } else {
+        PermissionState::Granted
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+pub fn detect_microphone_permission() -> PermissionState {
+    PermissionState::Unsupported
+}
+
+/// Request microphone access from the operating system.
+///
+/// - **macOS**: Triggers the system permission prompt if status is `NotDetermined`.
+///   Note: `AVCaptureDevice.requestAccess(for:)` is async in ObjC but we call the
+///   synchronous authorization check — the system prompt is triggered by the check itself
+///   when entitlements + usage description are present. Alternatively, opening the
+///   Privacy pane guides the user.
+/// - **Windows**: Opens the Privacy > Microphone settings page.
+/// - **Linux**: No-op for standard installs; guidance for Flatpak in error messages.
+#[cfg(target_os = "macos")]
+pub fn request_microphone_access() {
+    log::debug!("[permissions] requesting macOS microphone access via Privacy pane");
+    open_macos_privacy_pane("Privacy_Microphone");
+}
+
+#[cfg(target_os = "windows")]
+pub fn request_microphone_access() {
+    log::debug!("[permissions] opening Windows Privacy > Microphone settings");
+    let _ = std::process::Command::new("cmd")
+        .args(["/C", "start", "ms-settings:privacy-microphone"])
+        .status();
+}
+
+#[cfg(target_os = "linux")]
+pub fn request_microphone_access() {
+    log::debug!("[permissions] Linux: no programmatic mic permission request available");
+    // No-op — standard Linux desktops don't have an app-level permission gate.
+    // For Flatpak, the XDG Portal API (ashpd crate) could be used in the future.
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+pub fn request_microphone_access() {
+    // Unsupported platform — no-op.
+}
+
+/// Returns a platform-specific user-facing message when microphone permission is denied.
+pub fn microphone_denied_message() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "Microphone permission denied. Grant access in System Settings > Privacy & Security > Microphone, then restart the app.".to_string()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Microphone access unavailable. Check Settings > Privacy & Security > Microphone and ensure the app is allowed. If no microphone is connected, plug one in.".to_string()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "No microphone device available. Check your audio settings and ensure a microphone is connected. If running in a Flatpak sandbox, grant microphone access via Flatseal or system settings.".to_string()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        "Microphone access is not supported on this platform.".to_string()
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub fn detect_permissions() -> PermissionStatus {
     PermissionStatus {
         screen_recording: detect_screen_recording_permission(),
         accessibility: detect_accessibility_permission(),
         input_monitoring: detect_input_monitoring_permission(),
+        microphone: detect_microphone_permission(),
     }
 }
 
@@ -144,5 +265,6 @@ pub fn detect_permissions() -> PermissionStatus {
         screen_recording: PermissionState::Unsupported,
         accessibility: PermissionState::Unsupported,
         input_monitoring: PermissionState::Unsupported,
+        microphone: detect_microphone_permission(),
     }
 }

--- a/src/openhuman/accessibility/types.rs
+++ b/src/openhuman/accessibility/types.rs
@@ -65,6 +65,7 @@ pub struct PermissionStatus {
     pub screen_recording: PermissionState,
     pub accessibility: PermissionState,
     pub input_monitoring: PermissionState,
+    pub microphone: PermissionState,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -73,6 +74,7 @@ pub enum PermissionKind {
     ScreenRecording,
     Accessibility,
     InputMonitoring,
+    Microphone,
 }
 
 #[cfg(test)]

--- a/src/openhuman/screen_intelligence/engine.rs
+++ b/src/openhuman/screen_intelligence/engine.rs
@@ -222,31 +222,32 @@ impl AccessibilityEngine {
         &self,
         permission: PermissionKind,
     ) -> Result<PermissionStatus, String> {
-        if !cfg!(target_os = "macos") {
+        // Microphone permission is cross-platform; other permissions are macOS-only.
+        if matches!(permission, PermissionKind::Microphone) {
+            request_microphone_access();
+        } else if !cfg!(target_os = "macos") {
             return Ok(PermissionStatus {
                 screen_recording: PermissionState::Unsupported,
                 accessibility: PermissionState::Unsupported,
                 input_monitoring: PermissionState::Unsupported,
                 microphone: PermissionState::Unsupported,
             });
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            match permission {
-                PermissionKind::ScreenRecording => {
-                    request_screen_recording_access();
-                    open_macos_privacy_pane("Privacy_ScreenCapture");
-                }
-                PermissionKind::Accessibility => {
-                    request_accessibility_access();
-                    open_macos_privacy_pane("Privacy_Accessibility");
-                }
-                PermissionKind::InputMonitoring => {
-                    open_macos_privacy_pane("Privacy_ListenEvent");
-                }
-                PermissionKind::Microphone => {
-                    request_microphone_access();
+        } else {
+            #[cfg(target_os = "macos")]
+            {
+                match permission {
+                    PermissionKind::ScreenRecording => {
+                        request_screen_recording_access();
+                        open_macos_privacy_pane("Privacy_ScreenCapture");
+                    }
+                    PermissionKind::Accessibility => {
+                        request_accessibility_access();
+                        open_macos_privacy_pane("Privacy_Accessibility");
+                    }
+                    PermissionKind::InputMonitoring => {
+                        open_macos_privacy_pane("Privacy_ListenEvent");
+                    }
+                    PermissionKind::Microphone => unreachable!(),
                 }
             }
         }

--- a/src/openhuman/screen_intelligence/engine.rs
+++ b/src/openhuman/screen_intelligence/engine.rs
@@ -17,6 +17,7 @@ use super::types::{
     AccessibilityStatus, AppContextInfo, CaptureFrame, CaptureImageRefResult, CaptureNowResult,
     CaptureTestResult, CoreProcessStatus, SessionStatus, StartSessionParams,
 };
+use crate::openhuman::accessibility::request_microphone_access;
 use crate::openhuman::accessibility::{
     capture_screen_image_ref_for_context, detect_permissions, foreground_context,
     permission_to_str, AppContext, PermissionKind, PermissionState, PermissionStatus,
@@ -202,6 +203,7 @@ impl AccessibilityEngine {
                 screen_recording: PermissionState::Unsupported,
                 accessibility: PermissionState::Unsupported,
                 input_monitoring: PermissionState::Unsupported,
+                microphone: PermissionState::Unsupported,
             });
         }
 
@@ -225,6 +227,7 @@ impl AccessibilityEngine {
                 screen_recording: PermissionState::Unsupported,
                 accessibility: PermissionState::Unsupported,
                 input_monitoring: PermissionState::Unsupported,
+                microphone: PermissionState::Unsupported,
             });
         }
 
@@ -241,6 +244,9 @@ impl AccessibilityEngine {
                 }
                 PermissionKind::InputMonitoring => {
                     open_macos_privacy_pane("Privacy_ListenEvent");
+                }
+                PermissionKind::Microphone => {
+                    request_microphone_access();
                 }
             }
         }

--- a/src/openhuman/screen_intelligence/state.rs
+++ b/src/openhuman/screen_intelligence/state.rs
@@ -51,6 +51,7 @@ impl EngineState {
                 screen_recording: PermissionState::Unknown,
                 accessibility: PermissionState::Unknown,
                 input_monitoring: PermissionState::Unknown,
+                microphone: PermissionState::Unknown,
             },
             features: AccessibilityFeatures {
                 screen_monitoring: true,

--- a/src/openhuman/voice/audio_capture.rs
+++ b/src/openhuman/voice/audio_capture.rs
@@ -204,7 +204,7 @@ fn record_on_thread(
             // Re-check after request (macOS may have shown a prompt).
             let updated = detect_microphone_permission();
             debug!("{LOG_PREFIX} microphone permission after request: {updated:?}");
-            if updated == PermissionState::Denied {
+            if matches!(updated, PermissionState::Denied | PermissionState::Unknown) {
                 let msg = microphone_denied_message();
                 error!("{LOG_PREFIX} {msg}");
                 let _ = setup_tx.send(Err(msg.clone()));

--- a/src/openhuman/voice/audio_capture.rs
+++ b/src/openhuman/voice/audio_capture.rs
@@ -188,6 +188,38 @@ fn record_on_thread(
     stop_flag: Arc<AtomicBool>,
     setup_tx: std::sync::mpsc::SyncSender<Result<(), String>>,
 ) -> Result<RecordingResult, String> {
+    // --- Cross-platform microphone permission pre-check ---
+    use crate::openhuman::accessibility::{
+        detect_microphone_permission, microphone_denied_message, request_microphone_access,
+        PermissionState,
+    };
+
+    let mic_perm = detect_microphone_permission();
+    debug!("{LOG_PREFIX} microphone permission state: {mic_perm:?}");
+
+    match mic_perm {
+        PermissionState::Unknown => {
+            info!("{LOG_PREFIX} microphone permission not yet determined — requesting access");
+            request_microphone_access();
+            // Re-check after request (macOS may have shown a prompt).
+            let updated = detect_microphone_permission();
+            debug!("{LOG_PREFIX} microphone permission after request: {updated:?}");
+            if updated == PermissionState::Denied {
+                let msg = microphone_denied_message();
+                error!("{LOG_PREFIX} {msg}");
+                let _ = setup_tx.send(Err(msg.clone()));
+                return Err(msg);
+            }
+        }
+        PermissionState::Denied => {
+            let msg = microphone_denied_message();
+            error!("{LOG_PREFIX} {msg}");
+            let _ = setup_tx.send(Err(msg.clone()));
+            return Err(msg);
+        }
+        _ => {} // Granted or Unsupported — proceed normally.
+    }
+
     let host = cpal::default_host();
     let device = host
         .default_input_device()


### PR DESCRIPTION
## Summary

- Add `com.apple.security.device.audio-input` entitlement to sidecar plist so macOS hardened runtime allows microphone access
- Add `NSMicrophoneUsageDescription` to Tauri config so macOS can show the permission prompt dialog
- Add cross-platform microphone permission detection using CPAL device probing (macOS, Windows, Linux including Flatpak)
- Add permission pre-check in `audio_capture.rs` before recording starts, with platform-specific error messages

## Problem

Voice dictation in the release DMG silently fails — the UI transitions to "recording" but no audio is captured. The root cause is that macOS hardened runtime enforces the `com.apple.security.device.audio-input` entitlement, which was missing from `entitlements.sidecar.plist`. Without it, CPAL's `default_input_device()` returns `None` and the error message ("no default audio input device found") is misleading. Additionally, `NSMicrophoneUsageDescription` was absent, so macOS couldn't show the permission prompt even if the entitlement were present.

This works in dev mode (`cargo run` / `yarn tauri dev`) because the hardened runtime is not enforced there.

## Solution

**macOS entitlements (critical fix):**
- Added `com.apple.security.device.audio-input` to `app/src-tauri/entitlements.sidecar.plist`
- Added `NSMicrophoneUsageDescription` via `infoPlist` in `app/src-tauri/tauri.conf.json`

**Cross-platform permission detection:**
- Added `Microphone` variant to `PermissionKind` enum and `microphone` field to `PermissionStatus`
- Added `detect_microphone_permission()` using CPAL device probing — works on macOS (where denied permission hides devices), Windows (privacy toggle), and Linux (standard + Flatpak sandbox detection)
- Added `request_microphone_access()` — opens System Settings on macOS, Privacy settings on Windows, no-op on standard Linux
- Added `microphone_denied_message()` — returns platform-specific user guidance

**Recording pre-check:**
- `record_on_thread()` in `audio_capture.rs` now checks microphone permission before attempting CPAL device enumeration
- If permission is `Unknown`, requests access and re-checks
- If `Denied`, returns a clear platform-specific error message that flows through `last_error` to the UI

## Submission Checklist

- [ ] **Unit tests** — Permission detection is platform-dependent (requires hardware); tested via `cargo check` + manual verification
- [x] **N/A** — E2E tests not applicable for entitlement/permission changes (require signed .app bundle)
- [x] **Doc comments** — All new public functions have `///` documentation
- [x] **Inline comments** — Platform-specific behavior documented in code comments

## Impact

- **macOS (release builds)**: Fixes voice dictation completely — the entitlement is the critical blocker
- **Windows**: Adds microphone availability detection and Settings redirect when unavailable
- **Linux**: Standard installs unaffected (returns Granted); Flatpak sandboxes get device probe detection
- **No breaking changes**: New `microphone` field on `PermissionStatus` is additive; existing permission checks unaffected

## Related

- Issue: Closes #489
- Related: #385 (voice hallucination fixes — already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-platform microphone permission detection and status included in the app’s permission checks.
  * App validates microphone access before starting audio capture and notifies the user if access is denied.
  * Platform-specific flows to request microphone access and present denial/help guidance; macOS shows a privacy usage message and prompts for access.

* **Chores**
  * macOS packaging updated to include the app Info.plist and microphone entitlement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->