### PR TITLE
Move conversation persistence into workspace memory store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,7 +5082,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.52.3"
+version = "0.52.4"
 dependencies = [
  "env_logger",
  "log",

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -24,9 +24,11 @@ import { selectSocketStatus } from '../store/socketSelectors';
 import {
   addInferenceResponse,
   addMessageLocal,
-  addReaction,
   createThreadLocal,
   fetchSuggestedQuestions,
+  loadThreadMessages,
+  loadThreads,
+  persistReaction,
   setActiveThread,
   setLastViewed,
   setSelectedThread,
@@ -160,7 +162,6 @@ const Conversations = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const {
-    threads,
     selectedThreadId,
     messages,
     isLoadingMessages,
@@ -273,25 +274,28 @@ const Conversations = () => {
     typeof navigator.mediaDevices.getUserMedia === 'function';
 
   useEffect(() => {
-    const defaultThread = threads.find(t => t.id === DEFAULT_THREAD_ID);
-
-    if (!defaultThread) {
-      dispatch(
-        createThreadLocal({
-          id: DEFAULT_THREAD_ID,
-          title: DEFAULT_THREAD_TITLE,
-          createdAt: new Date().toISOString(),
-        })
-      );
-    }
-
-    // Always set selected thread to ensure messages view is synced from persisted storage
-    dispatch(setSelectedThread(DEFAULT_THREAD_ID));
+    void dispatch(loadThreads());
+    void dispatch(
+      createThreadLocal({
+        id: DEFAULT_THREAD_ID,
+        title: DEFAULT_THREAD_TITLE,
+        createdAt: new Date().toISOString(),
+      })
+    ).then(() => {
+      dispatch(setSelectedThread(DEFAULT_THREAD_ID));
+      void dispatch(loadThreadMessages(DEFAULT_THREAD_ID));
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
   useEffect(() => {
     if (selectedThreadId) dispatch(setLastViewed(selectedThreadId));
+  }, [selectedThreadId, dispatch]);
+
+  useEffect(() => {
+    if (selectedThreadId) {
+      void dispatch(loadThreadMessages(selectedThreadId));
+    }
   }, [selectedThreadId, dispatch]);
 
   useEffect(() => {
@@ -483,8 +487,8 @@ const Conversations = () => {
         if (event.reaction_emoji) {
           const pending = pendingReactionRef.current.get(event.thread_id);
           if (pending) {
-            dispatch(
-              addReaction({
+            void dispatch(
+              persistReaction({
                 threadId: pending.threadId,
                 messageId: pending.msgId,
                 emoji: event.reaction_emoji,
@@ -519,8 +523,8 @@ const Conversations = () => {
         if (event.reaction_emoji) {
           const pending = pendingReactionRef.current.get(event.thread_id);
           if (pending) {
-            dispatch(
-              addReaction({
+            void dispatch(
+              persistReaction({
                 threadId: pending.threadId,
                 messageId: pending.msgId,
                 emoji: event.reaction_emoji,
@@ -633,7 +637,7 @@ const Conversations = () => {
         if (!gifUrl) return;
 
         console.debug('[conversations:gif] sending gif:', picked.title || picked.id);
-        dispatch(addInferenceResponse({ content: gifUrl, threadId }));
+        void dispatch(addInferenceResponse({ content: gifUrl, threadId, type: 'gif' }));
       })
       .catch(err => {
         console.debug('[conversations:gif] failed:', err);
@@ -706,7 +710,7 @@ const Conversations = () => {
       createdAt: new Date().toISOString(),
     };
 
-    dispatch(addMessageLocal({ threadId: sendingThreadId, message: userMessage }));
+    void dispatch(addMessageLocal({ threadId: sendingThreadId, message: userMessage }));
     pendingReactionRef.current.set(sendingThreadId, {
       msgId: userMessage.id,
       content: trimmed,
@@ -1083,8 +1087,8 @@ const Conversations = () => {
                               key={emoji}
                               onClick={() =>
                                 selectedThreadId &&
-                                dispatch(
-                                  addReaction({
+                                void dispatch(
+                                  persistReaction({
                                     threadId: selectedThreadId,
                                     messageId: msg.id,
                                     emoji,
@@ -1104,8 +1108,8 @@ const Conversations = () => {
                                     key={emoji}
                                     onClick={() => {
                                       if (selectedThreadId) {
-                                        dispatch(
-                                          addReaction({
+                                        void dispatch(
+                                          persistReaction({
                                             threadId: selectedThreadId,
                                             messageId: msg.id,
                                             emoji,

--- a/app/src/services/api/threadApi.test.ts
+++ b/app/src/services/api/threadApi.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCallCoreRpc = vi.fn();
+
+vi.mock('../coreRpcClient', () => ({
+  callCoreRpc: (...args: unknown[]) => mockCallCoreRpc(...args),
+}));
+
+describe('threadApi', () => {
+  beforeEach(() => {
+    mockCallCoreRpc.mockReset();
+  });
+
+  it('loads threads from the memory RPC store', async () => {
+    mockCallCoreRpc.mockResolvedValueOnce({
+      data: {
+        threads: [
+          {
+            id: 'default-thread',
+            title: 'Conversation',
+            chatId: null,
+            isActive: true,
+            messageCount: 2,
+            lastMessageAt: '2026-04-10T12:01:00Z',
+            createdAt: '2026-04-10T12:00:00Z',
+          },
+        ],
+        count: 1,
+      },
+    });
+
+    const { threadApi } = await import('./threadApi');
+    const result = await threadApi.getThreads();
+
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({ method: 'openhuman.memory_threads_list' });
+    expect(result.count).toBe(1);
+    expect(result.threads[0].id).toBe('default-thread');
+  });
+
+  it('appends a message via memory RPC', async () => {
+    const message = {
+      id: 'm1',
+      content: 'hello',
+      type: 'text',
+      extraMetadata: {},
+      sender: 'user' as const,
+      createdAt: '2026-04-10T12:01:00Z',
+    };
+    mockCallCoreRpc.mockResolvedValueOnce({ data: message });
+
+    const { threadApi } = await import('./threadApi');
+    const result = await threadApi.appendMessage('default-thread', message);
+
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.memory_message_append',
+      params: { thread_id: 'default-thread', message },
+    });
+    expect(result).toEqual(message);
+  });
+});

--- a/app/src/services/api/threadApi.ts
+++ b/app/src/services/api/threadApi.ts
@@ -1,5 +1,3 @@
-import { callCoreRpc } from '../coreRpcClient';
-
 import type {
   PurgeResultData,
   Thread,
@@ -9,6 +7,7 @@ import type {
   ThreadMessagesData,
   ThreadsListData,
 } from '../../types/thread';
+import { callCoreRpc } from '../coreRpcClient';
 
 interface Envelope<T> {
   data?: T;
@@ -36,11 +35,7 @@ export const threadApi = {
   }): Promise<ThreadCreateData> => {
     const response = await callCoreRpc<Envelope<Thread>>({
       method: 'openhuman.memory_thread_upsert',
-      params: {
-        id: input.id,
-        title: input.title,
-        created_at: input.createdAt,
-      },
+      params: { id: input.id, title: input.title, created_at: input.createdAt },
     });
     const thread = unwrapEnvelope(response);
     return { id: thread.id };

--- a/app/src/services/api/threadApi.ts
+++ b/app/src/services/api/threadApi.ts
@@ -1,87 +1,91 @@
-import { isTauri as coreIsTauri } from '@tauri-apps/api/core';
+import { callCoreRpc } from '../coreRpcClient';
 
-import type { ApiResponse } from '../../types/api';
-import type { OutboundRoute } from '../../types/channels';
 import type {
-  PurgeRequestBody,
   PurgeResultData,
-  SendMessageResponseData,
-  SuggestQuestionsData,
+  Thread,
   ThreadCreateData,
   ThreadDeleteData,
+  ThreadMessage,
   ThreadMessagesData,
   ThreadsListData,
 } from '../../types/thread';
-import { openhumanAgentChat } from '../../utils/tauriCommands';
-import { apiClient } from '../apiClient';
+
+interface Envelope<T> {
+  data?: T;
+}
+
+function unwrapEnvelope<T>(response: Envelope<T> | T): T {
+  if (response && typeof response === 'object' && 'data' in response) {
+    return (response as Envelope<T>).data as T;
+  }
+  return response as T;
+}
 
 export const threadApi = {
-  /** GET /threads — list all threads for the authenticated user */
   getThreads: async (): Promise<ThreadsListData> => {
-    const response = await apiClient.get<ApiResponse<ThreadsListData>>('/threads');
-    return response.data;
+    const response = await callCoreRpc<Envelope<ThreadsListData>>({
+      method: 'openhuman.memory_threads_list',
+    });
+    return unwrapEnvelope(response);
   },
 
-  /** POST /threads — create a new thread */
-  createThread: async (chatId?: number): Promise<ThreadCreateData> => {
-    const response = await apiClient.post<ApiResponse<ThreadCreateData>>(
-      '/threads',
-      chatId != null ? { chatId } : undefined
-    );
-    return response.data;
+  createThread: async (input: {
+    id: string;
+    title: string;
+    createdAt: string;
+  }): Promise<ThreadCreateData> => {
+    const response = await callCoreRpc<Envelope<Thread>>({
+      method: 'openhuman.memory_thread_upsert',
+      params: {
+        id: input.id,
+        title: input.title,
+        created_at: input.createdAt,
+      },
+    });
+    const thread = unwrapEnvelope(response);
+    return { id: thread.id };
   },
 
-  /** GET /threads/:threadId/messages — get messages for a thread */
   getThreadMessages: async (threadId: string): Promise<ThreadMessagesData> => {
-    const response = await apiClient.get<ApiResponse<ThreadMessagesData>>(
-      `/threads/${encodeURIComponent(threadId)}/messages`
-    );
-    return response.data;
+    const response = await callCoreRpc<Envelope<ThreadMessagesData>>({
+      method: 'openhuman.memory_messages_list',
+      params: { thread_id: threadId },
+    });
+    return unwrapEnvelope(response);
   },
 
-  /** DELETE /threads/:threadId — delete a single thread */
+  appendMessage: async (threadId: string, message: ThreadMessage): Promise<ThreadMessage> => {
+    const response = await callCoreRpc<Envelope<ThreadMessage>>({
+      method: 'openhuman.memory_message_append',
+      params: { thread_id: threadId, message },
+    });
+    return unwrapEnvelope(response);
+  },
+
+  updateMessage: async (
+    threadId: string,
+    messageId: string,
+    extraMetadata: Record<string, unknown>
+  ): Promise<ThreadMessage> => {
+    const response = await callCoreRpc<Envelope<ThreadMessage>>({
+      method: 'openhuman.memory_message_update',
+      params: { thread_id: threadId, message_id: messageId, extra_metadata: extraMetadata },
+    });
+    return unwrapEnvelope(response);
+  },
+
   deleteThread: async (threadId: string): Promise<ThreadDeleteData> => {
-    const response = await apiClient.delete<ApiResponse<ThreadDeleteData>>(
-      `/threads/${encodeURIComponent(threadId)}`
-    );
-    return response.data;
+    const response = await callCoreRpc<Envelope<ThreadDeleteData>>({
+      method: 'openhuman.memory_thread_delete',
+      params: { thread_id: threadId, deleted_at: new Date().toISOString() },
+    });
+    return unwrapEnvelope(response);
   },
 
-  /** POST /chat/sendMessage — send a user message (context injection done by caller) */
-  sendMessage: async (
-    message: string,
-    conversationId: string,
-    route?: OutboundRoute
-  ): Promise<SendMessageResponseData> => {
-    if (coreIsTauri()) {
-      const response = await openhumanAgentChat(message);
-      return { response: response.result, conversationId, route };
-    }
-
-    const response = await apiClient.post<ApiResponse<SendMessageResponseData>>(
-      '/chat/sendMessage',
-      {
-        message,
-        conversationId,
-        ...(route ? { channel: route.channel, channelAuthMode: route.authMode } : {}),
-      }
-    );
-    return response.data;
-  },
-
-  /** GET /chat/autocomplete — suggested starter questions (e.g. for a new/empty thread) */
-  getSuggestQuestions: async (conversationId?: string): Promise<SuggestQuestionsData> => {
-    const url =
-      conversationId != null
-        ? `/chat/autocomplete?conversationId=${encodeURIComponent(conversationId)}`
-        : '/chat/autocomplete';
-    const response = await apiClient.get<ApiResponse<SuggestQuestionsData>>(url);
-    return response.data;
-  },
-
-  /** POST /purge — purge messages and/or threads */
-  purge: async (body: PurgeRequestBody): Promise<PurgeResultData> => {
-    const response = await apiClient.post<ApiResponse<PurgeResultData>>('/purge', body);
-    return response.data;
+  purge: async (): Promise<PurgeResultData> => {
+    const response = await callCoreRpc<Envelope<PurgeResultData>>({
+      method: 'openhuman.memory_threads_purge',
+    });
+    return unwrapEnvelope(response);
   },
 };

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -17,15 +17,6 @@ import channelConnectionsReducer from './channelConnectionsSlice';
 import socketReducer from './socketSlice';
 import threadReducer from './threadSlice';
 
-// Persist config for thread data and UI prefs (includes threads and messages)
-// Note: activeThreadId is intentionally excluded as it's transient state
-const threadPersistConfig = {
-  key: 'thread',
-  storage,
-  whitelist: ['panelWidth', 'lastViewedAt', 'threads', 'messagesByThreadId', 'selectedThreadId'],
-};
-
-const persistedThreadReducer = persistReducer(threadPersistConfig, threadReducer);
 const channelConnectionsPersistConfig = {
   key: 'channelConnections',
   storage,
@@ -39,7 +30,7 @@ const persistedChannelConnectionsReducer = persistReducer(
 export const store = configureStore({
   reducer: {
     socket: socketReducer,
-    thread: persistedThreadReducer,
+    thread: threadReducer,
     channelConnections: persistedChannelConnectionsReducer,
   },
   middleware: getDefaultMiddleware => {

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -83,13 +83,16 @@ function replaceMessagesForThread(state: ThreadState, threadId: string, messages
   }
 }
 
-export const loadThreads = createAsyncThunk('thread/loadThreads', async (_, { rejectWithValue }) => {
-  try {
-    return await threadApi.getThreads();
-  } catch (error) {
-    return rejectWithValue(error instanceof Error ? error.message : 'Failed to load threads');
+export const loadThreads = createAsyncThunk(
+  'thread/loadThreads',
+  async (_, { rejectWithValue }) => {
+    try {
+      return await threadApi.getThreads();
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to load threads');
+    }
   }
-});
+);
 
 export const createThreadLocal = createAsyncThunk(
   'thread/createThreadLocal',
@@ -121,10 +124,7 @@ export const loadThreadMessages = createAsyncThunk(
 
 export const addMessageLocal = createAsyncThunk(
   'thread/addMessageLocal',
-  async (
-    payload: { threadId: string; message: ThreadMessage },
-    { rejectWithValue }
-  ) => {
+  async (payload: { threadId: string; message: ThreadMessage }, { rejectWithValue }) => {
     try {
       const persisted = await threadApi.appendMessage(payload.threadId, payload.message);
       return { threadId: payload.threadId, message: persisted };
@@ -179,7 +179,8 @@ export const persistReaction = createAsyncThunk(
 
     const prev = (message.extraMetadata['myReactions'] as string[] | undefined) ?? [];
     const idx = prev.indexOf(payload.emoji);
-    const next = idx >= 0 ? prev.filter(entry => entry !== payload.emoji) : [...prev, payload.emoji];
+    const next =
+      idx >= 0 ? prev.filter(entry => entry !== payload.emoji) : [...prev, payload.emoji];
     const extraMetadata = { ...message.extraMetadata, myReactions: next };
 
     try {

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -1,28 +1,20 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
-import { resolveOutboundRoute } from '../lib/channels/routing';
 import { threadApi } from '../services/api/threadApi';
-import type { ChannelConnectionsState } from '../types/channels';
 import type { Thread, ThreadMessage } from '../types/thread';
 import { isTauri, openhumanLocalAiSuggestQuestions } from '../utils/tauriCommands';
 
 interface ThreadState {
-  // Existing local data (will be persisted)
   threads: Thread[];
   selectedThreadId: string | null;
   panelWidth: number;
   lastViewedAt: Record<string, number>;
-  activeThreadId: string | null; // Track which thread is currently sending/receiving
-
-  // NEW: Add efficient message storage
+  activeThreadId: string | null;
   messagesByThreadId: Record<string, ThreadMessage[]>;
-
-  // Current messages view (not persisted)
   messages: ThreadMessage[];
-
-  // Keep these API states (NOT persisted)
-  isLoadingMessages: boolean; // For AI response waiting
-  messagesError: string | null; // For send API errors
+  isLoadingThreads: boolean;
+  isLoadingMessages: boolean;
+  messagesError: string | null;
   sendStatus: 'idle' | 'loading' | 'success' | 'error';
   sendError: string | null;
   deleteStatus: 'idle' | 'loading' | 'success' | 'error';
@@ -40,6 +32,7 @@ const initialState: ThreadState = {
   activeThreadId: null,
   messagesByThreadId: {},
   messages: [],
+  isLoadingThreads: false,
   isLoadingMessages: false,
   messagesError: null,
   sendStatus: 'idle',
@@ -51,77 +44,166 @@ const initialState: ThreadState = {
   suggestError: null,
 };
 
-// Removed fetchThreads - threads are now managed locally
+function appendMessageToCache(
+  state: ThreadState,
+  threadId: string,
+  message: ThreadMessage,
+  replaceExisting = false
+) {
+  const existing = state.messagesByThreadId[threadId] ?? [];
+  const nextStored = replaceExisting
+    ? existing.map(entry => (entry.id === message.id ? message : entry))
+    : [...existing, message];
+  state.messagesByThreadId[threadId] = nextStored;
 
-// Removed fetchThreadMessages - messages are now managed locally
+  if (threadId === state.selectedThreadId) {
+    state.messages = replaceExisting
+      ? state.messages.map(entry => (entry.id === message.id ? message : entry))
+      : [...state.messages, message];
+  }
 
-// Removed createThread - using local thread creation
+  const thread = state.threads.find(entry => entry.id === threadId);
+  if (thread) {
+    thread.messageCount = nextStored.length;
+    thread.lastMessageAt =
+      nextStored.length > 0 ? nextStored[nextStored.length - 1].createdAt : thread.createdAt;
+  }
+}
 
-// Removed deleteThread - using local thread deletion
+function replaceMessagesForThread(state: ThreadState, threadId: string, messages: ThreadMessage[]) {
+  state.messagesByThreadId[threadId] = messages;
+  if (threadId === state.selectedThreadId) {
+    state.messages = messages;
+  }
+  const thread = state.threads.find(entry => entry.id === threadId);
+  if (thread) {
+    thread.messageCount = messages.length;
+    thread.lastMessageAt =
+      messages.length > 0 ? messages[messages.length - 1].createdAt : thread.createdAt;
+  }
+}
+
+export const loadThreads = createAsyncThunk('thread/loadThreads', async (_, { rejectWithValue }) => {
+  try {
+    return await threadApi.getThreads();
+  } catch (error) {
+    return rejectWithValue(error instanceof Error ? error.message : 'Failed to load threads');
+  }
+});
+
+export const createThreadLocal = createAsyncThunk(
+  'thread/createThreadLocal',
+  async (
+    payload: { id: string; title: string; createdAt: string },
+    { dispatch, rejectWithValue }
+  ) => {
+    try {
+      const created = await threadApi.createThread(payload);
+      await dispatch(loadThreads()).unwrap();
+      return created;
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to create thread');
+    }
+  }
+);
+
+export const loadThreadMessages = createAsyncThunk(
+  'thread/loadThreadMessages',
+  async (threadId: string, { rejectWithValue }) => {
+    try {
+      const response = await threadApi.getThreadMessages(threadId);
+      return { threadId, messages: response.messages };
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to load messages');
+    }
+  }
+);
+
+export const addMessageLocal = createAsyncThunk(
+  'thread/addMessageLocal',
+  async (
+    payload: { threadId: string; message: ThreadMessage },
+    { rejectWithValue }
+  ) => {
+    try {
+      const persisted = await threadApi.appendMessage(payload.threadId, payload.message);
+      return { threadId: payload.threadId, message: persisted };
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to save message');
+    }
+  }
+);
+
+export const addInferenceResponse = createAsyncThunk(
+  'thread/addInferenceResponse',
+  async (
+    payload: { content: string; threadId?: string; messageId?: string; type?: string },
+    { getState, rejectWithValue }
+  ) => {
+    const state = getState() as { thread: ThreadState };
+    const targetThreadId = payload.threadId ?? state.thread.activeThreadId;
+    if (!targetThreadId) {
+      return rejectWithValue('No target thread for inference response');
+    }
+
+    const message: ThreadMessage = {
+      id: payload.messageId ?? `inference-${Date.now()}-${Math.random()}`,
+      content: payload.content,
+      type: payload.type ?? 'text',
+      extraMetadata: {},
+      sender: 'agent',
+      createdAt: new Date().toISOString(),
+    };
+
+    try {
+      const persisted = await threadApi.appendMessage(targetThreadId, message);
+      return { threadId: targetThreadId, message: persisted };
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to save response');
+    }
+  }
+);
+
+export const persistReaction = createAsyncThunk(
+  'thread/persistReaction',
+  async (
+    payload: { threadId: string; messageId: string; emoji: string },
+    { getState, rejectWithValue }
+  ) => {
+    const state = getState() as { thread: ThreadState };
+    const stored = state.thread.messagesByThreadId[payload.threadId] ?? [];
+    const message = stored.find(entry => entry.id === payload.messageId);
+    if (!message) {
+      return rejectWithValue('Message not found for reaction update');
+    }
+
+    const prev = (message.extraMetadata['myReactions'] as string[] | undefined) ?? [];
+    const idx = prev.indexOf(payload.emoji);
+    const next = idx >= 0 ? prev.filter(entry => entry !== payload.emoji) : [...prev, payload.emoji];
+    const extraMetadata = { ...message.extraMetadata, myReactions: next };
+
+    try {
+      const persisted = await threadApi.updateMessage(
+        payload.threadId,
+        payload.messageId,
+        extraMetadata
+      );
+      return { threadId: payload.threadId, message: persisted };
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to save reaction');
+    }
+  }
+);
 
 export const purgeThreads = createAsyncThunk(
   'thread/purgeThreads',
   async (_, { dispatch, rejectWithValue }) => {
     try {
-      const data = await threadApi.purge({
-        messages: false,
-        agentThreads: true,
-        deleteEverything: true,
-      });
-      // Clear local threads after successful purge
-      dispatch({ type: 'thread/clearAllThreads' });
-      return data;
+      const result = await threadApi.purge();
+      dispatch(clearAllThreads());
+      return result;
     } catch (error) {
-      const msg =
-        error && typeof error === 'object' && 'error' in error
-          ? String(error.error)
-          : 'Failed to purge threads';
-      return rejectWithValue(msg);
-    }
-  }
-);
-
-export const sendMessage = createAsyncThunk(
-  'thread/sendMessage',
-  async (
-    { threadId, message }: { threadId: string; message: string },
-    { dispatch, getState, rejectWithValue }
-  ) => {
-    // 1. Add user message locally immediately (optimistic update)
-    const userMessage: ThreadMessage = {
-      id: `msg_${Date.now()}_${Math.random()}`,
-      content: message,
-      type: 'text',
-      extraMetadata: {},
-      sender: 'user',
-      createdAt: new Date().toISOString(),
-    };
-
-    try {
-      dispatch(addMessageLocal({ threadId, message: userMessage }));
-
-      // 2. Send plain message - orchestration and context injection happen in Rust.
-      const state = getState() as { channelConnections?: ChannelConnectionsState };
-      const route = state.channelConnections
-        ? resolveOutboundRoute(state.channelConnections)
-        : null;
-      const data = await threadApi.sendMessage(message, threadId, route ?? undefined);
-
-      // 3. For now, we'll handle AI response via the existing inference API
-      // The AI response will be added separately via addInferenceResponse
-
-      return data;
-    } catch (error) {
-      // Add an error message as an agent response so the conversation flow continues
-      dispatch(
-        addInferenceResponse({ content: 'Something went wrong — please try again.', threadId })
-      );
-
-      const msg =
-        error && typeof error === 'object' && 'error' in error
-          ? String((error as { error: unknown }).error)
-          : 'Failed to send message';
-      return rejectWithValue(msg);
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to purge threads');
     }
   }
 );
@@ -130,31 +212,25 @@ export const fetchSuggestedQuestions = createAsyncThunk(
   'thread/fetchSuggestedQuestions',
   async (conversationId: string | undefined, { getState, rejectWithValue }) => {
     try {
+      const state = getState() as { thread: ThreadState };
+      const selectedThreadId = conversationId ?? state.thread.selectedThreadId ?? undefined;
+      const threadMessages = selectedThreadId
+        ? (state.thread.messagesByThreadId[selectedThreadId] ?? [])
+        : [];
+
       if (isTauri()) {
-        const state = getState() as {
-          thread?: {
-            selectedThreadId?: string | null;
-            messagesByThreadId?: Record<string, ThreadMessage[]>;
-          };
-        };
-        const selectedThreadId = conversationId ?? state.thread?.selectedThreadId ?? undefined;
-        const threadMessages = selectedThreadId
-          ? (state.thread?.messagesByThreadId?.[selectedThreadId] ?? [])
-          : [];
         const lines = threadMessages
           .slice(-24)
           .map(msg => `${msg.sender === 'user' ? 'User' : 'Assistant'}: ${msg.content}`);
         const local = await openhumanLocalAiSuggestQuestions(undefined, lines);
         return local.result;
       }
-      const data = await threadApi.getSuggestQuestions(conversationId);
-      return data.suggestions;
+
+      return [];
     } catch (error) {
-      const msg =
-        error && typeof error === 'object' && 'error' in error
-          ? String(error.error)
-          : 'Failed to load suggestions';
-      return rejectWithValue(msg);
+      return rejectWithValue(
+        error instanceof Error ? error.message : 'Failed to load suggested questions'
+      );
     }
   }
 );
@@ -165,8 +241,7 @@ const threadSlice = createSlice({
   reducers: {
     setSelectedThread: (state, action: { payload: string }) => {
       state.selectedThreadId = action.payload;
-      // Load messages from local storage instead of clearing
-      state.messages = state.messagesByThreadId[action.payload] || [];
+      state.messages = state.messagesByThreadId[action.payload] ?? [];
       state.messagesError = null;
       state.suggestedQuestions = [];
       state.suggestError = null;
@@ -188,57 +263,6 @@ const threadSlice = createSlice({
     clearPurgeStatus: state => {
       state.purgeStatus = 'idle';
     },
-    addOptimisticMessage: (state, action: { payload: { content: string } }) => {
-      state.messages.push({
-        id: `optimistic-${Date.now()}`,
-        content: action.payload.content,
-        type: 'text',
-        extraMetadata: {},
-        sender: 'user',
-        createdAt: new Date().toISOString(),
-      });
-    },
-    addInferenceResponse: (state, action: { payload: { content: string; threadId?: string } }) => {
-      const aiMessage: ThreadMessage = {
-        id: `inference-${Date.now()}`,
-        content: action.payload.content,
-        type: 'text',
-        extraMetadata: {},
-        sender: 'agent',
-        createdAt: new Date().toISOString(),
-      };
-
-      // Use provided threadId or fall back to activeThreadId to ensure response goes to correct thread
-      const targetThreadId = action.payload.threadId || state.activeThreadId;
-
-      if (targetThreadId) {
-        // Ensure messagesByThreadId exists for this thread
-        if (!state.messagesByThreadId[targetThreadId]) {
-          state.messagesByThreadId[targetThreadId] = [];
-        }
-
-        // Add the AI response to persistent storage
-        state.messagesByThreadId[targetThreadId].push(aiMessage);
-
-        // Add to current messages view only if it's the currently selected thread
-        if (targetThreadId === state.selectedThreadId) {
-          state.messages.push(aiMessage);
-        }
-
-        // Update thread metadata
-        const thread = state.threads.find(t => t.id === targetThreadId);
-        if (thread) {
-          thread.messageCount = state.messagesByThreadId[targetThreadId].length;
-          thread.lastMessageAt = aiMessage.createdAt;
-        }
-      }
-
-      // Clear active thread when response is received
-      state.activeThreadId = null;
-    },
-    removeOptimisticMessages: state => {
-      state.messages = state.messages.filter(m => !m.id.startsWith('optimistic-'));
-    },
     clearSendError: state => {
       state.sendError = null;
     },
@@ -246,68 +270,7 @@ const threadSlice = createSlice({
       state.panelWidth = action.payload;
     },
     setLastViewed: (state, action: { payload: string }) => {
-      const ts = Date.now();
-      state.lastViewedAt[action.payload] = ts;
-    },
-    // Local thread management
-    createThreadLocal: (
-      state,
-      action: { payload: { id: string; title: string; createdAt: string } }
-    ) => {
-      const newThread: Thread = {
-        id: action.payload.id,
-        title: action.payload.title,
-        chatId: null,
-        isActive: true,
-        messageCount: 0,
-        lastMessageAt: action.payload.createdAt,
-        createdAt: action.payload.createdAt,
-      };
-      state.threads.unshift(newThread);
-      state.messagesByThreadId[action.payload.id] = [];
-    },
-    addMessageLocal: (state, action: { payload: { threadId: string; message: ThreadMessage } }) => {
-      const { threadId, message } = action.payload;
-      if (!state.messagesByThreadId[threadId]) {
-        state.messagesByThreadId[threadId] = [];
-      }
-      state.messagesByThreadId[threadId].push(message);
-
-      // Also update current messages view if this is the selected thread
-      if (threadId === state.selectedThreadId) {
-        state.messages.push(message);
-      }
-
-      // Update thread metadata
-      const thread = state.threads.find(t => t.id === threadId);
-      if (thread) {
-        thread.messageCount = state.messagesByThreadId[threadId].length;
-        thread.lastMessageAt = message.createdAt;
-      }
-    },
-    deleteThreadLocal: (state, action: { payload: string }) => {
-      const threadId = action.payload;
-      state.threads = state.threads.filter(t => t.id !== threadId);
-      delete state.messagesByThreadId[threadId];
-      delete state.lastViewedAt[threadId];
-      if (state.selectedThreadId === threadId) {
-        state.selectedThreadId = null;
-      }
-    },
-    updateMessagesForThread: (
-      state,
-      action: { payload: { threadId: string; messages: ThreadMessage[] } }
-    ) => {
-      const { threadId, messages } = action.payload;
-      state.messagesByThreadId[threadId] = messages;
-
-      // Update thread metadata
-      const thread = state.threads.find(t => t.id === threadId);
-      if (thread) {
-        thread.messageCount = messages.length;
-        thread.lastMessageAt =
-          messages.length > 0 ? messages[messages.length - 1].createdAt : thread.createdAt;
-      }
+      state.lastViewedAt[action.payload] = Date.now();
     },
     clearAllThreads: state => {
       state.threads = [];
@@ -320,79 +283,73 @@ const threadSlice = createSlice({
     setActiveThread: (state, action: { payload: string | null }) => {
       state.activeThreadId = action.payload;
     },
-    addReaction: (
-      state,
-      action: { payload: { threadId: string; messageId: string; emoji: string } }
-    ) => {
-      const { threadId, messageId, emoji } = action.payload;
-      const stored = state.messagesByThreadId[threadId];
-      if (stored) {
-        const msg = stored.find(m => m.id === messageId);
-        if (msg) {
-          const prev = (msg.extraMetadata['myReactions'] as string[] | undefined) ?? [];
-          const idx = prev.indexOf(emoji);
-          const next = idx >= 0 ? prev.filter(e => e !== emoji) : [...prev, emoji];
-          msg.extraMetadata = { ...msg.extraMetadata, myReactions: next };
-        }
-      }
-      if (threadId === state.selectedThreadId) {
-        const viewMsg = state.messages.find(m => m.id === messageId);
-        if (viewMsg) {
-          const prev = (viewMsg.extraMetadata['myReactions'] as string[] | undefined) ?? [];
-          const idx = prev.indexOf(emoji);
-          const next = idx >= 0 ? prev.filter(e => e !== emoji) : [...prev, emoji];
-          viewMsg.extraMetadata = { ...viewMsg.extraMetadata, myReactions: next };
-        }
-      }
-    },
   },
   extraReducers: builder => {
     builder
-      // Removed fetchThreads and fetchThreadMessages cases
-      // Removed createThread cases - using local thread creation
-      // Removed deleteThread cases - using local thread deletion
-      // purgeThreads
+      .addCase(loadThreads.pending, state => {
+        state.isLoadingThreads = true;
+      })
+      .addCase(loadThreads.fulfilled, (state, action) => {
+        state.isLoadingThreads = false;
+        state.threads = action.payload.threads;
+      })
+      .addCase(loadThreads.rejected, state => {
+        state.isLoadingThreads = false;
+      })
+      .addCase(createThreadLocal.pending, state => {
+        state.isLoadingThreads = true;
+      })
+      .addCase(createThreadLocal.fulfilled, state => {
+        state.isLoadingThreads = false;
+      })
+      .addCase(createThreadLocal.rejected, (state, action) => {
+        state.isLoadingThreads = false;
+        state.messagesError = action.payload as string;
+      })
+      .addCase(loadThreadMessages.pending, state => {
+        state.isLoadingMessages = true;
+        state.messagesError = null;
+      })
+      .addCase(loadThreadMessages.fulfilled, (state, action) => {
+        state.isLoadingMessages = false;
+        replaceMessagesForThread(state, action.payload.threadId, action.payload.messages);
+      })
+      .addCase(loadThreadMessages.rejected, (state, action) => {
+        state.isLoadingMessages = false;
+        state.messagesError = action.payload as string;
+      })
+      .addCase(addMessageLocal.pending, state => {
+        state.sendStatus = 'loading';
+        state.sendError = null;
+      })
+      .addCase(addMessageLocal.fulfilled, (state, action) => {
+        state.sendStatus = 'success';
+        appendMessageToCache(state, action.payload.threadId, action.payload.message);
+      })
+      .addCase(addMessageLocal.rejected, (state, action) => {
+        state.sendStatus = 'error';
+        state.sendError = action.payload as string;
+      })
+      .addCase(addInferenceResponse.fulfilled, (state, action) => {
+        appendMessageToCache(state, action.payload.threadId, action.payload.message);
+        state.activeThreadId = null;
+      })
+      .addCase(addInferenceResponse.rejected, (state, action) => {
+        state.sendError = action.payload as string;
+        state.activeThreadId = null;
+      })
+      .addCase(persistReaction.fulfilled, (state, action) => {
+        appendMessageToCache(state, action.payload.threadId, action.payload.message, true);
+      })
       .addCase(purgeThreads.pending, state => {
         state.purgeStatus = 'loading';
       })
       .addCase(purgeThreads.fulfilled, state => {
         state.purgeStatus = 'success';
-        // clearAllThreads is dispatched from the thunk
       })
       .addCase(purgeThreads.rejected, state => {
         state.purgeStatus = 'error';
       })
-      // clearAllThreads action
-      .addCase('thread/clearAllThreads', state => {
-        state.threads = [];
-        state.messagesByThreadId = {};
-        state.selectedThreadId = null;
-        state.messages = [];
-        state.lastViewedAt = {};
-        state.activeThreadId = null;
-      })
-      // sendMessage
-      .addCase(sendMessage.pending, (state, action) => {
-        state.sendStatus = 'loading';
-        state.sendError = null;
-        // Set the active thread when message sending starts
-        state.activeThreadId = action.meta.arg.threadId;
-      })
-      .addCase(sendMessage.fulfilled, state => {
-        state.sendStatus = 'success';
-        state.suggestedQuestions = [];
-        state.suggestError = null;
-        // Don't clear activeThreadId here - let addInferenceResponse handle it
-      })
-      .addCase(sendMessage.rejected, (state, action) => {
-        state.sendStatus = 'error';
-        state.sendError = action.payload as string;
-        // Remove optimistic messages so the user doesn't see phantom messages
-        state.messages = state.messages.filter(m => !m.id.startsWith('optimistic-'));
-        // Clear active thread on error
-        state.activeThreadId = null;
-      })
-      // fetchSuggestedQuestions
       .addCase(fetchSuggestedQuestions.pending, state => {
         state.isLoadingSuggestions = true;
         state.suggestError = null;
@@ -414,19 +371,12 @@ export const {
   clearSelectedThread,
   clearDeleteStatus,
   clearPurgeStatus,
-  addOptimisticMessage,
-  addInferenceResponse,
-  removeOptimisticMessages,
   clearSendError,
   clearSuggestedQuestions,
   setPanelWidth,
   setLastViewed,
-  createThreadLocal,
-  addMessageLocal,
-  deleteThreadLocal,
-  updateMessagesForThread,
   clearAllThreads,
   setActiveThread,
-  addReaction,
 } = threadSlice.actions;
+
 export default threadSlice.reducer;

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -801,7 +801,7 @@ async fn run_server_inner(
 ///
 /// Guarded by `std::sync::Once` so repeated calls to `bootstrap_skill_runtime`
 /// are safe and idempotent.
-fn register_domain_subscribers() {
+fn register_domain_subscribers(workspace_dir: std::path::PathBuf) {
     use std::sync::{Arc, Once};
 
     static REGISTERED: Once = Once::new();
@@ -826,6 +826,9 @@ fn register_domain_subscribers() {
 
         crate::openhuman::health::bus::register_health_subscriber();
         crate::openhuman::skills::bus::register_skill_cleanup_subscriber();
+        crate::openhuman::memory::conversations::register_conversation_persistence_subscriber(
+            workspace_dir,
+        );
 
         // Restart requests go through a subscriber so every trigger path shares
         // the same respawn logic.
@@ -880,7 +883,7 @@ pub async fn bootstrap_skill_runtime() {
     // Register domain subscribers for cross-module event handling.
     // Uses a Once guard so repeated calls to bootstrap_skill_runtime()
     // cannot double-subscribe.
-    register_domain_subscribers();
+    register_domain_subscribers(workspace_dir.clone());
 
     // --- Sub-agent definition registry bootstrap ---
     // Loads built-in archetype definitions plus any custom TOML files

--- a/src/openhuman/channels/mod.rs
+++ b/src/openhuman/channels/mod.rs
@@ -7,7 +7,7 @@ pub mod providers;
 pub mod traits;
 
 mod commands;
-mod context;
+pub(crate) mod context;
 mod prompt;
 mod routes;
 mod runtime;

--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -205,7 +205,9 @@ pub(crate) async fn process_channel_message(
 
     publish_global(DomainEvent::ChannelMessageReceived {
         channel: msg.channel.clone(),
+        message_id: msg.id.clone(),
         sender: msg.sender.clone(),
+        reply_target: msg.reply_target.clone(),
         content: msg.content.clone(),
         thread_ts: msg.thread_ts.clone(),
     });
@@ -503,8 +505,11 @@ pub(crate) async fn process_channel_message(
 
                 publish_global(DomainEvent::ChannelMessageProcessed {
                     channel: msg.channel.clone(),
+                    message_id: msg.id.clone(),
                     sender: msg.sender.clone(),
+                    reply_target: msg.reply_target.clone(),
                     content: msg.content.clone(),
+                    thread_ts: msg.thread_ts.clone(),
                     response: error_text.to_string(),
                     elapsed_ms: started_at.elapsed().as_millis() as u64,
                     success: false,
@@ -572,8 +577,11 @@ pub(crate) async fn process_channel_message(
 
     publish_global(DomainEvent::ChannelMessageProcessed {
         channel: msg.channel.clone(),
+        message_id: msg.id.clone(),
         sender: msg.sender.clone(),
+        reply_target: msg.reply_target.clone(),
         content: msg.content.clone(),
+        thread_ts: msg.thread_ts.clone(),
         response: response_text,
         elapsed_ms: started_at.elapsed().as_millis() as u64,
         success,

--- a/src/openhuman/channels/runtime/startup.rs
+++ b/src/openhuman/channels/runtime/startup.rs
@@ -46,6 +46,9 @@ pub async fn start_channels(config: Config) -> Result<()> {
     let _tracing_handle = bus.subscribe(Arc::new(TracingSubscriber));
     crate::openhuman::health::bus::register_health_subscriber();
     crate::openhuman::skills::bus::register_skill_cleanup_subscriber();
+    crate::openhuman::memory::conversations::register_conversation_persistence_subscriber(
+        config.workspace_dir.clone(),
+    );
     tracing::debug!("[event_bus] global singleton initialized in start_channels");
 
     // Initialise the sub-agent definition registry from this workspace.

--- a/src/openhuman/event_bus/events.rs
+++ b/src/openhuman/event_bus/events.rs
@@ -77,15 +77,20 @@ pub enum DomainEvent {
     /// A message was received on a channel.
     ChannelMessageReceived {
         channel: String,
+        message_id: String,
         sender: String,
+        reply_target: String,
         content: String,
         thread_ts: Option<String>,
     },
     /// A channel message was fully processed (LLM response sent or error).
     ChannelMessageProcessed {
         channel: String,
+        message_id: String,
         sender: String,
+        reply_target: String,
         content: String,
+        thread_ts: Option<String>,
         response: String,
         elapsed_ms: u64,
         success: bool,
@@ -362,7 +367,9 @@ mod tests {
             (
                 DomainEvent::ChannelMessageReceived {
                     channel: "c".into(),
+                    message_id: "m1".into(),
                     sender: "s".into(),
+                    reply_target: "r".into(),
                     content: "hi".into(),
                     thread_ts: None,
                 },
@@ -371,8 +378,11 @@ mod tests {
             (
                 DomainEvent::ChannelMessageProcessed {
                     channel: "c".into(),
+                    message_id: "m1".into(),
                     sender: "s".into(),
+                    reply_target: "r".into(),
                     content: "hi".into(),
+                    thread_ts: None,
                     response: "hello".into(),
                     elapsed_ms: 0,
                     success: true,

--- a/src/openhuman/memory/conversations/bus.rs
+++ b/src/openhuman/memory/conversations/bus.rs
@@ -1,0 +1,365 @@
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde_json::json;
+
+use crate::openhuman::channels::context::conversation_history_key;
+use crate::openhuman::channels::traits::ChannelMessage;
+use crate::openhuman::event_bus::{DomainEvent, EventHandler, SubscriptionHandle};
+
+use super::{
+    append_message, ensure_thread, get_messages, ConversationMessage, CreateConversationThread,
+};
+
+static CONVERSATION_PERSISTENCE_HANDLE: OnceLock<SubscriptionHandle> = OnceLock::new();
+
+const LOG_PREFIX: &str = "[memory:conversations:bus]";
+
+/// Register the long-lived channel conversation persistence subscriber.
+///
+/// This bridges typed channel events onto the workspace-backed JSONL
+/// conversation store so non-web channels persist alongside UI threads.
+pub fn register_conversation_persistence_subscriber(workspace_dir: PathBuf) {
+    if CONVERSATION_PERSISTENCE_HANDLE.get().is_some() {
+        return;
+    }
+
+    match crate::openhuman::event_bus::subscribe_global(Arc::new(
+        ConversationPersistenceSubscriber::new(workspace_dir),
+    )) {
+        Some(handle) => {
+            let _ = CONVERSATION_PERSISTENCE_HANDLE.set(handle);
+        }
+        None => {
+            log::warn!(
+                "{LOG_PREFIX} failed to register conversation persistence subscriber — bus not initialized"
+            );
+        }
+    }
+}
+
+pub struct ConversationPersistenceSubscriber {
+    workspace_dir: PathBuf,
+}
+
+impl ConversationPersistenceSubscriber {
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        Self { workspace_dir }
+    }
+}
+
+#[async_trait]
+impl EventHandler for ConversationPersistenceSubscriber {
+    fn name(&self) -> &str {
+        "memory::conversations::persistence"
+    }
+
+    fn domains(&self) -> Option<&[&str]> {
+        Some(&["channel"])
+    }
+
+    async fn handle(&self, event: &DomainEvent) {
+        match event {
+            DomainEvent::ChannelMessageReceived {
+                channel,
+                message_id,
+                sender,
+                reply_target,
+                content,
+                thread_ts,
+            } => {
+                if let Err(error) = persist_channel_turn(
+                    &self.workspace_dir,
+                    ChannelTurnDescriptor {
+                        channel,
+                        message_id,
+                        sender,
+                        reply_target,
+                        thread_ts: thread_ts.as_deref(),
+                        content,
+                        role: "user",
+                        success: None,
+                        elapsed_ms: None,
+                        source: "channel_received",
+                    },
+                ) {
+                    log::warn!(
+                        "{LOG_PREFIX} failed to persist inbound channel message channel={} message_id={} error={}",
+                        channel,
+                        message_id,
+                        error
+                    );
+                }
+            }
+            DomainEvent::ChannelMessageProcessed {
+                channel,
+                message_id,
+                sender,
+                reply_target,
+                thread_ts,
+                response,
+                elapsed_ms,
+                success,
+                ..
+            } => {
+                if let Err(error) = persist_channel_turn(
+                    &self.workspace_dir,
+                    ChannelTurnDescriptor {
+                        channel,
+                        message_id,
+                        sender,
+                        reply_target,
+                        thread_ts: thread_ts.as_deref(),
+                        content: response,
+                        role: "assistant",
+                        success: Some(*success),
+                        elapsed_ms: Some(*elapsed_ms),
+                        source: "channel_processed",
+                    },
+                ) {
+                    log::warn!(
+                        "{LOG_PREFIX} failed to persist processed channel message channel={} message_id={} error={}",
+                        channel,
+                        message_id,
+                        error
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+struct ChannelTurnDescriptor<'a> {
+    channel: &'a str,
+    message_id: &'a str,
+    sender: &'a str,
+    reply_target: &'a str,
+    thread_ts: Option<&'a str>,
+    content: &'a str,
+    role: &'a str,
+    success: Option<bool>,
+    elapsed_ms: Option<u64>,
+    source: &'a str,
+}
+
+fn persist_channel_turn(
+    workspace_dir: &PathBuf,
+    descriptor: ChannelTurnDescriptor<'_>,
+) -> Result<(), String> {
+    let thread_id = persisted_channel_thread_id(
+        descriptor.channel,
+        descriptor.sender,
+        descriptor.reply_target,
+        descriptor.thread_ts,
+    );
+    let title = channel_thread_title(
+        descriptor.channel,
+        descriptor.sender,
+        descriptor.reply_target,
+        descriptor.thread_ts,
+    );
+    let created_at = Utc::now().to_rfc3339();
+
+    ensure_thread(
+        workspace_dir.clone(),
+        CreateConversationThread {
+            id: thread_id.clone(),
+            title,
+            created_at: created_at.clone(),
+        },
+    )?;
+
+    let persisted_message_id = format!("{}:{}", descriptor.role, descriptor.message_id);
+    if get_messages(workspace_dir.clone(), &thread_id)?
+        .iter()
+        .any(|message| message.id == persisted_message_id)
+    {
+        log::debug!(
+            "{LOG_PREFIX} skipping duplicate persisted turn thread_id={} message_id={}",
+            thread_id,
+            persisted_message_id
+        );
+        return Ok(());
+    }
+
+    append_message(
+        workspace_dir.clone(),
+        &thread_id,
+        ConversationMessage {
+            id: persisted_message_id.clone(),
+            content: descriptor.content.to_string(),
+            message_type: "text".to_string(),
+            extra_metadata: json!({
+                "scope": "channel",
+                "channel": descriptor.channel,
+                "channelSender": descriptor.sender,
+                "replyTarget": descriptor.reply_target,
+                "threadTs": descriptor.thread_ts,
+                "sourceEvent": descriptor.source,
+                "success": descriptor.success,
+                "elapsedMs": descriptor.elapsed_ms,
+                "sourceMessageId": descriptor.message_id,
+            }),
+            sender: descriptor.role.to_string(),
+            created_at,
+        },
+    )?;
+
+    log::debug!(
+        "{LOG_PREFIX} persisted channel turn thread_id={} message_id={} role={}",
+        thread_id,
+        persisted_message_id,
+        descriptor.role
+    );
+    Ok(())
+}
+
+fn persisted_channel_thread_id(
+    channel: &str,
+    sender: &str,
+    reply_target: &str,
+    thread_ts: Option<&str>,
+) -> String {
+    let key = conversation_history_key(&ChannelMessage {
+        id: String::new(),
+        sender: sender.to_string(),
+        reply_target: reply_target.to_string(),
+        content: String::new(),
+        channel: channel.to_string(),
+        timestamp: 0,
+        thread_ts: thread_ts.map(ToOwned::to_owned),
+    });
+    format!("channel:{key}")
+}
+
+fn channel_thread_title(
+    channel: &str,
+    sender: &str,
+    reply_target: &str,
+    thread_ts: Option<&str>,
+) -> String {
+    match thread_ts.and_then(non_empty_trimmed) {
+        Some(thread_ts) if channel != "telegram" => {
+            format!("{channel} · {sender} · {reply_target} · thread {thread_ts}")
+        }
+        _ => format!("{channel} · {sender} · {reply_target}"),
+    }
+}
+
+fn non_empty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn persists_inbound_and_processed_turns_into_workspace_thread() {
+        let temp = TempDir::new().expect("tempdir");
+        let subscriber = ConversationPersistenceSubscriber::new(temp.path().to_path_buf());
+
+        subscriber
+            .handle(&DomainEvent::ChannelMessageReceived {
+                channel: "slack".into(),
+                message_id: "m1".into(),
+                sender: "alice".into(),
+                reply_target: "general".into(),
+                content: "hello".into(),
+                thread_ts: Some("thread-1".into()),
+            })
+            .await;
+        subscriber
+            .handle(&DomainEvent::ChannelMessageProcessed {
+                channel: "slack".into(),
+                message_id: "m1".into(),
+                sender: "alice".into(),
+                reply_target: "general".into(),
+                content: "hello".into(),
+                thread_ts: Some("thread-1".into()),
+                response: "hi there".into(),
+                elapsed_ms: 42,
+                success: true,
+            })
+            .await;
+
+        let threads = super::super::list_threads(temp.path().to_path_buf()).expect("threads");
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].id, "channel:slack_alice_general_thread:thread-1");
+
+        let messages = super::super::get_messages(temp.path().to_path_buf(), &threads[0].id)
+            .expect("messages");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].id, "user:m1");
+        assert_eq!(messages[0].sender, "user");
+        assert_eq!(messages[1].id, "assistant:m1");
+        assert_eq!(messages[1].sender, "assistant");
+        assert_eq!(messages[1].extra_metadata["elapsedMs"], 42);
+        assert_eq!(messages[1].extra_metadata["success"], true);
+    }
+
+    #[tokio::test]
+    async fn telegram_thread_ts_does_not_split_persisted_thread() {
+        let temp = TempDir::new().expect("tempdir");
+        let subscriber = ConversationPersistenceSubscriber::new(temp.path().to_path_buf());
+
+        subscriber
+            .handle(&DomainEvent::ChannelMessageReceived {
+                channel: "telegram".into(),
+                message_id: "m1".into(),
+                sender: "alice".into(),
+                reply_target: "chat-1".into(),
+                content: "hello".into(),
+                thread_ts: Some("100".into()),
+            })
+            .await;
+        subscriber
+            .handle(&DomainEvent::ChannelMessageReceived {
+                channel: "telegram".into(),
+                message_id: "m2".into(),
+                sender: "alice".into(),
+                reply_target: "chat-1".into(),
+                content: "follow-up".into(),
+                thread_ts: Some("200".into()),
+            })
+            .await;
+
+        let threads = super::super::list_threads(temp.path().to_path_buf()).expect("threads");
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].id, "channel:telegram_alice_chat-1");
+    }
+
+    #[tokio::test]
+    async fn duplicate_events_do_not_append_duplicate_messages() {
+        let temp = TempDir::new().expect("tempdir");
+        let subscriber = ConversationPersistenceSubscriber::new(temp.path().to_path_buf());
+
+        let event = DomainEvent::ChannelMessageReceived {
+            channel: "discord".into(),
+            message_id: "m1".into(),
+            sender: "alice".into(),
+            reply_target: "room-1".into(),
+            content: "hello".into(),
+            thread_ts: None,
+        };
+
+        subscriber.handle(&event).await;
+        subscriber.handle(&event).await;
+
+        let messages =
+            super::super::get_messages(temp.path().to_path_buf(), "channel:discord_alice_room-1")
+                .expect("messages");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, "user:m1");
+    }
+}

--- a/src/openhuman/memory/conversations/mod.rs
+++ b/src/openhuman/memory/conversations/mod.rs
@@ -1,0 +1,16 @@
+//! Workspace-backed conversation thread/message storage for the desktop UI.
+//!
+//! Conversations are stored as JSONL files under `<workspace>/memory/conversations/`.
+//! Thread metadata is append-only in `threads.jsonl`; each thread's messages live
+//! in a dedicated JSONL file for straightforward inspection and recovery.
+
+mod store;
+mod types;
+
+pub use store::{
+    append_message, delete_thread, ensure_thread, get_messages, list_threads, purge_threads,
+    update_message, ConversationPurgeStats, ConversationStore,
+};
+pub use types::{
+    ConversationMessage, ConversationMessagePatch, ConversationThread, CreateConversationThread,
+};

--- a/src/openhuman/memory/conversations/mod.rs
+++ b/src/openhuman/memory/conversations/mod.rs
@@ -4,9 +4,11 @@
 //! Thread metadata is append-only in `threads.jsonl`; each thread's messages live
 //! in a dedicated JSONL file for straightforward inspection and recovery.
 
+mod bus;
 mod store;
 mod types;
 
+pub use bus::register_conversation_persistence_subscriber;
 pub use store::{
     append_message, delete_thread, ensure_thread, get_messages, list_threads, purge_threads,
     update_message, ConversationPurgeStats, ConversationStore,

--- a/src/openhuman/memory/conversations/store.rs
+++ b/src/openhuman/memory/conversations/store.rs
@@ -1,0 +1,557 @@
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use log::{debug, warn};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use tempfile::NamedTempFile;
+
+use super::types::{
+    ConversationMessage, ConversationMessagePatch, ConversationThread, CreateConversationThread,
+};
+
+const LOG_PREFIX: &str = "[memory:conversations]";
+const THREADS_FILENAME: &str = "threads.jsonl";
+const THREAD_MESSAGES_DIR: &str = "threads";
+static CONVERSATION_STORE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConversationPurgeStats {
+    pub thread_count: usize,
+    pub message_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConversationStore {
+    workspace_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum ThreadLogEntry {
+    Upsert {
+        thread_id: String,
+        title: String,
+        created_at: String,
+        updated_at: String,
+    },
+    Delete {
+        thread_id: String,
+        deleted_at: String,
+    },
+}
+
+impl ConversationStore {
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        Self { workspace_dir }
+    }
+
+    pub fn ensure_thread(
+        &self,
+        request: CreateConversationThread,
+    ) -> Result<ConversationThread, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        let root = self.ensure_root()?;
+        let threads_path = root.join(THREADS_FILENAME);
+        let now = request.created_at.clone();
+        append_jsonl(
+            &threads_path,
+            &ThreadLogEntry::Upsert {
+                thread_id: request.id.clone(),
+                title: request.title.clone(),
+                created_at: request.created_at.clone(),
+                updated_at: now,
+            },
+        )?;
+        debug!(
+            "{LOG_PREFIX} ensured thread id={} path={}",
+            request.id,
+            threads_path.display()
+        );
+        self.thread_summary_unlocked(&request.id)?
+            .ok_or_else(|| format!("thread {} missing after ensure", request.id))
+    }
+
+    pub fn list_threads(&self) -> Result<Vec<ConversationThread>, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        self.list_threads_unlocked()
+    }
+
+    pub fn get_messages(&self, thread_id: &str) -> Result<Vec<ConversationMessage>, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        if !self.thread_exists_unlocked(thread_id)? {
+            return Ok(Vec::new());
+        }
+        read_jsonl::<ConversationMessage>(&self.thread_messages_path(thread_id))
+    }
+
+    pub fn append_message(
+        &self,
+        thread_id: &str,
+        message: ConversationMessage,
+    ) -> Result<ConversationMessage, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        if !self.thread_exists_unlocked(thread_id)? {
+            return Err(format!("thread {} does not exist", thread_id));
+        }
+        let path = self.thread_messages_path(thread_id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("create conversation dir {}: {e}", parent.display()))?;
+        }
+        append_jsonl(&path, &message)?;
+        debug!(
+            "{LOG_PREFIX} appended message thread_id={} message_id={} path={}",
+            thread_id,
+            message.id,
+            path.display()
+        );
+        Ok(message)
+    }
+
+    pub fn update_message(
+        &self,
+        thread_id: &str,
+        message_id: &str,
+        patch: ConversationMessagePatch,
+    ) -> Result<ConversationMessage, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        let path = self.thread_messages_path(thread_id);
+        let mut messages = read_jsonl::<ConversationMessage>(&path)?;
+        let mut updated: Option<ConversationMessage> = None;
+        for message in &mut messages {
+            if message.id == message_id {
+                if let Some(extra_metadata) = patch.extra_metadata.clone() {
+                    message.extra_metadata = extra_metadata;
+                }
+                updated = Some(message.clone());
+                break;
+            }
+        }
+        let updated = updated
+            .ok_or_else(|| format!("message {} not found in thread {}", message_id, thread_id))?;
+        rewrite_jsonl(&path, &messages)?;
+        debug!(
+            "{LOG_PREFIX} updated message thread_id={} message_id={} path={}",
+            thread_id,
+            message_id,
+            path.display()
+        );
+        Ok(updated)
+    }
+
+    pub fn delete_thread(&self, thread_id: &str, deleted_at: &str) -> Result<bool, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        if !self.thread_exists_unlocked(thread_id)? {
+            return Ok(false);
+        }
+        let root = self.ensure_root()?;
+        let threads_path = root.join(THREADS_FILENAME);
+        append_jsonl(
+            &threads_path,
+            &ThreadLogEntry::Delete {
+                thread_id: thread_id.to_string(),
+                deleted_at: deleted_at.to_string(),
+            },
+        )?;
+        let messages_path = self.thread_messages_path(thread_id);
+        match fs::remove_file(&messages_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "delete conversation messages {}: {error}",
+                    messages_path.display()
+                ));
+            }
+        }
+        debug!(
+            "{LOG_PREFIX} deleted thread id={} path={}",
+            thread_id,
+            messages_path.display()
+        );
+        Ok(true)
+    }
+
+    pub fn purge_threads(&self) -> Result<ConversationPurgeStats, String> {
+        let _guard = CONVERSATION_STORE_LOCK.lock();
+        let stats = self.purge_stats_unlocked()?;
+        let root = self.root_dir();
+        if root.exists() {
+            fs::remove_dir_all(&root)
+                .map_err(|e| format!("remove conversation dir {}: {e}", root.display()))?;
+        }
+        self.ensure_root()?;
+        debug!(
+            "{LOG_PREFIX} purged threads={} messages={} root={}",
+            stats.thread_count,
+            stats.message_count,
+            root.display()
+        );
+        Ok(stats)
+    }
+
+    fn ensure_root(&self) -> Result<PathBuf, String> {
+        let root = self.root_dir();
+        let threads_dir = root.join(THREAD_MESSAGES_DIR);
+        fs::create_dir_all(&threads_dir)
+            .map_err(|e| format!("create conversation dir {}: {e}", threads_dir.display()))?;
+        let threads_file = root.join(THREADS_FILENAME);
+        if !threads_file.exists() {
+            File::create(&threads_file)
+                .map_err(|e| format!("create threads log {}: {e}", threads_file.display()))?;
+        }
+        Ok(root)
+    }
+
+    fn root_dir(&self) -> PathBuf {
+        self.workspace_dir.join("memory").join("conversations")
+    }
+
+    fn thread_messages_path(&self, thread_id: &str) -> PathBuf {
+        self.root_dir()
+            .join(THREAD_MESSAGES_DIR)
+            .join(format!("{}.jsonl", hex::encode(thread_id.as_bytes())))
+    }
+
+    fn list_threads_unlocked(&self) -> Result<Vec<ConversationThread>, String> {
+        let index = self.thread_index_unlocked()?;
+        let mut threads = Vec::with_capacity(index.len());
+        for thread_id in index.keys() {
+            if let Some(summary) = self.thread_summary_unlocked(thread_id)? {
+                threads.push(summary);
+            }
+        }
+        threads.sort_by(|a, b| {
+            b.last_message_at
+                .cmp(&a.last_message_at)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
+        Ok(threads)
+    }
+
+    fn thread_summary_unlocked(
+        &self,
+        thread_id: &str,
+    ) -> Result<Option<ConversationThread>, String> {
+        let index = self.thread_index_unlocked()?;
+        let entry = match index.get(thread_id) {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
+        let messages = read_jsonl::<ConversationMessage>(&self.thread_messages_path(thread_id))?;
+        let message_count = messages.len();
+        let last_message_at = messages
+            .last()
+            .map(|message| message.created_at.clone())
+            .unwrap_or_else(|| entry.created_at.clone());
+        Ok(Some(ConversationThread {
+            id: thread_id.to_string(),
+            title: entry.title.clone(),
+            chat_id: None,
+            is_active: true,
+            message_count,
+            last_message_at,
+            created_at: entry.created_at.clone(),
+        }))
+    }
+
+    fn thread_exists_unlocked(&self, thread_id: &str) -> Result<bool, String> {
+        Ok(self.thread_index_unlocked()?.contains_key(thread_id))
+    }
+
+    fn thread_index_unlocked(&self) -> Result<BTreeMap<String, ThreadIndexEntry>, String> {
+        self.ensure_root()?;
+        let path = self.root_dir().join(THREADS_FILENAME);
+        let mut index: BTreeMap<String, ThreadIndexEntry> = BTreeMap::new();
+        for entry in read_jsonl::<ThreadLogEntry>(&path)? {
+            match entry {
+                ThreadLogEntry::Upsert {
+                    thread_id,
+                    title,
+                    created_at,
+                    ..
+                } => {
+                    let created_at_value = match index.get(&thread_id) {
+                        Some(existing) => existing.created_at.clone(),
+                        None => created_at,
+                    };
+                    index.insert(
+                        thread_id,
+                        ThreadIndexEntry {
+                            title,
+                            created_at: created_at_value,
+                        },
+                    );
+                }
+                ThreadLogEntry::Delete { thread_id, .. } => {
+                    index.remove(&thread_id);
+                }
+            }
+        }
+        Ok(index)
+    }
+
+    fn purge_stats_unlocked(&self) -> Result<ConversationPurgeStats, String> {
+        let threads = self.list_threads_unlocked()?;
+        let message_count = threads.iter().map(|thread| thread.message_count).sum();
+        Ok(ConversationPurgeStats {
+            thread_count: threads.len(),
+            message_count,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ThreadIndexEntry {
+    title: String,
+    created_at: String,
+}
+
+fn read_jsonl<T>(path: &Path) -> Result<Vec<T>, String>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut items = Vec::new();
+    for (line_no, line) in reader.lines().enumerate() {
+        let line =
+            line.map_err(|e| format!("read {} line {}: {e}", path.display(), line_no + 1))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<T>(trimmed) {
+            Ok(value) => items.push(value),
+            Err(error) => {
+                warn!(
+                    "{LOG_PREFIX} skipping invalid jsonl line path={} line={} error={}",
+                    path.display(),
+                    line_no + 1,
+                    error
+                );
+            }
+        }
+    }
+    Ok(items)
+}
+
+fn append_jsonl<T>(path: &Path, value: &T) -> Result<(), String>
+where
+    T: serde::Serialize,
+{
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("resolve parent dir for {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| format!("create jsonl dir {}: {e}", parent.display()))?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("open {} for append: {e}", path.display()))?;
+    let line = serde_json::to_string(value)
+        .map_err(|e| format!("serialize jsonl line for {}: {e}", path.display()))?;
+    writeln!(file, "{line}").map_err(|e| format!("write {}: {e}", path.display()))?;
+    file.sync_all()
+        .map_err(|e| format!("sync {}: {e}", path.display()))?;
+    Ok(())
+}
+
+fn rewrite_jsonl<T>(path: &Path, values: &[T]) -> Result<(), String>
+where
+    T: serde::Serialize,
+{
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("resolve parent dir for {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| format!("create jsonl dir {}: {e}", parent.display()))?;
+    let mut temp = NamedTempFile::new_in(parent)
+        .map_err(|e| format!("create temp jsonl in {}: {e}", parent.display()))?;
+    for value in values {
+        let line = serde_json::to_string(value)
+            .map_err(|e| format!("serialize jsonl line for {}: {e}", path.display()))?;
+        writeln!(temp, "{line}")
+            .map_err(|e| format!("write temp jsonl for {}: {e}", path.display()))?;
+    }
+    temp.as_file_mut()
+        .sync_all()
+        .map_err(|e| format!("sync temp jsonl for {}: {e}", path.display()))?;
+    temp.persist(path)
+        .map_err(|e| format!("persist {}: {}", path.display(), e.error))?;
+    Ok(())
+}
+
+pub fn ensure_thread(
+    workspace_dir: PathBuf,
+    request: CreateConversationThread,
+) -> Result<ConversationThread, String> {
+    ConversationStore::new(workspace_dir).ensure_thread(request)
+}
+
+pub fn list_threads(workspace_dir: PathBuf) -> Result<Vec<ConversationThread>, String> {
+    ConversationStore::new(workspace_dir).list_threads()
+}
+
+pub fn get_messages(
+    workspace_dir: PathBuf,
+    thread_id: &str,
+) -> Result<Vec<ConversationMessage>, String> {
+    ConversationStore::new(workspace_dir).get_messages(thread_id)
+}
+
+pub fn append_message(
+    workspace_dir: PathBuf,
+    thread_id: &str,
+    message: ConversationMessage,
+) -> Result<ConversationMessage, String> {
+    ConversationStore::new(workspace_dir).append_message(thread_id, message)
+}
+
+pub fn update_message(
+    workspace_dir: PathBuf,
+    thread_id: &str,
+    message_id: &str,
+    patch: ConversationMessagePatch,
+) -> Result<ConversationMessage, String> {
+    ConversationStore::new(workspace_dir).update_message(thread_id, message_id, patch)
+}
+
+pub fn purge_threads(workspace_dir: PathBuf) -> Result<ConversationPurgeStats, String> {
+    ConversationStore::new(workspace_dir).purge_threads()
+}
+
+pub fn delete_thread(
+    workspace_dir: PathBuf,
+    thread_id: &str,
+    deleted_at: &str,
+) -> Result<bool, String> {
+    ConversationStore::new(workspace_dir).delete_thread(thread_id, deleted_at)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use serde_json::json;
+
+    fn make_store() -> (TempDir, ConversationStore) {
+        let temp = TempDir::new().expect("tempdir");
+        let store = ConversationStore::new(temp.path().to_path_buf());
+        (temp, store)
+    }
+
+    #[test]
+    fn store_roundtrips_threads_and_messages() {
+        let (_temp, store) = make_store();
+        let created_at = "2026-04-10T12:00:00Z".to_string();
+        let thread = store
+            .ensure_thread(CreateConversationThread {
+                id: "default-thread".to_string(),
+                title: "Conversation".to_string(),
+                created_at: created_at.clone(),
+            })
+            .expect("ensure thread");
+        assert_eq!(thread.message_count, 0);
+
+        store
+            .append_message(
+                "default-thread",
+                ConversationMessage {
+                    id: "m1".to_string(),
+                    content: "hello".to_string(),
+                    message_type: "text".to_string(),
+                    extra_metadata: json!({}),
+                    sender: "user".to_string(),
+                    created_at: "2026-04-10T12:01:00Z".to_string(),
+                },
+            )
+            .expect("append message");
+
+        let threads = store.list_threads().expect("list threads");
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].message_count, 1);
+        assert_eq!(threads[0].last_message_at, "2026-04-10T12:01:00Z");
+
+        let messages = store.get_messages("default-thread").expect("get messages");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "hello");
+    }
+
+    #[test]
+    fn store_updates_message_metadata() {
+        let (_temp, store) = make_store();
+        store
+            .ensure_thread(CreateConversationThread {
+                id: "default-thread".to_string(),
+                title: "Conversation".to_string(),
+                created_at: "2026-04-10T12:00:00Z".to_string(),
+            })
+            .expect("ensure thread");
+        store
+            .append_message(
+                "default-thread",
+                ConversationMessage {
+                    id: "m1".to_string(),
+                    content: "hello".to_string(),
+                    message_type: "text".to_string(),
+                    extra_metadata: json!({}),
+                    sender: "user".to_string(),
+                    created_at: "2026-04-10T12:01:00Z".to_string(),
+                },
+            )
+            .expect("append message");
+
+        let updated = store
+            .update_message(
+                "default-thread",
+                "m1",
+                ConversationMessagePatch {
+                    extra_metadata: Some(json!({ "myReactions": ["👍"] })),
+                },
+            )
+            .expect("update message");
+
+        assert_eq!(updated.extra_metadata, json!({ "myReactions": ["👍"] }));
+        let messages = store.get_messages("default-thread").expect("get messages");
+        assert_eq!(messages[0].extra_metadata, json!({ "myReactions": ["👍"] }));
+    }
+
+    #[test]
+    fn purge_removes_threads_and_messages() {
+        let (_temp, store) = make_store();
+        store
+            .ensure_thread(CreateConversationThread {
+                id: "default-thread".to_string(),
+                title: "Conversation".to_string(),
+                created_at: "2026-04-10T12:00:00Z".to_string(),
+            })
+            .expect("ensure thread");
+        store
+            .append_message(
+                "default-thread",
+                ConversationMessage {
+                    id: "m1".to_string(),
+                    content: "hello".to_string(),
+                    message_type: "text".to_string(),
+                    extra_metadata: json!({}),
+                    sender: "user".to_string(),
+                    created_at: "2026-04-10T12:01:00Z".to_string(),
+                },
+            )
+            .expect("append message");
+
+        let stats = store.purge_threads().expect("purge");
+        assert_eq!(stats.thread_count, 1);
+        assert_eq!(stats.message_count, 1);
+        assert!(store.list_threads().expect("list threads").is_empty());
+    }
+}

--- a/src/openhuman/memory/conversations/types.rs
+++ b/src/openhuman/memory/conversations/types.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationThread {
+    pub id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<i64>,
+    pub is_active: bool,
+    pub message_count: usize,
+    pub last_message_at: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationMessage {
+    pub id: String,
+    pub content: String,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    #[serde(default)]
+    pub extra_metadata: Value,
+    pub sender: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateConversationThread {
+    pub id: String,
+    pub title: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationMessagePatch {
+    #[serde(default)]
+    pub extra_metadata: Option<Value>,
+}

--- a/src/openhuman/memory/mod.rs
+++ b/src/openhuman/memory/mod.rs
@@ -6,6 +6,7 @@
 //! a unified memory interface for AI agents.
 
 pub mod chunker;
+pub mod conversations;
 pub mod embeddings;
 pub mod global;
 pub mod ingestion;

--- a/src/openhuman/memory/ops.rs
+++ b/src/openhuman/memory/ops.rs
@@ -6,18 +6,26 @@
 //! for formatting and filtering memory results.
 
 use crate::openhuman::config::Config;
+use crate::openhuman::memory::conversations::{
+    self, ConversationMessage, ConversationMessagePatch, ConversationThread,
+    CreateConversationThread,
+};
 use crate::openhuman::memory::store::GraphRelationRecord;
 use crate::openhuman::memory::{
-    ApiEnvelope, ApiError, ApiMeta, DeleteDocumentRequest, DeleteDocumentResponse, EmptyRequest,
+    ApiEnvelope, ApiError, ApiMeta, AppendConversationMessageRequest, ConversationMessageRecord,
+    ConversationMessagesRequest, ConversationMessagesResponse, ConversationThreadSummary,
+    ConversationThreadsListResponse, DeleteConversationThreadRequest,
+    DeleteConversationThreadResponse, DeleteDocumentRequest, DeleteDocumentResponse, EmptyRequest,
     ListDocumentsRequest, ListDocumentsResponse, ListMemoryFilesRequest, ListMemoryFilesResponse,
     ListNamespacesResponse, MemoryClient, MemoryClientRef, MemoryDocumentSummary,
     MemoryIngestionConfig, MemoryIngestionRequest, MemoryIngestionResult, MemoryInitRequest,
     MemoryInitResponse, MemoryItemKind, MemoryRecallItem, MemoryRetrievalChunk,
     MemoryRetrievalContext, MemoryRetrievalEntity, MemoryRetrievalRelation, NamespaceDocumentInput,
-    NamespaceMemoryHit, NamespaceRetrievalContext, PaginationMeta, QueryNamespaceRequest,
-    QueryNamespaceResponse, ReadMemoryFileRequest, ReadMemoryFileResponse, RecallContextRequest,
-    RecallContextResponse, RecallMemoriesRequest, RecallMemoriesResponse, WriteMemoryFileRequest,
-    WriteMemoryFileResponse,
+    NamespaceMemoryHit, NamespaceRetrievalContext, PaginationMeta,
+    PurgeConversationThreadsResponse, QueryNamespaceRequest, QueryNamespaceResponse,
+    ReadMemoryFileRequest, ReadMemoryFileResponse, RecallContextRequest, RecallContextResponse,
+    RecallMemoriesRequest, RecallMemoriesResponse, UpdateConversationMessageRequest,
+    UpsertConversationThreadRequest, WriteMemoryFileRequest, WriteMemoryFileResponse,
 };
 use crate::rpc::RpcOutcome;
 use chrono::TimeZone;
@@ -691,6 +699,40 @@ fn default_category() -> String {
     "core".to_string()
 }
 
+fn conversation_thread_to_summary(thread: ConversationThread) -> ConversationThreadSummary {
+    ConversationThreadSummary {
+        id: thread.id,
+        title: thread.title,
+        chat_id: thread.chat_id,
+        is_active: thread.is_active,
+        message_count: thread.message_count,
+        last_message_at: thread.last_message_at,
+        created_at: thread.created_at,
+    }
+}
+
+fn conversation_message_to_record(message: ConversationMessage) -> ConversationMessageRecord {
+    ConversationMessageRecord {
+        id: message.id,
+        content: message.content,
+        message_type: message.message_type,
+        extra_metadata: message.extra_metadata,
+        sender: message.sender,
+        created_at: message.created_at,
+    }
+}
+
+fn conversation_record_to_message(record: ConversationMessageRecord) -> ConversationMessage {
+    ConversationMessage {
+        id: record.id,
+        content: record.content,
+        message_type: record.message_type,
+        extra_metadata: record.extra_metadata,
+        sender: record.sender,
+        created_at: record.created_at,
+    }
+}
+
 /// Lists all namespaces in the memory system.
 pub async fn namespace_list() -> Result<RpcOutcome<Vec<String>>, String> {
     let client = active_memory_client().await?;
@@ -963,6 +1005,128 @@ pub async fn memory_delete_document(
             namespace: parsed.namespace,
             document_id: parsed.document_id,
             deleted: parsed.deleted,
+        },
+        None,
+        None,
+    ))
+}
+
+/// Lists workspace-backed conversation threads from JSONL storage.
+pub async fn memory_threads_list(
+    _request: EmptyRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ConversationThreadsListResponse>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let threads = conversations::list_threads(workspace_dir)?
+        .into_iter()
+        .map(conversation_thread_to_summary)
+        .collect::<Vec<_>>();
+    let count = threads.len();
+    Ok(envelope(
+        ConversationThreadsListResponse { threads, count },
+        Some(memory_counts([("num_threads", count)])),
+        None,
+    ))
+}
+
+/// Ensures a workspace-backed conversation thread exists.
+pub async fn memory_thread_upsert(
+    request: UpsertConversationThreadRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ConversationThreadSummary>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let thread = conversations::ensure_thread(
+        workspace_dir,
+        CreateConversationThread {
+            id: request.id,
+            title: request.title,
+            created_at: request.created_at,
+        },
+    )?;
+    Ok(envelope(
+        conversation_thread_to_summary(thread),
+        Some(memory_counts([("num_threads", 1)])),
+        None,
+    ))
+}
+
+/// Lists persisted messages for a workspace-backed conversation thread.
+pub async fn memory_messages_list(
+    request: ConversationMessagesRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ConversationMessagesResponse>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let messages = conversations::get_messages(workspace_dir, &request.thread_id)?
+        .into_iter()
+        .map(conversation_message_to_record)
+        .collect::<Vec<_>>();
+    let count = messages.len();
+    Ok(envelope(
+        ConversationMessagesResponse { messages, count },
+        Some(memory_counts([("num_messages", count)])),
+        None,
+    ))
+}
+
+/// Appends a persisted message to a workspace-backed conversation thread.
+pub async fn memory_message_append(
+    request: AppendConversationMessageRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ConversationMessageRecord>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let message = conversations::append_message(
+        workspace_dir,
+        &request.thread_id,
+        conversation_record_to_message(request.message),
+    )?;
+    Ok(envelope(
+        conversation_message_to_record(message),
+        Some(memory_counts([("num_messages", 1)])),
+        None,
+    ))
+}
+
+/// Updates persisted metadata for an existing conversation message.
+pub async fn memory_message_update(
+    request: UpdateConversationMessageRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ConversationMessageRecord>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let message = conversations::update_message(
+        workspace_dir,
+        &request.thread_id,
+        &request.message_id,
+        ConversationMessagePatch {
+            extra_metadata: request.extra_metadata,
+        },
+    )?;
+    Ok(envelope(
+        conversation_message_to_record(message),
+        Some(memory_counts([("num_messages", 1)])),
+        None,
+    ))
+}
+
+/// Deletes a workspace-backed conversation thread and its JSONL message log.
+pub async fn memory_thread_delete(
+    request: DeleteConversationThreadRequest,
+) -> Result<RpcOutcome<ApiEnvelope<DeleteConversationThreadResponse>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let deleted = conversations::ConversationStore::new(workspace_dir)
+        .delete_thread(&request.thread_id, &request.deleted_at)?;
+    Ok(envelope(
+        DeleteConversationThreadResponse { deleted },
+        None,
+        None,
+    ))
+}
+
+/// Purges all workspace-backed conversation JSONL state.
+pub async fn memory_threads_purge(
+    _request: EmptyRequest,
+) -> Result<RpcOutcome<ApiEnvelope<PurgeConversationThreadsResponse>>, String> {
+    let workspace_dir = current_workspace_dir().await?;
+    let stats = conversations::purge_threads(workspace_dir)?;
+    Ok(envelope(
+        PurgeConversationThreadsResponse {
+            messages_deleted: stats.message_count,
+            agent_threads_deleted: stats.thread_count,
+            agent_messages_deleted: stats.message_count,
         },
         None,
         None,

--- a/src/openhuman/memory/rpc_models.rs
+++ b/src/openhuman/memory/rpc_models.rs
@@ -90,6 +90,108 @@ pub struct MemoryInitResponse {
     pub memory_dir: String,
 }
 
+/// Summary information for a workspace-backed conversation thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationThreadSummary {
+    pub id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<i64>,
+    pub is_active: bool,
+    pub message_count: usize,
+    pub last_message_at: String,
+    pub created_at: String,
+}
+
+/// A single persisted conversation message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationMessageRecord {
+    pub id: String,
+    pub content: String,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    #[serde(default)]
+    pub extra_metadata: serde_json::Value,
+    pub sender: String,
+    pub created_at: String,
+}
+
+/// Request to create or update a thread in workspace storage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpsertConversationThreadRequest {
+    pub id: String,
+    pub title: String,
+    pub created_at: String,
+}
+
+/// Response payload for thread list operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationThreadsListResponse {
+    pub threads: Vec<ConversationThreadSummary>,
+    pub count: usize,
+}
+
+/// Request to fetch messages for a specific thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConversationMessagesRequest {
+    pub thread_id: String,
+}
+
+/// Response payload for message list operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationMessagesResponse {
+    pub messages: Vec<ConversationMessageRecord>,
+    pub count: usize,
+}
+
+/// Request to append a message to a thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppendConversationMessageRequest {
+    pub thread_id: String,
+    pub message: ConversationMessageRecord,
+}
+
+/// Request to patch a persisted message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateConversationMessageRequest {
+    pub thread_id: String,
+    pub message_id: String,
+    #[serde(default)]
+    pub extra_metadata: Option<serde_json::Value>,
+}
+
+/// Request to delete a thread and its message log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeleteConversationThreadRequest {
+    pub thread_id: String,
+    pub deleted_at: String,
+}
+
+/// Response payload for single-thread deletion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteConversationThreadResponse {
+    pub deleted: bool,
+}
+
+/// Response payload for purging all workspace-backed conversations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PurgeConversationThreadsResponse {
+    pub messages_deleted: usize,
+    pub agent_threads_deleted: usize,
+    pub agent_messages_deleted: usize,
+}
+
 /// Request payload for `openhuman.list_documents`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/openhuman/memory/schemas.rs
+++ b/src/openhuman/memory/schemas.rs
@@ -15,9 +15,11 @@ use crate::openhuman::memory::rpc::{
     QueryNamespaceParams, RecallNamespaceParams,
 };
 use crate::openhuman::memory::{
+    AppendConversationMessageRequest, ConversationMessagesRequest, DeleteConversationThreadRequest,
     DeleteDocumentRequest, EmptyRequest, ListDocumentsRequest, ListMemoryFilesRequest,
     MemoryInitRequest, QueryNamespaceRequest, ReadMemoryFileRequest, RecallContextRequest,
-    RecallMemoriesRequest, WriteMemoryFileRequest,
+    RecallMemoriesRequest, UpdateConversationMessageRequest, UpsertConversationThreadRequest,
+    WriteMemoryFileRequest,
 };
 use crate::rpc::RpcOutcome;
 
@@ -38,6 +40,13 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("list_files"),
         schemas("read_file"),
         schemas("write_file"),
+        schemas("threads_list"),
+        schemas("thread_upsert"),
+        schemas("messages_list"),
+        schemas("message_append"),
+        schemas("message_update"),
+        schemas("thread_delete"),
+        schemas("threads_purge"),
         schemas("namespace_list"),
         schemas("doc_put"),
         schemas("doc_ingest"),
@@ -97,6 +106,34 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("write_file"),
             handler: handle_write_file,
+        },
+        RegisteredController {
+            schema: schemas("threads_list"),
+            handler: handle_threads_list,
+        },
+        RegisteredController {
+            schema: schemas("thread_upsert"),
+            handler: handle_thread_upsert,
+        },
+        RegisteredController {
+            schema: schemas("messages_list"),
+            handler: handle_messages_list,
+        },
+        RegisteredController {
+            schema: schemas("message_append"),
+            handler: handle_message_append,
+        },
+        RegisteredController {
+            schema: schemas("message_update"),
+            handler: handle_message_update,
+        },
+        RegisteredController {
+            schema: schemas("thread_delete"),
+            handler: handle_thread_delete,
+        },
+        RegisteredController {
+            schema: schemas("threads_purge"),
+            handler: handle_threads_purge,
         },
         RegisteredController {
             schema: schemas("namespace_list"),
@@ -431,6 +468,159 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 name: "result",
                 ty: TypeSchema::Json,
                 comment: "Envelope with write confirmation and bytes written.",
+                required: true,
+            }],
+        },
+        "threads_list" => ControllerSchema {
+            namespace: "memory",
+            function: "threads_list",
+            description: "List workspace-backed conversation threads stored as JSONL files.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with thread summaries and count.",
+                required: true,
+            }],
+        },
+        "thread_upsert" => ControllerSchema {
+            namespace: "memory",
+            function: "thread_upsert",
+            description: "Create or refresh a workspace-backed conversation thread entry.",
+            inputs: vec![
+                FieldSchema {
+                    name: "id",
+                    ty: TypeSchema::String,
+                    comment: "Stable thread identifier.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "title",
+                    ty: TypeSchema::String,
+                    comment: "Human-readable thread title.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "created_at",
+                    ty: TypeSchema::String,
+                    comment: "RFC3339 timestamp for first thread creation.",
+                    required: true,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with the resulting thread summary.",
+                required: true,
+            }],
+        },
+        "messages_list" => ControllerSchema {
+            namespace: "memory",
+            function: "messages_list",
+            description: "List persisted messages for a workspace-backed conversation thread.",
+            inputs: vec![FieldSchema {
+                name: "thread_id",
+                ty: TypeSchema::String,
+                comment: "Thread identifier.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with messages and count.",
+                required: true,
+            }],
+        },
+        "message_append" => ControllerSchema {
+            namespace: "memory",
+            function: "message_append",
+            description: "Append a persisted message record to a workspace-backed conversation thread.",
+            inputs: vec![
+                FieldSchema {
+                    name: "thread_id",
+                    ty: TypeSchema::String,
+                    comment: "Thread identifier.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "message",
+                    ty: TypeSchema::Json,
+                    comment: "Message payload to append.",
+                    required: true,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with the appended message payload.",
+                required: true,
+            }],
+        },
+        "message_update" => ControllerSchema {
+            namespace: "memory",
+            function: "message_update",
+            description: "Patch persisted metadata for an existing conversation message.",
+            inputs: vec![
+                FieldSchema {
+                    name: "thread_id",
+                    ty: TypeSchema::String,
+                    comment: "Thread identifier.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "message_id",
+                    ty: TypeSchema::String,
+                    comment: "Message identifier.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "extra_metadata",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Replacement message metadata object.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with the updated message payload.",
+                required: true,
+            }],
+        },
+        "thread_delete" => ControllerSchema {
+            namespace: "memory",
+            function: "thread_delete",
+            description: "Delete a workspace-backed conversation thread and its message log.",
+            inputs: vec![
+                FieldSchema {
+                    name: "thread_id",
+                    ty: TypeSchema::String,
+                    comment: "Thread identifier.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "deleted_at",
+                    ty: TypeSchema::String,
+                    comment: "RFC3339 deletion timestamp.",
+                    required: true,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with deletion status.",
+                required: true,
+            }],
+        },
+        "threads_purge" => ControllerSchema {
+            namespace: "memory",
+            function: "threads_purge",
+            description: "Remove all workspace-backed conversation JSONL files.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with deleted thread/message counts.",
                 required: true,
             }],
         },
@@ -1010,6 +1200,49 @@ fn handle_write_file(params: Map<String, Value>) -> ControllerFuture {
         let payload = parse_params::<WriteMemoryFileRequest>(params)?;
         to_json(rpc::ai_write_memory_file(payload).await?)
     })
+}
+
+fn handle_threads_list(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { to_json(rpc::memory_threads_list(EmptyRequest {}).await?) })
+}
+
+fn handle_thread_upsert(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = parse_params::<UpsertConversationThreadRequest>(params)?;
+        to_json(rpc::memory_thread_upsert(payload).await?)
+    })
+}
+
+fn handle_messages_list(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = parse_params::<ConversationMessagesRequest>(params)?;
+        to_json(rpc::memory_messages_list(payload).await?)
+    })
+}
+
+fn handle_message_append(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = parse_params::<AppendConversationMessageRequest>(params)?;
+        to_json(rpc::memory_message_append(payload).await?)
+    })
+}
+
+fn handle_message_update(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = parse_params::<UpdateConversationMessageRequest>(params)?;
+        to_json(rpc::memory_message_update(payload).await?)
+    })
+}
+
+fn handle_thread_delete(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = parse_params::<DeleteConversationThreadRequest>(params)?;
+        to_json(rpc::memory_thread_delete(payload).await?)
+    })
+}
+
+fn handle_threads_purge(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { to_json(rpc::memory_threads_purge(EmptyRequest {}).await?) })
 }
 
 fn handle_namespace_list(_params: Map<String, Value>) -> ControllerFuture {


### PR DESCRIPTION
## Summary

- Move conversation thread and message persistence from persisted Redux state into the Rust memory module backed by workspace JSONL files.
- Add `memory` RPC controllers for listing, creating, appending, updating, deleting, and purging conversation threads/messages.
- Update the app thread API, thread slice, and conversations page to load and persist chat state through core RPC instead of browser storage.
- Keep Redux as transient UI cache only; thread history now survives at the workspace level.
- Add focused Rust and Vitest coverage for the new conversation persistence path.

## Problem

- The current conversations UI stores all thread and message history in persisted Redux state.
- That makes session history a frontend-owned durability concern instead of workspace-owned application state.
- It also prevents the Rust core memory layer from being the source of truth for conversations and makes thread/message state harder to inspect, migrate, or reuse outside the UI process.

## Solution

- Add a new workspace-backed conversation store under `src/openhuman/memory/conversations/`.
- Store thread metadata in append-only `threads.jsonl` and store each thread's messages in its own JSONL log under the workspace memory directory.
- Expose the store through new memory RPC methods so the frontend can list threads, create the default thread, load messages, append streamed assistant/user messages, update message metadata for reactions, delete threads, and purge all conversation state.
- Replace persisted Redux thread storage with async core-backed loading and writing while preserving the existing UI flow in `Conversations.tsx`.
- Keep debug logging and JSONL rewrite behavior explicit for metadata patch operations such as reactions.

## Submission Checklist

- [x] **Unit tests** — Vitest (`app/`) and/or `cargo test` (core) for logic you add or change
- [ ] **E2E / integration** — Where behavior is user-visible or crosses UI → Tauri → sidecar → JSON-RPC; use existing harnesses (`app/test/e2e`, mock backend, `tests/json_rpc_e2e.rs` as appropriate)
- [x] **N/A** — No new E2E spec added in this PR; covered with focused Rust store tests plus app RPC client test and compile checks
- [x] **Doc comments** — `///` / `//!` (Rust), JSDoc or brief file/module headers (TS) on public APIs and non-obvious modules
- [x] **Inline comments** — Where logic, invariants, or edge cases aren’t clear from names alone (keep them grep-friendly; avoid restating the code)

## Impact

- Desktop conversation persistence now lives under the workspace instead of browser storage.
- This changes the durability boundary but keeps the existing user-facing conversation flow intact.
- Message metadata updates now rewrite a thread JSONL file, which is acceptable for the current low-frequency reaction/update path.
- Existing repo-wide lint warnings unrelated to this change still appear during pre-push, but push-blocking checks passed.

## Related

- Issue(s):
- Follow-up PR(s)/TODOs:
  - Add end-to-end coverage for conversation restore/reload and purge flows through the desktop stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations and messages now persist to workspace-backed storage; persisted channel turns are recorded and de-duplicated.
  * Message loading stays in sync with the selected thread; GIF responses are flagged as GIFs.
  * Reactions persist and synchronize from both events and the UI.

* **Tests**
  * Added unit tests covering thread API behavior.

* **Refactor**
  * Thread/message operations migrated from REST to RPC and storage/persistence behavior updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->