### PR TITLE
fix(onboarding): prevent home page flash after onboarding completion

### DIFF
--- a/app/src/components/OnboardingOverlay.tsx
+++ b/app/src/components/OnboardingOverlay.tsx
@@ -20,6 +20,8 @@ const OnboardingOverlay = () => {
   /** Which session token the 3s profile-timeout applied to (ref avoids stale boolean across logins). */
   const profileLoadTimedOutForTokenRef = useRef<string | null>(null);
   const [, profileTimeoutBump] = useState(0);
+  // Keep the overlay rendered while navigating away so the home page doesn't flash.
+  const [isDismissing, setIsDismissing] = useState(false);
 
   const prevTokenRef = useRef<string | null | undefined>(undefined);
   if (prevTokenRef.current !== token) {
@@ -45,18 +47,22 @@ const OnboardingOverlay = () => {
   const onboardingCompleted = snapshot.onboardingCompleted;
 
   const handleDone = useCallback(async () => {
+    // Navigate first while the overlay is still covering the screen, then
+    // persist the completed flag. This prevents the home page from flashing
+    // between overlay dismissal and route change.
+    setIsDismissing(true);
+    navigate('/conversations');
     try {
       await setOnboardingCompletedFlag(true);
     } catch {
       console.warn('[onboarding] Failed to persist onboarding_completed');
     }
-    navigate('/conversations');
   }, [setOnboardingCompletedFlag, navigate]);
 
   // Don't show if not logged in, bootstrap not complete, or user not ready
   if (!token || isBootstrapping || !userReady) return null;
 
-  const shouldShow = DEV_FORCE_ONBOARDING || !onboardingCompleted;
+  const shouldShow = isDismissing || DEV_FORCE_ONBOARDING || !onboardingCompleted;
 
   if (!shouldShow) return null;
 

--- a/app/src/components/OnboardingOverlay.tsx
+++ b/app/src/components/OnboardingOverlay.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import Onboarding from '../pages/onboarding/Onboarding';
 import { useCoreState } from '../providers/CoreStateProvider';
@@ -13,6 +13,7 @@ import { DEV_FORCE_ONBOARDING } from '../utils/config';
  * Reads `onboarding_completed` from the core config (persisted in config.toml).
  */
 const OnboardingOverlay = () => {
+  const location = useLocation();
   const navigate = useNavigate();
   const { isBootstrapping, snapshot, setOnboardingCompletedFlag } = useCoreState();
   const token = snapshot.sessionToken;
@@ -51,13 +52,27 @@ const OnboardingOverlay = () => {
     // persist the completed flag. This prevents the home page from flashing
     // between overlay dismissal and route change.
     setIsDismissing(true);
-    navigate('/conversations');
+    console.debug('[onboarding:overlay] completion finished; navigating to conversations');
+    navigate('/conversations', { replace: true });
     try {
       await setOnboardingCompletedFlag(true);
+      console.debug('[onboarding:overlay] persisted onboarding_completed=true');
     } catch {
       console.warn('[onboarding] Failed to persist onboarding_completed');
     }
   }, [setOnboardingCompletedFlag, navigate]);
+
+  useEffect(() => {
+    if (!isDismissing) return;
+    if (location.pathname === '/conversations') {
+      console.debug('[onboarding:overlay] conversations active; dismissing transition mask');
+      setIsDismissing(false);
+    }
+  }, [isDismissing, location.pathname]);
+
+  useEffect(() => {
+    setIsDismissing(false);
+  }, [token]);
 
   // Don't show if not logged in, bootstrap not complete, or user not ready
   if (!token || isBootstrapping || !userReady) return null;

--- a/app/src/components/__tests__/OnboardingOverlay.test.tsx
+++ b/app/src/components/__tests__/OnboardingOverlay.test.tsx
@@ -1,17 +1,28 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import OnboardingOverlay from '../OnboardingOverlay';
 
 const mockUseCoreState = vi.fn();
+const mockNavigate = vi.fn();
+let mockPathname = '/';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: mockPathname, search: '', hash: '', state: null, key: 'test' }),
+  };
+});
 
 vi.mock('../../providers/CoreStateProvider', () => ({ useCoreState: () => mockUseCoreState() }));
 
 vi.mock('../../pages/onboarding/Onboarding', () => ({
   default: ({ onComplete }: { onComplete: () => void }) => (
     <div>
-      <button onClick={onComplete}>Skip</button>
+      <button onClick={onComplete}>Complete</button>
     </div>
   ),
 }));
