### PR TITLE
feat(composio): backend-proxied Composio integration end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,7 +5120,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "env_logger",
  "log",

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -1,0 +1,323 @@
+/**
+ * Modal for connecting / managing a Composio toolkit.
+ *
+ * Mirrors the flow, positioning, and portal/backdrop plumbing of
+ * `SkillSetupModal` so the two feel identical to the user:
+ *
+ *   disconnected → "Connect" button → POST composio_authorize →
+ *   open connectUrl via tauri-opener → poll listConnections until
+ *   the toolkit flips to ACTIVE → "Connected" success screen with
+ *   a "Disconnect" action.
+ *
+ * Redundant refetches from the polling hook in `useComposioIntegrations`
+ * keep the Skills page badge in sync too, so the card reflects the new
+ * state as soon as the modal closes.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { authorize, deleteConnection, listConnections } from '../../lib/composio/composioApi';
+import {
+  deriveComposioState,
+  type ComposioConnection,
+} from '../../lib/composio/types';
+import { openUrl } from '../../utils/openUrl';
+import type { ComposioToolkitMeta } from './toolkitMeta';
+
+type Phase =
+  | 'idle'
+  | 'authorizing'
+  | 'waiting'
+  | 'connected'
+  | 'disconnecting'
+  | 'error';
+
+interface ComposioConnectModalProps {
+  toolkit: ComposioToolkitMeta;
+  /** Existing connection (if any) from the hook. */
+  connection?: ComposioConnection;
+  /** Invoked on successful connect/disconnect so the parent can refresh. */
+  onChanged?: () => void;
+  onClose: () => void;
+}
+
+const POLL_INTERVAL_MS = 4_000;
+const POLL_TIMEOUT_MS = 5 * 60 * 1_000;
+
+export default function ComposioConnectModal({
+  toolkit,
+  connection,
+  onChanged,
+  onClose,
+}: ComposioConnectModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const pollTimerRef = useRef<number | null>(null);
+  const pollDeadlineRef = useRef<number>(0);
+
+  const initiallyConnected = deriveComposioState(connection) === 'connected';
+  const [phase, setPhase] = useState<Phase>(initiallyConnected ? 'connected' : 'idle');
+  const [error, setError] = useState<string | null>(null);
+  const [connectUrl, setConnectUrl] = useState<string | null>(null);
+  const [activeConnection, setActiveConnection] = useState<ComposioConnection | undefined>(
+    connection,
+  );
+
+  // Escape to close
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  // Focus trap
+  useEffect(() => {
+    const previousFocus = document.activeElement as HTMLElement | null;
+    modalRef.current?.focus();
+    return () => {
+      previousFocus?.focus?.();
+    };
+  }, []);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current != null) {
+      window.clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => () => stopPolling(), [stopPolling]);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollDeadlineRef.current = Date.now() + POLL_TIMEOUT_MS;
+    const tick = async () => {
+      try {
+        const resp = await listConnections();
+        const hit = resp.connections.find(
+          c => c.toolkit.toLowerCase() === toolkit.slug.toLowerCase(),
+        );
+        if (hit) {
+          setActiveConnection(hit);
+          const state = deriveComposioState(hit);
+          if (state === 'connected') {
+            stopPolling();
+            setPhase('connected');
+            setError(null);
+            onChanged?.();
+            return;
+          }
+          if (state === 'error') {
+            stopPolling();
+            setPhase('error');
+            setError(`Connection failed (status: ${hit.status}).`);
+            return;
+          }
+        }
+      } catch (err) {
+        // Swallow transient errors during polling — we'll retry on next tick.
+        console.warn('[composio] poll failed:', err);
+      }
+      if (Date.now() > pollDeadlineRef.current) {
+        stopPolling();
+        setPhase('error');
+        setError(
+          'Timed out waiting for OAuth to complete. Please retry or check that the browser finished the flow.',
+        );
+      }
+    };
+    // Fire once immediately, then on interval.
+    void tick();
+    pollTimerRef.current = window.setInterval(() => void tick(), POLL_INTERVAL_MS);
+  }, [onChanged, stopPolling, toolkit.slug]);
+
+  const handleConnect = useCallback(async () => {
+    setPhase('authorizing');
+    setError(null);
+    setConnectUrl(null);
+    try {
+      const resp = await authorize(toolkit.slug);
+      setConnectUrl(resp.connectUrl);
+      await openUrl(resp.connectUrl);
+      setPhase('waiting');
+      startPolling();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setPhase('error');
+      setError(`Authorization failed: ${msg}`);
+    }
+  }, [startPolling, toolkit.slug]);
+
+  const handleDisconnect = useCallback(async () => {
+    if (!activeConnection) return;
+    setPhase('disconnecting');
+    setError(null);
+    try {
+      await deleteConnection(activeConnection.id);
+      setActiveConnection(undefined);
+      setPhase('idle');
+      onChanged?.();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setPhase('error');
+      setError(`Disconnect failed: ${msg}`);
+    }
+  }, [activeConnection, onChanged]);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const headerTitle =
+    phase === 'connected' ? `Manage ${toolkit.name}` : `Connect ${toolkit.name}`;
+
+  const modalContent = (
+    <div
+      className="fixed inset-0 z-[9999] bg-black/30 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="composio-setup-title">
+      <div
+        ref={modalRef}
+        className="bg-white border border-stone-200 rounded-3xl shadow-large w-full max-w-[460px] overflow-hidden animate-fade-up focus:outline-none focus:ring-0"
+        style={{
+          animationDuration: '200ms',
+          animationTimingFunction: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+          animationFillMode: 'both',
+        }}
+        tabIndex={-1}
+        onClick={e => e.stopPropagation()}>
+        {/* Header */}
+        <div className="p-4 border-b border-stone-200">
+          <div className="flex items-start justify-between">
+            <div className="flex-1 min-w-0 pr-2">
+              <div className="flex items-center gap-2">
+                <span className="text-lg">{toolkit.icon}</span>
+                <h2
+                  id="composio-setup-title"
+                  className="text-base font-semibold text-stone-900">
+                  {headerTitle}
+                </h2>
+                <span className="px-1.5 py-0.5 text-[10px] font-medium rounded-md bg-primary-500/15 text-primary-600">
+                  composio
+                </span>
+              </div>
+              <p className="text-xs text-stone-400 mt-1.5 line-clamp-2">
+                {toolkit.description}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1 text-stone-400 hover:text-stone-900 transition-colors rounded-lg hover:bg-stone-100 flex-shrink-0"
+              aria-label="Close">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="p-4 space-y-3">
+          {phase === 'idle' && (
+            <>
+              <p className="text-sm text-stone-600">
+                Connect your {toolkit.name} account through Composio. We will open a
+                browser window where you can grant access, and then this app will
+                detect the connection automatically.
+              </p>
+              <button
+                type="button"
+                onClick={() => void handleConnect()}
+                className="w-full rounded-xl bg-primary-500 text-white text-sm font-medium py-2.5 hover:bg-primary-600 transition-colors">
+                Connect {toolkit.name}
+              </button>
+            </>
+          )}
+
+          {phase === 'authorizing' && (
+            <p className="text-sm text-stone-500">Requesting connect URL…</p>
+          )}
+
+          {phase === 'waiting' && (
+            <>
+              <div className="flex items-center gap-2 text-sm text-stone-700">
+                <div className="w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
+                Waiting for {toolkit.name} OAuth to complete…
+              </div>
+              {connectUrl && (
+                <button
+                  type="button"
+                  onClick={() => void openUrl(connectUrl)}
+                  className="w-full rounded-xl border border-stone-200 bg-stone-50 text-stone-700 text-xs font-medium py-2 hover:bg-stone-100 transition-colors">
+                  Reopen browser
+                </button>
+              )}
+              <p className="text-xs text-stone-400">
+                Complete the sign-in in your browser. This window will update when
+                the connection is active.
+              </p>
+            </>
+          )}
+
+          {phase === 'connected' && (
+            <>
+              <div className="flex items-center gap-2 text-sm text-sage-700">
+                <div className="w-2 h-2 rounded-full bg-sage-500" />
+                {toolkit.name} is connected.
+              </div>
+              {activeConnection && (
+                <p className="text-[11px] text-stone-400 font-mono break-all">
+                  id: {activeConnection.id}
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={() => void handleDisconnect()}
+                className="w-full rounded-xl border border-coral-200 bg-coral-50 text-coral-700 text-sm font-medium py-2.5 hover:bg-coral-100 transition-colors">
+                Disconnect
+              </button>
+            </>
+          )}
+
+          {phase === 'disconnecting' && (
+            <p className="text-sm text-stone-500">Disconnecting…</p>
+          )}
+
+          {phase === 'error' && (
+            <>
+              <div className="rounded-xl border border-coral-200 bg-coral-50 p-3">
+                <p className="text-sm text-coral-700">{error ?? 'Something went wrong.'}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setPhase(initiallyConnected ? 'connected' : 'idle');
+                  setError(null);
+                }}
+                className="w-full rounded-xl border border-stone-200 bg-white text-stone-700 text-sm font-medium py-2 hover:bg-stone-50 transition-colors">
+                Dismiss
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -44,9 +44,14 @@ export default function ComposioConnectModal({
   const modalRef = useRef<HTMLDivElement>(null);
   const pollTimerRef = useRef<number | null>(null);
   const pollDeadlineRef = useRef<number>(0);
+  const isPollingRef = useRef<boolean>(false);
+  const inFlightRef = useRef<boolean>(false);
 
-  const initiallyConnected = deriveComposioState(connection) === 'connected';
-  const [phase, setPhase] = useState<Phase>(initiallyConnected ? 'connected' : 'idle');
+  const initialState = deriveComposioState(connection);
+  const initiallyConnected = initialState === 'connected';
+  const [phase, setPhase] = useState<Phase>(
+    initiallyConnected ? 'connected' : initialState === 'pending' ? 'waiting' : 'idle'
+  );
   const [error, setError] = useState<string | null>(null);
   const [connectUrl, setConnectUrl] = useState<string | null>(null);
   const [activeConnection, setActiveConnection] = useState<ComposioConnection | undefined>(
@@ -72,8 +77,9 @@ export default function ComposioConnectModal({
   }, []);
 
   const stopPolling = useCallback(() => {
+    isPollingRef.current = false;
     if (pollTimerRef.current != null) {
-      window.clearInterval(pollTimerRef.current);
+      window.clearTimeout(pollTimerRef.current);
       pollTimerRef.current = null;
     }
   }, []);
@@ -83,8 +89,27 @@ export default function ComposioConnectModal({
 
   const startPolling = useCallback(() => {
     stopPolling();
+    isPollingRef.current = true;
     pollDeadlineRef.current = Date.now() + POLL_TIMEOUT_MS;
+
+    const scheduleNext = () => {
+      if (!isPollingRef.current) return;
+      pollTimerRef.current = window.setTimeout(() => void tick(), POLL_INTERVAL_MS);
+    };
+
     const tick = async () => {
+      // Guard against overlapping executions: if a previous tick is still
+      // in flight or we've already stopped/deadlined, skip this round.
+      if (inFlightRef.current || !isPollingRef.current) return;
+      if (Date.now() > pollDeadlineRef.current) {
+        stopPolling();
+        setPhase('error');
+        setError(
+          'Timed out waiting for OAuth to complete. Please retry or check that the browser finished the flow.'
+        );
+        return;
+      }
+      inFlightRef.current = true;
       try {
         const resp = await listConnections();
         const hit = resp.connections.find(
@@ -110,19 +135,28 @@ export default function ComposioConnectModal({
       } catch (err) {
         // Swallow transient errors during polling — we'll retry on next tick.
         console.warn('[composio] poll failed:', err);
+      } finally {
+        inFlightRef.current = false;
       }
-      if (Date.now() > pollDeadlineRef.current) {
-        stopPolling();
-        setPhase('error');
-        setError(
-          'Timed out waiting for OAuth to complete. Please retry or check that the browser finished the flow.'
-        );
-      }
+      scheduleNext();
     };
-    // Fire once immediately, then on interval.
+
+    // Fire once immediately, then recurse via setTimeout once the previous
+    // tick resolves. Avoids overlapping async ticks entirely.
     void tick();
-    pollTimerRef.current = window.setInterval(() => void tick(), POLL_INTERVAL_MS);
   }, [onChanged, stopPolling, toolkit.slug]);
+
+  // If the modal opens while an OAuth handoff is already in flight
+  // (status = PENDING/INITIATED/…), resume polling instead of asking
+  // the user to click Connect again.
+  useEffect(() => {
+    if (initialState === 'pending') {
+      startPolling();
+    }
+    // intentionally run once on mount — startPolling has stable deps and
+    // re-running this on every identity change would restart the poller.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleConnect = useCallback(async () => {
     setPhase('authorizing');

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -13,25 +13,15 @@
  * keep the Skills page badge in sync too, so the card reflects the new
  * state as soon as the modal closes.
  */
-
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { authorize, deleteConnection, listConnections } from '../../lib/composio/composioApi';
-import {
-  deriveComposioState,
-  type ComposioConnection,
-} from '../../lib/composio/types';
+import { type ComposioConnection, deriveComposioState } from '../../lib/composio/types';
 import { openUrl } from '../../utils/openUrl';
 import type { ComposioToolkitMeta } from './toolkitMeta';
 
-type Phase =
-  | 'idle'
-  | 'authorizing'
-  | 'waiting'
-  | 'connected'
-  | 'disconnecting'
-  | 'error';
+type Phase = 'idle' | 'authorizing' | 'waiting' | 'connected' | 'disconnecting' | 'error';
 
 interface ComposioConnectModalProps {
   toolkit: ComposioToolkitMeta;
@@ -60,7 +50,7 @@ export default function ComposioConnectModal({
   const [error, setError] = useState<string | null>(null);
   const [connectUrl, setConnectUrl] = useState<string | null>(null);
   const [activeConnection, setActiveConnection] = useState<ComposioConnection | undefined>(
-    connection,
+    connection
   );
 
   // Escape to close
@@ -98,7 +88,7 @@ export default function ComposioConnectModal({
       try {
         const resp = await listConnections();
         const hit = resp.connections.find(
-          c => c.toolkit.toLowerCase() === toolkit.slug.toLowerCase(),
+          c => c.toolkit.toLowerCase() === toolkit.slug.toLowerCase()
         );
         if (hit) {
           setActiveConnection(hit);
@@ -125,7 +115,7 @@ export default function ComposioConnectModal({
         stopPolling();
         setPhase('error');
         setError(
-          'Timed out waiting for OAuth to complete. Please retry or check that the browser finished the flow.',
+          'Timed out waiting for OAuth to complete. Please retry or check that the browser finished the flow.'
         );
       }
     };
@@ -171,8 +161,7 @@ export default function ComposioConnectModal({
     if (e.target === e.currentTarget) onClose();
   };
 
-  const headerTitle =
-    phase === 'connected' ? `Manage ${toolkit.name}` : `Connect ${toolkit.name}`;
+  const headerTitle = phase === 'connected' ? `Manage ${toolkit.name}` : `Connect ${toolkit.name}`;
 
   const modalContent = (
     <div
@@ -197,29 +186,21 @@ export default function ComposioConnectModal({
             <div className="flex-1 min-w-0 pr-2">
               <div className="flex items-center gap-2">
                 <span className="text-lg">{toolkit.icon}</span>
-                <h2
-                  id="composio-setup-title"
-                  className="text-base font-semibold text-stone-900">
+                <h2 id="composio-setup-title" className="text-base font-semibold text-stone-900">
                   {headerTitle}
                 </h2>
                 <span className="px-1.5 py-0.5 text-[10px] font-medium rounded-md bg-primary-500/15 text-primary-600">
                   composio
                 </span>
               </div>
-              <p className="text-xs text-stone-400 mt-1.5 line-clamp-2">
-                {toolkit.description}
-              </p>
+              <p className="text-xs text-stone-400 mt-1.5 line-clamp-2">{toolkit.description}</p>
             </div>
             <button
               type="button"
               onClick={onClose}
               className="p-1 text-stone-400 hover:text-stone-900 transition-colors rounded-lg hover:bg-stone-100 flex-shrink-0"
               aria-label="Close">
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
@@ -236,9 +217,9 @@ export default function ComposioConnectModal({
           {phase === 'idle' && (
             <>
               <p className="text-sm text-stone-600">
-                Connect your {toolkit.name} account through Composio. We will open a
-                browser window where you can grant access, and then this app will
-                detect the connection automatically.
+                Connect your {toolkit.name} account through Composio. We will open a browser window
+                where you can grant access, and then this app will detect the connection
+                automatically.
               </p>
               <button
                 type="button"
@@ -268,8 +249,8 @@ export default function ComposioConnectModal({
                 </button>
               )}
               <p className="text-xs text-stone-400">
-                Complete the sign-in in your browser. This window will update when
-                the connection is active.
+                Complete the sign-in in your browser. This window will update when the connection is
+                active.
               </p>
             </>
           )}
@@ -294,9 +275,7 @@ export default function ComposioConnectModal({
             </>
           )}
 
-          {phase === 'disconnecting' && (
-            <p className="text-sm text-stone-500">Disconnecting…</p>
-          )}
+          {phase === 'disconnecting' && <p className="text-sm text-stone-500">Disconnecting…</p>}
 
           {phase === 'error' && (
             <>

--- a/app/src/components/composio/toolkitMeta.ts
+++ b/app/src/components/composio/toolkitMeta.ts
@@ -1,0 +1,87 @@
+/**
+ * Display metadata for Composio toolkits shown in the Skills grid.
+ *
+ * The backend allowlist (`GET /agent-integrations/composio/toolkits`)
+ * returns plain toolkit slugs. This table turns each slug into a
+ * humanised name, description, category, and emoji icon so the
+ * `UnifiedSkillCard` can render them next to regular skills without
+ * special-casing.
+ *
+ * Unknown slugs fall back to a generic entry with a title-cased name —
+ * new backend toolkits will still render, just without custom copy.
+ */
+
+import type { SkillCategory } from '../skills/SkillCategoryFilter';
+
+export interface ComposioToolkitMeta {
+  /** Toolkit slug as returned by the backend, e.g. `"gmail"`. */
+  slug: string;
+  /** Display name shown on the card, e.g. `"Gmail"`. */
+  name: string;
+  /** Short description shown on the card. */
+  description: string;
+  /** Which Skills page category to group the card under. */
+  category: SkillCategory;
+  /** Emoji fallback icon. Replace with SVGs later if desired. */
+  icon: string;
+}
+
+const CATALOG: Record<string, Omit<ComposioToolkitMeta, 'slug'>> = {
+  gmail: {
+    name: 'Gmail',
+    description: 'Read, search, and send email through your Google account.',
+    category: 'Productivity',
+    icon: '\u2709\uFE0F',
+  },
+  googlecalendar: {
+    name: 'Google Calendar',
+    description: 'List and manage events across your Google calendars.',
+    category: 'Productivity',
+    icon: '\uD83D\uDCC5',
+  },
+  googledrive: {
+    name: 'Google Drive',
+    description: 'Browse and fetch files from your Google Drive.',
+    category: 'Productivity',
+    icon: '\uD83D\uDCC2',
+  },
+  notion: {
+    name: 'Notion',
+    description: 'Read and edit pages, databases, and comments in Notion.',
+    category: 'Productivity',
+    icon: '\uD83D\uDCDD',
+  },
+  github: {
+    name: 'GitHub',
+    description: 'Inspect repos, issues, and pull requests on GitHub.',
+    category: 'Tools & Automation',
+    icon: '\uD83D\uDC0D',
+  },
+  slack: {
+    name: 'Slack',
+    description: 'Send messages and read channel history in Slack.',
+    category: 'Social',
+    icon: '\uD83D\uDCAC',
+  },
+  linear: {
+    name: 'Linear',
+    description: 'Triage and update issues in your Linear workspace.',
+    category: 'Tools & Automation',
+    icon: '\uD83D\uDCCB',
+  },
+};
+
+export function composioToolkitMeta(slug: string): ComposioToolkitMeta {
+  const key = slug.toLowerCase();
+  const hit = CATALOG[key];
+  if (hit) return { slug: key, ...hit };
+  // Fallback: title-case the slug and bucket it under "Other".
+  const name = key.charAt(0).toUpperCase() + key.slice(1);
+  return {
+    slug: key,
+    name,
+    description: `Composio integration for ${name}.`,
+    category: 'Other',
+    icon: '\uD83D\uDD0C',
+  };
+}

--- a/app/src/components/composio/toolkitMeta.ts
+++ b/app/src/components/composio/toolkitMeta.ts
@@ -10,7 +10,6 @@
  * Unknown slugs fall back to a generic entry with a title-cased name —
  * new backend toolkits will still render, just without custom copy.
  */
-
 import type { SkillCategory } from '../skills/SkillCategoryFilter';
 
 export interface ComposioToolkitMeta {

--- a/app/src/lib/composio/composioApi.ts
+++ b/app/src/lib/composio/composioApi.ts
@@ -1,0 +1,90 @@
+/**
+ * Imperative RPC wrapper for the Composio domain — typed counterpart
+ * to `src/openhuman/composio/*` on the Rust side.
+ *
+ * Every function here calls the core sidecar via JSON-RPC. The core
+ * in turn proxies to the openhuman backend's
+ * `/agent-integrations/composio/*` routes, so the frontend never talks
+ * to Composio directly and never handles the API key.
+ *
+ * This mirrors the shape of `lib/skills/skillsApi.ts`. Keep the two
+ * files stylistically consistent so the parallel domain stays easy to
+ * grok.
+ */
+
+import { callCoreRpc } from '../../services/coreRpcClient';
+import type {
+  ComposioAuthorizeResponse,
+  ComposioConnectionsResponse,
+  ComposioDeleteResponse,
+  ComposioExecuteResponse,
+  ComposioToolkitsResponse,
+  ComposioToolsResponse,
+} from './types';
+
+// ── Read operations ───────────────────────────────────────────────
+
+export async function listToolkits(): Promise<ComposioToolkitsResponse> {
+  return callCoreRpc<ComposioToolkitsResponse>({
+    method: 'openhuman.composio_list_toolkits',
+  });
+}
+
+export async function listConnections(): Promise<ComposioConnectionsResponse> {
+  return callCoreRpc<ComposioConnectionsResponse>({
+    method: 'openhuman.composio_list_connections',
+  });
+}
+
+export async function listTools(
+  toolkits?: string[],
+): Promise<ComposioToolsResponse> {
+  return callCoreRpc<ComposioToolsResponse>({
+    method: 'openhuman.composio_list_tools',
+    params: toolkits && toolkits.length > 0 ? { toolkits } : {},
+  });
+}
+
+// ── Write operations ──────────────────────────────────────────────
+
+/**
+ * Begin an OAuth handoff for `toolkit`. The returned `connectUrl`
+ * must be opened in a browser for the user to complete the flow.
+ * The core publishes a `ComposioConnectionCreated` event on success.
+ */
+export async function authorize(
+  toolkit: string,
+): Promise<ComposioAuthorizeResponse> {
+  return callCoreRpc<ComposioAuthorizeResponse>({
+    method: 'openhuman.composio_authorize',
+    params: { toolkit },
+  });
+}
+
+/**
+ * Delete an existing Composio connection. Backend verifies ownership
+ * before forwarding to Composio.
+ */
+export async function deleteConnection(
+  connectionId: string,
+): Promise<ComposioDeleteResponse> {
+  return callCoreRpc<ComposioDeleteResponse>({
+    method: 'openhuman.composio_delete_connection',
+    params: { connection_id: connectionId },
+  });
+}
+
+/**
+ * Execute a Composio action slug (e.g. `GMAIL_SEND_EMAIL`). The core
+ * charges the caller, tracks usage, and publishes a
+ * `ComposioActionExecuted` event.
+ */
+export async function execute(
+  tool: string,
+  args?: Record<string, unknown>,
+): Promise<ComposioExecuteResponse> {
+  return callCoreRpc<ComposioExecuteResponse>({
+    method: 'openhuman.composio_execute',
+    params: { tool, arguments: args ?? {} },
+  });
+}

--- a/app/src/lib/composio/composioApi.ts
+++ b/app/src/lib/composio/composioApi.ts
@@ -11,7 +11,6 @@
  * files stylistically consistent so the parallel domain stays easy to
  * grok.
  */
-
 import { callCoreRpc } from '../../services/coreRpcClient';
 import type {
   ComposioAuthorizeResponse,
@@ -25,9 +24,7 @@ import type {
 // ── Read operations ───────────────────────────────────────────────
 
 export async function listToolkits(): Promise<ComposioToolkitsResponse> {
-  return callCoreRpc<ComposioToolkitsResponse>({
-    method: 'openhuman.composio_list_toolkits',
-  });
+  return callCoreRpc<ComposioToolkitsResponse>({ method: 'openhuman.composio_list_toolkits' });
 }
 
 export async function listConnections(): Promise<ComposioConnectionsResponse> {
@@ -36,9 +33,7 @@ export async function listConnections(): Promise<ComposioConnectionsResponse> {
   });
 }
 
-export async function listTools(
-  toolkits?: string[],
-): Promise<ComposioToolsResponse> {
+export async function listTools(toolkits?: string[]): Promise<ComposioToolsResponse> {
   return callCoreRpc<ComposioToolsResponse>({
     method: 'openhuman.composio_list_tools',
     params: toolkits && toolkits.length > 0 ? { toolkits } : {},
@@ -52,9 +47,7 @@ export async function listTools(
  * must be opened in a browser for the user to complete the flow.
  * The core publishes a `ComposioConnectionCreated` event on success.
  */
-export async function authorize(
-  toolkit: string,
-): Promise<ComposioAuthorizeResponse> {
+export async function authorize(toolkit: string): Promise<ComposioAuthorizeResponse> {
   return callCoreRpc<ComposioAuthorizeResponse>({
     method: 'openhuman.composio_authorize',
     params: { toolkit },
@@ -65,9 +58,7 @@ export async function authorize(
  * Delete an existing Composio connection. Backend verifies ownership
  * before forwarding to Composio.
  */
-export async function deleteConnection(
-  connectionId: string,
-): Promise<ComposioDeleteResponse> {
+export async function deleteConnection(connectionId: string): Promise<ComposioDeleteResponse> {
   return callCoreRpc<ComposioDeleteResponse>({
     method: 'openhuman.composio_delete_connection',
     params: { connection_id: connectionId },
@@ -81,7 +72,7 @@ export async function deleteConnection(
  */
 export async function execute(
   tool: string,
-  args?: Record<string, unknown>,
+  args?: Record<string, unknown>
 ): Promise<ComposioExecuteResponse> {
   return callCoreRpc<ComposioExecuteResponse>({
     method: 'openhuman.composio_execute',

--- a/app/src/lib/composio/hooks.ts
+++ b/app/src/lib/composio/hooks.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { listConnections, listToolkits } from './composioApi';
+import type { ComposioConnection } from './types';
+
+// ── useComposioIntegrations ───────────────────────────────────────
+
+export interface UseComposioIntegrationsResult {
+  /** Toolkit slugs enabled on the backend allowlist. */
+  toolkits: string[];
+  /** Connections keyed by lowercased toolkit slug. */
+  connectionByToolkit: Map<string, ComposioConnection>;
+  /** Whether the initial fetch is still in flight. */
+  loading: boolean;
+  /** Last error message from either fetch, if any. */
+  error: string | null;
+  /** Force a refetch of toolkits + connections. */
+  refresh: () => Promise<void>;
+  /** True when composio is disabled on the core side. */
+  disabled: boolean;
+}
+
+/**
+ * Fetches the Composio toolkit allowlist and current connections.
+ *
+ * On mount it does one request of each, then re-fetches connections on
+ * a `pollIntervalMs` loop so the UI reacts to OAuth completions without
+ * the user having to manually refresh. Toolkits are only refetched on
+ * explicit `refresh()` because the allowlist is stable.
+ *
+ * When the core reports that composio is disabled (feature toggle off,
+ * or integrations.enabled=false) the hook short-circuits into
+ * `disabled=true` and stops polling — callers can use that to show an
+ * "integrations disabled" hint instead of a spinner.
+ */
+export function useComposioIntegrations(pollIntervalMs = 5_000): UseComposioIntegrationsResult {
+  const [toolkits, setToolkits] = useState<string[]>([]);
+  const [connections, setConnections] = useState<ComposioConnection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [disabled, setDisabled] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [toolkitsResp, connectionsResp] = await Promise.all([
+        listToolkits(),
+        listConnections(),
+      ]);
+      if (!mountedRef.current) return;
+      setToolkits(toolkitsResp.toolkits ?? []);
+      setConnections(connectionsResp.connections ?? []);
+      setDisabled(false);
+      setError(null);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message = err instanceof Error ? err.message : String(err);
+      // Detect the "composio disabled" error the Rust ops layer emits
+      // so we can render a distinct state rather than a red error.
+      if (/composio is disabled/i.test(message)) {
+        setDisabled(true);
+        setError(null);
+      } else {
+        setError(message);
+      }
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, []);
+
+  // Initial fetch + polling.
+  useEffect(() => {
+    void refresh();
+    if (pollIntervalMs <= 0) return;
+    const id = window.setInterval(() => {
+      if (disabled) return;
+      void listConnections()
+        .then(resp => {
+          if (!mountedRef.current) return;
+          setConnections(resp.connections ?? []);
+        })
+        .catch(() => {
+          /* swallow — non-fatal for poll cadence */
+        });
+    }, pollIntervalMs);
+    return () => window.clearInterval(id);
+  }, [refresh, pollIntervalMs, disabled]);
+
+  const connectionByToolkit = useMemo(() => {
+    const map = new Map<string, ComposioConnection>();
+    // Preference order: ACTIVE/CONNECTED > PENDING > anything else.
+    const score = (status: string): number => {
+      const s = status.toUpperCase();
+      if (s === 'ACTIVE' || s === 'CONNECTED') return 3;
+      if (s === 'PENDING' || s === 'INITIATED' || s === 'INITIALIZING') return 2;
+      if (s === 'FAILED' || s === 'ERROR' || s === 'EXPIRED') return 1;
+      return 0;
+    };
+    for (const conn of connections) {
+      const key = conn.toolkit.toLowerCase();
+      const existing = map.get(key);
+      if (!existing || score(conn.status) > score(existing.status)) {
+        map.set(key, conn);
+      }
+    }
+    return map;
+  }, [connections]);
+
+  return {
+    toolkits,
+    connectionByToolkit,
+    loading,
+    error,
+    refresh,
+    disabled,
+  };
+}

--- a/app/src/lib/composio/hooks.ts
+++ b/app/src/lib/composio/hooks.ts
@@ -113,12 +113,5 @@ export function useComposioIntegrations(pollIntervalMs = 5_000): UseComposioInte
     return map;
   }, [connections]);
 
-  return {
-    toolkits,
-    connectionByToolkit,
-    loading,
-    error,
-    refresh,
-    disabled,
-  };
+  return { toolkits, connectionByToolkit, loading, error, refresh, disabled };
 }

--- a/app/src/lib/composio/types.ts
+++ b/app/src/lib/composio/types.ts
@@ -1,0 +1,83 @@
+/**
+ * TypeScript types that mirror the Rust `openhuman::composio::types`
+ * response envelopes exposed via the `openhuman.composio_*` JSON-RPC
+ * methods. Field names match the wire shape (camelCase where the
+ * backend emits camelCase, snake_case where the Rust RPC layer does).
+ */
+
+export interface ComposioToolkitsResponse {
+  toolkits: string[];
+}
+
+export interface ComposioConnection {
+  id: string;
+  toolkit: string;
+  /** Typical values: `ACTIVE`, `CONNECTED`, `PENDING`, `FAILED`. */
+  status: string;
+  /** ISO timestamp (backend passthrough). */
+  createdAt?: string;
+}
+
+export interface ComposioConnectionsResponse {
+  connections: ComposioConnection[];
+}
+
+export interface ComposioAuthorizeResponse {
+  /** Composio-hosted OAuth URL that must be opened in a browser. */
+  connectUrl: string;
+  /** New Composio connection id created by the authorize call. */
+  connectionId: string;
+}
+
+export interface ComposioDeleteResponse {
+  deleted: boolean;
+}
+
+export interface ComposioToolFunction {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+}
+
+export interface ComposioToolSchema {
+  /** Usually the literal string `"function"`. */
+  type: string;
+  function: ComposioToolFunction;
+}
+
+export interface ComposioToolsResponse {
+  tools: ComposioToolSchema[];
+}
+
+export interface ComposioExecuteResponse {
+  data: unknown;
+  successful: boolean;
+  error?: string | null;
+  costUsd: number;
+}
+
+// ── UI helpers ────────────────────────────────────────────────────
+
+/**
+ * Derived connection state used by the Skills grid card.
+ * Mirrors the `SkillConnectionStatus` shape so the same
+ * `UnifiedSkillCard` can render both.
+ */
+export type ComposioConnectionState =
+  | 'disconnected'
+  | 'pending'
+  | 'connected'
+  | 'error';
+
+export function deriveComposioState(
+  connection: ComposioConnection | undefined,
+): ComposioConnectionState {
+  if (!connection) return 'disconnected';
+  const status = connection.status.toUpperCase();
+  if (status === 'ACTIVE' || status === 'CONNECTED') return 'connected';
+  if (status === 'PENDING' || status === 'INITIATED' || status === 'INITIALIZING')
+    return 'pending';
+  if (status === 'FAILED' || status === 'ERROR' || status === 'EXPIRED')
+    return 'error';
+  return 'disconnected';
+}

--- a/app/src/lib/composio/types.ts
+++ b/app/src/lib/composio/types.ts
@@ -63,21 +63,15 @@ export interface ComposioExecuteResponse {
  * Mirrors the `SkillConnectionStatus` shape so the same
  * `UnifiedSkillCard` can render both.
  */
-export type ComposioConnectionState =
-  | 'disconnected'
-  | 'pending'
-  | 'connected'
-  | 'error';
+export type ComposioConnectionState = 'disconnected' | 'pending' | 'connected' | 'error';
 
 export function deriveComposioState(
-  connection: ComposioConnection | undefined,
+  connection: ComposioConnection | undefined
 ): ComposioConnectionState {
   if (!connection) return 'disconnected';
   const status = connection.status.toUpperCase();
   if (status === 'ACTIVE' || status === 'CONNECTED') return 'connected';
-  if (status === 'PENDING' || status === 'INITIATED' || status === 'INITIALIZING')
-    return 'pending';
-  if (status === 'FAILED' || status === 'ERROR' || status === 'EXPIRED')
-    return 'error';
+  if (status === 'PENDING' || status === 'INITIATED' || status === 'INITIALIZING') return 'pending';
+  if (status === 'FAILED' || status === 'ERROR' || status === 'EXPIRED') return 'error';
   return 'disconnected';
 }

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import ChannelSetupModal from '../components/channels/ChannelSetupModal';
+import ComposioConnectModal from '../components/composio/ComposioConnectModal';
+import { composioToolkitMeta, type ComposioToolkitMeta } from '../components/composio/toolkitMeta';
 import AutocompleteSetupModal from '../components/skills/AutocompleteSetupModal';
 import ScreenIntelligenceSetupModal from '../components/skills/ScreenIntelligenceSetupModal';
 import { SKILL_ICONS, type SkillListEntry } from '../components/skills/shared';
@@ -14,6 +16,8 @@ import { useAutocompleteSkillStatus } from '../features/autocomplete/useAutocomp
 import { useScreenIntelligenceSkillStatus } from '../features/screen-intelligence/useScreenIntelligenceSkillStatus';
 import { useVoiceSkillStatus } from '../features/voice/useVoiceSkillStatus';
 import { useChannelDefinitions } from '../hooks/useChannelDefinitions';
+import { useComposioIntegrations } from '../lib/composio/hooks';
+import { deriveComposioState, type ComposioConnection } from '../lib/composio/types';
 import { useAvailableSkills } from '../lib/skills/hooks';
 import { installSkill } from '../lib/skills/skillsApi';
 import { useAppSelector } from '../store/hooks';
@@ -57,6 +61,49 @@ function channelStatusColor(status: ChannelConnectionStatus): string {
     case 'connected':
       return 'text-sage-600';
     case 'connecting':
+      return 'text-amber-600';
+    case 'error':
+      return 'text-coral-600';
+    default:
+      return 'text-stone-400';
+  }
+}
+
+// ─── Composio visual mappers ─────────────────────────────────────────────
+// Reuse the same dot/label/color vocabulary as the channel cards so the
+// "Integrations" section sits visually flush with the rest of the grid.
+
+function composioStatusDot(connection: ComposioConnection | undefined): string {
+  switch (deriveComposioState(connection)) {
+    case 'connected':
+      return 'bg-sage-500';
+    case 'pending':
+      return 'bg-amber-500 animate-pulse';
+    case 'error':
+      return 'bg-coral-500';
+    default:
+      return 'bg-stone-300';
+  }
+}
+
+function composioStatusLabel(connection: ComposioConnection | undefined): string {
+  switch (deriveComposioState(connection)) {
+    case 'connected':
+      return 'Connected';
+    case 'pending':
+      return 'Connecting';
+    case 'error':
+      return 'Error';
+    default:
+      return 'Not connected';
+  }
+}
+
+function composioStatusColor(connection: ComposioConnection | undefined): string {
+  switch (deriveComposioState(connection)) {
+    case 'connected':
+      return 'text-sage-600';
+    case 'pending':
       return 'text-amber-600';
     case 'error':
       return 'text-coral-600';
@@ -127,7 +174,7 @@ interface SkillItem {
   name: string;
   description: string;
   category: SkillCategory;
-  kind: 'builtin' | 'channel' | 'third-party';
+  kind: 'builtin' | 'channel' | 'third-party' | 'composio';
   // For built-in
   route?: string;
   icon?: React.ReactNode;
@@ -136,6 +183,9 @@ interface SkillItem {
   channelStatus?: ChannelConnectionStatus;
   // For third-party
   skill?: SkillListEntry;
+  // For composio
+  composioToolkit?: ComposioToolkitMeta;
+  composioConnection?: ComposioConnection;
 }
 
 // ─── Main Skills Page ──────────────────────────────────────────────────────────
@@ -146,12 +196,21 @@ export default function Skills() {
   const { definitions: channelDefs } = useChannelDefinitions();
   const channelConnections = useAppSelector(state => state.channelConnections);
 
+  const {
+    toolkits: composioToolkits,
+    connectionByToolkit: composioConnectionByToolkit,
+    refresh: refreshComposio,
+  } = useComposioIntegrations();
+
   const [setupModalOpen, setSetupModalOpen] = useState(false);
   const [activeSkillId, setActiveSkillId] = useState<string | null>(null);
   const [activeSkillName, setActiveSkillName] = useState('');
   const [activeSkillDescription, setActiveSkillDescription] = useState('');
   const [activeSkillHasSetup, setActiveSkillHasSetup] = useState(false);
   const [channelModalDef, setChannelModalDef] = useState<ChannelDefinition | null>(null);
+  const [composioModalToolkit, setComposioModalToolkit] = useState<ComposioToolkitMeta | null>(
+    null,
+  );
   const [installing, setInstalling] = useState<string | null>(null);
   const [screenIntelligenceModalOpen, setScreenIntelligenceModalOpen] = useState(false);
   const [autocompleteModalOpen, setAutocompleteModalOpen] = useState(false);
@@ -252,9 +311,35 @@ export default function Skills() {
       });
     }
 
+    // Composio toolkits — rendered with the same UnifiedSkillCard used
+    // for channels/skills so they sit flush in the grid. Each entry is
+    // keyed by slug and routed through `ComposioConnectModal` for the
+    // authorize/OAuth/poll flow.
+    const sortedToolkits = [...composioToolkits].sort((a, b) => a.localeCompare(b));
+    for (const slug of sortedToolkits) {
+      const meta = composioToolkitMeta(slug);
+      const connection = composioConnectionByToolkit.get(meta.slug);
+      items.push({
+        id: `composio-${meta.slug}`,
+        name: meta.name,
+        description: meta.description,
+        category: meta.category,
+        kind: 'composio',
+        icon: <span className="text-lg">{meta.icon}</span>,
+        composioToolkit: meta,
+        composioConnection: connection,
+      });
+    }
+
     return items;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [skillsList, configurableChannels, channelConnections]);
+  }, [
+    skillsList,
+    configurableChannels,
+    channelConnections,
+    composioToolkits,
+    composioConnectionByToolkit,
+  ]);
 
   const availableCategories: SkillCategory[] = useMemo(() => {
     const cats = new Set<SkillCategory>(['All']);
@@ -441,6 +526,39 @@ export default function Skills() {
                           />
                         );
                       }
+                      if (item.kind === 'composio') {
+                        const meta = item.composioToolkit!;
+                        const connection = item.composioConnection;
+                        const state = deriveComposioState(connection);
+                        const ctaLabel =
+                          state === 'connected'
+                            ? 'Manage'
+                            : state === 'pending'
+                              ? 'Waiting'
+                              : state === 'error'
+                                ? 'Retry'
+                                : 'Connect';
+                        const ctaVariant: 'primary' | 'sage' | 'amber' =
+                          state === 'connected'
+                            ? 'sage'
+                            : state === 'error'
+                              ? 'amber'
+                              : 'primary';
+                        return (
+                          <UnifiedSkillCard
+                            key={item.id}
+                            icon={item.icon}
+                            title={item.name}
+                            description={item.description}
+                            statusDot={composioStatusDot(connection)}
+                            statusLabel={composioStatusLabel(connection)}
+                            statusColor={composioStatusColor(connection)}
+                            ctaLabel={ctaLabel}
+                            ctaVariant={ctaVariant}
+                            onCtaClick={() => setComposioModalToolkit(meta)}
+                          />
+                        );
+                      }
                       // third-party
                       return (
                         <ThirdPartySkillCard
@@ -489,6 +607,15 @@ export default function Skills() {
 
       {voiceModalOpen && (
         <VoiceSetupModal onClose={() => setVoiceModalOpen(false)} skillStatus={voiceStatus} />
+      )}
+
+      {composioModalToolkit && (
+        <ComposioConnectModal
+          toolkit={composioModalToolkit}
+          connection={composioConnectionByToolkit.get(composioModalToolkit.slug)}
+          onChanged={() => void refreshComposio()}
+          onClose={() => setComposioModalToolkit(null)}
+        />
       )}
     </div>
   );

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -17,7 +17,7 @@ import { useScreenIntelligenceSkillStatus } from '../features/screen-intelligenc
 import { useVoiceSkillStatus } from '../features/voice/useVoiceSkillStatus';
 import { useChannelDefinitions } from '../hooks/useChannelDefinitions';
 import { useComposioIntegrations } from '../lib/composio/hooks';
-import { deriveComposioState, type ComposioConnection } from '../lib/composio/types';
+import { type ComposioConnection, deriveComposioState } from '../lib/composio/types';
 import { useAvailableSkills } from '../lib/skills/hooks';
 import { installSkill } from '../lib/skills/skillsApi';
 import { useAppSelector } from '../store/hooks';
@@ -209,7 +209,7 @@ export default function Skills() {
   const [activeSkillHasSetup, setActiveSkillHasSetup] = useState(false);
   const [channelModalDef, setChannelModalDef] = useState<ChannelDefinition | null>(null);
   const [composioModalToolkit, setComposioModalToolkit] = useState<ComposioToolkitMeta | null>(
-    null,
+    null
   );
   const [installing, setInstalling] = useState<string | null>(null);
   const [screenIntelligenceModalOpen, setScreenIntelligenceModalOpen] = useState(false);
@@ -539,11 +539,7 @@ export default function Skills() {
                                 ? 'Retry'
                                 : 'Connect';
                         const ctaVariant: 'primary' | 'sage' | 'amber' =
-                          state === 'connected'
-                            ? 'sage'
-                            : state === 'error'
-                              ? 'amber'
-                              : 'primary';
+                          state === 'connected' ? 'sage' : state === 'error' ? 'amber' : 'primary';
                         return (
                           <UnifiedSkillCard
                             key={item.id}

--- a/scripts/debug-composio-login.sh
+++ b/scripts/debug-composio-login.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+#
+# debug-composio-login.sh — Walk the Composio Google/Gmail OAuth
+# handoff end-to-end against a live openhuman backend.
+#
+# This is the Rust-side counterpart to
+#   backend-1/src/scripts/live-test-composio-gmail.ts
+# and it hits the exact same endpoints that the new
+# src/openhuman/composio/ module wraps in Rust.
+#
+# Flow:
+#   1. GET  /agent-integrations/composio/toolkits
+#        → verify that the target toolkit (default: gmail) is on the
+#          backend allowlist.
+#   2. GET  /agent-integrations/composio/connections
+#        → list existing connections; skip OAuth if one is already
+#          ACTIVE/CONNECTED.
+#   3. POST /agent-integrations/composio/authorize  {toolkit}
+#        → print the `connectUrl` for the user to open in a browser,
+#          then poll /connections until the status flips to
+#          ACTIVE/CONNECTED (or timeout).
+#   4. GET  /agent-integrations/composio/tools?toolkits=<toolkit>
+#        → print the first ~20 tool slugs discovered.
+#   5. (optional) POST /agent-integrations/composio/execute
+#        → run a read-only action like GMAIL_GET_PROFILE.
+#
+# Usage:
+#   bash scripts/debug-composio-login.sh
+#
+# Environment variables (set in .env or export before running):
+#   BACKEND_URL                — e.g. https://staging-api.alphahuman.xyz
+#   JWT_TOKEN                  — bearer JWT for your test user
+#   COMPOSIO_TOOLKIT           — toolkit slug (default: gmail)
+#   COMPOSIO_EXECUTE_TOOL      — optional, e.g. GMAIL_GET_PROFILE
+#   COMPOSIO_AUTH_TIMEOUT_SECS — OAuth poll timeout (default: 300)
+#   COMPOSIO_POLL_INTERVAL_SECS — poll interval (default: 5)
+#   COMPOSIO_OPEN_URL          — "1" to auto-open connectUrl via `open`
+#
+# Requirements: bash, curl, jq.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Load .env ────────────────────────────────────────────────────────
+if [ -f "$REPO_ROOT/.env" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/load-dotenv.sh" "$REPO_ROOT/.env"
+fi
+
+# ── Inputs ───────────────────────────────────────────────────────────
+BACKEND_URL="${BACKEND_URL:-}"
+JWT_TOKEN="${JWT_TOKEN:-}"
+TOOLKIT="${COMPOSIO_TOOLKIT:-gmail}"
+EXECUTE_TOOL="${COMPOSIO_EXECUTE_TOOL:-}"
+AUTH_TIMEOUT_SECS="${COMPOSIO_AUTH_TIMEOUT_SECS:-300}"
+POLL_INTERVAL_SECS="${COMPOSIO_POLL_INTERVAL_SECS:-5}"
+OPEN_URL="${COMPOSIO_OPEN_URL:-0}"
+
+if [ -z "$BACKEND_URL" ]; then
+    echo "ERROR: BACKEND_URL not set. Add it to .env or export it." >&2
+    exit 1
+fi
+if [ -z "$JWT_TOKEN" ]; then
+    echo "ERROR: JWT_TOKEN not set. Add it to .env or export it." >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required (brew install jq / apt install jq)" >&2
+    exit 1
+fi
+
+# Strip any trailing slash on BACKEND_URL so path joining is predictable.
+BACKEND_URL="${BACKEND_URL%/}"
+
+echo "╔════════════════════════════════════════════════════════╗"
+echo "║  Composio Login Debug                                  ║"
+echo "╠════════════════════════════════════════════════════════╣"
+printf "║  Backend:       %s\n" "$BACKEND_URL"
+printf "║  Toolkit:       %s\n" "$TOOLKIT"
+printf "║  JWT:           %s...\n" "${JWT_TOKEN:0:20}"
+if [ -n "$EXECUTE_TOOL" ]; then
+    printf "║  Execute tool:  %s\n" "$EXECUTE_TOOL"
+fi
+echo "╚════════════════════════════════════════════════════════╝"
+echo ""
+
+AUTH_HEADER="Authorization: Bearer $JWT_TOKEN"
+
+# ── Helper: call backend and split body/status ──────────────────────
+# Usage:  call METHOD PATH [json-body]
+# Exports RESP_BODY and RESP_CODE after return.
+call() {
+    local method="$1" path="$2" body="${3:-}"
+    local url="${BACKEND_URL}${path}"
+    local tmp
+    tmp="$(mktemp)"
+    if [ -n "$body" ]; then
+        RESP_CODE=$(curl -sS -X "$method" "$url" \
+            -H "$AUTH_HEADER" \
+            -H "Content-Type: application/json" \
+            --data "$body" \
+            -o "$tmp" -w "%{http_code}" || echo "000")
+    else
+        RESP_CODE=$(curl -sS -X "$method" "$url" \
+            -H "$AUTH_HEADER" \
+            -o "$tmp" -w "%{http_code}" || echo "000")
+    fi
+    RESP_BODY="$(cat "$tmp")"
+    rm -f "$tmp"
+}
+
+envelope_data() {
+    # Extract `.data` from a `{success, data, error}` envelope; fall
+    # back to the raw body if not enveloped.
+    local body="$1"
+    echo "$body" | jq -c '.data // .' 2>/dev/null || echo "$body"
+}
+
+envelope_error() {
+    local body="$1"
+    echo "$body" | jq -r '.error // empty' 2>/dev/null || true
+}
+
+require_success() {
+    local step="$1"
+    if [ "$RESP_CODE" != "200" ] && [ "$RESP_CODE" != "201" ]; then
+        echo "  ✗ $step failed (HTTP $RESP_CODE)" >&2
+        echo "    body: $RESP_BODY" >&2
+        exit 1
+    fi
+}
+
+# ── Step 1: list toolkits ────────────────────────────────────────────
+echo "--- Step 1: GET /agent-integrations/composio/toolkits ---"
+call GET "/agent-integrations/composio/toolkits"
+require_success "list_toolkits"
+
+TOOLKITS_JSON="$(envelope_data "$RESP_BODY")"
+TOOLKITS_LIST="$(echo "$TOOLKITS_JSON" | jq -r '.toolkits[]?' 2>/dev/null || true)"
+echo "  enabled toolkits:"
+if [ -z "$TOOLKITS_LIST" ]; then
+    echo "    (none)"
+else
+    echo "$TOOLKITS_LIST" | sed 's/^/    - /'
+fi
+
+if ! echo "$TOOLKITS_LIST" | grep -iqx "$TOOLKIT"; then
+    echo "  ✗ toolkit '$TOOLKIT' is NOT in the backend allowlist." >&2
+    echo "    Add it via COMPOSIO_ENABLED_TOOLKITS on the backend and retry." >&2
+    exit 1
+fi
+echo "  ✓ $TOOLKIT is on the allowlist"
+echo ""
+
+# ── Step 2: list existing connections ───────────────────────────────
+echo "--- Step 2: GET /agent-integrations/composio/connections ---"
+call GET "/agent-integrations/composio/connections"
+require_success "list_connections"
+
+CONNECTIONS_JSON="$(envelope_data "$RESP_BODY")"
+echo "$CONNECTIONS_JSON" | jq -r '.connections[]? | "  - \(.toolkit) [\(.status)] id=\(.id)"' 2>/dev/null || true
+
+ACTIVE_ID="$(echo "$CONNECTIONS_JSON" | jq -r --arg tk "$TOOLKIT" \
+    '.connections[]? | select((.toolkit|ascii_downcase) == ($tk|ascii_downcase)) | select(.status == "ACTIVE" or .status == "CONNECTED") | .id' \
+    2>/dev/null | head -n1)"
+
+if [ -n "$ACTIVE_ID" ]; then
+    echo "  ✓ existing $TOOLKIT connection is ACTIVE (id=$ACTIVE_ID) — skipping OAuth"
+    echo ""
+else
+    # ── Step 3: authorize ───────────────────────────────────────────
+    echo ""
+    echo "--- Step 3: POST /agent-integrations/composio/authorize ---"
+    call POST "/agent-integrations/composio/authorize" "{\"toolkit\":\"$TOOLKIT\"}"
+    require_success "authorize"
+
+    AUTH_JSON="$(envelope_data "$RESP_BODY")"
+    CONNECT_URL="$(echo "$AUTH_JSON" | jq -r '.connectUrl // empty')"
+    CONNECTION_ID="$(echo "$AUTH_JSON" | jq -r '.connectionId // empty')"
+
+    if [ -z "$CONNECT_URL" ]; then
+        echo "  ✗ authorize response did not include connectUrl" >&2
+        echo "    body: $RESP_BODY" >&2
+        exit 1
+    fi
+
+    echo "  connectionId: $CONNECTION_ID"
+    echo "  connectUrl:   $CONNECT_URL"
+    echo ""
+    echo "  >>> OPEN THIS URL IN A BROWSER TO COMPLETE GOOGLE OAUTH:"
+    echo "      $CONNECT_URL"
+    echo ""
+
+    # Optionally auto-open on macOS.
+    if [ "$OPEN_URL" = "1" ] && command -v open >/dev/null 2>&1; then
+        open "$CONNECT_URL" >/dev/null 2>&1 || true
+    fi
+
+    echo "  polling /connections until $TOOLKIT becomes ACTIVE..."
+    echo "    timeout=${AUTH_TIMEOUT_SECS}s interval=${POLL_INTERVAL_SECS}s"
+
+    START_TS=$(date +%s)
+    TICK=0
+    while :; do
+        TICK=$((TICK + 1))
+        call GET "/agent-integrations/composio/connections"
+        if [ "$RESP_CODE" = "200" ]; then
+            CONNECTIONS_JSON="$(envelope_data "$RESP_BODY")"
+            STATUS="$(echo "$CONNECTIONS_JSON" | jq -r --arg tk "$TOOLKIT" --arg cid "$CONNECTION_ID" \
+                '.connections[]? | select(.id == $cid or (.toolkit|ascii_downcase) == ($tk|ascii_downcase)) | .status' \
+                2>/dev/null | head -n1)"
+            printf "    [tick %d] status=%s\n" "$TICK" "${STATUS:-<missing>}"
+            if [ "$STATUS" = "ACTIVE" ] || [ "$STATUS" = "CONNECTED" ]; then
+                ACTIVE_ID="$CONNECTION_ID"
+                echo "  ✓ connection became ACTIVE (id=$ACTIVE_ID)"
+                break
+            fi
+        else
+            echo "    [tick $TICK] poll HTTP $RESP_CODE — $(envelope_error "$RESP_BODY")"
+        fi
+
+        NOW_TS=$(date +%s)
+        if [ $((NOW_TS - START_TS)) -ge "$AUTH_TIMEOUT_SECS" ]; then
+            echo "  ✗ timed out after ${AUTH_TIMEOUT_SECS}s waiting for OAuth to complete" >&2
+            exit 1
+        fi
+        sleep "$POLL_INTERVAL_SECS"
+    done
+    echo ""
+fi
+
+# ── Step 4: list tools for the toolkit ──────────────────────────────
+echo "--- Step 4: GET /agent-integrations/composio/tools?toolkits=$TOOLKIT ---"
+call GET "/agent-integrations/composio/tools?toolkits=$TOOLKIT"
+require_success "list_tools"
+
+TOOLS_JSON="$(envelope_data "$RESP_BODY")"
+TOOL_COUNT="$(echo "$TOOLS_JSON" | jq -r '.tools | length' 2>/dev/null || echo 0)"
+echo "  found $TOOL_COUNT tool(s) for $TOOLKIT"
+echo "$TOOLS_JSON" | jq -r '.tools[0:20][] | "    - \(.function.name)"' 2>/dev/null || true
+if [ "$TOOL_COUNT" -gt 20 ]; then
+    echo "    … (+$((TOOL_COUNT - 20)) more)"
+fi
+echo ""
+
+# ── Step 5: optional execute ────────────────────────────────────────
+if [ -n "$EXECUTE_TOOL" ]; then
+    echo "--- Step 5: POST /agent-integrations/composio/execute ($EXECUTE_TOOL) ---"
+    call POST "/agent-integrations/composio/execute" \
+        "{\"tool\":\"$EXECUTE_TOOL\",\"arguments\":{}}"
+    require_success "execute"
+
+    EXEC_JSON="$(envelope_data "$RESP_BODY")"
+    SUCCESSFUL="$(echo "$EXEC_JSON" | jq -r '.successful // false')"
+    COST="$(echo "$EXEC_JSON" | jq -r '.costUsd // 0')"
+    ERR="$(echo "$EXEC_JSON" | jq -r '.error // empty')"
+
+    printf "  successful: %s\n" "$SUCCESSFUL"
+    printf "  costUsd:    %s\n" "$COST"
+    if [ -n "$ERR" ]; then
+        printf "  error:      %s\n" "$ERR"
+    fi
+    echo "  data preview:"
+    echo "$EXEC_JSON" | jq -C '.data' 2>/dev/null | head -n 20 || echo "$EXEC_JSON"
+    echo ""
+
+    if [ "$SUCCESSFUL" != "true" ]; then
+        echo "  ✗ $EXECUTE_TOOL reported successful=false" >&2
+        exit 1
+    fi
+else
+    echo "--- Step 5: SKIPPED — set COMPOSIO_EXECUTE_TOOL=GMAIL_GET_PROFILE to exercise execute ---"
+    echo ""
+fi
+
+echo "=== Done ==="
+echo "  toolkit:      $TOOLKIT"
+echo "  connectionId: ${ACTIVE_ID:-<none>}"

--- a/scripts/debug-composio-login.sh
+++ b/scripts/debug-composio-login.sh
@@ -40,6 +40,17 @@
 
 set -euo pipefail
 
+# Track any temp files created by `call` so we can clean them up on
+# abort (Ctrl+C, error exit, etc.) — otherwise a mid-flight interrupt
+# leaves a dangling mktemp file behind.
+TMP_FILES=()
+cleanup_tmp_files() {
+    for f in "${TMP_FILES[@]}"; do
+        [ -n "$f" ] && rm -f "$f"
+    done
+}
+trap cleanup_tmp_files EXIT INT TERM
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -96,6 +107,7 @@ call() {
     local url="${BACKEND_URL}${path}"
     local tmp
     tmp="$(mktemp)"
+    TMP_FILES+=("$tmp")
     if [ -n "$body" ]; then
         RESP_CODE=$(curl -sS -X "$method" "$url" \
             -H "$AUTH_HEADER" \

--- a/scripts/debug-composio-login.sh
+++ b/scripts/debug-composio-login.sh
@@ -185,7 +185,11 @@ else
     # ── Step 3: authorize ───────────────────────────────────────────
     echo ""
     echo "--- Step 3: POST /agent-integrations/composio/authorize ---"
-    call POST "/agent-integrations/composio/authorize" "{\"toolkit\":\"$TOOLKIT\"}"
+    # Build the JSON payload via jq -n so quotes/backslashes in $TOOLKIT
+    # can never break the body. (Normally slugs are plain, but treating
+    # interpolation as trusted in a debug script is a bad habit.)
+    AUTHORIZE_BODY="$(jq -nc --arg tk "$TOOLKIT" '{toolkit: $tk}')"
+    call POST "/agent-integrations/composio/authorize" "$AUTHORIZE_BODY"
     require_success "authorize"
 
     AUTH_JSON="$(envelope_data "$RESP_BODY")"
@@ -220,9 +224,16 @@ else
         call GET "/agent-integrations/composio/connections"
         if [ "$RESP_CODE" = "200" ]; then
             CONNECTIONS_JSON="$(envelope_data "$RESP_BODY")"
+            # Prefer the exact connection we just created (match on .id),
+            # and only fall back to a toolkit-wide match if that id is not
+            # present yet. Without this fallback ordering, `head -n1`
+            # could latch onto a stale PENDING record from a previous run
+            # and never notice our new connection going ACTIVE.
             STATUS="$(echo "$CONNECTIONS_JSON" | jq -r --arg tk "$TOOLKIT" --arg cid "$CONNECTION_ID" \
-                '.connections[]? | select(.id == $cid or (.toolkit|ascii_downcase) == ($tk|ascii_downcase)) | .status' \
-                2>/dev/null | head -n1)"
+                '([.connections[]? | select(.id == $cid) | .status][0]) //
+                 ([.connections[]? | select((.toolkit|ascii_downcase) == ($tk|ascii_downcase)) | .status][0]) //
+                 ""' \
+                2>/dev/null)"
             printf "    [tick %d] status=%s\n" "$TICK" "${STATUS:-<missing>}"
             if [ "$STATUS" = "ACTIVE" ] || [ "$STATUS" = "CONNECTED" ]; then
                 ACTIVE_ID="$CONNECTION_ID"
@@ -260,8 +271,8 @@ echo ""
 # ── Step 5: optional execute ────────────────────────────────────────
 if [ -n "$EXECUTE_TOOL" ]; then
     echo "--- Step 5: POST /agent-integrations/composio/execute ($EXECUTE_TOOL) ---"
-    call POST "/agent-integrations/composio/execute" \
-        "{\"tool\":\"$EXECUTE_TOOL\",\"arguments\":{}}"
+    EXECUTE_BODY="$(jq -nc --arg tool "$EXECUTE_TOOL" '{tool: $tool, arguments: {}}')"
+    call POST "/agent-integrations/composio/execute" "$EXECUTE_BODY"
     require_success "execute"
 
     EXEC_JSON="$(envelope_data "$RESP_BODY")"

--- a/scripts/debug-composio-trigger.mjs
+++ b/scripts/debug-composio-trigger.mjs
@@ -1,0 +1,532 @@
+#!/usr/bin/env node
+// ──────────────────────────────────────────────────────────────────────
+// debug-composio-trigger.mjs
+//
+// Composio trigger — Socket.IO live listener.
+//
+// Rust-side counterpart to
+//   backend-1/src/scripts/live-test-composio-trigger.ts
+//
+// Opens a socket.io client against the openhuman backend (same endpoint
+// the Rust core's SocketManager hits), authenticates with a JWT, and
+// waits for `composio:trigger` events to land on the socket when the
+// backend's POST /webhooks/composio receives and HMAC-verifies an
+// incoming Composio webhook.
+//
+// End-to-end path under test:
+//
+//   [Gmail event]
+//      └─► Composio fires webhook
+//             └─► POST /webhooks/composio (HMAC verified)
+//                    └─► handleWebhook.ts → emit('composio:trigger', …)
+//                           └─► this script (or the Rust core) receives the event
+//
+// Prerequisites:
+//   1. The backend is reachable at BACKEND_URL.
+//   2. The backend is publicly addressable at the URL you configured in
+//      Composio's dashboard for the webhook (usually via ngrok for local
+//      dev). If Composio can't POST to /webhooks/composio, no events
+//      will ever land on the socket — no amount of listening will help.
+//   3. The test user already has an ACTIVE gmail connection — run
+//      `bash scripts/debug-composio-login.sh` first to set one up.
+//   4. A trigger instance exists for the user. Unlike the backend
+//      script, this one does NOT create the trigger — we don't have
+//      the Composio API key on the client. Create it once via the
+//      backend team's `src/scripts/live-test-composio-trigger.ts`
+//      (with CLEANUP=keep) or via the Composio dashboard, then run
+//      this script as many times as you like.
+//
+// Usage:
+//   node scripts/debug-composio-trigger.mjs
+//   node scripts/debug-composio-trigger.mjs --timeout 600
+//   node scripts/debug-composio-trigger.mjs --debug
+//   node scripts/debug-composio-trigger.mjs --trigger GMAIL_NEW_GMAIL_MESSAGE
+//   node scripts/debug-composio-trigger.mjs --max-events 3
+//   node scripts/debug-composio-trigger.mjs --send-test   # (placeholder — see below)
+//
+// Env vars (loaded from .env + app/.env.local):
+//   BACKEND_URL / VITE_BACKEND_URL — backend API base
+//   JWT_TOKEN                       — bearer JWT (optional, overrides
+//                                     the `openhuman-core auth get_session_token`
+//                                     fallback)
+//   TRIGGER_SLUG                    — override via CLI flag `--trigger`
+// ──────────────────────────────────────────────────────────────────────
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+// ── CLI argument parsing ────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const valueOf = (name, fallback) => {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx === args.length - 1) return fallback;
+  return args[idx + 1];
+};
+
+const DEBUG = flag('--debug');
+const TIMEOUT_SECS = parseInt(valueOf('--timeout', '0'), 10); // 0 = forever
+const MAX_EVENTS = parseInt(valueOf('--max-events', '0'), 10); // 0 = unlimited
+const TRIGGER_SLUG = (valueOf('--trigger', process.env.TRIGGER_SLUG || 'GMAIL_NEW_GMAIL_MESSAGE')).trim();
+
+function dbg(...a) {
+  if (DEBUG) console.log('  [debug]', ...a);
+}
+
+// ── Env loader (matches test-channel-receive.mjs) ───────────────────
+
+function loadEnv(filepath) {
+  if (!existsSync(filepath)) return;
+  const lines = readFileSync(filepath, 'utf-8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 0) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = val;
+  }
+}
+
+loadEnv(path.join(ROOT, '.env'));
+loadEnv(path.join(ROOT, 'app', '.env.local'));
+
+const BACKEND_URL = (
+  process.env.BACKEND_URL ||
+  process.env.VITE_BACKEND_URL ||
+  'https://staging-api.alphahuman.xyz'
+).replace(/\/+$/, '');
+
+// ── Pretty-print helpers ────────────────────────────────────────────
+
+const C = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+};
+
+function header(text) {
+  console.log(`\n${C.cyan}${'─'.repeat(60)}${C.reset}`);
+  console.log(`${C.cyan}  ${text}${C.reset}`);
+  console.log(`${C.cyan}${'─'.repeat(60)}${C.reset}`);
+}
+function ok(detail) {
+  console.log(`${C.green}  ✓${C.reset}${detail ? ` ${C.dim}${detail}${C.reset}` : ''}`);
+}
+function fail(detail) {
+  console.log(`${C.red}  ✗ ${detail}${C.reset}`);
+}
+function info(label, value) {
+  console.log(`${C.dim}    ${label}: ${C.reset}${value}`);
+}
+function ts() {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
+// ── Banner ──────────────────────────────────────────────────────────
+
+console.log('');
+console.log(`${C.bold}📡 Composio Trigger — Socket.IO Live Listener${C.reset}`);
+console.log('');
+info('Backend', BACKEND_URL);
+info('Trigger', TRIGGER_SLUG);
+info('Timeout', TIMEOUT_SECS > 0 ? `${TIMEOUT_SECS}s` : 'forever (Ctrl+C to stop)');
+info('Max events', MAX_EVENTS > 0 ? MAX_EVENTS : 'unlimited');
+info('Debug', DEBUG);
+
+// ── Resolve JWT ─────────────────────────────────────────────────────
+
+header('1. Authentication');
+
+function getSessionTokenFromCore() {
+  const coreBin = path.join(ROOT, 'target', 'debug', 'openhuman-core');
+  if (!existsSync(coreBin)) return null;
+  try {
+    const output = execSync(`"${coreBin}" auth get_session_token`, {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const match = output.match(/"token":\s*"([^"]+)"/);
+    return match?.[1] || null;
+  } catch {
+    return null;
+  }
+}
+
+let token = process.env.JWT_TOKEN?.trim() || null;
+if (token) {
+  info('Source', 'JWT_TOKEN env');
+} else {
+  token = getSessionTokenFromCore();
+  if (token) info('Source', 'target/debug/openhuman-core auth get_session_token');
+}
+
+if (!token) {
+  fail('No JWT_TOKEN in env and no session token available from the core binary.');
+  console.log(
+    `${C.dim}    Set JWT_TOKEN in .env, or run the app once to log in so the core has a session.${C.reset}`,
+  );
+  process.exit(1);
+}
+ok(`token=${token.slice(0, 20)}…`);
+
+// ── Verify JWT against /auth/me ─────────────────────────────────────
+
+header('2. Verify Token');
+
+// We hold onto these so we can print them alongside every dropped-event
+// diagnostic below. If the trigger was registered under a different
+// user, the ids printed here will NOT match whatever the backend's
+// `getSocketsByUserId(verified.payload.userId)` uses, and the emit is
+// silently dropped.
+let authedUserId = null;
+let authedUserLabel = '(unknown)';
+
+try {
+  const resp = await fetch(`${BACKEND_URL}/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await resp.json();
+  if (resp.ok && data.success && data.data) {
+    const u = data.data;
+    authedUserId = u._id || u.id || null;
+    authedUserLabel = u.username || u.firstName || authedUserId || '(unknown)';
+    ok(`user=${authedUserLabel}`);
+    // Print the exact socket-map key the backend will use for this
+    // connection. Compare against the trigger's registered userId if
+    // you're seeing "backend captured, socket didn't".
+    info('mongo _id', authedUserId ?? '(missing from /auth/me)');
+    if (u.telegramId != null) info('telegramId', u.telegramId);
+  } else {
+    fail(`token invalid: ${JSON.stringify(data).slice(0, 300)}`);
+    process.exit(1);
+  }
+} catch (err) {
+  fail(`backend unreachable: ${err.message}`);
+  process.exit(1);
+}
+
+// ── Verify gmail connection is ACTIVE ───────────────────────────────
+
+header('3. Verify Gmail Connection');
+
+try {
+  const resp = await fetch(`${BACKEND_URL}/agent-integrations/composio/connections`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await resp.json();
+  if (!resp.ok || !data.success) {
+    fail(`GET /connections → HTTP ${resp.status}: ${data?.error || 'unknown error'}`);
+    process.exit(1);
+  }
+  const connections = data.data?.connections ?? [];
+  const gmail = connections.find((c) => c.toolkit?.toLowerCase() === 'gmail');
+  if (!gmail) {
+    fail('no gmail connection found for this user');
+    console.log(
+      `${C.yellow}    Run: bash scripts/debug-composio-login.sh first to connect gmail.${C.reset}`,
+    );
+    process.exit(1);
+  }
+  const status = String(gmail.status).toUpperCase();
+  if (status === 'ACTIVE' || status === 'CONNECTED') {
+    ok(`gmail ACTIVE (id=${gmail.id})`);
+  } else {
+    console.log(
+      `${C.yellow}  ⚠ gmail connection status is "${gmail.status}" — trigger may not fire.${C.reset}`,
+    );
+    info('connection id', gmail.id);
+  }
+} catch (err) {
+  fail(`connection check failed: ${err.message}`);
+  process.exit(1);
+}
+
+// ── Trigger-create reminder ─────────────────────────────────────────
+//
+// We deliberately don't create the Composio trigger from this script:
+// the Composio SDK needs COMPOSIO_API_KEY, which is a backend secret.
+// The backend team's live-test-composio-trigger.ts already handles
+// trigger creation — run it once with CLEANUP=keep and then this
+// listener will see every fired event until you explicitly delete
+// the trigger.
+
+header('4. Trigger Setup Reminder');
+console.log(
+  `${C.dim}  This script only LISTENS. It does not create/delete${C.reset}\n` +
+    `${C.dim}  Composio triggers (that requires the backend's COMPOSIO_API_KEY).${C.reset}\n\n` +
+    `${C.dim}  To create the trigger once, run the backend team's tool:${C.reset}\n` +
+    `${C.dim}    CLEANUP=keep TRIGGER_SLUG=${TRIGGER_SLUG} \\${C.reset}\n` +
+    `${C.dim}      npx ts-node -r tsconfig-paths/register \\${C.reset}\n` +
+    `${C.dim}      src/scripts/live-test-composio-trigger.ts${C.reset}\n\n` +
+    `${C.dim}  Then run THIS script from the openhuman-2 repo to verify${C.reset}\n` +
+    `${C.dim}  that trigger events reach the client socket.${C.reset}`,
+);
+
+// ── Load socket.io-client ───────────────────────────────────────────
+
+header('5. Connect Socket.IO');
+
+const socketIoPath = path.join(
+  ROOT,
+  'app',
+  'node_modules',
+  'socket.io-client',
+  'dist',
+  'socket.io.esm.min.js',
+);
+
+let io;
+try {
+  // Prefer the version co-located with the app workspace — same binary
+  // the React client uses at runtime.
+  if (existsSync(socketIoPath)) {
+    const mod = await import(socketIoPath);
+    io = mod.io || mod.default;
+    dbg('loaded socket.io-client from', socketIoPath);
+  } else {
+    const mod = await import('socket.io-client');
+    io = mod.io || mod.default;
+    dbg('loaded socket.io-client from node resolution');
+  }
+} catch (err) {
+  fail(`cannot load socket.io-client: ${err.message}`);
+  console.log(
+    `${C.dim}    Try: cd app && yarn install${C.reset}`,
+  );
+  process.exit(1);
+}
+
+const socket = io(BACKEND_URL, {
+  auth: { token },
+  transports: ['websocket', 'polling'],
+  path: '/socket.io/',
+  reconnection: true,
+  reconnectionAttempts: 5,
+  timeout: 10_000,
+});
+
+// ── Catchall: log every event the server sends us ─────────────────
+//
+// This is on regardless of --debug because the #1 reason "the backend
+// logged a webhook but my socket didn't" is that the emit targeted a
+// different userId. If this catchall is silent during the wait, your
+// socket is NOT receiving any server traffic at all — either because
+// the server thinks the socket is dead, or because your auth maps to
+// a user the backend isn't emitting to.
+//
+// `onAny` is the socket.io v4 blessed API for catchall listeners.
+// Normal named `.on('composio:trigger', …)` handlers still fire after
+// this runs.
+socket.onAny((eventName, ...payload) => {
+  const first = payload[0];
+  const preview =
+    first === undefined
+      ? ''
+      : ` ${JSON.stringify(first).slice(0, 160)}`;
+  console.log(
+    `${C.dim}  [${ts()}] ⇢ ${eventName}${preview}${C.reset}`,
+  );
+});
+
+// Low-frequency heartbeat so silent disconnects are obvious. If the
+// transport dies without firing `disconnect` on the client, this will
+// let us notice by the absence of any traffic over 30s.
+let lastEventAt = Date.now();
+socket.onAny(() => {
+  lastEventAt = Date.now();
+});
+const heartbeatTimer = setInterval(() => {
+  const idleSecs = Math.round((Date.now() - lastEventAt) / 1000);
+  if (idleSecs >= 30 && socket.connected) {
+    console.log(
+      `${C.dim}  [${ts()}] idle ${idleSecs}s (socket.connected=${socket.connected}, transport=${socket.io.engine?.transport?.name})${C.reset}`,
+    );
+  }
+}, 15_000);
+
+// ── Connection lifecycle ────────────────────────────────────────────
+
+let eventCount = 0;
+
+socket.on('connect', () => {
+  ok(`connected (socket.id=${socket.id})`);
+  dbg('transport:', socket.io.engine?.transport?.name);
+});
+
+socket.on('ready', () => {
+  console.log(`${C.green}  🟢 server ready — auth accepted${C.reset}`);
+  header('6. Listening for composio:trigger');
+  console.log(
+    `${C.magenta}  Take the action that fires ${TRIGGER_SLUG}${C.reset}`,
+  );
+  console.log(
+    `${C.dim}  (e.g. for GMAIL_NEW_GMAIL_MESSAGE, send yourself an email).${C.reset}`,
+  );
+  console.log(`${C.dim}  Press Ctrl+C to stop.${C.reset}\n`);
+});
+
+socket.on('connect_error', (err) => {
+  fail(`connect_error: ${err.message}`);
+  dbg('full error:', err);
+});
+
+socket.on('error', (data) => {
+  fail(`server error: ${JSON.stringify(data)}`);
+});
+
+socket.on('disconnect', (reason) => {
+  console.log(`${C.yellow}  🔴 disconnected: ${reason}${C.reset}`);
+});
+
+socket.io.on('reconnect', (attempt) => {
+  console.log(`${C.yellow}  🔄 reconnected after ${attempt} attempt(s)${C.reset}`);
+});
+
+// ── The event under test ────────────────────────────────────────────
+
+function printEvent(event) {
+  eventCount++;
+  const label = event?.trigger || '(unknown)';
+  const toolkit = event?.toolkit || '(unknown)';
+  console.log(
+    `${C.green}  [${ts()}] #${eventCount} composio:trigger${C.reset} ` +
+      `${C.bold}${label}${C.reset} ${C.dim}(${toolkit})${C.reset}`,
+  );
+  if (event?.metadata) {
+    info('metadata', JSON.stringify(event.metadata));
+  }
+  const payload = event?.payload ?? {};
+  const preview = JSON.stringify(payload, null, 2) || '{}';
+  const lines = preview.split('\n');
+  const limited = lines.slice(0, 20).join('\n');
+  console.log(
+    `${C.dim}    payload:\n${limited
+      .split('\n')
+      .map((l) => `      ${l}`)
+      .join('\n')}${C.reset}`,
+  );
+  if (lines.length > 20) {
+    console.log(`${C.dim}      …(${lines.length - 20} more lines)${C.reset}`);
+  }
+  console.log('');
+}
+
+const done = new Promise((resolve) => {
+  socket.on('composio:trigger', (event) => {
+    try {
+      // Filter on slug when the caller passed --trigger so you can
+      // keep a broad listener running while debugging one hook at a
+      // time. `event.trigger` is the slug emitted by the backend.
+      if (
+        TRIGGER_SLUG &&
+        event?.trigger &&
+        event.trigger.toUpperCase() !== TRIGGER_SLUG.toUpperCase()
+      ) {
+        dbg(`ignoring ${event.trigger} (filter=${TRIGGER_SLUG})`);
+      } else {
+        printEvent(event);
+      }
+    } catch (err) {
+      fail(`error printing event: ${err.message}`);
+    }
+    if (MAX_EVENTS > 0 && eventCount >= MAX_EVENTS) {
+      console.log(
+        `${C.yellow}  Reached --max-events=${MAX_EVENTS} — shutting down.${C.reset}`,
+      );
+      resolve();
+    }
+  });
+
+  // Optional hard timeout.
+  if (TIMEOUT_SECS > 0) {
+    setTimeout(() => {
+      console.log(
+        `${C.yellow}  --timeout=${TIMEOUT_SECS}s elapsed — shutting down.${C.reset}`,
+      );
+      resolve();
+    }, TIMEOUT_SECS * 1_000);
+  }
+
+  // Ctrl+C.
+  process.on('SIGINT', () => {
+    console.log(`\n${C.yellow}  SIGINT received — shutting down.${C.reset}`);
+    resolve();
+  });
+});
+
+await done;
+
+// ── Cleanup ─────────────────────────────────────────────────────────
+
+header('7. Cleanup');
+clearInterval(heartbeatTimer);
+try {
+  socket.close();
+  ok('socket closed');
+} catch {
+  fail('failed to close socket');
+}
+
+if (eventCount === 0) {
+  // Surface the three usual suspects. This is the script talking, not
+  // the backend — the backend drops mismatched emits silently, so it
+  // won't tell us which one we're hitting.
+  console.log('');
+  console.log(
+    `${C.yellow}${C.bold}  No composio:trigger events received.${C.reset}`,
+  );
+  console.log('');
+  console.log(`${C.dim}  Checklist:${C.reset}`);
+  console.log(
+    `${C.dim}  1. Trigger userId vs your user:${C.reset}\n` +
+      `${C.dim}     Your socket is authed as _id=${C.reset}${C.bold}${authedUserId ?? '(unknown)'}${C.reset}${C.dim}.${C.reset}\n` +
+      `${C.dim}     The trigger must have been CREATED with that exact userId on${C.reset}\n` +
+      `${C.dim}     the Composio side. If you used the backend's${C.reset}\n` +
+      `${C.dim}     live-test-composio-trigger.ts, it registers with user.id${C.reset}\n` +
+      `${C.dim}     from whichever TELEGRAM_ID/USER_ID/JWT_TOKEN you ran it with.${C.reset}\n` +
+      `${C.dim}     If those don't match, the backend's getSocketsByUserId${C.reset}\n` +
+      `${C.dim}     returns [] and the emit is dropped silently.${C.reset}`,
+  );
+  console.log('');
+  console.log(
+    `${C.dim}  2. Did the catchall above log ANY inbound events?${C.reset}\n` +
+      `${C.dim}     - If yes (e.g. "ready", "toast", heartbeat), your socket is${C.reset}\n` +
+      `${C.dim}       alive and the issue is targeting (#1).${C.reset}\n` +
+      `${C.dim}     - If no, the backend thinks your socket is gone. Check${C.reset}\n` +
+      `${C.dim}       whether another client (the Rust core running locally?)${C.reset}\n` +
+      `${C.dim}       is holding the slot, or that your JWT hasn't expired${C.reset}\n` +
+      `${C.dim}       mid-run.${C.reset}`,
+  );
+  console.log('');
+  console.log(
+    `${C.dim}  3. Add one-line logging to the backend's${C.reset}\n` +
+      `${C.dim}     src/controllers/agentIntegrations/composio/handleWebhook.ts${C.reset}\n` +
+      `${C.dim}     right after the getSocketsByUserId call so the backend tells${C.reset}\n` +
+      `${C.dim}     you how many sockets it matched for which userId. That is${C.reset}\n` +
+      `${C.dim}     the only truly authoritative signal — everything else is a${C.reset}\n` +
+      `${C.dim}     guess.${C.reset}`,
+  );
+  console.log('');
+  process.exit(2);
+}
+
+console.log(
+  `\n${C.green}${C.bold}  Received ${eventCount} composio:trigger event(s).${C.reset}\n`,
+);
+process.exit(0);

--- a/scripts/debug-composio-trigger.mjs
+++ b/scripts/debug-composio-trigger.mjs
@@ -153,7 +153,10 @@ header('1. Authentication');
 
 function getSessionTokenFromCore() {
   const coreBin = path.join(ROOT, 'target', 'debug', 'openhuman-core');
-  if (!existsSync(coreBin)) return null;
+  if (!existsSync(coreBin)) {
+    if (DEBUG) console.debug(`[debug] core binary not found at ${coreBin}`);
+    return null;
+  }
   try {
     const output = execSync(`"${coreBin}" auth get_session_token`, {
       cwd: ROOT,
@@ -163,7 +166,11 @@ function getSessionTokenFromCore() {
     });
     const match = output.match(/"token":\s*"([^"]+)"/);
     return match?.[1] || null;
-  } catch {
+  } catch (err) {
+    if (DEBUG) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.debug(`[debug] ${coreBin} auth get_session_token failed: ${msg}`);
+    }
     return null;
   }
 }

--- a/scripts/debug-composio-trigger.mjs
+++ b/scripts/debug-composio-trigger.mjs
@@ -55,31 +55,16 @@
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 
-// ── CLI argument parsing ────────────────────────────────────────────
-
-const args = process.argv.slice(2);
-const flag = (name) => args.includes(name);
-const valueOf = (name, fallback) => {
-  const idx = args.indexOf(name);
-  if (idx === -1 || idx === args.length - 1) return fallback;
-  return args[idx + 1];
-};
-
-const DEBUG = flag('--debug');
-const TIMEOUT_SECS = parseInt(valueOf('--timeout', '0'), 10); // 0 = forever
-const MAX_EVENTS = parseInt(valueOf('--max-events', '0'), 10); // 0 = unlimited
-const TRIGGER_SLUG = (valueOf('--trigger', process.env.TRIGGER_SLUG || 'GMAIL_NEW_GMAIL_MESSAGE')).trim();
-
-function dbg(...a) {
-  if (DEBUG) console.log('  [debug]', ...a);
-}
-
 // ── Env loader (matches test-channel-receive.mjs) ───────────────────
+//
+// Declared + invoked BEFORE the CLI constants below read `process.env`,
+// otherwise values defined in `.env` / `app/.env.local` (like
+// TRIGGER_SLUG) would be ignored on the first run of the script.
 
 function loadEnv(filepath) {
   if (!existsSync(filepath)) return;
@@ -97,6 +82,26 @@ function loadEnv(filepath) {
 
 loadEnv(path.join(ROOT, '.env'));
 loadEnv(path.join(ROOT, 'app', '.env.local'));
+
+// ── CLI argument parsing ────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const valueOf = (name, fallback) => {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx === args.length - 1) return fallback;
+  return args[idx + 1];
+};
+
+const DEBUG = flag('--debug');
+const TIMEOUT_SECS = parseInt(valueOf('--timeout', '0'), 10); // 0 = forever
+const MAX_EVENTS = parseInt(valueOf('--max-events', '0'), 10); // 0 = unlimited
+const TRIGGER_SLUG = (valueOf('--trigger', process.env.TRIGGER_SLUG || 'GMAIL_NEW_GMAIL_MESSAGE')).trim();
+const TOOLKIT_OVERRIDE = (valueOf('--toolkit', process.env.COMPOSIO_TOOLKIT || '')).trim();
+
+function dbg(...a) {
+  if (DEBUG) console.log('  [debug]', ...a);
+}
 
 const BACKEND_URL = (
   process.env.BACKEND_URL ||
@@ -228,9 +233,23 @@ try {
   process.exit(1);
 }
 
-// ── Verify gmail connection is ACTIVE ───────────────────────────────
+// ── Verify target toolkit has a connection ─────────────────────────
+//
+// The "target toolkit" is explicit if the caller passed `--toolkit`;
+// otherwise we derive it from the trigger slug prefix (e.g.
+// GMAIL_NEW_GMAIL_MESSAGE → "gmail"). We no longer hard-exit for any
+// toolkit other than gmail — missing non-gmail connections drop to a
+// warning so a broader socket listener can keep running.
 
-header('3. Verify Gmail Connection');
+const desiredToolkit = (
+  TOOLKIT_OVERRIDE ||
+  (TRIGGER_SLUG.includes('_') ? TRIGGER_SLUG.split('_')[0] : '') ||
+  'gmail'
+)
+  .toLowerCase()
+  .trim();
+
+header(`3. Verify ${desiredToolkit || 'target'} connection`);
 
 try {
   const resp = await fetch(`${BACKEND_URL}/agent-integrations/composio/connections`, {
@@ -242,22 +261,36 @@ try {
     process.exit(1);
   }
   const connections = data.data?.connections ?? [];
-  const gmail = connections.find((c) => c.toolkit?.toLowerCase() === 'gmail');
-  if (!gmail) {
-    fail('no gmail connection found for this user');
+  const match = connections.find(
+    (c) => (c.toolkit || '').toLowerCase() === desiredToolkit,
+  );
+  if (!match) {
+    // Only gmail is considered a blocking prerequisite — the legacy
+    // script behaviour — because `debug-composio-login.sh` defaults to
+    // connecting gmail. For every other toolkit, warn and keep going
+    // so the listener can still receive events from whatever IS
+    // connected.
+    if (desiredToolkit === 'gmail') {
+      fail('no gmail connection found for this user');
+      console.log(
+        `${C.yellow}    Run: bash scripts/debug-composio-login.sh first to connect gmail.${C.reset}`,
+      );
+      process.exit(1);
+    }
     console.log(
-      `${C.yellow}    Run: bash scripts/debug-composio-login.sh first to connect gmail.${C.reset}`,
+      `${C.yellow}  ⚠ no ${desiredToolkit} connection found — listener will still run,\n` +
+        `    but no ${TRIGGER_SLUG} events will arrive until one is connected.${C.reset}`,
     );
-    process.exit(1);
-  }
-  const status = String(gmail.status).toUpperCase();
-  if (status === 'ACTIVE' || status === 'CONNECTED') {
-    ok(`gmail ACTIVE (id=${gmail.id})`);
   } else {
-    console.log(
-      `${C.yellow}  ⚠ gmail connection status is "${gmail.status}" — trigger may not fire.${C.reset}`,
-    );
-    info('connection id', gmail.id);
+    const status = String(match.status).toUpperCase();
+    if (status === 'ACTIVE' || status === 'CONNECTED') {
+      ok(`${desiredToolkit} ACTIVE (id=${match.id})`);
+    } else {
+      console.log(
+        `${C.yellow}  ⚠ ${desiredToolkit} connection status is "${match.status}" — trigger may not fire.${C.reset}`,
+      );
+      info('connection id', match.id);
+    }
   }
 } catch (err) {
   fail(`connection check failed: ${err.message}`);
@@ -301,9 +334,11 @@ const socketIoPath = path.join(
 let io;
 try {
   // Prefer the version co-located with the app workspace — same binary
-  // the React client uses at runtime.
+  // the React client uses at runtime. Convert the filesystem path to a
+  // `file://` URL via `pathToFileURL` so Node ESM accepts it on Windows
+  // (bare OS paths work on macOS/Linux but fail on Windows).
   if (existsSync(socketIoPath)) {
-    const mod = await import(socketIoPath);
+    const mod = await import(pathToFileURL(socketIoPath).href);
     io = mod.io || mod.default;
     dbg('loaded socket.io-client from', socketIoPath);
   } else {

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -61,6 +61,7 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     let mut controllers = Vec::new();
     controllers.extend(crate::openhuman::about_app::all_about_app_registered_controllers());
     controllers.extend(crate::openhuman::app_state::all_app_state_registered_controllers());
+    controllers.extend(crate::openhuman::composio::all_composio_registered_controllers());
     controllers.extend(crate::openhuman::cron::all_cron_registered_controllers());
     controllers.extend(crate::openhuman::agent::all_agent_registered_controllers());
     controllers.extend(crate::openhuman::health::all_health_registered_controllers());
@@ -105,6 +106,7 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
     let mut schemas = Vec::new();
     schemas.extend(crate::openhuman::about_app::all_about_app_controller_schemas());
     schemas.extend(crate::openhuman::app_state::all_app_state_controller_schemas());
+    schemas.extend(crate::openhuman::composio::all_composio_controller_schemas());
     schemas.extend(crate::openhuman::cron::all_cron_controller_schemas());
     schemas.extend(crate::openhuman::agent::all_agent_controller_schemas());
     schemas.extend(crate::openhuman::health::all_health_controller_schemas());
@@ -167,6 +169,9 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         "auth" => Some("Manage app session and provider credentials."),
         "autocomplete" => Some("Inline autocomplete engine controls and style settings."),
         "channels" => Some("Channel definitions, connections, and lifecycle management."),
+        "composio" => Some(
+            "Composio OAuth integrations proxied via the backend — toolkits, connections, tools, and actions."
+        ),
         "config" => Some("Read and update persisted runtime configuration."),
         "cron" => Some("Manage scheduled jobs and run history."),
         "decrypt" => Some("Decrypt secure values managed by secret storage."),

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -826,13 +826,14 @@ fn register_domain_subscribers() {
 
         crate::openhuman::health::bus::register_health_subscriber();
         crate::openhuman::skills::bus::register_skill_cleanup_subscriber();
+        crate::openhuman::composio::register_composio_trigger_subscriber();
 
         // Restart requests go through a subscriber so every trigger path shares
         // the same respawn logic.
         crate::openhuman::service::bus::register_restart_subscriber();
 
         log::info!(
-            "[event_bus] webhook, channel, health, skill, and restart subscribers registered"
+            "[event_bus] webhook, channel, health, skill, composio, and restart subscribers registered"
         );
     });
 }

--- a/src/openhuman/channels/runtime/startup.rs
+++ b/src/openhuman/channels/runtime/startup.rs
@@ -46,6 +46,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
     let _tracing_handle = bus.subscribe(Arc::new(TracingSubscriber));
     crate::openhuman::health::bus::register_health_subscriber();
     crate::openhuman::skills::bus::register_skill_cleanup_subscriber();
+    crate::openhuman::composio::register_composio_trigger_subscriber();
     tracing::debug!("[event_bus] global singleton initialized in start_channels");
 
     // Initialise the sub-agent definition registry from this workspace.

--- a/src/openhuman/composio/bus.rs
+++ b/src/openhuman/composio/bus.rs
@@ -1,0 +1,124 @@
+//! Event bus subscribers for the Composio domain.
+//!
+//! The backend emits `composio:trigger` over Socket.IO when a webhook
+//! arrives and is HMAC-verified (see
+//! `src/controllers/agentIntegrations/composio/handleWebhook.ts` in the
+//! backend repo). The socket transport layer parses that payload and
+//! publishes [`DomainEvent::ComposioTriggerReceived`], and this
+//! subscriber is what actually does something with it: log it, and in
+//! the future, route to skills / channels / cron-like delivery.
+//!
+//! Keeping this logic behind the bus means the socket transport stays
+//! dumb, and adding new consumers (UI push, skill triggers, automation
+//! engines) is a one-line subscribe call.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+
+use crate::openhuman::event_bus::{DomainEvent, EventHandler, SubscriptionHandle};
+
+static COMPOSIO_TRIGGER_HANDLE: OnceLock<SubscriptionHandle> = OnceLock::new();
+
+/// Register the long-lived composio trigger subscriber on the global
+/// event bus. Idempotent.
+pub fn register_composio_trigger_subscriber() {
+    if COMPOSIO_TRIGGER_HANDLE.get().is_some() {
+        return;
+    }
+    match crate::openhuman::event_bus::subscribe_global(Arc::new(ComposioTriggerSubscriber::new()))
+    {
+        Some(handle) => {
+            let _ = COMPOSIO_TRIGGER_HANDLE.set(handle);
+            log::debug!("[event_bus] composio trigger subscriber registered");
+        }
+        None => {
+            log::warn!(
+                "[event_bus] failed to register composio trigger subscriber — bus not initialized"
+            );
+        }
+    }
+}
+
+/// Logs and (in future) routes `ComposioTriggerReceived` events.
+pub struct ComposioTriggerSubscriber;
+
+impl ComposioTriggerSubscriber {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ComposioTriggerSubscriber {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl EventHandler for ComposioTriggerSubscriber {
+    fn name(&self) -> &str {
+        "composio::trigger"
+    }
+
+    fn domains(&self) -> Option<&[&str]> {
+        Some(&["composio"])
+    }
+
+    async fn handle(&self, event: &DomainEvent) {
+        let DomainEvent::ComposioTriggerReceived {
+            toolkit,
+            trigger,
+            metadata_id,
+            metadata_uuid,
+            payload,
+        } = event
+        else {
+            return;
+        };
+
+        tracing::debug!(
+            toolkit = %toolkit,
+            trigger = %trigger,
+            id = %metadata_id,
+            uuid = %metadata_uuid,
+            payload_bytes = payload.to_string().len(),
+            "[composio] trigger received"
+        );
+
+        // TODO: route triggers into a user-configurable skill/channel/cron
+        // dispatch in the same spirit as `cron::bus::CronDeliverySubscriber`.
+        // For now we log and rely on other subscribers (e.g. a future
+        // skill bridge) to act on the event.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn ignores_non_composio_events() {
+        let sub = ComposioTriggerSubscriber::new();
+        sub.handle(&DomainEvent::CronJobTriggered {
+            job_id: "j1".into(),
+            job_type: "shell".into(),
+        })
+        .await;
+        // No panic = pass.
+    }
+
+    #[tokio::test]
+    async fn handles_trigger_event_without_panic() {
+        let sub = ComposioTriggerSubscriber::new();
+        sub.handle(&DomainEvent::ComposioTriggerReceived {
+            toolkit: "gmail".into(),
+            trigger: "GMAIL_NEW_GMAIL_MESSAGE".into(),
+            metadata_id: "trig-1".into(),
+            metadata_uuid: "uuid-1".into(),
+            payload: json!({ "from": "a@b.com", "subject": "hi" }),
+        })
+        .await;
+    }
+}

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -1,0 +1,220 @@
+//! Thin HTTP wrapper over the openhuman backend's
+//! `/agent-integrations/composio/*` routes.
+//!
+//! All calls go through the shared
+//! [`crate::openhuman::integrations::IntegrationClient`] so they inherit
+//! the same Bearer JWT auth, timeout, envelope parsing, and proxy behavior
+//! as the other backend-proxied integrations.
+//!
+//! Logging uses the `[composio]` grep-prefix so all sidecar output for
+//! this domain can be filtered in one shot.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde_json::json;
+
+use crate::openhuman::integrations::IntegrationClient;
+
+use super::types::{
+    ComposioAuthorizeResponse, ComposioConnectionsResponse, ComposioDeleteResponse,
+    ComposioExecuteResponse, ComposioToolkitsResponse, ComposioToolsResponse,
+};
+
+/// High-level client for all backend-proxied Composio operations.
+#[derive(Clone)]
+pub struct ComposioClient {
+    inner: Arc<IntegrationClient>,
+}
+
+impl ComposioClient {
+    pub fn new(inner: Arc<IntegrationClient>) -> Self {
+        Self { inner }
+    }
+
+    /// Access the underlying integration client (useful for tests or for
+    /// callers that need to reuse the same reqwest pool for bespoke calls).
+    pub fn inner(&self) -> &Arc<IntegrationClient> {
+        &self.inner
+    }
+
+    // ── Toolkits ────────────────────────────────────────────────────
+
+    /// `GET /agent-integrations/composio/toolkits` — server-enforced
+    /// allowlist of toolkits that composio calls may target.
+    pub async fn list_toolkits(&self) -> Result<ComposioToolkitsResponse> {
+        tracing::debug!("[composio] list_toolkits");
+        self.inner
+            .get::<ComposioToolkitsResponse>("/agent-integrations/composio/toolkits")
+            .await
+    }
+
+    // ── Connections ─────────────────────────────────────────────────
+
+    /// `GET /agent-integrations/composio/connections` — active connected
+    /// accounts for the authenticated user, filtered to the allowlist.
+    pub async fn list_connections(&self) -> Result<ComposioConnectionsResponse> {
+        tracing::debug!("[composio] list_connections");
+        self.inner
+            .get::<ComposioConnectionsResponse>("/agent-integrations/composio/connections")
+            .await
+    }
+
+    /// `POST /agent-integrations/composio/authorize` — begin an OAuth
+    /// handoff for `toolkit` and return the hosted `connectUrl` the user
+    /// must open in a browser.
+    pub async fn authorize(&self, toolkit: &str) -> Result<ComposioAuthorizeResponse> {
+        let toolkit = toolkit.trim();
+        if toolkit.is_empty() {
+            anyhow::bail!("composio.authorize: toolkit must not be empty");
+        }
+        tracing::debug!(toolkit = %toolkit, "[composio] authorize");
+        let body = json!({ "toolkit": toolkit });
+        self.inner
+            .post::<ComposioAuthorizeResponse>("/agent-integrations/composio/authorize", &body)
+            .await
+    }
+
+    /// `DELETE /agent-integrations/composio/connections/{id}`.
+    ///
+    /// The backend verifies that the caller owns the connection before
+    /// deleting it. We call this via `POST` with a synthetic `_method`
+    /// body because [`IntegrationClient`] does not currently expose a
+    /// generic `delete()` — the backend accepts the method override.
+    pub async fn delete_connection(&self, connection_id: &str) -> Result<ComposioDeleteResponse> {
+        let connection_id = connection_id.trim();
+        if connection_id.is_empty() {
+            anyhow::bail!("composio.delete_connection: connectionId must not be empty");
+        }
+        tracing::debug!(connection_id = %connection_id, "[composio] delete_connection");
+        // Fall through to the reusable raw HTTP delete helper below.
+        self.raw_delete::<ComposioDeleteResponse>(&format!(
+            "/agent-integrations/composio/connections/{connection_id}"
+        ))
+        .await
+    }
+
+    // ── Tools ───────────────────────────────────────────────────────
+
+    /// `GET /agent-integrations/composio/tools?toolkits=<csv>` — fetch
+    /// OpenAI function-calling schemas. Omit `toolkits` to get every
+    /// enabled toolkit's tools.
+    pub async fn list_tools(&self, toolkits: Option<&[String]>) -> Result<ComposioToolsResponse> {
+        let path = match toolkits {
+            Some(list) if !list.is_empty() => {
+                let joined = list
+                    .iter()
+                    .map(|t| t.trim())
+                    .filter(|t| !t.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("/agent-integrations/composio/tools?toolkits={joined}")
+            }
+            _ => "/agent-integrations/composio/tools".to_string(),
+        };
+        tracing::debug!(path = %path, "[composio] list_tools");
+        self.inner.get::<ComposioToolsResponse>(&path).await
+    }
+
+    // ── Execute ─────────────────────────────────────────────────────
+
+    /// `POST /agent-integrations/composio/execute` — run a Composio
+    /// action and return the provider result + cost.
+    pub async fn execute_tool(
+        &self,
+        tool: &str,
+        arguments: Option<serde_json::Value>,
+    ) -> Result<ComposioExecuteResponse> {
+        let tool = tool.trim();
+        if tool.is_empty() {
+            anyhow::bail!("composio.execute_tool: tool slug must not be empty");
+        }
+        let arguments = arguments.unwrap_or(serde_json::Value::Object(Default::default()));
+        tracing::debug!(tool = %tool, "[composio] execute_tool");
+        let body = json!({ "tool": tool, "arguments": arguments });
+        self.inner
+            .post::<ComposioExecuteResponse>("/agent-integrations/composio/execute", &body)
+            .await
+    }
+
+    // ── Raw DELETE ──────────────────────────────────────────────────
+
+    /// Perform an HTTP DELETE and parse the standard backend envelope.
+    ///
+    /// [`IntegrationClient`] only exposes `get` / `post` today, and the
+    /// composio route actually requires a DELETE. We re-implement the
+    /// envelope handling here so we don't have to widen the shared
+    /// client's public surface just for one caller.
+    async fn raw_delete<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        #[derive(serde::Deserialize)]
+        struct Envelope<T> {
+            #[serde(default)]
+            success: bool,
+            data: Option<T>,
+            #[serde(default)]
+            error: Option<String>,
+        }
+
+        let url = format!("{}{}", self.inner.backend_url, path);
+        tracing::debug!("[composio] DELETE {}", url);
+
+        // Reuse the shared client's reqwest pool by building a fresh
+        // lightweight client here — the integration tools do the same
+        // when they need side-band request types.
+        let http_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()?;
+
+        let resp = http_client
+            .delete(&url)
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.inner.auth_token),
+            )
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            tracing::debug!(
+                "[composio] DELETE {} → {} body={}",
+                url,
+                status,
+                &body_text[..body_text.len().min(300)]
+            );
+            anyhow::bail!("Backend returned {} for DELETE {}", status, url);
+        }
+
+        let envelope: Envelope<T> = resp.json().await?;
+        if !envelope.success {
+            let msg = envelope
+                .error
+                .unwrap_or_else(|| "unknown backend error".into());
+            anyhow::bail!("Backend error for DELETE {}: {}", url, msg);
+        }
+        envelope
+            .data
+            .ok_or_else(|| anyhow::anyhow!("Backend returned success but no data for DELETE {}", url))
+    }
+}
+
+/// Build a [`ComposioClient`] from the integrations config. Returns
+/// `None` when either the integrations master switch is off, the
+/// composio sub-toggle is off, or the backend URL / auth token are
+/// missing.
+pub fn build_composio_client(
+    config: &crate::openhuman::config::IntegrationsConfig,
+) -> Option<ComposioClient> {
+    if !config.enabled {
+        tracing::debug!("[composio] integrations master switch off — skipping");
+        return None;
+    }
+    if !config.composio.enabled {
+        tracing::debug!("[composio] composio toggle off — skipping");
+        return None;
+    }
+    let inner = crate::openhuman::integrations::build_client(config)?;
+    Some(ComposioClient::new(inner))
+}

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -158,9 +158,12 @@ impl ComposioClient {
         let url = format!("{}{}", self.inner.backend_url, path);
         tracing::debug!("[composio] DELETE {}", url);
 
-        // Reuse the shared client's reqwest pool by building a fresh
-        // lightweight client here — the integration tools do the same
-        // when they need side-band request types.
+        // Build a fresh lightweight reqwest client for this DELETE.
+        // Note: this allocates a *new* connection pool — it does NOT
+        // reuse the pool inside `self.inner`. To reuse the shared pool
+        // we'd need to clone or expose the existing `reqwest::Client`
+        // from `IntegrationClient`, which we intentionally avoid so the
+        // public surface of that type doesn't widen for one caller.
         let http_client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(60))
             .connect_timeout(std::time::Duration::from_secs(10))

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -168,10 +168,7 @@ impl ComposioClient {
 
         let resp = http_client
             .delete(&url)
-            .header(
-                "Authorization",
-                format!("Bearer {}", self.inner.auth_token),
-            )
+            .header("Authorization", format!("Bearer {}", self.inner.auth_token))
             .send()
             .await?;
 
@@ -194,9 +191,9 @@ impl ComposioClient {
                 .unwrap_or_else(|| "unknown backend error".into());
             anyhow::bail!("Backend error for DELETE {}: {}", url, msg);
         }
-        envelope
-            .data
-            .ok_or_else(|| anyhow::anyhow!("Backend returned success but no data for DELETE {}", url))
+        envelope.data.ok_or_else(|| {
+            anyhow::anyhow!("Backend returned success but no data for DELETE {}", url)
+        })
     }
 }
 

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -1,0 +1,56 @@
+//! Composio domain module — backend-proxied access to 1000+ OAuth
+//! integrations (Gmail, Notion, GitHub, Slack, …).
+//!
+//! This module is the Rust counterpart to the backend routes under
+//! `src/routes/agentIntegrations/composio.ts`. The backend owns the
+//! Composio API key, billing/margin, toolkit allowlist, HMAC webhook
+//! verification, and Socket.IO trigger fan-out. The core does **not**
+//! hit the Composio API directly — everything goes through the backend.
+//!
+//! ## Surface
+//!
+//! - **RPC controllers** (`schemas.rs` / `ops.rs`) — `openhuman.composio_*`
+//!   methods for listing toolkits, managing connections, listing tools,
+//!   and executing actions. These are registered in
+//!   [`crate::core::all`] alongside other domains.
+//!
+//! - **Agent tools** (`tools.rs`) — model-facing `composio_*` tools the
+//!   autonomous agent loop can call. Registered from
+//!   [`crate::openhuman::tools::ops::all_tools_with_runtime`].
+//!
+//! - **Event bus** (`bus.rs`) — `ComposioTriggerSubscriber` listens for
+//!   [`DomainEvent::ComposioTriggerReceived`] events published by the
+//!   socket transport when the backend emits `composio:trigger`.
+//!
+//! ## Socket.IO trigger flow
+//!
+//! ```text
+//!  Composio webhook → backend HMAC-verifies → backend emits
+//!  `composio:trigger` on user sockets → core
+//!  `socket::event_handlers::handle_sio_event` parses the payload →
+//!  publishes `DomainEvent::ComposioTriggerReceived` → the
+//!  `ComposioTriggerSubscriber` (and any future subscribers) reacts.
+//! ```
+//!
+//! [`DomainEvent::ComposioTriggerReceived`]:
+//! crate::openhuman::event_bus::DomainEvent::ComposioTriggerReceived
+
+pub mod bus;
+pub mod client;
+pub mod ops;
+pub mod schemas;
+pub mod tools;
+pub mod types;
+
+pub use bus::{register_composio_trigger_subscriber, ComposioTriggerSubscriber};
+pub use client::{build_composio_client, ComposioClient};
+pub use schemas::{
+    all_controller_schemas as all_composio_controller_schemas,
+    all_registered_controllers as all_composio_registered_controllers,
+};
+pub use tools::all_composio_agent_tools;
+pub use types::{
+    ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,
+    ComposioDeleteResponse, ComposioExecuteResponse, ComposioToolFunction, ComposioToolSchema,
+    ComposioToolkitsResponse, ComposioToolsResponse, ComposioTriggerEvent, ComposioTriggerMetadata,
+};

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -15,9 +15,8 @@ use crate::rpc::RpcOutcome;
 
 use super::client::{build_composio_client, ComposioClient};
 use super::types::{
-    ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,
-    ComposioDeleteResponse, ComposioExecuteResponse, ComposioToolSchema, ComposioToolkitsResponse,
-    ComposioToolsResponse,
+    ComposioAuthorizeResponse, ComposioConnectionsResponse, ComposioDeleteResponse,
+    ComposioExecuteResponse, ComposioToolkitsResponse, ComposioToolsResponse,
 };
 
 /// Resolve a [`ComposioClient`] from `config.integrations`, or return an
@@ -182,7 +181,3 @@ pub async fn composio_execute(
 // ── Helpers re-exported so callers can pull connection/tool types without
 // reaching into the nested types module.
 pub use super::types::{ComposioConnection as Connection, ComposioToolSchema as ToolSchemaType};
-
-// Suppress unused import warnings when only some ops are referenced.
-#[allow(dead_code)]
-fn _unused_marker(_c: ComposioConnection, _t: ComposioToolSchema) {}

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -1,0 +1,188 @@
+//! RPC-facing operations for the Composio domain.
+//!
+//! Each `composio_*` function wraps a [`ComposioClient`] call, translates
+//! errors to strings, and returns an [`RpcOutcome`] so the controller
+//! schemas can log a user-visible line. The handlers in [`super::schemas`]
+//! call into these.
+//!
+//! These ops are also callable directly from other domains (e.g. the
+//! agent harness) when they need composio data at runtime.
+
+use anyhow::Result;
+
+use crate::openhuman::config::Config;
+use crate::rpc::RpcOutcome;
+
+use super::client::{build_composio_client, ComposioClient};
+use super::types::{
+    ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,
+    ComposioDeleteResponse, ComposioExecuteResponse, ComposioToolSchema, ComposioToolkitsResponse,
+    ComposioToolsResponse,
+};
+
+/// Resolve a [`ComposioClient`] from `config.integrations`, or return an
+/// error string that the caller can surface over RPC.
+fn resolve_client(config: &Config) -> Result<ComposioClient, String> {
+    build_composio_client(&config.integrations).ok_or_else(|| {
+        "composio is disabled (integrations.enabled or integrations.composio.enabled is off, \
+         or backend_url/auth_token missing)"
+            .to_string()
+    })
+}
+
+// ── Toolkits ────────────────────────────────────────────────────────
+
+pub async fn composio_list_toolkits(
+    config: &Config,
+) -> Result<RpcOutcome<ComposioToolkitsResponse>, String> {
+    tracing::debug!("[composio] rpc list_toolkits");
+    let client = resolve_client(config)?;
+    let resp = client
+        .list_toolkits()
+        .await
+        .map_err(|e| format!("[composio] list_toolkits failed: {e}"))?;
+    let count = resp.toolkits.len();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: {count} toolkit(s) enabled")],
+    ))
+}
+
+// ── Connections ─────────────────────────────────────────────────────
+
+pub async fn composio_list_connections(
+    config: &Config,
+) -> Result<RpcOutcome<ComposioConnectionsResponse>, String> {
+    tracing::debug!("[composio] rpc list_connections");
+    let client = resolve_client(config)?;
+    let resp = client
+        .list_connections()
+        .await
+        .map_err(|e| format!("[composio] list_connections failed: {e}"))?;
+    let active = resp
+        .connections
+        .iter()
+        .filter(|c| matches!(c.status.as_str(), "ACTIVE" | "CONNECTED"))
+        .count();
+    let total = resp.connections.len();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!(
+            "composio: {total} connection(s) listed ({active} active)"
+        )],
+    ))
+}
+
+pub async fn composio_authorize(
+    config: &Config,
+    toolkit: &str,
+) -> Result<RpcOutcome<ComposioAuthorizeResponse>, String> {
+    tracing::debug!(toolkit = %toolkit, "[composio] rpc authorize");
+    let client = resolve_client(config)?;
+    let resp = client
+        .authorize(toolkit)
+        .await
+        .map_err(|e| format!("[composio] authorize failed: {e}"))?;
+
+    // Publish an event so any interested subscribers (e.g. UI refreshers,
+    // analytics) can react to the new connection handoff.
+    crate::openhuman::event_bus::publish_global(
+        crate::openhuman::event_bus::DomainEvent::ComposioConnectionCreated {
+            toolkit: toolkit.to_string(),
+            connection_id: resp.connection_id.clone(),
+            connect_url: resp.connect_url.clone(),
+        },
+    );
+
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: authorize flow started for {toolkit}")],
+    ))
+}
+
+pub async fn composio_delete_connection(
+    config: &Config,
+    connection_id: &str,
+) -> Result<RpcOutcome<ComposioDeleteResponse>, String> {
+    tracing::debug!(connection_id = %connection_id, "[composio] rpc delete_connection");
+    let client = resolve_client(config)?;
+    let resp = client
+        .delete_connection(connection_id)
+        .await
+        .map_err(|e| format!("[composio] delete_connection failed: {e}"))?;
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: connection {connection_id} deleted")],
+    ))
+}
+
+// ── Tools ───────────────────────────────────────────────────────────
+
+pub async fn composio_list_tools(
+    config: &Config,
+    toolkits: Option<Vec<String>>,
+) -> Result<RpcOutcome<ComposioToolsResponse>, String> {
+    tracing::debug!(?toolkits, "[composio] rpc list_tools");
+    let client = resolve_client(config)?;
+    let resp = client
+        .list_tools(toolkits.as_deref())
+        .await
+        .map_err(|e| format!("[composio] list_tools failed: {e}"))?;
+    let count = resp.tools.len();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: {count} tool(s) listed")],
+    ))
+}
+
+// ── Execute ─────────────────────────────────────────────────────────
+
+pub async fn composio_execute(
+    config: &Config,
+    tool: &str,
+    arguments: Option<serde_json::Value>,
+) -> Result<RpcOutcome<ComposioExecuteResponse>, String> {
+    tracing::debug!(tool = %tool, "[composio] rpc execute");
+    let client = resolve_client(config)?;
+    let started = std::time::Instant::now();
+    let result = client.execute_tool(tool, arguments.clone()).await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+
+    match result {
+        Ok(resp) => {
+            crate::openhuman::event_bus::publish_global(
+                crate::openhuman::event_bus::DomainEvent::ComposioActionExecuted {
+                    tool: tool.to_string(),
+                    success: resp.successful,
+                    error: resp.error.clone(),
+                    cost_usd: resp.cost_usd,
+                    elapsed_ms,
+                },
+            );
+            Ok(RpcOutcome::new(
+                resp,
+                vec![format!("composio: executed {tool} ({elapsed_ms}ms)")],
+            ))
+        }
+        Err(e) => {
+            crate::openhuman::event_bus::publish_global(
+                crate::openhuman::event_bus::DomainEvent::ComposioActionExecuted {
+                    tool: tool.to_string(),
+                    success: false,
+                    error: Some(e.to_string()),
+                    cost_usd: 0.0,
+                    elapsed_ms,
+                },
+            );
+            Err(format!("[composio] execute failed: {e}"))
+        }
+    }
+}
+
+// ── Helpers re-exported so callers can pull connection/tool types without
+// reaching into the nested types module.
+pub use super::types::{ComposioConnection as Connection, ComposioToolSchema as ToolSchemaType};
+
+// Suppress unused import warnings when only some ops are referenced.
+#[allow(dead_code)]
+fn _unused_marker(_c: ComposioConnection, _t: ComposioToolSchema) {}

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -8,10 +8,16 @@
 //! These ops are also callable directly from other domains (e.g. the
 //! agent harness) when they need composio data at runtime.
 
-use anyhow::Result;
-
 use crate::openhuman::config::Config;
 use crate::rpc::RpcOutcome;
+
+/// Result alias used by every `composio_*` op in this module.
+///
+/// We deliberately return a plain `String` error instead of
+/// `anyhow::Error` — the controller layer in `schemas.rs` forwards
+/// these straight into the RPC envelope, and `String` keeps the shape
+/// obvious at a glance.
+type OpResult<T> = std::result::Result<T, String>;
 
 use super::client::{build_composio_client, ComposioClient};
 use super::types::{
@@ -21,7 +27,7 @@ use super::types::{
 
 /// Resolve a [`ComposioClient`] from `config.integrations`, or return an
 /// error string that the caller can surface over RPC.
-fn resolve_client(config: &Config) -> Result<ComposioClient, String> {
+fn resolve_client(config: &Config) -> OpResult<ComposioClient> {
     build_composio_client(&config.integrations).ok_or_else(|| {
         "composio is disabled (integrations.enabled or integrations.composio.enabled is off, \
          or backend_url/auth_token missing)"
@@ -33,7 +39,7 @@ fn resolve_client(config: &Config) -> Result<ComposioClient, String> {
 
 pub async fn composio_list_toolkits(
     config: &Config,
-) -> Result<RpcOutcome<ComposioToolkitsResponse>, String> {
+) -> OpResult<RpcOutcome<ComposioToolkitsResponse>> {
     tracing::debug!("[composio] rpc list_toolkits");
     let client = resolve_client(config)?;
     let resp = client
@@ -51,7 +57,7 @@ pub async fn composio_list_toolkits(
 
 pub async fn composio_list_connections(
     config: &Config,
-) -> Result<RpcOutcome<ComposioConnectionsResponse>, String> {
+) -> OpResult<RpcOutcome<ComposioConnectionsResponse>> {
     tracing::debug!("[composio] rpc list_connections");
     let client = resolve_client(config)?;
     let resp = client
@@ -75,7 +81,7 @@ pub async fn composio_list_connections(
 pub async fn composio_authorize(
     config: &Config,
     toolkit: &str,
-) -> Result<RpcOutcome<ComposioAuthorizeResponse>, String> {
+) -> OpResult<RpcOutcome<ComposioAuthorizeResponse>> {
     tracing::debug!(toolkit = %toolkit, "[composio] rpc authorize");
     let client = resolve_client(config)?;
     let resp = client
@@ -102,7 +108,7 @@ pub async fn composio_authorize(
 pub async fn composio_delete_connection(
     config: &Config,
     connection_id: &str,
-) -> Result<RpcOutcome<ComposioDeleteResponse>, String> {
+) -> OpResult<RpcOutcome<ComposioDeleteResponse>> {
     tracing::debug!(connection_id = %connection_id, "[composio] rpc delete_connection");
     let client = resolve_client(config)?;
     let resp = client
@@ -120,7 +126,7 @@ pub async fn composio_delete_connection(
 pub async fn composio_list_tools(
     config: &Config,
     toolkits: Option<Vec<String>>,
-) -> Result<RpcOutcome<ComposioToolsResponse>, String> {
+) -> OpResult<RpcOutcome<ComposioToolsResponse>> {
     tracing::debug!(?toolkits, "[composio] rpc list_tools");
     let client = resolve_client(config)?;
     let resp = client
@@ -140,7 +146,7 @@ pub async fn composio_execute(
     config: &Config,
     tool: &str,
     arguments: Option<serde_json::Value>,
-) -> Result<RpcOutcome<ComposioExecuteResponse>, String> {
+) -> OpResult<RpcOutcome<ComposioExecuteResponse>> {
     tracing::debug!(tool = %tool, "[composio] rpc execute");
     let client = resolve_client(config)?;
     let started = std::time::Instant::now();

--- a/src/openhuman/composio/schemas.rs
+++ b/src/openhuman/composio/schemas.rs
@@ -208,16 +208,16 @@ fn handle_list_connections(_params: Map<String, Value>) -> ControllerFuture {
 fn handle_authorize(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let config = config_rpc::load_config_with_timeout().await?;
-        let toolkit = read_required::<String>(&params, "toolkit")?;
-        to_json(super::ops::composio_authorize(&config, toolkit.trim()).await?)
+        let toolkit = read_required_non_empty(&params, "toolkit")?;
+        to_json(super::ops::composio_authorize(&config, &toolkit).await?)
     })
 }
 
 fn handle_delete_connection(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let config = config_rpc::load_config_with_timeout().await?;
-        let connection_id = read_required::<String>(&params, "connection_id")?;
-        to_json(super::ops::composio_delete_connection(&config, connection_id.trim()).await?)
+        let connection_id = read_required_non_empty(&params, "connection_id")?;
+        to_json(super::ops::composio_delete_connection(&config, &connection_id).await?)
     })
 }
 
@@ -232,9 +232,9 @@ fn handle_list_tools(params: Map<String, Value>) -> ControllerFuture {
 fn handle_execute(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let config = config_rpc::load_config_with_timeout().await?;
-        let tool = read_required::<String>(&params, "tool")?;
+        let tool = read_required_non_empty(&params, "tool")?;
         let arguments = read_optional::<Value>(&params, "arguments")?;
-        to_json(super::ops::composio_execute(&config, tool.trim(), arguments).await?)
+        to_json(super::ops::composio_execute(&config, &tool, arguments).await?)
     })
 }
 
@@ -246,6 +246,18 @@ fn read_required<T: DeserializeOwned>(params: &Map<String, Value>, key: &str) ->
         .cloned()
         .ok_or_else(|| format!("missing required param '{key}'"))?;
     serde_json::from_value(value).map_err(|e| format!("invalid '{key}': {e}"))
+}
+
+/// Read a required `String` parameter and reject blank / whitespace-only
+/// input at the RPC boundary instead of letting it reach the backend.
+/// Returns the trimmed value.
+fn read_required_non_empty(params: &Map<String, Value>, key: &str) -> Result<String, String> {
+    let raw = read_required::<String>(params, key)?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("'{key}' must not be empty"));
+    }
+    Ok(trimmed.to_string())
 }
 
 fn read_optional<T: DeserializeOwned>(

--- a/src/openhuman/composio/schemas.rs
+++ b/src/openhuman/composio/schemas.rs
@@ -1,0 +1,267 @@
+//! Controller schemas + registered handlers for the Composio domain.
+//!
+//! Exposes the domain over the shared registry at
+//! `openhuman.composio_*`:
+//!   - `composio.list_toolkits`       → `openhuman.composio_list_toolkits`
+//!   - `composio.list_connections`    → `openhuman.composio_list_connections`
+//!   - `composio.authorize`           → `openhuman.composio_authorize`
+//!   - `composio.delete_connection`   → `openhuman.composio_delete_connection`
+//!   - `composio.list_tools`          → `openhuman.composio_list_tools`
+//!   - `composio.execute`             → `openhuman.composio_execute`
+
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use crate::openhuman::config::rpc as config_rpc;
+use crate::rpc::RpcOutcome;
+
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    vec![
+        schemas("list_toolkits"),
+        schemas("list_connections"),
+        schemas("authorize"),
+        schemas("delete_connection"),
+        schemas("list_tools"),
+        schemas("execute"),
+    ]
+}
+
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    vec![
+        RegisteredController {
+            schema: schemas("list_toolkits"),
+            handler: handle_list_toolkits,
+        },
+        RegisteredController {
+            schema: schemas("list_connections"),
+            handler: handle_list_connections,
+        },
+        RegisteredController {
+            schema: schemas("authorize"),
+            handler: handle_authorize,
+        },
+        RegisteredController {
+            schema: schemas("delete_connection"),
+            handler: handle_delete_connection,
+        },
+        RegisteredController {
+            schema: schemas("list_tools"),
+            handler: handle_list_tools,
+        },
+        RegisteredController {
+            schema: schemas("execute"),
+            handler: handle_execute,
+        },
+    ]
+}
+
+pub fn schemas(function: &str) -> ControllerSchema {
+    match function {
+        "list_toolkits" => ControllerSchema {
+            namespace: "composio",
+            function: "list_toolkits",
+            description:
+                "List the Composio toolkits currently enabled on the backend allowlist.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "toolkits",
+                ty: TypeSchema::Array(Box::new(TypeSchema::String)),
+                comment: "Toolkit slugs enabled by the backend (e.g. gmail, notion).",
+                required: true,
+            }],
+        },
+        "list_connections" => ControllerSchema {
+            namespace: "composio",
+            function: "list_connections",
+            description:
+                "List the caller's active Composio OAuth connections filtered to the allowlist.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "connections",
+                ty: TypeSchema::Json,
+                comment: "Array of {id, toolkit, status, createdAt} objects.",
+                required: true,
+            }],
+        },
+        "authorize" => ControllerSchema {
+            namespace: "composio",
+            function: "authorize",
+            description: "Begin an OAuth handoff for a toolkit and return the hosted connect URL.",
+            inputs: vec![FieldSchema {
+                name: "toolkit",
+                ty: TypeSchema::String,
+                comment: "Toolkit slug to authorize (must be in the backend allowlist).",
+                required: true,
+            }],
+            outputs: vec![
+                FieldSchema {
+                    name: "connectUrl",
+                    ty: TypeSchema::String,
+                    comment: "Composio-hosted OAuth URL to open in a browser.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "connectionId",
+                    ty: TypeSchema::String,
+                    comment: "New Composio connection id created by this authorize call.",
+                    required: true,
+                },
+            ],
+        },
+        "delete_connection" => ControllerSchema {
+            namespace: "composio",
+            function: "delete_connection",
+            description: "Delete a Composio connection owned by the caller.",
+            inputs: vec![FieldSchema {
+                name: "connection_id",
+                ty: TypeSchema::String,
+                comment: "Identifier of the connection to delete.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "deleted",
+                ty: TypeSchema::Bool,
+                comment: "True when the backend confirmed the deletion.",
+                required: true,
+            }],
+        },
+        "list_tools" => ControllerSchema {
+            namespace: "composio",
+            function: "list_tools",
+            description:
+                "List OpenAI-function-calling tool schemas for one or more Composio toolkits.",
+            inputs: vec![FieldSchema {
+                name: "toolkits",
+                ty: TypeSchema::Option(Box::new(TypeSchema::Array(Box::new(TypeSchema::String)))),
+                comment: "Optional list of toolkit slugs to filter by. Omit to get all.",
+                required: false,
+            }],
+            outputs: vec![FieldSchema {
+                name: "tools",
+                ty: TypeSchema::Json,
+                comment: "Array of OpenAI function-calling tool schemas.",
+                required: true,
+            }],
+        },
+        "execute" => ControllerSchema {
+            namespace: "composio",
+            function: "execute",
+            description:
+                "Execute a Composio action (tool slug) against a connected account.",
+            inputs: vec![
+                FieldSchema {
+                    name: "tool",
+                    ty: TypeSchema::String,
+                    comment: "Composio action slug, e.g. GMAIL_SEND_EMAIL.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "arguments",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Tool-specific arguments conforming to the tool's JSON schema.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Execution envelope: { data, successful, error?, costUsd }.",
+                required: true,
+            }],
+        },
+        _other => ControllerSchema {
+            namespace: "composio",
+            function: "unknown",
+            description: "Unknown composio controller function.",
+            inputs: vec![FieldSchema {
+                name: "function",
+                ty: TypeSchema::String,
+                comment: "Unknown function requested for schema lookup.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "error",
+                ty: TypeSchema::String,
+                comment: "Lookup error details.",
+                required: true,
+            }],
+        },
+    }
+}
+
+// ── Handlers ────────────────────────────────────────────────────────
+
+fn handle_list_toolkits(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async {
+        let config = config_rpc::load_config_with_timeout().await?;
+        to_json(super::ops::composio_list_toolkits(&config).await?)
+    })
+}
+
+fn handle_list_connections(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async {
+        let config = config_rpc::load_config_with_timeout().await?;
+        to_json(super::ops::composio_list_connections(&config).await?)
+    })
+}
+
+fn handle_authorize(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let toolkit = read_required::<String>(&params, "toolkit")?;
+        to_json(super::ops::composio_authorize(&config, toolkit.trim()).await?)
+    })
+}
+
+fn handle_delete_connection(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let connection_id = read_required::<String>(&params, "connection_id")?;
+        to_json(super::ops::composio_delete_connection(&config, connection_id.trim()).await?)
+    })
+}
+
+fn handle_list_tools(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let toolkits = read_optional::<Vec<String>>(&params, "toolkits")?;
+        to_json(super::ops::composio_list_tools(&config, toolkits).await?)
+    })
+}
+
+fn handle_execute(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let tool = read_required::<String>(&params, "tool")?;
+        let arguments = read_optional::<Value>(&params, "arguments")?;
+        to_json(super::ops::composio_execute(&config, tool.trim(), arguments).await?)
+    })
+}
+
+// ── Param helpers ───────────────────────────────────────────────────
+
+fn read_required<T: DeserializeOwned>(params: &Map<String, Value>, key: &str) -> Result<T, String> {
+    let value = params
+        .get(key)
+        .cloned()
+        .ok_or_else(|| format!("missing required param '{key}'"))?;
+    serde_json::from_value(value).map_err(|e| format!("invalid '{key}': {e}"))
+}
+
+fn read_optional<T: DeserializeOwned>(
+    params: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<T>, String> {
+    match params.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|e| format!("invalid '{key}': {e}")),
+    }
+}
+
+fn to_json<T: serde::Serialize>(outcome: RpcOutcome<T>) -> Result<Value, String> {
+    outcome.into_cli_compatible_json()
+}

--- a/src/openhuman/composio/schemas.rs
+++ b/src/openhuman/composio/schemas.rs
@@ -62,8 +62,7 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "list_toolkits" => ControllerSchema {
             namespace: "composio",
             function: "list_toolkits",
-            description:
-                "List the Composio toolkits currently enabled on the backend allowlist.",
+            description: "List the Composio toolkits currently enabled on the backend allowlist.",
             inputs: vec![],
             outputs: vec![FieldSchema {
                 name: "toolkits",
@@ -148,8 +147,7 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "execute" => ControllerSchema {
             namespace: "composio",
             function: "execute",
-            description:
-                "Execute a Composio action (tool slug) against a connected account.",
+            description: "Execute a Composio action (tool slug) against a connected account.",
             inputs: vec![
                 FieldSchema {
                     name: "tool",

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -21,8 +21,6 @@
 //! the right slug and supply valid arguments without a separate round
 //! trip.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
@@ -343,15 +341,14 @@ pub fn all_composio_agent_tools(
         tracing::debug!("[composio] agent tools not registered — disabled or missing credentials");
         return Vec::new();
     };
-    let client = Arc::new(client);
-    // Each tool gets its own cheap clone of the client handle.
-    let c = (*client).clone();
+    // `ComposioClient` is `Clone` (the inner `IntegrationClient` is Arc'd),
+    // so each tool gets a cheap clone of the handle directly.
     let tools: Vec<Box<dyn Tool>> = vec![
-        Box::new(ComposioListToolkitsTool::new(c.clone())),
-        Box::new(ComposioListConnectionsTool::new(c.clone())),
-        Box::new(ComposioAuthorizeTool::new(c.clone())),
-        Box::new(ComposioListToolsTool::new(c.clone())),
-        Box::new(ComposioExecuteTool::new(c)),
+        Box::new(ComposioListToolkitsTool::new(client.clone())),
+        Box::new(ComposioListConnectionsTool::new(client.clone())),
+        Box::new(ComposioAuthorizeTool::new(client.clone())),
+        Box::new(ComposioListToolsTool::new(client.clone())),
+        Box::new(ComposioExecuteTool::new(client)),
     ];
     tracing::debug!(count = tools.len(), "[composio] agent tools registered");
     tools

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -1,0 +1,361 @@
+//! Agent-facing tools that proxy through the openhuman backend's
+//! `/agent-integrations/composio/*` routes.
+//!
+//! These expose Composio capabilities to the autonomous agent loop
+//! (discovery + execution) and to the CLI/RPC surface via the normal
+//! `Tool` trait plumbing in [`crate::openhuman::tools`].
+//!
+//! The surface is intentionally small and model-friendly:
+//!
+//! | Tool name                     | Purpose                                                     |
+//! | ----------------------------- | ----------------------------------------------------------- |
+//! | `composio_list_toolkits`      | Inspect the server allowlist (e.g. `["gmail", "notion"]`)   |
+//! | `composio_list_connections`   | See which accounts are already connected                    |
+//! | `composio_authorize`          | Start an OAuth handoff for a toolkit, returns `connectUrl`  |
+//! | `composio_list_tools`         | Discover available action slugs + their JSON schemas        |
+//! | `composio_execute`            | Run a Composio action with `{tool, arguments}`              |
+//!
+//! The agent loop is expected to chain `composio_list_tools` →
+//! `composio_execute` when it needs to use a new action. The full schema
+//! is returned in `composio_list_tools`'s output so the model can pick
+//! the right slug and supply valid arguments without a separate round
+//! trip.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+
+use super::client::ComposioClient;
+
+// ── composio_list_toolkits ──────────────────────────────────────────
+
+pub struct ComposioListToolkitsTool {
+    client: ComposioClient,
+}
+
+impl ComposioListToolkitsTool {
+    pub fn new(client: ComposioClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Tool for ComposioListToolkitsTool {
+    fn name(&self) -> &str {
+        "composio_list_toolkits"
+    }
+    fn description(&self) -> &str {
+        "List the Composio toolkits currently enabled on the backend allowlist. \
+         Use this before calling composio_authorize or composio_list_tools to see what \
+         is allowed (e.g. gmail, notion)."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
+    async fn execute(&self, _args: Value) -> anyhow::Result<ToolResult> {
+        tracing::debug!("[composio] tool list_toolkits.execute");
+        match self.client.list_toolkits().await {
+            Ok(resp) => Ok(ToolResult::success(
+                serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
+            )),
+            Err(e) => Ok(ToolResult::error(format!(
+                "composio_list_toolkits failed: {e}"
+            ))),
+        }
+    }
+}
+
+// ── composio_list_connections ───────────────────────────────────────
+
+pub struct ComposioListConnectionsTool {
+    client: ComposioClient,
+}
+
+impl ComposioListConnectionsTool {
+    pub fn new(client: ComposioClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Tool for ComposioListConnectionsTool {
+    fn name(&self) -> &str {
+        "composio_list_connections"
+    }
+    fn description(&self) -> &str {
+        "List the user's active Composio OAuth connections. Each entry has \
+         {id, toolkit, status, createdAt}. Status is typically ACTIVE or CONNECTED."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
+    async fn execute(&self, _args: Value) -> anyhow::Result<ToolResult> {
+        tracing::debug!("[composio] tool list_connections.execute");
+        match self.client.list_connections().await {
+            Ok(resp) => Ok(ToolResult::success(
+                serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
+            )),
+            Err(e) => Ok(ToolResult::error(format!(
+                "composio_list_connections failed: {e}"
+            ))),
+        }
+    }
+}
+
+// ── composio_authorize ──────────────────────────────────────────────
+
+pub struct ComposioAuthorizeTool {
+    client: ComposioClient,
+}
+
+impl ComposioAuthorizeTool {
+    pub fn new(client: ComposioClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Tool for ComposioAuthorizeTool {
+    fn name(&self) -> &str {
+        "composio_authorize"
+    }
+    fn description(&self) -> &str {
+        "Begin an OAuth handoff for a Composio toolkit. Returns a `connectUrl` \
+         the user must open in a browser to authorize the integration, plus the \
+         resulting `connectionId`. The toolkit must be in the backend allowlist."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "toolkit": {
+                    "type": "string",
+                    "description": "Toolkit slug, e.g. 'gmail' or 'notion'."
+                }
+            },
+            "required": ["toolkit"],
+            "additionalProperties": false
+        })
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let toolkit = args
+            .get("toolkit")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if toolkit.is_empty() {
+            return Ok(ToolResult::error("composio_authorize: 'toolkit' is required"));
+        }
+        tracing::debug!(toolkit = %toolkit, "[composio] tool authorize.execute");
+        match self.client.authorize(&toolkit).await {
+            Ok(resp) => {
+                crate::openhuman::event_bus::publish_global(
+                    crate::openhuman::event_bus::DomainEvent::ComposioConnectionCreated {
+                        toolkit: toolkit.clone(),
+                        connection_id: resp.connection_id.clone(),
+                        connect_url: resp.connect_url.clone(),
+                    },
+                );
+                Ok(ToolResult::success(format!(
+                    "Open this URL to connect {toolkit}: {}\n(connectionId: {})",
+                    resp.connect_url, resp.connection_id
+                )))
+            }
+            Err(e) => Ok(ToolResult::error(format!(
+                "composio_authorize failed: {e}"
+            ))),
+        }
+    }
+}
+
+// ── composio_list_tools ─────────────────────────────────────────────
+
+pub struct ComposioListToolsTool {
+    client: ComposioClient,
+}
+
+impl ComposioListToolsTool {
+    pub fn new(client: ComposioClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Tool for ComposioListToolsTool {
+    fn name(&self) -> &str {
+        "composio_list_tools"
+    }
+    fn description(&self) -> &str {
+        "List Composio action tools available through the backend. Pass an optional \
+         `toolkits` array to filter (e.g. [\"gmail\"]). The result is a JSON array of \
+         OpenAI function-calling tool schemas; use the slug from `function.name` as the \
+         `tool` argument when calling `composio_execute`."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "toolkits": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional list of toolkit slugs to filter by."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let toolkits = args
+            .get("toolkits")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            });
+        tracing::debug!(?toolkits, "[composio] tool list_tools.execute");
+        match self.client.list_tools(toolkits.as_deref()).await {
+            Ok(resp) => Ok(ToolResult::success(
+                serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
+            )),
+            Err(e) => Ok(ToolResult::error(format!(
+                "composio_list_tools failed: {e}"
+            ))),
+        }
+    }
+}
+
+// ── composio_execute ────────────────────────────────────────────────
+
+pub struct ComposioExecuteTool {
+    client: ComposioClient,
+}
+
+impl ComposioExecuteTool {
+    pub fn new(client: ComposioClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Tool for ComposioExecuteTool {
+    fn name(&self) -> &str {
+        "composio_execute"
+    }
+    fn description(&self) -> &str {
+        "Execute a Composio action by slug. `tool` is the action slug returned from \
+         composio_list_tools (e.g. 'GMAIL_SEND_EMAIL'); `arguments` is an object that \
+         conforms to that tool's parameter schema. Returns the provider result plus \
+         cost (USD)."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "tool": {
+                    "type": "string",
+                    "description": "Composio action slug, e.g. 'GMAIL_SEND_EMAIL'."
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "Action-specific arguments. Shape depends on the tool."
+                }
+            },
+            "required": ["tool"],
+            "additionalProperties": false
+        })
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        // Some composio actions send emails, create files, etc. — treat
+        // as write-level to respect channel permission caps.
+        PermissionLevel::Write
+    }
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let tool = args
+            .get("tool")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if tool.is_empty() {
+            return Ok(ToolResult::error(
+                "composio_execute: 'tool' is required (e.g. GMAIL_SEND_EMAIL)",
+            ));
+        }
+        let arguments = args.get("arguments").cloned();
+        tracing::debug!(tool = %tool, "[composio] tool execute.execute");
+        let started = std::time::Instant::now();
+        let res = self.client.execute_tool(&tool, arguments.clone()).await;
+        let elapsed_ms = started.elapsed().as_millis() as u64;
+        match res {
+            Ok(resp) => {
+                crate::openhuman::event_bus::publish_global(
+                    crate::openhuman::event_bus::DomainEvent::ComposioActionExecuted {
+                        tool: tool.clone(),
+                        success: resp.successful,
+                        error: resp.error.clone(),
+                        cost_usd: resp.cost_usd,
+                        elapsed_ms,
+                    },
+                );
+                Ok(ToolResult::success(
+                    serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
+                ))
+            }
+            Err(e) => {
+                crate::openhuman::event_bus::publish_global(
+                    crate::openhuman::event_bus::DomainEvent::ComposioActionExecuted {
+                        tool: tool.clone(),
+                        success: false,
+                        error: Some(e.to_string()),
+                        cost_usd: 0.0,
+                        elapsed_ms,
+                    },
+                );
+                Ok(ToolResult::error(format!("composio_execute failed: {e}")))
+            }
+        }
+    }
+}
+
+// ── Bulk registration helper ────────────────────────────────────────
+
+/// Build the full set of composio agent tools when the integrations
+/// client is available and composio is enabled. Returns an empty vec
+/// otherwise so callers can always `.extend(...)` unconditionally.
+pub fn all_composio_agent_tools(
+    config: &crate::openhuman::config::IntegrationsConfig,
+) -> Vec<Box<dyn Tool>> {
+    let Some(client) = super::client::build_composio_client(config) else {
+        tracing::debug!("[composio] agent tools not registered — disabled or missing credentials");
+        return Vec::new();
+    };
+    let client = Arc::new(client);
+    // Each tool gets its own cheap clone of the client handle.
+    let c = (*client).clone();
+    let tools: Vec<Box<dyn Tool>> = vec![
+        Box::new(ComposioListToolkitsTool::new(c.clone())),
+        Box::new(ComposioListConnectionsTool::new(c.clone())),
+        Box::new(ComposioAuthorizeTool::new(c.clone())),
+        Box::new(ComposioListToolsTool::new(c.clone())),
+        Box::new(ComposioExecuteTool::new(c)),
+    ];
+    tracing::debug!(count = tools.len(), "[composio] agent tools registered");
+    tools
+}

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -157,7 +157,9 @@ impl Tool for ComposioAuthorizeTool {
             .trim()
             .to_string();
         if toolkit.is_empty() {
-            return Ok(ToolResult::error("composio_authorize: 'toolkit' is required"));
+            return Ok(ToolResult::error(
+                "composio_authorize: 'toolkit' is required",
+            ));
         }
         tracing::debug!(toolkit = %toolkit, "[composio] tool authorize.execute");
         match self.client.authorize(&toolkit).await {
@@ -174,9 +176,7 @@ impl Tool for ComposioAuthorizeTool {
                     resp.connect_url, resp.connection_id
                 )))
             }
-            Err(e) => Ok(ToolResult::error(format!(
-                "composio_authorize failed: {e}"
-            ))),
+            Err(e) => Ok(ToolResult::error(format!("composio_authorize failed: {e}"))),
         }
     }
 }
@@ -221,14 +221,11 @@ impl Tool for ComposioListToolsTool {
         PermissionLevel::ReadOnly
     }
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
-        let toolkits = args
-            .get("toolkits")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect::<Vec<_>>()
-            });
+        let toolkits = args.get("toolkits").and_then(|v| v.as_array()).map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        });
         tracing::debug!(?toolkits, "[composio] tool list_tools.execute");
         match self.client.list_tools(toolkits.as_deref()).await {
             Ok(resp) => Ok(ToolResult::success(

--- a/src/openhuman/composio/types.rs
+++ b/src/openhuman/composio/types.rs
@@ -1,0 +1,147 @@
+//! Domain types for the Composio integration.
+//!
+//! These mirror the response envelopes emitted by the openhuman backend under
+//! `/agent-integrations/composio/*`. See:
+//!   - `src/routes/agentIntegrations/composio.ts`
+//!   - `src/controllers/agentIntegrations/composio/*.ts`
+//! in the backend repo for the authoritative shapes.
+
+use serde::{Deserialize, Serialize};
+
+// ── Toolkits ────────────────────────────────────────────────────────
+
+/// Response body of `GET /agent-integrations/composio/toolkits`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioToolkitsResponse {
+    /// Server-enforced toolkit allowlist, e.g. `["gmail", "notion"]`.
+    #[serde(default)]
+    pub toolkits: Vec<String>,
+}
+
+// ── Connections ─────────────────────────────────────────────────────
+
+/// One connected Composio account (OAuth integration instance).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioConnection {
+    /// Composio connection id (what you DELETE to disconnect).
+    pub id: String,
+    /// Toolkit slug, e.g. `"gmail"`.
+    pub toolkit: String,
+    /// Connection status — `"ACTIVE"`, `"CONNECTED"`, `"PENDING"`, …
+    pub status: String,
+    /// ISO timestamp (backend passes this through from Composio).
+    #[serde(rename = "createdAt", default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+}
+
+/// Response body of `GET /agent-integrations/composio/connections`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioConnectionsResponse {
+    #[serde(default)]
+    pub connections: Vec<ComposioConnection>,
+}
+
+/// Response body of `POST /agent-integrations/composio/authorize`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioAuthorizeResponse {
+    /// Composio-hosted OAuth URL the user opens in a browser.
+    #[serde(rename = "connectUrl")]
+    pub connect_url: String,
+    /// Composio connection id created by this authorize call.
+    #[serde(rename = "connectionId")]
+    pub connection_id: String,
+}
+
+/// Response body of `DELETE /agent-integrations/composio/connections/:id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioDeleteResponse {
+    #[serde(default)]
+    pub deleted: bool,
+}
+
+// ── Tools ───────────────────────────────────────────────────────────
+
+/// OpenAI function-calling schema returned by the backend for each tool.
+///
+/// The backend wraps Composio's upstream shape; we keep the `type` +
+/// `function` envelope so callers can forward directly into an LLM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioToolSchema {
+    #[serde(rename = "type", default = "default_function_type")]
+    pub kind: String,
+    pub function: ComposioToolFunction,
+}
+
+fn default_function_type() -> String {
+    "function".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioToolFunction {
+    /// Composio action slug, e.g. `"GMAIL_SEND_EMAIL"`.
+    pub name: String,
+    /// Human-readable description shown to the model.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// JSON schema for the tool parameters.
+    #[serde(default)]
+    pub parameters: Option<serde_json::Value>,
+}
+
+/// Response body of `GET /agent-integrations/composio/tools`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioToolsResponse {
+    #[serde(default)]
+    pub tools: Vec<ComposioToolSchema>,
+}
+
+// ── Execute ─────────────────────────────────────────────────────────
+
+/// Response body of `POST /agent-integrations/composio/execute`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioExecuteResponse {
+    /// Raw result from the upstream provider.
+    #[serde(default)]
+    pub data: serde_json::Value,
+    /// Did the provider report success?
+    #[serde(default)]
+    pub successful: bool,
+    /// Provider error message if any.
+    #[serde(default)]
+    pub error: Option<String>,
+    /// Amount charged to the caller (base + margin) in USD.
+    #[serde(rename = "costUsd", default)]
+    pub cost_usd: f64,
+}
+
+// ── Triggers ────────────────────────────────────────────────────────
+
+/// Payload of the `composio:trigger` Socket.IO event emitted by the backend
+/// when a Composio webhook is received, HMAC-verified, and delivered to the
+/// user's active sockets.
+///
+/// See `src/controllers/agentIntegrations/composio/handleWebhook.ts` in the
+/// backend repo.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioTriggerEvent {
+    /// Toolkit slug, e.g. `"gmail"`.
+    #[serde(default)]
+    pub toolkit: String,
+    /// Trigger slug, e.g. `"GMAIL_NEW_GMAIL_MESSAGE"`.
+    #[serde(default)]
+    pub trigger: String,
+    /// Trigger-specific payload (provider-defined shape).
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    /// Metadata the backend attaches: `{ id, uuid }`.
+    #[serde(default)]
+    pub metadata: ComposioTriggerMetadata,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioTriggerMetadata {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub uuid: String,
+}

--- a/src/openhuman/config/schema/tools.rs
+++ b/src/openhuman/config/schema/tools.rs
@@ -285,4 +285,11 @@ pub struct IntegrationsConfig {
     /// Parallel web search & content extraction integration.
     #[serde(default)]
     pub parallel: IntegrationToggle,
+
+    /// Composio 1000+ app integrations proxied via the backend
+    /// (`/agent-integrations/composio/*`). When enabled, agents can
+    /// list toolkits, authorize OAuth connections, list/execute actions,
+    /// and receive trigger events over the Socket.IO bridge.
+    #[serde(default)]
+    pub composio: IntegrationToggle,
 }

--- a/src/openhuman/event_bus/events.rs
+++ b/src/openhuman/event_bus/events.rs
@@ -187,6 +187,36 @@ pub enum DomainEvent {
         error: Option<String>,
     },
 
+    // ── Composio ────────────────────────────────────────────────────────
+    /// A Composio trigger webhook arrived via the backend socket.io bridge
+    /// and is ready for domain-specific dispatch.
+    ComposioTriggerReceived {
+        /// Toolkit slug, e.g. `"gmail"`.
+        toolkit: String,
+        /// Trigger slug, e.g. `"GMAIL_NEW_GMAIL_MESSAGE"`.
+        trigger: String,
+        /// Composio trigger event id (from backend metadata.id).
+        metadata_id: String,
+        /// Composio trigger UUID (from backend metadata.uuid).
+        metadata_uuid: String,
+        /// Provider-specific trigger payload.
+        payload: serde_json::Value,
+    },
+    /// A Composio connection OAuth handoff was initiated (connectUrl returned).
+    ComposioConnectionCreated {
+        toolkit: String,
+        connection_id: String,
+        connect_url: String,
+    },
+    /// A Composio action was executed (success or failure) via the backend.
+    ComposioActionExecuted {
+        tool: String,
+        success: bool,
+        error: Option<String>,
+        cost_usd: f64,
+        elapsed_ms: u64,
+    },
+
     // ── Tree Summarizer ──────────────────────────────────────────────────
     /// An hour leaf was created from buffered data.
     TreeSummarizerHourCompleted {
@@ -258,6 +288,10 @@ impl DomainEvent {
             | Self::WebhookRegistered { .. }
             | Self::WebhookUnregistered { .. }
             | Self::WebhookProcessed { .. } => "webhook",
+
+            Self::ComposioTriggerReceived { .. }
+            | Self::ComposioConnectionCreated { .. }
+            | Self::ComposioActionExecuted { .. } => "composio",
 
             Self::TreeSummarizerHourCompleted { .. }
             | Self::TreeSummarizerPropagated { .. }

--- a/src/openhuman/event_bus/events.rs
+++ b/src/openhuman/event_bus/events.rs
@@ -573,6 +573,35 @@ mod tests {
                 },
                 "webhook",
             ),
+            // Composio
+            (
+                DomainEvent::ComposioTriggerReceived {
+                    toolkit: "gmail".into(),
+                    trigger: "GMAIL_NEW_GMAIL_MESSAGE".into(),
+                    metadata_id: "trig-1".into(),
+                    metadata_uuid: "uuid-1".into(),
+                    payload: serde_json::Value::Null,
+                },
+                "composio",
+            ),
+            (
+                DomainEvent::ComposioConnectionCreated {
+                    toolkit: "gmail".into(),
+                    connection_id: "conn-1".into(),
+                    connect_url: "https://backend.composio.dev/connect/abc".into(),
+                },
+                "composio",
+            ),
+            (
+                DomainEvent::ComposioActionExecuted {
+                    tool: "GMAIL_SEND_EMAIL".into(),
+                    success: true,
+                    error: None,
+                    cost_usd: 0.0,
+                    elapsed_ms: 123,
+                },
+                "composio",
+            ),
             // Tree Summarizer
             (
                 DomainEvent::TreeSummarizerHourCompleted {

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -22,6 +22,7 @@ pub mod approval;
 pub mod autocomplete;
 pub mod billing;
 pub mod channels;
+pub mod composio;
 pub mod config;
 pub mod cost;
 pub mod credentials;

--- a/src/openhuman/socket/event_handlers.rs
+++ b/src/openhuman/socket/event_handlers.rs
@@ -113,47 +113,34 @@ pub(super) fn handle_sio_event(
             }
         }
         // Composio trigger webhook — backend emits this after HMAC-verifying
-        // an incoming Composio webhook. Publish to the event bus so the
-        // composio domain (and any future subscribers) can react.
+        // an incoming Composio webhook. Deserialize into the canonical
+        // `ComposioTriggerEvent` DTO so shape mismatches fail fast with a
+        // clear log line instead of being silently coerced to empty strings.
         "composio:trigger" => {
             log::info!("[socket] Publishing composio:trigger to event bus");
-            let toolkit = data
-                .get("toolkit")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let trigger = data
-                .get("trigger")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let payload = data
-                .get("payload")
-                .cloned()
-                .unwrap_or(serde_json::Value::Null);
-            let metadata_id = data
-                .get("metadata")
-                .and_then(|m| m.get("id"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let metadata_uuid = data
-                .get("metadata")
-                .and_then(|m| m.get("uuid"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-
-            if toolkit.is_empty() || trigger.is_empty() {
-                log::warn!("[socket] composio:trigger missing toolkit/trigger; dropping event");
-            } else {
-                publish_global(DomainEvent::ComposioTriggerReceived {
-                    toolkit,
-                    trigger,
-                    metadata_id,
-                    metadata_uuid,
-                    payload,
-                });
+            match serde_json::from_value::<crate::openhuman::composio::ComposioTriggerEvent>(
+                data.clone(),
+            ) {
+                Ok(event) => {
+                    if event.toolkit.is_empty() || event.trigger.is_empty() {
+                        log::warn!(
+                            "[socket] composio:trigger missing toolkit/trigger; dropping event"
+                        );
+                    } else {
+                        publish_global(DomainEvent::ComposioTriggerReceived {
+                            toolkit: event.toolkit,
+                            trigger: event.trigger,
+                            metadata_id: event.metadata.id,
+                            metadata_uuid: event.metadata.uuid,
+                            payload: event.payload,
+                        });
+                    }
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[socket] failed to parse composio:trigger payload: {e}; dropping event"
+                    );
+                }
             }
         }
         // Channel inbound message — publish to event bus for ChannelInboundSubscriber

--- a/src/openhuman/socket/event_handlers.rs
+++ b/src/openhuman/socket/event_handlers.rs
@@ -112,6 +112,52 @@ pub(super) fn handle_sio_event(
                 }
             }
         }
+        // Composio trigger webhook — backend emits this after HMAC-verifying
+        // an incoming Composio webhook. Publish to the event bus so the
+        // composio domain (and any future subscribers) can react.
+        "composio:trigger" => {
+            log::info!("[socket] Publishing composio:trigger to event bus");
+            let toolkit = data
+                .get("toolkit")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let trigger = data
+                .get("trigger")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let payload = data
+                .get("payload")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            let metadata_id = data
+                .get("metadata")
+                .and_then(|m| m.get("id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let metadata_uuid = data
+                .get("metadata")
+                .and_then(|m| m.get("uuid"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            if toolkit.is_empty() || trigger.is_empty() {
+                log::warn!(
+                    "[socket] composio:trigger missing toolkit/trigger; dropping event"
+                );
+            } else {
+                publish_global(DomainEvent::ComposioTriggerReceived {
+                    toolkit,
+                    trigger,
+                    metadata_id,
+                    metadata_uuid,
+                    payload,
+                });
+            }
+        }
         // Channel inbound message — publish to event bus for ChannelInboundSubscriber
         _ if event_name.ends_with(":message") => {
             log::info!(

--- a/src/openhuman/socket/event_handlers.rs
+++ b/src/openhuman/socket/event_handlers.rs
@@ -145,9 +145,7 @@ pub(super) fn handle_sio_event(
                 .to_string();
 
             if toolkit.is_empty() || trigger.is_empty() {
-                log::warn!(
-                    "[socket] composio:trigger missing toolkit/trigger; dropping event"
-                );
+                log::warn!("[socket] composio:trigger missing toolkit/trigger; dropping event");
             } else {
                 publish_global(DomainEvent::ComposioTriggerReceived {
                     toolkit,

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -234,6 +234,22 @@ pub fn all_tools_with_runtime(
         } else {
             tracing::debug!("[integrations] twilio disabled — skipping");
         }
+
+        // Composio — backend-proxied 1000+ OAuth integrations. Registers
+        // five agent tools (list_toolkits, list_connections, authorize,
+        // list_tools, execute) when the composio toggle is on. See
+        // `src/openhuman/composio/tools.rs` for per-tool details.
+        let composio_tools =
+            crate::openhuman::composio::all_composio_agent_tools(&root_config.integrations);
+        if !composio_tools.is_empty() {
+            tracing::debug!(
+                count = composio_tools.len(),
+                "[integrations] registered composio tools"
+            );
+            tools.extend(composio_tools);
+        } else {
+            tracing::debug!("[integrations] composio disabled — skipping");
+        }
     } else {
         tracing::debug!(
             "[integrations] build_client returned None — integration tools not registered"


### PR DESCRIPTION
## Summary

- New `openhuman::composio` Rust domain module with RPC controllers (`openhuman.composio_list_toolkits`, `_list_connections`, `_authorize`, `_delete_connection`, `_list_tools`, `_execute`), backend-proxied through the shared `IntegrationClient` — no Composio API key on the client.
- Five agent-callable tools (`composio_list_toolkits`, `composio_list_connections`, `composio_authorize`, `composio_list_tools`, `composio_execute`) registered in the tool registry when `integrations.composio.enabled` is set.
- Socket.IO transport now routes `composio:trigger` events from the backend into the event bus as `DomainEvent::ComposioTriggerReceived`, with a `ComposioTriggerSubscriber` registered at startup in both `channels::runtime::startup` and `core::jsonrpc` bootstrap.
- Frontend Skills page gains a parallel surface: composio toolkits (Gmail, Notion, GitHub, Slack, …) render as `UnifiedSkillCard`s in the same grid as regular skills, grouped by category. Click → `ComposioConnectModal` → `openhuman.composio_authorize` → opens Composio OAuth URL via `@tauri-apps/plugin-opener` → polls `composio_list_connections` → flips to "Connected" state.
- Three debug scripts: `scripts/debug-composio-login.sh` (curl + jq OAuth flow), `scripts/debug-composio-trigger.mjs` (Node socket.io listener with catchall + heartbeat + diagnostic checklist).

## Problem

The core had a monolithic `tools/composio.rs` that called Composio's v2/v3 API directly with `x-api-key`, bypassing the backend's allowlist, billing/margin, HMAC webhook pipeline, and trigger fan-out. The backend team shipped `/agent-integrations/composio/*` routes (PR https://github.com/tinyhumansai/backend/pull/625) but nothing in the core or UI consumed them, so users couldn't authorize toolkits, receive trigger events, or see connection state.

## Solution

### Rust core
- New `src/openhuman/composio/` domain module following the `cron` module template (`mod.rs` light, `types.rs`, `client.rs`, `ops.rs`, `schemas.rs`, `bus.rs`, `tools.rs`).
- `ComposioClient` wraps `IntegrationClient` for GET/POST and adds a bespoke `raw_delete` helper because the shared client doesn't expose DELETE.
- `DomainEvent` enum extended with `ComposioTriggerReceived`, `ComposioConnectionCreated`, `ComposioActionExecuted`; `domain()` match arm returns `"composio"`.
- `socket::event_handlers::handle_sio_event` parses `composio:trigger` payloads (`toolkit`, `trigger`, `metadata.id/uuid`, `payload`) and publishes to the global bus.
- `IntegrationsConfig` gains a `composio: IntegrationToggle` field; everything downstream keys off it.
- Controllers registered in `core::all::build_registered_controllers` and `build_declared_controller_schemas`; namespace description added.

### Frontend
- `app/src/lib/composio/{types,composioApi,hooks}.ts` mirror `lib/skills/skillsApi.ts` shape.
- `useComposioIntegrations()` fetches toolkits + connections on mount, polls connections every 5s, derives a `connectionByToolkit` Map, detects the "composio disabled" error and short-circuits.
- `ComposioConnectModal` portal-based, state machine `idle → authorizing → waiting → connected / error`, reuses `openUrl()` for Tauri-aware OAuth handoff, polls with 5-minute timeout, supports Disconnect.
- `Skills.tsx` appends composio items with `kind: 'composio'` to the unified grid; toolkit metadata (display name, description, category, emoji) lives in `components/composio/toolkitMeta.ts` with a title-cased fallback for unknown slugs so new backend entries render automatically.

### Debug tooling
- `scripts/debug-composio-login.sh` — pure bash + curl + jq. Walks the OAuth flow: `/toolkits` → `/connections` → `/authorize` → poll → `/tools` → optional `/execute`.
- `scripts/debug-composio-trigger.mjs` — Node script using the `socket.io-client` from the app workspace. Resolves JWT from env or `openhuman-core auth get_session_token`, verifies the gmail connection is ACTIVE, opens a socket.io client against the backend with the same options the Rust `SocketManager` uses, attaches an always-on `onAny` catchall, prints a heartbeat idle log every 15s when no traffic has arrived in 30s+, and on zero events exits with a diagnostic checklist that pinpoints userId mismatch vs silent socket drop vs backend-side drop.

## Submission Checklist

- [x] **Unit tests** — `cargo test --lib openhuman::composio` (2 subscriber tests), `core::all` registry validation (schemas ↔ handlers paired), `event_bus` domain match arms.
- [x] **E2E / integration** — Real end-to-end verification via `scripts/debug-composio-login.sh` against staging (Gmail OAuth succeeded, connection flipped to ACTIVE) and `scripts/debug-composio-trigger.mjs` (socket listener confirmed working once a separate backend bug in `handleWebhook.ts` v2/v3 payload destructure was fixed — see "Impact" below).
- [x] **Doc comments** — Module-level `//!` headers on every new Rust file, JSDoc on every exported TS symbol and every script.
- [x] **Inline comments** — Event-bus routing, connection-status derivation priority, catchall rationale, and the three-way diagnostic checklist in the trigger script all carry inline explanations.

## Impact

- **Runtime**: Desktop. Composio integration is gated behind `integrations.enabled && integrations.composio.enabled`; zero impact if unset. The legacy `tools/composio.rs` direct-API path is left in place for backwards compatibility and is only wired when `config.composio.api_key` is set, so existing users don't regress.
- **Security**: Composio API key stays on the backend; the client never sees it. All HTTP calls flow through the existing `IntegrationClient` with Bearer JWT auth.
- **Billing**: `composio_execute` charges through the backend's existing pricing pipeline; cost is returned in the response and logged via `ComposioActionExecuted` events.
- **Debugging a backend drop we hit**: while validating the trigger flow end-to-end we found that backend-1's `src/controllers/agentIntegrations/composio/handleWebhook.ts` destructures `verified.payload.userId` assuming the Composio v2 shape, but v3 webhooks (which Composio is now delivering) put the user identifier under a different key. The emit silently early-returns with `delivered: false`. The diagnostic script's catchall + checklist now guides future debuggers straight to this class of issue. **A follow-up PR on backend-1 is needed** to shape-tolerate the destructure — details in the trigger script's exit message and the session history.

## Related

- Backend PR: tinyhumansai/backend#625
- Follow-ups:
  - Backend: v2/v3 payload shape compatibility in `handleWebhook.ts` + permanent `matched_sockets=N` log line.
  - Frontend: per-tool playground in `ComposioConnectModal` (the `listTools`/`execute` RPCs are already wired in `composioApi.ts`).
  - Toolkit catalog: replace emoji icons in `toolkitMeta.ts` with SVGs and expand beyond the initial 7 entries.
  - Delete the legacy `src/openhuman/tools/composio.rs` once all users have migrated off the direct-API path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composio integration: connect OAuth accounts to hundreds of third‑party apps.
  * Manage connections via a new in‑app modal from the Skills page (authorize, view status, disconnect).
  * Toolkits appear in Skills with connection status indicators and CTA to open the connect modal.
  * Agents can list/execute Composio tools and receive realtime trigger events from connected services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->