### PR TITLE
fix(overlay): restore status bubble visibility during voice dictation (#604)

### DIFF
--- a/app/src/overlay/OverlayApp.tsx
+++ b/app/src/overlay/OverlayApp.tsx
@@ -515,6 +515,7 @@ export default function OverlayApp() {
   }, [status]);
 
   // ── Render ────────────────────────────────────────────────────────────
+  const bubbles = useMemo<OverlayBubble[]>(() => (bubble ? [bubble] : []), [bubble]);
   const orbClassName = useMemo(() => {
     if (status === 'active') {
       return 'border-blue-950 bg-blue-700';
@@ -531,13 +532,14 @@ export default function OverlayApp() {
     <div className="flex h-screen w-screen items-end justify-end bg-transparent px-0 py-0">
       <div
         className={`relative flex select-none flex-col items-end ${status === 'active' ? 'gap-3' : 'gap-0'}`}>
-        {status === 'active' && bubble && (
-          <div className="max-w-[184px]">
-            <div className="animate-[overlay-bubble-in_220ms_ease-out]">
-              <OverlayBubbleChip key={bubble.id} bubble={bubble} />
+        <div
+          className={`flex flex-col items-end gap-2 overflow-hidden transition-all duration-200 ${status === 'active' ? 'max-w-[184px] opacity-100' : 'max-w-0 opacity-0'}`}>
+          {bubbles.map(b => (
+            <div key={b.id} className="animate-[overlay-bubble-in_220ms_ease-out]">
+              <OverlayBubbleChip key={b.id} bubble={b} />
             </div>
-          </div>
-        )}
+          ))}
+        </div>
 
         <div className="relative">
           <button


### PR DESCRIPTION
## Summary

- Restore the overlay status bubble ("Listening…", "Transcribing…") that disappeared during voice dictation.
- Revert bubble rendering to a CSS-transition-based wrapper so the DOM node is always mounted.
- Keeps fullscreen and orb-active behavior untouched.

## Problem

Issue #604 — when the voice dictation hotkey is held, the orb correctly turns blue (active) but the hovering status-text chip never renders. The typewriter animation ("Listening…", "Transcribing…") that used to appear above the orb is now missing entirely.

Root cause: commit `d4f5b9a3` (PR #585, "fix(overlay): simplify window resize and bubble rendering") changed bubble rendering from a CSS-transition-based visibility pattern (wrapper always mounted) to a conditional mount (`{status === 'active' && bubble && ...}`). The conditional mount creates a race with the async Tauri window resize: the bubble mounts when `status` flips to `active`, but the overlay webview is still the idle 50×50 size with `overflow: hidden`, so the bubble is clipped above the visible area. WKWebView does not reliably relayout after the async Tauri resize completes.

## Solution

In `app/src/overlay/OverlayApp.tsx`:

- Restore the `bubbles` memo so the render can map over an array.
- Replace the conditional mount with an always-mounted wrapper that toggles visibility via `transition-all duration-200` between `max-w-0 opacity-0` (idle) and `max-w-[184px] opacity-100` (active). Added `overflow-hidden` on the wrapper so the width collapse hides content cleanly during the idle state.

With the wrapper always in the DOM, the bubble survives the async resize race and the typewriter animation reappears as expected.

## Submission Checklist

- [ ] **Unit tests** — Vitest (`app/`) and/or `cargo test` (core) for logic you add or change
- [ ] **E2E / integration** — Where behavior is user-visible or crosses UI → Tauri → sidecar → JSON-RPC; use existing harnesses (`app/test/e2e`, mock backend, `tests/json_rpc_e2e.rs` as appropriate)
- [x] **N/A** — Visual regression fix in overlay-only rendering; existing unit tests for `OverlayApp` cover status transitions and no new logic was added. Manually verified in `yarn tauri dev`: orb activates blue on hotkey hold and the "Listening…" typewriter text appears above it.
- [ ] **Doc comments** — `///` / `//!` (Rust), JSDoc or brief file/module headers (TS) on public APIs and non-obvious modules
- [ ] **Inline comments** — Where logic, invariants, or edge cases aren't clear from names alone (keep them grep-friendly; avoid restating the code)

## Impact

- Desktop only (Tauri overlay window).
- No performance impact — one extra always-mounted wrapper `<div>` that's already hidden in idle state via `max-w-0 opacity-0`.
- No Rust or JSON-RPC surface changes.
- No fullscreen interaction: the NSPanel reclassing for fullscreen support lives entirely in `src-tauri/src/lib.rs` and is orthogonal to this React render change.

## Related

- Issue(s): Closes #604
- Follow-up PR(s)/TODOs: _none_