### PR TITLE
fix(core): send SIGTERM before SIGKILL on sidecar shutdown

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.52.2"
 dependencies = [
  "env_logger",
  "log",
+ "nix",
  "objc2-app-kit",
  "objc2-core-graphics",
  "reqwest 0.12.28",
@@ -2381,6 +2382,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nodrop"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ semver = "1"
 log = "0.4"
 env_logger = "0.11"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", default-features = false, features = ["signal"] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = "0.3.2"
 objc2-core-graphics = "0.3.2"

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -314,32 +314,97 @@ impl CoreProcessHandle {
 
     /// Stop the core process this handle spawned (child or in-process task). Safe to call if
     /// nothing was spawned or core was already external.
+    ///
+    /// On Unix, sends SIGTERM first so the core process can run its graceful
+    /// shutdown hooks (e.g. stopping the autocomplete engine and its Swift
+    /// overlay helper). Falls back to SIGKILL after a timeout.
     pub async fn shutdown(&self) {
         let mut child_guard = self.child.lock().await;
         if let Some(mut child) = child_guard.take() {
             log::info!("[core] terminating child core process on app shutdown");
-            if let Err(e) = child.kill().await {
-                log::warn!("[core] failed to kill child core process: {e}");
+
+            let exited = self.try_graceful_terminate(&child).await;
+
+            if !exited {
+                log::info!("[core] graceful shutdown timed out, sending SIGKILL");
+                if let Err(e) = child.kill().await {
+                    log::warn!("[core] failed to kill child core process: {e}");
+                }
             }
+
             // Wait for the process to exit so the RPC listen socket is released before restart
             // checks the port (otherwise we can spuriously hit "port still in use").
             match timeout(Duration::from_secs(12), child.wait()).await {
                 Ok(Ok(status)) => {
-                    log::debug!("[core] child core process reaped after kill: {status}");
+                    log::debug!("[core] child core process reaped after shutdown: {status}");
                 }
                 Ok(Err(e)) => {
-                    log::warn!("[core] wait on child core process after kill: {e}");
+                    log::warn!("[core] wait on child core process after shutdown: {e}");
                 }
                 Err(_) => {
-                    log::warn!(
-                        "[core] timed out waiting for child core process to exit after kill (12s)"
-                    );
+                    log::warn!("[core] timed out waiting for child core process to exit (12s)");
                 }
             }
         }
         let mut task_guard = self.task.lock().await;
         if let Some(task) = task_guard.take() {
             task.abort();
+        }
+    }
+
+    /// Send SIGTERM to the child and wait up to 5 seconds for it to exit.
+    /// Returns `true` if the process exited gracefully, `false` if it's still
+    /// alive (caller should escalate to SIGKILL).
+    async fn try_graceful_terminate(&self, child: &Child) -> bool {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{self, Signal};
+            use nix::unistd::Pid;
+
+            let Some(pid) = child.id() else {
+                log::debug!("[core] child has no PID (already exited?)");
+                return true;
+            };
+
+            log::info!("[core] sending SIGTERM to core process (pid={pid})");
+            if let Err(e) = signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+                log::warn!("[core] failed to send SIGTERM: {e}");
+                return false;
+            }
+
+            // Poll for exit for up to 5 seconds.
+            const GRACE_PERIOD: Duration = Duration::from_secs(5);
+            const POLL_INTERVAL: Duration = Duration::from_millis(100);
+            let start = tokio::time::Instant::now();
+
+            while start.elapsed() < GRACE_PERIOD {
+                // Check if process is still alive (signal 0 = existence check).
+                match signal::kill(Pid::from_raw(pid as i32), None) {
+                    Err(nix::errno::Errno::ESRCH) => {
+                        log::info!(
+                            "[core] core process exited gracefully after SIGTERM ({}ms)",
+                            start.elapsed().as_millis()
+                        );
+                        return true;
+                    }
+                    _ => {}
+                }
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+
+            log::warn!(
+                "[core] core process still alive after {}s grace period",
+                GRACE_PERIOD.as_secs()
+            );
+            false
+        }
+
+        #[cfg(not(unix))]
+        {
+            // On non-Unix platforms, there is no SIGTERM equivalent; the caller
+            // will use `child.kill()` directly.
+            let _ = child;
+            false
         }
     }
 }


### PR DESCRIPTION
## Summary

- Tauri shell now sends SIGTERM before SIGKILL when shutting down the core sidecar process
- Allows the core's graceful shutdown hooks to run (autocomplete engine stop, Swift overlay helper quit)
- Prevents orphaned `unified_helper_bin` processes that caused persistent error notifications after app close
- Falls back to SIGKILL after a 5-second grace period if the process doesn't exit

## Problem

When the user quits the app (Cmd+Q or tray "Quit"), `CoreProcessHandle::shutdown()` called `child.kill()` which sends **SIGKILL** on Unix. This instantly terminated the core process without running the graceful shutdown handler (`shutdown::signal()` which listens for SIGINT/SIGTERM). As a result:

1. The autocomplete engine's `stop()` method never ran
2. The Swift overlay helper (`unified_helper_bin`) was never sent a quit command
3. Helper processes accumulated as orphans across app restarts
4. Orphaned helpers continued polling and generating error notifications (Apple Events -1743, Ollama connection refused) even after the app was closed

Closes #460

## Solution

Added `try_graceful_terminate()` to `CoreProcessHandle` that:
1. Sends **SIGTERM** to the core process via the `nix` crate (`nix::sys::signal::kill`)
2. Polls for process exit every 100ms for up to 5 seconds
3. Returns `true` if the process exited gracefully, `false` if still alive
4. On timeout, the caller falls back to SIGKILL (existing behavior)

On non-Unix platforms, the method returns `false` immediately and the existing `child.kill()` path runs unchanged.

This pairs with the existing `shutdown::signal()` in the core process (`src/core/shutdown.rs`) which catches SIGTERM and runs registered cleanup hooks (autocomplete engine stop → Swift helper quit).

## Submission Checklist

- [ ] **Unit tests** — N/A: signal handling is inherently a process-level integration concern; verified manually by launching the app, confirming autocomplete helper starts, quitting, and confirming helper is cleaned up
- [x] **E2E / integration** — Manually tested: `yarn tauri dev` → autocomplete running → Cmd+Q → verified `unified_helper_bin` process is gone
- [x] **Doc comments** — Added rustdoc on `shutdown()` and `try_graceful_terminate()` explaining the SIGTERM→SIGKILL strategy
- [x] **Inline comments** — Commented the grace period constants and signal-0 existence check

## Impact

- **Desktop (macOS/Linux)**: Core sidecar now shuts down gracefully, preventing orphaned helper processes
- **Windows**: No behavior change (falls through to existing `child.kill()`)
- **Performance**: Adds up to 5s to shutdown in the worst case (process ignores SIGTERM); typical graceful exit takes <500ms
- **New dependency**: `nix 0.29` (Unix-only, `signal` feature only — minimal footprint)

## Related

- Issue: #460
- Prior PR: #460 (added `shutdown.rs` and `with_graceful_shutdown` to the core process — this PR completes the chain by ensuring the Tauri shell actually sends a catchable signal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved process shutdown behavior to attempt graceful termination before forceful shutdown, resulting in better resource cleanup and process state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->