### PR TITLE
fix(ci): unblock release-packages workflow YAML parse

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -293,36 +293,38 @@ jobs:
               });
             } catch (_) { /* label may already exist */ }
 
-            const body = `## Summary
-
-Track remaining package manager channels. Each tier reflects expected maintenance commitment from the core team.
-
-## Tier 1 — Official (core team maintains)
-
-- [ ] **npx / pnpm dlx** — zero-install via the npm package already published; document the one-liner: \`npx openhuman@latest\`
-- [ ] **Scoop (Windows)** — needs a Windows binary (un-comment the Windows matrix in \`release.yml\` first); add a \`tinyhumansai/scoop-openhuman\` bucket
-
-## Tier 2 — Community-supported (PRs welcome, core team reviews)
-
-- [ ] **AUR (Arch Linux)** — add \`PKGBUILD\` pointing at the GitHub release tarball; list in \`packages/\`
-- [ ] **Nix / nixpkgs** — upstream a \`pkgs/tools/openhuman/default.nix\` derivation; document local flake overlay as interim
-
-## Tier 3 — Planned (no timeline)
-
-- [ ] **Snap / Snapcraft** — \`snapcraft.yaml\`, publish to Snap Store
-- [ ] **Flatpak** — \`org.tinyhumans.Openhuman.yaml\`, publish to Flathub
-- [ ] **WinGet** — manifest in \`microsoft/winget-pkgs\` once Windows binary is stable
-
-## Acceptance criteria
-
-- [ ] Each official channel has a CI smoke test (install + \`openhuman --version\`)
-- [ ] Install commands appear in \`docs/install.md\`
-- [ ] Checksums shipped for all artifacts
-`;
+            const body = [
+              '## Summary',
+              '',
+              'Track remaining package manager channels. Each tier reflects expected maintenance commitment from the core team.',
+              '',
+              '## Tier 1 — Official (core team maintains)',
+              '',
+              '- [ ] **npx / pnpm dlx** — zero-install via the npm package already published; document the one-liner: `npx openhuman@latest`',
+              '- [ ] **Scoop (Windows)** — needs a Windows binary (un-comment the Windows matrix in `release.yml` first); add a `tinyhumansai/scoop-openhuman` bucket',
+              '',
+              '## Tier 2 — Community-supported (PRs welcome, core team reviews)',
+              '',
+              '- [ ] **AUR (Arch Linux)** — add `PKGBUILD` pointing at the GitHub release tarball; list in `packages/`',
+              '- [ ] **Nix / nixpkgs** — upstream a `pkgs/tools/openhuman/default.nix` derivation; document local flake overlay as interim',
+              '',
+              '## Tier 3 — Planned (no timeline)',
+              '',
+              '- [ ] **Snap / Snapcraft** — `snapcraft.yaml`, publish to Snap Store',
+              '- [ ] **Flatpak** — `org.tinyhumans.Openhuman.yaml`, publish to Flathub',
+              '- [ ] **WinGet** — manifest in `microsoft/winget-pkgs` once Windows binary is stable',
+              '',
+              '## Acceptance criteria',
+              '',
+              '- [ ] Each official channel has a CI smoke test (install + `openhuman --version`)',
+              '- [ ] Install commands appear in `docs/install.md`',
+              '- [ ] Checksums shipped for all artifacts',
+              '',
+            ].join('\n');
             const issue = await github.rest.issues.create({
               owner, repo,
               title,
               body,
               labels: [label],
             });
-            core.info(\`Created backlog issue: \${issue.data.html_url}\`);
+            core.info(`Created backlog issue: ${issue.data.html_url}`);


### PR DESCRIPTION
## Summary

- `release-packages.yml` has been failing at workflow-load time (example failing run: https://github.com/tinyhumansai/openhuman/actions/runs/24550456065) with the generic *"workflow file issue"* message and zero jobs executed.
- Root cause: inside the final `actions/github-script` step (create-backlog-issue), the JS `const body = \`## Summary ... \`` template literal spans multiple lines, but its inner markdown lines sit at column 1 — outside the `script: |` YAML literal block. YAML treats `## Tier 1 — Official (core team maintains)` as a new mapping key, fails on the missing `:`, and rejects the whole file. Confirmed locally with PyYAML:
  ```
  yaml.scanner.ScannerError: while scanning a simple key
    in ".github/workflows/release-packages.yml", line 298, column 1
    could not find expected ':'
  ```
- Consequence: no linux-arm64 CLI tarball, no Homebrew tap update, no apt repo deploy, no npm publish, no smoke tests — none of the 8 jobs ever dispatched for recent releases.

## Fix

- Rewrite the issue body as a `string[].join('\n')` so every line lives inside the `script: |` block at the correct indentation. Rendered issue body is byte-identical to the original intent.
- Drop the stray backslash-escapes (`\\\`` / `\\\${...}`) around the final `core.info(...)` template literal — they were JS-invalid even before YAML choked on the body.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-packages.yml'))"` — parses cleanly.
- [ ] Merge to `main` → GitHub re-validates the workflow on push; the red cross against the file should disappear.
- [ ] Next `release: published` event fires → verify `build-cli-linux-arm64`, `update-homebrew`, `build-apt-repo`, `publish-npm`, `create-backlog-issue` all enqueue and run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal workflow configuration for improved code maintainability with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->