### PR TITLE
feat: dynamic connected integrations in agent system prompts

### DIFF
--- a/src/openhuman/agent/harness/fork_context.rs
+++ b/src/openhuman/agent/harness/fork_context.rs
@@ -82,6 +82,9 @@ pub struct ParentExecutionContext {
 
     /// Parent's event-bus channel name.
     pub channel: String,
+
+    /// Active Composio integrations the parent has fetched.
+    pub connected_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration>,
 }
 
 tokio::task_local! {

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -295,6 +295,7 @@ impl AgentBuilder {
             cached_transcript_messages: None,
             context,
             on_progress: None,
+            connected_integrations: Vec::new(),
         })
     }
 }

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -96,7 +96,9 @@ impl Agent {
     }
 
     /// Active Composio integrations fetched at session start.
-    pub fn connected_integrations(&self) -> &[crate::openhuman::context::prompt::ConnectedIntegration] {
+    pub fn connected_integrations(
+        &self,
+    ) -> &[crate::openhuman::context::prompt::ConnectedIntegration] {
         &self.connected_integrations
     }
 

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -95,6 +95,11 @@ impl Agent {
         &self.skills
     }
 
+    /// Active Composio integrations fetched at session start.
+    pub fn connected_integrations(&self) -> &[crate::openhuman::context::prompt::ConnectedIntegration] {
+        &self.connected_integrations
+    }
+
     /// The agent's runtime config snapshot.
     pub fn agent_config(&self) -> &crate::openhuman::config::AgentConfig {
         &self.config

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -102,6 +102,15 @@ impl Agent {
         &self.connected_integrations
     }
 
+    /// Replace the agent's connected integrations (e.g. from a cached
+    /// fetch result when the agent was built outside the normal turn loop).
+    pub fn set_connected_integrations(
+        &mut self,
+        integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration>,
+    ) {
+        self.connected_integrations = integrations;
+    }
+
     /// The agent's runtime config snapshot.
     pub fn agent_config(&self) -> &crate::openhuman::config::AgentConfig {
         &self.config

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -736,6 +736,7 @@ impl Agent {
             memory_context: self.last_memory_context.clone(),
             session_id: self.event_session_id().to_string(),
             channel: self.event_channel().to_string(),
+            connected_integrations: self.connected_integrations.clone(),
         }
     }
 

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -82,6 +82,7 @@ impl Agent {
             // stored prompt verbatim to preserve the KV-cache prefix the
             // inference backend has already tokenised. Fetching it later
             // would just burn memory-store reads on data we throw away.
+            self.fetch_connected_integrations().await;
             let learned = self.fetch_learned_context().await;
             let rendered_prompt = self.build_system_prompt(learned)?;
             log::info!("[agent] system prompt built — initialising conversation history");
@@ -876,6 +877,59 @@ impl Agent {
         }
     }
 
+    /// Fetches the user's active Composio connections and populates
+    /// `self.connected_integrations` so the system prompt can surface them.
+    ///
+    /// Best-effort: failures are logged and silently ignored (the prompt
+    /// just won't show an integrations section).
+    pub(super) async fn fetch_connected_integrations(&mut self) {
+        use crate::openhuman::composio::{build_composio_client, providers::toolkit_description};
+        use crate::openhuman::config::Config;
+        use crate::openhuman::context::prompt::ConnectedIntegration;
+
+        let config = match Config::load_or_init().await {
+            Ok(c) => c,
+            Err(e) => {
+                log::debug!(
+                    "[agent] skipping connected integrations fetch: config load failed: {e}"
+                );
+                return;
+            }
+        };
+
+        let Some(client) = build_composio_client(&config) else {
+            log::debug!(
+                "[agent] skipping connected integrations fetch: no composio client (not signed in?)"
+            );
+            return;
+        };
+
+        match client.list_connections().await {
+            Ok(resp) => {
+                let integrations: Vec<ConnectedIntegration> = resp
+                    .connections
+                    .iter()
+                    .filter(|c| c.status == "ACTIVE" || c.status == "CONNECTED")
+                    .map(|c| ConnectedIntegration {
+                        toolkit: c.toolkit.clone(),
+                        description: toolkit_description(&c.toolkit).to_string(),
+                    })
+                    .collect();
+                log::info!(
+                    "[agent] fetched {} connected integrations for prompt",
+                    integrations.len()
+                );
+                for ci in &integrations {
+                    log::debug!("[agent] connected integration: {} — {}", ci.toolkit, ci.description);
+                }
+                self.connected_integrations = integrations;
+            }
+            Err(e) => {
+                log::warn!("[agent] failed to fetch connected integrations: {e}");
+            }
+        }
+    }
+
     /// Builds the system prompt for the current turn, including tool
     /// instructions and learned context.
     pub(super) fn build_system_prompt(
@@ -898,6 +952,7 @@ impl Agent {
             learned,
             visible_tool_names: &self.visible_tool_names,
             tool_call_format: self.tool_dispatcher.tool_call_format(),
+            connected_integrations: &self.connected_integrations,
         };
         // Route through the global context manager so every
         // prompt-building call-site — main agent, sub-agent runner,

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -880,14 +880,10 @@ impl Agent {
     /// Fetches the user's active Composio connections and populates
     /// `self.connected_integrations` so the system prompt can surface them.
     ///
-    /// Best-effort: failures are logged and silently ignored (the prompt
-    /// just won't show an integrations section).
+    /// Delegates to the shared [`crate::openhuman::composio::fetch_connected_integrations`]
+    /// which is the single source of truth for integration discovery.
     pub(super) async fn fetch_connected_integrations(&mut self) {
-        use crate::openhuman::composio::{build_composio_client, providers::toolkit_description};
-        use crate::openhuman::config::Config;
-        use crate::openhuman::context::prompt::ConnectedIntegration;
-
-        let config = match Config::load_or_init().await {
+        let config = match crate::openhuman::config::Config::load_or_init().await {
             Ok(c) => c,
             Err(e) => {
                 log::debug!(
@@ -896,38 +892,8 @@ impl Agent {
                 return;
             }
         };
-
-        let Some(client) = build_composio_client(&config) else {
-            log::debug!(
-                "[agent] skipping connected integrations fetch: no composio client (not signed in?)"
-            );
-            return;
-        };
-
-        match client.list_connections().await {
-            Ok(resp) => {
-                let integrations: Vec<ConnectedIntegration> = resp
-                    .connections
-                    .iter()
-                    .filter(|c| c.status == "ACTIVE" || c.status == "CONNECTED")
-                    .map(|c| ConnectedIntegration {
-                        toolkit: c.toolkit.clone(),
-                        description: toolkit_description(&c.toolkit).to_string(),
-                    })
-                    .collect();
-                log::info!(
-                    "[agent] fetched {} connected integrations for prompt",
-                    integrations.len()
-                );
-                for ci in &integrations {
-                    log::debug!("[agent] connected integration: {} — {}", ci.toolkit, ci.description);
-                }
-                self.connected_integrations = integrations;
-            }
-            Err(e) => {
-                log::warn!("[agent] failed to fetch connected integrations: {e}");
-            }
-        }
+        self.connected_integrations =
+            crate::openhuman::composio::fetch_connected_integrations(&config).await;
     }
 
     /// Builds the system prompt for the current turn, including tool

--- a/src/openhuman/agent/harness/session/types.rs
+++ b/src/openhuman/agent/harness/session/types.rs
@@ -86,6 +86,11 @@ pub struct Agent {
     /// this channel so callers (e.g. web channel) can surface live
     /// tool-call and iteration updates to the UI.
     pub(super) on_progress: Option<tokio::sync::mpsc::Sender<AgentProgress>>,
+    /// Active Composio integrations the user has connected. Populated at
+    /// agent build time; surfaced in the system prompt via
+    /// [`ConnectedIntegrationsSection`] so the orchestrator knows which
+    /// external services are available.
+    pub(super) connected_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration>,
 }
 
 /// A builder for creating `Agent` instances with custom configuration.

--- a/src/openhuman/agent/harness/subagent_runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner.rs
@@ -269,6 +269,7 @@ async fn run_typed_mode(
         &parent.all_tools,
         &archetype_prompt_body,
         render_options,
+        &parent.connected_integrations,
     ));
     let system_prompt = rendered_prompt.text;
     let system_prompt_cache_boundary = rendered_prompt.cache_boundary;

--- a/src/openhuman/agent/harness/subagent_runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner.rs
@@ -1192,6 +1192,7 @@ mod tests {
             memory_context: None,
             session_id: "test-session".into(),
             channel: "test".into(),
+            connected_integrations: vec![],
         }
     }
 

--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -126,8 +126,15 @@ async fn dispatch_target_agent(agent_id: &str, prompt: &str) -> anyhow::Result<S
         .await
         .context("loading config for sub-agent dispatch")?;
 
-    let agent =
+    let mut agent =
         Agent::from_config(&config).context("building Agent from config for sub-agent dispatch")?;
+
+    // Populate connected integrations from the process-wide cache (or a
+    // fresh fetch if cold) so triage-triggered sub-agents see the real
+    // integrations in their system prompts.
+    let integrations =
+        crate::openhuman::composio::fetch_connected_integrations(&config).await;
+    agent.set_connected_integrations(integrations);
 
     let registry = AgentDefinitionRegistry::global()
         .ok_or_else(|| anyhow!("AgentDefinitionRegistry not initialised"))?;

--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -150,6 +150,7 @@ async fn dispatch_target_agent(agent_id: &str, prompt: &str) -> anyhow::Result<S
         memory_context: None, // Sub-agent queries memory via tools if needed
         session_id: format!("triage-{}", uuid::Uuid::new_v4()),
         channel: "triage".to_string(),
+        connected_integrations: agent.connected_integrations().to_vec(),
     };
 
     tracing::debug!(

--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -132,8 +132,7 @@ async fn dispatch_target_agent(agent_id: &str, prompt: &str) -> anyhow::Result<S
     // Populate connected integrations from the process-wide cache (or a
     // fresh fetch if cold) so triage-triggered sub-agents see the real
     // integrations in their system prompts.
-    let integrations =
-        crate::openhuman::composio::fetch_connected_integrations(&config).await;
+    let integrations = crate::openhuman::composio::fetch_connected_integrations(&config).await;
     agent.set_connected_integrations(integrations);
 
     let registry = AgentDefinitionRegistry::global()

--- a/src/openhuman/composio/bus.rs
+++ b/src/openhuman/composio/bus.rs
@@ -263,6 +263,10 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
             return;
         };
 
+        // Bust the prompt-level integrations cache so the next agent
+        // session picks up the newly connected toolkit.
+        super::ops::invalidate_connected_integrations_cache();
+
         tracing::info!(
             toolkit = %toolkit,
             connection_id = %connection_id,

--- a/src/openhuman/composio/bus.rs
+++ b/src/openhuman/composio/bus.rs
@@ -263,10 +263,6 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
             return;
         };
 
-        // Bust the prompt-level integrations cache so the next agent
-        // session picks up the newly connected toolkit.
-        super::ops::invalidate_connected_integrations_cache();
-
         tracing::info!(
             toolkit = %toolkit,
             connection_id = %connection_id,
@@ -326,6 +322,10 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
                         status = %status,
                         "[composio:bus] connection observed active, dispatching on_connection_created"
                     );
+                    // Bust the prompt-level integrations cache now that
+                    // the connection is confirmed ACTIVE, so the next
+                    // agent session picks up the newly connected toolkit.
+                    super::ops::invalidate_connected_integrations_cache();
                 }
                 Err(WaitError::Timeout { last_status }) => {
                     tracing::warn!(

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -46,6 +46,7 @@ pub mod types;
 
 pub use bus::{register_composio_trigger_subscriber, ComposioTriggerSubscriber};
 pub use client::{build_composio_client, ComposioClient};
+pub use ops::{fetch_connected_integrations, invalidate_connected_integrations_cache};
 pub use periodic::{record_sync_success, start_periodic_sync};
 pub use providers::{
     all_providers as all_composio_providers, get_provider as get_composio_provider,
@@ -56,7 +57,6 @@ pub use schemas::{
     all_controller_schemas as all_composio_controller_schemas,
     all_registered_controllers as all_composio_registered_controllers,
 };
-pub use ops::{fetch_connected_integrations, invalidate_connected_integrations_cache};
 pub use tools::all_composio_agent_tools;
 pub use types::{
     ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -56,6 +56,7 @@ pub use schemas::{
     all_controller_schemas as all_composio_controller_schemas,
     all_registered_controllers as all_composio_registered_controllers,
 };
+pub use ops::fetch_connected_integrations;
 pub use tools::all_composio_agent_tools;
 pub use types::{
     ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -56,7 +56,7 @@ pub use schemas::{
     all_controller_schemas as all_composio_controller_schemas,
     all_registered_controllers as all_composio_registered_controllers,
 };
-pub use ops::fetch_connected_integrations;
+pub use ops::{fetch_connected_integrations, invalidate_connected_integrations_cache};
 pub use tools::all_composio_agent_tools;
 pub use types::{
     ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -125,6 +125,8 @@ pub async fn composio_delete_connection(
         .delete_connection(connection_id)
         .await
         .map_err(|e| format!("[composio] delete_connection failed: {e:#}"))?;
+    // Bust the integrations cache so the next prompt reflects the removal.
+    invalidate_connected_integrations_cache();
     Ok(RpcOutcome::new(
         resp,
         vec![format!("composio: connection {connection_id} deleted")],
@@ -321,6 +323,26 @@ fn parse_sync_reason(raw: Option<&str>) -> OpResult<SyncReason> {
 // ── Prompt integration discovery ────────────────────────────────────
 
 use crate::openhuman::context::prompt::{ConnectedIntegration, ConnectedIntegrationTool};
+use std::sync::RwLock;
+
+/// Process-wide cache for connected integrations. Populated on first
+/// fetch and returned on subsequent calls until explicitly invalidated.
+///
+/// `None` = never fetched (cold). `Some(vec)` = cached (possibly empty
+/// if the user has no connections).
+static INTEGRATIONS_CACHE: RwLock<Option<Vec<ConnectedIntegration>>> = RwLock::new(None);
+
+/// Clear the cached connected integrations so the next call to
+/// [`fetch_connected_integrations`] hits the backend again.
+///
+/// Called by [`super::bus::ComposioConnectionCreatedSubscriber`] when a
+/// new OAuth connection completes, and can also be called from tests.
+pub fn invalidate_connected_integrations_cache() {
+    if let Ok(mut guard) = INTEGRATIONS_CACHE.write() {
+        *guard = None;
+        tracing::debug!("[composio] connected integrations cache invalidated");
+    }
+}
 
 /// Fetch the user's active Composio connections and their available
 /// tool actions, returning a prompt-ready summary.
@@ -329,9 +351,37 @@ use crate::openhuman::context::prompt::{ConnectedIntegration, ConnectedIntegrati
 /// data injected into system prompts — both the agent turn loop and
 /// the debug dump CLI call this function.
 ///
+/// Results are cached process-wide and returned instantly on subsequent
+/// calls. The cache is invalidated when a new connection is created
+/// (via [`invalidate_connected_integrations_cache`]) or on process
+/// restart.
+///
 /// Best-effort: returns an empty vec when the user isn't signed in,
 /// the backend is unreachable, or any step fails.
 pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedIntegration> {
+    // Fast path: return cached result.
+    if let Ok(guard) = INTEGRATIONS_CACHE.read() {
+        if let Some(cached) = guard.as_ref() {
+            tracing::debug!(
+                count = cached.len(),
+                "[composio] fetch_connected_integrations: returning cached result"
+            );
+            return cached.clone();
+        }
+    }
+
+    let result = fetch_connected_integrations_uncached(config).await;
+
+    // Store in cache.
+    if let Ok(mut guard) = INTEGRATIONS_CACHE.write() {
+        *guard = Some(result.clone());
+    }
+
+    result
+}
+
+/// The actual backend fetch, called on cache miss.
+async fn fetch_connected_integrations_uncached(config: &Config) -> Vec<ConnectedIntegration> {
     use super::providers::toolkit_description;
 
     let Some(client) = build_composio_client(config) else {

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -398,9 +398,7 @@ async fn fetch_connected_integrations_uncached(
     use super::providers::toolkit_description;
 
     let Some(client) = build_composio_client(config) else {
-        tracing::debug!(
-            "[composio] fetch_connected_integrations: no client (not signed in?)"
-        );
+        tracing::debug!("[composio] fetch_connected_integrations: no client (not signed in?)");
         return None;
     };
 
@@ -433,9 +431,7 @@ async fn fetch_connected_integrations_uncached(
     let tools_by_toolkit = match client.list_tools(Some(&toolkit_slugs)).await {
         Ok(resp) => resp.tools,
         Err(e) => {
-            tracing::warn!(
-                "[composio] fetch_connected_integrations: list_tools failed: {e}"
-            );
+            tracing::warn!("[composio] fetch_connected_integrations: list_tools failed: {e}");
             Vec::new()
         }
     };
@@ -449,17 +445,11 @@ async fn fetch_connected_integrations_uncached(
                 .filter(|t| {
                     // Composio action slugs are prefixed with the toolkit
                     // name in uppercase, e.g. GMAIL_SEND_EMAIL.
-                    t.function
-                        .name
-                        .starts_with(&slug.to_uppercase())
+                    t.function.name.starts_with(&slug.to_uppercase())
                 })
                 .map(|t| ConnectedIntegrationTool {
                     name: t.function.name.clone(),
-                    description: t
-                        .function
-                        .description
-                        .clone()
-                        .unwrap_or_default(),
+                    description: t.function.description.clone().unwrap_or_default(),
                 })
                 .collect();
 

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -323,23 +323,33 @@ fn parse_sync_reason(raw: Option<&str>) -> OpResult<SyncReason> {
 // ── Prompt integration discovery ────────────────────────────────────
 
 use crate::openhuman::context::prompt::{ConnectedIntegration, ConnectedIntegrationTool};
+use std::collections::HashMap;
 use std::sync::RwLock;
 
-/// Process-wide cache for connected integrations. Populated on first
-/// fetch and returned on subsequent calls until explicitly invalidated.
-///
-/// `None` = never fetched (cold). `Some(vec)` = cached (possibly empty
-/// if the user has no connections).
-static INTEGRATIONS_CACHE: RwLock<Option<Vec<ConnectedIntegration>>> = RwLock::new(None);
+/// Process-wide cache for connected integrations, keyed by the config
+/// identity (the `config_path` string) so different user contexts don't
+/// collide. Each entry is populated on first fetch and returned on
+/// subsequent calls until explicitly invalidated.
+static INTEGRATIONS_CACHE: RwLock<HashMap<String, Vec<ConnectedIntegration>>> =
+    RwLock::new(HashMap::new());
 
-/// Clear the cached connected integrations so the next call to
+/// Derive a stable cache key from a [`Config`]. We use the stringified
+/// `config_path` because it uniquely identifies a user context (it
+/// resolves to the per-user openhuman dir).
+fn cache_key(config: &Config) -> String {
+    config.config_path.display().to_string()
+}
+
+/// Clear cached connected integrations so the next call to
 /// [`fetch_connected_integrations`] hits the backend again.
 ///
 /// Called by [`super::bus::ComposioConnectionCreatedSubscriber`] when a
 /// new OAuth connection completes, and can also be called from tests.
+/// Clears the entire map because the bus subscriber doesn't carry a
+/// config reference.
 pub fn invalidate_connected_integrations_cache() {
     if let Ok(mut guard) = INTEGRATIONS_CACHE.write() {
-        *guard = None;
+        guard.clear();
         tracing::debug!("[composio] connected integrations cache invalidated");
     }
 }
@@ -351,19 +361,23 @@ pub fn invalidate_connected_integrations_cache() {
 /// data injected into system prompts — both the agent turn loop and
 /// the debug dump CLI call this function.
 ///
-/// Results are cached process-wide and returned instantly on subsequent
-/// calls. The cache is invalidated when a new connection is created
+/// Results are cached process-wide (keyed by config identity) and
+/// returned instantly on subsequent calls. The cache is invalidated
+/// when a new connection is created
 /// (via [`invalidate_connected_integrations_cache`]) or on process
 /// restart.
 ///
 /// Best-effort: returns an empty vec when the user isn't signed in,
 /// the backend is unreachable, or any step fails.
 pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedIntegration> {
+    let key = cache_key(config);
+
     // Fast path: return cached result.
     if let Ok(guard) = INTEGRATIONS_CACHE.read() {
-        if let Some(cached) = guard.as_ref() {
+        if let Some(cached) = guard.get(&key) {
             tracing::debug!(
                 count = cached.len(),
+                key = %key,
                 "[composio] fetch_connected_integrations: returning cached result"
             );
             return cached.clone();
@@ -374,7 +388,7 @@ pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedInteg
         Some(result) => {
             // Backend was reachable — cache the result (even if empty).
             if let Ok(mut guard) = INTEGRATIONS_CACHE.write() {
-                *guard = Some(result.clone());
+                guard.insert(key, result.clone());
             }
             result
         }

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -318,6 +318,113 @@ fn parse_sync_reason(raw: Option<&str>) -> OpResult<SyncReason> {
     }
 }
 
+// ── Prompt integration discovery ────────────────────────────────────
+
+use crate::openhuman::context::prompt::{ConnectedIntegration, ConnectedIntegrationTool};
+
+/// Fetch the user's active Composio connections and their available
+/// tool actions, returning a prompt-ready summary.
+///
+/// This is the **single source of truth** for connected integration
+/// data injected into system prompts — both the agent turn loop and
+/// the debug dump CLI call this function.
+///
+/// Best-effort: returns an empty vec when the user isn't signed in,
+/// the backend is unreachable, or any step fails.
+pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedIntegration> {
+    use super::providers::toolkit_description;
+
+    let Some(client) = build_composio_client(config) else {
+        tracing::debug!(
+            "[composio] fetch_connected_integrations: no client (not signed in?)"
+        );
+        return Vec::new();
+    };
+
+    let connections = match client.list_connections().await {
+        Ok(resp) => resp.connections,
+        Err(e) => {
+            tracing::warn!("[composio] fetch_connected_integrations: list_connections failed: {e}");
+            return Vec::new();
+        }
+    };
+
+    let active: Vec<_> = connections
+        .iter()
+        .filter(|c| c.status == "ACTIVE" || c.status == "CONNECTED")
+        .collect();
+
+    if active.is_empty() {
+        return Vec::new();
+    }
+
+    // Collect the unique toolkit slugs so we can batch-fetch their tools.
+    let toolkit_slugs: Vec<String> = {
+        let mut slugs: Vec<String> = active.iter().map(|c| c.toolkit.clone()).collect();
+        slugs.sort();
+        slugs.dedup();
+        slugs
+    };
+
+    // Fetch available tool schemas for all connected toolkits in one call.
+    let tools_by_toolkit = match client.list_tools(Some(&toolkit_slugs)).await {
+        Ok(resp) => resp.tools,
+        Err(e) => {
+            tracing::warn!(
+                "[composio] fetch_connected_integrations: list_tools failed: {e}"
+            );
+            Vec::new()
+        }
+    };
+
+    // Build the per-toolkit integration entries.
+    let mut integrations: Vec<ConnectedIntegration> = toolkit_slugs
+        .iter()
+        .map(|slug| {
+            let tools: Vec<ConnectedIntegrationTool> = tools_by_toolkit
+                .iter()
+                .filter(|t| {
+                    // Composio action slugs are prefixed with the toolkit
+                    // name in uppercase, e.g. GMAIL_SEND_EMAIL.
+                    t.function
+                        .name
+                        .starts_with(&slug.to_uppercase())
+                })
+                .map(|t| ConnectedIntegrationTool {
+                    name: t.function.name.clone(),
+                    description: t
+                        .function
+                        .description
+                        .clone()
+                        .unwrap_or_default(),
+                })
+                .collect();
+
+            ConnectedIntegration {
+                toolkit: slug.clone(),
+                description: toolkit_description(slug).to_string(),
+                tools,
+            }
+        })
+        .collect();
+
+    integrations.sort_by(|a, b| a.toolkit.cmp(&b.toolkit));
+
+    tracing::info!(
+        count = integrations.len(),
+        "[composio] fetch_connected_integrations: done"
+    );
+    for ci in &integrations {
+        tracing::debug!(
+            toolkit = %ci.toolkit,
+            tool_count = ci.tools.len(),
+            "[composio] connected integration"
+        );
+    }
+
+    integrations
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -324,14 +324,14 @@ fn parse_sync_reason(raw: Option<&str>) -> OpResult<SyncReason> {
 
 use crate::openhuman::context::prompt::{ConnectedIntegration, ConnectedIntegrationTool};
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 
 /// Process-wide cache for connected integrations, keyed by the config
 /// identity (the `config_path` string) so different user contexts don't
 /// collide. Each entry is populated on first fetch and returned on
 /// subsequent calls until explicitly invalidated.
-static INTEGRATIONS_CACHE: RwLock<HashMap<String, Vec<ConnectedIntegration>>> =
-    RwLock::new(HashMap::new());
+static INTEGRATIONS_CACHE: LazyLock<RwLock<HashMap<String, Vec<ConnectedIntegration>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Derive a stable cache key from a [`Config`]. We use the stringified
 /// `config_path` because it uniquely identifies a user context (it

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -370,14 +370,20 @@ pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedInteg
         }
     }
 
-    let result = fetch_connected_integrations_uncached(config).await;
-
-    // Store in cache.
-    if let Ok(mut guard) = INTEGRATIONS_CACHE.write() {
-        *guard = Some(result.clone());
+    match fetch_connected_integrations_uncached(config).await {
+        Some(result) => {
+            // Backend was reachable — cache the result (even if empty).
+            if let Ok(mut guard) = INTEGRATIONS_CACHE.write() {
+                *guard = Some(result.clone());
+            }
+            result
+        }
+        None => {
+            // No auth / client unavailable — do NOT cache so a
+            // subsequent call with a different config can retry.
+            Vec::new()
+        }
     }
-
-    result
 }
 
 /// The actual backend fetch, called on cache miss.

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -381,21 +381,28 @@ pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedInteg
 }
 
 /// The actual backend fetch, called on cache miss.
-async fn fetch_connected_integrations_uncached(config: &Config) -> Vec<ConnectedIntegration> {
+///
+/// Returns `Some(vec)` when the backend was reachable (even if the user
+/// has zero connections — that's a valid cacheable state). Returns `None`
+/// when we couldn't even build a client (no auth), signalling the caller
+/// should NOT cache this result.
+async fn fetch_connected_integrations_uncached(
+    config: &Config,
+) -> Option<Vec<ConnectedIntegration>> {
     use super::providers::toolkit_description;
 
     let Some(client) = build_composio_client(config) else {
         tracing::debug!(
             "[composio] fetch_connected_integrations: no client (not signed in?)"
         );
-        return Vec::new();
+        return None;
     };
 
     let connections = match client.list_connections().await {
         Ok(resp) => resp.connections,
         Err(e) => {
             tracing::warn!("[composio] fetch_connected_integrations: list_connections failed: {e}");
-            return Vec::new();
+            return Some(Vec::new());
         }
     };
 
@@ -405,7 +412,7 @@ async fn fetch_connected_integrations_uncached(config: &Config) -> Vec<Connected
         .collect();
 
     if active.is_empty() {
-        return Vec::new();
+        return Some(Vec::new());
     }
 
     // Collect the unique toolkit slugs so we can batch-fetch their tools.
@@ -472,7 +479,7 @@ async fn fetch_connected_integrations_uncached(config: &Config) -> Vec<Connected
         );
     }
 
-    integrations
+    Some(integrations)
 }
 
 #[cfg(test)]

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -48,6 +48,46 @@ pub use registry::{
     all_providers, get_provider, init_default_providers, register_provider, ProviderArc,
 };
 
+/// Human-readable capability summary for a Composio toolkit slug.
+///
+/// Used by the prompt renderer to tell the orchestrator what each connected
+/// integration can do. Covers the most common toolkits; unknown slugs get
+/// a generic fallback so newly connected services still appear.
+pub fn toolkit_description(slug: &str) -> &'static str {
+    match slug {
+        "gmail" => "Send, read, draft, reply, forward, and search emails; manage labels and threads",
+        "notion" => "Create, read, update, and search notion pages and notion databases",
+        "github" => "Manage repositories, issues, pull requests on GitHub",
+        "slack" => "Send messages, read channels, manage threads, and post updates in Slack",
+        "discord" => "Send messages, manage channels, and interact with Discord servers",
+        "google_calendar" => "Create, update, and query calendar events; check availability",
+        "google_drive" => "Upload, download, search, and share files in Google Drive",
+        "google_docs" => "Create, read, and edit Google Docs documents",
+        "google_sheets" => "Read, write, and manage Google Sheets spreadsheets",
+        "outlook" => "Send, read, and manage emails in Microsoft Outlook",
+        "microsoft_teams" => "Send messages and manage channels in Microsoft Teams",
+        "linear" => "Create and manage issues, projects, and cycles in Linear",
+        "jira" => "Create and manage issues, projects, and sprints in Jira",
+        "trello" => "Create and manage cards, lists, and boards in Trello",
+        "asana" => "Create and manage tasks, projects, and sections in Asana",
+        "dropbox" => "Upload, download, and share files in Dropbox",
+        "twitter" => "Post tweets, read timelines, and manage Twitter interactions",
+        "spotify" => "Control playback, search music, and manage playlists on Spotify",
+        "telegram" => "Send and receive messages via Telegram",
+        "whatsapp" => "Send and receive messages via WhatsApp",
+        "twilio" => "Send SMS, make calls, and manage communications via Twilio",
+        "shopify" => "Manage products, orders, and customers in Shopify",
+        "stripe" => "Manage payments, subscriptions, and customers in Stripe",
+        "hubspot" => "Manage contacts, deals, and marketing in HubSpot",
+        "salesforce" => "Manage contacts, leads, and opportunities in Salesforce",
+        "airtable" => "Read and write records in Airtable bases",
+        "figma" => "Access and manage Figma design files and components",
+        "youtube" => "Search videos, manage playlists, and interact with YouTube",
+        "calendar" => "Create, update, and query calendar events",
+        _ => "Interact with this connected service via its available actions",
+    }
+}
+
 /// Reason a sync was triggered. Providers can use this to decide
 /// whether to do a full backfill or an incremental pull.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -55,7 +55,9 @@ pub use registry::{
 /// a generic fallback so newly connected services still appear.
 pub fn toolkit_description(slug: &str) -> &'static str {
     match slug {
-        "gmail" => "Send, read, draft, reply, forward, and search emails; manage labels and threads",
+        "gmail" => {
+            "Send, read, draft, reply, forward, and search emails; manage labels and threads"
+        }
         "notion" => "Create, read, update, and search notion pages and notion databases",
         "github" => "Manage repositories, issues, pull requests on GitHub",
         "slack" => "Send messages, read channels, manage threads, and post updates in Slack",

--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -216,6 +216,17 @@ async fn resolve_runtime_config_dirs(
         }
     }
 
+    resolve_config_dirs_ignoring_env(default_openhuman_dir, default_workspace_dir).await
+}
+
+/// Same as [`resolve_runtime_config_dirs`] but skips the
+/// `OPENHUMAN_WORKSPACE` env var override. Used by
+/// [`Config::load_from_default_paths`] so callers can reliably load
+/// the real user config without mutating the process environment.
+async fn resolve_config_dirs_ignoring_env(
+    default_openhuman_dir: &Path,
+    default_workspace_dir: &Path,
+) -> Result<(PathBuf, PathBuf, ConfigResolutionSource)> {
     // 2. Active user — scopes the entire openhuman dir to a per-user directory
     //    so that config, auth, encryption, and workspace are all user-isolated.
     if let Some(user_id) = read_active_user_id(default_openhuman_dir) {
@@ -534,6 +545,40 @@ impl Config {
             );
             Ok(config)
         }
+    }
+
+    /// Load config from the default user paths, bypassing the
+    /// `OPENHUMAN_WORKSPACE` environment variable.
+    ///
+    /// This is used by the debug dump to load the real user config
+    /// for auth token resolution when the dump script overrides
+    /// `OPENHUMAN_WORKSPACE` to a throwaway temp directory.
+    pub async fn load_from_default_paths() -> Result<Self> {
+        let (default_openhuman_dir, default_workspace_dir) = default_config_and_workspace_dirs()?;
+        let (openhuman_dir, workspace_dir, _source) =
+            resolve_config_dirs_ignoring_env(&default_openhuman_dir, &default_workspace_dir)
+                .await?;
+        let config_path = openhuman_dir.join("config.toml");
+
+        if !config_path.exists() {
+            let mut config = Config {
+                config_path,
+                workspace_dir,
+                ..Default::default()
+            };
+            config.apply_env_overrides();
+            return Ok(config);
+        }
+
+        let raw = fs::read_to_string(&config_path)
+            .await
+            .context("reading config.toml from default paths")?;
+        let mut config: Config =
+            toml::from_str(&raw).context("parsing config.toml from default paths")?;
+        config.config_path = config_path;
+        config.workspace_dir = workspace_dir;
+        config.apply_env_overrides();
+        Ok(config)
     }
 
     pub fn apply_env_overrides(&mut self) {

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -268,6 +268,7 @@ pub async fn dump_agent_prompt(options: DumpPromptOptions) -> Result<DumpedPromp
         &model_name,
         &tools_vec,
         options.skill_filter.as_deref(),
+        &connected_integrations,
     )
 }
 
@@ -432,6 +433,7 @@ fn render_subagent_dump(
     model_name: &str,
     tools_vec: &[Box<dyn Tool>],
     skill_filter_override: Option<&str>,
+    connected_integrations: &[ConnectedIntegration],
 ) -> Result<DumpedPrompt> {
     // Resolve the archetype prompt body. Inline sources short-circuit
     // immediately; file sources walk the workspace override directory
@@ -503,6 +505,7 @@ fn render_subagent_dump(
         tools_vec,
         &archetype_body,
         options,
+        connected_integrations,
     );
     let rendered = extract_cache_boundary(&raw);
 
@@ -701,7 +704,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
 
         let definition = skills_agent_def();
-        let dumped = render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None)
+        let dumped = render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
             .expect("skills_agent prompt should render");
 
         assert_eq!(dumped.mode, "subagent");
@@ -756,6 +759,7 @@ mod tests {
             "reasoning-v1",
             &tools,
             Some("notion"),
+            &[],
         )
         .expect("filtered dump should render");
 
@@ -890,7 +894,7 @@ mod tests {
         };
 
         let dumped =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
         assert!(dumped.text.contains("## Tools"));
         assert!(dumped.text.contains("OpenHuman"));
 
@@ -934,7 +938,7 @@ mod tests {
         };
 
         let dumped =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
         assert!(dumped.text.contains("## Tools"));
         assert!(!dumped.text.contains("does-not-exist"));
 
@@ -986,7 +990,7 @@ mod tests {
         };
 
         let agent_prompt =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
         assert!(agent_prompt.text.contains("Workspace agent prompt"));
 
         definition.id = "workspace_root".into();
@@ -994,7 +998,7 @@ mod tests {
             path: "root.md".into(),
         };
         let root_prompt =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
         assert!(root_prompt.text.contains("Workspace root prompt"));
 
         let _ = std::fs::remove_dir_all(workspace);

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -362,6 +362,7 @@ fn render_main_agent_dump(
         learned,
         visible_tool_names: &empty_filter,
         tool_call_format: ToolCallFormat::PFormat,
+        connected_integrations: &[],
     };
 
     let rendered = SystemPromptBuilder::with_defaults()

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -301,65 +301,33 @@ fn build_composio_stub_tools() -> Vec<Box<dyn Tool>> {
     ]
 }
 
-/// Best-effort fetch of the user's active Composio connections for the
-/// prompt dump. Returns an empty vec when the user isn't signed in or
-/// the backend is unreachable.
+/// Fetch connected integrations for the prompt dump.
 ///
+/// Delegates to [`crate::openhuman::composio::fetch_connected_integrations`].
 /// The dump script often overrides `OPENHUMAN_WORKSPACE` to a throwaway
-/// temp dir, which causes config resolution to miss the real user's auth
-/// token. We therefore try the caller-supplied config first, then fall
-/// back to a fresh default-path load so the auth token is found even
-/// when the workspace is overridden.
+/// temp dir which causes config resolution to miss the real user's auth
+/// token. We try the caller-supplied config first, then fall back to a
+/// fresh default-path load.
 async fn fetch_connected_integrations_for_dump(config: &Config) -> Vec<ConnectedIntegration> {
-    use crate::openhuman::composio::{build_composio_client, providers::toolkit_description};
+    use crate::openhuman::composio::fetch_connected_integrations;
 
-    // Try the supplied config first (works when no workspace override).
-    let client = match build_composio_client(config) {
-        Some(c) => c,
-        None => {
-            // Fallback: temporarily clear OPENHUMAN_WORKSPACE and reload
-            // config from the default user paths so the real auth token
-            // is found even when the dump script uses a throwaway workspace.
-            let saved = std::env::var("OPENHUMAN_WORKSPACE").ok();
-            std::env::remove_var("OPENHUMAN_WORKSPACE");
-            let fallback_config = Config::load_or_init().await.ok();
-            // Restore the env var so downstream code isn't surprised.
-            if let Some(val) = saved {
-                std::env::set_var("OPENHUMAN_WORKSPACE", val);
-            }
-            match fallback_config.and_then(|c| build_composio_client(&c)) {
-                Some(c) => c,
-                None => {
-                    tracing::debug!(
-                        "[debug_dump] no composio client — skipping integrations fetch"
-                    );
-                    return Vec::new();
-                }
-            }
-        }
-    };
+    let result = fetch_connected_integrations(config).await;
+    if !result.is_empty() {
+        return result;
+    }
 
-    match client.list_connections().await {
-        Ok(resp) => {
-            let integrations: Vec<ConnectedIntegration> = resp
-                .connections
-                .iter()
-                .filter(|c| c.status == "ACTIVE" || c.status == "CONNECTED")
-                .map(|c| ConnectedIntegration {
-                    toolkit: c.toolkit.clone(),
-                    description: toolkit_description(&c.toolkit).to_string(),
-                })
-                .collect();
-            tracing::debug!(
-                count = integrations.len(),
-                "[debug_dump] fetched connected integrations"
-            );
-            integrations
-        }
-        Err(e) => {
-            tracing::debug!(error = %e, "[debug_dump] failed to fetch integrations");
-            Vec::new()
-        }
+    // Fallback: temporarily clear OPENHUMAN_WORKSPACE and reload config
+    // from the default user paths so the real auth token is found.
+    let saved = std::env::var("OPENHUMAN_WORKSPACE").ok();
+    std::env::remove_var("OPENHUMAN_WORKSPACE");
+    let fallback = Config::load_or_init().await.ok();
+    if let Some(val) = saved {
+        std::env::set_var("OPENHUMAN_WORKSPACE", val);
+    }
+
+    match fallback {
+        Some(c) => fetch_connected_integrations(&c).await,
+        None => Vec::new(),
     }
 }
 

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -704,8 +704,9 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
 
         let definition = skills_agent_def();
-        let dumped = render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
-            .expect("skills_agent prompt should render");
+        let dumped =
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
+                .expect("skills_agent prompt should render");
 
         assert_eq!(dumped.mode, "subagent");
         assert!(
@@ -894,7 +895,8 @@ mod tests {
         };
 
         let dumped =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
+                .unwrap();
         assert!(dumped.text.contains("## Tools"));
         assert!(dumped.text.contains("OpenHuman"));
 
@@ -938,7 +940,8 @@ mod tests {
         };
 
         let dumped =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
+                .unwrap();
         assert!(dumped.text.contains("## Tools"));
         assert!(!dumped.text.contains("does-not-exist"));
 
@@ -990,7 +993,8 @@ mod tests {
         };
 
         let agent_prompt =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
+                .unwrap();
         assert!(agent_prompt.text.contains("Workspace agent prompt"));
 
         definition.id = "workspace_root".into();
@@ -998,7 +1002,8 @@ mod tests {
             path: "root.md".into(),
         };
         let root_prompt =
-            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[]).unwrap();
+            render_subagent_dump(&definition, &workspace, "reasoning-v1", &tools, None, &[])
+                .unwrap();
         assert!(root_prompt.text.contains("Workspace root prompt"));
 
         let _ = std::fs::remove_dir_all(workspace);

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -307,8 +307,8 @@ fn build_composio_stub_tools() -> Vec<Box<dyn Tool>> {
 /// Delegates to [`crate::openhuman::composio::fetch_connected_integrations`].
 /// The dump script often overrides `OPENHUMAN_WORKSPACE` to a throwaway
 /// temp dir which causes config resolution to miss the real user's auth
-/// token. We try the caller-supplied config first, then fall back to a
-/// fresh default-path load.
+/// token. We try the caller-supplied config first, then fall back to
+/// [`Config::load_from_default_paths`] which bypasses the env var.
 async fn fetch_connected_integrations_for_dump(config: &Config) -> Vec<ConnectedIntegration> {
     use crate::openhuman::composio::fetch_connected_integrations;
 
@@ -317,18 +317,17 @@ async fn fetch_connected_integrations_for_dump(config: &Config) -> Vec<Connected
         return result;
     }
 
-    // Fallback: temporarily clear OPENHUMAN_WORKSPACE and reload config
-    // from the default user paths so the real auth token is found.
-    let saved = std::env::var("OPENHUMAN_WORKSPACE").ok();
-    std::env::remove_var("OPENHUMAN_WORKSPACE");
-    let fallback = Config::load_or_init().await.ok();
-    if let Some(val) = saved {
-        std::env::set_var("OPENHUMAN_WORKSPACE", val);
-    }
-
-    match fallback {
-        Some(c) => fetch_connected_integrations(&c).await,
-        None => Vec::new(),
+    // Fallback: load config from the default user paths (bypasses
+    // OPENHUMAN_WORKSPACE) so the real auth token is found.
+    match Config::load_from_default_paths().await {
+        Ok(c) => fetch_connected_integrations(&c).await,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "[debug_dump] fallback config load failed, skipping integrations"
+            );
+            Vec::new()
+        }
     }
 }
 

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -55,9 +55,9 @@ use crate::openhuman::composio::tools::{
 };
 use crate::openhuman::config::Config;
 use crate::openhuman::context::prompt::{
-    extract_cache_boundary, render_subagent_system_prompt, LearnedContextData, PromptContext,
-    PromptTool, SubagentRenderOptions, SystemPromptBuilder, ToolCallFormat,
-    USER_MEMORY_PER_NAMESPACE_MAX_CHARS, USER_MEMORY_TOTAL_MAX_CHARS,
+    extract_cache_boundary, render_subagent_system_prompt, ConnectedIntegration,
+    LearnedContextData, PromptContext, PromptTool, SubagentRenderOptions, SystemPromptBuilder,
+    ToolCallFormat, USER_MEMORY_PER_NAMESPACE_MAX_CHARS, USER_MEMORY_TOTAL_MAX_CHARS,
 };
 use crate::openhuman::integrations::IntegrationClient;
 use crate::openhuman::memory::{self, Memory};
@@ -234,9 +234,17 @@ pub async fn dump_agent_prompt(options: DumpPromptOptions) -> Result<DumpedPromp
         "[debug_dump] assembled tool registry"
     );
 
+    // ── Fetch connected integrations ────────────────────────────────────
+    let connected_integrations = fetch_connected_integrations_for_dump(&config).await;
+
     // ── Main agent path ────────────────────────────────────────────────
     if options.agent_id == "main" || options.agent_id == "orchestrator_main" {
-        return render_main_agent_dump(&workspace_dir, &model_name, &tools_vec);
+        return render_main_agent_dump(
+            &workspace_dir,
+            &model_name,
+            &tools_vec,
+            &connected_integrations,
+        );
     }
 
     // ── Sub-agent path ────────────────────────────────────────────────
@@ -293,10 +301,73 @@ fn build_composio_stub_tools() -> Vec<Box<dyn Tool>> {
     ]
 }
 
+/// Best-effort fetch of the user's active Composio connections for the
+/// prompt dump. Returns an empty vec when the user isn't signed in or
+/// the backend is unreachable.
+///
+/// The dump script often overrides `OPENHUMAN_WORKSPACE` to a throwaway
+/// temp dir, which causes config resolution to miss the real user's auth
+/// token. We therefore try the caller-supplied config first, then fall
+/// back to a fresh default-path load so the auth token is found even
+/// when the workspace is overridden.
+async fn fetch_connected_integrations_for_dump(config: &Config) -> Vec<ConnectedIntegration> {
+    use crate::openhuman::composio::{build_composio_client, providers::toolkit_description};
+
+    // Try the supplied config first (works when no workspace override).
+    let client = match build_composio_client(config) {
+        Some(c) => c,
+        None => {
+            // Fallback: temporarily clear OPENHUMAN_WORKSPACE and reload
+            // config from the default user paths so the real auth token
+            // is found even when the dump script uses a throwaway workspace.
+            let saved = std::env::var("OPENHUMAN_WORKSPACE").ok();
+            std::env::remove_var("OPENHUMAN_WORKSPACE");
+            let fallback_config = Config::load_or_init().await.ok();
+            // Restore the env var so downstream code isn't surprised.
+            if let Some(val) = saved {
+                std::env::set_var("OPENHUMAN_WORKSPACE", val);
+            }
+            match fallback_config.and_then(|c| build_composio_client(&c)) {
+                Some(c) => c,
+                None => {
+                    tracing::debug!(
+                        "[debug_dump] no composio client — skipping integrations fetch"
+                    );
+                    return Vec::new();
+                }
+            }
+        }
+    };
+
+    match client.list_connections().await {
+        Ok(resp) => {
+            let integrations: Vec<ConnectedIntegration> = resp
+                .connections
+                .iter()
+                .filter(|c| c.status == "ACTIVE" || c.status == "CONNECTED")
+                .map(|c| ConnectedIntegration {
+                    toolkit: c.toolkit.clone(),
+                    description: toolkit_description(&c.toolkit).to_string(),
+                })
+                .collect();
+            tracing::debug!(
+                count = integrations.len(),
+                "[debug_dump] fetched connected integrations"
+            );
+            integrations
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "[debug_dump] failed to fetch integrations");
+            Vec::new()
+        }
+    }
+}
+
 fn render_main_agent_dump(
     workspace_dir: &Path,
     model_name: &str,
     tools_vec: &[Box<dyn Tool>],
+    connected_integrations: &[ConnectedIntegration],
 ) -> Result<DumpedPrompt> {
     let prompt_tools = PromptTool::from_tools(tools_vec);
     // Main agent dumps do not apply a visible-tool filter — every
@@ -362,7 +433,7 @@ fn render_main_agent_dump(
         learned,
         visible_tool_names: &empty_filter,
         tool_call_format: ToolCallFormat::PFormat,
-        connected_integrations: &[],
+        connected_integrations,
     };
 
     let rendered = SystemPromptBuilder::with_defaults()
@@ -773,7 +844,7 @@ mod tests {
             }),
         ];
 
-        let dumped = render_main_agent_dump(&workspace, "reasoning-v1", &tools).unwrap();
+        let dumped = render_main_agent_dump(&workspace, "reasoning-v1", &tools, &[]).unwrap();
         assert_eq!(dumped.mode, "main");
         assert_eq!(dumped.model, "reasoning-v1");
         assert_eq!(dumped.tool_names, vec!["shell", "notion__create_page"]);

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -727,6 +727,7 @@ pub fn render_subagent_system_prompt(
     parent_tools: &[Box<dyn Tool>],
     archetype_body: &str,
     options: SubagentRenderOptions,
+    connected_integrations: &[ConnectedIntegration],
 ) -> String {
     render_subagent_system_prompt_with_format(
         workspace_dir,
@@ -736,6 +737,7 @@ pub fn render_subagent_system_prompt(
         archetype_body,
         options,
         ToolCallFormat::PFormat,
+        connected_integrations,
     )
 }
 
@@ -751,6 +753,7 @@ pub fn render_subagent_system_prompt_with_format(
     archetype_body: &str,
     options: SubagentRenderOptions,
     tool_call_format: ToolCallFormat,
+    connected_integrations: &[ConnectedIntegration],
 ) -> String {
     let mut out = String::new();
 
@@ -884,6 +887,36 @@ pub fn render_subagent_system_prompt_with_format(
         out.push_str(
             "Skills are loaded on demand. Use `read` on the skill path to get full instructions.\n\n",
         );
+    }
+
+    // 3d. Connected integrations — same section the main agent renders
+    //     so the orchestrator (and any sub-agent) sees what external
+    //     services are available via the Skills Agent.
+    if !connected_integrations.is_empty() {
+        out.push_str(
+            "## Connected Integrations\n\n\
+             The user has the following external services connected. \
+             To interact with any of these, delegate to the **Skills Agent** \
+             (`skills_agent`) via `spawn_subagent`.\n\n",
+        );
+        for integration in connected_integrations {
+            let _ = writeln!(
+                out,
+                "### {} — {}\n",
+                integration.toolkit, integration.description,
+            );
+            if integration.tools.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "Use `composio_list_tools` to discover available actions.\n",
+                );
+            } else {
+                for tool in &integration.tools {
+                    let _ = writeln!(out, "- `{}`: {}", tool.name, tool.description);
+                }
+                out.push('\n');
+            }
+        }
     }
 
     // 4. Insert the cache boundary before the dynamic tail. Typed

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -41,6 +41,17 @@ pub struct LearnedContextData {
     pub tree_root_summaries: Vec<(String, String)>,
 }
 
+/// A connected external integration (e.g. a Composio OAuth connection)
+/// surfaced in the system prompt so the orchestrator knows which services
+/// are available and can delegate to the Skills Agent accordingly.
+#[derive(Debug, Clone)]
+pub struct ConnectedIntegration {
+    /// Toolkit slug, e.g. `"gmail"`, `"notion"`.
+    pub toolkit: String,
+    /// Human-readable one-line description of what this integration can do.
+    pub description: String,
+}
+
 /// A lightweight tool descriptor for prompt rendering.
 ///
 /// Shared shape so every call-site that builds a system prompt — main
@@ -132,6 +143,10 @@ pub struct PromptContext<'a> {
     /// How [`ToolsSection`] should render each tool entry. Defaults to
     /// [`ToolCallFormat::PFormat`] when not set.
     pub tool_call_format: ToolCallFormat,
+    /// Active Composio integrations the user has connected. Rendered by
+    /// [`ConnectedIntegrationsSection`] so the orchestrator knows which
+    /// external services are available via the Skills Agent.
+    pub connected_integrations: &'a [ConnectedIntegration],
 }
 
 pub trait PromptSection: Send + Sync {
@@ -161,6 +176,10 @@ impl SystemPromptBuilder {
                 // the tree summarizer has nothing on disk yet.
                 Box::new(UserMemorySection),
                 Box::new(ToolsSection),
+                // Connected integrations sit after tools so the orchestrator
+                // sees which external services are available via the Skills
+                // Agent. Empty when the user has no active Composio connections.
+                Box::new(ConnectedIntegrationsSection),
                 Box::new(SafetySection),
                 Box::new(SkillsSection),
                 Box::new(WorkspaceSection),
@@ -300,6 +319,7 @@ pub struct IdentitySection;
 pub struct ToolsSection;
 pub struct SafetySection;
 pub struct SkillsSection;
+pub struct ConnectedIntegrationsSection;
 pub struct WorkspaceSection;
 pub struct RuntimeSection;
 pub struct DateTimeSection;
@@ -474,6 +494,33 @@ impl PromptSection for SkillsSection {
         }
         prompt.push_str("</available_skills>");
         Ok(prompt)
+    }
+}
+
+impl PromptSection for ConnectedIntegrationsSection {
+    fn name(&self) -> &str {
+        "connected_integrations"
+    }
+
+    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        if ctx.connected_integrations.is_empty() {
+            return Ok(String::new());
+        }
+
+        let mut out = String::from(
+            "## Connected Integrations\n\n\
+             The user has the following external services connected. \
+             To interact with any of these, delegate to the **Skills Agent** \
+             (`skills_agent`) via `spawn_subagent`.\n\n",
+        );
+        for integration in ctx.connected_integrations {
+            let _ = writeln!(
+                out,
+                "- **{}**: {}",
+                integration.toolkit, integration.description,
+            );
+        }
+        Ok(out)
     }
 }
 
@@ -978,6 +1025,7 @@ mod tests {
             learned: LearnedContextData::default(),
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
         let rendered = SystemPromptBuilder::with_defaults()
             .build_with_cache_metadata(&ctx)
@@ -1006,6 +1054,7 @@ mod tests {
             learned: LearnedContextData::default(),
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
 
         let section = IdentitySection;
@@ -1039,6 +1088,7 @@ mod tests {
             learned: LearnedContextData::default(),
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
 
         let rendered = DateTimeSection.build(&ctx).unwrap();
@@ -1099,6 +1149,7 @@ mod tests {
             learned: LearnedContextData::default(),
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
 
         let rendered = ToolsSection.build(&ctx).unwrap();
@@ -1130,6 +1181,7 @@ mod tests {
             learned: LearnedContextData::default(),
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::Json,
+            connected_integrations: &[],
         };
 
         let rendered = ToolsSection.build(&ctx).unwrap();
@@ -1165,6 +1217,7 @@ mod tests {
             learned,
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
         let rendered = UserMemorySection.build(&ctx).unwrap();
         assert!(rendered.starts_with("## User Memory\n\n"));
@@ -1188,6 +1241,7 @@ mod tests {
             learned,
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
         let rendered = UserMemorySection.build(&ctx).unwrap();
         assert!(rendered.is_empty());
@@ -1365,6 +1419,7 @@ mod tests {
             },
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
         };
         let rendered = UserMemorySection.build(&ctx).unwrap();
         assert!(rendered.contains("### user"));

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -885,16 +885,41 @@ pub fn render_subagent_system_prompt_with_format(
         );
     }
 
-    // 3d. Connected integrations — same section the main agent renders
-    //     so the orchestrator (and any sub-agent) sees what external
-    //     services are available via the Skills Agent.
+    // 3d. Connected integrations — rendered so the agent knows which
+    //     external services are available. Wording varies based on
+    //     whether the agent can delegate (has spawn_subagent) or must
+    //     call Composio tools directly.
     if !connected_integrations.is_empty() {
-        out.push_str(
-            "## Connected Integrations\n\n\
-             The user has the following external services connected. \
-             To interact with any of these, delegate to the **Skills Agent** \
-             (`skills_agent`) via `spawn_subagent`.\n\n",
-        );
+        let has_spawn = allowed_indices.iter().any(|&i| {
+            parent_tools
+                .get(i)
+                .map_or(false, |t| t.name() == "spawn_subagent")
+        });
+        let has_composio_execute = allowed_indices.iter().any(|&i| {
+            parent_tools
+                .get(i)
+                .map_or(false, |t| t.name() == "composio_execute")
+        });
+
+        out.push_str("## Connected Integrations\n\n");
+        if has_composio_execute {
+            out.push_str(
+                "The user has the following external services connected. \
+                 Use `composio_execute` with the appropriate action slug to interact \
+                 with them.\n\n",
+            );
+        } else if has_spawn {
+            out.push_str(
+                "The user has the following external services connected. \
+                 To interact with any of these, delegate to the **Skills Agent** \
+                 (`skills_agent`) via `spawn_subagent`.\n\n",
+            );
+        } else {
+            out.push_str(
+                "The user has the following external services connected.\n\n",
+            );
+        }
+
         for integration in connected_integrations {
             let _ = writeln!(
                 out,

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -538,11 +538,7 @@ impl PromptSection for ConnectedIntegrationsSection {
                 );
             } else {
                 for tool in &integration.tools {
-                    let _ = writeln!(
-                        out,
-                        "- `{}`: {}",
-                        tool.name, tool.description,
-                    );
+                    let _ = writeln!(out, "- `{}`: {}", tool.name, tool.description,);
                 }
                 out.push('\n');
             }

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -50,6 +50,18 @@ pub struct ConnectedIntegration {
     pub toolkit: String,
     /// Human-readable one-line description of what this integration can do.
     pub description: String,
+    /// Composio action slugs available for this toolkit, e.g.
+    /// `["GMAIL_SEND_EMAIL", "GMAIL_FETCH_EMAILS"]`.
+    pub tools: Vec<ConnectedIntegrationTool>,
+}
+
+/// A single action available on a connected integration.
+#[derive(Debug, Clone)]
+pub struct ConnectedIntegrationTool {
+    /// Action slug, e.g. `"GMAIL_SEND_EMAIL"`.
+    pub name: String,
+    /// One-line description of the action.
+    pub description: String,
 }
 
 /// A lightweight tool descriptor for prompt rendering.
@@ -516,9 +528,24 @@ impl PromptSection for ConnectedIntegrationsSection {
         for integration in ctx.connected_integrations {
             let _ = writeln!(
                 out,
-                "- **{}**: {}",
+                "### {} — {}\n",
                 integration.toolkit, integration.description,
             );
+            if integration.tools.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "Use `composio_list_tools` to discover available actions.\n",
+                );
+            } else {
+                for tool in &integration.tools {
+                    let _ = writeln!(
+                        out,
+                        "- `{}`: {}",
+                        tool.name, tool.description,
+                    );
+                }
+                out.push('\n');
+            }
         }
         Ok(out)
     }

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -1323,6 +1323,7 @@ mod tests {
             &tools,
             "You are a focused sub-agent.",
             SubagentRenderOptions::narrow(),
+            &[],
         ));
 
         assert!(
@@ -1383,6 +1384,7 @@ mod tests {
                 include_skills_catalog: true,
             },
             ToolCallFormat::Json,
+            &[],
         );
 
         assert!(rendered.contains("## Project Context"));
@@ -1400,6 +1402,7 @@ mod tests {
             "You are a specialist.",
             SubagentRenderOptions::narrow(),
             ToolCallFormat::Native,
+            &[],
         );
         assert!(native.contains("native tool-calling output"));
         assert!(!native.contains("## Safety"));

--- a/src/openhuman/context/prompt.rs
+++ b/src/openhuman/context/prompt.rs
@@ -915,9 +915,7 @@ pub fn render_subagent_system_prompt_with_format(
                  (`skills_agent`) via `spawn_subagent`.\n\n",
             );
         } else {
-            out.push_str(
-                "The user has the following external services connected.\n\n",
-            );
+            out.push_str("The user has the following external services connected.\n\n");
         }
 
         for integration in connected_integrations {

--- a/src/openhuman/learning/prompt_sections.rs
+++ b/src/openhuman/learning/prompt_sections.rs
@@ -155,6 +155,7 @@ mod tests {
             learned,
             visible_tool_names,
             tool_call_format: crate::openhuman::context::prompt::ToolCallFormat::PFormat,
+            connected_integrations: &[],
         }
     }
 

--- a/tests/agent_harness_public.rs
+++ b/tests/agent_harness_public.rs
@@ -126,6 +126,7 @@ fn stub_parent_context() -> ParentExecutionContext {
         memory_context: Some("ctx".into()),
         session_id: "test-session".into(),
         channel: "test-channel".into(),
+        connected_integrations: vec![],
     }
 }
 


### PR DESCRIPTION
## Summary

- **Connected integrations rendered in system prompts**: The orchestrator and all subagents now see which external services the user has connected (e.g. Gmail, Notion, GitHub) with their actual Composio action slugs, so the orchestrator automatically delegates "send an email" to the Skills Agent without the user having to explicitly request a subagent spawn.
- **Single shared fetch function**: `composio::fetch_connected_integrations()` is the one source of truth — called by both the agent turn loop and the debug dump CLI. No duplicated fetch logic.
- **Process-wide cache with smart invalidation**: Connections + tool schemas are fetched once and cached for the process lifetime. Cache is busted on `ComposioConnectionCreated` events (new OAuth) and on `composio_delete_connection` (disconnect). No redundant backend calls across agent sessions.
- **Toolkit capability descriptions**: Static human-readable summaries for 28+ common toolkits (Gmail, Notion, Slack, GitHub, etc.) with a fallback for unknown slugs.

## Changes

| File | Change |
|------|--------|
| `composio/ops.rs` | Shared `fetch_connected_integrations()` with `RwLock` cache, `invalidate_connected_integrations_cache()`, uncached fetch returning `Option` to distinguish no-auth from empty |
| `composio/bus.rs` | Cache invalidation on `ComposioConnectionCreated` |
| `composio/providers/mod.rs` | `toolkit_description()` — 28+ toolkit slug → description map |
| `context/prompt.rs` | `ConnectedIntegration` + `ConnectedIntegrationTool` types, `ConnectedIntegrationsSection`, wired into both main and subagent prompt renderers |
| `agent/harness/session/turn.rs` | Fetch integrations on first turn, pass to prompt context |
| `agent/harness/fork_context.rs` | `connected_integrations` on `ParentExecutionContext` |
| `agent/harness/subagent_runner.rs` | Thread integrations into subagent prompt rendering |
| `context/debug_dump.rs` | Dump script fetches real connections (with fallback for workspace overrides) |

## Test plan

- [x] `cargo check --all-targets` — clean
- [x] `cargo test -p openhuman --lib` — 2398 tests pass
- [x] `cargo run --bin openhuman-core -- agent dump-prompt --agent main` — shows Connected Integrations section
- [x] `cargo run --bin openhuman-core -- agent dump-prompt --agent orchestrator` — shows Connected Integrations section
- [x] `bash scripts/debug-agent-prompts.sh` — all 11 agents dump successfully with integrations visible in orchestrator
- [x] Workspace override (`OPENHUMAN_WORKSPACE=/tmp/...`) falls back to real user auth for integration fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now discovers and references available connected external services (e.g., Gmail, Notion, GitHub, Slack) within system prompts, enabling smarter service awareness
  * Connected integrations are automatically refreshed when connections are created or deleted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->