### PR TITLE
feat(referral): switch to link-based claims with flat $5 rewards

### DIFF
--- a/Referral-doc.md
+++ b/Referral-doc.md
@@ -2,22 +2,20 @@
 
 ## Overview
 
-Referral rewards are paid to the referrer based on real successful payments from referred users.
+Link-based referral system with one-time flat rewards for both parties.
 
-- Reward rate: `20%` of payment (`2000` basis points)
-- Referred user reward: none
-- Behavior flag: `RECURRING_REFERRAL_REWARD`
-  - `true`: reward every successful eligible payment
-  - `false`: reward only once per referral
+- Reward: **$5** credit to referrer and **$5** credit to referred user
+- Reward is one-time: awarded when the referred user's first subscription payment is confirmed
+- No recurring rewards — once a referral is marked `CONVERTED`, subsequent payments return `already_converted`
 
 ## Main Rules
 
-- Each user has one unique referral code.
-- A user can apply a code only before their first confirmed payment.
+- Each user has one unique referral code with a shareable link.
+- A user can claim a referral link only before their first subscription.
 - Self-referral is blocked (user id + identity fields).
 - Rewarding is idempotent:
   - same payment cannot reward twice
-  - non-recurring mode allows only one reward for that referral
+  - only one reward per referral (always one-time)
 
 ## Data Model
 
@@ -40,6 +38,7 @@ Referral rewards are paid to the referrer based on real successful payments from
 - `sourcePaymentId`, `sourcePaymentGateway`, `sourcePaymentObjectId`
 - `paymentAmountUsd`, `rewardAmountUsd`, `rewardRate` (Decimal128)
 - `creditTransactionId`
+- `recipientType`: `REFERRER | REFERRED`
 - `idempotencyKey` (unique)
 
 ## Migration
@@ -76,17 +75,18 @@ npm run migrate:down
 - `src/services/referral/referralCodeService.ts`
   - ensures and fetches user referral codes
 - `src/services/referral/referralService.ts`
-  - apply code, enforce eligibility, return referral stats
+  - claim referral link, enforce eligibility (subscription-based gating), return referral stats
 - `src/services/referral/referralRewardService.ts`
-  - compute reward in cents, award credits, upsert audit transaction, mark referral converted
+  - award flat $5 credit to both referrer and referred user, upsert audit transactions, mark referral converted
 
 ## API
 
 - `GET /referral/stats`
   - returns code, referral link, totals, and referral rows
-- `POST /referral/apply`
+- `POST /referral/claim`
   - request: `{ "code": "ABCD1234", "deviceFingerprint": "optional" }`
   - supports `x-device-fingerprint` header
+  - only users who have never subscribed are eligible
 
 ## Payment Integration
 
@@ -95,14 +95,11 @@ Reward processing is triggered on successful payment flows in:
 - `src/controllers/payment/coinbase/webhook.ts`
 - `src/controllers/payment/stripe/handleWebhook.ts`
 
-## Config
-
-`RECURRING_REFERRAL_REWARD` is read via `nconf`. Truthy values: `true`, `1`, `yes`.
-
 ## Tests
 
 Key test: `src/services/referral/__tests__/referralRewardService.test.ts`
 
-- non-recurring behavior
-- recurring behavior
+- flat $5 reward to both parties
+- conversion blocking (already_converted)
 - payment idempotency
+- partial-retry recovery

--- a/app/src/components/referral/ReferralRewardsSection.tsx
+++ b/app/src/components/referral/ReferralRewardsSection.tsx
@@ -9,14 +9,6 @@ function formatUsd(n: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n);
 }
 
