### PR TITLE
fix(local_ai): hard-override to disabled until explicit opt-in (#573)

### DIFF
--- a/app/src/pages/onboarding/steps/LocalAIStep.tsx
+++ b/app/src/pages/onboarding/steps/LocalAIStep.tsx
@@ -125,52 +125,67 @@ const LocalAIStep = ({ onNext, onBack: _onBack, onDownloadError }: LocalAIStepPr
     );
   }
 
-  // Sufficient RAM: show the standard local AI onboarding.
+  // Sufficient RAM: local AI is opt-in. Present cloud as the primary path and
+  // local AI as an explicit choice for users who want full privacy.
   return (
     <div className="rounded-2xl border border-stone-200 bg-white p-8 shadow-soft animate-fade-up">
       <div className="flex flex-col items-center mb-5">
-        <img src="/ollama.svg" alt="Ollama" className="w-16 h-16 mb-3" />
-        <h1 className="text-xl font-bold mb-2 text-stone-900">Run AI Models Locally with Ollama</h1>
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary-50 mb-3">
+          <svg
+            className="h-8 w-8 text-primary-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z"
+            />
+          </svg>
+        </div>
+        <h1 className="text-xl font-bold mb-2 text-stone-900">Choose how AI runs</h1>
         <p className="text-stone-600 text-sm text-center">
-          OpenHuman will auto-install Ollama for you so that you can download and run AI models
-          locally on your device.
+          We&apos;ll start with a fast cloud model so you&apos;re productive right away. You can
+          switch to fully local AI any time — either now or later from Settings.
         </p>
       </div>
 
       <div className="space-y-2 mb-5">
-        <div className="rounded-xl border border-stone-200 bg-stone-50 px-3 py-2">
+        <div className="rounded-xl border border-primary-200 bg-primary-50 px-3 py-2">
           <p className="text-xs text-stone-700">
-            <span className="font-semibold">Complete Privacy</span>
+            <span className="font-semibold">Cloud AI (default)</span>
             <span className="text-stone-600">
-              &nbsp;- all data stays on your device. Nothing is sent to any third party or cloud.
+              &nbsp;— fast, lightweight, no downloads. Requires an internet connection.
             </span>
           </p>
         </div>
         <div className="rounded-xl border border-stone-200 bg-stone-50 px-3 py-2">
           <p className="text-xs text-stone-700">
-            <span className="font-semibold">Absolutely Free</span>
+            <span className="font-semibold">Local AI (opt-in)</span>
             <span className="text-stone-600">
-              &nbsp;- Ollama and the AI models are open-source. No subscription needed.
+              &nbsp;— runs fully on-device with Ollama for complete privacy. Uses disk space and
+              RAM.
             </span>
           </p>
         </div>
-        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
+        <div className="rounded-xl border border-stone-200 bg-stone-50 px-3 py-2">
           <p className="text-xs text-stone-700">
-            <span className="font-semibold">Resource impact</span>
+            <span className="font-semibold">Switch any time</span>
             <span className="text-stone-600">
-              &nbsp;- uses some disk space and RAM. We will optimize this for your device.
+              &nbsp;— change your AI mode later from Settings → Local AI Model.
             </span>
           </p>
         </div>
       </div>
 
-      <OnboardingNextButton label="Continue" onClick={handleConsent} />
+      <OnboardingNextButton label="Continue with Cloud" onClick={handleSkip} />
 
       <button
         type="button"
-        onClick={handleSkip}
+        onClick={handleConsent}
         className="mt-3 w-full text-center text-xs text-stone-400 hover:text-stone-600 transition-colors">
-        Skip — use cloud AI instead
+        Use local AI instead (install Ollama now)
       </button>
     </div>
   );

--- a/app/src/pages/onboarding/steps/__tests__/LocalAIStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/LocalAIStep.test.tsx
@@ -34,18 +34,38 @@ describe('LocalAIStep', () => {
     vi.clearAllMocks();
   });
 
