### PR TITLE
fix(agent): use canonical assistant history format in subagent_runner

### DIFF
--- a/src/openhuman/agent/harness/subagent_runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner.rs
@@ -728,8 +728,15 @@ async fn run_inner_loop(
 
         // Persist assistant message with the original tool_calls payload so
         // subsequent role=tool messages can reference call ids correctly.
+        // Uses the canonical serialiser from `parse` — the old inline
+        // `build_native_assistant_payload` used `"text"` instead of
+        // `"content"` and nested `{"type":"function","function":{…}}`
+        // wrappers instead of flat `{id, name, arguments}`, which caused
+        // 400 errors from the backend jinja template ("Message has tool
+        // role, but there was no previous assistant message with a tool
+        // call!").
         let assistant_history_content =
-            build_native_assistant_payload(&response_text, &native_calls);
+            super::parse::build_native_assistant_history(&response_text, &native_calls);
         history.push(ChatMessage::assistant(assistant_history_content));
 
         // Execute each call, append role=tool messages.
@@ -777,31 +784,6 @@ async fn run_inner_loop(
     }
 
     Err(SubagentRunError::MaxIterationsExceeded(max_iterations))
-}
-
-fn build_native_assistant_payload(text: &str, tool_calls: &[ToolCall]) -> String {
-    // Mirror the existing native-tool-call serialisation pattern used by
-    // `agent::loop_::parse::build_native_assistant_history`. We inline a
-    // small subset here to avoid an inter-module dep cycle.
-    let calls_json: Vec<serde_json::Value> = tool_calls
-        .iter()
-        .map(|call| {
-            serde_json::json!({
-                "id": call.id,
-                "type": "function",
-                "function": {
-                    "name": call.name,
-                    "arguments": call.arguments,
-                },
-            })
-        })
-        .collect();
-
-    let payload = serde_json::json!({
-        "text": text,
-        "tool_calls": calls_json,
-    });
-    payload.to_string()
 }
 
 fn parse_tool_arguments(arguments: &str) -> serde_json::Value {


### PR DESCRIPTION
## Summary

- Fixes subagent_runner's inner tool-call loop producing 400 errors from the backend on iteration 1+: `"jinja template rendering failed. Message has tool role, but there was no previous assistant message with a tool call!"`
- Root cause: `build_native_assistant_payload` used `"text"` instead of `"content"` and nested `{"type":"function","function":{...}}` wrappers instead of flat `{id, name, arguments}` — two mismatches vs the format `parse::build_native_assistant_history` produces and the backend expects.
- Fix: replace the broken inline copy with a direct call to `parse::build_native_assistant_history` (the same serialiser `tool_loop.rs` uses successfully for the orchestrator's tool calls). Dead function removed.

## Problem

Every sub-agent that made a tool call and entered iteration 1+ hit a 400 from the backend. The backend's jinja template saw a `role=tool` message without a recognised `assistant-with-tool-calls` predecessor because the assistant message was formatted with the wrong keys and structure.

Introduced in PR #474 (`6465f3d3`, 2026-04-09). Latent since then because the orchestrator self-heals by retrying via other agents.

## Solution

One-line fix in `subagent_runner.rs`: replace `build_native_assistant_payload(&response_text, &native_calls)` with `super::parse::build_native_assistant_history(&response_text, &native_calls)`. Delete the dead function.

## E2E verification

skills_agent with gmail toolkit progressed through iterations 0->1->2 successfully (previously died at iteration 1 with the 400 error every time). code_executor also confirmed working through iteration 0->1 on staging API.

## Submission Checklist

- [x] Single file change, minimal diff
- [x] E2E verified on staging-api.tinyhumans.ai
- [x] No new dependencies

## Impact

- Unblocks ALL sub-agent multi-iteration tool calls (skills_agent, code_executor, researcher, etc.)
- Zero risk to orchestrator path (it already uses `parse::build_native_assistant_history` via `tool_loop.rs`)

## Related

- Introduced in: PR #474
- Author: @senamakel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool call ID references in agent message serialization, ensuring proper communication between sequential tool interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->