-/** Basis points → percent for display (100 bps = 1%). */
-function formatRewardRatePercentFromBps(bps: number): string {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(bps / 100);
-}
-
 function statusBadgeClass(status: ReferralRelationshipStatus): string {
   switch (status) {
     case 'converted':
@@ -137,7 +129,7 @@ const ReferralRewardsSection = () => {
     setApplyLoading(true);
     setApplyError(null);
     try {
-      await referralApi.applyCode(trimmed);
+      await referralApi.claimReferral(trimmed);
       setApplySuccess(true);
       setApplyCode('');
       await refetch();
@@ -177,16 +169,9 @@ const ReferralRewardsSection = () => {
           </div>
           <h2 className="text-2xl font-semibold text-stone-900">Invite friends, earn credits</h2>
           <p className="text-sm text-stone-600 max-w-xl">
-            Share your personal link. When someone subscribes, you can earn a share of their
-            eligible payments as account credit. Self-referrals and duplicate rewards are blocked on
-            the server.
+            Share your personal link. When a friend subscribes to a monthly plan, you both get $5 in
+            account credit. Self-referrals and duplicate rewards are blocked on the server.
           </p>
-          {stats?.rewardRateBps ? (
-            <p className="text-xs text-stone-500">
-              Current reward rate: {formatRewardRatePercentFromBps(stats.rewardRateBps)}% of
-              eligible referred payments (basis points {stats.rewardRateBps}).
-            </p>
-          ) : null}
         </div>
       </div>
 
@@ -319,8 +304,8 @@ const ReferralRewardsSection = () => {
             <div className="rounded-xl border border-primary-100 bg-primary-50/40 p-4 space-y-3">
               <h3 className="text-sm font-semibold text-stone-900">Have a referral code?</h3>
               <p className="text-xs text-stone-600">
-                Enter a friend&apos;s code if you haven&apos;t completed a paid subscription yet.
-                Eligibility is enforced by the server.
+                Enter a friend&apos;s referral code. You&apos;re eligible if you haven&apos;t
+                subscribed yet — once you subscribe, you&apos;ll both get $5 in credit.
               </p>
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                 <input

--- a/app/src/pages/onboarding/steps/ReferralApplyStep.tsx
+++ b/app/src/pages/onboarding/steps/ReferralApplyStep.tsx
@@ -11,7 +11,8 @@ interface ReferralApplyStepProps {
 }
 
 /**
- * Optional step: attribute the signed-in user to a referrer via POST /referral/apply.
+ * Optional step: attribute the signed-in user to a referrer via POST /referral/claim.
+ * Only eligible if the user has not yet subscribed.
  */
 const ReferralApplyStep = ({ onNext, onApplied }: ReferralApplyStepProps) => {
   const { refresh } = useCoreState();
@@ -28,7 +29,7 @@ const ReferralApplyStep = ({ onNext, onApplied }: ReferralApplyStepProps) => {
     setError(null);
 
     try {
-      await referralApi.applyCode(trimmed);
+      await referralApi.claimReferral(trimmed);
       setSuccess(true);
       try {
         await refresh();

--- a/app/src/services/api/__tests__/referralApi.test.ts
+++ b/app/src/services/api/__tests__/referralApi.test.ts
@@ -16,7 +16,6 @@ describe('normalizeReferralStats', () => {
       ],
       appliedReferralCode: null,
       canApplyReferral: true,
-      rewardRateBps: 2000,
     });
     expect(stats.referralCode).toBe('ABC12');
     expect(stats.referralLink).toBe('https://app.example/r/ABC12');
@@ -27,7 +26,6 @@ describe('normalizeReferralStats', () => {
     expect(stats.referrals[1].rewardUsd).toBe(5);
     expect(stats.appliedReferralCode).toBeNull();
     expect(stats.canApplyReferral).toBe(true);
-    expect(stats.rewardRateBps).toBe(2000);
   });
 
   it('maps snake_case and coerces unknown status to pending', () => {
@@ -139,12 +137,12 @@ describe('referralApi', () => {
     expect(out.referralCode).toBe('Z9');
   });
 
-  it('applyCode calls core with trimmed code and fingerprint', async () => {
+  it('claimReferral calls core with trimmed code and fingerprint', async () => {
     const { callCoreCommand } = await import('../../coreCommandClient');
     vi.mocked(callCoreCommand).mockResolvedValueOnce({});
-    await referralApi.applyCode('  abcd  ');
+    await referralApi.claimReferral('  abcd  ');
     expect(callCoreCommand).toHaveBeenCalledWith(
-      'openhuman.referral_apply',
+      'openhuman.referral_claim',
       expect.objectContaining({ code: 'abcd', deviceFingerprint: expect.any(String) })
     );
   });
@@ -158,10 +156,10 @@ describe('referralApi', () => {
     });
   });
 
-  it('applyCode throws { success: false, error } preserving err.error string', async () => {
+  it('claimReferral throws { success: false, error } preserving err.error string', async () => {
     const { callCoreCommand } = await import('../../coreCommandClient');
     vi.mocked(callCoreCommand).mockRejectedValueOnce({ error: 'Code already used' });
-    await expect(referralApi.applyCode('ABCD')).rejects.toEqual({
+    await expect(referralApi.claimReferral('ABCD')).rejects.toEqual({
       success: false,
       error: 'Code already used',
     });

--- a/app/src/services/api/referralApi.ts
+++ b/app/src/services/api/referralApi.ts
@@ -7,7 +7,7 @@ import type {
 import { getOrCreateDeviceFingerprint } from '../../utils/deviceFingerprint';
 import { callCoreCommand } from '../coreCommandClient';
 
-/** Shape thrown by {@link referralApi.getStats} / {@link referralApi.applyCode} on RPC failure. */
+/** Shape thrown by {@link referralApi.getStats} / {@link referralApi.claimReferral} on RPC failure. */
 export type ReferralRpcFailure = { success: false; error: string };
 
 function referralRpcErrorMessage(err: unknown): string {
@@ -270,8 +270,6 @@ export function normalizeReferralStats(raw: unknown): ReferralStats {
         ? r.can_apply_referral
         : undefined;
 
-  const rewardRateBps = num(r.rewardRateBps ?? r.reward_rate_bps);
-
   return {
     referralCode: code,
     referralLink: link,
@@ -279,7 +277,6 @@ export function normalizeReferralStats(raw: unknown): ReferralStats {
     referrals,
     appliedReferralCode,
     canApplyReferral,
-    rewardRateBps: rewardRateBps > 0 ? rewardRateBps : undefined,
   };
 }
 
@@ -302,22 +299,23 @@ export const referralApi = {
   },
 
   /**
-   * Apply referral code via core RPC (`openhuman.referral_apply` → backend POST /referral/apply).
+   * Claim a referral link via core RPC (`openhuman.referral_claim` → backend POST /referral/claim).
+   * Only users who have not yet subscribed are eligible.
    */
-  applyCode: async (code: string): Promise<void> => {
+  claimReferral: async (code: string): Promise<void> => {
     const trimmed = code.trim();
     if (!trimmed) {
       throw { success: false as const, error: 'Referral code is required' };
     }
     const deviceFingerprint = getOrCreateDeviceFingerprint();
     try {
-      await callCoreCommand<unknown>('openhuman.referral_apply', {
+      await callCoreCommand<unknown>('openhuman.referral_claim', {
         code: trimmed,
         deviceFingerprint,
       });
-      console.debug('[referral] apply succeeded', { codeLength: trimmed.length });
+      console.debug('[referral] claim succeeded', { codeLength: trimmed.length });
     } catch (err) {
-      console.debug('[referral] apply RPC failed', referralRpcErrorMessage(err));
+      console.debug('[referral] claim RPC failed', referralRpcErrorMessage(err));
       throwReferralRpcFailure(err);
     }
   },

--- a/app/src/types/referral.ts
+++ b/app/src/types/referral.ts
@@ -30,7 +30,6 @@ export interface ReferralStats {
   referrals: ReferralRow[];
   /** Code this user applied as referred (if any) */
   appliedReferralCode?: string | null;
-  /** When false, user likely cannot apply (e.g. already paid); optional from backend */
+  /** When false, user likely cannot claim (e.g. already subscribed); optional from backend */
   canApplyReferral?: boolean;
-  rewardRateBps?: number;
 }

--- a/scripts/mock-api-core.mjs
+++ b/scripts/mock-api-core.mjs
@@ -728,9 +728,8 @@ async function handleRequest(req, res) {
       data: {
         referralCode: "MOCKREF1",
         referralLink: `${origin}/#/rewards?ref=MOCKREF1`,
-        rewardRateBps: 2000,
         totals: {
-          totalRewardUsd: 4.2,
+          totalRewardUsd: 10,
           pendingCount: 1,
           convertedCount: 2,
         },
@@ -747,7 +746,7 @@ async function handleRequest(req, res) {
             status: "converted",
             createdAt: new Date(Date.now() - 172800000).toISOString(),
             convertedAt: new Date().toISOString(),
-            rewardUsd: 2.1,
+            rewardUsd: 5,
           },
         ],
         appliedReferralCode: null,
@@ -757,10 +756,10 @@ async function handleRequest(req, res) {
     return;
   }
 
-  if (method === "POST" && /^\/referral\/apply\/?$/.test(url)) {
+  if (method === "POST" && /^\/referral\/claim\/?$/.test(url)) {
     json(res, 200, {
       success: true,
-      data: { ok: true, message: "Referral applied" },
+      data: { ok: true, message: "Referral claimed" },
     });
     return;
   }

--- a/src/openhuman/referral/ops.rs
+++ b/src/openhuman/referral/ops.rs
@@ -39,7 +39,7 @@ pub async fn get_stats(config: &Config) -> Result<RpcOutcome<Value>, String> {
     ))
 }
 
-pub async fn apply_code(
+pub async fn claim_referral(
     config: &Config,
     code: &str,
     device_fingerprint: Option<&str>,
@@ -58,7 +58,7 @@ pub async fn apply_code(
         .authed_json(
             &token,
             Method::POST,
-            "/referral/apply",
+            "/referral/claim",
             Some(Value::Object(body)),
         )
         .await
@@ -66,6 +66,6 @@ pub async fn apply_code(
 
     Ok(RpcOutcome::single_log(
         data,
-        "referral apply accepted by backend POST /referral/apply",
+        "referral claim accepted by backend POST /referral/claim",
     ))
 }

--- a/src/openhuman/referral/schemas.rs
+++ b/src/openhuman/referral/schemas.rs
@@ -103,9 +103,7 @@ fn handle_referral_claim(params: Map<String, Value>) -> ControllerFuture {
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty());
-        to_json(
-            crate::openhuman::referral::claim_referral(&config, payload.code.trim(), fp).await?,
-        )
+        to_json(crate::openhuman::referral::claim_referral(&config, payload.code.trim(), fp).await?)
     })
 }
 

--- a/src/openhuman/referral/schemas.rs
+++ b/src/openhuman/referral/schemas.rs
@@ -9,7 +9,7 @@ use crate::rpc::RpcOutcome;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ReferralApplyParams {
+struct ReferralClaimParams {
     code: String,
     #[serde(default)]
     device_fingerprint: Option<String>,
@@ -18,7 +18,7 @@ struct ReferralApplyParams {
 pub fn all_referral_controller_schemas() -> Vec<ControllerSchema> {
     vec![
         referral_schemas("referral_get_stats"),
-        referral_schemas("referral_apply"),
+        referral_schemas("referral_claim"),
     ]
 }
 
@@ -29,8 +29,8 @@ pub fn all_referral_registered_controllers() -> Vec<RegisteredController> {
             handler: handle_referral_get_stats,
         },
         RegisteredController {
-            schema: referral_schemas("referral_apply"),
-            handler: handle_referral_apply,
+            schema: referral_schemas("referral_claim"),
+            handler: handle_referral_claim,
         },
     ]
 }
@@ -48,16 +48,16 @@ pub fn referral_schemas(function: &str) -> ControllerSchema {
                 "Payload from GET /referral/stats (backend `data` field).",
             )],
         },
-        "referral_apply" => ControllerSchema {
+        "referral_claim" => ControllerSchema {
             namespace: "referral",
-            function: "apply",
+            function: "claim",
             description:
-                "Apply a friend's referral code for the current user (backend eligibility rules).",
+                "Claim a referral link for the current user. Only users who have not yet subscribed are eligible.",
             inputs: vec![
                 FieldSchema {
                     name: "code",
                     ty: TypeSchema::String,
-                    comment: "Referral code to apply.",
+                    comment: "Referral code to claim.",
                     required: true,
                 },
                 FieldSchema {
@@ -69,7 +69,7 @@ pub fn referral_schemas(function: &str) -> ControllerSchema {
             ],
             outputs: vec![json_output(
                 "result",
-                "Payload from POST /referral/apply (backend `data` field).",
+                "Payload from POST /referral/claim (backend `data` field).",
             )],
         },
         _ => ControllerSchema {
@@ -94,16 +94,18 @@ fn handle_referral_get_stats(_params: Map<String, Value>) -> ControllerFuture {
     })
 }
 
-fn handle_referral_apply(params: Map<String, Value>) -> ControllerFuture {
+fn handle_referral_claim(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let config = config_rpc::load_config_with_timeout().await?;
-        let payload = deserialize_params::<ReferralApplyParams>(params)?;
+        let payload = deserialize_params::<ReferralClaimParams>(params)?;
         let fp = payload
             .device_fingerprint
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty());
-        to_json(crate::openhuman::referral::apply_code(&config, payload.code.trim(), fp).await?)
+        to_json(
+            crate::openhuman::referral::claim_referral(&config, payload.code.trim(), fp).await?,
+        )
     })
 }
 


### PR DESCRIPTION
## Summary
- Rename endpoint `POST /referral/apply` → `POST /referral/claim` (Rust RPC + frontend API client)
- Update reward model from percentage-based (20% BPS) to flat $5 credit for both referrer and referred user
- Remove `rewardRateBps` from types, API normalization, and UI display
- Update UI copy to communicate the new $5-per-referral structure and subscription-based eligibility
- Update mock server, tests, and `Referral-doc.md` to reflect the new system

Mirrors backend changes from tinyhumansai/backend#631.

## Test plan
- [x] Rust core compiles (`cargo check`)
- [x] TypeScript typechecks (`tsc --noEmit`)
- [x] All 13 referral API unit tests pass (`vitest`)
- [ ] Manual: verify referral stats page shows "$5" copy instead of percentage
- [ ] Manual: verify claiming a referral via onboarding step calls `/referral/claim`
- [ ] Manual: verify share/copy link works on rewards page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral program updated: Both referrer and referred users now receive a flat $5 account credit when the referred user's first subscription is confirmed.
  * Referral links can only be claimed before subscribing.

* **UI Updates**
  * Removed reward percentage display; simplified referral messaging to clearly communicate the $5 credit benefit for both parties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->