### PR TITLE
feat(overlay): activate main window on orb click (#605)

### DIFF
--- a/app/src-tauri/permissions/allow-core-process.toml
+++ b/app/src-tauri/permissions/allow-core-process.toml
@@ -13,5 +13,6 @@ allow = [
     "service_uninstall_direct",
     "register_dictation_hotkey",
     "unregister_dictation_hotkey",
+    "activate_main_window",
 ]
 deny = []

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -404,6 +404,13 @@ fn is_daemon_mode() -> bool {
     std::env::args().any(|arg| arg == "daemon" || arg == "--daemon")
 }
 
+/// Tauri command: bring the main window to front from any webview (e.g. overlay orb click).
+#[tauri::command]
+fn activate_main_window(app: AppHandle) {
+    log::debug!("[window] activate_main_window called from overlay");
+    show_main_window(&app);
+}
+
 fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         if let Err(err) = window.show() {
@@ -567,7 +574,8 @@ pub fn run() {
             service_status_direct,
             service_uninstall_direct,
             register_dictation_hotkey,
-            unregister_dictation_hotkey
+            unregister_dictation_hotkey,
+            activate_main_window
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -406,25 +406,25 @@ fn is_daemon_mode() -> bool {
 
 /// Tauri command: bring the main window to front from any webview (e.g. overlay orb click).
 #[tauri::command]
-fn activate_main_window(app: AppHandle) {
+fn activate_main_window(app: AppHandle) -> Result<(), String> {
     log::debug!("[window] activate_main_window called from overlay");
-    show_main_window(&app);
+    show_main_window(&app)
 }
 
-fn show_main_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
-        if let Err(err) = window.show() {
-            log::error!("[tray] failed to show main window: {err}");
-        }
-        if let Err(err) = window.unminimize() {
-            log::error!("[tray] failed to unminimize main window: {err}");
-        }
-        if let Err(err) = window.set_focus() {
-            log::error!("[tray] failed to focus main window: {err}");
-        }
-    } else {
-        log::error!("[tray] main window not found");
-    }
+fn show_main_window(app: &AppHandle) -> Result<(), String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "main window not found".to_string())?;
+    window
+        .show()
+        .map_err(|err| format!("failed to show main window: {err}"))?;
+    window
+        .unminimize()
+        .map_err(|err| format!("failed to unminimize main window: {err}"))?;
+    window
+        .set_focus()
+        .map_err(|err| format!("failed to focus main window: {err}"))?;
+    Ok(())
 }
 
 fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
@@ -451,7 +451,9 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
         .on_menu_event(|app, event| match event.id().as_ref() {
             "tray_show_window" => {
                 log::info!("[tray] action=show_window source=menu");
-                show_main_window(app);
+                if let Err(err) = show_main_window(app) {
+                    log::error!("[tray] failed to show main window from menu: {err}");
+                }
             }
             "tray_quit" => {
                 log::info!("[tray] action=quit source=menu");
@@ -467,7 +469,9 @@ fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
             } = event
             {
                 log::info!("[tray] action=show_window source=left_click");
-                show_main_window(tray.app_handle());
+                if let Err(err) = show_main_window(tray.app_handle()) {
+                    log::error!("[tray] failed to show main window from tray click: {err}");
+                }
             }
         })
         .build(app)?;
@@ -582,7 +586,9 @@ pub fn run() {
         .run(move |app_handle, event| match event {
             #[cfg(target_os = "macos")]
             RunEvent::Reopen { .. } => {
-                show_main_window(app_handle);
+                if let Err(err) = show_main_window(app_handle) {
+                    log::error!("[macos] failed to show main window on reopen: {err}");
+                }
             }
             RunEvent::Exit => {
                 if let Some(core) = app_handle.try_state::<core_process::CoreProcessHandle>() {

--- a/app/src/overlay/OverlayApp.tsx
+++ b/app/src/overlay/OverlayApp.tsx
@@ -194,6 +194,18 @@ export default function OverlayApp() {
     setBubble(null);
   }, [clearDismissTimer]);
 
+  /** Click handler for the orb: idle → bring main window to front; active → dismiss bubble. */
+  const handleOrbClick = useCallback(() => {
+    if (mode === 'idle') {
+      console.debug('[overlay] orb clicked while idle — activating main window');
+      invoke('activate_main_window').catch(err => {
+        console.error('[overlay] failed to activate main window:', err);
+      });
+    } else {
+      goIdle();
+    }
+  }, [mode, goIdle]);
+
   // ── Dictation: pressed / released ──────────────────────────────────────
   const handleDictationToggle = useCallback(
     (payload: DictationTogglePayload) => {
@@ -420,22 +432,55 @@ export default function OverlayApp() {
     userDraggedRef.current = false;
   }, []);
 
-  /** Initiate native window drag on mouse-down. */
-  const handleDragStart = useCallback(
+  // NSPanel (non-activating overlay) doesn't deliver synthesized `click`
+  // events to the webview, and calling `startDragging()` eagerly on
+  // mouse-down blocks `mouseup` from firing. We instead arm the drag only
+  // after the pointer moves past a small threshold, so a pure click fires
+  // `mouseup` normally and we can activate the main window there.
+  const pressRef = useRef<{ x: number; y: number; dragStarted: boolean } | null>(null);
+  const CLICK_SLOP_PX = 4;
+
+  /** Record mouse-down position; defer drag until the pointer actually moves. */
+  const handleDragStart = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    pressRef.current = { x: e.screenX, y: e.screenY, dragStarted: false };
+  }, []);
+
+  /** If pointer moves past the slop, escalate into a native window drag. */
+  const handleMouseMove = useCallback(
     async (e: React.MouseEvent) => {
-      // Only drag on primary button; ignore if a click handler should fire
-      if (e.button !== 0) return;
-      e.preventDefault();
+      const press = pressRef.current;
+      if (!press || press.dragStarted) return;
+      const dx = Math.abs(e.screenX - press.x);
+      const dy = Math.abs(e.screenY - press.y);
+      if (dx <= CLICK_SLOP_PX && dy <= CLICK_SLOP_PX) return;
+      press.dragStarted = true;
       try {
         const appWindow = getCurrentWindow();
         await appWindow.startDragging();
-        // After the drag completes, persist the new position
         void persistPosition();
       } catch {
         // startDragging can fail if not supported — fall through silently
       }
     },
     [persistPosition]
+  );
+
+  /**
+   * On mouse-up, treat as a click if no drag was initiated. Emulates
+   * `onClick` for the non-activating panel.
+   */
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      const press = pressRef.current;
+      pressRef.current = null;
+      if (e.button !== 0 || !press) return;
+      if (!press.dragStarted) {
+        console.debug('[overlay] orb mouseup → click');
+        handleOrbClick();
+      }
+    },
+    [handleOrbClick]
   );
 
   useEffect(() => {
@@ -549,8 +594,9 @@ export default function OverlayApp() {
                   ? 'Attention message'
                   : 'OpenHuman overlay'
             }
-            onClick={goIdle}
             onMouseDown={handleDragStart}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
             onDoubleClick={resetPosition}
             onMouseEnter={() => {
               setIsHovered(true);

--- a/app/src/overlay/OverlayApp.tsx
+++ b/app/src/overlay/OverlayApp.tsx
@@ -439,6 +439,9 @@ export default function OverlayApp() {
   // `mouseup` normally and we can activate the main window there.
   const pressRef = useRef<{ x: number; y: number; dragStarted: boolean } | null>(null);
   const CLICK_SLOP_PX = 4;
+  /** Pending single-click, deferred so a follow-up double-click can cancel it. */
+  const clickTimerRef = useRef<number | null>(null);
+  const CLICK_DOUBLE_CLICK_DELAY_MS = 250;
 
   /** Record mouse-down position; defer drag until the pointer actually moves. */
   const handleDragStart = useCallback((e: React.MouseEvent) => {
@@ -450,7 +453,15 @@ export default function OverlayApp() {
   const handleMouseMove = useCallback(
     async (e: React.MouseEvent) => {
       const press = pressRef.current;
-      if (!press || press.dragStarted) return;
+      if (!press) return;
+      // If the primary button is no longer held, a prior mouseup was missed
+      // (window-drag steals it, focus change, etc). Drop the stale press so
+      // we don't spuriously start a drag on a hover.
+      if ((e.buttons & 1) === 0) {
+        pressRef.current = null;
+        return;
+      }
+      if (press.dragStarted) return;
       const dx = Math.abs(e.screenX - press.x);
       const dy = Math.abs(e.screenY - press.y);
       if (dx <= CLICK_SLOP_PX && dy <= CLICK_SLOP_PX) return;
@@ -468,20 +479,44 @@ export default function OverlayApp() {
 
   /**
    * On mouse-up, treat as a click if no drag was initiated. Emulates
-   * `onClick` for the non-activating panel.
+   * `onClick` for the non-activating panel. The click is deferred briefly
+   * so a follow-up `dblclick` (used to reset position) can cancel it.
    */
   const handleMouseUp = useCallback(
     (e: React.MouseEvent) => {
       const press = pressRef.current;
       pressRef.current = null;
       if (e.button !== 0 || !press) return;
-      if (!press.dragStarted) {
+      if (press.dragStarted) return;
+      if (clickTimerRef.current !== null) {
+        window.clearTimeout(clickTimerRef.current);
+      }
+      clickTimerRef.current = window.setTimeout(() => {
+        clickTimerRef.current = null;
         console.debug('[overlay] orb mouseup → click');
         handleOrbClick();
-      }
+      }, CLICK_DOUBLE_CLICK_DELAY_MS);
     },
     [handleOrbClick]
   );
+
+  /** Double-click resets position — cancel any pending single-click first. */
+  const handleDoubleClick = useCallback(() => {
+    if (clickTimerRef.current !== null) {
+      window.clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+    }
+    resetPosition();
+  }, [resetPosition]);
+
+  useEffect(() => {
+    return () => {
+      if (clickTimerRef.current !== null) {
+        window.clearTimeout(clickTimerRef.current);
+        clickTimerRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const appWindow = getCurrentWindow();
@@ -597,7 +632,7 @@ export default function OverlayApp() {
             onMouseDown={handleDragStart}
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
-            onDoubleClick={resetPosition}
+            onDoubleClick={handleDoubleClick}
             onMouseEnter={() => {
               setIsHovered(true);
             }}


### PR DESCRIPTION
## Summary

- Clicking the overlay orb in idle mode now brings the main app window to the foreground (show + unminimize + focus).
- Exposes `activate_main_window` as a Tauri command so the overlay webview can reuse the existing `show_main_window` helper (the same one the tray icon uses).
- Works around NSPanel (non-activating) on macOS swallowing synthesized `click` events by emulating click on `mouseup` when the pointer stays within a 4px slop.

## Problem

The overlay orb is always visible but clicking it had no effect — the main window stayed wherever it was (hidden, minimized, or behind other apps). Users had no way to surface the main window from the orb short of using the Dock / tray icon. See [#605](https://github.com/tinyhumansai/openhuman/issues/605).

Two layered root causes had to be fixed:
1. **No command wired up** — the overlay couldn't invoke any backend function to show the main window, and the existing `show_main_window` helper in `lib.rs` was only reachable from tray / Reopen handlers.
2. **macOS NSPanel quirk** — the overlay window is reclassed to `NSPanel` with `NonactivatingPanel` style (from #528, required for fullscreen visibility). That panel doesn't become key on click, so React's synthesized `onClick` never fires on the orb. Naively adding an `onMouseUp` handler also didn't work because the existing `onMouseDown` immediately calls `startDragging()`, which takes over the native event loop and prevents `mouseup` from reaching the webview.

## Solution

**Backend (`app/src-tauri/src/lib.rs`, `app/src-tauri/permissions/allow-core-process.toml`)**

- Added a thin `#[tauri::command] fn activate_main_window(app: AppHandle)` that delegates to the existing `show_main_window(&app)` helper — same show / unminimize / set_focus flow that the tray icon and macOS Reopen event use.
- Registered the command in `generate_handler![]` and added it to the `allow-core-process` capability so the overlay window can invoke it. Without the capability entry, `invoke()` from the overlay is silently rejected.

**Frontend (`app/src/overlay/OverlayApp.tsx`)**

- `handleOrbClick`: idle → `invoke('activate_main_window')`; active → dismiss bubble (old `goIdle` behavior).
- Restructured the mouse handlers so drag is **deferred** until the pointer actually moves:
  - `onMouseDown` just records the press position — no `startDragging()` yet.
  - `onMouseMove` escalates to `startDragging()` only once the pointer moves past a 4px slop.
  - `onMouseUp` fires `handleOrbClick` if no drag was initiated.
- This preserves the existing drag-to-reposition and double-click-to-reset behaviors while adding click-to-activate.

## Submission Checklist

- [ ] **Unit tests** — N/A: behavior is user-visible interaction (mouse events + native window activation) that is not meaningful to cover with Vitest. Manual verification done.
- [ ] **E2E / integration** — N/A: the overlay runs in a separate NSPanel webview with Tauri native drag; current WDIO harness doesn't drive the overlay window.
- [x] **N/A** — see above.
- [x] **Doc comments** — `///` doc comment on the new Rust command; JSDoc-style comments on the new TS handlers; a block comment at `pressRef` explains why drag is deferred.
- [x] **Inline comments** — kept minimal; one comment near `pressRef` captures the NSPanel + `startDragging()` constraint.

## Impact

- **Platforms**: Desktop only. Tested on macOS (NSPanel path). Windows/Linux overlays aren't reclassed to `NSPanel` so click would work there regardless; the new handlers also work on those.
- **Performance**: Negligible — one ref write per mousedown, one comparison per mousemove while a press is active.
- **Security**: The new command is gated by the existing `allow-core-process` capability; only the `main` and `overlay` windows can invoke it.
- **Migration / compatibility**: No schema, storage, or protocol changes. No existing event handlers removed (drag, double-click, hover all preserved).

## Related

- Issue(s): Closes #605
- Follow-up PR(s)/TODOs: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clicking the orb when idle now activates and brings the main window to the foreground.
  * Added a user-invokable action to activate the main window.

* **Improvements**
  * Refined orb interaction: deferred drag start, improved press/move/up handling, and reliable click vs. double-click behavior.

* **Permissions**
  * App permissions updated to explicitly allow the main-window activation action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->