### PR TITLE
feat: native mouse and keyboard control tools

### DIFF
--- a/src/openhuman/config/schema/mod.rs
+++ b/src/openhuman/config/schema/mod.rs
@@ -59,8 +59,9 @@ pub use storage_memory::{
     MemoryConfig, StorageConfig, StorageProviderConfig, StorageProviderSection,
 };
 pub use tools::{
-    BrowserComputerUseConfig, BrowserConfig, ComposioConfig, HttpRequestConfig, IntegrationToggle,
-    IntegrationsConfig, MultimodalConfig, SecretsConfig, WebSearchConfig,
+    BrowserComputerUseConfig, BrowserConfig, ComposioConfig, ComputerControlConfig,
+    HttpRequestConfig, IntegrationToggle, IntegrationsConfig, MultimodalConfig, SecretsConfig,
+    WebSearchConfig,
 };
 pub use update::UpdateConfig;
 mod voice_server;

--- a/src/openhuman/config/schema/tools.rs
+++ b/src/openhuman/config/schema/tools.rs
@@ -237,6 +237,22 @@ impl Default for SecretsConfig {
     }
 }
 
+// ── Native computer control (mouse + keyboard) ─────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ComputerControlConfig {
+    /// Master toggle for mouse and keyboard tools. Disabled by default —
+    /// the user must explicitly opt in.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for ComputerControlConfig {
+    fn default() -> Self {
+        Self { enabled: false }
+    }
+}
+
 // ── Agent integration tools (backend-proxied) ───────────────────────
 
 /// Per-integration on/off toggle.

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -113,6 +113,9 @@ pub struct Config {
     pub cost: CostConfig,
 
     #[serde(default)]
+    pub computer_control: ComputerControlConfig,
+
+    #[serde(default)]
     pub peripherals: PeripheralsConfig,
 
     #[serde(default)]
@@ -181,6 +184,7 @@ impl Default for Config {
             web_search: WebSearchConfig::default(),
             proxy: ProxyConfig::default(),
             cost: CostConfig::default(),
+            computer_control: ComputerControlConfig::default(),
             peripherals: PeripheralsConfig::default(),
             agents: HashMap::new(),
             local_ai: LocalAiConfig::default(),

--- a/src/openhuman/tools/impl/computer/keyboard.rs
+++ b/src/openhuman/tools/impl/computer/keyboard.rs
@@ -143,9 +143,14 @@ impl Tool for KeyboardTool {
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
         if !self.security.can_act() {
+            debug!(
+                tool = "keyboard",
+                "[computer] blocked: autonomy is read-only"
+            );
             return Ok(ToolResult::error("Action blocked: autonomy is read-only"));
         }
         if !self.security.record_action() {
+            debug!(tool = "keyboard", "[computer] blocked: rate limit exceeded");
             return Ok(ToolResult::error("Action blocked: rate limit exceeded"));
         }
 
@@ -225,13 +230,19 @@ impl Tool for KeyboardTool {
             }
 
             "hotkey" => {
-                let key_names: Vec<String> = args
+                let raw_keys = args
                     .get("keys")
                     .and_then(Value::as_array)
-                    .ok_or_else(|| anyhow::anyhow!("Missing 'keys' array for hotkey action"))?
-                    .iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect();
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'keys' array for hotkey action"))?;
+
+                // Reject non-string entries up front.
+                let mut key_names: Vec<String> = Vec::with_capacity(raw_keys.len());
+                for (i, v) in raw_keys.iter().enumerate() {
+                    let s = v.as_str().ok_or_else(|| {
+                        anyhow::anyhow!("Element {i} in 'keys' array is not a string (got {v})")
+                    })?;
+                    key_names.push(s.to_string());
+                }
 
                 if key_names.is_empty() {
                     return Ok(ToolResult::error("'keys' array cannot be empty"));
@@ -241,7 +252,13 @@ impl Tool for KeyboardTool {
                         "Too many keys in hotkey combination (max 6)",
                     ));
                 }
+                if key_names.len() < 2 {
+                    return Ok(ToolResult::error(
+                        "Hotkey requires at least one modifier and one final key (e.g. ['Ctrl', 'C'])",
+                    ));
+                }
 
+                // Parse all key names into Key values.
                 let mut keys: Vec<Key> = Vec::with_capacity(key_names.len());
                 for name in &key_names {
                     let key = parse_key(name).ok_or_else(|| {
@@ -250,25 +267,58 @@ impl Tool for KeyboardTool {
                     keys.push(key);
                 }
 
+                // Validate modifier-first pattern: all keys except the last
+                // must be modifiers, and the last must be a non-modifier.
+                let (modifiers, final_key) = keys.split_at(keys.len() - 1);
+                for (i, key) in modifiers.iter().enumerate() {
+                    if !is_modifier(key) {
+                        return Ok(ToolResult::error(format!(
+                            "Key '{}' at position {i} must be a modifier (Ctrl/Shift/Alt/Cmd). Non-modifier keys must be last.",
+                            key_names[i]
+                        )));
+                    }
+                }
+                if is_modifier(&final_key[0]) {
+                    return Ok(ToolResult::error(format!(
+                        "Last key '{}' cannot be a modifier. Hotkey must end with a non-modifier key (e.g. 'C', 'Enter').",
+                        key_names.last().unwrap()
+                    )));
+                }
+
                 let combo_desc = key_names.join("+");
                 tokio::task::spawn_blocking(move || {
                     let mut enigo = Enigo::new(&Settings::default())
                         .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
 
-                    // Press all keys in order (modifiers first, then the final key)
-                    for key in &keys {
-                        enigo
-                            .key(*key, Direction::Press)
-                            .map_err(|e| anyhow::anyhow!("key press failed: {e}"))?;
-                        std::thread::sleep(HOTKEY_INTER_KEY_DELAY);
+                    // Press keys in order, tracking which were successfully
+                    // pressed so we can release them on error.
+                    let mut pressed_keys: Vec<Key> = Vec::with_capacity(keys.len());
+                    let press_result: Result<(), anyhow::Error> = (|| {
+                        for key in &keys {
+                            enigo.key(*key, Direction::Press).map_err(|e| {
+                                anyhow::anyhow!("key press failed for {key:?}: {e}")
+                            })?;
+                            pressed_keys.push(*key);
+                            std::thread::sleep(HOTKEY_INTER_KEY_DELAY);
+                        }
+                        Ok(())
+                    })();
+
+                    // Always release all successfully pressed keys in reverse
+                    // order, even if a press failed partway through.
+                    for key in pressed_keys.iter().rev() {
+                        if let Err(e) = enigo.key(*key, Direction::Release) {
+                            tracing::warn!(
+                                tool = "keyboard",
+                                key = ?key,
+                                error = %e,
+                                "[computer] best-effort key release failed during cleanup"
+                            );
+                        }
                     }
 
-                    // Release in reverse order
-                    for key in keys.iter().rev() {
-                        enigo
-                            .key(*key, Direction::Release)
-                            .map_err(|e| anyhow::anyhow!("key release failed: {e}"))?;
-                    }
+                    // Now propagate any press error.
+                    press_result?;
 
                     info!(
                         tool = "keyboard",
@@ -480,5 +530,46 @@ mod tests {
             .unwrap();
         assert!(result.is_error);
         assert!(result.output().contains("too long"));
+    }
+
+    // ── hotkey validation tests ──────────────────────────────────
+
+    #[tokio::test]
+    async fn hotkey_non_string_entry_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "hotkey", "keys": ["Ctrl", 1]}))
+            .await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn hotkey_modifier_only_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "hotkey", "keys": ["Ctrl"]}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn hotkey_non_modifier_before_last_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "hotkey", "keys": ["a", "Ctrl"]}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn hotkey_modifier_as_last_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "hotkey", "keys": ["Ctrl", "Shift"]}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
     }
 }

--- a/src/openhuman/tools/impl/computer/keyboard.rs
+++ b/src/openhuman/tools/impl/computer/keyboard.rs
@@ -93,10 +93,7 @@ fn parse_key(name: &str) -> Option<Key> {
 
 /// Returns true if the key is a modifier (Ctrl, Shift, Alt, Meta).
 fn is_modifier(key: &Key) -> bool {
-    matches!(
-        key,
-        Key::Control | Key::Shift | Key::Alt | Key::Meta
-    )
+    matches!(key, Key::Control | Key::Shift | Key::Alt | Key::Meta)
 }
 
 #[async_trait]
@@ -157,7 +154,11 @@ impl Tool for KeyboardTool {
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow::anyhow!("Missing 'action' parameter"))?;
 
-        debug!(tool = "keyboard", action = action, "[computer] keyboard action requested");
+        debug!(
+            tool = "keyboard",
+            action = action,
+            "[computer] keyboard action requested"
+        );
 
         match action {
             "type" => {
@@ -185,7 +186,9 @@ impl Tool for KeyboardTool {
                         .text(&text)
                         .map_err(|e| anyhow::anyhow!("text typing failed: {e}"))?;
                     info!(
-                        tool = "keyboard", action = "type", chars = len,
+                        tool = "keyboard",
+                        action = "type",
+                        chars = len,
                         "[computer] typed text"
                     );
                     Ok(ToolResult::success(format!("Typed {len} characters")))
@@ -211,7 +214,9 @@ impl Tool for KeyboardTool {
                         .key(key, Direction::Click)
                         .map_err(|e| anyhow::anyhow!("key press failed: {e}"))?;
                     info!(
-                        tool = "keyboard", action = "press", key = key_name.as_str(),
+                        tool = "keyboard",
+                        action = "press",
+                        key = key_name.as_str(),
                         "[computer] pressed key"
                     );
                     Ok(ToolResult::success(format!("Pressed key '{key_name}'")))
@@ -266,10 +271,14 @@ impl Tool for KeyboardTool {
                     }
 
                     info!(
-                        tool = "keyboard", action = "hotkey", combo = combo_desc.as_str(),
+                        tool = "keyboard",
+                        action = "hotkey",
+                        combo = combo_desc.as_str(),
                         "[computer] hotkey executed"
                     );
-                    Ok(ToolResult::success(format!("Executed hotkey: {combo_desc}")))
+                    Ok(ToolResult::success(format!(
+                        "Executed hotkey: {combo_desc}"
+                    )))
                 })
                 .await?
             }

--- a/src/openhuman/tools/impl/computer/keyboard.rs
+++ b/src/openhuman/tools/impl/computer/keyboard.rs
@@ -1,0 +1,475 @@
+//! Native keyboard control tool using enigo.
+//!
+//! Provides text typing, individual key presses, and hotkey combinations
+//! via platform-native APIs (Core Graphics on macOS, SendInput on Windows,
+//! X11/libxdo on Linux).
+
+use crate::openhuman::security::SecurityPolicy;
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use async_trait::async_trait;
+use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, info};
+
+/// Small delay between key events in a hotkey sequence so the OS
+/// registers each modifier correctly.
+const HOTKEY_INTER_KEY_DELAY: Duration = Duration::from_millis(20);
+
+/// Maximum text length for the `type` action to prevent accidental floods.
+const MAX_TYPE_LENGTH: usize = 10_000;
+
+pub struct KeyboardTool {
+    security: Arc<SecurityPolicy>,
+}
+
+impl KeyboardTool {
+    pub fn new(security: Arc<SecurityPolicy>) -> Self {
+        Self { security }
+    }
+}
+
+/// Parse a human-readable key name into an enigo `Key`.
+///
+/// Accepts common names (case-insensitive) plus single characters.
+fn parse_key(name: &str) -> Option<Key> {
+    let lower = name.to_ascii_lowercase();
+    match lower.as_str() {
+        // Modifiers
+        "ctrl" | "control" => Some(Key::Control),
+        "shift" => Some(Key::Shift),
+        "alt" | "option" => Some(Key::Alt),
+        "cmd" | "command" | "meta" | "super" | "win" | "windows" => Some(Key::Meta),
+
+        // Navigation
+        "enter" | "return" => Some(Key::Return),
+        "tab" => Some(Key::Tab),
+        "escape" | "esc" => Some(Key::Escape),
+        "backspace" => Some(Key::Backspace),
+        "delete" | "del" => Some(Key::Delete),
+        "space" => Some(Key::Space),
+
+        // Arrow keys
+        "up" | "arrowup" => Some(Key::UpArrow),
+        "down" | "arrowdown" => Some(Key::DownArrow),
+        "left" | "arrowleft" => Some(Key::LeftArrow),
+        "right" | "arrowright" => Some(Key::RightArrow),
+
+        // Home / End / Page
+        "home" => Some(Key::Home),
+        "end" => Some(Key::End),
+        "pageup" | "page_up" => Some(Key::PageUp),
+        "pagedown" | "page_down" => Some(Key::PageDown),
+
+        // Function keys
+        "f1" => Some(Key::F1),
+        "f2" => Some(Key::F2),
+        "f3" => Some(Key::F3),
+        "f4" => Some(Key::F4),
+        "f5" => Some(Key::F5),
+        "f6" => Some(Key::F6),
+        "f7" => Some(Key::F7),
+        "f8" => Some(Key::F8),
+        "f9" => Some(Key::F9),
+        "f10" => Some(Key::F10),
+        "f11" => Some(Key::F11),
+        "f12" => Some(Key::F12),
+
+        // Caps Lock
+        "capslock" | "caps_lock" => Some(Key::CapsLock),
+
+        // Single character — letters, digits, punctuation
+        _ => {
+            let chars: Vec<char> = name.chars().collect();
+            if chars.len() == 1 {
+                Some(Key::Unicode(chars[0]))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Returns true if the key is a modifier (Ctrl, Shift, Alt, Meta).
+fn is_modifier(key: &Key) -> bool {
+    matches!(
+        key,
+        Key::Control | Key::Shift | Key::Alt | Key::Meta
+    )
+}
+
+#[async_trait]
+impl Tool for KeyboardTool {
+    fn name(&self) -> &str {
+        "keyboard"
+    }
+
+    fn description(&self) -> &str {
+        concat!(
+            "Simulate keyboard input natively. Actions: type (enter a text string), ",
+            "press (tap a single key like Enter or Tab), hotkey (key combination like ",
+            "Ctrl+C or Cmd+Shift+S). Key names are case-insensitive."
+        )
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Dangerous
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["type", "press", "hotkey"],
+                    "description": "Keyboard action to perform"
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Text to type. Required for 'type' action. Max 10,000 chars."
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Key name (e.g. 'Enter', 'Tab', 'Escape', 'a', 'F5'). Required for 'press' action."
+                },
+                "keys": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Key combination as ordered array. Modifiers first, then the final key (e.g. ['Ctrl', 'C'] or ['Cmd', 'Shift', 'S']). Required for 'hotkey' action."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        if !self.security.can_act() {
+            return Ok(ToolResult::error("Action blocked: autonomy is read-only"));
+        }
+        if !self.security.record_action() {
+            return Ok(ToolResult::error("Action blocked: rate limit exceeded"));
+        }
+
+        let action = args
+            .get("action")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("Missing 'action' parameter"))?;
+
+        debug!(tool = "keyboard", action = action, "[computer] keyboard action requested");
+
+        match action {
+            "type" => {
+                let text = args
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'text' for type action"))?
+                    .to_string();
+
+                if text.is_empty() {
+                    return Ok(ToolResult::error("'text' cannot be empty"));
+                }
+                if text.len() > MAX_TYPE_LENGTH {
+                    return Ok(ToolResult::error(format!(
+                        "Text too long ({} chars). Maximum is {MAX_TYPE_LENGTH}.",
+                        text.len()
+                    )));
+                }
+
+                let len = text.len();
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    enigo
+                        .text(&text)
+                        .map_err(|e| anyhow::anyhow!("text typing failed: {e}"))?;
+                    info!(
+                        tool = "keyboard", action = "type", chars = len,
+                        "[computer] typed text"
+                    );
+                    Ok(ToolResult::success(format!("Typed {len} characters")))
+                })
+                .await?
+            }
+
+            "press" => {
+                let key_name = args
+                    .get("key")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'key' for press action"))?
+                    .to_string();
+
+                let key = parse_key(&key_name).ok_or_else(|| {
+                    anyhow::anyhow!("Unknown key '{key_name}'. Use names like Enter, Tab, Escape, F1-F12, a-z, 0-9, Space, etc.")
+                })?;
+
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    enigo
+                        .key(key, Direction::Click)
+                        .map_err(|e| anyhow::anyhow!("key press failed: {e}"))?;
+                    info!(
+                        tool = "keyboard", action = "press", key = key_name.as_str(),
+                        "[computer] pressed key"
+                    );
+                    Ok(ToolResult::success(format!("Pressed key '{key_name}'")))
+                })
+                .await?
+            }
+
+            "hotkey" => {
+                let key_names: Vec<String> = args
+                    .get("keys")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'keys' array for hotkey action"))?
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+
+                if key_names.is_empty() {
+                    return Ok(ToolResult::error("'keys' array cannot be empty"));
+                }
+                if key_names.len() > 6 {
+                    return Ok(ToolResult::error(
+                        "Too many keys in hotkey combination (max 6)",
+                    ));
+                }
+
+                let mut keys: Vec<Key> = Vec::with_capacity(key_names.len());
+                for name in &key_names {
+                    let key = parse_key(name).ok_or_else(|| {
+                        anyhow::anyhow!("Unknown key '{name}' in hotkey combination")
+                    })?;
+                    keys.push(key);
+                }
+
+                let combo_desc = key_names.join("+");
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+
+                    // Press all keys in order (modifiers first, then the final key)
+                    for key in &keys {
+                        enigo
+                            .key(*key, Direction::Press)
+                            .map_err(|e| anyhow::anyhow!("key press failed: {e}"))?;
+                        std::thread::sleep(HOTKEY_INTER_KEY_DELAY);
+                    }
+
+                    // Release in reverse order
+                    for key in keys.iter().rev() {
+                        enigo
+                            .key(*key, Direction::Release)
+                            .map_err(|e| anyhow::anyhow!("key release failed: {e}"))?;
+                    }
+
+                    info!(
+                        tool = "keyboard", action = "hotkey", combo = combo_desc.as_str(),
+                        "[computer] hotkey executed"
+                    );
+                    Ok(ToolResult::success(format!("Executed hotkey: {combo_desc}")))
+                })
+                .await?
+            }
+
+            other => Ok(ToolResult::error(format!(
+                "Unknown keyboard action '{other}'. Use: type, press, hotkey"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool() -> KeyboardTool {
+        KeyboardTool::new(Arc::new(SecurityPolicy::default()))
+    }
+
+    #[test]
+    fn schema_has_required_action() {
+        let tool = make_tool();
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["required"], json!(["action"]));
+    }
+
+    #[test]
+    fn schema_enumerates_actions() {
+        let tool = make_tool();
+        let schema = tool.parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(names.contains(&"type"));
+        assert!(names.contains(&"press"));
+        assert!(names.contains(&"hotkey"));
+    }
+
+    #[test]
+    fn permission_is_dangerous() {
+        assert_eq!(make_tool().permission_level(), PermissionLevel::Dangerous);
+    }
+
+    #[test]
+    fn name_is_keyboard() {
+        assert_eq!(make_tool().name(), "keyboard");
+    }
+
+    // ── parse_key tests ──────────────────────────────────────────
+
+    #[test]
+    fn parse_key_modifiers() {
+        assert_eq!(parse_key("Ctrl"), Some(Key::Control));
+        assert_eq!(parse_key("control"), Some(Key::Control));
+        assert_eq!(parse_key("Shift"), Some(Key::Shift));
+        assert_eq!(parse_key("Alt"), Some(Key::Alt));
+        assert_eq!(parse_key("Option"), Some(Key::Alt));
+        assert_eq!(parse_key("Cmd"), Some(Key::Meta));
+        assert_eq!(parse_key("Command"), Some(Key::Meta));
+        assert_eq!(parse_key("Meta"), Some(Key::Meta));
+        assert_eq!(parse_key("Super"), Some(Key::Meta));
+        assert_eq!(parse_key("Win"), Some(Key::Meta));
+    }
+
+    #[test]
+    fn parse_key_navigation() {
+        assert_eq!(parse_key("Enter"), Some(Key::Return));
+        assert_eq!(parse_key("Return"), Some(Key::Return));
+        assert_eq!(parse_key("Tab"), Some(Key::Tab));
+        assert_eq!(parse_key("Escape"), Some(Key::Escape));
+        assert_eq!(parse_key("Esc"), Some(Key::Escape));
+        assert_eq!(parse_key("Backspace"), Some(Key::Backspace));
+        assert_eq!(parse_key("Delete"), Some(Key::Delete));
+        assert_eq!(parse_key("Space"), Some(Key::Space));
+    }
+
+    #[test]
+    fn parse_key_arrows() {
+        assert_eq!(parse_key("Up"), Some(Key::UpArrow));
+        assert_eq!(parse_key("Down"), Some(Key::DownArrow));
+        assert_eq!(parse_key("Left"), Some(Key::LeftArrow));
+        assert_eq!(parse_key("Right"), Some(Key::RightArrow));
+    }
+
+    #[test]
+    fn parse_key_function_keys() {
+        assert_eq!(parse_key("F1"), Some(Key::F1));
+        assert_eq!(parse_key("f5"), Some(Key::F5));
+        assert_eq!(parse_key("F12"), Some(Key::F12));
+    }
+
+    #[test]
+    fn parse_key_single_chars() {
+        assert_eq!(parse_key("a"), Some(Key::Unicode('a')));
+        assert_eq!(parse_key("A"), Some(Key::Unicode('A')));
+        assert_eq!(parse_key("5"), Some(Key::Unicode('5')));
+        assert_eq!(parse_key("/"), Some(Key::Unicode('/')));
+    }
+
+    #[test]
+    fn parse_key_unknown_returns_none() {
+        assert_eq!(parse_key("FooBar"), None);
+        assert_eq!(parse_key(""), None);
+    }
+
+    #[test]
+    fn modifier_detection() {
+        assert!(is_modifier(&Key::Control));
+        assert!(is_modifier(&Key::Shift));
+        assert!(is_modifier(&Key::Alt));
+        assert!(is_modifier(&Key::Meta));
+        assert!(!is_modifier(&Key::Return));
+        assert!(!is_modifier(&Key::Unicode('a')));
+    }
+
+    // ── execute validation tests ─────────────────────────────────
+
+    #[tokio::test]
+    async fn missing_action_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"action": "smash"})).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Unknown keyboard action"));
+    }
+
+    #[tokio::test]
+    async fn type_missing_text_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"action": "type"})).await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn type_empty_text_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "type", "text": ""}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn press_missing_key_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"action": "press"})).await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn press_unknown_key_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "press", "key": "FooBarBaz"}))
+            .await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn hotkey_missing_keys_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"action": "hotkey"})).await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn hotkey_empty_array_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "hotkey", "keys": []}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn hotkey_too_many_keys_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "hotkey", "keys": ["a","b","c","d","e","f","g"]}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn type_too_long_returns_error() {
+        let tool = make_tool();
+        let long_text = "x".repeat(MAX_TYPE_LENGTH + 1);
+        let result = tool
+            .execute(json!({"action": "type", "text": long_text}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("too long"));
+    }
+}

