### PR TITLE
fix(agent): thread agent_id into build_session_agent_inner

### DIFF
--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -186,9 +186,43 @@ impl AgentBuilder {
         self
     }
 
-    /// Sets the human-readable agent definition name used as the
-    /// `{agent}` prefix in session transcript filenames
-    /// (`sessions/DDMMYYYY/{agent}_{index}.md`).
+    /// Sets the agent definition id this session is running
+    /// (`welcome`, `orchestrator`, `skills_agent`, …).
+    ///
+    /// This value is stamped onto the built [`Agent`] and surfaces in
+    /// the following places:
+    ///
+    /// * **Transcript filename on disk** — `transcript::write_transcript`
+    ///   and `transcript::find_latest_transcript` use it as the
+    ///   `{agent}` prefix in `sessions/DDMMYYYY/{agent}_{index}.md`.
+    ///   Both the write path and the resume-lookup path read the same
+    ///   field on `self`, so a session is always self-consistent; the
+    ///   user-visible signal is which filename the transcript lands
+    ///   under. Leaving it at the legacy `"main"` fallback silently
+    ///   misfiles every non-orchestrator session under `main_*.md`.
+    /// * **Transcript metadata header** — `transcript::write_transcript`
+    ///   stamps it into the `<!-- session_transcript\nagent: {name}\n… -->`
+    ///   block at the top of every `.md` file. This is the ground-truth
+    ///   signal for "which agent definition ran this session" when
+    ///   inspecting transcripts after the fact.
+    /// * **[`PromptContext::agent_id`]** at prompt-build time (see
+    ///   `turn.rs`). Today only one prompt section reads this field —
+    ///   the `Connected Integrations` branch in `context/prompt.rs`
+    ///   that special-cases `skills_agent` vs every other agent — so
+    ///   the current user-visible impact of a wrong id is limited to
+    ///   the two bullets above. The stamped `prompt_builder` injected
+    ///   by [`Agent::from_config_for_agent`] is what actually drives
+    ///   prompt flavour per archetype, independent of this field. That
+    ///   said, any future prompt section that branches on a
+    ///   non-`skills_agent` id (e.g. welcome-specific banner, planner-
+    ///   specific rubric) would silently never fire if the field were
+    ///   left at `"main"`, so keeping it correctly stamped closes a
+    ///   latent foot-gun for code that hasn't been written yet.
+    ///
+    /// Callers building via [`Agent::from_config_for_agent`] get this
+    /// wired automatically inside `build_session_agent_inner`; direct
+    /// builder users (tests, CLI) must set it explicitly if they care
+    /// about any of the surfaces above.
     pub fn agent_definition_name(mut self, name: impl Into<String>) -> Self {
         self.agent_definition_name = Some(name.into());
         self
@@ -789,14 +823,32 @@ impl Agent {
         let effective_omit_profile = target_def.map(|def| def.omit_profile).unwrap_or(true);
         let effective_omit_memory_md = target_def.map(|def| def.omit_memory_md).unwrap_or(true);
 
-        // `agent_id` is not stamped onto the returned Agent here — the
-        // `event_channel` field on `Agent` is for transport identity
-        // (which channel the session belongs to: "web_channel", "cli",
-        // etc.), not the agent-definition id. Callers that want to
-        // record which definition they asked for should log it at
-        // call-site. The `[agent::builder]` info trace at the top of
-        // `from_config_for_agent` already captures this.
-        let _ = agent_id; // silence unused-warning if all code paths above move
+        // Stamp the resolved agent definition id onto the Agent via the
+        // builder. Without this call, `agent_definition_name` falls
+        // back to the legacy `"main"` default (see `AgentBuilder::build`)
+        // for every non-orchestrator caller. In the current codebase
+        // that is benign for the orchestrator (which is already aliased
+        // as `"main"` everywhere downstream) but causes two concrete
+        // bugs for the welcome agent, which is the only other id that
+        // reaches this function in practice:
+        //
+        //   1. Its session transcripts are misfiled on disk under
+        //      `sessions/DDMMYYYY/main_*.md` instead of `welcome_*.md`.
+        //   2. The `agent:` line inside each transcript's metadata
+        //      header stamps `agent: main` instead of `agent: welcome`.
+        //
+        // Skills_agent and every other typed sub-agent are unaffected
+        // because they never build via `from_config_for_agent` — they
+        // are spawned through `subagent_runner` which constructs its
+        // prompt and history directly.
+        //
+        // See the docstring on `AgentBuilder::agent_definition_name`
+        // for the full list of surfaces and the latent prompt-section
+        // foot-gun this call also closes.
+        log::debug!(
+            "[agent::builder] stamping agent_definition_name={} onto session agent",
+            agent_id
+        );
 
         Agent::builder()
             .provider(provider)
@@ -818,6 +870,7 @@ impl Agent {
             .auto_save(config.memory.auto_save)
             .post_turn_hooks(post_turn_hooks)
             .learning_enabled(config.learning.enabled)
+            .agent_definition_name(agent_id.to_string())
             .omit_profile(effective_omit_profile)
             .omit_memory_md(effective_omit_memory_md)
             .build()

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -33,6 +33,20 @@ impl Agent {
         &self.event_channel
     }
 
+    /// The agent definition id this session is running
+    /// (`"welcome"`, `"orchestrator"`, `"skills_agent"`, …).
+    ///
+    /// Exposed so callers that build sessions via
+    /// [`Agent::from_config_for_agent`] can stamp the resolved id onto
+    /// correlation logs and progress events without reaching for the
+    /// source `Config`. See [`AgentBuilder::agent_definition_name`]
+    /// for the full list of downstream surfaces (transcript filename,
+    /// transcript metadata header, and `PromptContext::agent_id`) that
+    /// read this field.
+    pub fn agent_definition_name(&self) -> &str {
+        &self.agent_definition_name
+    }
+
     /// Returns a new `AgentBuilder`.
     pub fn builder() -> AgentBuilder {
         AgentBuilder::new()

--- a/src/openhuman/agent/harness/session/tests.rs
+++ b/src/openhuman/agent/harness/session/tests.rs
@@ -138,6 +138,108 @@ fn _assert_builder_is_exported() -> AgentBuilder {
     Agent::builder()
 }
 
+/// Minimal in-memory `Agent` build that every agent_definition_name
+/// regression test reuses. Spins up a scratch workspace, a `none`
+/// memory backend, a one-response `MockProvider`, and a single
+/// `MockTool`, then feeds those into [`Agent::builder`]. Returns the
+/// built `Agent` so individual tests can assert against the
+/// [`Agent::agent_definition_name`] accessor.
+fn build_minimal_agent_with_definition_name(definition_name: Option<&str>) -> Agent {
+    let workspace = tempfile::TempDir::new().expect("temp workspace");
+    let workspace_path = workspace.path().to_path_buf();
+
+    let provider = Box::new(MockProvider {
+        responses: Mutex::new(vec![]),
+    });
+
+    let memory_cfg = crate::openhuman::config::MemoryConfig {
+        backend: "none".into(),
+        ..crate::openhuman::config::MemoryConfig::default()
+    };
+    let mem: Arc<dyn Memory> = Arc::from(
+        crate::openhuman::memory::create_memory(&memory_cfg, &workspace_path, None).unwrap(),
+    );
+
+    let mut builder = Agent::builder()
+        .provider(provider)
+        .tools(vec![Box::new(MockTool)])
+        .memory(mem)
+        .tool_dispatcher(Box::new(NativeToolDispatcher))
+        .workspace_dir(workspace_path);
+
+    if let Some(name) = definition_name {
+        builder = builder.agent_definition_name(name);
+    }
+
+    builder.build().expect("minimal agent build should succeed")
+}
+
+/// Regression test for the `build_session_agent_inner` agent-id
+/// threading bug.
+///
+/// Prior to the fix, `build_session_agent_inner` took an `agent_id:
+/// &str` parameter but never threaded it into the `Agent::builder()`
+/// chain. The builder's `.build()` then fell back to the legacy
+/// `"main"` default, and every session built via
+/// `Agent::from_config_for_agent` carried `agent_definition_name =
+/// "main"` at runtime regardless of which id the caller asked for.
+///
+/// In the current codebase only two ids actually reach
+/// `from_config_for_agent` in production: `"orchestrator"` (via the
+/// `Agent::from_config` legacy wrapper and the post-onboarding web
+/// dispatch path) and `"welcome"` (via `welcome_proactive` and the
+/// pre-onboarding web dispatch path). The orchestrator case is
+/// benign — `"main"` is already an alias for orchestrator everywhere
+/// downstream, so the behavior is a no-op. The welcome case is the
+/// one the user sees: welcome sessions were being misfiled on disk
+/// as `sessions/DDMMYYYY/main_*.md` instead of `welcome_*.md`, and
+/// the `agent:` line inside each transcript's `<!-- session_transcript
+/// -->` metadata header stamped `agent: main` instead of
+/// `agent: welcome`. Skills_agent and the other typed sub-agents are
+/// unaffected because they're spawned through `subagent_runner` and
+/// never touch the `from_config_for_agent` / builder fallback path.
+///
+/// This test pins the builder contract the fix relies on: calling
+/// `.agent_definition_name(id)` on the builder chain produces an
+/// `Agent` whose [`Agent::agent_definition_name`] accessor returns
+/// that id verbatim. `"welcome"` and `"orchestrator"` exercise the
+/// two ids that reach `from_config_for_agent` today; `"skills_agent"`
+/// and `"trigger_triage"` are defensive coverage so that if a
+/// future commit adds a new top-level caller for one of those ids
+/// the builder contract is already pinned.
+#[test]
+fn agent_builder_threads_agent_definition_name_when_set() {
+    for expected in ["welcome", "skills_agent", "orchestrator", "trigger_triage"] {
+        let agent = build_minimal_agent_with_definition_name(Some(expected));
+        assert_eq!(
+            agent.agent_definition_name(),
+            expected,
+            "agent.agent_definition_name() should return the value passed to the builder"
+        );
+    }
+}
+
+/// Complementary to [`agent_builder_threads_agent_definition_name_when_set`]:
+/// when a caller builds an `Agent` without ever calling
+/// [`AgentBuilder::agent_definition_name`], the legacy `"main"`
+/// fallback still applies. This pins the fallback contract that
+/// direct builder users (tests, CLI harnesses) rely on, and
+/// documents the exact misbehaviour the threading fix prevents —
+/// `build_session_agent_inner` used to hit this fallback even when
+/// a caller asked for `welcome`, because the `.agent_definition_name`
+/// setter was missing from the builder chain. The result was that
+/// welcome sessions landed on disk as `main_*.md` with `agent: main`
+/// stamped into their transcript metadata header.
+#[test]
+fn agent_builder_falls_back_to_main_when_definition_name_unset() {
+    let agent = build_minimal_agent_with_definition_name(None);
+    assert_eq!(
+        agent.agent_definition_name(),
+        "main",
+        "AgentBuilder::build should default agent_definition_name to \"main\" when unset"
+    );
+}
+
 #[tokio::test]
 async fn turn_without_tools_returns_text() {
     let workspace = tempfile::TempDir::new().expect("temp workspace");


### PR DESCRIPTION
## Summary

- Fixes `agent_definition_name` silently falling back to `"main"` for every `Agent` built via `Agent::from_config_for_agent`, because `build_session_agent_inner` dropped its `agent_id: &str` parameter via a `let _ = agent_id;` suppression instead of threading it into the `Agent::builder()` chain.
- Latently activated by #525 / #526 (PR #544): before that, only `orchestrator` reached this path and `"main"` was already its historical alias, so the bug was invisible. After #544 landed real dispatch routing that builds `welcome` via `from_config_for_agent("welcome", ...)`, welcome sessions became the first production caller to pass a non-orchestrator id through this code, and the bug became observable on disk.
- User-visible impact on welcome sessions: wrong transcript filename (`sessions/DDMMYYYY/main_*.md` instead of `welcome_*.md`), wrong metadata header (`agent: main`), and — most seriously — transcript resume cross-contamination where `find_latest_transcript("main")` loads the most recent orchestrator session's history into the welcome agent's `history` as a resume prefix before `run_single`.
- Prompt content is NOT affected (`context/prompt.rs` only branches on `ctx.agent_id` for one `is_skill_executor` check at `prompt.rs:655`). `skills_agent` and the other typed sub-agents are NOT affected either (they go through `subagent_runner`, which bypasses this builder).
- Two regression unit tests pin the builder contract (setter path + legacy fallback); both green.
- Verified live end-to-end with `yarn tauri dev` against a fresh workspace: pre-fix writes `sessions/16042026/main_0.md` with `agent: main` for a welcome session; post-fix writes `welcome_0.md` with `agent: welcome`.

## Problem

`Agent::from_config_for_agent(config, agent_id)` resolves the target `AgentDefinition` from the registry and hands off to `build_session_agent_inner(config, agent_id, target_def)`. That inner function **takes `agent_id: &str` as a parameter but never threads it into the `Agent::builder()` chain**. A `let _ = agent_id;` was silencing the unused-variable warning, and an 8-line comment block at the call site rationalised the omission by claiming *"event_channel is for transport identity, not the agent-definition id"* — conflating two unrelated fields (`event_channel` and `agent_definition_name`).

When `AgentBuilder::build()` runs, the missing field falls back to the legacy default at `builder.rs:310-312`:

```rust
agent_definition_name: self.agent_definition_name.unwrap_or_else(|| "main".to_string()),
```

Every session built via `from_config_for_agent` came out stamped `"main"` at runtime, regardless of which id the caller asked for.

### Scope — which ids actually reach this path

A grep of all callers of `Agent::from_config_for_agent` and `Agent::from_config` across the repo returns exactly two agent ids in production:

| Caller | Agent id |
|---|---|
| `agent/triage/escalation.rs:130` | `"orchestrator"` (via `Agent::from_config` legacy wrapper) |
| `cron/scheduler.rs:197` | `"orchestrator"` (via `Agent::from_config`) |
| `local_ai/ops.rs:41` | `"orchestrator"` (via `Agent::from_config`) |
| `channels/providers/web.rs:826` | `"orchestrator"` OR `"welcome"` (via `pick_target_agent_id` — the #525/#526 routing) |
| `agent/welcome_proactive.rs:94` | `"welcome"` (hardcoded, fired from `set_onboarding_completed(true)`) |

No caller passes `"skills_agent"`, `"researcher"`, `"planner"`, `"code_executor"`, `"critic"`, `"archivist"`, `"tool_maker"`, `"trigger_triage"`, `"trigger_reactor"`, `"morning_briefing"`, or `"fork"`. Those agent ids are spawned exclusively via `agent/harness/subagent_runner.rs::run_subagent`, which constructs its own system prompt via `render_subagent_system_prompt` and writes transcripts under the explicit id it is handed. The pre-existing `sessions/15042026/skills_agent_0.md` on disk with `agent: skills_agent` stamped in its metadata header confirms the subagent_runner path has always been correct.

### Why this was latent

The legacy `.unwrap_or_else(|| "main".to_string())` default was designed for a world where the only top-level agent was the orchestrator, and the orchestrator was called `"main"` in logs and file paths. You can see that assumption baked into `context/debug_dump.rs:249`:

```rust
if options.agent_id == "main" || options.agent_id == "orchestrator_main" {
```

Every downstream consumer already treats `"main"` as an orchestrator alias, which made the bug benign for the orchestrator path — the field's value was wrong but the downstream effect was zero.

#525 / #526 (PR #544) added real dispatch routing that builds the welcome agent via `from_config_for_agent("welcome", ...)` pre-onboarding. That was the first production caller to pass a non-orchestrator id through this code path, and it latently activated the bug.

### User-visible impact — three surfaces, all silently wrong pre-fix for welcome

**1. Session transcript filename**

`transcript::resolve_new_transcript_path(workspace_dir, agent_name)` at `transcript.rs:166` uses `agent_name` as the `{agent}` prefix in `sessions/DDMMYYYY/{agent}_{index}.md`:

- Pre-fix: welcome session → `sessions/16042026/main_0.md`
- Post-fix: welcome session → `sessions/16042026/welcome_0.md`

**2. Transcript metadata header**

`transcript::write_transcript` at `transcript.rs:94` stamps the `agent:` line inside the `<!-- session_transcript -->` block from `meta.agent_name`, populated from `self.agent_definition_name` in `turn.rs:1140`:

```
<!-- session_transcript
agent: main           ← pre-fix; should be `welcome`
dispatcher: native
...
-->
```

**3. Transcript resume cross-contamination** — the nastiest one

`Agent::try_load_session_transcript` at `turn.rs:1061` calls `transcript::find_latest_transcript(workspace_dir, self.agent_definition_name)` on every session start. That function scans **all dated session dirs** for `{agent_name}_*.md` and returns the most recent one.

Pre-fix, a welcome session stamped `"main"` asks for the latest `main_*.md` across all dated dirs and **finds the most recent orchestrator session's transcript** (which is also filed under `main_*.md` because of the historical alias). It loads its 5 messages — system prompt, user message, assistant tool-call history, tool result — into the welcome agent's `history` as a resume prefix before the welcome agent's `run_single` call. The welcome agent then runs its inference on top of that cross-contaminated history.

This was reproduced live on 2026-04-16 against `G:/projects/vezures/.openhuman`:

```
01:37:55 [welcome::proactive] starting proactive welcome
01:37:55 [agent::builder] building session agent id=welcome    (builder.rs:423)
01:37:55 [agent_loop] turn start message_chars=1030 history_len=0
01:37:55 [transcript] found previous transcript path=…\15042026\main_0.md  ← BUG
01:37:55 [transcript] loaded 5 messages from …\15042026\main_0.md          ← BUG
01:37:55 [transcript] loaded 5 messages for resume (cache_boundary=9464)
01:38:00 [transcript] resumed from cached transcript prefix_len=5 new_tail=1
01:38:06 [transcript] new session transcript path=…\16042026\main_0.md      ← BUG
01:38:06 [transcript] wrote 6 messages
```

Inspecting the written `sessions/16042026/main_0.md` afterwards showed a mix of yesterday's orchestrator email thread (`send an email to alan@mahadao.com say hi from openhuman` → `spawn_subagent(agent_id="skills_agent", toolkit="gmail", ...)` → tool result `Email sent successfully!`) with today's welcome agent's response appended on top. The welcome agent's LLM call had been fed an unrelated orchestrator session as context.

### What is NOT affected

**Prompt rendering.** A grep across the entire `context::prompt` module finds exactly one reader of `ctx.agent_id`:

```rust
// prompt.rs:655
let is_skill_executor = ctx.agent_id == "skills_agent";
```

That is the only branch. Welcome / main / orchestrator all fall through the same delegator path regardless of `ctx.agent_id`. The welcome agent's persona prompt comes from a `SystemPromptBuilder::for_subagent(target_def.system_prompt)` constructed at session-build time and stamped into the `Agent` as `.prompt_builder(prompt_builder)` — that builder renders welcome-correct bytes independently of `agent_definition_name`. Verified on disk: the clean pre-fix `main_0.md` opens with `# Welcome Agent\n\nYou are the **Welcome** agent...`, confirming the system prompt body was welcome-flavored even though the filename and metadata were wrong.

## Solution

One functional line added in `build_session_agent_inner`:

```rust
.agent_definition_name(agent_id.to_string())
```

Plus supporting scaffolding:

- **Delete** the `let _ = agent_id;` suppression.
- **Replace** the misleading 8-line comment block at the call site (which conflated `event_channel` with `agent_definition_name`) with an accurate description of the three downstream surfaces and the concrete pre-fix manifestation.
- **Expand** the docstring on `AgentBuilder::agent_definition_name` to document all three surfaces and note the latent prompt-section foot-gun the fix closes for future code (any future prompt section that branches on a non-`skills_agent` id would silently never fire if this field stayed at `"main"`).
- **Add** `pub fn agent_definition_name(&self) -> &str` accessor on `Agent` in `runtime.rs`, for runtime introspection and test assertions.
- **Add** new `log::debug!` call at the stamping site so the fix is greppable in runtime logs: `[agent::builder] stamping agent_definition_name=<id> onto session agent`.
- **Add** two regression unit tests in `session/tests.rs`:
  - `agent_builder_threads_agent_definition_name_when_set` — parameterised over `["welcome", "skills_agent", "orchestrator", "trigger_triage"]`, asserts `.agent_definition_name(id).build()` produces an `Agent` whose accessor returns that id verbatim. `welcome` and `orchestrator` are the two ids that reach `from_config_for_agent` in production today; `skills_agent` and `trigger_triage` are defensive coverage in case a future commit adds a new top-level caller.
  - `agent_builder_falls_back_to_main_when_definition_name_unset` — builds via a minimal helper without the setter, asserts the legacy `"main"` fallback still fires (so direct builder users in tests / CLI still work).

Both tests pass: `2 passed; 0 failed; 0 ignored; 3477 filtered out; finished in 0.21s`.

The fix does **NOT** touch:

- `subagent_runner.rs` or any sub-agent spawn path
- Any `agent/agents/*/agent.toml` definition
- Any `spawn_subagent` / `dispatch_subagent` tool implementation
- Any prompt-rendering code in `context::prompt`
- The `AgentBuilder::build()` fallback itself (preserved for direct-builder callers)

## Submission Checklist

- [x] **Unit tests** — two new regression tests in `src/openhuman/agent/harness/session/tests.rs` pinning the builder contract. Both green.
- [x] **E2E / integration** — verified end-to-end with `yarn tauri dev` against `OPENHUMAN_WORKSPACE=G:/projects/vezures/.openhuman`:
  - **Pre-fix run** (stashed fix, rebuilt sidecar from the upstream baseline): welcome_proactive wrote `sessions/16042026/main_0.md` with `agent: main` in the metadata. On an earlier attempt with existing `main_*.md` transcripts on disk, the welcome session also demonstrated the resume cross-contamination path, loading 5 messages from yesterday's orchestrator transcript as the welcome agent's prefix.
  - **Post-fix run**: welcome_proactive wrote `sessions/16042026/welcome_0.md` with `agent: welcome`. The subsequent web-chat turn routed through `pick_target_agent_id` to orchestrator, which wrote `sessions/16042026/orchestrator_0.md` with `agent: orchestrator`. The new debug log `[agent::builder] stamping agent_definition_name=<id> onto session agent` fired on both turns.
- [x] **Doc comments** — docstring on `AgentBuilder::agent_definition_name` rewritten; accessor docstring on `Agent::agent_definition_name` added; test docstrings describe the bug surfaces accurately; call-site comment block replaced with a correct narrative.
- [x] **Inline comments** — the new `log::debug!` call at the stamping site gives the fix a grep-friendly runtime trace.

## Impact

- **Runtime/platform**: desktop only. No mobile or web-only code paths touched.
- **Behavioral change**:
  - Orchestrator sessions moved from historical `main_*.md` to `orchestrator_*.md` filenames. Behaviorally identical everywhere downstream because `"main"` was already an orchestrator alias.
  - Welcome sessions move from `main_*.md` to `welcome_*.md` filenames with `agent: welcome` metadata, and no longer cross-contaminate on resume.
  - `Agent::try_load_session_transcript` looks up by the new correct `agent_definition_name`. A freshly-patched orchestrator session will not discover existing `main_*.md` files on resume — it starts cold on the first turn after the upgrade. Welcome's cold start is the correct behavior.
  - Net effect: one cold-start for orchestrator per install after upgrade; welcome sessions start clean on fresh installs and on first run after upgrade.
- **Performance**: none. One extra `String` allocation per session construction — negligible on a path that only runs at session start.
- **Security**: closes a small information-leak foot-gun (welcome transcripts were misattributed as `main` in forensics) and closes the cross-contamination path, which was loading orchestrator tool-call history (tool arguments and results) into welcome agent LLM context unintentionally.
- **Migration**: none. Config schema unchanged, no database migrations.
- **Backward compat**: the legacy `"main"` fallback in `AgentBuilder::build()` is preserved; only `build_session_agent_inner` now overrides it. Direct builder users (tests, CLI, custom agents) that never call the setter still get the `"main"` default.

## Related

- Issues: none linked. The bug was latently activated by #525 / #526 (merged in PR #544).
- Follow-up PR(s) / TODOs:
  - `welcome_proactive` publishes its generated message to socket.io as `event=proactive_message room=system thread_id=proactive:welcome`, but the React app has no subscriber for that event — it is logged via an `onAny` catch-all in `socketService.ts:182` and dropped. The welcome agent's message is never rendered anywhere user-facing. Out of scope for this PR; should be filed as a separate frontend issue.
  - Potential refactor: collapse the `"main"` alias for orchestrator by updating `debug_dump.rs:249`, the `Agent::from_config` legacy wrapper, and any other `"main" | "orchestrator"` disjunctions to use `"orchestrator"` directly. Would eliminate the historical alias and the foot-gun it creates. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent definition names are now properly propagated through the system, ensuring consistent transcript filenames and accurate metadata headers.
  * Agent identifiers are now correctly reflected in session transcripts and prompt context.

* **Tests**
  * Added regression tests to verify agent definition name handling and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->