@@ -32,6 +43,8 @@ function makeCoreState(overrides?: Record<string, unknown>) {
 describe('OnboardingOverlay', () => {
   beforeEach(() => {
     mockUseCoreState.mockReset();
+    mockNavigate.mockReset();
+    mockPathname = '/';
   });
 
   it('does not render when onboarding is completed', () => {
@@ -43,7 +56,7 @@ describe('OnboardingOverlay', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByText('Skip')).not.toBeInTheDocument();
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument();
   });
 
   it('does not render when no token', () => {
@@ -55,7 +68,7 @@ describe('OnboardingOverlay', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByText('Skip')).not.toBeInTheDocument();
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument();
   });
 
   it('does not render when user profile is not loaded yet', () => {
@@ -67,7 +80,7 @@ describe('OnboardingOverlay', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByText('Skip')).not.toBeInTheDocument();
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument();
   });
 
   it('renders when the user is authenticated and onboarding is incomplete', () => {
@@ -79,7 +92,7 @@ describe('OnboardingOverlay', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText('Skip')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
   });
 
   it('does not render while bootstrapping', () => {
@@ -91,6 +104,53 @@ describe('OnboardingOverlay', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByText('Skip')).not.toBeInTheDocument();
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument();
+  });
+
+  it('navigates to conversations and persists onboarding completion on finish', async () => {
+    const coreState = makeCoreState();
+    mockUseCoreState.mockReturnValue(coreState);
+
+    render(
+      <MemoryRouter>
+        <OnboardingOverlay />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Complete'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/conversations', { replace: true });
+      expect(coreState.setOnboardingCompletedFlag).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('drops dismissing mask after conversations route becomes active', async () => {
+    const coreState = makeCoreState();
+    mockUseCoreState.mockReturnValue(coreState);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <OnboardingOverlay />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Complete'));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/conversations', { replace: true });
+    });
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+
+    mockPathname = '/conversations';
+    mockUseCoreState.mockReturnValue(makeCoreState({ onboardingCompleted: true }));
+    rerender(
+      <MemoryRouter>
+        <OnboardingOverlay />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Complete')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Prevent the onboarding completion flow from exposing the home screen between onboarding finish and conversations navigation.
- Keep the onboarding overlay mounted as a transition mask during route change, then dismiss it once `/conversations` is active.
- Preserve onboarding completion persistence while making navigation deterministic (`replace: true`) to avoid jarring back-stack behavior.
- Add regression tests for finish behavior and transition-mask teardown.

## Problem

After users clicked Continue/Finish on the onboarding overlay, the underlying home page could briefly render before the app reached `/conversations`. The intermediate flash made onboarding feel slow and visually unstable.

The previous attempt to mask this transition introduced `isDismissing` but did not reliably clear it after navigation, which risked leaving the overlay visible longer than intended.

## Solution

- **Overlay transition mask** (`app/src/components/OnboardingOverlay.tsx`):
  - On finish, set `isDismissing` before navigation so the overlay remains visible during route change.
  - Navigate to `/conversations` using `{ replace: true }`.
  - Persist `onboarding_completed=true` in the existing completion path.
  - Clear `isDismissing` when the active route becomes `/conversations`, and reset it on session token changes for safety.
- **Regression tests** (`app/src/components/__tests__/OnboardingOverlay.test.tsx`):
  - Verify finish triggers navigation to `/conversations` with replace semantics.
  - Verify onboarding completion is persisted on finish.
  - Verify transition mask is removed after conversations route activation.

## Submission Checklist

- [x] **Unit tests** — `yarn workspace openhuman-app test -- src/components/__tests__/OnboardingOverlay.test.tsx`
- [ ] **E2E / integration** — Not run in this change set (recommended manual desktop onboarding verification)
- [x] **N/A** — Core/Rust integration tests not applicable; frontend-only overlay transition fix
- [x] **Doc comments** — Existing flow comments retained and expanded with transition diagnostics
- [x] **Inline comments** — Added/kept comments around transition-mask behavior and route handoff

## Impact

- **Desktop app UI flow** (Tauri WebView on macOS/Windows/Linux): onboarding completion transition.
- No changes to Rust core, backend API, RPC contracts, or mobile targets.
- No new dependencies.

## Related

- Issue: tinyhumansai/openhuman#598
- Follow-up: Add targeted E2E coverage for onboarding completion transition on desktop.
