### PR TITLE
fix(tauri): hide main window on close instead of destroying it (#601)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Emitter, Manager, PhysicalPosition, RunEvent, WebviewWindow,
+    AppHandle, Emitter, Manager, PhysicalPosition, RunEvent, WebviewWindow, WindowEvent,
 };
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
@@ -573,7 +573,20 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(move |app_handle, event| match event {
             #[cfg(target_os = "macos")]
+            RunEvent::WindowEvent {
+                label,
+                event: WindowEvent::CloseRequested { api, .. },
+                ..
+            } if label == "main" => {
+                log::info!("[window] close requested on main window — hiding instead of destroying");
+                api.prevent_close();
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+            }
+            #[cfg(target_os = "macos")]
             RunEvent::Reopen { .. } => {
+                log::info!("[window] reopen event — showing main window");
                 show_main_window(app_handle);
             }
             RunEvent::Exit => {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -578,7 +578,9 @@ pub fn run() {
                 event: WindowEvent::CloseRequested { api, .. },
                 ..
             } if label == "main" => {
-                log::info!("[window] close requested on main window — hiding instead of destroying");
+                log::info!(
+                    "[window] close requested on main window — hiding instead of destroying"
+                );
                 api.prevent_close();
                 if let Some(window) = app_handle.get_webview_window("main") {
                     let _ = window.hide();


### PR DESCRIPTION
## Summary

- On macOS, closing the app window now hides it instead of destroying it, allowing dock icon and tray icon clicks to bring it back without a force quit and relaunch.

## Problem

- After closing the app window (Cmd+W or red close button), clicking the dock icon or tray icon did nothing — the app appeared stuck and required a force quit to reopen.
- Root cause: the `.run()` event handler had no `WindowEvent::CloseRequested` handler, so Tauri destroyed the window on close. Since a tray icon keeps the process alive, the app stayed running but `get_webview_window("main")` returned `None` on reopen attempts, silently failing.

## Solution

- Added a `#[cfg(target_os = "macos")]` handler for `RunEvent::WindowEvent { CloseRequested }` that calls `api.prevent_close()` and `window.hide()` instead of allowing window destruction.
- The existing `RunEvent::Reopen` and tray icon handlers already call `show_main_window()` which does `window.show()` + `window.unminimize()` + `window.set_focus()` — these now work because the window still exists.
- Added debug logging to both the close and reopen paths for diagnostics.

## Submission Checklist

- [ ] **Unit tests** — N/A: this is a Tauri window lifecycle change that requires manual desktop testing (build `.app` bundle, close window, click dock icon). No testable logic was extracted.
- [ ] **E2E / integration** — N/A: Tauri window events are not exercisable from WDIO/WebDriver E2E tests.
- [x] **Doc comments** — Existing `show_main_window` function is self-documenting; added log lines for runtime diagnostics.
- [x] **Inline comments** — Log messages explain the hide-instead-of-destroy intent.

## Impact

- **macOS only** — the `CloseRequested` handler is gated behind `#[cfg(target_os = "macos")]`. Windows/Linux behavior unchanged.
- No performance impact — single window hide/show call.
- Tray "Quit" and Cmd+Q still exit the app normally via `app.exit(0)` and `RunEvent::Exit`.

## Related

- Issue(s): Closes #601
- Follow-up PR(s)/TODOs: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS: The main window now hides instead of closing, keeping the application active and running in the background when you request close.
  * Enhanced event logging for macOS app reopen actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->