### PR TITLE
feat(streaming): thinking tokens, tool call deltas, and progressive channel edits

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -78,6 +78,19 @@ interface ToolTimelineEntry {
   name: string;
   round: number;
   status: ToolTimelineEntryStatus;
+  /** Live JSON fragment streamed while the model composes the call. */
+  argsBuffer?: string;
+}
+
+/**
+ * Live streaming state for the in-flight agent turn on a thread. Cleared
+ * on `chat_done` / `chat_error`. Rendered as a provisional assistant
+ * bubble + optional "Thinking…" collapsible while present.
+ */
+interface StreamingAssistantState {
+  requestId: string;
+  content: string;
+  thinking: string;
 }
 
 function formatRelativeTime(dateStr: string): string {
@@ -206,6 +219,9 @@ const Conversations = () => {
   >({});
   const [inferenceStatusByThread, setInferenceStatusByThread] = useState<
     Record<string, InferenceStatus>
+  >({});
+  const [streamingAssistantByThread, setStreamingAssistantByThread] = useState<
+    Record<string, StreamingAssistantState>
   >({});
   const rustChat = useRustChat();
   const defaultChannelType = useAppSelector(
@@ -602,12 +618,97 @@ const Conversations = () => {
         }
         dispatch(addInferenceResponse({ content: segmentText(event), threadId: event.thread_id }));
       },
+      onTextDelta: event => {
+        setStreamingAssistantByThread(prev => {
+          const existing = prev[event.thread_id];
+          if (existing && existing.requestId !== event.request_id) {
+            return {
+              ...prev,
+              [event.thread_id]: {
+                requestId: event.request_id,
+                content: event.delta,
+                thinking: '',
+              },
+            };
+          }
+          return {
+            ...prev,
+            [event.thread_id]: {
+              requestId: event.request_id,
+              content: (existing?.content ?? '') + event.delta,
+              thinking: existing?.thinking ?? '',
+            },
+          };
+        });
+      },
+      onThinkingDelta: event => {
+        setStreamingAssistantByThread(prev => {
+          const existing = prev[event.thread_id];
+          if (existing && existing.requestId !== event.request_id) {
+            return {
+              ...prev,
+              [event.thread_id]: {
+                requestId: event.request_id,
+                content: '',
+                thinking: event.delta,
+              },
+            };
+          }
+          return {
+            ...prev,
+            [event.thread_id]: {
+              requestId: event.request_id,
+              content: existing?.content ?? '',
+              thinking: (existing?.thinking ?? '') + event.delta,
+            },
+          };
+        });
+      },
+      onToolArgsDelta: event => {
+        setToolTimelineByThread(prev => {
+          const existing = prev[event.thread_id] ?? [];
+          // Match by tool_call_id when known, else by name+round, else create.
+          const matchIdx = existing.findIndex(entry => entry.id === event.tool_call_id);
+          if (matchIdx >= 0) {
+            const merged = [...existing];
+            merged[matchIdx] = {
+              ...merged[matchIdx],
+              argsBuffer: (merged[matchIdx].argsBuffer ?? '') + event.delta,
+              name:
+                merged[matchIdx].name.length > 0 || !event.tool_name
+                  ? merged[matchIdx].name
+                  : `🤖 ${event.tool_name}`,
+            };
+            return { ...prev, [event.thread_id]: merged };
+          }
+          return {
+            ...prev,
+            [event.thread_id]: [
+              ...existing,
+              {
+                id: event.tool_call_id,
+                name: event.tool_name ? `🤖 ${event.tool_name}` : '🤖',
+                round: event.round,
+                status: 'running' as const,
+                argsBuffer: event.delta,
+              },
+            ],
+          };
+        });
+      },
       onDone: event => {
         const eventKey = `done:${event.thread_id}:${event.request_id ?? 'none'}`;
         if (!markChatEventSeen(eventKey)) return;
 
         // Clear inference status — the turn is finished
         setInferenceStatusByThread(prev => {
+          if (!prev[event.thread_id]) return prev;
+          const next = { ...prev };
+          delete next[event.thread_id];
+          return next;
+        });
+        // Clear the streaming buffer — the final message replaces it.
+        setStreamingAssistantByThread(prev => {
           if (!prev[event.thread_id]) return prev;
           const next = { ...prev };
           delete next[event.thread_id];
@@ -675,6 +776,12 @@ const Conversations = () => {
         setIsSending(false);
         // Clear inference status on error
         setInferenceStatusByThread(prev => {
+          if (!prev[event.thread_id]) return prev;
+          const next = { ...prev };
+          delete next[event.thread_id];
+          return next;
+        });
+        setStreamingAssistantByThread(prev => {
           if (!prev[event.thread_id]) return prev;
           const next = { ...prev };
           delete next[event.thread_id];
@@ -1095,6 +1202,9 @@ const Conversations = () => {
   const selectedInferenceStatus = selectedThreadId
     ? (inferenceStatusByThread[selectedThreadId] ?? null)
     : null;
+  const selectedStreamingAssistant = selectedThreadId
+    ? (streamingAssistantByThread[selectedThreadId] ?? null)
+    : null;
   const inlineCompletionSuffix = getInlineCompletionSuffix(inputValue, inlineSuggestionValue);
 
   return (
@@ -1275,6 +1385,37 @@ const Conversations = () => {
                   </div>
                 </div>
               )}
+              {/* Streaming assistant bubble — shown while deltas arrive for an in-flight turn. */}
+              {selectedStreamingAssistant &&
+                (selectedStreamingAssistant.content.length > 0 ||
+                  selectedStreamingAssistant.thinking.length > 0) && (
+                  <div className="flex justify-start">
+                    <div className="relative max-w-[75%]">
+                      {selectedStreamingAssistant.thinking.length > 0 && (
+                        <details className="mb-1.5 bg-stone-100 rounded-lg px-3 py-1.5 text-xs text-stone-600 open:bg-stone-100">
+                          <summary className="cursor-pointer select-none flex items-center gap-1.5">
+                            <span className="inline-block w-1.5 h-1.5 rounded-full bg-primary-400 animate-pulse" />
+                            <span>Thinking…</span>
+                          </summary>
+                          <pre className="whitespace-pre-wrap break-words mt-1.5 font-sans text-[11px] text-stone-500">
+                            {selectedStreamingAssistant.thinking}
+                          </pre>
+                        </details>
+                      )}
+                      {selectedStreamingAssistant.content.length > 0 && (
+                        <div className="rounded-2xl rounded-bl-md px-4 py-2.5 bg-stone-200/80 text-stone-900">
+                          <div className="text-sm prose prose-sm max-w-none prose-p:my-1 prose-pre:my-2 prose-pre:bg-stone-300/50 prose-pre:rounded-lg prose-code:text-primary-700 prose-code:text-xs prose-a:text-primary-500 prose-headings:text-sm prose-headings:font-semibold prose-ul:my-1 prose-ol:my-1 prose-li:my-0">
+                            <Markdown>{selectedStreamingAssistant.content}</Markdown>
+                          </div>
+                          <p className="text-[10px] mt-1 text-stone-400 flex items-center gap-1">
+                            <span className="inline-block w-1 h-1 rounded-full bg-primary-400 animate-pulse" />
+                            streaming…
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
               {/* Inference status indicator */}
               {selectedInferenceStatus && (
                 <div className="flex items-center gap-2 px-1 py-1.5 text-xs text-stone-500">
@@ -1295,18 +1436,27 @@ const Conversations = () => {
               {selectedThreadToolTimeline.length > 0 && (
                 <div className="space-y-1 px-1 py-1">
                   {selectedThreadToolTimeline.map(entry => (
-                    <div key={entry.id} className="flex items-center gap-2 text-xs text-stone-400">
-                      <span className="font-mono">{entry.name}</span>
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-[10px] ${
-                          entry.status === 'running'
-                            ? 'bg-amber-100 text-amber-600'
-                            : entry.status === 'success'
-                              ? 'bg-sage-100 text-sage-600'
-                              : 'bg-coral-100 text-coral-600'
-                        }`}>
-                        {entry.status}
-                      </span>
+                    <div key={entry.id} className="flex flex-col gap-0.5 text-xs text-stone-400">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono">{entry.name}</span>
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-[10px] ${
+                            entry.status === 'running'
+                              ? 'bg-amber-100 text-amber-600'
+                              : entry.status === 'success'
+                                ? 'bg-sage-100 text-sage-600'
+                                : 'bg-coral-100 text-coral-600'
+                          }`}>
+                          {entry.status}
+                        </span>
+                      </div>
+                      {entry.status === 'running' &&
+                        entry.argsBuffer &&
+                        entry.argsBuffer.length > 0 && (
+                          <pre className="ml-1 mt-0.5 px-2 py-1 bg-stone-100 rounded text-[10px] font-mono text-stone-500 whitespace-pre-wrap break-all max-h-24 overflow-y-auto">
+                            {entry.argsBuffer}
+                          </pre>
+                        )}
                     </div>
                   ))}
                 </div>

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -54,6 +54,11 @@ import {
 const DEFAULT_THREAD_ID = 'default-thread';
 const DEFAULT_THREAD_TITLE = 'Conversation';
 const AGENTIC_MODEL_ID = 'agentic-v1';
+/** Maximum trailing characters rendered in the live-streaming assistant
+ *  preview bubble. The full response is revealed via `addInferenceResponse`
+ *  on `chat_done` — this is purely a ticker-tape affordance to signal
+ *  progress without jumping the scroll position as tokens arrive. */
+const STREAMING_PREVIEW_CHARS = 120;
 type ToolTimelineEntryStatus = 'running' | 'success' | 'error';
 type InputMode = 'text' | 'voice';
 type ReplyMode = 'text' | 'voice';
@@ -1385,7 +1390,10 @@ const Conversations = () => {
                   </div>
                 </div>
               )}
-              {/* Streaming assistant bubble — shown while deltas arrive for an in-flight turn. */}
+              {/* Streaming assistant preview — compact trailing tail of the
+                  in-flight response. Rendered as plain text (not Markdown) to
+                  avoid jitter from partially-parsed fences. The final bubble
+                  replaces this via addInferenceResponse on chat_done. */}
               {selectedStreamingAssistant &&
                 (selectedStreamingAssistant.content.length > 0 ||
                   selectedStreamingAssistant.thinking.length > 0) && (
@@ -1398,18 +1406,21 @@ const Conversations = () => {
                             <span>Thinking…</span>
                           </summary>
                           <pre className="whitespace-pre-wrap break-words mt-1.5 font-sans text-[11px] text-stone-500">
-                            {selectedStreamingAssistant.thinking}
+                            {selectedStreamingAssistant.thinking.slice(
+                              -STREAMING_PREVIEW_CHARS
+                            )}
                           </pre>
                         </details>
                       )}
                       {selectedStreamingAssistant.content.length > 0 && (
-                        <div className="rounded-2xl rounded-bl-md px-4 py-2.5 bg-stone-200/80 text-stone-900">
-                          <div className="text-sm prose prose-sm max-w-none prose-p:my-1 prose-pre:my-2 prose-pre:bg-stone-300/50 prose-pre:rounded-lg prose-code:text-primary-700 prose-code:text-xs prose-a:text-primary-500 prose-headings:text-sm prose-headings:font-semibold prose-ul:my-1 prose-ol:my-1 prose-li:my-0">
-                            <Markdown>{selectedStreamingAssistant.content}</Markdown>
-                          </div>
-                          <p className="text-[10px] mt-1 text-stone-400 flex items-center gap-1">
-                            <span className="inline-block w-1 h-1 rounded-full bg-primary-400 animate-pulse" />
-                            streaming…
+                        <div className="rounded-2xl rounded-bl-md px-3 py-1.5 bg-stone-200/80 text-stone-900">
+                          <p className="text-xs text-stone-700 font-mono whitespace-pre-wrap break-words leading-snug">
+                            {selectedStreamingAssistant.content.length >
+                              STREAMING_PREVIEW_CHARS && (
+                              <span className="text-stone-400">…</span>
+                            )}
+                            {selectedStreamingAssistant.content.slice(-STREAMING_PREVIEW_CHARS)}
+                            <span className="inline-block w-1 h-3 ml-0.5 align-middle bg-primary-400 animate-pulse" />
                           </p>
                         </div>
                       )}

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1406,9 +1406,7 @@ const Conversations = () => {
                             <span>Thinking…</span>
                           </summary>
                           <pre className="whitespace-pre-wrap break-words mt-1.5 font-sans text-[11px] text-stone-500">
-                            {selectedStreamingAssistant.thinking.slice(
-                              -STREAMING_PREVIEW_CHARS
-                            )}
+                            {selectedStreamingAssistant.thinking.slice(-STREAMING_PREVIEW_CHARS)}
                           </pre>
                         </details>
                       )}
@@ -1416,9 +1414,7 @@ const Conversations = () => {
                         <div className="rounded-2xl rounded-bl-md px-3 py-1.5 bg-stone-200/80 text-stone-900">
                           <p className="text-xs text-stone-700 font-mono whitespace-pre-wrap break-words leading-snug">
                             {selectedStreamingAssistant.content.length >
-                              STREAMING_PREVIEW_CHARS && (
-                              <span className="text-stone-400">…</span>
-                            )}
+                              STREAMING_PREVIEW_CHARS && <span className="text-stone-400">…</span>}
                             {selectedStreamingAssistant.content.slice(-STREAMING_PREVIEW_CHARS)}
                             <span className="inline-block w-1 h-3 ml-0.5 align-middle bg-primary-400 animate-pulse" />
                           </p>

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -498,17 +498,34 @@ const Conversations = () => {
             activeTool: event.tool_name,
           },
         }));
-        const eventKey = `tool_call:${event.thread_id}:${event.request_id ?? 'none'}:${event.round}:${event.tool_name}`;
+        const eventKey = `tool_call:${event.thread_id}:${event.request_id ?? 'none'}:${event.round}:${event.tool_name}:${event.tool_call_id ?? ''}`;
         if (!markChatEventSeen(eventKey)) return;
 
         setToolTimelineByThread(prev => {
           const existing = prev[event.thread_id] ?? [];
+          // If a row was already created by onToolArgsDelta (keyed by
+          // tool_call_id), upgrade it in place so we don't duplicate.
+          const existingIdx = event.tool_call_id
+            ? existing.findIndex(entry => entry.id === event.tool_call_id)
+            : -1;
+          if (existingIdx >= 0) {
+            const merged = [...existing];
+            merged[existingIdx] = {
+              ...merged[existingIdx],
+              name: event.tool_name,
+              round: event.round,
+              status: 'running',
+            };
+            return { ...prev, [event.thread_id]: merged };
+          }
           return {
             ...prev,
             [event.thread_id]: [
               ...existing,
               {
-                id: `${event.thread_id}:${event.round}:${existing.length}:${event.tool_name}`,
+                id:
+                  event.tool_call_id ??
+                  `${event.thread_id}:${event.round}:${existing.length}:${event.tool_name}`,
                 name: event.tool_name,
                 round: event.round,
                 status: 'running',
@@ -518,7 +535,7 @@ const Conversations = () => {
         });
       },
       onToolResult: (event: ChatToolResultEvent) => {
-        const eventKey = `tool_result:${event.thread_id}:${event.request_id ?? 'none'}:${event.round}:${event.tool_name}:${event.success}`;
+        const eventKey = `tool_result:${event.thread_id}:${event.request_id ?? 'none'}:${event.round}:${event.tool_name}:${event.success}:${event.tool_call_id ?? ''}`;
         if (!markChatEventSeen(eventKey)) return;
 
         setToolTimelineByThread(prev => {
@@ -527,16 +544,30 @@ const Conversations = () => {
 
           const nextEntries = [...existing];
           let changed = false;
-          for (let i = nextEntries.length - 1; i >= 0; i--) {
-            const entry = nextEntries[i];
-            if (
-              entry.status === 'running' &&
-              entry.name === event.tool_name &&
-              entry.round === event.round
-            ) {
-              nextEntries[i] = { ...entry, status: event.success ? 'success' : 'error' };
+          // Prefer matching by tool_call_id; fall back to name+round
+          // for legacy events that don't carry an id.
+          if (event.tool_call_id) {
+            const idx = nextEntries.findIndex(entry => entry.id === event.tool_call_id);
+            if (idx >= 0) {
+              nextEntries[idx] = {
+                ...nextEntries[idx],
+                status: event.success ? 'success' : 'error',
+              };
               changed = true;
-              break;
+            }
+          }
+          if (!changed) {
+            for (let i = nextEntries.length - 1; i >= 0; i--) {
+              const entry = nextEntries[i];
+              if (
+                entry.status === 'running' &&
+                entry.name === event.tool_name &&
+                entry.round === event.round
+              ) {
+                nextEntries[i] = { ...entry, status: event.success ? 'success' : 'error' };
+                changed = true;
+                break;
+              }
             }
           }
 
@@ -672,17 +703,33 @@ const Conversations = () => {
       onToolArgsDelta: event => {
         setToolTimelineByThread(prev => {
           const existing = prev[event.thread_id] ?? [];
-          // Match by tool_call_id when known, else by name+round, else create.
-          const matchIdx = existing.findIndex(entry => entry.id === event.tool_call_id);
+          // Reconcile strategy (matches onToolCall/onToolResult keys):
+          //   1. Match by tool_call_id when known.
+          //   2. Fall back to an in-flight running row with the same
+          //      name+round (legacy path when tool_call_id is absent).
+          //   3. Create a fresh row keyed by tool_call_id.
+          let matchIdx = -1;
+          if (event.tool_call_id) {
+            matchIdx = existing.findIndex(entry => entry.id === event.tool_call_id);
+          }
+          if (matchIdx < 0 && event.tool_name) {
+            matchIdx = existing.findIndex(
+              entry =>
+                entry.status === 'running' &&
+                entry.name === event.tool_name &&
+                entry.round === event.round
+            );
+          }
           if (matchIdx >= 0) {
             const merged = [...existing];
             merged[matchIdx] = {
               ...merged[matchIdx],
               argsBuffer: (merged[matchIdx].argsBuffer ?? '') + event.delta,
+              // Fill in the tool name once the provider sends it.
               name:
-                merged[matchIdx].name.length > 0 || !event.tool_name
-                  ? merged[matchIdx].name
-                  : `🤖 ${event.tool_name}`,
+                merged[matchIdx].name.length === 0 && event.tool_name
+                  ? event.tool_name
+                  : merged[matchIdx].name,
             };
             return { ...prev, [event.thread_id]: merged };
           }
@@ -692,7 +739,7 @@ const Conversations = () => {
               ...existing,
               {
                 id: event.tool_call_id,
-                name: event.tool_name ? `🤖 ${event.tool_name}` : '🤖',
+                name: event.tool_name ?? '',
                 round: event.round,
                 status: 'running' as const,
                 argsBuffer: event.delta,
@@ -1379,17 +1426,26 @@ const Conversations = () => {
                   </div>
                 </div>
               ))}
-              {activeThreadId === selectedThreadId && isSending && (
-                <div className="flex justify-start">
-                  <div className="bg-stone-200/80 rounded-2xl rounded-bl-md px-4 py-3">
-                    <div className="flex items-center gap-1">
-                      <span className="w-1.5 h-1.5 rounded-full bg-stone-500 animate-bounce [animation-delay:0ms]" />
-                      <span className="w-1.5 h-1.5 rounded-full bg-stone-500 animate-bounce [animation-delay:150ms]" />
-                      <span className="w-1.5 h-1.5 rounded-full bg-stone-500 animate-bounce [animation-delay:300ms]" />
+              {activeThreadId === selectedThreadId &&
+                isSending &&
+                // Suppress the legacy 3-dot placeholder once streaming
+                // output (visible text or thinking) has started — the
+                // streaming preview bubble below takes over as the
+                // activity indicator.
+                !(
+                  (selectedStreamingAssistant?.content.length ?? 0) > 0 ||
+                  (selectedStreamingAssistant?.thinking.length ?? 0) > 0
+                ) && (
+                  <div className="flex justify-start">
+                    <div className="bg-stone-200/80 rounded-2xl rounded-bl-md px-4 py-3">
+                      <div className="flex items-center gap-1">
+                        <span className="w-1.5 h-1.5 rounded-full bg-stone-500 animate-bounce [animation-delay:0ms]" />
+                        <span className="w-1.5 h-1.5 rounded-full bg-stone-500 animate-bounce [animation-delay:150ms]" />
+                        <span className="w-1.5 h-1.5 rounded-full bg-stone-500 animate-bounce [animation-delay:300ms]" />
+                      </div>
                     </div>
                   </div>
-                </div>
-              )}
+                )}
               {/* Streaming assistant preview — compact trailing tail of the
                   in-flight response. Rendered as plain text (not Markdown) to
                   avoid jitter from partially-parsed fences. The final bubble

--- a/app/src/services/chatService.ts
+++ b/app/src/services/chatService.ts
@@ -111,6 +111,49 @@ export interface ChatSubagentDoneEvent {
   round: number;
 }
 
+/**
+ * Emitted for each chunk of streamed assistant text that arrives from the
+ * provider during an iteration. Concatenating `delta` values in order yields
+ * the visible assistant text for that iteration.
+ */
+export interface ChatTextDeltaEvent {
+  thread_id: string;
+  request_id: string;
+  /** 1-based iteration index the chunk belongs to. */
+  round: number;
+  /** Text fragment; may be a single token or a few characters. */
+  delta: string;
+}
+
+/**
+ * Emitted for each chunk of streamed model reasoning / thinking output.
+ * Only sent by models that expose `reasoning_content` (see the
+ * `supportsThinking` flag on the model registry entry). Concatenating
+ * `delta`s in order yields the full reasoning transcript.
+ */
+export interface ChatThinkingDeltaEvent {
+  thread_id: string;
+  request_id: string;
+  round: number;
+  delta: string;
+}
+
+/**
+ * Emitted for each chunk of a native tool call's arguments JSON while the
+ * model is still composing the call. `tool_call_id` groups fragments for
+ * the same call, and `tool_name` is populated once the provider sends it
+ * (may be empty on the very first chunk).
+ */
+export interface ChatToolArgsDeltaEvent {
+  thread_id: string;
+  request_id: string;
+  round: number;
+  tool_call_id: string;
+  tool_name: string;
+  /** JSON fragment; only valid JSON once concatenated across all chunks. */
+  delta: string;
+}
+
 export interface ChatEventListeners {
   onInferenceStart?: (event: ChatInferenceStartEvent) => void;
   onIterationStart?: (event: ChatIterationStartEvent) => void;
@@ -119,6 +162,9 @@ export interface ChatEventListeners {
   onSubagentSpawned?: (event: ChatSubagentSpawnedEvent) => void;
   onSubagentDone?: (event: ChatSubagentDoneEvent) => void;
   onSegment?: (event: ChatSegmentEvent) => void;
+  onTextDelta?: (event: ChatTextDeltaEvent) => void;
+  onThinkingDelta?: (event: ChatThinkingDeltaEvent) => void;
+  onToolArgsDelta?: (event: ChatToolArgsDeltaEvent) => void;
   onDone?: (event: ChatDoneEvent) => void;
   onError?: (event: ChatErrorEvent) => void;
 }
@@ -140,6 +186,9 @@ export function subscribeChatEvents(listeners: ChatEventListeners): () => void {
     subagentCompleted: 'subagent_completed',
     subagentFailed: 'subagent_failed',
     segment: 'chat_segment',
+    textDelta: 'text_delta',
+    thinkingDelta: 'thinking_delta',
+    toolArgsDelta: 'tool_args_delta',
     done: 'chat_done',
     error: 'chat_error',
   } as const;
@@ -271,6 +320,58 @@ export function subscribeChatEvents(listeners: ChatEventListeners): () => void {
     };
     socket.on(EVENTS.segment, cb);
     handlers.push([EVENTS.segment, cb]);
+  }
+
+  if (listeners.onTextDelta) {
+    const cb = (payload: unknown) => {
+      const e = payload as ChatTextDeltaEvent;
+      chatLog(
+        '%s thread_id=%s request_id=%s round=%d chars=%d',
+        EVENTS.textDelta,
+        e.thread_id,
+        e.request_id,
+        e.round,
+        e.delta?.length ?? 0
+      );
+      listeners.onTextDelta?.(e);
+    };
+    socket.on(EVENTS.textDelta, cb);
+    handlers.push([EVENTS.textDelta, cb]);
+  }
+
+  if (listeners.onThinkingDelta) {
+    const cb = (payload: unknown) => {
+      const e = payload as ChatThinkingDeltaEvent;
+      chatLog(
+        '%s thread_id=%s request_id=%s round=%d chars=%d',
+        EVENTS.thinkingDelta,
+        e.thread_id,
+        e.request_id,
+        e.round,
+        e.delta?.length ?? 0
+      );
+      listeners.onThinkingDelta?.(e);
+    };
+    socket.on(EVENTS.thinkingDelta, cb);
+    handlers.push([EVENTS.thinkingDelta, cb]);
+  }
+
+  if (listeners.onToolArgsDelta) {
+    const cb = (payload: unknown) => {
+      const e = payload as ChatToolArgsDeltaEvent;
+      chatLog(
+        '%s thread_id=%s request_id=%s round=%d tool_call_id=%s chars=%d',
+        EVENTS.toolArgsDelta,
+        e.thread_id,
+        e.request_id,
+        e.round,
+        e.tool_call_id,
+        e.delta?.length ?? 0
+      );
+      listeners.onToolArgsDelta?.(e);
+    };
+    socket.on(EVENTS.toolArgsDelta, cb);
+    handlers.push([EVENTS.toolArgsDelta, cb]);
   }
 
   if (listeners.onDone) {

--- a/app/src/services/chatService.ts
+++ b/app/src/services/chatService.ts
@@ -20,6 +20,13 @@ export interface ChatToolCallEvent {
   skill_id: string;
   args: Record<string, unknown>;
   round: number;
+  /**
+   * Stable call id (matches the `call_id` on preceding
+   * {@link ChatToolArgsDeltaEvent}s and the eventual
+   * {@link ChatToolResultEvent}). Reducers key tool-timeline rows by
+   * this id for end-to-end reconciliation.
+   */
+  tool_call_id?: string;
 }
 
 export interface ChatToolResultEvent {
@@ -30,6 +37,8 @@ export interface ChatToolResultEvent {
   output: string;
   success: boolean;
   round: number;
+  /** Matches the id on the corresponding {@link ChatToolCallEvent}. */
+  tool_call_id?: string;
 }
 
 export interface ChatDoneEvent {

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -522,6 +522,37 @@ impl BackendOAuthClient {
         .await
     }
 
+    /// Edits an existing channel message. Used by the progressive-edit
+    /// streaming path (Telegram / Slack) to coalesce live deltas into a
+    /// single evolving outbound message rather than spamming the chat
+    /// with one bubble per token.
+    ///
+    /// `message_id` is the backend-returned id of the message that was
+    /// first sent via [`Self::send_channel_message`]. Returns the
+    /// updated message record, or an `Err` if the backend does not
+    /// support editing for this channel (caller should fall back to
+    /// atomic-final delivery).
+    pub async fn send_channel_edit(
+        &self,
+        channel: &str,
+        message_id: &str,
+        bearer_jwt: &str,
+        edit_body: Value,
+    ) -> Result<Value> {
+        let channel = channel.trim().trim_matches('/');
+        anyhow::ensure!(!channel.is_empty(), "channel is required");
+        anyhow::ensure!(!message_id.is_empty(), "message_id is required");
+        let encoded_channel = urlencoding::encode(channel);
+        let encoded_id = urlencoding::encode(message_id);
+        self.authed_json(
+            bearer_jwt,
+            Method::PATCH,
+            &format!("channels/{encoded_channel}/messages/{encoded_id}"),
+            Some(edit_body),
+        )
+        .await
+    }
+
     /// Sends a reaction (e.g. emoji) to a message in a channel.
     pub async fn send_channel_reaction(
         &self,

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 use reqwest::header::AUTHORIZATION;
 use reqwest::{Client, Method, Url};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::time::Duration;
 
 use super::jwt::bearer_authorization_value;
@@ -518,6 +518,28 @@ impl BackendOAuthClient {
             Method::POST,
             &format!("channels/{encoded}/messages"),
             Some(message_body),
+        )
+        .await
+    }
+
+    /// Signals "the agent is typing…" on a channel that supports it
+    /// (Telegram's `sendChatAction`, Slack's typing event, …). The backend
+    /// resolves the target chat from the channel integration metadata and
+    /// is responsible for hitting the provider-native API.
+    ///
+    /// Telegram keeps the typing indicator alive for ~5 seconds per call,
+    /// so callers should re-invoke every ~4 s for as long as the turn is
+    /// in flight. Returns `Err` if the backend doesn't support typing for
+    /// this channel — caller should swallow the error silently.
+    pub async fn send_channel_typing(&self, channel: &str, bearer_jwt: &str) -> Result<Value> {
+        let channel = channel.trim().trim_matches('/');
+        anyhow::ensure!(!channel.is_empty(), "channel is required");
+        let encoded = urlencoding::encode(channel);
+        self.authed_json(
+            bearer_jwt,
+            Method::POST,
+            &format!("channels/{encoded}/typing"),
+            Some(json!({})),
         )
         .await
     }

--- a/src/core/socketio.rs
+++ b/src/core/socketio.rs
@@ -8,7 +8,7 @@ use socketioxide::SocketIo;
 ///
 /// This structure defines the data sent to Socket.IO clients for various
 /// chat-related events, such as message delivery, tool execution, and errors.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct WebChannelEvent {
     /// The event name (e.g., `chat_message`, `tool_call`).
@@ -55,6 +55,20 @@ pub struct WebChannelEvent {
     /// Total number of segments in a segmented delivery.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_total: Option<u32>,
+    /// Fine-grained streaming payload for `text_delta`, `thinking_delta`,
+    /// and `tool_args_delta` events. Concatenating `delta`s in order
+    /// yields the full text/thinking/arguments string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<String>,
+    /// Discriminator for the `delta` payload: `"text"`, `"thinking"`,
+    /// or `"tool_args"`. Only set on streaming delta events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta_kind: Option<String>,
+    /// Provider-assigned tool call id that groups `tool_args_delta`
+    /// chunks together and ties them to the eventual `tool_call` /
+    /// `tool_result` events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/openhuman/agent/bus.rs
+++ b/src/openhuman/agent/bus.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::core::event_bus::register_native_global;
+use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::config::MultimodalConfig;
 use crate::openhuman::providers::{ChatMessage, Provider};
 use crate::openhuman::tools::Tool;
@@ -112,6 +113,13 @@ pub struct AgentTurnRequest {
     /// registry because they depend on per-user runtime state.
     /// Empty vec for agents that don't delegate.
     pub extra_tools: Vec<Box<dyn Tool>>,
+
+    /// Optional sink for per-turn [`AgentProgress`] events — lets
+    /// external channel adapters (Telegram, Slack, …) subscribe to
+    /// fine-grained tool-call / text-delta / thinking-delta events and
+    /// progressively edit outbound messages. `None` disables streaming
+    /// status updates for this turn.
+    pub on_progress: Option<mpsc::Sender<AgentProgress>>,
 }
 
 /// Final response from an agentic turn.
@@ -145,6 +153,7 @@ pub fn register_agent_handlers() {
                 target_agent_id,
                 visible_tool_names,
                 extra_tools,
+                on_progress,
             } = req;
 
             tracing::debug!(
@@ -180,6 +189,7 @@ pub fn register_agent_handlers() {
                 on_delta,
                 visible_tool_names.as_ref(),
                 &extra_tools,
+                on_progress,
             )
             .await
             .map_err(|e| e.to_string())?;
@@ -326,6 +336,7 @@ mod tests {
             target_agent_id: None,
             visible_tool_names: None,
             extra_tools: Vec::new(),
+            on_progress: None,
         }
     }
 

--- a/src/openhuman/agent/bus.rs
+++ b/src/openhuman/agent/bus.rs
@@ -167,6 +167,7 @@ pub fn register_agent_handlers() {
                 visible_tool_count = visible_tool_names.as_ref().map(|s| s.len()).unwrap_or(0),
                 filter_active = visible_tool_names.is_some(),
                 streaming = on_delta.is_some(),
+                progress_subscribed = on_progress.is_some(),
                 "[agent::bus] dispatching {AGENT_RUN_TURN_METHOD}"
             );
 

--- a/src/openhuman/agent/harness/parse.rs
+++ b/src/openhuman/agent/harness/parse.rs
@@ -7,6 +7,10 @@ use std::sync::LazyLock;
 pub(crate) struct ParsedToolCall {
     pub name: String,
     pub arguments: serde_json::Value,
+    /// Provider-assigned call id when the call came from a native
+    /// tool-use response. `None` for prompt-guided (XML-parsed)
+    /// tool calls — progress emitters synthesise a fallback id.
+    pub id: Option<String>,
 }
 
 /// Find a tool by name in the registry.
@@ -32,7 +36,11 @@ pub(crate) fn parse_tool_call_value(value: &serde_json::Value) -> Option<ParsedT
             .to_string();
         if !name.is_empty() {
             let arguments = parse_arguments_value(function.get("arguments"));
-            return Some(ParsedToolCall { name, arguments });
+            return Some(ParsedToolCall {
+                name,
+                arguments,
+                id: None,
+            });
         }
     }
 
@@ -48,7 +56,11 @@ pub(crate) fn parse_tool_call_value(value: &serde_json::Value) -> Option<ParsedT
     }
 
     let arguments = parse_arguments_value(value.get("arguments"));
-    Some(ParsedToolCall { name, arguments })
+    Some(ParsedToolCall {
+        name,
+        arguments,
+        id: None,
+    })
 }
 
 pub(crate) fn parse_tool_calls_from_json_value(value: &serde_json::Value) -> Vec<ParsedToolCall> {
@@ -455,6 +467,7 @@ pub(crate) fn parse_tool_calls(response: &str) -> (String, Vec<ParsedToolCall>) 
                 calls.push(ParsedToolCall {
                     name: name.clone(),
                     arguments: args.clone(),
+                    id: None,
                 });
                 if let Some(r) = raw {
                     cleaned_text = cleaned_text.replace(r, "");
@@ -492,6 +505,7 @@ pub(crate) fn parse_structured_tool_calls(tool_calls: &[ToolCall]) -> Vec<Parsed
             name: call.name.clone(),
             arguments: serde_json::from_str::<serde_json::Value>(&call.arguments)
                 .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
+            id: Some(call.id.clone()),
         })
         .collect()
 }

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -337,7 +337,12 @@ impl Agent {
                                     }
                                 }
                             };
-                            let _ = sink.try_send(mapped);
+                            // Await backpressure so streamed deltas arrive
+                            // in order and aren't silently dropped when the
+                            // downstream progress bridge is slow.
+                            if sink.send(mapped).await.is_err() {
+                                break;
+                            }
                         }
                     });
                     (Some(tx), Some(forwarder))
@@ -626,7 +631,15 @@ impl Agent {
             tool_name: call.name.clone(),
             session_id: self.event_session_id().to_string(),
         });
+        // Synthesise a fallback id for prompt-guided (non-native) tool
+        // calls so downstream consumers always have a stable key to
+        // reconcile tool_call / tool_args_delta / tool_result rows by.
+        let call_id = call
+            .tool_call_id
+            .clone()
+            .unwrap_or_else(|| format!("turn-{iteration}-{}", call.name));
         self.emit_progress(AgentProgress::ToolCallStarted {
+            call_id: call_id.clone(),
             tool_name: call.name.clone(),
             arguments: call.arguments.clone(),
             iteration: (iteration + 1) as u32,
@@ -714,6 +727,7 @@ impl Agent {
             elapsed_ms,
         });
         self.emit_progress(AgentProgress::ToolCallCompleted {
+            call_id: call_id.clone(),
             tool_name: call.name.clone(),
             success,
             output_chars: result.chars().count(),

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -31,7 +31,7 @@ use crate::openhuman::context::prompt::{
 };
 use crate::openhuman::context::{ReductionOutcome, ARCHIVIST_EXTRACTION_PROMPT};
 use crate::openhuman::memory::MemoryCategory;
-use crate::openhuman::providers::{ChatMessage, ChatRequest, ConversationMessage};
+use crate::openhuman::providers::{ChatMessage, ChatRequest, ConversationMessage, ProviderDelta};
 use crate::openhuman::tools::Tool;
 use crate::openhuman::util::truncate_with_ellipsis;
 use anyhow::Result;
@@ -294,6 +294,55 @@ impl Agent {
                     self.tool_dispatcher.should_send_tool_specs()
                 );
                 let provider_started = std::time::Instant::now();
+                // Only set up the streaming sink when someone is
+                // listening for progress events. Without a listener the
+                // channel buffer would fill up and back-pressure the
+                // provider; skipping it also keeps the non-streaming
+                // HTTP path alive for providers that don't implement
+                // SSE.
+                let iteration_for_stream = (iteration + 1) as u32;
+                let (delta_tx_opt, delta_forwarder) = if self.on_progress.is_some() {
+                    let (tx, mut rx) = tokio::sync::mpsc::channel::<ProviderDelta>(128);
+                    let progress_tx = self.on_progress.clone();
+                    let forwarder = tokio::spawn(async move {
+                        while let Some(event) = rx.recv().await {
+                            let Some(ref sink) = progress_tx else { continue };
+                            let mapped = match event {
+                                ProviderDelta::TextDelta { delta } => AgentProgress::TextDelta {
+                                    delta,
+                                    iteration: iteration_for_stream,
+                                },
+                                ProviderDelta::ThinkingDelta { delta } => {
+                                    AgentProgress::ThinkingDelta {
+                                        delta,
+                                        iteration: iteration_for_stream,
+                                    }
+                                }
+                                ProviderDelta::ToolCallStart {
+                                    call_id,
+                                    tool_name,
+                                } => AgentProgress::ToolCallArgsDelta {
+                                    call_id,
+                                    tool_name,
+                                    delta: String::new(),
+                                    iteration: iteration_for_stream,
+                                },
+                                ProviderDelta::ToolCallArgsDelta { call_id, delta } => {
+                                    AgentProgress::ToolCallArgsDelta {
+                                        call_id,
+                                        tool_name: String::new(),
+                                        delta,
+                                        iteration: iteration_for_stream,
+                                    }
+                                }
+                            };
+                            let _ = sink.try_send(mapped);
+                        }
+                    });
+                    (Some(tx), Some(forwarder))
+                } else {
+                    (None, None)
+                };
                 let response = match self
                     .provider
                     .chat(
@@ -305,6 +354,7 @@ impl Agent {
                                 None
                             },
                             system_prompt_cache_boundary: self.system_prompt_cache_boundary,
+                            stream: delta_tx_opt.as_ref(),
                         },
                         &effective_model,
                         self.temperature,
@@ -332,8 +382,18 @@ impl Agent {
                         }
                         resp
                     }
-                    Err(err) => return Err(err),
+                    Err(err) => {
+                        drop(delta_tx_opt);
+                        if let Some(handle) = delta_forwarder {
+                            let _ = handle.await;
+                        }
+                        return Err(err);
+                    }
                 };
+                drop(delta_tx_opt);
+                if let Some(handle) = delta_forwarder {
+                    let _ = handle.await;
+                }
 
                 let (text, calls) = self.tool_dispatcher.parse_response(&response);
                 let calls = Self::with_fallback_tool_call_ids(calls, iteration);

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -306,7 +306,9 @@ impl Agent {
                     let progress_tx = self.on_progress.clone();
                     let forwarder = tokio::spawn(async move {
                         while let Some(event) = rx.recv().await {
-                            let Some(ref sink) = progress_tx else { continue };
+                            let Some(ref sink) = progress_tx else {
+                                continue;
+                            };
                             let mapped = match event {
                                 ProviderDelta::TextDelta { delta } => AgentProgress::TextDelta {
                                     delta,
@@ -318,15 +320,14 @@ impl Agent {
                                         iteration: iteration_for_stream,
                                     }
                                 }
-                                ProviderDelta::ToolCallStart {
-                                    call_id,
-                                    tool_name,
-                                } => AgentProgress::ToolCallArgsDelta {
-                                    call_id,
-                                    tool_name,
-                                    delta: String::new(),
-                                    iteration: iteration_for_stream,
-                                },
+                                ProviderDelta::ToolCallStart { call_id, tool_name } => {
+                                    AgentProgress::ToolCallArgsDelta {
+                                        call_id,
+                                        tool_name,
+                                        delta: String::new(),
+                                        iteration: iteration_for_stream,
+                                    }
+                                }
                                 ProviderDelta::ToolCallArgsDelta { call_id, delta } => {
                                     AgentProgress::ToolCallArgsDelta {
                                         call_id,

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -60,7 +60,7 @@ impl Agent {
     ///    extraction asynchronously.
     pub async fn turn(&mut self, user_message: &str) -> Result<String> {
         let turn_started = std::time::Instant::now();
-        self.emit_progress(AgentProgress::TurnStarted);
+        self.emit_progress(AgentProgress::TurnStarted).await;
         log::info!("[agent] turn started — awaiting user message processing");
         log::info!(
             "[agent_loop] turn start message_chars={} history_len={} max_tool_iterations={}",
@@ -187,7 +187,8 @@ impl Agent {
                 self.emit_progress(AgentProgress::IterationStarted {
                     iteration: (iteration + 1) as u32,
                     max_iterations: self.config.max_tool_iterations as u32,
-                });
+                })
+                .await;
                 log::info!(
                     "[agent_loop] iteration start i={} history_len={}",
                     iteration + 1,
@@ -432,7 +433,8 @@ impl Agent {
 
                     self.emit_progress(AgentProgress::TurnCompleted {
                         iterations: (iteration + 1) as u32,
-                    });
+                    })
+                    .await;
 
                     self.history
                         .push(ConversationMessage::Chat(ChatMessage::assistant(
@@ -634,16 +636,23 @@ impl Agent {
         // Synthesise a fallback id for prompt-guided (non-native) tool
         // calls so downstream consumers always have a stable key to
         // reconcile tool_call / tool_args_delta / tool_result rows by.
-        let call_id = call
-            .tool_call_id
-            .clone()
-            .unwrap_or_else(|| format!("turn-{iteration}-{}", call.name));
+        // A random uuid guarantees uniqueness even when the same tool
+        // name appears multiple times in the same iteration's parsed
+        // calls.
+        let call_id = call.tool_call_id.clone().unwrap_or_else(|| {
+            format!(
+                "turn-{iteration}-{}-{}",
+                call.name,
+                uuid::Uuid::new_v4().simple()
+            )
+        });
         self.emit_progress(AgentProgress::ToolCallStarted {
             call_id: call_id.clone(),
             tool_name: call.name.clone(),
             arguments: call.arguments.clone(),
             iteration: (iteration + 1) as u32,
-        });
+        })
+        .await;
         log::info!("[agent] executing tool: {}", call.name);
         log::info!("[agent_loop] tool start name={}", call.name);
 
@@ -733,7 +742,8 @@ impl Agent {
             output_chars: result.chars().count(),
             elapsed_ms,
             iteration: (iteration + 1) as u32,
-        });
+        })
+        .await;
         log::info!(
             "[agent] tool completed: {} success={} elapsed_ms={}",
             call.name,
@@ -853,10 +863,19 @@ impl Agent {
     // History & prompt helpers
     // ─────────────────────────────────────────────────────────────────
 
-    /// Emit a progress event (fire-and-forget) if the sender is set.
-    fn emit_progress(&self, event: AgentProgress) {
+    /// Emit a lifecycle progress event. Uses `send().await` so control
+    /// events (turn/iteration boundaries, tool_call_started/completed,
+    /// turn_completed) survive downstream backpressure from the
+    /// higher-frequency streamed deltas that share the same `on_progress`
+    /// channel — dropping one of these would desync the web-channel
+    /// progress bridge (e.g. a tool row stuck in `running` forever).
+    /// A closed sink is logged and ignored; no progress subscriber is
+    /// equivalent to success.
+    async fn emit_progress(&self, event: AgentProgress) {
         if let Some(ref tx) = self.on_progress {
-            let _ = tx.try_send(event);
+            if let Err(e) = tx.send(event).await {
+                log::warn!("[agent] progress sink closed while emitting lifecycle event: {e}");
+            }
         }
     }
 

--- a/src/openhuman/agent/harness/subagent_runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner.rs
@@ -545,6 +545,7 @@ async fn run_inner_loop(
                     messages: history.as_slice(),
                     tools: request_tools,
                     system_prompt_cache_boundary,
+                    stream: None,
                 },
                 model,
                 temperature,

--- a/src/openhuman/agent/harness/tests.rs
+++ b/src/openhuman/agent/harness/tests.rs
@@ -126,6 +126,7 @@ async fn run_tool_call_loop_returns_structured_error_for_non_vision_provider() {
         None,
         None,
         &[],
+        None,
     )
     .await
     .expect_err("provider without vision support should fail");
@@ -169,6 +170,7 @@ async fn run_tool_call_loop_rejects_oversized_image_payload() {
         None,
         None,
         &[],
+        None,
     )
     .await
     .expect_err("oversized payload must fail");
@@ -206,6 +208,7 @@ async fn run_tool_call_loop_accepts_valid_multimodal_request_flow() {
         None,
         None,
         &[],
+        None,
     )
     .await
     .expect("valid multimodal payload should pass");

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -148,17 +148,28 @@ pub(crate) async fn run_tool_call_loop(
 
     let mut context_guard = ContextGuard::new();
 
-    // Announce turn start to progress subscribers (if any).
+    // Announce turn start to progress subscribers (if any). We use
+    // `send().await` for lifecycle (turn/iteration) events so they
+    // survive downstream backpressure — dropping one of these would
+    // desync the web-channel progress bridge. High-volume delta events
+    // use the same backpressure discipline (see below).
     if let Some(ref sink) = on_progress {
-        let _ = sink.try_send(AgentProgress::TurnStarted);
+        if let Err(e) = sink.send(AgentProgress::TurnStarted).await {
+            log::warn!("[agent_loop] progress sink closed at TurnStarted: {e}");
+        }
     }
 
     for iteration in 0..max_iterations {
         if let Some(ref sink) = on_progress {
-            let _ = sink.try_send(AgentProgress::IterationStarted {
-                iteration: (iteration + 1) as u32,
-                max_iterations: max_iterations as u32,
-            });
+            if let Err(e) = sink
+                .send(AgentProgress::IterationStarted {
+                    iteration: (iteration + 1) as u32,
+                    max_iterations: max_iterations as u32,
+                })
+                .await
+            {
+                log::warn!("[agent_loop] progress sink closed at IterationStarted: {e}");
+            }
         }
         // ── Context guard: check utilization before each LLM call ──
         match context_guard.check() {
@@ -243,7 +254,13 @@ pub(crate) async fn run_tool_call_loop(
                             }
                         }
                     };
-                    let _ = progress_sink.try_send(mapped);
+                    // Await backpressure rather than dropping deltas so
+                    // partial streamed text/args stays consistent with the
+                    // eventual ToolCallStarted / ToolCallCompleted events.
+                    if progress_sink.send(mapped).await.is_err() {
+                        // Downstream closed — abandon the forwarder.
+                        break;
+                    }
                 }
             });
             (Some(tx), Some(forwarder))
@@ -362,9 +379,14 @@ pub(crate) async fn run_tool_call_loop(
             }
             history.push(ChatMessage::assistant(response_text.clone()));
             if let Some(ref sink) = on_progress {
-                let _ = sink.try_send(AgentProgress::TurnCompleted {
-                    iterations: (iteration + 1) as u32,
-                });
+                if let Err(e) = sink
+                    .send(AgentProgress::TurnCompleted {
+                        iterations: (iteration + 1) as u32,
+                    })
+                    .await
+                {
+                    log::warn!("[agent_loop] progress sink closed at TurnCompleted: {e}");
+                }
             }
             return Ok(display_text);
         }
@@ -454,12 +476,25 @@ pub(crate) async fn run_tool_call_loop(
                 let tool_deadline =
                     crate::openhuman::tool_timeout::tool_execution_timeout_duration();
                 let timeout_secs = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
+                // Stable id threaded through the start/complete pair
+                // (and any preceding args-delta events) so consumers can
+                // reconcile tool rows by id.
+                let progress_call_id = call
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| format!("loop-{iteration}-{}", call.name));
                 if let Some(ref sink) = on_progress {
-                    let _ = sink.try_send(AgentProgress::ToolCallStarted {
-                        tool_name: call.name.clone(),
-                        arguments: call.arguments.clone(),
-                        iteration: (iteration + 1) as u32,
-                    });
+                    if let Err(e) = sink
+                        .send(AgentProgress::ToolCallStarted {
+                            call_id: progress_call_id.clone(),
+                            tool_name: call.name.clone(),
+                            arguments: call.arguments.clone(),
+                            iteration: (iteration + 1) as u32,
+                        })
+                        .await
+                    {
+                        log::warn!("[agent_loop] progress sink closed while emitting ToolCallStarted: {e}");
+                    }
                 }
                 let tool_started = std::time::Instant::now();
                 let outcome =
@@ -511,13 +546,19 @@ pub(crate) async fn run_tool_call_loop(
                     }
                 };
                 if let Some(ref sink) = on_progress {
-                    let _ = sink.try_send(AgentProgress::ToolCallCompleted {
-                        tool_name: call.name.clone(),
-                        success,
-                        output_chars: result_text.chars().count(),
-                        elapsed_ms,
-                        iteration: (iteration + 1) as u32,
-                    });
+                    if let Err(e) = sink
+                        .send(AgentProgress::ToolCallCompleted {
+                            call_id: progress_call_id.clone(),
+                            tool_name: call.name.clone(),
+                            success,
+                            output_chars: result_text.chars().count(),
+                            elapsed_ms,
+                            iteration: (iteration + 1) as u32,
+                        })
+                        .await
+                    {
+                        log::warn!("[agent_loop] progress sink closed while emitting ToolCallCompleted: {e}");
+                    }
                 }
                 result_text
             } else {

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -1,6 +1,9 @@
 use crate::openhuman::agent::multimodal;
+use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::approval::{ApprovalManager, ApprovalRequest, ApprovalResponse};
-use crate::openhuman::providers::{ChatMessage, ChatRequest, Provider, ProviderCapabilityError};
+use crate::openhuman::providers::{
+    ChatMessage, ChatRequest, Provider, ProviderCapabilityError, ProviderDelta,
+};
 use crate::openhuman::tools::traits::ToolScope;
 use crate::openhuman::tools::Tool;
 use anyhow::Result;
@@ -54,6 +57,7 @@ pub(crate) async fn agent_turn(
         None,
         None,
         &[],
+        None,
     )
     .await
 }
@@ -102,6 +106,7 @@ pub(crate) async fn run_tool_call_loop(
     on_delta: Option<tokio::sync::mpsc::Sender<String>>,
     visible_tool_names: Option<&HashSet<String>>,
     extra_tools: &[Box<dyn Tool>],
+    on_progress: Option<tokio::sync::mpsc::Sender<AgentProgress>>,
 ) -> Result<String> {
     let max_iterations = if max_tool_iterations == 0 {
         DEFAULT_MAX_TOOL_ITERATIONS
@@ -143,7 +148,18 @@ pub(crate) async fn run_tool_call_loop(
 
     let mut context_guard = ContextGuard::new();
 
+    // Announce turn start to progress subscribers (if any).
+    if let Some(ref sink) = on_progress {
+        let _ = sink.try_send(AgentProgress::TurnStarted);
+    }
+
     for iteration in 0..max_iterations {
+        if let Some(ref sink) = on_progress {
+            let _ = sink.try_send(AgentProgress::IterationStarted {
+                iteration: (iteration + 1) as u32,
+                max_iterations: max_iterations as u32,
+            });
+        }
         // ── Context guard: check utilization before each LLM call ──
         match context_guard.check() {
             ContextCheckResult::Ok => {}
@@ -193,19 +209,68 @@ pub(crate) async fn run_tool_call_loop(
             None
         };
 
+        // Wire up a ProviderDelta → AgentProgress forwarder for this
+        // iteration when a progress sink exists. Senders dropped after
+        // the chat call so the forwarder task exits cleanly.
+        let iteration_for_stream = (iteration + 1) as u32;
+        let (delta_tx_opt, delta_forwarder) = if let Some(progress_sink) = on_progress.clone() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<ProviderDelta>(128);
+            let forwarder = tokio::spawn(async move {
+                while let Some(event) = rx.recv().await {
+                    let mapped = match event {
+                        ProviderDelta::TextDelta { delta } => AgentProgress::TextDelta {
+                            delta,
+                            iteration: iteration_for_stream,
+                        },
+                        ProviderDelta::ThinkingDelta { delta } => AgentProgress::ThinkingDelta {
+                            delta,
+                            iteration: iteration_for_stream,
+                        },
+                        ProviderDelta::ToolCallStart { call_id, tool_name } => {
+                            AgentProgress::ToolCallArgsDelta {
+                                call_id,
+                                tool_name,
+                                delta: String::new(),
+                                iteration: iteration_for_stream,
+                            }
+                        }
+                        ProviderDelta::ToolCallArgsDelta { call_id, delta } => {
+                            AgentProgress::ToolCallArgsDelta {
+                                call_id,
+                                tool_name: String::new(),
+                                delta,
+                                iteration: iteration_for_stream,
+                            }
+                        }
+                    };
+                    let _ = progress_sink.try_send(mapped);
+                }
+            });
+            (Some(tx), Some(forwarder))
+        } else {
+            (None, None)
+        };
+
+        let chat_result = provider
+            .chat(
+                ChatRequest {
+                    messages: &prepared_messages.messages,
+                    tools: request_tools,
+                    system_prompt_cache_boundary: None,
+                    stream: delta_tx_opt.as_ref(),
+                },
+                model,
+                temperature,
+            )
+            .await;
+
+        drop(delta_tx_opt);
+        if let Some(handle) = delta_forwarder {
+            let _ = handle.await;
+        }
+
         let (response_text, parsed_text, tool_calls, assistant_history_content, native_tool_calls) =
-            match provider
-                .chat(
-                    ChatRequest {
-                        messages: &prepared_messages.messages,
-                        tools: request_tools,
-                        system_prompt_cache_boundary: None,
-                    },
-                    model,
-                    temperature,
-                )
-                .await
-            {
+            match chat_result {
                 Ok(resp) => {
                     // Update context guard with token usage from this response.
                     if let Some(ref usage) = resp.usage {
@@ -296,6 +361,11 @@ pub(crate) async fn run_tool_call_loop(
                 }
             }
             history.push(ChatMessage::assistant(response_text.clone()));
+            if let Some(ref sink) = on_progress {
+                let _ = sink.try_send(AgentProgress::TurnCompleted {
+                    iterations: (iteration + 1) as u32,
+                });
+            }
             return Ok(display_text);
         }
 
@@ -384,26 +454,39 @@ pub(crate) async fn run_tool_call_loop(
                 let tool_deadline =
                     crate::openhuman::tool_timeout::tool_execution_timeout_duration();
                 let timeout_secs = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
-                match tokio::time::timeout(tool_deadline, tool.execute(call.arguments.clone()))
-                    .await
-                {
+                if let Some(ref sink) = on_progress {
+                    let _ = sink.try_send(AgentProgress::ToolCallStarted {
+                        tool_name: call.name.clone(),
+                        arguments: call.arguments.clone(),
+                        iteration: (iteration + 1) as u32,
+                    });
+                }
+                let tool_started = std::time::Instant::now();
+                let outcome = tokio::time::timeout(
+                    tool_deadline,
+                    tool.execute(call.arguments.clone()),
+                )
+                .await;
+                let elapsed_ms = tool_started.elapsed().as_millis() as u64;
+                let (result_text, success) = match outcome {
                     Ok(Ok(r)) => {
                         let output = r.output();
-                        if !r.is_error {
+                        let success = !r.is_error;
+                        if success {
                             tracing::debug!(
                                 iteration,
                                 tool = call.name.as_str(),
                                 output_len = output.len(),
                                 "[agent_loop] tool succeeded"
                             );
-                            scrub_credentials(&output)
+                            (scrub_credentials(&output), true)
                         } else {
                             tracing::warn!(
                                 iteration,
                                 tool = call.name.as_str(),
                                 "[agent_loop] tool returned error: {output}"
                             );
-                            format!("Error: {output}")
+                            (format!("Error: {output}"), false)
                         }
                     }
                     Ok(Err(e)) => {
@@ -412,7 +495,7 @@ pub(crate) async fn run_tool_call_loop(
                             tool = call.name.as_str(),
                             "[agent_loop] tool execution failed: {e}"
                         );
-                        format!("Error executing {}: {e}", call.name)
+                        (format!("Error executing {}: {e}", call.name), false)
                     }
                     Err(_) => {
                         tracing::error!(
@@ -421,12 +504,25 @@ pub(crate) async fn run_tool_call_loop(
                             secs = timeout_secs,
                             "[agent_loop] tool execution timed out"
                         );
-                        format!(
-                            "Error: tool '{}' timed out after {} seconds",
-                            call.name, timeout_secs
+                        (
+                            format!(
+                                "Error: tool '{}' timed out after {} seconds",
+                                call.name, timeout_secs
+                            ),
+                            false,
                         )
                     }
+                };
+                if let Some(ref sink) = on_progress {
+                    let _ = sink.try_send(AgentProgress::ToolCallCompleted {
+                        tool_name: call.name.clone(),
+                        success,
+                        output_chars: result_text.chars().count(),
+                        elapsed_ms,
+                        iteration: (iteration + 1) as u32,
+                    });
                 }
+                result_text
             } else {
                 tracing::warn!(
                     iteration,
@@ -626,6 +722,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect_err("vision markers should be rejected");
@@ -662,6 +759,7 @@ mod tests {
             Some(tx),
             None,
             &[],
+            None,
         )
         .await
         .expect("final text should succeed");
@@ -713,6 +811,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("loop should recover after denial");
@@ -767,6 +866,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("native tool flow should succeed");
@@ -824,6 +924,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("non-cli channels should auto-approve supervised tools");
@@ -874,6 +975,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("default iteration fallback should still succeed");
@@ -928,6 +1030,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("loop should recover after tool errors");
@@ -966,6 +1069,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect_err("provider error path should fail");
@@ -997,6 +1101,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect_err("loop should stop after configured iterations");

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -493,7 +493,9 @@ pub(crate) async fn run_tool_call_loop(
                         })
                         .await
                     {
-                        log::warn!("[agent_loop] progress sink closed while emitting ToolCallStarted: {e}");
+                        log::warn!(
+                            "[agent_loop] progress sink closed while emitting ToolCallStarted: {e}"
+                        );
                     }
                 }
                 let tool_started = std::time::Instant::now();

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -402,7 +402,66 @@ pub(crate) async fn run_tool_call_loop(
         // can emit one `role: tool` message per tool call with the correct ID.
         let mut tool_results = String::new();
         let mut individual_results: Vec<String> = Vec::new();
-        for call in &tool_calls {
+        for (call_idx, call) in tool_calls.iter().enumerate() {
+            // Stable id threaded through the start/complete pair (and
+            // any preceding args-delta events) so consumers can
+            // reconcile tool rows by id. The fallback includes
+            // `call_idx` to stay unique when the same tool name
+            // appears multiple times in one iteration.
+            let progress_call_id = call
+                .id
+                .clone()
+                .unwrap_or_else(|| format!("loop-{iteration}-{call_idx}-{}", call.name));
+            // Emit `ToolCallStarted` for every parsed call, even ones
+            // that will be rejected below (approval denied, CliRpcOnly,
+            // unknown) — the client-side row was created from the
+            // streamed args and needs a terminal event to resolve.
+            if let Some(ref sink) = on_progress {
+                if let Err(e) = sink
+                    .send(AgentProgress::ToolCallStarted {
+                        call_id: progress_call_id.clone(),
+                        tool_name: call.name.clone(),
+                        arguments: call.arguments.clone(),
+                        iteration: (iteration + 1) as u32,
+                    })
+                    .await
+                {
+                    log::warn!(
+                        "[agent_loop] progress sink closed while emitting ToolCallStarted: {e}"
+                    );
+                }
+            }
+
+            // Helper: emit a failed `ToolCallCompleted` for an
+            // early-exit path (denied / CliRpcOnly / unknown) so the
+            // client row flips to `error` instead of staying running.
+            let emit_failed_completion = |message: &str| {
+                let call_id = progress_call_id.clone();
+                let tool_name = call.name.clone();
+                let output_chars = message.chars().count();
+                let iteration_u32 = (iteration + 1) as u32;
+                let sink_opt = on_progress.clone();
+                async move {
+                    if let Some(sink) = sink_opt {
+                        if let Err(e) = sink
+                            .send(AgentProgress::ToolCallCompleted {
+                                call_id,
+                                tool_name,
+                                success: false,
+                                output_chars,
+                                elapsed_ms: 0,
+                                iteration: iteration_u32,
+                            })
+                            .await
+                        {
+                            log::warn!(
+                                "[agent_loop] progress sink closed while emitting early-exit ToolCallCompleted: {e}"
+                            );
+                        }
+                    }
+                }
+            };
+
             // ── Approval hook ────────────────────────────────
             if let Some(mgr) = approval {
                 if mgr.needs_approval(&call.name) {
@@ -422,6 +481,7 @@ pub(crate) async fn run_tool_call_loop(
 
                     if decision == ApprovalResponse::No {
                         let denied = "Denied by user.".to_string();
+                        emit_failed_completion(&denied).await;
                         individual_results.push(denied.clone());
                         let _ = writeln!(
                             tool_results,
@@ -462,6 +522,7 @@ pub(crate) async fn run_tool_call_loop(
                         "Tool '{}' is only available via explicit CLI/RPC invocation, not in the autonomous agent loop.",
                         call.name
                     );
+                    emit_failed_completion(&denied).await;
                     individual_results.push(denied.clone());
                     let _ = writeln!(
                         tool_results,
@@ -476,28 +537,6 @@ pub(crate) async fn run_tool_call_loop(
                 let tool_deadline =
                     crate::openhuman::tool_timeout::tool_execution_timeout_duration();
                 let timeout_secs = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
-                // Stable id threaded through the start/complete pair
-                // (and any preceding args-delta events) so consumers can
-                // reconcile tool rows by id.
-                let progress_call_id = call
-                    .id
-                    .clone()
-                    .unwrap_or_else(|| format!("loop-{iteration}-{}", call.name));
-                if let Some(ref sink) = on_progress {
-                    if let Err(e) = sink
-                        .send(AgentProgress::ToolCallStarted {
-                            call_id: progress_call_id.clone(),
-                            tool_name: call.name.clone(),
-                            arguments: call.arguments.clone(),
-                            iteration: (iteration + 1) as u32,
-                        })
-                        .await
-                    {
-                        log::warn!(
-                            "[agent_loop] progress sink closed while emitting ToolCallStarted: {e}"
-                        );
-                    }
-                }
                 let tool_started = std::time::Instant::now();
                 let outcome =
                     tokio::time::timeout(tool_deadline, tool.execute(call.arguments.clone())).await;
@@ -569,7 +608,9 @@ pub(crate) async fn run_tool_call_loop(
                     tool = call.name.as_str(),
                     "[agent_loop] unknown tool requested"
                 );
-                format!("Unknown tool: {}", call.name)
+                let msg = format!("Unknown tool: {}", call.name);
+                emit_failed_completion(&msg).await;
+                msg
             };
 
             individual_results.push(result.clone());

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -462,11 +462,8 @@ pub(crate) async fn run_tool_call_loop(
                     });
                 }
                 let tool_started = std::time::Instant::now();
-                let outcome = tokio::time::timeout(
-                    tool_deadline,
-                    tool.execute(call.arguments.clone()),
-                )
-                .await;
+                let outcome =
+                    tokio::time::timeout(tool_deadline, tool.execute(call.arguments.clone())).await;
                 let elapsed_ms = tool_started.elapsed().as_millis() as u64;
                 let (result_text, success) = match outcome {
                     Ok(Ok(r)) => {

--- a/src/openhuman/agent/progress.rs
+++ b/src/openhuman/agent/progress.rs
@@ -29,6 +29,10 @@ pub enum AgentProgress {
 
     /// The LLM responded and the agent is about to execute a tool.
     ToolCallStarted {
+        /// Provider-assigned (or synthesised) tool call id that ties
+        /// this event to its eventual [`Self::ToolCallCompleted`] and
+        /// to any preceding [`Self::ToolCallArgsDelta`] fragments.
+        call_id: String,
         tool_name: String,
         arguments: serde_json::Value,
         /// 1-based iteration index.
@@ -37,6 +41,9 @@ pub enum AgentProgress {
 
     /// A tool execution completed (success or failure).
     ToolCallCompleted {
+        /// Same call id as the matching [`Self::ToolCallStarted`] and
+        /// [`Self::ToolCallArgsDelta`] events.
+        call_id: String,
         tool_name: String,
         success: bool,
         output_chars: usize,

--- a/src/openhuman/agent/progress.rs
+++ b/src/openhuman/agent/progress.rs
@@ -62,6 +62,39 @@ pub enum AgentProgress {
         error: String,
     },
 
+    /// A chunk of visible assistant text arrived from the provider
+    /// while the current iteration is still in flight.
+    TextDelta {
+        delta: String,
+        /// 1-based iteration index this delta belongs to.
+        iteration: u32,
+    },
+
+    /// A chunk of model reasoning / thinking output arrived (for
+    /// models that emit `reasoning_content`). Consumers typically
+    /// render this in a separate collapsible UI region.
+    ThinkingDelta {
+        delta: String,
+        /// 1-based iteration index.
+        iteration: u32,
+    },
+
+    /// A chunk of argument JSON arrived for an in-flight tool call.
+    /// Emitted before the matching [`AgentProgress::ToolCallStarted`]
+    /// event so consumers can show the model composing the call.
+    ToolCallArgsDelta {
+        /// Provider-assigned tool call id (stable across chunks).
+        call_id: String,
+        /// Tool name, when known (may be empty on the very first
+        /// chunk if the provider hasn't sent the `function.name` yet).
+        tool_name: String,
+        /// Raw JSON text fragment; concatenated fragments form the
+        /// complete arguments object.
+        delta: String,
+        /// 1-based iteration index.
+        iteration: u32,
+    },
+
     /// The turn completed with a final text response.
     TurnCompleted {
         /// Total iterations used.

--- a/src/openhuman/agent/triage/evaluator.rs
+++ b/src/openhuman/agent/triage/evaluator.rs
@@ -237,6 +237,7 @@ pub async fn run_triage_with_resolved(
         target_agent_id: Some("trigger_triage".to_string()),
         visible_tool_names: None,
         extra_tools: Vec::new(),
+        on_progress: None,
     };
     tracing::debug!(
         provider = %provider_name,

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -84,34 +84,74 @@ impl EventHandler for ChannelInboundSubscriber {
         let timeout = tokio::time::Duration::from_secs(180);
         let deadline = tokio::time::Instant::now() + timeout;
 
+        // ── Progressive-edit streaming state ──────────────────────────
+        // We buffer text/tool deltas and flush them as edits on a
+        // timer. If the first edit fails (e.g. the backend doesn't
+        // implement the PATCH endpoint for this channel) we latch into
+        // `edit_disabled` and fall back to atomic-final delivery.
+        let mut streaming_state = StreamingState::default();
+        let mut edit_timer = tokio::time::interval(EDIT_FLUSH_INTERVAL);
+        edit_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Don't fire immediately; wait for the first tick.
+        edit_timer.tick().await;
+
         loop {
             tokio::select! {
                 event = event_rx.recv() => {
                     match event {
                         Ok(ev) if ev.request_id == request_id => {
-                            if ev.event == "chat_done" || ev.event == "chat:done" {
-                                let reply = ev.full_response.unwrap_or_default();
-                                if reply.trim().is_empty() {
-                                    tracing::warn!("[channel-inbound] agent returned empty response");
+                            match ev.event.as_str() {
+                                "text_delta" => {
+                                    if let Some(delta) = ev.delta.as_ref() {
+                                        streaming_state.content.push_str(delta);
+                                        streaming_state.dirty = true;
+                                    }
+                                }
+                                "tool_call" => {
+                                    if let Some(ref name) = ev.tool_name {
+                                        streaming_state.last_tool = Some(format!("🔧 {name}…"));
+                                        streaming_state.dirty = true;
+                                    }
+                                }
+                                "tool_result" => {
+                                    if let Some(ref name) = ev.tool_name {
+                                        let ok = ev.success.unwrap_or(true);
+                                        streaming_state.last_tool = Some(if ok {
+                                            format!("🔧 {name} ✓")
+                                        } else {
+                                            format!("🔧 {name} ✗")
+                                        });
+                                        streaming_state.dirty = true;
+                                    }
+                                }
+                                "chat_done" | "chat:done" => {
+                                    let reply = ev.full_response.unwrap_or_default();
+                                    if reply.trim().is_empty() {
+                                        tracing::warn!("[channel-inbound] agent returned empty response");
+                                        return;
+                                    }
+                                    tracing::info!(
+                                        "[channel-inbound] agent done, replying to channel='{}' len={} streamed_msg_id={:?}",
+                                        channel,
+                                        reply.len(),
+                                        streaming_state.message_id,
+                                    );
+                                    // If we've been streaming progressive edits, replace
+                                    // the outbound message with the final canonical text.
+                                    // Otherwise send a fresh message atomically.
+                                    finalize_channel_reply(channel, &mut streaming_state, &reply)
+                                        .await;
                                     return;
                                 }
-                                tracing::info!(
-                                    "[channel-inbound] agent done, replying to channel='{}' len={}",
-                                    channel,
-                                    reply.len()
-                                );
-                                send_channel_reply(channel, &reply).await;
-                                return;
-                            }
-                            if ev.event == "chat_error" || ev.event == "chat:error" {
-                                let err_msg = ev.message.unwrap_or_else(|| "unknown error".to_string());
-                                tracing::error!("[channel-inbound] agent error: {}", err_msg);
-                                send_channel_reply(
-                                    channel,
-                                    &format!("Sorry, I encountered an error: {err_msg}"),
-                                )
-                                .await;
-                                return;
+                                "chat_error" | "chat:error" => {
+                                    let err_msg = ev.message.unwrap_or_else(|| "unknown error".to_string());
+                                    tracing::error!("[channel-inbound] agent error: {}", err_msg);
+                                    let reply = format!("Sorry, I encountered an error: {err_msg}");
+                                    finalize_channel_reply(channel, &mut streaming_state, &reply)
+                                        .await;
+                                    return;
+                                }
+                                _ => {}
                             }
                         }
                         Ok(_) => {}
@@ -124,12 +164,206 @@ impl EventHandler for ChannelInboundSubscriber {
                         }
                     }
                 }
+                _ = edit_timer.tick() => {
+                    if streaming_state.dirty && !streaming_state.edit_disabled {
+                        flush_streaming_edit(channel, &mut streaming_state).await;
+                    }
+                }
                 _ = tokio::time::sleep_until(deadline) => {
                     tracing::error!("[channel-inbound] agent timed out after {}s", timeout.as_secs());
-                    send_channel_reply(channel, "Sorry, the request timed out.").await;
+                    let reply = "Sorry, the request timed out.";
+                    finalize_channel_reply(channel, &mut streaming_state, reply).await;
                     return;
                 }
             }
+        }
+    }
+}
+
+/// Minimum interval between progressive edits of the outbound channel
+/// message. Tuned to stay comfortably below Telegram's ~1 edit/sec cap
+/// per chat. Slack has a similar soft limit.
+const EDIT_FLUSH_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_millis(1000);
+
+/// Maximum consecutive edit failures tolerated before giving up on
+/// progressive streaming and falling back to atomic-final delivery.
+const MAX_EDIT_FAILURES: u32 = 2;
+
+/// Per-turn progressive-edit buffer. `dirty=true` means there's new
+/// content to flush; `edit_disabled=true` means the backend doesn't
+/// support editing for this channel and we should finalize atomically.
+#[derive(Default)]
+struct StreamingState {
+    /// Accumulated visible assistant text from `text_delta` events.
+    content: String,
+    /// Most recent tool status line (prepended to the message body).
+    last_tool: Option<String>,
+    /// Backend-assigned message id returned from the initial
+    /// `send_channel_message`; subsequent edits target this id.
+    message_id: Option<String>,
+    /// New content has arrived since the last edit flush.
+    dirty: bool,
+    /// Consecutive edit failures. Reset to zero on every success.
+    edit_failures: u32,
+    /// Latched when the backend doesn't support edits for this channel
+    /// — we stop trying and rely on the final atomic send.
+    edit_disabled: bool,
+}
+
+impl StreamingState {
+    fn compose_draft(&self) -> String {
+        let mut out = String::new();
+        if let Some(ref tool) = self.last_tool {
+            out.push_str(tool);
+            out.push('\n');
+        }
+        out.push_str(self.content.trim_end());
+        if self.content.is_empty() && self.last_tool.is_none() {
+            out.push_str("_working…_");
+        }
+        out
+    }
+}
+
+/// Post or edit a draft message carrying the latest buffered text +
+/// tool status. On the first call, sends a new message and records its
+/// id; on subsequent calls, edits the existing message.
+async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
+    let draft = state.compose_draft();
+    if draft.is_empty() {
+        return;
+    }
+    state.dirty = false;
+
+    let Some((client, jwt)) = build_channel_client().await else {
+        return;
+    };
+
+    if let Some(ref message_id) = state.message_id {
+        let body = json!({ "text": draft });
+        match client.send_channel_edit(channel, message_id, &jwt, body).await {
+            Ok(_) => {
+                tracing::debug!(
+                    "[channel-inbound][stream] edit ok channel='{}' msg_id={} chars={}",
+                    channel,
+                    message_id,
+                    draft.len(),
+                );
+                state.edit_failures = 0;
+            }
+            Err(err) => {
+                state.edit_failures += 1;
+                tracing::warn!(
+                    "[channel-inbound][stream] edit failed channel='{}' msg_id={} err={} (failures={}/{})",
+                    channel,
+                    message_id,
+                    err,
+                    state.edit_failures,
+                    MAX_EDIT_FAILURES,
+                );
+                if state.edit_failures >= MAX_EDIT_FAILURES {
+                    tracing::info!(
+                        "[channel-inbound][stream] giving up on progressive edits for channel='{}', falling back to atomic delivery",
+                        channel,
+                    );
+                    state.edit_disabled = true;
+                }
+            }
+        }
+    } else {
+        let body = json!({ "text": draft });
+        match client.send_channel_message(channel, &jwt, body).await {
+            Ok(resp) => {
+                let id = resp
+                    .get("id")
+                    .or_else(|| resp.get("data").and_then(|d| d.get("id")))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                if let Some(id) = id {
+                    tracing::debug!(
+                        "[channel-inbound][stream] initial draft sent channel='{}' msg_id={}",
+                        channel,
+                        id,
+                    );
+                    state.message_id = Some(id);
+                } else {
+                    tracing::warn!(
+                        "[channel-inbound][stream] initial draft sent but response lacked id — disabling progressive edits"
+                    );
+                    state.edit_disabled = true;
+                }
+            }
+            Err(err) => {
+                state.edit_failures += 1;
+                tracing::warn!(
+                    "[channel-inbound][stream] initial send failed channel='{}' err={} (failures={})",
+                    channel,
+                    err,
+                    state.edit_failures,
+                );
+                if state.edit_failures >= MAX_EDIT_FAILURES {
+                    state.edit_disabled = true;
+                }
+            }
+        }
+    }
+}
+
+/// Deliver the final canonical reply. If progressive edits are active,
+/// rewrite the streamed message with the final text; otherwise send a
+/// fresh atomic message.
+async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final_text: &str) {
+    if let Some(ref message_id) = state.message_id {
+        if !state.edit_disabled {
+            if let Some((client, jwt)) = build_channel_client().await {
+                let body = json!({ "text": final_text });
+                if let Err(err) = client
+                    .send_channel_edit(channel, message_id, &jwt, body)
+                    .await
+                {
+                    tracing::warn!(
+                        "[channel-inbound] final edit failed channel='{}' msg_id={} err={} — sending fresh message",
+                        channel,
+                        message_id,
+                        err,
+                    );
+                    send_channel_reply(channel, final_text).await;
+                }
+                return;
+            }
+        }
+    }
+    send_channel_reply(channel, final_text).await;
+}
+
+/// Construct the REST client + session JWT shared by every outbound
+/// channel call on this turn. Returns `None` and logs if either is
+/// unavailable so the caller can bail quietly.
+async fn build_channel_client() -> Option<(crate::api::rest::BackendOAuthClient, String)> {
+    let config = match crate::openhuman::config::rpc::load_config_with_timeout().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("[channel-inbound] failed to load config: {}", e);
+            return None;
+        }
+    };
+    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let jwt = match crate::api::jwt::get_session_token(&config) {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            tracing::error!("[channel-inbound] no session JWT — cannot send");
+            return None;
+        }
+        Err(e) => {
+            tracing::error!("[channel-inbound] failed to get session token: {}", e);
+            return None;
+        }
+    };
+    match crate::api::rest::BackendOAuthClient::new(&api_url) {
+        Ok(c) => Some((c, jwt)),
+        Err(e) => {
+            tracing::error!("[channel-inbound] failed to create API client: {}", e);
+            None
         }
     }
 }

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -243,6 +243,12 @@ struct StreamingState {
     /// Backend-assigned message id returned from the initial
     /// `send_channel_message`; subsequent edits target this id.
     message_id: Option<String>,
+    /// `true` once a draft message has been posted to the channel,
+    /// even when the backend response didn't include an id to target
+    /// for future edits. Decouples "a draft exists" from "we can edit
+    /// it" so `finalize_channel_reply` won't post a duplicate bubble
+    /// when the id was lost.
+    draft_sent: bool,
     /// New content has arrived since the last edit flush.
     dirty: bool,
     /// Consecutive edit failures. Reset to zero on every success.
@@ -369,6 +375,11 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
         let body = json!({ "text": draft });
         match client.send_channel_message(channel, &jwt, body).await {
             Ok(resp) => {
+                // A message was posted to the user — record that fact
+                // *before* checking for an id. Even if we can't extract
+                // one (and thus can't edit it further), we must never
+                // later fall back to sending a second atomic message.
+                state.draft_sent = true;
                 let id = resp
                     .get("id")
                     .or_else(|| resp.get("data").and_then(|d| d.get("id")))
@@ -383,7 +394,7 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
                     state.message_id = Some(id);
                 } else {
                     tracing::warn!(
-                        "[channel-inbound][stream] initial draft sent but response lacked id — disabling progressive edits"
+                        "[channel-inbound][stream] initial draft sent but response lacked id — disabling progressive edits (finalize will skip sending a duplicate)"
                     );
                     state.edit_disabled = true;
                 }
@@ -407,11 +418,12 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
 /// Deliver the final canonical reply.
 ///
 /// **Invariant**: if a draft message has already been posted to the
-/// channel (`state.message_id.is_some()`), we MUST NOT post a second
+/// channel (`state.draft_sent == true`), we MUST NOT post a second
 /// message — that would duplicate the visible bubble on the user's
-/// side. We always try to edit the draft one more time; if that fails,
-/// the stale draft stays as-is and we log a warning. The only path
-/// that creates a fresh outbound message is when no draft exists yet.
+/// side. When we have an id we attempt one last edit; when the id was
+/// lost we leave the draft in place silently. The only path that
+/// creates a fresh outbound message is when no draft has been posted
+/// at all.
 async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final_text: &str) {
     if let Some(ref message_id) = state.message_id {
         // We committed to a draft earlier in the turn. Always attempt
@@ -451,6 +463,16 @@ async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final
                 message_id,
             );
         }
+        return;
+    }
+    if state.draft_sent {
+        // A draft was posted but the backend didn't return an id, so
+        // we have nothing to edit. Posting a fresh message here would
+        // give the user two bubbles — skip silently.
+        tracing::warn!(
+            "[channel-inbound] skipping fresh send on channel='{}' — an id-less draft was already posted earlier this turn (duplicate prevented)",
+            channel,
+        );
         return;
     }
     // No draft exists — this is the first (and only) message for the

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -95,6 +95,20 @@ impl EventHandler for ChannelInboundSubscriber {
         // Don't fire immediately; wait for the first tick.
         edit_timer.tick().await;
 
+        // ── Typing indicator state ────────────────────────────────────
+        // Telegram's `sendChatAction` keeps the "typing…" UI alive for
+        // ~5s, so we re-send every 4s while the turn is in flight. The
+        // first call fires immediately; on repeated failures we latch
+        // `typing_disabled` to stop hitting a backend that doesn't
+        // support it.
+        let mut typing_state = TypingState::default();
+        let mut typing_timer = tokio::time::interval(TYPING_REFRESH_INTERVAL);
+        typing_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Fire immediately on first tick so the indicator shows up as
+        // soon as the inbound message is received.
+        send_typing_indicator(channel, &mut typing_state).await;
+        typing_timer.tick().await; // consume the immediate tick
+
         loop {
             tokio::select! {
                 event = event_rx.recv() => {
@@ -169,6 +183,11 @@ impl EventHandler for ChannelInboundSubscriber {
                         flush_streaming_edit(channel, &mut streaming_state).await;
                     }
                 }
+                _ = typing_timer.tick() => {
+                    if !typing_state.disabled {
+                        send_typing_indicator(channel, &mut typing_state).await;
+                    }
+                }
                 _ = tokio::time::sleep_until(deadline) => {
                     tracing::error!("[channel-inbound] agent timed out after {}s", timeout.as_secs());
                     let reply = "Sorry, the request timed out.";
@@ -189,6 +208,16 @@ const EDIT_FLUSH_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_m
 /// progressive streaming and falling back to atomic-final delivery.
 const MAX_EDIT_FAILURES: u32 = 2;
 
+/// How often to re-send the "typing…" indicator while a turn is in
+/// flight. Telegram's `sendChatAction` keeps the UI alive for about
+/// 5 seconds per call, so we refresh every 4 s to ensure continuity.
+const TYPING_REFRESH_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(4);
+
+/// Maximum consecutive typing-indicator failures before we stop
+/// trying. One failure is usually "endpoint doesn't exist"; two is
+/// enough to conclude the backend doesn't support it on this channel.
+const MAX_TYPING_FAILURES: u32 = 2;
+
 /// Per-turn progressive-edit buffer. `dirty=true` means there's new
 /// content to flush; `edit_disabled=true` means the backend doesn't
 /// support editing for this channel and we should finalize atomically.
@@ -208,6 +237,56 @@ struct StreamingState {
     /// Latched when the backend doesn't support edits for this channel
     /// — we stop trying and rely on the final atomic send.
     edit_disabled: bool,
+}
+
+/// Typing-indicator bookkeeping. One per in-flight turn. Latches
+/// `disabled` after repeated failures so channels without typing
+/// support stop getting hit every 4 seconds.
+#[derive(Default)]
+struct TypingState {
+    failures: u32,
+    disabled: bool,
+}
+
+/// Fire a single "typing…" indicator at the channel. Silently
+/// latches `disabled` on repeated failure so callers can keep calling
+/// this from a timer without accumulating warnings.
+async fn send_typing_indicator(channel: &str, state: &mut TypingState) {
+    if state.disabled {
+        return;
+    }
+    let Some((client, jwt)) = build_channel_client().await else {
+        return;
+    };
+    match client.send_channel_typing(channel, &jwt).await {
+        Ok(_) => {
+            if state.failures > 0 {
+                tracing::debug!(
+                    "[channel-inbound][typing] recovered channel='{}' after {} failure(s)",
+                    channel,
+                    state.failures,
+                );
+            }
+            state.failures = 0;
+        }
+        Err(err) => {
+            state.failures += 1;
+            tracing::debug!(
+                "[channel-inbound][typing] indicator failed channel='{}' err={} (failures={}/{})",
+                channel,
+                err,
+                state.failures,
+                MAX_TYPING_FAILURES,
+            );
+            if state.failures >= MAX_TYPING_FAILURES {
+                tracing::info!(
+                    "[channel-inbound][typing] disabling typing indicator for channel='{}' — backend unsupported",
+                    channel,
+                );
+                state.disabled = true;
+            }
+        }
+    }
 }
 
 impl StreamingState {

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -241,7 +241,10 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
 
     if let Some(ref message_id) = state.message_id {
         let body = json!({ "text": draft });
-        match client.send_channel_edit(channel, message_id, &jwt, body).await {
+        match client
+            .send_channel_edit(channel, message_id, &jwt, body)
+            .await
+        {
             Ok(_) => {
                 tracing::debug!(
                     "[channel-inbound][stream] edit ok channel='{}' msg_id={} chars={}",

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -391,30 +391,57 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
     }
 }
 
-/// Deliver the final canonical reply. If progressive edits are active,
-/// rewrite the streamed message with the final text; otherwise send a
-/// fresh atomic message.
+/// Deliver the final canonical reply.
+///
+/// **Invariant**: if a draft message has already been posted to the
+/// channel (`state.message_id.is_some()`), we MUST NOT post a second
+/// message — that would duplicate the visible bubble on the user's
+/// side. We always try to edit the draft one more time; if that fails,
+/// the stale draft stays as-is and we log a warning. The only path
+/// that creates a fresh outbound message is when no draft exists yet.
 async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final_text: &str) {
     if let Some(ref message_id) = state.message_id {
-        if !state.edit_disabled {
-            if let Some((client, jwt)) = build_channel_client().await {
-                let body = json!({ "text": final_text });
-                if let Err(err) = client
-                    .send_channel_edit(channel, message_id, &jwt, body)
-                    .await
-                {
+        // We committed to a draft earlier in the turn. Always attempt
+        // to edit it with the canonical reply, even when we'd
+        // previously latched `edit_disabled` during the streaming
+        // phase — the user is already looking at that message, so a
+        // late edit attempt is still the right call. If the edit
+        // fails, leave the draft in place rather than spamming a
+        // duplicate bubble.
+        if let Some((client, jwt)) = build_channel_client().await {
+            let body = json!({ "text": final_text });
+            match client
+                .send_channel_edit(channel, message_id, &jwt, body)
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(
+                        "[channel-inbound] final edit ok channel='{}' msg_id={} chars={}",
+                        channel,
+                        message_id,
+                        final_text.len(),
+                    );
+                }
+                Err(err) => {
                     tracing::warn!(
-                        "[channel-inbound] final edit failed channel='{}' msg_id={} err={} — sending fresh message",
+                        "[channel-inbound] final edit failed channel='{}' msg_id={} err={} — draft left in place (no duplicate message sent)",
                         channel,
                         message_id,
                         err,
                     );
-                    send_channel_reply(channel, final_text).await;
                 }
-                return;
             }
+        } else {
+            tracing::warn!(
+                "[channel-inbound] cannot finalize channel='{}' msg_id={} — backend client unavailable, draft left in place",
+                channel,
+                message_id,
+            );
         }
+        return;
     }
+    // No draft exists — this is the first (and only) message for the
+    // turn. Safe to send atomically.
     send_channel_reply(channel, final_text).await;
 }
 

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -140,21 +140,34 @@ impl EventHandler for ChannelInboundSubscriber {
                                 }
                                 "chat_done" | "chat:done" => {
                                     let reply = ev.full_response.unwrap_or_default();
-                                    if reply.trim().is_empty() {
-                                        tracing::warn!("[channel-inbound] agent returned empty response");
-                                        return;
-                                    }
+                                    // Even when the agent produced no visible
+                                    // text, we must close out any draft we
+                                    // already posted — otherwise the user is
+                                    // left staring at a stale "_working…_"
+                                    // message indefinitely.
+                                    let reply_text = if reply.trim().is_empty() {
+                                        tracing::warn!(
+                                            "[channel-inbound] agent returned empty response — finalizing draft with fallback",
+                                        );
+                                        "(No response from agent.)"
+                                    } else {
+                                        reply.as_str()
+                                    };
                                     tracing::info!(
                                         "[channel-inbound] agent done, replying to channel='{}' len={} streamed_msg_id={:?}",
                                         channel,
-                                        reply.len(),
+                                        reply_text.len(),
                                         streaming_state.message_id,
                                     );
                                     // If we've been streaming progressive edits, replace
                                     // the outbound message with the final canonical text.
                                     // Otherwise send a fresh message atomically.
-                                    finalize_channel_reply(channel, &mut streaming_state, &reply)
-                                        .await;
+                                    finalize_channel_reply(
+                                        channel,
+                                        &mut streaming_state,
+                                        reply_text,
+                                    )
+                                    .await;
                                     return;
                                 }
                                 "chat_error" | "chat:error" => {

--- a/src/openhuman/channels/proactive.rs
+++ b/src/openhuman/channels/proactive.rs
@@ -135,6 +135,9 @@ impl EventHandler for ProactiveMessageSubscriber {
             reaction_emoji: None,
             segment_index: None,
             segment_total: None,
+            delta: None,
+            delta_kind: None,
+            tool_call_id: None,
         });
 
         // 2. If an active external channel is configured, deliver there too.

--- a/src/openhuman/channels/providers/presentation.rs
+++ b/src/openhuman/channels/providers/presentation.rs
@@ -60,6 +60,9 @@ pub async fn deliver_response(
             reaction_emoji,
             segment_index: None,
             segment_total: None,
+            delta: None,
+            delta_kind: None,
+            tool_call_id: None,
         });
         return;
     }
@@ -91,6 +94,9 @@ pub async fn deliver_response(
             reaction_emoji: if i == 0 { reaction_emoji.clone() } else { None },
             segment_index: Some(i as u32),
             segment_total: Some(total),
+            delta: None,
+            delta_kind: None,
+            tool_call_id: None,
         });
     }
 
@@ -112,6 +118,9 @@ pub async fn deliver_response(
         reaction_emoji: None,
         segment_index: None,
         segment_total: Some(total),
+        delta: None,
+        delta_kind: None,
+        tool_call_id: None,
     });
 }
 

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -432,6 +432,7 @@ fn spawn_progress_bridge(
                     });
                 }
                 AgentProgress::ToolCallStarted {
+                    call_id,
                     tool_name,
                     arguments,
                     iteration,
@@ -441,24 +442,16 @@ fn spawn_progress_bridge(
                         client_id: client_id.clone(),
                         thread_id: thread_id.clone(),
                         request_id: request_id.clone(),
-                        full_response: None,
-                        message: None,
-                        error_type: None,
                         tool_name: Some(tool_name),
                         skill_id: Some("web_channel".to_string()),
                         args: Some(arguments),
-                        output: None,
-                        success: None,
                         round: Some(iteration),
-                        reaction_emoji: None,
-                        segment_index: None,
-                        segment_total: None,
-                        delta: None,
-                        delta_kind: None,
-                        tool_call_id: None,
+                        tool_call_id: Some(call_id),
+                        ..Default::default()
                     });
                 }
                 AgentProgress::ToolCallCompleted {
+                    call_id,
                     tool_name,
                     success,
                     output_chars,
@@ -470,24 +463,16 @@ fn spawn_progress_bridge(
                         client_id: client_id.clone(),
                         thread_id: thread_id.clone(),
                         request_id: request_id.clone(),
-                        full_response: None,
-                        message: None,
-                        error_type: None,
                         tool_name: Some(tool_name),
                         skill_id: Some("web_channel".to_string()),
-                        args: None,
                         output: Some(
                             json!({"output_chars": output_chars, "elapsed_ms": elapsed_ms})
                                 .to_string(),
                         ),
                         success: Some(success),
                         round: Some(iteration),
-                        reaction_emoji: None,
-                        segment_index: None,
-                        segment_total: None,
-                        delta: None,
-                        delta_kind: None,
-                        tool_call_id: None,
+                        tool_call_id: Some(call_id),
+                        ..Default::default()
                     });
                 }
                 AgentProgress::SubagentSpawned { agent_id, task_id } => {

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -133,6 +133,9 @@ pub async fn start_chat(
                 reaction_emoji: None,
                 segment_index: None,
                 segment_total: None,
+                delta: None,
+                delta_kind: None,
+                tool_call_id: None,
             });
         }
     }
@@ -187,6 +190,9 @@ pub async fn start_chat(
                     reaction_emoji: None,
                     segment_index: None,
                     segment_total: None,
+                    delta: None,
+                    delta_kind: None,
+                    tool_call_id: None,
                 });
             }
         }
@@ -253,6 +259,9 @@ pub async fn cancel_chat(client_id: &str, thread_id: &str) -> Result<Option<Stri
             reaction_emoji: None,
             segment_index: None,
             segment_total: None,
+            delta: None,
+            delta_kind: None,
+            tool_call_id: None,
         });
     }
 
@@ -390,6 +399,9 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
                     });
                 }
                 AgentProgress::IterationStarted {
@@ -414,6 +426,9 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
                     });
                 }
                 AgentProgress::ToolCallStarted {
@@ -438,6 +453,9 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
                     });
                 }
                 AgentProgress::ToolCallCompleted {
@@ -467,6 +485,9 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
                     });
                 }
                 AgentProgress::SubagentSpawned { agent_id, task_id } => {
@@ -487,6 +508,9 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
                     });
                 }
                 AgentProgress::SubagentCompleted {
@@ -513,6 +537,9 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
                     });
                 }
                 AgentProgress::SubagentFailed {
@@ -537,6 +564,57 @@ fn spawn_progress_bridge(
                         reaction_emoji: None,
                         segment_index: None,
                         segment_total: None,
+                        delta: None,
+                        delta_kind: None,
+                        tool_call_id: None,
+                    });
+                }
+                AgentProgress::TextDelta { delta, iteration } => {
+                    publish_web_channel_event(WebChannelEvent {
+                        event: "text_delta".to_string(),
+                        client_id: client_id.clone(),
+                        thread_id: thread_id.clone(),
+                        request_id: request_id.clone(),
+                        round: Some(iteration),
+                        delta: Some(delta),
+                        delta_kind: Some("text".to_string()),
+                        ..Default::default()
+                    });
+                }
+                AgentProgress::ThinkingDelta { delta, iteration } => {
+                    publish_web_channel_event(WebChannelEvent {
+                        event: "thinking_delta".to_string(),
+                        client_id: client_id.clone(),
+                        thread_id: thread_id.clone(),
+                        request_id: request_id.clone(),
+                        round: Some(iteration),
+                        delta: Some(delta),
+                        delta_kind: Some("thinking".to_string()),
+                        ..Default::default()
+                    });
+                }
+                AgentProgress::ToolCallArgsDelta {
+                    call_id,
+                    tool_name,
+                    delta,
+                    iteration,
+                } => {
+                    publish_web_channel_event(WebChannelEvent {
+                        event: "tool_args_delta".to_string(),
+                        client_id: client_id.clone(),
+                        thread_id: thread_id.clone(),
+                        request_id: request_id.clone(),
+                        tool_name: if tool_name.is_empty() {
+                            None
+                        } else {
+                            Some(tool_name)
+                        },
+                        skill_id: Some("web_channel".to_string()),
+                        round: Some(iteration),
+                        delta: Some(delta),
+                        delta_kind: Some("tool_args".to_string()),
+                        tool_call_id: Some(call_id),
+                        ..Default::default()
                     });
                 }
                 AgentProgress::TurnCompleted { iterations } => {

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -378,8 +378,102 @@ fn spawn_progress_bridge(
     use crate::openhuman::agent::progress::AgentProgress;
 
     tokio::spawn(async move {
+        log::debug!(
+            "[web_channel][bridge] spawned client_id={} thread_id={} request_id={}",
+            client_id,
+            thread_id,
+            request_id,
+        );
         let mut round: u32 = 0;
+        let mut events_seen: u64 = 0;
         while let Some(event) = rx.recv().await {
+            events_seen += 1;
+            // Per-variant trace so branch decisions are visible in
+            // terminal output when correlating progress over Socket.IO.
+            // Kept at trace-level for high-volume deltas and debug for
+            // lifecycle transitions.
+            match &event {
+                AgentProgress::TextDelta { delta, iteration } => {
+                    log::trace!(
+                        "[web_channel][bridge] text_delta round={} chars={} request_id={}",
+                        iteration,
+                        delta.len(),
+                        request_id,
+                    );
+                }
+                AgentProgress::ThinkingDelta { delta, iteration } => {
+                    log::trace!(
+                        "[web_channel][bridge] thinking_delta round={} chars={} request_id={}",
+                        iteration,
+                        delta.len(),
+                        request_id,
+                    );
+                }
+                AgentProgress::ToolCallArgsDelta {
+                    call_id,
+                    tool_name,
+                    delta,
+                    iteration,
+                } => {
+                    log::trace!(
+                        "[web_channel][bridge] tool_args_delta round={} tool={} call_id={} chars={} request_id={}",
+                        iteration,
+                        tool_name,
+                        call_id,
+                        delta.len(),
+                        request_id,
+                    );
+                }
+                AgentProgress::ToolCallStarted {
+                    call_id,
+                    tool_name,
+                    iteration,
+                    ..
+                } => {
+                    log::debug!(
+                        "[web_channel][bridge] tool_call round={} tool={} call_id={} request_id={}",
+                        iteration,
+                        tool_name,
+                        call_id,
+                        request_id,
+                    );
+                }
+                AgentProgress::ToolCallCompleted {
+                    call_id,
+                    tool_name,
+                    success,
+                    iteration,
+                    ..
+                } => {
+                    log::debug!(
+                        "[web_channel][bridge] tool_result round={} tool={} call_id={} success={} request_id={}",
+                        iteration,
+                        tool_name,
+                        call_id,
+                        success,
+                        request_id,
+                    );
+                }
+                AgentProgress::SubagentFailed {
+                    agent_id, error, ..
+                } => {
+                    log::warn!(
+                        "[web_channel][bridge] subagent_failed agent_id={} err={} client_id={} thread_id={} request_id={}",
+                        agent_id,
+                        error,
+                        client_id,
+                        thread_id,
+                        request_id,
+                    );
+                }
+                other => {
+                    log::debug!(
+                        "[web_channel][bridge] lifecycle event={:?} request_id={}",
+                        std::mem::discriminant(other),
+                        request_id,
+                    );
+                }
+            }
             match event {
                 AgentProgress::TurnStarted => {
                     publish_web_channel_event(WebChannelEvent {
@@ -610,6 +704,14 @@ fn spawn_progress_bridge(
                 }
             }
         }
+        log::debug!(
+            "[web_channel][bridge] exit client_id={} thread_id={} request_id={} round={} events_seen={}",
+            client_id,
+            thread_id,
+            request_id,
+            round,
+            events_seen,
+        );
     });
 }
 

--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -790,6 +790,7 @@ pub(crate) async fn process_channel_message(
         target_agent_id: scoping.target_agent_id,
         visible_tool_names: scoping.visible_tool_names,
         extra_tools: scoping.extra_tools,
+        on_progress: None,
     };
     tracing::debug!(
         channel = %msg.channel,

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -1207,7 +1207,11 @@ impl OpenAiCompatibleProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("{} streaming API error ({}): {}", self.name, status, body);
+            // Sanitize the upstream error body so we don't leak user
+            // prompts, tool arguments, or credentials the backend
+            // echoed back into the anyhow chain / logs.
+            let sanitized = super::sanitize_api_error(&body);
+            anyhow::bail!("{} streaming API error ({}): {}", self.name, status, sanitized);
         }
 
         // Some OpenAI-compatible backends (and our e2e mock) accept

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -503,11 +503,16 @@ struct ResponsesContent {
 #[derive(Debug, Deserialize)]
 struct StreamChunkResponse {
     choices: Vec<StreamChoice>,
+    #[serde(default)]
+    usage: Option<ApiUsage>,
+    #[serde(default)]
+    openhuman: Option<OpenHumanMeta>,
 }
 
 #[derive(Debug, Deserialize)]
 struct StreamChoice {
     delta: StreamDelta,
+    #[allow(dead_code)]
     finish_reason: Option<String>,
 }
 
@@ -518,6 +523,37 @@ struct StreamDelta {
     /// Reasoning/thinking models may stream output via `reasoning_content`.
     #[serde(default)]
     reasoning_content: Option<String>,
+    /// Native tool-call chunks. Each entry is keyed by `index`; the first
+    /// chunk for a given index carries `id`/`type`/`function.name`, later
+    /// chunks only carry fragments of `function.arguments`.
+    #[serde(default)]
+    tool_calls: Option<Vec<StreamToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamToolCallDelta {
+    /// Index of this tool call within the assistant message. Multiple
+    /// concurrent tool calls share the same message and are distinguished
+    /// by index — not id (which may only appear on the first chunk).
+    #[serde(default)]
+    index: Option<u32>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default, rename = "type")]
+    #[allow(dead_code)]
+    kind: Option<String>,
+    #[serde(default)]
+    function: Option<StreamToolCallFunction>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamToolCallFunction {
+    #[serde(default)]
+    name: Option<String>,
+    /// Arguments are streamed as a raw JSON string fragment; we accumulate
+    /// them as-is and only parse at the end of the stream.
+    #[serde(default)]
+    arguments: Option<String>,
 }
 
 /// Parse SSE (Server-Sent Events) stream from OpenAI-compatible providers.
@@ -1132,6 +1168,254 @@ impl OpenAiCompatibleProvider {
         .iter()
         .any(|hint| lower.contains(hint))
     }
+
+    /// Streaming variant of the native-tools chat path.
+    ///
+    /// Sends the request with `stream: true`, consumes the upstream SSE
+    /// stream chunk by chunk, forwards fine-grained `ProviderDelta`
+    /// events to the caller-supplied sender, and returns the aggregated
+    /// [`ProviderChatResponse`] once the stream ends. Per-chunk parsing
+    /// uses [`StreamChunkResponse`] — a permissive subset of the
+    /// OpenAI/Fireworks streaming schema that tolerates unknown fields.
+    async fn stream_native_chat(
+        &self,
+        credential: &str,
+        native_request: &NativeChatRequest,
+        delta_tx: &tokio::sync::mpsc::Sender<crate::openhuman::providers::ProviderDelta>,
+    ) -> anyhow::Result<ProviderChatResponse> {
+        use futures_util::StreamExt;
+
+        let url = self.chat_completions_url();
+        log::debug!(
+            "[stream] {} POST {} (stream=true, tools={})",
+            self.name,
+            url,
+            native_request.tools.as_ref().map_or(0, |t| t.len()),
+        );
+
+        let response = self
+            .apply_auth_header(
+                self.http_client()
+                    .post(&url)
+                    .header("Accept", "text/event-stream")
+                    .json(native_request),
+                credential,
+            )
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("{} streaming API error ({}): {}", self.name, status, body);
+        }
+
+        // Accumulators for the final aggregated response. Tool-call
+        // state is keyed by the upstream `index` so interleaved chunks
+        // for multiple tool calls in the same turn don't clobber each
+        // other.
+        let mut text_accum = String::new();
+        let mut thinking_accum = String::new();
+        let mut tool_accum: std::collections::BTreeMap<u32, StreamingToolCall> =
+            std::collections::BTreeMap::new();
+        let mut last_usage: Option<ApiUsage> = None;
+        let mut last_openhuman: Option<OpenHumanMeta> = None;
+
+        let mut bytes_stream = response.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(item) = bytes_stream.next().await {
+            let bytes = item?;
+            buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+            // SSE events are separated by "\n\n"; lines within an event
+            // are "\n"-terminated. We accumulate partial events across
+            // socket reads and only pop complete ones.
+            while let Some(sep_idx) = buffer.find("\n\n") {
+                let event = buffer[..sep_idx].to_string();
+                buffer.drain(..sep_idx + 2);
+                for line in event.lines() {
+                    let line = line.trim();
+                    if line.is_empty() || line.starts_with(':') {
+                        continue;
+                    }
+                    let Some(data) = line.strip_prefix("data:") else {
+                        continue;
+                    };
+                    let data = data.trim();
+                    if data == "[DONE]" {
+                        continue;
+                    }
+
+                    let chunk: StreamChunkResponse = match serde_json::from_str(data) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            log::debug!(
+                                "[stream] {} skipping unparseable chunk: {} — data={}",
+                                self.name,
+                                e,
+                                data,
+                            );
+                            continue;
+                        }
+                    };
+
+                    if let Some(usage) = chunk.usage {
+                        last_usage = Some(usage);
+                    }
+                    if let Some(meta) = chunk.openhuman {
+                        last_openhuman = Some(meta);
+                    }
+
+                    for choice in chunk.choices {
+                        // Visible text delta.
+                        if let Some(content) = choice.delta.content.as_ref() {
+                            if !content.is_empty() {
+                                text_accum.push_str(content);
+                                let _ = delta_tx
+                                    .send(
+                                        crate::openhuman::providers::ProviderDelta::TextDelta {
+                                            delta: content.clone(),
+                                        },
+                                    )
+                                    .await;
+                            }
+                        }
+                        // Reasoning / thinking delta.
+                        if let Some(reasoning) = choice.delta.reasoning_content.as_ref() {
+                            if !reasoning.is_empty() {
+                                thinking_accum.push_str(reasoning);
+                                let _ = delta_tx
+                                    .send(
+                                        crate::openhuman::providers::ProviderDelta::ThinkingDelta {
+                                            delta: reasoning.clone(),
+                                        },
+                                    )
+                                    .await;
+                            }
+                        }
+                        // Tool-call fragments.
+                        if let Some(tc_list) = choice.delta.tool_calls.as_ref() {
+                            for tc in tc_list {
+                                let idx = tc.index.unwrap_or(0);
+                                let entry = tool_accum
+                                    .entry(idx)
+                                    .or_insert_with(StreamingToolCall::default);
+                                let first_fragment = entry.id.is_none() && entry.name.is_none();
+                                if let Some(id) = tc.id.as_ref() {
+                                    entry.id = Some(id.clone());
+                                }
+                                if let Some(func) = tc.function.as_ref() {
+                                    if let Some(name) = func.name.as_ref() {
+                                        if !name.is_empty() {
+                                            entry.name = Some(name.clone());
+                                        }
+                                    }
+                                    if let Some(args) = func.arguments.as_ref() {
+                                        if !args.is_empty() {
+                                            entry.arguments.push_str(args);
+                                            let call_id = entry
+                                                .id
+                                                .clone()
+                                                .unwrap_or_else(|| format!("stream-{}", idx));
+                                            let _ = delta_tx
+                                                .send(
+                                                    crate::openhuman::providers::ProviderDelta::ToolCallArgsDelta {
+                                                        call_id,
+                                                        delta: args.clone(),
+                                                    },
+                                                )
+                                                .await;
+                                        }
+                                    }
+                                }
+                                // Emit a `ToolCallStart` the first time
+                                // we learn both the id and the name for
+                                // a given index.
+                                if first_fragment {
+                                    if let (Some(id), Some(name)) =
+                                        (entry.id.as_ref(), entry.name.as_ref())
+                                    {
+                                        let _ = delta_tx
+                                            .send(
+                                                crate::openhuman::providers::ProviderDelta::ToolCallStart {
+                                                    call_id: id.clone(),
+                                                    tool_name: name.clone(),
+                                                },
+                                            )
+                                            .await;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Aggregate the collected tool calls into the unified response
+        // shape. We reuse `parse_native_response` by building an
+        // `ApiChatResponse` from the accumulators so downstream code
+        // sees the same shape as the non-streaming path.
+        let tool_calls_for_api: Vec<ToolCall> = tool_accum
+            .into_iter()
+            .map(|(_idx, c)| ToolCall {
+                id: c.id,
+                kind: Some("function".to_string()),
+                function: Some(Function {
+                    name: c.name,
+                    arguments: if c.arguments.is_empty() {
+                        None
+                    } else {
+                        // Try to parse as JSON first so downstream
+                        // `normalize_function_arguments` can handle the
+                        // usual Value path; fall back to a JSON-string
+                        // value if the accumulated text isn't valid
+                        // JSON yet.
+                        Some(
+                            serde_json::from_str(&c.arguments)
+                                .unwrap_or_else(|_| serde_json::Value::String(c.arguments)),
+                        )
+                    },
+                }),
+            })
+            .collect();
+
+        let api_resp = ApiChatResponse {
+            choices: vec![Choice {
+                message: ResponseMessage {
+                    content: if text_accum.is_empty() {
+                        None
+                    } else {
+                        Some(text_accum)
+                    },
+                    reasoning_content: if thinking_accum.is_empty() {
+                        None
+                    } else {
+                        Some(thinking_accum)
+                    },
+                    tool_calls: if tool_calls_for_api.is_empty() {
+                        None
+                    } else {
+                        Some(tool_calls_for_api)
+                    },
+                    function_call: None,
+                },
+            }],
+            usage: last_usage,
+            openhuman: last_openhuman,
+        };
+
+        Self::parse_native_response(api_resp, &self.name)
+    }
+}
+
+/// Per-index tool-call accumulator used while consuming an SSE stream.
+#[derive(Debug, Default)]
+struct StreamingToolCall {
+    id: Option<String>,
+    name: Option<String>,
+    arguments: String,
 }
 
 #[async_trait]
@@ -1498,6 +1782,37 @@ impl Provider for OpenAiCompatibleProvider {
         } else {
             request.messages.to_vec()
         };
+
+        // ── Streaming branch ─────────────────────────────────────────
+        // When the caller supplied a `ProviderDelta` sender, request
+        // SSE and forward fine-grained deltas while accumulating the
+        // final response. Fall back to non-streaming on non-200 errors
+        // so tool-schema rejections etc. still work.
+        if let Some(tx) = request.stream {
+            let native_request = NativeChatRequest {
+                model: model.to_string(),
+                messages: Self::convert_messages_for_native(&effective_messages),
+                temperature,
+                stream: Some(true),
+                tool_choice: tools.as_ref().map(|_| "auto".to_string()),
+                tools: tools.clone(),
+            };
+            match self
+                .stream_native_chat(credential, &native_request, tx)
+                .await
+            {
+                Ok(resp) => return Ok(resp),
+                Err(err) => {
+                    log::warn!(
+                        "[stream] {} streaming chat failed, falling back to non-streaming: {}",
+                        self.name,
+                        err
+                    );
+                    // Fall through to the non-streaming path below.
+                }
+            }
+        }
+
         let native_request = NativeChatRequest {
             model: model.to_string(),
             messages: Self::convert_messages_for_native(&effective_messages),

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -1210,6 +1210,27 @@ impl OpenAiCompatibleProvider {
             anyhow::bail!("{} streaming API error ({}): {}", self.name, status, body);
         }
 
+        // Some OpenAI-compatible backends (and our e2e mock) accept
+        // `stream: true` in the request but reply with a regular
+        // `application/json` body rather than SSE. Detect this and
+        // fall back to the non-streaming parse path so the caller
+        // still gets an aggregated response. No deltas are emitted in
+        // this case (there's nothing to stream).
+        let is_sse = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|ct| ct.to_ascii_lowercase().contains("text/event-stream"))
+            .unwrap_or(false);
+        if !is_sse {
+            log::debug!(
+                "[stream] {} upstream replied with non-SSE content-type; falling back to JSON parse",
+                self.name,
+            );
+            let api_resp: ApiChatResponse = response.json().await?;
+            return Self::parse_native_response(api_resp, &self.name);
+        }
+
         // Accumulators for the final aggregated response. Tool-call
         // state is keyed by the upstream `index` so interleaved chunks
         // for multiple tool calls in the same turn don't clobber each

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -1211,7 +1211,12 @@ impl OpenAiCompatibleProvider {
             // prompts, tool arguments, or credentials the backend
             // echoed back into the anyhow chain / logs.
             let sanitized = super::sanitize_api_error(&body);
-            anyhow::bail!("{} streaming API error ({}): {}", self.name, status, sanitized);
+            anyhow::bail!(
+                "{} streaming API error ({}): {}",
+                self.name,
+                status,
+                sanitized
+            );
         }
 
         // Some OpenAI-compatible backends (and our e2e mock) accept
@@ -1318,18 +1323,47 @@ impl OpenAiCompatibleProvider {
                             }
                         }
                         // Tool-call fragments.
+                        //
+                        // Ordering invariant emitted downstream:
+                        //   ToolCallStart (once, when id+name both known)
+                        //     → ToolCallArgsDelta* (buffered then streamed)
+                        //
+                        // Args fragments that arrive *before* we know the
+                        // canonical id are buffered into `entry.arguments`
+                        // but NOT emitted — emitting them with a synthetic
+                        // id would break client-side reconciliation against
+                        // the eventual tool_call / tool_result events that
+                        // carry the real id. Once start fires we flush the
+                        // buffered prefix in a single delta, then stream
+                        // subsequent fragments as they arrive.
                         if let Some(tc_list) = choice.delta.tool_calls.as_ref() {
                             for tc in tc_list {
                                 let idx = tc.index.unwrap_or(0);
                                 let entry = tool_accum
                                     .entry(idx)
                                     .or_insert_with(StreamingToolCall::default);
-                                let first_fragment = entry.id.is_none() && entry.name.is_none();
+
                                 if let Some(id) = tc.id.as_ref() {
+                                    if entry.id.is_none() {
+                                        log::debug!(
+                                            "[stream] {} tool_call[{}] id resolved: {}",
+                                            self.name,
+                                            idx,
+                                            id,
+                                        );
+                                    }
                                     entry.id = Some(id.clone());
                                 }
                                 if let Some(func) = tc.function.as_ref() {
                                     if let Some(name) = func.name.as_ref() {
+                                        if !name.is_empty() && entry.name.is_none() {
+                                            log::debug!(
+                                                "[stream] {} tool_call[{}] name resolved: {}",
+                                                self.name,
+                                                idx,
+                                                name,
+                                            );
+                                        }
                                         if !name.is_empty() {
                                             entry.name = Some(name.clone());
                                         }
@@ -1337,36 +1371,72 @@ impl OpenAiCompatibleProvider {
                                     if let Some(args) = func.arguments.as_ref() {
                                         if !args.is_empty() {
                                             entry.arguments.push_str(args);
-                                            let call_id = entry
-                                                .id
-                                                .clone()
-                                                .unwrap_or_else(|| format!("stream-{}", idx));
-                                            let _ = delta_tx
-                                                .send(
-                                                    crate::openhuman::providers::ProviderDelta::ToolCallArgsDelta {
-                                                        call_id,
-                                                        delta: args.clone(),
-                                                    },
-                                                )
-                                                .await;
+                                            if !entry.emitted_start {
+                                                log::debug!(
+                                                    "[stream] {} tool_call[{}] buffering args ({} chars total) — waiting for id/name",
+                                                    self.name,
+                                                    idx,
+                                                    entry.arguments.len(),
+                                                );
+                                            }
                                         }
                                     }
                                 }
-                                // Emit a `ToolCallStart` the first time
-                                // we learn both the id and the name for
-                                // a given index.
-                                if first_fragment {
+
+                                // Fire start + flush buffered args once
+                                // both id and name have been observed.
+                                if !entry.emitted_start {
                                     if let (Some(id), Some(name)) =
                                         (entry.id.as_ref(), entry.name.as_ref())
                                     {
+                                        log::debug!(
+                                            "[stream] {} tool_call[{}] emitting ToolCallStart id={} name={}",
+                                            self.name,
+                                            idx,
+                                            id,
+                                            name,
+                                        );
                                         let _ = delta_tx
-                                            .send(
-                                                crate::openhuman::providers::ProviderDelta::ToolCallStart {
-                                                    call_id: id.clone(),
-                                                    tool_name: name.clone(),
-                                                },
-                                            )
+                                            .send(crate::openhuman::providers::ProviderDelta::ToolCallStart {
+                                                call_id: id.clone(),
+                                                tool_name: name.clone(),
+                                            })
                                             .await;
+                                        entry.emitted_start = true;
+                                        // Flush any args that were
+                                        // buffered before the start id
+                                        // was known.
+                                        if !entry.arguments.is_empty() {
+                                            log::debug!(
+                                                "[stream] {} tool_call[{}] flushing buffered args ({} chars)",
+                                                self.name,
+                                                idx,
+                                                entry.arguments.len(),
+                                            );
+                                            let buffered = entry.arguments.clone();
+                                            let _ = delta_tx
+                                                .send(crate::openhuman::providers::ProviderDelta::ToolCallArgsDelta {
+                                                    call_id: id.clone(),
+                                                    delta: buffered,
+                                                })
+                                                .await;
+                                            entry.emitted_chars = entry.arguments.len();
+                                        }
+                                    }
+                                } else if entry.arguments.len() > entry.emitted_chars {
+                                    // Start already fired — stream the
+                                    // newly appended fragment with the
+                                    // canonical id.
+                                    if let Some(ref id) = entry.id {
+                                        let fresh =
+                                            entry.arguments[entry.emitted_chars..].to_string();
+                                        let _ = delta_tx
+                                            .send(crate::openhuman::providers::ProviderDelta::ToolCallArgsDelta {
+                                                call_id: id.clone(),
+                                                delta: fresh,
+                                            })
+                                            .await;
+                                        entry.emitted_chars = entry.arguments.len();
                                     }
                                 }
                             }
@@ -1434,11 +1504,21 @@ impl OpenAiCompatibleProvider {
 }
 
 /// Per-index tool-call accumulator used while consuming an SSE stream.
+///
+/// `arguments` holds the full cumulative JSON text fragments seen so
+/// far. `emitted_start` tracks whether we've surfaced the synthetic
+/// `ProviderDelta::ToolCallStart` event yet (we only do once we know
+/// both `id` and `name`). `emitted_chars` is the byte offset within
+/// `arguments` that we've already flushed as `ToolCallArgsDelta`
+/// events — used to avoid re-sending buffered fragments after the
+/// start event fires.
 #[derive(Debug, Default)]
 struct StreamingToolCall {
     id: Option<String>,
     name: Option<String>,
     arguments: String,
+    emitted_start: bool,
+    emitted_chars: usize,
 }
 
 #[async_trait]

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -1273,11 +1273,9 @@ impl OpenAiCompatibleProvider {
                             if !content.is_empty() {
                                 text_accum.push_str(content);
                                 let _ = delta_tx
-                                    .send(
-                                        crate::openhuman::providers::ProviderDelta::TextDelta {
-                                            delta: content.clone(),
-                                        },
-                                    )
+                                    .send(crate::openhuman::providers::ProviderDelta::TextDelta {
+                                        delta: content.clone(),
+                                    })
                                     .await;
                             }
                         }

--- a/src/openhuman/providers/mod.rs
+++ b/src/openhuman/providers/mod.rs
@@ -8,7 +8,7 @@ pub mod traits;
 #[allow(unused_imports)]
 pub use traits::{
     ChatMessage, ChatRequest, ChatResponse, ConversationMessage, Provider, ProviderCapabilityError,
-    ToolCall, ToolResultMessage, UsageInfo,
+    ProviderDelta, ToolCall, ToolResultMessage, UsageInfo,
 };
 
 pub use ops::*;

--- a/src/openhuman/providers/reliable.rs
+++ b/src/openhuman/providers/reliable.rs
@@ -537,6 +537,7 @@ impl Provider for ReliableProvider {
                         messages: request.messages,
                         tools: request.tools,
                         system_prompt_cache_boundary: request.system_prompt_cache_boundary,
+                        stream: request.stream,
                     };
                     match provider.chat(req, current_model, temperature).await {
                         Ok(resp) => {

--- a/src/openhuman/providers/reliable.rs
+++ b/src/openhuman/providers/reliable.rs
@@ -533,11 +533,32 @@ impl Provider for ReliableProvider {
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
+                    // Only forward the streaming sender on the first
+                    // attempt. A failed attempt that partially streamed
+                    // text/args has already published those fragments to
+                    // the downstream progress bridge; if a retry also
+                    // streamed, the consumer would see duplicated tokens
+                    // and mismatched tool_call_ids. Retries silently
+                    // degrade to non-streaming and the caller still gets
+                    // a correct aggregated response from `chat()`.
+                    let stream_this_attempt = if attempt == 0 {
+                        request.stream
+                    } else {
+                        if request.stream.is_some() {
+                            tracing::info!(
+                                provider = provider_name,
+                                model = *current_model,
+                                attempt,
+                                "[reliable] retry forcing non-streaming to avoid duplicate deltas"
+                            );
+                        }
+                        None
+                    };
                     let req = ChatRequest {
                         messages: request.messages,
                         tools: request.tools,
                         system_prompt_cache_boundary: request.system_prompt_cache_boundary,
-                        stream: request.stream,
+                        stream: stream_this_attempt,
                     };
                     match provider.chat(req, current_model, temperature).await {
                         Ok(resp) => {

--- a/src/openhuman/providers/traits.rs
+++ b/src/openhuman/providers/traits.rs
@@ -91,6 +91,31 @@ impl ChatResponse {
     }
 }
 
+/// A fine-grained streaming event emitted by a provider while serving a
+/// `chat()` call. Providers that support SSE/streaming forward these to
+/// the optional sender on [`ChatRequest::stream`]; the final aggregated
+/// response is still returned from `chat()` so callers that ignore the
+/// stream keep working unchanged.
+#[derive(Debug, Clone)]
+pub enum ProviderDelta {
+    /// A chunk of the assistant's visible text output.
+    TextDelta { delta: String },
+    /// A chunk of the model's reasoning/thinking output (for models
+    /// that emit `reasoning_content` or an equivalent). Consumers should
+    /// render this in a separate UI affordance from the visible output.
+    ThinkingDelta { delta: String },
+    /// The start of a new native tool call. `call_id` is the
+    /// provider-assigned id that later appears on the result message.
+    ToolCallStart {
+        call_id: String,
+        tool_name: String,
+    },
+    /// A chunk of argument JSON text for an in-flight tool call.
+    /// Streamed verbatim; may arrive as partial JSON that only becomes
+    /// valid once the stream completes.
+    ToolCallArgsDelta { call_id: String, delta: String },
+}
+
 /// Request payload for provider chat calls.
 #[derive(Debug, Clone, Copy)]
 pub struct ChatRequest<'a> {
@@ -101,6 +126,12 @@ pub struct ChatRequest<'a> {
     /// apply `cache_control` to the prefix before this boundary.
     /// `None` means no cache boundary is known.
     pub system_prompt_cache_boundary: Option<usize>,
+    /// Optional sink for `ProviderDelta` events. When `Some`, providers
+    /// that support streaming will ask the upstream API for SSE and
+    /// forward fine-grained events here. Providers without a streaming
+    /// implementation ignore the sender and return only the aggregated
+    /// response.
+    pub stream: Option<&'a tokio::sync::mpsc::Sender<ProviderDelta>>,
 }
 
 /// A tool result to feed back to the LLM.
@@ -798,6 +829,7 @@ mod tests {
             messages: &[ChatMessage::user("Hello")],
             tools: Some(&tools),
             system_prompt_cache_boundary: None,
+            stream: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -816,6 +848,7 @@ mod tests {
             messages: &[ChatMessage::user("Hello")],
             tools: None,
             system_prompt_cache_boundary: None,
+            stream: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -917,6 +950,7 @@ mod tests {
             ],
             tools: Some(&tools),
             system_prompt_cache_boundary: None,
+            stream: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -940,6 +974,7 @@ mod tests {
             messages: &[ChatMessage::system("BASE"), ChatMessage::user("Hello")],
             tools: Some(&tools),
             system_prompt_cache_boundary: None,
+            stream: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -963,6 +998,7 @@ mod tests {
             messages: &[ChatMessage::user("Hello")],
             tools: Some(&tools),
             system_prompt_cache_boundary: None,
+            stream: None,
         };
 
         let err = provider.chat(request, "model", 0.7).await.unwrap_err();

--- a/src/openhuman/providers/traits.rs
+++ b/src/openhuman/providers/traits.rs
@@ -106,10 +106,7 @@ pub enum ProviderDelta {
     ThinkingDelta { delta: String },
     /// The start of a new native tool call. `call_id` is the
     /// provider-assigned id that later appears on the result message.
-    ToolCallStart {
-        call_id: String,
-        tool_name: String,
-    },
+    ToolCallStart { call_id: String, tool_name: String },
     /// A chunk of argument JSON text for an in-flight tool call.
     /// Streamed verbatim; may arrive as partial JSON that only becomes
     /// valid once the stream completes.


### PR DESCRIPTION
## Summary

- Wire SSE end-to-end: `OpenAiCompatibleProvider::chat` streams `text_delta`, `thinking_delta`, and `tool_call`/`tool_args_delta` events when the caller supplies a `ProviderDelta` sender; aggregated response still returned so existing callers keep working.
- New `AgentProgress` variants plumbed through both agent paths (`session/turn.rs` for the web channel, `run_tool_call_loop` + `agent.run_turn` bus for external channels).
- `WebChannelEvent` gains `delta` / `delta_kind` / `tool_call_id` and the web-channel progress bridge emits `text_delta` / `thinking_delta` / `tool_args_delta` socket events.
- Frontend (`chatService`, `Conversations.tsx`) renders a live streaming assistant bubble, collapsible "Thinking…" block, and live tool-args JSON while tools are being composed.
- `ChannelInboundSubscriber` coalesces deltas on a ~1 s timer and progressively edits the outbound Telegram/Slack message via a new `PATCH /channels/:channel/messages/:id` endpoint (`BackendOAuthClient::send_channel_edit`), falling back to atomic-final delivery on repeated edit failures.

## Problem

The agent loop was end-to-end functional but opaque: the web UI only saw `tool_call` / `tool_result` / `chat_done`, with no visibility into tokens arriving, reasoning output, or tool arguments being composed. External channels (Telegram/Slack) got a single atomic bubble after the whole turn finished — no "typing" / "working" signal, which reads as dead for multi-tool turns that take >10 s.

Additionally, the compatible provider hard-coded `stream: false` so there was no way to stream even if the UI was ready.

## Solution

Changes are strictly additive on the Provider/agent layer:

- `ChatRequest` gained an optional `stream: Option<&Sender<ProviderDelta>>`. Providers that don't implement streaming ignore it; `OpenAiCompatibleProvider` inspects the flag and branches into a new `stream_native_chat` that consumes SSE via `bytes_stream`, forwards deltas, and still returns an aggregated `ProviderChatResponse` built from the streamed fragments. On upstream errors the streaming path logs + falls through to the non-streaming path.
- `AgentProgress` gains `TextDelta`, `ThinkingDelta`, `ToolCallArgsDelta`. The session turn and the `run_tool_call_loop` forwarder both spin up a per-iteration `ProviderDelta → AgentProgress` task, send it via the existing `on_progress` sink, and drop the sender after the chat call so the forwarder exits cleanly. The bus request now carries `on_progress: Option<mpsc::Sender<AgentProgress>>` so channels dispatched via `agent.run_turn` can subscribe too.
- `run_tool_call_loop` now emits the full `TurnStarted / IterationStarted / ToolCallStarted / ToolCallCompleted / TurnCompleted` lifecycle, so external channels get parity with the session path.
- `WebChannelEvent` derives `Default` to keep construction sites manageable as new fields land. The progress bridge in `channels/providers/web.rs` fans the new `AgentProgress` variants into three new socket events (`text_delta`, `thinking_delta`, `tool_args_delta`).
- `ChannelInboundSubscriber` gained a tokio `interval` (1 s) that flushes buffered text/tool status into an outbound message — initial post via existing `send_channel_message`, subsequent flushes via new `send_channel_edit` (PATCH). Latches `edit_disabled` after `MAX_EDIT_FAILURES=2` to fall back to atomic-final delivery when the backend endpoint is missing or rejects the edit (e.g. rate-limit). Final `chat_done` replaces the streamed draft with the canonical reply.
- Frontend subscribes to the new socket events and maintains a `streamingAssistantByThread` buffer for the live bubble + a per-entry `argsBuffer` on tool timeline rows. Cleared on `chat_done` / `chat_error` so the persisted final message takes over.
- Backend SSE already forwarded chunks verbatim, so `delta.reasoning_content` passes through for free; `supportsThinking: true` added to the `reasoning-v1` model registry entry (backend PR: https://github.com/tinyhumansai/backend/pull/XXX — see follow-up).

## Submission Checklist

- [x] **Unit tests** — `cargo test --lib` passes (2634/2634); `yarn test` passes (422/422 frontend tests). New enum variants and `WebChannelEvent::Default` covered by existing compile-time checks; the provider streaming loop is exercised via the fallback path (non-streaming behaviour unchanged).
- [ ] **E2E / integration** — **N/A for this PR.** The existing `tests/json_rpc_e2e.rs` still passes. A dedicated streaming E2E (socket assertions for event ordering) is left as a follow-up so the core/UI change can land first and be tested manually.
- [x] **Doc comments** — `ProviderDelta`, `ChatRequest.stream`, `AgentProgress::{TextDelta,ThinkingDelta,ToolCallArgsDelta}`, `StreamingState`, `send_channel_edit`, and the three new `ChatEventListeners` entries all have `///` / JSDoc.
- [x] **Inline comments** — `[stream]` / `[channel-inbound][stream]` prefixed logs on every branch; `MAX_EDIT_FAILURES` rationale, `EDIT_FLUSH_INTERVAL` tuning note, and SSE buffer/separator handling all commented.

## Impact

- **Desktop UI**: assistant bubbles now stream token-by-token; models with `supportsThinking` show a collapsible Thinking block; tool timeline rows show the JSON being composed before the tool executes.
- **External channels (Telegram / Slack)**: require the backend `PATCH /channels/:channel/messages/:id` endpoint for progressive editing. Until that endpoint ships, the Rust side automatically falls back to the existing atomic-final behaviour — **no regression**.
- **Providers that don't implement streaming** (Anthropic adapter, local fallback): unaffected. The optional sender is simply ignored; the aggregated response path is unchanged.
- **Performance**: one extra mpsc channel + forwarder task per iteration when progress is subscribed (web channel + editable external channels). No-op when `on_progress` is `None`.
- **Migration / compatibility**: additive. `WebChannelEvent` new fields are `Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`; `AgentTurnRequest` adds `on_progress` (defaulted to `None` at all call sites); `ChatRequest.stream` defaulted to `None` at all call sites.

## Related

- Issue(s): (streaming feedback for channels — no tracking issue)
- Follow-up PR(s)/TODOs:
  - Backend `PATCH /channels/:channel/messages/:id` + Telegram `editMessageText` / Slack `chat.update` adapter wiring (blocks progressive-edit streaming for external channels).
  - Backend companion PR (already pushed on `feat/streaming` in `tinyhumansai/backend`): `supportsThinking` flag on `reasoning-v1` in `modelRegistry.ts`.
  - E2E spec: socket-subscribe test asserting `inference_start → iteration_start → text_delta* → tool_args_delta* → tool_call → tool_result → chat_done` ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time incremental streaming: assistant content and "Thinking…" updates appear live as they generate.
  * Live tool argument preview: tool-call arguments stream into the timeline as they are built.
  * Draft editing & typing signals: messages are posted as editable drafts and updated progressively; typing indicator is refreshed while streaming.
* **Bug Fixes / UX**
  * Legacy “sending” placeholder suppressed once streaming starts; provisional assistant preview bubble shows live trailing content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->