--- a/src/openhuman/tools/impl/computer/mod.rs
+++ b/src/openhuman/tools/impl/computer/mod.rs
@@ -1,0 +1,5 @@
+mod keyboard;
+mod mouse;
+
+pub use keyboard::KeyboardTool;
+pub use mouse::MouseTool;

--- a/src/openhuman/tools/impl/computer/mouse.rs
+++ b/src/openhuman/tools/impl/computer/mouse.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use enigo::{Button, Coordinate, Direction, Enigo, Mouse, Settings};
 use serde_json::{json, Value};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Coordinate safety bound — reject values outside this range.
 const MAX_COORD: i64 = 32768;
@@ -25,11 +25,18 @@ impl MouseTool {
     }
 }
 
-fn parse_button(args: &Value) -> Button {
-    match args.get("button").and_then(Value::as_str) {
-        Some("right") => Button::Right,
-        Some("middle") => Button::Middle,
-        _ => Button::Left,
+fn parse_button(args: &Value) -> anyhow::Result<Button> {
+    match args.get("button") {
+        None => Ok(Button::Left),
+        Some(v) => match v.as_str() {
+            Some("left") => Ok(Button::Left),
+            Some("right") => Ok(Button::Right),
+            Some("middle") => Ok(Button::Middle),
+            Some(other) => {
+                anyhow::bail!("Invalid mouse button '{other}'. Use: left, right, middle")
+            }
+            None => anyhow::bail!("'button' must be a string, got {v}"),
+        },
     }
 }
 
@@ -117,9 +124,11 @@ impl Tool for MouseTool {
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
         if !self.security.can_act() {
+            debug!(tool = "mouse", "[computer] blocked: autonomy is read-only");
             return Ok(ToolResult::error("Action blocked: autonomy is read-only"));
         }
         if !self.security.record_action() {
+            debug!(tool = "mouse", "[computer] blocked: rate limit exceeded");
             return Ok(ToolResult::error("Action blocked: rate limit exceeded"));
         }
 
@@ -157,7 +166,7 @@ impl Tool for MouseTool {
 
             "click" => {
                 let (x, y) = require_xy(&args)?;
-                let button = parse_button(&args);
+                let button = parse_button(&args)?;
                 tokio::task::spawn_blocking(move || {
                     let mut enigo = Enigo::new(&Settings::default())
                         .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
@@ -181,7 +190,7 @@ impl Tool for MouseTool {
 
             "double_click" => {
                 let (x, y) = require_xy(&args)?;
-                let button = parse_button(&args);
+                let button = parse_button(&args)?;
                 tokio::task::spawn_blocking(move || {
                     let mut enigo = Enigo::new(&Settings::default())
                         .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
@@ -218,7 +227,7 @@ impl Tool for MouseTool {
                 validate_coord("start_x", start_x)?;
                 validate_coord("start_y", start_y)?;
                 let (end_x, end_y) = require_xy(&args)?;
-                let button = parse_button(&args);
+                let button = parse_button(&args)?;
                 let sx = start_x as i32;
                 let sy = start_y as i32;
 
@@ -231,12 +240,28 @@ impl Tool for MouseTool {
                     enigo
                         .button(button, Direction::Press)
                         .map_err(|e| anyhow::anyhow!("button press failed: {e}"))?;
-                    enigo
-                        .move_mouse(end_x, end_y, Coordinate::Abs)
-                        .map_err(|e| anyhow::anyhow!("move_mouse (end) failed: {e}"))?;
-                    enigo
-                        .button(button, Direction::Release)
-                        .map_err(|e| anyhow::anyhow!("button release failed: {e}"))?;
+
+                    // After press succeeds, guarantee release even on error.
+                    let drag_result: Result<(), anyhow::Error> = (|| {
+                        enigo
+                            .move_mouse(end_x, end_y, Coordinate::Abs)
+                            .map_err(|e| anyhow::anyhow!("move_mouse (end) failed: {e}"))?;
+                        Ok(())
+                    })();
+
+                    // Always release — best-effort cleanup.
+                    if let Err(e) = enigo.button(button, Direction::Release) {
+                        warn!(
+                            tool = "mouse",
+                            button = ?button,
+                            error = %e,
+                            "[computer] best-effort button release failed during drag cleanup"
+                        );
+                    }
+
+                    // Propagate the drag error if the move failed.
+                    drag_result?;
+
                     info!(
                         tool = "mouse", action = "drag",
                         start_x = sx, start_y = sy,
@@ -251,8 +276,23 @@ impl Tool for MouseTool {
             }
 
             "scroll" => {
-                let scroll_x = args.get("scroll_x").and_then(Value::as_i64).unwrap_or(0) as i32;
-                let scroll_y = args.get("scroll_y").and_then(Value::as_i64).unwrap_or(0) as i32;
+                let raw_x = args.get("scroll_x").and_then(Value::as_i64).unwrap_or(0);
+                let raw_y = args.get("scroll_y").and_then(Value::as_i64).unwrap_or(0);
+
+                let scroll_x = i32::try_from(raw_x).map_err(|_| {
+                    anyhow::anyhow!(
+                        "'scroll_x' value {raw_x} is out of i32 range ({min}..={max})",
+                        min = i32::MIN,
+                        max = i32::MAX
+                    )
+                })?;
+                let scroll_y = i32::try_from(raw_y).map_err(|_| {
+                    anyhow::anyhow!(
+                        "'scroll_y' value {raw_y} is out of i32 range ({min}..={max})",
+                        min = i32::MIN,
+                        max = i32::MAX
+                    )
+                })?;
 
                 if scroll_x == 0 && scroll_y == 0 {
                     return Ok(ToolResult::error(
@@ -355,18 +395,37 @@ mod tests {
 
     #[test]
     fn parse_button_defaults_to_left() {
-        assert_eq!(parse_button(&json!({})), Button::Left);
-        assert_eq!(parse_button(&json!({"button": "left"})), Button::Left);
+        assert_eq!(parse_button(&json!({})).unwrap(), Button::Left);
+        assert_eq!(
+            parse_button(&json!({"button": "left"})).unwrap(),
+            Button::Left
+        );
     }
 
     #[test]
     fn parse_button_right() {
-        assert_eq!(parse_button(&json!({"button": "right"})), Button::Right);
+        assert_eq!(
+            parse_button(&json!({"button": "right"})).unwrap(),
+            Button::Right
+        );
     }
 
     #[test]
     fn parse_button_middle() {
-        assert_eq!(parse_button(&json!({"button": "middle"})), Button::Middle);
+        assert_eq!(
+            parse_button(&json!({"button": "middle"})).unwrap(),
+            Button::Middle
+        );
+    }
+
+    #[test]
+    fn parse_button_unknown_returns_error() {
+        assert!(parse_button(&json!({"button": "laser"})).is_err());
+    }
+
+    #[test]
+    fn parse_button_non_string_returns_error() {
+        assert!(parse_button(&json!({"button": 42})).is_err());
     }
 
     #[tokio::test]

--- a/src/openhuman/tools/impl/computer/mouse.rs
+++ b/src/openhuman/tools/impl/computer/mouse.rs
@@ -1,0 +1,401 @@
+//! Native mouse control tool using enigo.
+//!
+//! Provides absolute-coordinate mouse movement, clicking, double-clicking,
+//! dragging, and scrolling via platform-native APIs (Core Graphics on macOS,
+//! SendInput on Windows, X11/libxdo on Linux).
+
+use crate::openhuman::security::SecurityPolicy;
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use async_trait::async_trait;
+use enigo::{Button, Coordinate, Direction, Enigo, Mouse, Settings};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tracing::{debug, info};
+
+/// Coordinate safety bound — reject values outside this range.
+const MAX_COORD: i64 = 32768;
+
+pub struct MouseTool {
+    security: Arc<SecurityPolicy>,
+}
+
+impl MouseTool {
+    pub fn new(security: Arc<SecurityPolicy>) -> Self {
+        Self { security }
+    }
+}
+
+fn parse_button(args: &Value) -> Button {
+    match args.get("button").and_then(Value::as_str) {
+        Some("right") => Button::Right,
+        Some("middle") => Button::Middle,
+        _ => Button::Left,
+    }
+}
+
+fn require_xy(args: &Value) -> anyhow::Result<(i32, i32)> {
+    let x = args
+        .get("x")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow::anyhow!("Missing required 'x' parameter"))?;
+    let y = args
+        .get("y")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| anyhow::anyhow!("Missing required 'y' parameter"))?;
+    validate_coord("x", x)?;
+    validate_coord("y", y)?;
+    Ok((x as i32, y as i32))
+}
+
+fn validate_coord(name: &str, value: i64) -> anyhow::Result<()> {
+    if value < 0 || value > MAX_COORD {
+        anyhow::bail!("'{name}' coordinate {value} is out of range (0..{MAX_COORD})");
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl Tool for MouseTool {
+    fn name(&self) -> &str {
+        "mouse"
+    }
+
+    fn description(&self) -> &str {
+        concat!(
+            "Control the mouse cursor natively. Actions: move (reposition cursor), ",
+            "click (move + click), double_click, drag (press at start, release at end), ",
+            "scroll (vertical/horizontal). All coordinates are absolute screen pixels."
+        )
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Dangerous
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["move", "click", "double_click", "drag", "scroll"],
+                    "description": "Mouse action to perform"
+                },
+                "x": {
+                    "type": "integer",
+                    "description": "Target X coordinate (absolute screen pixels). Required for move, click, double_click."
+                },
+                "y": {
+                    "type": "integer",
+                    "description": "Target Y coordinate (absolute screen pixels). Required for move, click, double_click."
+                },
+                "button": {
+                    "type": "string",
+                    "enum": ["left", "right", "middle"],
+                    "description": "Mouse button for click/double_click/drag. Default: left."
+                },
+                "start_x": {
+                    "type": "integer",
+                    "description": "Drag start X coordinate (absolute). Required for drag."
+                },
+                "start_y": {
+                    "type": "integer",
+                    "description": "Drag start Y coordinate (absolute). Required for drag."
+                },
+                "scroll_x": {
+                    "type": "integer",
+                    "description": "Horizontal scroll amount (positive = right, negative = left). For scroll action."
+                },
+                "scroll_y": {
+                    "type": "integer",
+                    "description": "Vertical scroll amount (positive = down, negative = up). For scroll action."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        if !self.security.can_act() {
+            return Ok(ToolResult::error("Action blocked: autonomy is read-only"));
+        }
+        if !self.security.record_action() {
+            return Ok(ToolResult::error("Action blocked: rate limit exceeded"));
+        }
+
+        let action = args
+            .get("action")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("Missing 'action' parameter"))?;
+
+        debug!(tool = "mouse", action = action, "[computer] mouse action requested");
+
+        match action {
+            "move" => {
+                let (x, y) = require_xy(&args)?;
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    enigo
+                        .move_mouse(x, y, Coordinate::Abs)
+                        .map_err(|e| anyhow::anyhow!("move_mouse failed: {e}"))?;
+                    info!(tool = "mouse", action = "move", x = x, y = y, "[computer] cursor moved");
+                    Ok(ToolResult::success(format!("Moved cursor to ({x}, {y})")))
+                })
+                .await?
+            }
+
+            "click" => {
+                let (x, y) = require_xy(&args)?;
+                let button = parse_button(&args);
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    enigo
+                        .move_mouse(x, y, Coordinate::Abs)
+                        .map_err(|e| anyhow::anyhow!("move_mouse failed: {e}"))?;
+                    enigo
+                        .button(button, Direction::Click)
+                        .map_err(|e| anyhow::anyhow!("button click failed: {e}"))?;
+                    info!(
+                        tool = "mouse", action = "click",
+                        x = x, y = y, button = ?button,
+                        "[computer] clicked"
+                    );
+                    Ok(ToolResult::success(format!(
+                        "Clicked {button:?} at ({x}, {y})"
+                    )))
+                })
+                .await?
+            }
+
+            "double_click" => {
+                let (x, y) = require_xy(&args)?;
+                let button = parse_button(&args);
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    enigo
+                        .move_mouse(x, y, Coordinate::Abs)
+                        .map_err(|e| anyhow::anyhow!("move_mouse failed: {e}"))?;
+                    enigo
+                        .button(button, Direction::Click)
+                        .map_err(|e| anyhow::anyhow!("button click failed: {e}"))?;
+                    enigo
+                        .button(button, Direction::Click)
+                        .map_err(|e| anyhow::anyhow!("button click failed: {e}"))?;
+                    info!(
+                        tool = "mouse", action = "double_click",
+                        x = x, y = y, button = ?button,
+                        "[computer] double-clicked"
+                    );
+                    Ok(ToolResult::success(format!(
+                        "Double-clicked {button:?} at ({x}, {y})"
+                    )))
+                })
+                .await?
+            }
+
+            "drag" => {
+                let start_x = args
+                    .get("start_x")
+                    .and_then(Value::as_i64)
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'start_x' for drag"))?;
+                let start_y = args
+                    .get("start_y")
+                    .and_then(Value::as_i64)
+                    .ok_or_else(|| anyhow::anyhow!("Missing 'start_y' for drag"))?;
+                validate_coord("start_x", start_x)?;
+                validate_coord("start_y", start_y)?;
+                let (end_x, end_y) = require_xy(&args)?;
+                let button = parse_button(&args);
+                let sx = start_x as i32;
+                let sy = start_y as i32;
+
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    enigo
+                        .move_mouse(sx, sy, Coordinate::Abs)
+                        .map_err(|e| anyhow::anyhow!("move_mouse (start) failed: {e}"))?;
+                    enigo
+                        .button(button, Direction::Press)
+                        .map_err(|e| anyhow::anyhow!("button press failed: {e}"))?;
+                    enigo
+                        .move_mouse(end_x, end_y, Coordinate::Abs)
+                        .map_err(|e| anyhow::anyhow!("move_mouse (end) failed: {e}"))?;
+                    enigo
+                        .button(button, Direction::Release)
+                        .map_err(|e| anyhow::anyhow!("button release failed: {e}"))?;
+                    info!(
+                        tool = "mouse", action = "drag",
+                        start_x = sx, start_y = sy,
+                        end_x = end_x, end_y = end_y, button = ?button,
+                        "[computer] dragged"
+                    );
+                    Ok(ToolResult::success(format!(
+                        "Dragged {button:?} from ({sx}, {sy}) to ({end_x}, {end_y})"
+                    )))
+                })
+                .await?
+            }
+
+            "scroll" => {
+                let scroll_x = args.get("scroll_x").and_then(Value::as_i64).unwrap_or(0) as i32;
+                let scroll_y = args.get("scroll_y").and_then(Value::as_i64).unwrap_or(0) as i32;
+
+                if scroll_x == 0 && scroll_y == 0 {
+                    return Ok(ToolResult::error(
+                        "At least one of 'scroll_x' or 'scroll_y' must be non-zero",
+                    ));
+                }
+
+                tokio::task::spawn_blocking(move || {
+                    let mut enigo = Enigo::new(&Settings::default())
+                        .map_err(|e| anyhow::anyhow!("Failed to create enigo instance: {e}"))?;
+                    if scroll_y != 0 {
+                        enigo
+                            .scroll(scroll_y, enigo::Axis::Vertical)
+                            .map_err(|e| anyhow::anyhow!("vertical scroll failed: {e}"))?;
+                    }
+                    if scroll_x != 0 {
+                        enigo
+                            .scroll(scroll_x, enigo::Axis::Horizontal)
+                            .map_err(|e| anyhow::anyhow!("horizontal scroll failed: {e}"))?;
+                    }
+                    info!(
+                        tool = "mouse", action = "scroll",
+                        scroll_x = scroll_x, scroll_y = scroll_y,
+                        "[computer] scrolled"
+                    );
+                    Ok(ToolResult::success(format!(
+                        "Scrolled (x={scroll_x}, y={scroll_y})"
+                    )))
+                })
+                .await?
+            }
+
+            other => Ok(ToolResult::error(format!(
+                "Unknown mouse action '{other}'. Use: move, click, double_click, drag, scroll"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool() -> MouseTool {
+        MouseTool::new(Arc::new(SecurityPolicy::default()))
+    }
+
+    #[test]
+    fn schema_has_required_action() {
+        let tool = make_tool();
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["required"], json!(["action"]));
+    }
+
+    #[test]
+    fn schema_enumerates_actions() {
+        let tool = make_tool();
+        let schema = tool.parameters_schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        let names: Vec<&str> = actions.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(names.contains(&"move"));
+        assert!(names.contains(&"click"));
+        assert!(names.contains(&"double_click"));
+        assert!(names.contains(&"drag"));
+        assert!(names.contains(&"scroll"));
+    }
+
+    #[test]
+    fn permission_is_dangerous() {
+        let tool = make_tool();
+        assert_eq!(tool.permission_level(), PermissionLevel::Dangerous);
+    }
+
+    #[test]
+    fn name_is_mouse() {
+        assert_eq!(make_tool().name(), "mouse");
+    }
+
+    #[test]
+    fn coord_validation_rejects_negative() {
+        assert!(validate_coord("x", -1).is_err());
+    }
+
+    #[test]
+    fn coord_validation_rejects_overflow() {
+        assert!(validate_coord("x", MAX_COORD + 1).is_err());
+    }
+
+    #[test]
+    fn coord_validation_accepts_zero() {
+        assert!(validate_coord("x", 0).is_ok());
+    }
+
+    #[test]
+    fn coord_validation_accepts_max() {
+        assert!(validate_coord("x", MAX_COORD).is_ok());
+    }
+
+    #[test]
+    fn parse_button_defaults_to_left() {
+        assert_eq!(parse_button(&json!({})), Button::Left);
+        assert_eq!(parse_button(&json!({"button": "left"})), Button::Left);
+    }
+
+    #[test]
+    fn parse_button_right() {
+        assert_eq!(parse_button(&json!({"button": "right"})), Button::Right);
+    }
+
+    #[test]
+    fn parse_button_middle() {
+        assert_eq!(parse_button(&json!({"button": "middle"})), Button::Middle);
+    }
+
+    #[tokio::test]
+    async fn missing_action_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"action": "teleport"})).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Unknown mouse action"));
+    }
+
+    #[tokio::test]
+    async fn click_missing_coords_returns_error() {
+        let tool = make_tool();
+        let result = tool.execute(json!({"action": "click"})).await;
+        // Should fail with missing x/y
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+
+    #[tokio::test]
+    async fn scroll_zero_both_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "scroll", "scroll_x": 0, "scroll_y": 0}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn drag_missing_start_returns_error() {
+        let tool = make_tool();
+        let result = tool
+            .execute(json!({"action": "drag", "x": 100, "y": 100}))
+            .await;
+        assert!(result.is_err() || result.unwrap().is_error);
+    }
+}

--- a/src/openhuman/tools/impl/computer/mouse.rs
+++ b/src/openhuman/tools/impl/computer/mouse.rs
@@ -128,7 +128,11 @@ impl Tool for MouseTool {
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow::anyhow!("Missing 'action' parameter"))?;
 
-        debug!(tool = "mouse", action = action, "[computer] mouse action requested");
+        debug!(
+            tool = "mouse",
+            action = action,
+            "[computer] mouse action requested"
+        );
 
         match action {
             "move" => {
@@ -139,7 +143,13 @@ impl Tool for MouseTool {
                     enigo
                         .move_mouse(x, y, Coordinate::Abs)
                         .map_err(|e| anyhow::anyhow!("move_mouse failed: {e}"))?;
-                    info!(tool = "mouse", action = "move", x = x, y = y, "[computer] cursor moved");
+                    info!(
+                        tool = "mouse",
+                        action = "move",
+                        x = x,
+                        y = y,
+                        "[computer] cursor moved"
+                    );
                     Ok(ToolResult::success(format!("Moved cursor to ({x}, {y})")))
                 })
                 .await?
@@ -264,8 +274,10 @@ impl Tool for MouseTool {
                             .map_err(|e| anyhow::anyhow!("horizontal scroll failed: {e}"))?;
                     }
                     info!(
-                        tool = "mouse", action = "scroll",
-                        scroll_x = scroll_x, scroll_y = scroll_y,
+                        tool = "mouse",
+                        action = "scroll",
+                        scroll_x = scroll_x,
+                        scroll_y = scroll_y,
                         "[computer] scrolled"
                     );
                     Ok(ToolResult::success(format!(

--- a/src/openhuman/tools/impl/mod.rs
+++ b/src/openhuman/tools/impl/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod browser;
+pub mod computer;
 pub mod cron;
 pub mod filesystem;
 pub mod memory;
@@ -8,6 +9,7 @@ pub mod system;
 
 pub use agent::*;
 pub use browser::*;
+pub use computer::*;
 pub use cron::*;
 pub use filesystem::*;
 pub use memory::*;

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -593,4 +593,84 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(!names.contains(&"delegate"));
     }
+
+    #[test]
+    fn all_tools_excludes_computer_control_when_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(crate::openhuman::memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig::default();
+        let http = crate::openhuman::config::HttpRequestConfig::default();
+        let cfg = test_config(&tmp);
+
+        // Default config has computer_control.enabled = false
+        let tools = all_tools(
+            Arc::new(Config::default()),
+            &security,
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+        );
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"mouse"),
+            "mouse tool should not be registered when computer_control.enabled=false"
+        );
+        assert!(
+            !names.contains(&"keyboard"),
+            "keyboard tool should not be registered when computer_control.enabled=false"
+        );
+    }
+
+    #[test]
+    fn all_tools_includes_computer_control_when_enabled() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(crate::openhuman::memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig::default();
+        let http = crate::openhuman::config::HttpRequestConfig::default();
+        let mut cfg = test_config(&tmp);
+        cfg.computer_control.enabled = true;
+
+        let tools = all_tools(
+            Arc::new(Config::default()),
+            &security,
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+        );
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(
+            names.contains(&"mouse"),
+            "mouse tool must be registered when computer_control.enabled=true; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"keyboard"),
+            "keyboard tool must be registered when computer_control.enabled=true; got: {names:?}"
+        );
+    }
 }

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -154,6 +154,13 @@ pub fn all_tools_with_runtime(
     tools.push(Box::new(ScreenshotTool::new(security.clone())));
     tools.push(Box::new(ImageInfoTool::new(security.clone())));
 
+    // Native mouse + keyboard control (disabled by default)
+    if root_config.computer_control.enabled {
+        tools.push(Box::new(MouseTool::new(security.clone())));
+        tools.push(Box::new(KeyboardTool::new(security.clone())));
+        tracing::debug!("[computer] mouse and keyboard tools registered");
+    }
+
     if let Some(key) = composio_key {
         if !key.is_empty() {
             tools.push(Box::new(ComposioTool::new(


### PR DESCRIPTION
## Summary

- Adds two new native OS-control tools (`mouse` and `keyboard`) that use `enigo` for platform-native input simulation (Core Graphics on macOS, SendInput on Windows, X11/libxdo on Linux)
- `mouse` tool: move, click, double_click, drag, scroll actions with absolute screen coordinates
- `keyboard` tool: type (text string), press (single key), hotkey (key combinations like Ctrl+C) with comprehensive key name parser
- Both tools are `PermissionLevel::Dangerous` and gated behind `[computer_control] enabled = true` in config (disabled by default)

## Changes

| File | What |
|------|------|
| `src/openhuman/tools/impl/computer/mouse.rs` | `MouseTool` — 5 actions, coordinate validation, button selection |
| `src/openhuman/tools/impl/computer/keyboard.rs` | `KeyboardTool` — 3 actions, key name parser (modifiers, nav, arrows, F-keys, single chars), hotkey sequencing |
| `src/openhuman/tools/impl/computer/mod.rs` | Module exports |
| `src/openhuman/tools/impl/mod.rs` | Wire `computer` module |
| `src/openhuman/tools/ops.rs` | Register tools conditionally when `computer_control.enabled` |
| `src/openhuman/config/schema/tools.rs` | `ComputerControlConfig` struct |
| `src/openhuman/config/schema/types.rs` | Add `computer_control` to `Config` |
| `src/openhuman/config/schema/mod.rs` | Re-export `ComputerControlConfig` |

## Test plan

- [x] 37 unit tests covering schemas, key parsing, coordinate validation, parameter validation, and error handling
- [x] `cargo check` passes clean
- [x] `cargo fmt` applied
- [x] Pre-push hooks (format, lint, typecheck, rust check) all pass
- [ ] Manual test: enable `[computer_control] enabled = true`, invoke mouse/keyboard tools via agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard control tool for typing, key presses, and shortcuts.
  * Added mouse control tool for cursor movement, clicking, dragging, and scrolling.
  * Added a top-level `computer_control` config toggle to enable/disable these input-control tools.
* **Tests**
  * Added coverage verifying tools are present when enabled and absent when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->