-  it('happy path: advances immediately and calls onNext with correct payload', async () => {
+  it('happy path (sufficient RAM): defaults to cloud, no local AI bootstrap', async () => {
+    const { bootstrapLocalAiWithRecommendedPreset } =
+      await import('../../../../utils/localAiBootstrap');
+
     const onNext = vi.fn();
     renderWithProviders(<LocalAIStep onNext={onNext} />);
 
-    const button = await screen.findByRole('button', { name: /continue/i });
-    fireEvent.click(button);
+    const cloudButton = await screen.findByRole('button', { name: /continue with cloud/i });
+    fireEvent.click(cloudButton);
+
+    expect(onNext).toHaveBeenCalledOnce();
+    expect(onNext).toHaveBeenCalledWith({ consentGiven: false, downloadStarted: false });
+    expect(bootstrapLocalAiWithRecommendedPreset).not.toHaveBeenCalled();
+  });
+
+  it('opt-in (sufficient RAM): starts local AI bootstrap when user chooses local AI', async () => {
+    const { bootstrapLocalAiWithRecommendedPreset } =
+      await import('../../../../utils/localAiBootstrap');
+
+    const onNext = vi.fn();
+    renderWithProviders(<LocalAIStep onNext={onNext} />);
+
+    const optInButton = await screen.findByRole('button', { name: /use local ai instead/i });
+    fireEvent.click(optInButton);
 
     expect(onNext).toHaveBeenCalledOnce();
     expect(onNext).toHaveBeenCalledWith({ consentGiven: true, downloadStarted: true });
+    expect(bootstrapLocalAiWithRecommendedPreset).toHaveBeenCalledOnce();
+    expect(bootstrapLocalAiWithRecommendedPreset).toHaveBeenCalledWith(false, '[LocalAIStep]');
   });
 
-  it('error path: calls onDownloadError once when bootstrap fails', async () => {
+  it('error path: calls onDownloadError once when opt-in bootstrap fails', async () => {
     const { bootstrapLocalAiWithRecommendedPreset } =
       await import('../../../../utils/localAiBootstrap');
     vi.mocked(bootstrapLocalAiWithRecommendedPreset).mockRejectedValueOnce(
@@ -56,8 +76,8 @@ describe('LocalAIStep', () => {
     const onDownloadError = vi.fn();
     renderWithProviders(<LocalAIStep onNext={onNext} onDownloadError={onDownloadError} />);
 
-    const button = await screen.findByRole('button', { name: /continue/i });
-    fireEvent.click(button);
+    const optInButton = await screen.findByRole('button', { name: /use local ai instead/i });
+    fireEvent.click(optInButton);
 
     // onNext still fires immediately
     expect(onNext).toHaveBeenCalledOnce();
@@ -69,21 +89,7 @@ describe('LocalAIStep', () => {
     expect(onDownloadError).toHaveBeenCalledWith('Local AI setup encountered an issue');
   });
 
-  it('starts the recommended-preset bootstrap flow once', async () => {
-    const { bootstrapLocalAiWithRecommendedPreset } =
-      await import('../../../../utils/localAiBootstrap');
-
-    const onNext = vi.fn();
-    renderWithProviders(<LocalAIStep onNext={onNext} />);
-
-    const button = await screen.findByRole('button', { name: /continue/i });
-    fireEvent.click(button);
-
-    expect(bootstrapLocalAiWithRecommendedPreset).toHaveBeenCalledOnce();
-    expect(bootstrapLocalAiWithRecommendedPreset).toHaveBeenCalledWith(false, '[LocalAIStep]');
-  });
-
-  it('double-click guard: download functions called only once', async () => {
+  it('double-click guard (opt-in): bootstrap runs only once', async () => {
     const { bootstrapLocalAiWithRecommendedPreset } =
       await import('../../../../utils/localAiBootstrap');
     vi.mocked(bootstrapLocalAiWithRecommendedPreset).mockResolvedValue({} as never);
@@ -91,9 +97,9 @@ describe('LocalAIStep', () => {
     const onNext = vi.fn();
     renderWithProviders(<LocalAIStep onNext={onNext} />);
 
-    const button = await screen.findByRole('button', { name: /continue/i });
-    fireEvent.click(button);
-    fireEvent.click(button);
+    const optInButton = await screen.findByRole('button', { name: /use local ai instead/i });
+    fireEvent.click(optInButton);
+    fireEvent.click(optInButton);
 
     expect(onNext).toHaveBeenCalledOnce();
     expect(bootstrapLocalAiWithRecommendedPreset).toHaveBeenCalledOnce();

--- a/src/openhuman/config/schema/local_ai.rs
+++ b/src/openhuman/config/schema/local_ai.rs
@@ -51,6 +51,12 @@ pub struct LocalAiConfig {
     pub max_suggestions: usize,
     #[serde(default)]
     pub selected_tier: Option<String>,
+    /// Explicit MVP opt-in marker. Bootstrap disables local AI unless this is
+    /// `true`, regardless of any prior `selected_tier` value. Existing installs
+    /// (upgrading from pre-MVP) default to `false` and must re-opt-in from
+    /// Settings. Set by `apply_preset` on any non-disabled tier.
+    #[serde(default)]
+    pub opt_in_confirmed: bool,
     /// Optional path to a manually-installed Ollama binary.
     #[serde(default)]
     pub ollama_binary_path: Option<String>,
@@ -191,6 +197,7 @@ impl Default for LocalAiConfig {
             context_compaction_threshold_tokens: default_context_compaction_threshold_tokens(),
             max_suggestions: default_max_suggestions(),
             selected_tier: None,
+            opt_in_confirmed: false,
             ollama_binary_path: None,
             whisper_in_process: default_whisper_in_process(),
             voice_llm_cleanup_enabled: default_voice_llm_cleanup_enabled(),

--- a/src/openhuman/local_ai/schemas.rs
+++ b/src/openhuman/local_ai/schemas.rs
@@ -755,7 +755,11 @@ fn handle_local_ai_presets(_params: Map<String, Value>) -> ControllerFuture {
                 .map(|tier| tier.as_str().to_string())
                 .or_else(|| (!normalized.is_empty()).then_some(normalized))
         });
-        let presets = crate::openhuman::local_ai::presets::all_presets();
+        // MVP: expose only the single allowed tier (`ram_2_4gb` / `gemma3:1b-it-qat`).
+        // The full preset catalog is still available in Rust via `all_presets()`
+        // for internal use (e.g., honoring a legacy `selected_tier`), but the UI
+        // should render a single opt-in option, not 5 tier choices.
+        let presets = crate::openhuman::local_ai::presets::mvp_presets();
         tracing::debug!(
             ?recommended,
             ?current,
@@ -789,6 +793,9 @@ fn handle_local_ai_apply_preset(params: Map<String, Value>) -> ControllerFuture 
             let mut config = config_rpc::load_config_with_timeout().await?;
             config.local_ai.enabled = false;
             config.local_ai.selected_tier = Some("disabled".to_string());
+            // Explicit opt-out also clears the MVP opt-in marker so bootstrap
+            // keeps local AI off across restarts.
+            config.local_ai.opt_in_confirmed = false;
             config
                 .save()
                 .await
@@ -816,6 +823,10 @@ fn handle_local_ai_apply_preset(params: Map<String, Value>) -> ControllerFuture 
         // Re-enable local AI in case it was previously disabled via the
         // "disabled" tier, so the user can switch back to local inference.
         config.local_ai.enabled = true;
+        // Explicit tier selection is the MVP opt-in — flip the marker so
+        // `config_with_recommended_tier_if_unselected` stops hard-overriding
+        // to disabled on subsequent boots.
+        config.local_ai.opt_in_confirmed = true;
         crate::openhuman::local_ai::presets::apply_preset_to_config(&mut config.local_ai, tier);
         config
             .save()

--- a/src/openhuman/local_ai/schemas.rs
+++ b/src/openhuman/local_ai/schemas.rs
@@ -755,11 +755,7 @@ fn handle_local_ai_presets(_params: Map<String, Value>) -> ControllerFuture {
                 .map(|tier| tier.as_str().to_string())
                 .or_else(|| (!normalized.is_empty()).then_some(normalized))
         });
-        // MVP: expose only the single allowed tier (`ram_2_4gb` / `gemma3:1b-it-qat`).
-        // The full preset catalog is still available in Rust via `all_presets()`
-        // for internal use (e.g., honoring a legacy `selected_tier`), but the UI
-        // should render a single opt-in option, not 5 tier choices.
-        let presets = crate::openhuman::local_ai::presets::mvp_presets();
+        let presets = crate::openhuman::local_ai::presets::all_presets();
         tracing::debug!(
             ?recommended,
             ?current,

--- a/src/openhuman/local_ai/service/bootstrap.rs
+++ b/src/openhuman/local_ai/service/bootstrap.rs
@@ -420,8 +420,7 @@ mod tests {
             "explicit tier selection on sufficient-RAM device must stay enabled"
         );
         assert_eq!(
-            effective.local_ai.chat_model_id,
-            config.local_ai.chat_model_id,
+            effective.local_ai.chat_model_id, config.local_ai.chat_model_id,
             "explicit config must not be mutated"
         );
     }

--- a/src/openhuman/local_ai/service/bootstrap.rs
+++ b/src/openhuman/local_ai/service/bootstrap.rs
@@ -265,32 +265,28 @@ impl LocalAiService {
 }
 
 fn config_with_recommended_tier_if_unselected(config: &Config, device: &DeviceProfile) -> Config {
-    let selected_tier = config
-        .local_ai
-        .selected_tier
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
     let current_tier =
         crate::openhuman::local_ai::presets::current_tier_from_config(&config.local_ai);
 
-    // Local AI is opt-in. When the user has *not* explicitly picked a tier,
-    // default to disabled (cloud fallback) regardless of device RAM. The user
-    // can still opt in via onboarding or Settings. This is the MVP behavior:
-    // all users start on cloud and must explicitly turn local AI on.
-    if selected_tier.is_none() {
+    // Local AI is opt-in on every device. The only way to keep it enabled
+    // across a restart is an explicit opt-in (`apply_preset` on a real tier),
+    // which sets `opt_in_confirmed = true`. Every other state — fresh install,
+    // pre-MVP upgrade with a stale `selected_tier`, manual config edit — is
+    // hard-overridden to disabled here, regardless of device RAM.
+    if !config.local_ai.opt_in_confirmed {
         tracing::debug!(
             total_ram_gb = device.total_ram_gb(),
             min_required_gb = crate::openhuman::local_ai::presets::MIN_RAM_GB_FOR_LOCAL_AI,
             ?current_tier,
-            "[local_ai] bootstrap: no tier selected, defaulting to disabled (opt-in cloud fallback)"
+            selected_tier = ?config.local_ai.selected_tier,
+            "[local_ai] bootstrap: opt_in_confirmed=false, hard-overriding to disabled (cloud fallback)"
         );
         let mut effective_config = config.clone();
         effective_config.local_ai.enabled = false;
         return effective_config;
     }
 
-    // User has already picked a tier (explicit selection). Honor it as-is.
+    // User has explicitly opted in via apply_preset. Honor the config as-is.
     config.clone()
 }
 
@@ -383,9 +379,10 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_respects_explicit_tier_on_low_ram_device() {
+    fn bootstrap_honors_opt_in_on_low_ram_device() {
         let mut config = Config::default();
         config.local_ai.selected_tier = Some("ram_2_4gb".to_string());
+        config.local_ai.opt_in_confirmed = true;
         crate::openhuman::local_ai::presets::apply_preset_to_config(
             &mut config.local_ai,
             crate::openhuman::local_ai::presets::ModelTier::Ram2To4Gb,
@@ -394,22 +391,20 @@ mod tests {
 
         let effective = config_with_recommended_tier_if_unselected(&config, &device);
 
-        // User explicitly chose a tier, so local_ai stays enabled.
         assert!(
             effective.local_ai.enabled,
-            "explicit tier selection must be honored even on low-RAM device"
+            "explicit opt-in must be honored even on low-RAM device"
         );
     }
 
     #[test]
-    fn bootstrap_respects_explicit_tier_on_sufficient_ram_device() {
-        // Opt-in confirmation: once the user has picked a tier, local AI stays
-        // enabled and the config is returned untouched.
+    fn bootstrap_honors_opt_in_on_sufficient_ram_device() {
         let mut config = Config::default();
-        config.local_ai.selected_tier = Some("ram_8_16gb".to_string());
+        config.local_ai.selected_tier = Some("ram_2_4gb".to_string());
+        config.local_ai.opt_in_confirmed = true;
         crate::openhuman::local_ai::presets::apply_preset_to_config(
             &mut config.local_ai,
-            crate::openhuman::local_ai::presets::ModelTier::Ram8To16Gb,
+            crate::openhuman::local_ai::presets::ModelTier::Ram2To4Gb,
         );
         let device = test_device(16);
 
@@ -417,23 +412,35 @@ mod tests {
 
         assert!(
             effective.local_ai.enabled,
-            "explicit tier selection on sufficient-RAM device must stay enabled"
+            "explicit opt-in on sufficient-RAM device must stay enabled"
         );
         assert_eq!(
             effective.local_ai.chat_model_id, config.local_ai.chat_model_id,
-            "explicit config must not be mutated"
+            "opt-in config must not be mutated"
         );
     }
 
     #[test]
-    fn bootstrap_honors_explicit_non_mvp_tier_selection() {
+    fn bootstrap_overrides_stale_selected_tier_without_opt_in() {
+        // Existing install (pre-MVP) had `selected_tier = "ram_2_4gb"` auto-populated
+        // by old RAM-based bootstrap logic, but never went through an explicit MVP
+        // opt-in. `opt_in_confirmed = false` must hard-override to disabled.
         let mut config = Config::default();
-        config.local_ai.selected_tier = Some("high".to_string());
-        let device = test_device(8);
+        config.local_ai.enabled = true;
+        config.local_ai.selected_tier = Some("ram_2_4gb".to_string());
+        config.local_ai.opt_in_confirmed = false;
+        let device = test_device(16);
 
         let effective = config_with_recommended_tier_if_unselected(&config, &device);
 
-        // User explicitly picked a high-tier preset — honor it, no MVP clamp.
-        assert_eq!(effective.local_ai.selected_tier.as_deref(), Some("high"));
+        assert!(
+            !effective.local_ai.enabled,
+            "stale selected_tier without opt_in_confirmed must be hard-overridden to disabled"
+        );
+        assert_eq!(
+            effective.local_ai.selected_tier.as_deref(),
+            Some("ram_2_4gb"),
+            "bootstrap must leave the persisted selected_tier untouched — only the effective `enabled` flips"
+        );
     }
 }

--- a/src/openhuman/local_ai/service/bootstrap.rs
+++ b/src/openhuman/local_ai/service/bootstrap.rs
@@ -274,45 +274,24 @@ fn config_with_recommended_tier_if_unselected(config: &Config, device: &DevicePr
     let current_tier =
         crate::openhuman::local_ai::presets::current_tier_from_config(&config.local_ai);
 
-    // When the user has *not* explicitly picked a tier and the device is below
-    // the RAM floor, default to disabled (cloud fallback). The user can still
-    // opt in via Settings. This check runs first so even a "detected" tier from
-    // matching defaults gets overridden on low-RAM hosts.
-    if selected_tier.is_none()
-        && crate::openhuman::local_ai::presets::should_default_to_cloud_fallback(device)
-    {
+    // Local AI is opt-in. When the user has *not* explicitly picked a tier,
+    // default to disabled (cloud fallback) regardless of device RAM. The user
+    // can still opt in via onboarding or Settings. This is the MVP behavior:
+    // all users start on cloud and must explicitly turn local AI on.
+    if selected_tier.is_none() {
         tracing::debug!(
             total_ram_gb = device.total_ram_gb(),
             min_required_gb = crate::openhuman::local_ai::presets::MIN_RAM_GB_FOR_LOCAL_AI,
-            "[local_ai] bootstrap: device below RAM floor, defaulting to disabled (cloud fallback)"
+            ?current_tier,
+            "[local_ai] bootstrap: no tier selected, defaulting to disabled (opt-in cloud fallback)"
         );
         let mut effective_config = config.clone();
         effective_config.local_ai.enabled = false;
         return effective_config;
     }
 
-    // If the user has already picked a tier (explicit or matching defaults),
-    // honor it. No MVP ceiling — users can pick any tier.
-    if selected_tier.is_some()
-        || !matches!(
-            current_tier,
-            crate::openhuman::local_ai::presets::ModelTier::Custom
-        )
-    {
-        return config.clone();
-    }
-
-    let recommended = crate::openhuman::local_ai::presets::recommend_tier(device);
-    let mut effective_config = config.clone();
-    crate::openhuman::local_ai::presets::apply_preset_to_config(
-        &mut effective_config.local_ai,
-        recommended,
-    );
-    tracing::debug!(
-        ?recommended,
-        "[local_ai] bootstrap: no tier selected, using recommended preset"
-    );
-    effective_config
+    // User has already picked a tier (explicit selection). Honor it as-is.
+    config.clone()
 }
 
 fn format_degraded_warning(err: &str, config: &Config) -> String {
@@ -389,15 +368,17 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_keeps_enabled_on_sufficient_ram_device() {
+    fn bootstrap_defaults_to_disabled_on_sufficient_ram_device() {
+        // Local AI is opt-in. Even with >= 8 GB RAM, an unselected tier must
+        // leave local AI disabled — the user has to explicitly turn it on.
         let config = Config::default();
         let device = test_device(16);
 
         let effective = config_with_recommended_tier_if_unselected(&config, &device);
 
         assert!(
-            effective.local_ai.enabled,
-            "local_ai.enabled must stay true on >= 8 GB device"
+            !effective.local_ai.enabled,
+            "local_ai.enabled must default to false when no tier selected, regardless of RAM"
         );
     }
 
@@ -421,18 +402,27 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_keeps_default_tier_when_selection_missing_and_ram_sufficient() {
-        // Default config already matches a preset (Ram8To16Gb) and device has
-        // enough RAM, so bootstrap returns it untouched (no auto-change).
-        let config = Config::default();
-        let device = test_device(8);
+    fn bootstrap_respects_explicit_tier_on_sufficient_ram_device() {
+        // Opt-in confirmation: once the user has picked a tier, local AI stays
+        // enabled and the config is returned untouched.
+        let mut config = Config::default();
+        config.local_ai.selected_tier = Some("ram_8_16gb".to_string());
+        crate::openhuman::local_ai::presets::apply_preset_to_config(
+            &mut config.local_ai,
+            crate::openhuman::local_ai::presets::ModelTier::Ram8To16Gb,
+        );
+        let device = test_device(16);
 
         let effective = config_with_recommended_tier_if_unselected(&config, &device);
 
-        assert!(effective.local_ai.enabled);
+        assert!(
+            effective.local_ai.enabled,
+            "explicit tier selection on sufficient-RAM device must stay enabled"
+        );
         assert_eq!(
             effective.local_ai.chat_model_id,
-            config.local_ai.chat_model_id
+            config.local_ai.chat_model_id,
+            "explicit config must not be mutated"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `opt_in_confirmed` marker to local AI config; bootstrap hard-overrides `enabled=false` unless it is `true`.
- `apply_preset` sets the marker on any non-disabled tier (user's explicit choice) and clears it on `disabled`.
- Onboarding cloud-default presentation preserved; tests cover opt-in and stale-config override paths.
- Settings panel continues to render all 5 tier cards (with non-MVP tiers shown as "Coming soon" / non-selectable per PR #588) — roadmap visibility is the intended UX.

## Problem

PR #588 (MVP model lockdown) clamped `selected_tier` to the allowlisted range but did not gate enablement. On upgrade, users who already had `local_ai.enabled = true` with a saved `selected_tier` (from the pre-MVP default-on era) would still boot with local AI running, bypassing the explicit opt-in the MVP expects.

Reported behaviour: "onboarding flow didn't come for me, but the model selected was for 2-4 GB one, which shouldn't be the case — it should be default cloud, with only a single model available to opt in."

Closes #573

## Solution

Close the enablement gap with a config-schema marker + bootstrap gate, defense-in-depth against stale configs and manual edits:

1. **Schema** (`src/openhuman/config/schema/local_ai.rs`): Add `opt_in_confirmed: bool` with `#[serde(default)]` → defaults to `false` for any existing config missing the field.
2. **Bootstrap gate** (`src/openhuman/local_ai/service/bootstrap.rs`): `config_with_recommended_tier_if_unselected` hard-overrides `enabled = false` whenever `opt_in_confirmed == false`, regardless of device RAM or `selected_tier`. Every pre-MVP upgrade path therefore lands on cloud fallback.
3. **Opt-in write path** (`src/openhuman/local_ai/schemas.rs`): `apply_preset` is the single source of truth for the marker — any non-disabled tier flips it to `true`; `disabled` clears it. Onboarding and Settings already call `apply_preset`, so no frontend changes are required.

The Settings preset catalog continues to return `all_presets()` so non-MVP tiers render as "Coming soon" cards (UX established in PR #588), while the existing RPC guard rejects any `apply_preset` for a non-MVP tier.

## Submission Checklist

- [x] **Unit tests** — `cargo test --lib -- local_ai::service::bootstrap` (6/6 pass, including new `bootstrap_overrides_stale_selected_tier_without_opt_in` and renamed `bootstrap_honors_opt_in_on_*` cases); `yarn test:unit LocalAIStep` (6/6 pass); `yarn test:unit localAiBootstrap` (2/2 pass)
- [x] **Integration** — `cargo test --test json_rpc_e2e json_rpc_local_ai_device_profile_and_presets` asserts the full 5-preset catalog shape; this PR keeps that contract.
- [x] **Doc comments** — `///` on the new `opt_in_confirmed` field explaining migration semantics; module-level rationale on the bootstrap gate
- [x] **Inline comments** — Bootstrap gate explains why each non-opted-in state (fresh install, pre-MVP upgrade with stale `selected_tier`, manual config edit) is overridden; `apply_preset` explains the marker flip as the single source of truth

## Impact

- **Migration**: Existing configs without `opt_in_confirmed` (pre-#588 and post-#588 upgrades) deserialise the field as `false` → next boot lands on cloud fallback with `enabled = false`. `selected_tier` is preserved on disk for UX display; nothing is destructively rewritten.
- **UX**: Users on the affected migration path see cloud-default behaviour and must re-opt-in via onboarding or Settings → Local AI. This matches the MVP product decision that local AI is strictly opt-in.
- **Settings UI**: Unchanged — all 5 tier cards remain visible, only `ram_2_4gb` is selectable (per PR #588's "Coming soon" lockdown).
- **Performance**: No runtime change beyond one extra boolean check at bootstrap.
- **Platform**: Desktop-only (local AI never ran on mobile/web).

## Related

- Issue: https://github.com/tinyhumansai/openhuman/issues/573
- Prior PR: #588 — MVP model lockdown clamped tier selection but did not gate enablement. This PR closes the enablement gap that surfaced after #588 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
