### PR TITLE
feat(onboarding): inject CONNECTION_STATE block into welcome-agent turns (#593)

### DIFF
--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -188,9 +188,7 @@ async fn build_connection_state_block() -> String {
             return String::new();
         }
         Err(_) => {
-            tracing::debug!(
-                "[dispatch::connection_state] config load timed out — skipping block"
-            );
+            tracing::debug!("[dispatch::connection_state] config load timed out — skipping block");
             return String::new();
         }
     };
@@ -211,9 +209,7 @@ async fn build_connection_state_block() -> String {
     };
 
     if integrations.is_empty() {
-        tracing::debug!(
-            "[dispatch::connection_state] no integrations returned — skipping block"
-        );
+        tracing::debug!("[dispatch::connection_state] no integrations returned — skipping block");
         return String::new();
     }
 

--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -156,6 +156,98 @@ fn log_worker_join_result(result: Result<(), tokio::task::JoinError>) {
     }
 }
 
+/// Build a `[CONNECTION_STATE]...[/CONNECTION_STATE]` block listing the
+/// current Composio connection status for each connected or available
+/// integration.
+///
+/// Fetches integration state at call time so the agent always sees the
+/// up-to-date status for the user's current turn (including connections
+/// that completed mid-conversation via OAuth in a browser). The fetch is
+/// wrapped in a short timeout so Composio API latency never blocks the
+/// channel turn.
+///
+/// Returns an empty string on any failure (API down, not authenticated,
+/// timeout) so the caller can safely append it without branching.
+async fn build_connection_state_block() -> String {
+    // 3-second ceiling — connection state is best-effort context. If the
+    // Composio API is slow, skip the block rather than delaying the turn.
+    const COMPOSIO_FETCH_TIMEOUT_SECS: u64 = 3;
+
+    let config = match tokio::time::timeout(
+        Duration::from_secs(COMPOSIO_FETCH_TIMEOUT_SECS),
+        Config::load_or_init(),
+    )
+    .await
+    {
+        Ok(Ok(c)) => c,
+        Ok(Err(e)) => {
+            tracing::debug!(
+                error = %e,
+                "[dispatch::connection_state] config load failed — skipping block"
+            );
+            return String::new();
+        }
+        Err(_) => {
+            tracing::debug!(
+                "[dispatch::connection_state] config load timed out — skipping block"
+            );
+            return String::new();
+        }
+    };
+
+    let integrations = match tokio::time::timeout(
+        Duration::from_secs(COMPOSIO_FETCH_TIMEOUT_SECS),
+        fetch_connected_integrations(&config),
+    )
+    .await
+    {
+        Ok(list) => list,
+        Err(_) => {
+            tracing::debug!(
+                "[dispatch::connection_state] Composio fetch timed out — skipping block"
+            );
+            return String::new();
+        }
+    };
+
+    if integrations.is_empty() {
+        tracing::debug!(
+            "[dispatch::connection_state] no integrations returned — skipping block"
+        );
+        return String::new();
+    }
+
+    let mut lines = Vec::with_capacity(integrations.len());
+    for integration in &integrations {
+        let status = if integration.connected {
+            // Include account identifier if available (first tool name often encodes it,
+            // but the toolkit slug is the clearest label available here).
+            format!("connected (toolkit: {})", integration.toolkit)
+        } else {
+            "not connected".to_string()
+        };
+        // Capitalize the toolkit name for readability (e.g. "gmail" → "Gmail").
+        let display_name = {
+            let mut chars = integration.toolkit.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+            }
+        };
+        lines.push(format!("{display_name}: {status}"));
+    }
+
+    tracing::debug!(
+        integration_count = integrations.len(),
+        "[dispatch::connection_state] built connection state block for welcome agent"
+    );
+
+    format!(
+        "\n\n[CONNECTION_STATE]\n{}\n[/CONNECTION_STATE]",
+        lines.join("\n")
+    )
+}
+
 fn spawn_scoped_typing_task(
     channel: Arc<dyn Channel>,
     recipient: String,
@@ -776,6 +868,25 @@ pub(crate) async fn process_channel_message(
     // Fresh disk read of `Config::onboarding_completed` happens inside
     // `resolve_target_agent` — see the `[dispatch::routing]` traces.
     let scoping = resolve_target_agent(&msg.channel).await;
+
+    // When routing to the welcome agent, inject up-to-date Composio connection
+    // state into the last user message so the agent always knows which
+    // integrations are live without burning a tool call to check. The block is
+    // appended — not prepended — so it does not interfere with memory context
+    // that was already prepended to `enriched_message`. Scoped strictly to the
+    // welcome agent: orchestrator turns are not annotated.
+    if scoping.target_agent_id.as_deref() == Some("welcome") {
+        let conn_block = build_connection_state_block().await;
+        if !conn_block.is_empty() {
+            if let Some(last_user_msg) = history.iter_mut().rev().find(|m| m.role == "user") {
+                last_user_msg.content.push_str(&conn_block);
+                tracing::debug!(
+                    block_chars = conn_block.len(),
+                    "[dispatch::connection_state] appended CONNECTION_STATE block to welcome-agent turn"
+                );
+            }
+        }
+    }
 
     let turn_request = AgentTurnRequest {
         provider: Arc::clone(&active_provider),


### PR DESCRIPTION
## Summary

- Added `build_connection_state_block()` to `dispatch.rs`: fetches current Composio integration status with a 3-second timeout (graceful degradation on slow/down API) and formats it as a `[CONNECTION_STATE]...[/CONNECTION_STATE]` block.
- After `resolve_target_agent` confirms the welcome agent is the target, the block is appended to the last user message in history.
- Captures OAuth completions that happened mid-conversation (user clicked auth link in chat, authenticated in browser, returned to conversation) without requiring a tool call.
- Scoped strictly to welcome-agent turns (`chat_onboarding_completed = false`). Orchestrator turns are unaffected.

## Example injection

```
[CONNECTION_STATE]
Gmail: connected (toolkit: gmail)
Slack: not connected
Notion: not connected
Google Calendar: not connected
[/CONNECTION_STATE]
```

## Test plan

- [x] `cargo check` — clean
- [x] `cargo fmt --check` — clean
- [x] `yarn lint` / `yarn typecheck` — clean
- [ ] Manual: complete UI onboarding, type a message → verify `[CONNECTION_STATE]` block appears in welcome agent context (visible in `--log-level debug`)
- [ ] Manual: complete OAuth for Gmail mid-conversation → next message shows Gmail as connected without agent calling a tool

Closes #593
Part of #599