### PR TITLE
feat(cache): wire-level prompt/response dumps + JSONL into session_raw/

### DIFF
--- a/src/openhuman/agent/harness/session/transcript.rs
+++ b/src/openhuman/agent/harness/session/transcript.rs
@@ -1,54 +1,69 @@
 //! Session transcript persistence for KV cache stability.
 //!
-//! Stores the **exact** `Vec<ChatMessage>` sent to the LLM provider as
-//! a human-readable `.md` file. On session resume the transcript is read
-//! back to produce byte-identical messages, ensuring the inference
-//! backend's KV cache prefix is reused rather than re-prefilled.
+//! **Source of truth**: `sessions/{DDMMYYYY}/{agent}_{index}.jsonl`
 //!
-//! ## File format
+//! Each JSONL file starts with a single metadata line (identified by an
+//! `_meta` key) followed by one JSON object per `ChatMessage`. On every
+//! write the companion `.md` file is re-rendered for human readability;
+//! it is **never** read back — all round-trip / resume logic uses the
+//! JSONL.
 //!
-//! ```text
-//! <!-- session_transcript
-//! agent: code_executor
-//! dispatcher: native
-//! cache_boundary: 1847
-//! created: 2026-04-11T14:30:00Z
-//! updated: 2026-04-11T14:35:22Z
-//! turn_count: 3
-//! -->
+//! ## JSONL schema
 //!
-//! <!--MSG role="system"-->
-//! <exact system prompt bytes>
-//! <!--/MSG-->
-//!
-//! <!--MSG role="user"-->
-//! <exact user message bytes>
-//! <!--/MSG-->
+//! **Line 1 (meta):**
+//! ```json
+//! {"_meta":{"agent":"code_executor","dispatcher":"native","cache_boundary":1847,"created":"...","updated":"...","turn_count":3,"input_tokens":5000,"output_tokens":1200,"cached_input_tokens":3500,"charged_amount_usd":0.0045}}
 //! ```
 //!
-//! Content between `<!--MSG ...-->` and `<!--/MSG-->` is the **exact**
-//! `ChatMessage.content`. The single escape: any literal `<!--/MSG-->`
-//! inside content is written as `<!--\/MSG-->` and reversed on read.
+//! **Message lines:**
+//! ```json
+//! {"role":"system","content":"..."}
+//! {"role":"user","content":"..."}
+//! {"role":"assistant","content":"...","model":"claude-...","usage":{"input":1234,"output":567,"cached_input":1000,"cost_usd":0.0012},"ts":"2026-04-17T..."}
+//! {"role":"tool","content":"..."}
+//! ```
+//!
+//! Only `role` and `content` are required. All other fields are optional.
+//! Unknown fields on read are ignored (forward-compat).
 //!
 //! ## Storage layout
 //!
 //! ```text
-//! {workspace}/sessions/DDMMYYYY/{agent}_{index}.md
+//! {workspace}/sessions/DDMMYYYY/{agent}_{index}.jsonl   ← source of truth
+//! {workspace}/sessions/DDMMYYYY/{agent}_{index}.md      ← human-readable view
 //! ```
 
 use crate::openhuman::providers::ChatMessage;
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const MSG_OPEN_PREFIX: &str = "<!--MSG role=\"";
-const MSG_OPEN_SUFFIX: &str = "\"-->";
-const MSG_CLOSE: &str = "<!--/MSG-->";
-const MSG_CLOSE_ESCAPED: &str = "<!--\\/MSG-->";
+// ── Types ────────────────────────────────────────────────────────────
+
+/// Per-message usage figures attributed to the last assistant turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageUsage {
+    pub input: u64,
+    pub output: u64,
+    pub cached_input: u64,
+    pub cost_usd: f64,
+}
+
+/// Usage + provenance for one provider response, attached to the last
+/// assistant message in a turn.
+#[derive(Debug, Clone)]
+pub struct TurnUsage {
+    pub model: String,
+    pub usage: MessageUsage,
+    /// RFC-3339 timestamp of the response.
+    pub ts: String,
+}
 
 /// Metadata header for a session transcript file.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptMeta {
     pub agent_name: String,
     pub dispatcher: String,
@@ -73,63 +88,153 @@ pub struct SessionTranscript {
     pub messages: Vec<ChatMessage>,
 }
 
-// ── Write ────────────────────────────────────────────────────────────
+// ── Internal JSONL types ─────────────────────────────────────────────
 
-/// Write a session transcript to `path`. Full rewrite (not append)
-/// because context reduction may have removed earlier messages.
+/// The `_meta` line serialisation shape.
+#[derive(Serialize, Deserialize)]
+struct MetaLine {
+    #[serde(rename = "_meta")]
+    meta: MetaPayload,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MetaPayload {
+    agent: String,
+    dispatcher: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_boundary: Option<usize>,
+    created: String,
+    updated: String,
+    turn_count: usize,
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_input_tokens: u64,
+    charged_amount_usd: f64,
+}
+
+/// One message line in the JSONL — only `role` and `content` are required.
+/// All other fields are optional; unknown fields are flattened to preserve
+/// forward-compatibility.
+#[derive(Serialize, Deserialize)]
+struct MessageLine {
+    role: String,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usage: Option<MessageUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ts: Option<String>,
+    /// Absorb any unknown fields so forward-compat reads don't error.
+    #[serde(flatten)]
+    _extra: HashMap<String, serde_json::Value>,
+}
+
+// ── Write ─────────────────────────────────────────────────────────────
+
+/// Write JSONL as source of truth **and** re-render the companion `.md`.
+///
+/// `jsonl_path` must end in `.jsonl`; the `.md` companion is derived by
+/// swapping the extension. Full rewrite on every call (not append) so
+/// that context-reduction that removed earlier messages is reflected
+/// immediately.
 pub fn write_transcript(
-    path: &Path,
+    jsonl_path: &Path,
     messages: &[ChatMessage],
     meta: &TranscriptMeta,
+    last_assistant_turn_usage: Option<&TurnUsage>,
 ) -> Result<()> {
-    if let Some(parent) = path.parent() {
+    if let Some(parent) = jsonl_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("create transcript dir {}", parent.display()))?;
     }
 
-    let mut buf = String::new();
+    // ── JSONL ────────────────────────────────────────────────────────
+    let mut jsonl_buf = String::new();
 
-    // Header
-    buf.push_str("<!-- session_transcript\n");
-    let _ = writeln!(buf, "agent: {}", meta.agent_name);
-    let _ = writeln!(buf, "dispatcher: {}", meta.dispatcher);
-    if let Some(boundary) = meta.cache_boundary {
-        let _ = writeln!(buf, "cache_boundary: {}", boundary);
-    }
-    let _ = writeln!(buf, "created: {}", meta.created);
-    let _ = writeln!(buf, "updated: {}", meta.updated);
-    let _ = writeln!(buf, "turn_count: {}", meta.turn_count);
-    if meta.input_tokens > 0 || meta.output_tokens > 0 {
-        let _ = writeln!(buf, "input_tokens: {}", meta.input_tokens);
-        let _ = writeln!(buf, "output_tokens: {}", meta.output_tokens);
-        let _ = writeln!(buf, "cached_input_tokens: {}", meta.cached_input_tokens);
-        if meta.input_tokens > 0 {
-            let cache_pct = (meta.cached_input_tokens as f64 / meta.input_tokens as f64) * 100.0;
-            let _ = writeln!(buf, "cache_hit_pct: {:.1}%", cache_pct);
-        }
-        if meta.charged_amount_usd > 0.0 {
-            let _ = writeln!(buf, "charged_usd: ${:.6}", meta.charged_amount_usd);
-        }
-    }
-    buf.push_str("-->\n");
+    // Line 1: meta header.
+    let meta_line = MetaLine {
+        meta: MetaPayload {
+            agent: meta.agent_name.clone(),
+            dispatcher: meta.dispatcher.clone(),
+            cache_boundary: meta.cache_boundary,
+            created: meta.created.clone(),
+            updated: meta.updated.clone(),
+            turn_count: meta.turn_count,
+            input_tokens: meta.input_tokens,
+            output_tokens: meta.output_tokens,
+            cached_input_tokens: meta.cached_input_tokens,
+            charged_amount_usd: meta.charged_amount_usd,
+        },
+    };
+    let meta_json = serde_json::to_string(&meta_line)
+        .context("serialise transcript meta header")?;
+    jsonl_buf.push_str(&meta_json);
+    jsonl_buf.push('\n');
 
-    // Messages
-    for msg in messages {
-        buf.push('\n');
-        let _ = writeln!(buf, "{}{}{}", MSG_OPEN_PREFIX, msg.role, MSG_OPEN_SUFFIX);
-        buf.push_str(&escape_content(&msg.content));
-        buf.push('\n');
-        buf.push_str(MSG_CLOSE);
-        buf.push('\n');
+    // Identify the index of the last assistant message so we can attach
+    // per-turn usage to it.
+    let last_assistant_idx = messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(i, m)| if m.role == "assistant" { Some(i) } else { None });
+
+    for (i, msg) in messages.iter().enumerate() {
+        let is_last_assistant =
+            Some(i) == last_assistant_idx && last_assistant_turn_usage.is_some();
+
+        let line = if is_last_assistant {
+            let tu = last_assistant_turn_usage.unwrap();
+            MessageLine {
+                role: msg.role.clone(),
+                content: msg.content.clone(),
+                model: Some(tu.model.clone()),
+                usage: Some(tu.usage.clone()),
+                ts: Some(tu.ts.clone()),
+                _extra: HashMap::new(),
+            }
+        } else {
+            MessageLine {
+                role: msg.role.clone(),
+                content: msg.content.clone(),
+                model: None,
+                usage: None,
+                ts: None,
+                _extra: HashMap::new(),
+            }
+        };
+
+        let line_json = serde_json::to_string(&line)
+            .with_context(|| format!("serialise message line {i}"))?;
+        jsonl_buf.push_str(&line_json);
+        jsonl_buf.push('\n');
     }
 
-    fs::write(path, buf.as_bytes())
-        .with_context(|| format!("write transcript {}", path.display()))?;
+    fs::write(jsonl_path, jsonl_buf.as_bytes())
+        .with_context(|| format!("write transcript {}", jsonl_path.display()))?;
 
     log::debug!(
-        "[transcript] wrote {} messages to {}",
+        "[transcript] wrote {} messages (jsonl) to {}",
         messages.len(),
-        path.display()
+        jsonl_path.display()
+    );
+
+    // ── Companion .md ────────────────────────────────────────────────
+    // Build per-message usage index for the renderer (only last assistant).
+    let mut per_msg_usage: HashMap<usize, &TurnUsage> = HashMap::new();
+    if let (Some(idx), Some(tu)) = (last_assistant_idx, last_assistant_turn_usage) {
+        per_msg_usage.insert(idx, tu);
+    }
+
+    let md_path = jsonl_path.with_extension("md");
+    let md = render_markdown(messages, meta, &per_msg_usage);
+    fs::write(&md_path, md.as_bytes())
+        .with_context(|| format!("write markdown companion {}", md_path.display()))?;
+
+    log::debug!(
+        "[transcript] wrote markdown companion to {}",
+        md_path.display()
     );
 
     Ok(())
@@ -137,19 +242,109 @@ pub fn write_transcript(
 
 // ── Read ─────────────────────────────────────────────────────────────
 
-/// Read a session transcript from `path` and return the exact messages.
-pub fn read_transcript(path: &Path) -> Result<SessionTranscript> {
-    let raw =
-        fs::read_to_string(path).with_context(|| format!("read transcript {}", path.display()))?;
+/// Read a session transcript.
+///
+/// **Primary path**: reads the `.jsonl` source of truth.
+/// **Fallback**: if the `.jsonl` does not exist but the legacy `.md` does
+/// (migration path — old sessions), reads it via the legacy HTML-comment
+/// parser and returns a `SessionTranscript` with default meta where the
+/// `.md` format didn't track a field.
+pub fn read_transcript(jsonl_path: &Path) -> Result<SessionTranscript> {
+    if jsonl_path.exists() {
+        read_transcript_jsonl(jsonl_path)
+    } else {
+        // Fallback: try the .md sibling (legacy one-release compat).
+        let md_path = jsonl_path.with_extension("md");
+        if md_path.exists() {
+            log::debug!(
+                "[transcript] .jsonl not found, falling back to legacy .md: {}",
+                md_path.display()
+            );
+            read_transcript_legacy_md(&md_path)
+        } else {
+            // Neither exists — propagate the original jsonl error.
+            read_transcript_jsonl(jsonl_path)
+        }
+    }
+}
 
-    let meta =
-        parse_meta(&raw).with_context(|| format!("parse transcript meta in {}", path.display()))?;
+fn read_transcript_jsonl(path: &Path) -> Result<SessionTranscript> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("read transcript jsonl {}", path.display()))?;
 
-    let messages = parse_messages(&raw)
-        .with_context(|| format!("parse transcript messages in {}", path.display()))?;
+    let mut meta: Option<TranscriptMeta> = None;
+    let mut messages: Vec<ChatMessage> = Vec::new();
+
+    for (line_no, line) in raw.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        // Attempt to detect meta line cheaply before deserialising the whole thing.
+        if line.contains("\"_meta\"") {
+            match serde_json::from_str::<MetaLine>(line) {
+                Ok(ml) => {
+                    let mp = ml.meta;
+                    meta = Some(TranscriptMeta {
+                        agent_name: mp.agent,
+                        dispatcher: mp.dispatcher,
+                        cache_boundary: mp.cache_boundary,
+                        created: mp.created,
+                        updated: mp.updated,
+                        turn_count: mp.turn_count,
+                        input_tokens: mp.input_tokens,
+                        output_tokens: mp.output_tokens,
+                        cached_input_tokens: mp.cached_input_tokens,
+                        charged_amount_usd: mp.charged_amount_usd,
+                    });
+                    continue;
+                }
+                Err(err) => {
+                    log::warn!(
+                        "[transcript] failed to parse meta line {} in {}: {err}",
+                        line_no + 1,
+                        path.display()
+                    );
+                    // If the very first non-empty line fails to parse as meta, error out.
+                    if meta.is_none() {
+                        return Err(anyhow::anyhow!(
+                            "first non-empty line of {} is not a valid _meta object: {err}",
+                            path.display()
+                        ));
+                    }
+                    continue;
+                }
+            }
+        }
+
+        // Message line.
+        match serde_json::from_str::<MessageLine>(line) {
+            Ok(ml) => {
+                messages.push(ChatMessage {
+                    role: ml.role,
+                    content: ml.content,
+                });
+            }
+            Err(err) => {
+                log::warn!(
+                    "[transcript] skipping malformed message line {} in {}: {err}",
+                    line_no + 1,
+                    path.display()
+                );
+            }
+        }
+    }
+
+    let meta = meta.with_context(|| {
+        format!(
+            "missing _meta header line in jsonl transcript {}",
+            path.display()
+        )
+    })?;
 
     log::debug!(
-        "[transcript] loaded {} messages from {}",
+        "[transcript] loaded {} messages (jsonl) from {}",
         messages.len(),
         path.display()
     );
@@ -160,17 +355,19 @@ pub fn read_transcript(path: &Path) -> Result<SessionTranscript> {
 // ── Path resolution ──────────────────────────────────────────────────
 
 /// Resolve a new transcript path under
-/// `{workspace}/sessions/DDMMYYYY/{agent}_{index}.md`.
+/// `{workspace}/sessions/DDMMYYYY/{agent}_{index}.jsonl`.
 ///
 /// Creates the date directory if needed. Index = max existing + 1.
+/// Scans both `.jsonl` **and** `.md` files when computing the next index
+/// so indices don't collide during migration.
 pub fn resolve_new_transcript_path(workspace_dir: &Path, agent_name: &str) -> Result<PathBuf> {
     let date_dir = today_session_dir(workspace_dir);
     fs::create_dir_all(&date_dir)
         .with_context(|| format!("create session dir {}", date_dir.display()))?;
 
     let sanitized = sanitize_agent_name(agent_name);
-    let next_index = next_index(&date_dir, &sanitized)?;
-    let filename = format!("{}_{}.md", sanitized, next_index);
+    let next_idx = next_index(&date_dir, &sanitized)?;
+    let filename = format!("{}_{}.jsonl", sanitized, next_idx);
 
     Ok(date_dir.join(filename))
 }
@@ -178,12 +375,12 @@ pub fn resolve_new_transcript_path(workspace_dir: &Path, agent_name: &str) -> Re
 /// Find the most recent transcript for `agent_name`.
 ///
 /// Searches today's directory first, then yesterday's. Returns the
-/// file with the highest index (most recent session).
+/// `.jsonl` with the highest index (or falls back to `.md` when only legacy
+/// files exist).
 pub fn find_latest_transcript(workspace_dir: &Path, agent_name: &str) -> Option<PathBuf> {
     let sanitized = sanitize_agent_name(agent_name);
     let sessions_root = workspace_dir.join("sessions");
 
-    // Search today first, then yesterday
     let today = chrono::Local::now().format("%d%m%Y").to_string();
     let yesterday = (chrono::Local::now() - chrono::Duration::days(1))
         .format("%d%m%Y")
@@ -202,28 +399,101 @@ pub fn find_latest_transcript(workspace_dir: &Path, agent_name: &str) -> Option<
     None
 }
 
-// ── Internals ────────────────────────────────────────────────────────
+// ── Markdown rendering ────────────────────────────────────────────────
 
-/// Escape the closing delimiter so it cannot appear literally in message
-/// content. Replaces `<!--/MSG-->` with `<!--\/MSG-->`.
+/// Render a human-readable markdown representation of the transcript.
 ///
-/// **Known edge case:** if the original content already contains the literal
-/// escape sequence `<!--\/MSG-->`, `unescape_content` will convert it into
-/// `<!--/MSG-->`, corrupting the round-trip. In practice this sequence is
-/// vanishingly unlikely in LLM output. A fully reversible fix would require
-/// a two-pass escaping scheme (e.g. also escaping the backslash), but that
-/// added complexity is not warranted unless the edge case materialises.
-fn escape_content(content: &str) -> String {
-    content.replace(MSG_CLOSE, MSG_CLOSE_ESCAPED)
+/// This output is **for humans only** — it is never read back by the
+/// application. All resume / round-trip logic uses the JSONL source of truth.
+fn render_markdown(
+    messages: &[ChatMessage],
+    meta: &TranscriptMeta,
+    per_message_usage: &HashMap<usize, &TurnUsage>,
+) -> String {
+    let mut buf = String::new();
+
+    let _ = writeln!(buf, "# Session transcript — {}", meta.agent_name);
+    buf.push('\n');
+    let _ = writeln!(buf, "- Dispatcher: {}", meta.dispatcher);
+    if let Some(boundary) = meta.cache_boundary {
+        let _ = writeln!(buf, "- Cache boundary: {}", boundary);
+    }
+    let _ = writeln!(buf, "- Turns: {}", meta.turn_count);
+    if meta.input_tokens > 0 || meta.output_tokens > 0 {
+        let cache_pct = if meta.input_tokens > 0 {
+            (meta.cached_input_tokens as f64 / meta.input_tokens as f64) * 100.0
+        } else {
+            0.0
+        };
+        let _ = writeln!(
+            buf,
+            "- Tokens: {} in / {} out / {} cached ({:.1}% hit)",
+            meta.input_tokens, meta.output_tokens, meta.cached_input_tokens, cache_pct
+        );
+    }
+    if meta.charged_amount_usd > 0.0 {
+        let _ = writeln!(buf, "- Charged: ${:.6}", meta.charged_amount_usd);
+    }
+    let _ = writeln!(buf, "- Updated: {}", meta.updated);
+
+    for (i, msg) in messages.iter().enumerate() {
+        buf.push_str("\n---\n\n");
+
+        if let Some(tu) = per_message_usage.get(&i) {
+            let _ = writeln!(
+                buf,
+                "## [{}] · {} · {} in / {} out / {} cached · ${:.6}",
+                msg.role,
+                tu.model,
+                tu.usage.input,
+                tu.usage.output,
+                tu.usage.cached_input,
+                tu.usage.cost_usd
+            );
+        } else {
+            let _ = writeln!(buf, "## [{}]", msg.role);
+        }
+
+        buf.push('\n');
+        buf.push_str(&msg.content);
+        buf.push('\n');
+    }
+
+    buf
 }
 
-/// Reverse the escaping applied by [`escape_content`]. See that function's
-/// doc comment for the known edge case with pre-existing escape sequences.
-fn unescape_content(content: &str) -> String {
-    content.replace(MSG_CLOSE_ESCAPED, MSG_CLOSE)
+// ── Legacy .md reader (one-release migration compat) ─────────────────
+
+/// Read a legacy HTML-comment `.md` transcript. Used as a fallback when
+/// only a `.md` exists (no `.jsonl` sibling).
+///
+/// Returns a `SessionTranscript` with whatever fields the `.md` tracked;
+/// fields the old format didn't carry are defaulted.
+pub fn read_transcript_legacy_md(path: &Path) -> Result<SessionTranscript> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("read legacy transcript {}", path.display()))?;
+
+    let meta = parse_legacy_meta(&raw)
+        .with_context(|| format!("parse legacy transcript meta in {}", path.display()))?;
+
+    let messages = parse_legacy_messages(&raw)
+        .with_context(|| format!("parse legacy transcript messages in {}", path.display()))?;
+
+    log::debug!(
+        "[transcript] loaded {} messages (legacy md) from {}",
+        messages.len(),
+        path.display()
+    );
+
+    Ok(SessionTranscript { meta, messages })
 }
 
-fn parse_meta(raw: &str) -> Result<TranscriptMeta> {
+const LEGACY_MSG_OPEN_PREFIX: &str = "<!--MSG role=\"";
+const LEGACY_MSG_OPEN_SUFFIX: &str = "\"-->";
+const LEGACY_MSG_CLOSE: &str = "<!--/MSG-->";
+const LEGACY_MSG_CLOSE_ESCAPED: &str = "<!--\\/MSG-->";
+
+fn parse_legacy_meta(raw: &str) -> Result<TranscriptMeta> {
     let header_start = raw
         .find("<!-- session_transcript")
         .context("missing session_transcript header")?;
@@ -265,52 +535,47 @@ fn parse_meta(raw: &str) -> Result<TranscriptMeta> {
     })
 }
 
-fn parse_messages(raw: &str) -> Result<Vec<ChatMessage>> {
+fn parse_legacy_messages(raw: &str) -> Result<Vec<ChatMessage>> {
     let mut messages = Vec::new();
     let mut search_from = 0;
 
     loop {
-        // Find next <!--MSG role="..."--> opening tag
-        let Some(open_start) = raw[search_from..].find(MSG_OPEN_PREFIX) else {
+        let Some(open_start) = raw[search_from..].find(LEGACY_MSG_OPEN_PREFIX) else {
             break;
         };
         let open_start = search_from + open_start;
-        let after_prefix = open_start + MSG_OPEN_PREFIX.len();
+        let after_prefix = open_start + LEGACY_MSG_OPEN_PREFIX.len();
 
-        // Extract role from between the quotes
-        let Some(role_end) = raw[after_prefix..].find(MSG_OPEN_SUFFIX) else {
+        let Some(role_end) = raw[after_prefix..].find(LEGACY_MSG_OPEN_SUFFIX) else {
             break;
         };
         let role = raw[after_prefix..after_prefix + role_end].to_string();
 
-        // Content starts after the opening tag + newline
-        let content_start = after_prefix + role_end + MSG_OPEN_SUFFIX.len();
+        let content_start = after_prefix + role_end + LEGACY_MSG_OPEN_SUFFIX.len();
         let content_start = if raw[content_start..].starts_with('\n') {
             content_start + 1
         } else {
             content_start
         };
 
-        // Find closing tag
-        let close_tag = format!("\n{MSG_CLOSE}");
+        let close_tag = format!("\n{LEGACY_MSG_CLOSE}");
         let Some(content_end_rel) = raw[content_start..].find(&close_tag) else {
-            // Try without leading newline for empty content
-            let Some(content_end_rel) = raw[content_start..].find(MSG_CLOSE) else {
+            let Some(content_end_rel) = raw[content_start..].find(LEGACY_MSG_CLOSE) else {
                 break;
             };
             let content = &raw[content_start..content_start + content_end_rel];
             messages.push(ChatMessage {
                 role,
-                content: unescape_content(content),
+                content: content.replace(LEGACY_MSG_CLOSE_ESCAPED, LEGACY_MSG_CLOSE),
             });
-            search_from = content_start + content_end_rel + MSG_CLOSE.len();
+            search_from = content_start + content_end_rel + LEGACY_MSG_CLOSE.len();
             continue;
         };
 
         let content = &raw[content_start..content_start + content_end_rel];
         messages.push(ChatMessage {
             role,
-            content: unescape_content(content),
+            content: content.replace(LEGACY_MSG_CLOSE_ESCAPED, LEGACY_MSG_CLOSE),
         });
 
         search_from = content_start + content_end_rel + close_tag.len();
@@ -318,6 +583,8 @@ fn parse_messages(raw: &str) -> Result<Vec<ChatMessage>> {
 
     Ok(messages)
 }
+
+// ── Private helpers ───────────────────────────────────────────────────
 
 fn today_session_dir(workspace_dir: &Path) -> PathBuf {
     let date = chrono::Local::now().format("%d%m%Y").to_string();
@@ -336,6 +603,10 @@ fn sanitize_agent_name(name: &str) -> String {
         .collect()
 }
 
+/// Compute the next free index for `agent_prefix` in `dir`.
+///
+/// Considers both `.jsonl` and `.md` files so that indices stay unique
+/// during the one-release migration window when both extensions may exist.
 fn next_index(dir: &Path, agent_prefix: &str) -> Result<usize> {
     let prefix = format!("{}_", agent_prefix);
     let mut max_idx: Option<usize> = None;
@@ -344,11 +615,20 @@ fn next_index(dir: &Path, agent_prefix: &str) -> Result<usize> {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if name.starts_with(&prefix) && name.ends_with(".md") {
-                let idx_str = &name[prefix.len()..name.len() - 3];
-                if let Ok(idx) = idx_str.parse::<usize>() {
-                    max_idx = Some(max_idx.map_or(idx, |m: usize| m.max(idx)));
-                }
+            if !name.starts_with(&prefix) {
+                continue;
+            }
+            // Accept both extensions.
+            let stem_end = if name.ends_with(".jsonl") {
+                name.len() - 6
+            } else if name.ends_with(".md") {
+                name.len() - 3
+            } else {
+                continue;
+            };
+            let idx_str = &name[prefix.len()..stem_end];
+            if let Ok(idx) = idx_str.parse::<usize>() {
+                max_idx = Some(max_idx.map_or(idx, |m: usize| m.max(idx)));
             }
         }
     }
@@ -356,26 +636,58 @@ fn next_index(dir: &Path, agent_prefix: &str) -> Result<usize> {
     Ok(max_idx.map_or(0, |m| m + 1))
 }
 
+/// Find the latest transcript file for `agent_prefix` in `dir`.
+///
+/// Prefers `.jsonl` files; falls back to `.md` if no `.jsonl` exists
+/// (legacy sessions). When both exist for the same index the `.jsonl`
+/// wins.
 fn latest_in_dir(dir: &Path, agent_prefix: &str) -> Option<PathBuf> {
     let prefix = format!("{}_", agent_prefix);
-    let mut best: Option<(usize, PathBuf)> = None;
+    // Track best (index, path) for each extension.
+    let mut best_jsonl: Option<(usize, PathBuf)> = None;
+    let mut best_md: Option<(usize, PathBuf)> = None;
 
     let entries = fs::read_dir(dir).ok()?;
     for entry in entries.flatten() {
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
-        if name_str.starts_with(&prefix) && name_str.ends_with(".md") {
+        if !name_str.starts_with(&prefix) {
+            continue;
+        }
+        if name_str.ends_with(".jsonl") {
+            let idx_str = &name_str[prefix.len()..name_str.len() - 6];
+            if let Ok(idx) = idx_str.parse::<usize>() {
+                if best_jsonl.as_ref().is_none_or(|(best_idx, _)| idx > *best_idx) {
+                    best_jsonl = Some((idx, entry.path()));
+                }
+            }
+        } else if name_str.ends_with(".md") {
             let idx_str = &name_str[prefix.len()..name_str.len() - 3];
             if let Ok(idx) = idx_str.parse::<usize>() {
-                if best.as_ref().is_none_or(|(best_idx, _)| idx > *best_idx) {
-                    best = Some((idx, entry.path()));
+                if best_md.as_ref().is_none_or(|(best_idx, _)| idx > *best_idx) {
+                    best_md = Some((idx, entry.path()));
                 }
             }
         }
     }
 
-    best.map(|(_, path)| path)
+    // Prefer the best .jsonl; fall back to .md if no .jsonl exists.
+    match (best_jsonl, best_md) {
+        (Some(jsonl), Some(md)) => {
+            // Take the one with the higher index; on a tie prefer .jsonl.
+            if md.0 > jsonl.0 {
+                Some(md.1)
+            } else {
+                Some(jsonl.1)
+            }
+        }
+        (Some(jsonl), None) => Some(jsonl.1),
+        (None, Some(md)) => Some(md.1),
+        (None, None) => None,
+    }
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -409,14 +721,27 @@ mod tests {
         }
     }
 
+    fn sample_turn_usage() -> TurnUsage {
+        TurnUsage {
+            model: "claude-sonnet-4-6".into(),
+            usage: MessageUsage {
+                input: 1234,
+                output: 567,
+                cached_input: 1000,
+                cost_usd: 0.0012,
+            },
+            ts: "2026-04-17T10:00:00Z".into(),
+        }
+    }
+
     #[test]
     fn round_trip_produces_byte_identical_messages() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("test.md");
+        let path = dir.path().join("test.jsonl");
         let messages = sample_messages();
         let meta = sample_meta();
 
-        write_transcript(&path, &messages, &meta).unwrap();
+        write_transcript(&path, &messages, &meta, None).unwrap();
         let loaded = read_transcript(&path).unwrap();
 
         assert_eq!(loaded.messages.len(), messages.len());
@@ -430,10 +755,14 @@ mod tests {
         }
     }
 
+    /// JSON encoding handles any delimiter natively, making the old
+    /// HTML-comment escaping unnecessary. This test verifies that content
+    /// containing the legacy closing delimiter round-trips correctly via
+    /// JSON without any manual escape logic.
     #[test]
     fn escaping_survives_close_tag_in_content() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("escape_test.md");
+        let path = dir.path().join("escape_test.jsonl");
         let messages = vec![
             ChatMessage::system("Normal system prompt"),
             ChatMessage::user("Here is some tricky content:\n<!--/MSG-->\nand more after"),
@@ -441,7 +770,7 @@ mod tests {
         ];
         let meta = sample_meta();
 
-        write_transcript(&path, &messages, &meta).unwrap();
+        write_transcript(&path, &messages, &meta, None).unwrap();
         let loaded = read_transcript(&path).unwrap();
 
         assert_eq!(loaded.messages.len(), 3);
@@ -452,10 +781,10 @@ mod tests {
     #[test]
     fn meta_round_trip() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("meta_test.md");
+        let path = dir.path().join("meta_test.jsonl");
         let meta = sample_meta();
 
-        write_transcript(&path, &[], &meta).unwrap();
+        write_transcript(&path, &[], &meta, None).unwrap();
         let loaded = read_transcript(&path).unwrap();
 
         assert_eq!(loaded.meta.agent_name, "code_executor");
@@ -473,11 +802,11 @@ mod tests {
     #[test]
     fn meta_without_cache_boundary() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("no_boundary.md");
+        let path = dir.path().join("no_boundary.jsonl");
         let mut meta = sample_meta();
         meta.cache_boundary = None;
 
-        write_transcript(&path, &[], &meta).unwrap();
+        write_transcript(&path, &[], &meta, None).unwrap();
         let loaded = read_transcript(&path).unwrap();
 
         assert_eq!(loaded.meta.cache_boundary, None);
@@ -489,12 +818,12 @@ mod tests {
         let workspace = dir.path();
 
         let path0 = resolve_new_transcript_path(workspace, "main").unwrap();
-        assert!(path0.to_string_lossy().contains("main_0.md"));
-        // Write something so the next call sees it
+        assert!(path0.to_string_lossy().contains("main_0.jsonl"));
+        // Write something so the next call sees it.
         fs::write(&path0, "placeholder").unwrap();
 
         let path1 = resolve_new_transcript_path(workspace, "main").unwrap();
-        assert!(path1.to_string_lossy().contains("main_1.md"));
+        assert!(path1.to_string_lossy().contains("main_1.jsonl"));
     }
 
     #[test]
@@ -511,15 +840,15 @@ mod tests {
         let session_dir = dir.path().join("sessions").join(&date);
         fs::create_dir_all(&session_dir).unwrap();
 
-        fs::write(session_dir.join("main_0.md"), "a").unwrap();
-        fs::write(session_dir.join("main_2.md"), "c").unwrap();
-        fs::write(session_dir.join("main_1.md"), "b").unwrap();
-        fs::write(session_dir.join("other_0.md"), "x").unwrap();
+        fs::write(session_dir.join("main_0.jsonl"), "a").unwrap();
+        fs::write(session_dir.join("main_2.jsonl"), "c").unwrap();
+        fs::write(session_dir.join("main_1.jsonl"), "b").unwrap();
+        fs::write(session_dir.join("other_0.jsonl"), "x").unwrap();
 
         let latest = find_latest_transcript(dir.path(), "main");
         assert!(latest.is_some());
         let latest = latest.unwrap();
-        assert!(latest.to_string_lossy().contains("main_2.md"));
+        assert!(latest.to_string_lossy().contains("main_2.jsonl"));
     }
 
     #[test]
@@ -531,7 +860,7 @@ mod tests {
     #[test]
     fn empty_content_message_round_trips() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("empty.md");
+        let path = dir.path().join("empty.jsonl");
         let messages = vec![
             ChatMessage::system("prompt"),
             ChatMessage::assistant(""),
@@ -539,7 +868,7 @@ mod tests {
         ];
         let meta = sample_meta();
 
-        write_transcript(&path, &messages, &meta).unwrap();
+        write_transcript(&path, &messages, &meta, None).unwrap();
         let loaded = read_transcript(&path).unwrap();
 
         assert_eq!(loaded.messages.len(), 3);
@@ -549,14 +878,134 @@ mod tests {
     #[test]
     fn multiline_content_preserves_exact_whitespace() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("whitespace.md");
+        let path = dir.path().join("whitespace.jsonl");
         let content = "  leading spaces\n\n\nmultiple blanks\n  trailing  ";
         let messages = vec![ChatMessage::user(content)];
         let meta = sample_meta();
 
-        write_transcript(&path, &messages, &meta).unwrap();
+        write_transcript(&path, &messages, &meta, None).unwrap();
         let loaded = read_transcript(&path).unwrap();
 
         assert_eq!(loaded.messages[0].content, content);
+    }
+
+    #[test]
+    fn usage_round_trips_on_last_assistant_message() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("usage.jsonl");
+        let messages = sample_messages();
+        let meta = sample_meta();
+        let tu = sample_turn_usage();
+
+        write_transcript(&path, &messages, &meta, Some(&tu)).unwrap();
+
+        // Verify by reading raw JSONL lines: the last assistant line should
+        // carry model + usage + ts fields.
+        let raw = fs::read_to_string(&path).unwrap();
+        let last_assistant_line = raw
+            .lines()
+            .filter(|l| l.contains("\"role\":\"assistant\""))
+            .last()
+            .expect("should have an assistant line");
+
+        assert!(
+            last_assistant_line.contains("claude-sonnet-4-6"),
+            "model missing from last assistant line"
+        );
+        assert!(
+            last_assistant_line.contains("\"cost_usd\""),
+            "cost_usd missing"
+        );
+
+        // Messages themselves still round-trip byte-identically.
+        let loaded = read_transcript(&path).unwrap();
+        assert_eq!(loaded.messages.len(), messages.len());
+        for (orig, got) in messages.iter().zip(loaded.messages.iter()) {
+            assert_eq!(orig.role, got.role);
+            assert_eq!(orig.content, got.content);
+        }
+    }
+
+    #[test]
+    fn md_companion_file_is_written() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("companion.jsonl");
+        let messages = sample_messages();
+        let meta = sample_meta();
+        let tu = sample_turn_usage();
+
+        write_transcript(&path, &messages, &meta, Some(&tu)).unwrap();
+
+        let md_path = path.with_extension("md");
+        assert!(md_path.exists(), ".md companion should be written");
+        let md = fs::read_to_string(&md_path).unwrap();
+        assert!(md.contains("# Session transcript — code_executor"));
+        assert!(md.contains("claude-sonnet-4-6"), "model should appear in md");
+        assert!(md.contains("## [system]"), "system section missing");
+        assert!(md.contains("## [user]"), "user section missing");
+    }
+
+    #[test]
+    fn legacy_md_fallback_reads_old_session() {
+        let dir = TempDir::new().unwrap();
+        // Write a legacy .md file directly (old format).
+        let md_path = dir.path().join("legacy.md");
+        let legacy_content = "<!-- session_transcript\nagent: test_agent\ndispatcher: native\ncache_boundary: 100\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:01:00Z\nturn_count: 1\ninput_tokens: 10\noutput_tokens: 5\ncached_input_tokens: 3\n-->\n\n<!--MSG role=\"system\"-->\nhello\n<!--/MSG-->\n";
+        fs::write(&md_path, legacy_content).unwrap();
+
+        // read_transcript called with a .jsonl path that doesn't exist
+        // should fall back to the .md sibling.
+        let jsonl_path = dir.path().join("legacy.jsonl");
+        let loaded = read_transcript(&jsonl_path).unwrap();
+        assert_eq!(loaded.meta.agent_name, "test_agent");
+        assert_eq!(loaded.meta.cache_boundary, Some(100));
+        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages[0].role, "system");
+        assert_eq!(loaded.messages[0].content, "hello");
+    }
+
+    #[test]
+    fn unknown_fields_on_jsonl_lines_are_ignored() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("forward_compat.jsonl");
+
+        // Write a JSONL with future unknown fields.
+        let content = concat!(
+            r#"{"_meta":{"agent":"a","dispatcher":"native","created":"t","updated":"t","turn_count":0,"input_tokens":0,"output_tokens":0,"cached_input_tokens":0,"charged_amount_usd":0.0}}"#,
+            "\n",
+            r#"{"role":"user","content":"hello","future_field":"ignored","another":42}"#,
+            "\n"
+        );
+        fs::write(&path, content).unwrap();
+
+        let loaded = read_transcript(&path).unwrap();
+        assert_eq!(loaded.messages.len(), 1);
+        assert_eq!(loaded.messages[0].role, "user");
+        assert_eq!(loaded.messages[0].content, "hello");
+    }
+
+    #[test]
+    fn next_index_counts_both_jsonl_and_md_files() {
+        let dir = TempDir::new().unwrap();
+        // Mix of legacy .md and new .jsonl for the same agent.
+        fs::write(dir.path().join("main_0.md"), "legacy").unwrap();
+        fs::write(dir.path().join("main_1.jsonl"), "new").unwrap();
+
+        let next = next_index(dir.path(), "main").unwrap();
+        assert_eq!(next, 2, "should account for both .md and .jsonl when computing next index");
+    }
+
+    #[test]
+    fn latest_in_dir_prefers_jsonl_over_md() {
+        let dir = TempDir::new().unwrap();
+        // Same index: both .jsonl and .md exist — .jsonl should win.
+        fs::write(dir.path().join("main_0.md"), "legacy").unwrap();
+        fs::write(dir.path().join("main_0.jsonl"), "new").unwrap();
+
+        let latest = latest_in_dir(dir.path(), "main").unwrap();
+        assert!(
+            latest.to_string_lossy().ends_with(".jsonl"),
+            "should prefer .jsonl when both exist at same index"
+        );
     }
 }

--- a/src/openhuman/agent/harness/session/transcript.rs
+++ b/src/openhuman/agent/harness/session/transcript.rs
@@ -174,37 +174,29 @@ pub fn write_transcript(
 
     // Identify the index of the last assistant message so we can attach
     // per-turn usage to it.
-    let last_assistant_idx = messages.iter().enumerate().rev().find_map(|(i, m)| {
-        if m.role == "assistant" {
-            Some(i)
-        } else {
-            None
-        }
-    });
+    let last_assistant_idx = messages.iter().rposition(|m| m.role == "assistant");
 
     for (i, msg) in messages.iter().enumerate() {
-        let is_last_assistant =
-            Some(i) == last_assistant_idx && last_assistant_turn_usage.is_some();
-
-        let line = if is_last_assistant {
-            let tu = last_assistant_turn_usage.unwrap();
-            MessageLine {
+        // Only the last assistant message carries usage/model/ts; every
+        // other line has those fields omitted. Pattern-match both
+        // options together so there's no separate unwrap.
+        let line = match (last_assistant_idx, last_assistant_turn_usage) {
+            (Some(idx), Some(tu)) if idx == i => MessageLine {
                 role: msg.role.clone(),
                 content: msg.content.clone(),
                 model: Some(tu.model.clone()),
                 usage: Some(tu.usage.clone()),
                 ts: Some(tu.ts.clone()),
                 _extra: HashMap::new(),
-            }
-        } else {
-            MessageLine {
+            },
+            _ => MessageLine {
                 role: msg.role.clone(),
                 content: msg.content.clone(),
                 model: None,
                 usage: None,
                 ts: None,
                 _extra: HashMap::new(),
-            }
+            },
         };
 
         let line_json =
@@ -229,14 +221,28 @@ pub fn write_transcript(
         per_msg_usage.insert(idx, tu);
     }
 
+    // The .md companion is a *derived* view — the JSONL above is the
+    // source of truth. Failures here must not propagate: a readable-log
+    // hiccup shouldn't take down the session's state persistence. Log
+    // and move on.
     let md_path = md_companion_path(jsonl_path);
     if let Some(parent) = md_path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("create md companion dir {}", parent.display()))?;
+        if let Err(err) = fs::create_dir_all(parent) {
+            log::warn!(
+                "[transcript] failed to create md companion dir {}: {err}",
+                parent.display()
+            );
+            return Ok(());
+        }
     }
     let md = render_markdown(messages, meta, &per_msg_usage);
-    fs::write(&md_path, md.as_bytes())
-        .with_context(|| format!("write markdown companion {}", md_path.display()))?;
+    if let Err(err) = fs::write(&md_path, md.as_bytes()) {
+        log::warn!(
+            "[transcript] failed to write markdown companion {}: {err}",
+            md_path.display()
+        );
+        return Ok(());
+    }
 
     log::debug!(
         "[transcript] wrote markdown companion to {}",
@@ -292,47 +298,38 @@ fn read_transcript_jsonl(path: &Path) -> Result<SessionTranscript> {
     let mut meta: Option<TranscriptMeta> = None;
     let mut messages: Vec<ChatMessage> = Vec::new();
 
+    // The JSONL format is positional: line 1 (the first non-empty line)
+    // is the `_meta` header; every subsequent non-empty line is a message.
+    // This avoids a substring check that could false-positive if message
+    // content contains `"_meta"`.
     for (line_no, line) in raw.lines().enumerate() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
 
-        // Attempt to detect meta line cheaply before deserialising the whole thing.
-        if line.contains("\"_meta\"") {
-            match serde_json::from_str::<MetaLine>(line) {
-                Ok(ml) => {
-                    let mp = ml.meta;
-                    meta = Some(TranscriptMeta {
-                        agent_name: mp.agent,
-                        dispatcher: mp.dispatcher,
-                        cache_boundary: mp.cache_boundary,
-                        created: mp.created,
-                        updated: mp.updated,
-                        turn_count: mp.turn_count,
-                        input_tokens: mp.input_tokens,
-                        output_tokens: mp.output_tokens,
-                        cached_input_tokens: mp.cached_input_tokens,
-                        charged_amount_usd: mp.charged_amount_usd,
-                    });
-                    continue;
-                }
-                Err(err) => {
-                    log::warn!(
-                        "[transcript] failed to parse meta line {} in {}: {err}",
-                        line_no + 1,
-                        path.display()
-                    );
-                    // If the very first non-empty line fails to parse as meta, error out.
-                    if meta.is_none() {
-                        return Err(anyhow::anyhow!(
-                            "first non-empty line of {} is not a valid _meta object: {err}",
-                            path.display()
-                        ));
-                    }
-                    continue;
-                }
-            }
+        if meta.is_none() {
+            let ml: MetaLine = serde_json::from_str(line).map_err(|err| {
+                anyhow::anyhow!(
+                    "first non-empty line of {} (line {}) is not a valid _meta object: {err}",
+                    path.display(),
+                    line_no + 1,
+                )
+            })?;
+            let mp = ml.meta;
+            meta = Some(TranscriptMeta {
+                agent_name: mp.agent,
+                dispatcher: mp.dispatcher,
+                cache_boundary: mp.cache_boundary,
+                created: mp.created,
+                updated: mp.updated,
+                turn_count: mp.turn_count,
+                input_tokens: mp.input_tokens,
+                output_tokens: mp.output_tokens,
+                cached_input_tokens: mp.cached_input_tokens,
+                charged_amount_usd: mp.charged_amount_usd,
+            });
+            continue;
         }
 
         // Message line.

--- a/src/openhuman/agent/harness/session/transcript.rs
+++ b/src/openhuman/agent/harness/session/transcript.rs
@@ -1,12 +1,12 @@
 //! Session transcript persistence for KV cache stability.
 //!
-//! **Source of truth**: `sessions/{DDMMYYYY}/{agent}_{index}.jsonl`
+//! **Source of truth**: `session_raw/{DDMMYYYY}/{agent}_{index}.jsonl`
 //!
 //! Each JSONL file starts with a single metadata line (identified by an
 //! `_meta` key) followed by one JSON object per `ChatMessage`. On every
-//! write the companion `.md` file is re-rendered for human readability;
-//! it is **never** read back — all round-trip / resume logic uses the
-//! JSONL.
+//! write the companion `.md` file is re-rendered for human readability
+//! under `sessions/{DDMMYYYY}/{agent}_{index}.md`; it is **never** read
+//! back — all round-trip / resume logic uses the JSONL.
 //!
 //! ## JSONL schema
 //!
@@ -29,8 +29,8 @@
 //! ## Storage layout
 //!
 //! ```text
-//! {workspace}/sessions/DDMMYYYY/{agent}_{index}.jsonl   ← source of truth
-//! {workspace}/sessions/DDMMYYYY/{agent}_{index}.md      ← human-readable view
+//! {workspace}/session_raw/DDMMYYYY/{agent}_{index}.jsonl   ← source of truth
+//! {workspace}/sessions/DDMMYYYY/{agent}_{index}.md         ← human-readable view
 //! ```
 
 use crate::openhuman::providers::ChatMessage;
@@ -167,18 +167,20 @@ pub fn write_transcript(
             charged_amount_usd: meta.charged_amount_usd,
         },
     };
-    let meta_json = serde_json::to_string(&meta_line)
-        .context("serialise transcript meta header")?;
+    let meta_json =
+        serde_json::to_string(&meta_line).context("serialise transcript meta header")?;
     jsonl_buf.push_str(&meta_json);
     jsonl_buf.push('\n');
 
     // Identify the index of the last assistant message so we can attach
     // per-turn usage to it.
-    let last_assistant_idx = messages
-        .iter()
-        .enumerate()
-        .rev()
-        .find_map(|(i, m)| if m.role == "assistant" { Some(i) } else { None });
+    let last_assistant_idx = messages.iter().enumerate().rev().find_map(|(i, m)| {
+        if m.role == "assistant" {
+            Some(i)
+        } else {
+            None
+        }
+    });
 
     for (i, msg) in messages.iter().enumerate() {
         let is_last_assistant =
@@ -205,8 +207,8 @@ pub fn write_transcript(
             }
         };
 
-        let line_json = serde_json::to_string(&line)
-            .with_context(|| format!("serialise message line {i}"))?;
+        let line_json =
+            serde_json::to_string(&line).with_context(|| format!("serialise message line {i}"))?;
         jsonl_buf.push_str(&line_json);
         jsonl_buf.push('\n');
     }
@@ -227,7 +229,11 @@ pub fn write_transcript(
         per_msg_usage.insert(idx, tu);
     }
 
-    let md_path = jsonl_path.with_extension("md");
+    let md_path = md_companion_path(jsonl_path);
+    if let Some(parent) = md_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create md companion dir {}", parent.display()))?;
+    }
     let md = render_markdown(messages, meta, &per_msg_usage);
     fs::write(&md_path, md.as_bytes())
         .with_context(|| format!("write markdown companion {}", md_path.display()))?;
@@ -254,7 +260,10 @@ pub fn read_transcript(path: &Path) -> Result<SessionTranscript> {
     // `find_latest_transcript` when only legacy files exist) must go to
     // the legacy parser, never to the JSONL parser.
     if path.extension().and_then(|s| s.to_str()) == Some("md") {
-        log::debug!("[transcript] reading legacy .md transcript: {}", path.display());
+        log::debug!(
+            "[transcript] reading legacy .md transcript: {}",
+            path.display()
+        );
         return read_transcript_legacy_md(path);
     }
 
@@ -363,30 +372,36 @@ fn read_transcript_jsonl(path: &Path) -> Result<SessionTranscript> {
 // ── Path resolution ──────────────────────────────────────────────────
 
 /// Resolve a new transcript path under
-/// `{workspace}/sessions/DDMMYYYY/{agent}_{index}.jsonl`.
+/// `{workspace}/session_raw/DDMMYYYY/{agent}_{index}.jsonl`.
 ///
 /// Creates the date directory if needed. Index = max existing + 1.
-/// Scans both `.jsonl` **and** `.md` files when computing the next index
-/// so indices don't collide during migration.
+/// Scans both the new `session_raw/` dir (for `.jsonl`) **and** the legacy
+/// `sessions/` dir (for `.md`) so indices stay unique across migration.
 pub fn resolve_new_transcript_path(workspace_dir: &Path, agent_name: &str) -> Result<PathBuf> {
-    let date_dir = today_session_dir(workspace_dir);
-    fs::create_dir_all(&date_dir)
-        .with_context(|| format!("create session dir {}", date_dir.display()))?;
+    let raw_dir = today_raw_session_dir(workspace_dir);
+    fs::create_dir_all(&raw_dir)
+        .with_context(|| format!("create session_raw dir {}", raw_dir.display()))?;
 
     let sanitized = sanitize_agent_name(agent_name);
-    let next_idx = next_index(&date_dir, &sanitized)?;
+    let idx_raw = next_index(&raw_dir, &sanitized)?;
+    // Also consider the legacy sessions/ dir so companion .md (or legacy
+    // standalone .md) files don't cause index collisions.
+    let legacy_dir = today_session_dir(workspace_dir);
+    let idx_legacy = next_index(&legacy_dir, &sanitized)?;
+    let next_idx = idx_raw.max(idx_legacy);
     let filename = format!("{}_{}.jsonl", sanitized, next_idx);
 
-    Ok(date_dir.join(filename))
+    Ok(raw_dir.join(filename))
 }
 
 /// Find the most recent transcript for `agent_name`.
 ///
-/// Searches today's directory first, then yesterday's. Returns the
-/// `.jsonl` with the highest index (or falls back to `.md` when only legacy
-/// files exist).
+/// Searches today's directory first, then yesterday's. Prefers `.jsonl`
+/// under `session_raw/` and falls back to `.md` under `sessions/` when
+/// only legacy files exist.
 pub fn find_latest_transcript(workspace_dir: &Path, agent_name: &str) -> Option<PathBuf> {
     let sanitized = sanitize_agent_name(agent_name);
+    let raw_root = workspace_dir.join("session_raw");
     let sessions_root = workspace_dir.join("sessions");
 
     let today = chrono::Local::now().format("%d%m%Y").to_string();
@@ -395,12 +410,19 @@ pub fn find_latest_transcript(workspace_dir: &Path, agent_name: &str) -> Option<
         .to_string();
 
     for date_str in [&today, &yesterday] {
-        let dir = sessions_root.join(date_str);
-        if !dir.is_dir() {
-            continue;
+        // Prefer the new session_raw/ location.
+        let raw_dir = raw_root.join(date_str);
+        if raw_dir.is_dir() {
+            if let Some(path) = latest_in_dir(&raw_dir, &sanitized) {
+                return Some(path);
+            }
         }
-        if let Some(path) = latest_in_dir(&dir, &sanitized) {
-            return Some(path);
+        // Fall back to legacy sessions/ for pre-migration .md only.
+        let legacy_dir = sessions_root.join(date_str);
+        if legacy_dir.is_dir() {
+            if let Some(path) = latest_in_dir(&legacy_dir, &sanitized) {
+                return Some(path);
+            }
         }
     }
 
@@ -599,6 +621,36 @@ fn today_session_dir(workspace_dir: &Path) -> PathBuf {
     workspace_dir.join("sessions").join(date)
 }
 
+fn today_raw_session_dir(workspace_dir: &Path) -> PathBuf {
+    let date = chrono::Local::now().format("%d%m%Y").to_string();
+    workspace_dir.join("session_raw").join(date)
+}
+
+/// Given a `session_raw/DDMMYYYY/agent_N.jsonl` path, derive the companion
+/// `sessions/DDMMYYYY/agent_N.md` path by swapping the `session_raw`
+/// path component with `sessions` and the extension with `.md`.
+///
+/// If no `session_raw` component is present (e.g. tests using a flat
+/// tempdir), just swap the extension so the companion lives alongside.
+fn md_companion_path(jsonl_path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    let mut swapped = false;
+    for comp in jsonl_path.components() {
+        match comp {
+            std::path::Component::Normal(s) if s == "session_raw" => {
+                out.push("sessions");
+                swapped = true;
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    if !swapped {
+        // Fall back to sibling .md in the same directory.
+        return jsonl_path.with_extension("md");
+    }
+    out.with_extension("md")
+}
+
 fn sanitize_agent_name(name: &str) -> String {
     name.chars()
         .map(|c| {
@@ -665,7 +717,10 @@ fn latest_in_dir(dir: &Path, agent_prefix: &str) -> Option<PathBuf> {
         if name_str.ends_with(".jsonl") {
             let idx_str = &name_str[prefix.len()..name_str.len() - 6];
             if let Ok(idx) = idx_str.parse::<usize>() {
-                if best_jsonl.as_ref().is_none_or(|(best_idx, _)| idx > *best_idx) {
+                if best_jsonl
+                    .as_ref()
+                    .is_none_or(|(best_idx, _)| idx > *best_idx)
+                {
                     best_jsonl = Some((idx, entry.path()));
                 }
             }
@@ -827,11 +882,52 @@ mod tests {
 
         let path0 = resolve_new_transcript_path(workspace, "main").unwrap();
         assert!(path0.to_string_lossy().contains("main_0.jsonl"));
+        assert!(
+            path0.to_string_lossy().contains("session_raw"),
+            "jsonl should live under session_raw/, got {}",
+            path0.display()
+        );
         // Write something so the next call sees it.
         fs::write(&path0, "placeholder").unwrap();
 
         let path1 = resolve_new_transcript_path(workspace, "main").unwrap();
         assert!(path1.to_string_lossy().contains("main_1.jsonl"));
+    }
+
+    #[test]
+    fn md_companion_path_swaps_session_raw_to_sessions() {
+        let jsonl = PathBuf::from("/tmp/ws/session_raw/17042026/main_0.jsonl");
+        let md = md_companion_path(&jsonl);
+        assert_eq!(
+            md,
+            PathBuf::from("/tmp/ws/sessions/17042026/main_0.md"),
+            "md companion should live under sessions/ with .md extension"
+        );
+    }
+
+    #[test]
+    fn md_companion_path_falls_back_to_sibling_when_no_session_raw_component() {
+        let jsonl = PathBuf::from("/tmp/flat/main_0.jsonl");
+        let md = md_companion_path(&jsonl);
+        assert_eq!(md, PathBuf::from("/tmp/flat/main_0.md"));
+    }
+
+    #[test]
+    fn resolve_avoids_index_collision_with_legacy_md_in_sessions_dir() {
+        let dir = TempDir::new().unwrap();
+        let workspace = dir.path();
+        let date = chrono::Local::now().format("%d%m%Y").to_string();
+        let legacy = workspace.join("sessions").join(&date);
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("main_0.md"), "legacy").unwrap();
+        fs::write(legacy.join("main_1.md"), "legacy").unwrap();
+
+        let path = resolve_new_transcript_path(workspace, "main").unwrap();
+        assert!(
+            path.to_string_lossy().contains("main_2.jsonl"),
+            "should advance past legacy indices, got {}",
+            path.display()
+        );
     }
 
     #[test]
@@ -845,18 +941,33 @@ mod tests {
     fn find_latest_returns_highest_index() {
         let dir = TempDir::new().unwrap();
         let date = chrono::Local::now().format("%d%m%Y").to_string();
-        let session_dir = dir.path().join("sessions").join(&date);
-        fs::create_dir_all(&session_dir).unwrap();
+        let raw_dir = dir.path().join("session_raw").join(&date);
+        fs::create_dir_all(&raw_dir).unwrap();
 
-        fs::write(session_dir.join("main_0.jsonl"), "a").unwrap();
-        fs::write(session_dir.join("main_2.jsonl"), "c").unwrap();
-        fs::write(session_dir.join("main_1.jsonl"), "b").unwrap();
-        fs::write(session_dir.join("other_0.jsonl"), "x").unwrap();
+        fs::write(raw_dir.join("main_0.jsonl"), "a").unwrap();
+        fs::write(raw_dir.join("main_2.jsonl"), "c").unwrap();
+        fs::write(raw_dir.join("main_1.jsonl"), "b").unwrap();
+        fs::write(raw_dir.join("other_0.jsonl"), "x").unwrap();
 
         let latest = find_latest_transcript(dir.path(), "main");
         assert!(latest.is_some());
         let latest = latest.unwrap();
         assert!(latest.to_string_lossy().contains("main_2.jsonl"));
+        assert!(latest.to_string_lossy().contains("session_raw"));
+    }
+
+    #[test]
+    fn find_latest_falls_back_to_legacy_sessions_md() {
+        let dir = TempDir::new().unwrap();
+        let date = chrono::Local::now().format("%d%m%Y").to_string();
+        let legacy = dir.path().join("sessions").join(&date);
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("main_0.md"), "legacy").unwrap();
+
+        let latest = find_latest_transcript(dir.path(), "main");
+        assert!(latest.is_some());
+        let latest = latest.unwrap();
+        assert!(latest.to_string_lossy().ends_with("main_0.md"));
     }
 
     #[test]
@@ -948,7 +1059,10 @@ mod tests {
         assert!(md_path.exists(), ".md companion should be written");
         let md = fs::read_to_string(&md_path).unwrap();
         assert!(md.contains("# Session transcript — code_executor"));
-        assert!(md.contains("claude-sonnet-4-6"), "model should appear in md");
+        assert!(
+            md.contains("claude-sonnet-4-6"),
+            "model should appear in md"
+        );
         assert!(md.contains("## [system]"), "system section missing");
         assert!(md.contains("## [user]"), "user section missing");
     }
@@ -1000,7 +1114,10 @@ mod tests {
         fs::write(dir.path().join("main_1.jsonl"), "new").unwrap();
 
         let next = next_index(dir.path(), "main").unwrap();
-        assert_eq!(next, 2, "should account for both .md and .jsonl when computing next index");
+        assert_eq!(
+            next, 2,
+            "should account for both .md and .jsonl when computing next index"
+        );
     }
 
     #[test]

--- a/src/openhuman/agent/harness/session/transcript.rs
+++ b/src/openhuman/agent/harness/session/transcript.rs
@@ -249,12 +249,20 @@ pub fn write_transcript(
 /// (migration path — old sessions), reads it via the legacy HTML-comment
 /// parser and returns a `SessionTranscript` with default meta where the
 /// `.md` format didn't track a field.
-pub fn read_transcript(jsonl_path: &Path) -> Result<SessionTranscript> {
-    if jsonl_path.exists() {
-        read_transcript_jsonl(jsonl_path)
+pub fn read_transcript(path: &Path) -> Result<SessionTranscript> {
+    // Route by extension first: a legacy `.md` path (returned by
+    // `find_latest_transcript` when only legacy files exist) must go to
+    // the legacy parser, never to the JSONL parser.
+    if path.extension().and_then(|s| s.to_str()) == Some("md") {
+        log::debug!("[transcript] reading legacy .md transcript: {}", path.display());
+        return read_transcript_legacy_md(path);
+    }
+
+    if path.exists() {
+        read_transcript_jsonl(path)
     } else {
         // Fallback: try the .md sibling (legacy one-release compat).
-        let md_path = jsonl_path.with_extension("md");
+        let md_path = path.with_extension("md");
         if md_path.exists() {
             log::debug!(
                 "[transcript] .jsonl not found, falling back to legacy .md: {}",
@@ -263,7 +271,7 @@ pub fn read_transcript(jsonl_path: &Path) -> Result<SessionTranscript> {
             read_transcript_legacy_md(&md_path)
         } else {
             // Neither exists — propagate the original jsonl error.
-            read_transcript_jsonl(jsonl_path)
+            read_transcript_jsonl(path)
         }
     }
 }

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -422,6 +422,12 @@ impl Agent {
                                 },
                                 ts: chrono::Utc::now().to_rfc3339(),
                             });
+                        } else {
+                            // Missing usage on this iteration: clear any
+                            // snapshot carried from a prior iteration so
+                            // the transcript doesn't attribute stale
+                            // numbers to the final assistant message.
+                            last_turn_usage = None;
                         }
                         resp
                     }

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -201,6 +201,10 @@ impl Agent {
         let mut cumulative_cached_input_tokens: u64 = 0;
         let mut cumulative_charged_usd: f64 = 0.0;
 
+        // Per-turn usage from the final provider response, attached to the
+        // last assistant message in the persisted transcript.
+        let mut last_turn_usage: Option<transcript::TurnUsage> = None;
+
         let turn_body = async {
             for iteration in 0..self.config.max_tool_iterations {
                 self.emit_progress(AgentProgress::IterationStarted {
@@ -405,6 +409,19 @@ impl Agent {
                             cumulative_output_tokens += usage.output_tokens;
                             cumulative_cached_input_tokens += usage.cached_input_tokens;
                             cumulative_charged_usd += usage.charged_amount_usd;
+                            // Snapshot this turn's usage so the transcript
+                            // writer can attribute it to the last assistant
+                            // message.
+                            last_turn_usage = Some(transcript::TurnUsage {
+                                model: effective_model.clone(),
+                                usage: transcript::MessageUsage {
+                                    input: usage.input_tokens,
+                                    output: usage.output_tokens,
+                                    cached_input: usage.cached_input_tokens,
+                                    cost_usd: usage.charged_amount_usd,
+                                },
+                                ts: chrono::Utc::now().to_rfc3339(),
+                            });
                         }
                         resp
                     }
@@ -604,6 +621,7 @@ impl Agent {
                     cumulative_output_tokens,
                     cumulative_cached_input_tokens,
                     cumulative_charged_usd,
+                    last_turn_usage.as_ref(),
                 );
             }
         }
@@ -1102,9 +1120,14 @@ impl Agent {
 
     /// Persist the exact provider messages as a session transcript.
     ///
-    /// Best-effort: failures are logged and silently ignored. The JSONL
-    /// conversation store remains the authoritative persistence layer;
-    /// session transcripts are an optimization for KV cache stability.
+    /// Writes JSONL as source of truth and re-renders the companion `.md`
+    /// for human readability. Best-effort: failures are logged and silently
+    /// ignored. The JSONL conversation store remains the authoritative
+    /// persistence layer; session transcripts are an optimization for KV
+    /// cache stability.
+    ///
+    /// `turn_usage` — when `Some`, attributes per-message token/cost figures
+    /// to the last assistant message in the written transcript.
     pub(super) fn persist_session_transcript(
         &mut self,
         messages: &[ChatMessage],
@@ -1112,6 +1135,7 @@ impl Agent {
         output_tokens: u64,
         cached_input_tokens: u64,
         charged_amount_usd: f64,
+        turn_usage: Option<&transcript::TurnUsage>,
     ) {
         // Resolve the transcript path on first write.
         if self.session_transcript_path.is_none() {
@@ -1153,7 +1177,7 @@ impl Agent {
             charged_amount_usd,
         };
 
-        if let Err(err) = transcript::write_transcript(path, messages, &meta) {
+        if let Err(err) = transcript::write_transcript(path, messages, &meta, turn_usage) {
             log::warn!(
                 "[transcript] failed to write transcript {}: {err}",
                 path.display()
@@ -1577,7 +1601,7 @@ mod tests {
             ChatMessage::assistant("done"),
         ];
         agent.system_prompt_cache_boundary = Some(12);
-        agent.persist_session_transcript(&messages, 10, 5, 3, 0.25);
+        agent.persist_session_transcript(&messages, 10, 5, 3, 0.25, None);
         assert!(agent.session_transcript_path.is_some());
 
         let loaded = transcript::read_transcript(agent.session_transcript_path.as_ref().unwrap())

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -478,6 +478,13 @@ impl Agent {
                         )));
                     self.trim_history();
 
+                    // Mirror the final assistant reply into the transcript
+                    // snapshot so the JSONL persisted below captures the
+                    // response (not just the prompt that was sent).
+                    if let Some(ref mut msgs) = last_provider_messages {
+                        msgs.push(ChatMessage::assistant(final_text.clone()));
+                    }
+
                     if self.auto_save {
                         let summary = truncate_with_ellipsis(&final_text, 100);
                         let _ = self

--- a/src/openhuman/agent/harness/subagent_runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner.rs
@@ -618,7 +618,7 @@ fn persist_subagent_transcript(
         charged_amount_usd: usage.charged_amount_usd,
     };
 
-    if let Err(err) = transcript::write_transcript(&path, history, &meta) {
+    if let Err(err) = transcript::write_transcript(&path, history, &meta, None) {
         tracing::debug!(
             agent_id = %agent_id,
             error = %err,

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -29,8 +29,9 @@ static PROMPT_DUMP_SEQ: AtomicU64 = AtomicU64::new(0);
 /// bytes of the prefix drifted and broke the cache hit.
 /// Write raw response bytes to the dump dir paired with the most-recent
 /// prompt file (same `seq` prefix, `.response.json` suffix). `seq` must
-/// be the value returned by `dump_prompt_if_enabled` so request/response
-/// files sort next to each other.
+/// be the value reserved via `reserve_dump_seq` and passed to
+/// `dump_prompt_if_enabled` so request/response files sort next to
+/// each other.
 fn dump_response_if_enabled(provider: &str, model: &str, seq: u64, bytes: &[u8]) {
     let Ok(dir) = std::env::var("OPENHUMAN_PROMPT_DUMP_DIR") else {
         return;
@@ -68,7 +69,7 @@ fn dump_response_if_enabled(provider: &str, model: &str, seq: u64, bytes: &[u8])
             path.display()
         );
     } else {
-        log::info!(
+        log::debug!(
             "[prompt_dump] wrote response {} bytes -> {}",
             payload.len(),
             path.display()
@@ -76,14 +77,17 @@ fn dump_response_if_enabled(provider: &str, model: &str, seq: u64, bytes: &[u8])
     }
 }
 
-/// Current sequence counter (the value that will be assigned on the next
-/// `dump_prompt_if_enabled` call). Callers that want to pair a response
-/// with its request should read this *before* calling the prompt dumper.
-fn peek_dump_seq() -> u64 {
-    PROMPT_DUMP_SEQ.load(Ordering::Relaxed)
+/// Atomically reserve the next dump sequence number. This is the single
+/// source of truth for seq allocation — both the prompt dump and its
+/// paired response dump must use the value returned here. A non-atomic
+/// peek-then-increment split would race under concurrent requests (two
+/// callers could reserve the same seq or correlate a request/response
+/// pair across different turns).
+fn reserve_dump_seq() -> u64 {
+    PROMPT_DUMP_SEQ.fetch_add(1, Ordering::Relaxed)
 }
 
-fn dump_prompt_if_enabled<T: Serialize>(provider: &str, model: &str, body: &T) {
+fn dump_prompt_if_enabled<T: Serialize>(provider: &str, model: &str, seq: u64, body: &T) {
     let Ok(dir) = std::env::var("OPENHUMAN_PROMPT_DUMP_DIR") else {
         return;
     };
@@ -96,7 +100,6 @@ fn dump_prompt_if_enabled<T: Serialize>(provider: &str, model: &str, body: &T) {
         return;
     }
     let ts = chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ");
-    let seq = PROMPT_DUMP_SEQ.fetch_add(1, Ordering::Relaxed);
     let safe_model: String = model
         .chars()
         .map(|c| {
@@ -114,7 +117,7 @@ fn dump_prompt_if_enabled<T: Serialize>(provider: &str, model: &str, body: &T) {
             if let Err(err) = std::fs::write(&path, &bytes) {
                 log::warn!("[prompt_dump] write failed {}: {err}", path.display());
             } else {
-                log::info!(
+                log::debug!(
                     "[prompt_dump] wrote {} bytes -> {}",
                     bytes.len(),
                     path.display()
@@ -2058,8 +2061,8 @@ impl Provider for OpenAiCompatibleProvider {
                 tool_choice: tools.as_ref().map(|_| "auto".to_string()),
                 tools: tools.clone(),
             };
-            let stream_dump_seq = peek_dump_seq();
-            dump_prompt_if_enabled(&self.name, model, &native_request);
+            let stream_dump_seq = reserve_dump_seq();
+            dump_prompt_if_enabled(&self.name, model, stream_dump_seq, &native_request);
             match self
                 .stream_native_chat(credential, &native_request, tx, stream_dump_seq)
                 .await
@@ -2084,8 +2087,8 @@ impl Provider for OpenAiCompatibleProvider {
             tool_choice: tools.as_ref().map(|_| "auto".to_string()),
             tools,
         };
-        let dump_seq = peek_dump_seq();
-        dump_prompt_if_enabled(&self.name, model, &native_request);
+        let dump_seq = reserve_dump_seq();
+        dump_prompt_if_enabled(&self.name, model, dump_seq, &native_request);
 
         let url = self.chat_completions_url();
         let response = match self

--- a/src/openhuman/providers/compatible.rs
+++ b/src/openhuman/providers/compatible.rs
@@ -14,6 +14,118 @@ use reqwest::{
     Client,
 };
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic sequence so multiple requests in the same millisecond sort
+/// deterministically in the dump directory.
+static PROMPT_DUMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// When `OPENHUMAN_PROMPT_DUMP_DIR` is set, write `body` (the exact JSON
+/// payload we're about to POST to the provider) to a timestamped file
+/// under that directory. Best-effort: failures are logged and swallowed
+/// so a dump outage never breaks inference.
+///
+/// Intended for KV-cache debugging — diff consecutive turns to see which
+/// bytes of the prefix drifted and broke the cache hit.
+/// Write raw response bytes to the dump dir paired with the most-recent
+/// prompt file (same `seq` prefix, `.response.json` suffix). `seq` must
+/// be the value returned by `dump_prompt_if_enabled` so request/response
+/// files sort next to each other.
+fn dump_response_if_enabled(provider: &str, model: &str, seq: u64, bytes: &[u8]) {
+    let Ok(dir) = std::env::var("OPENHUMAN_PROMPT_DUMP_DIR") else {
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    if let Err(err) = std::fs::create_dir_all(&dir) {
+        log::warn!(
+            "[prompt_dump] failed to create dir {}: {err}",
+            dir.display()
+        );
+        return;
+    }
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ");
+    let safe_model: String = model
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let filename = format!("{ts}_{seq:06}_{provider}_{safe_model}.response.json");
+    let path = dir.join(filename);
+    // Re-pretty-print if it parses as JSON so diffs are stable; otherwise
+    // write raw bytes (SSE fragments, error HTML, etc).
+    let payload: Vec<u8> = match serde_json::from_slice::<serde_json::Value>(bytes) {
+        Ok(v) => serde_json::to_vec_pretty(&v).unwrap_or_else(|_| bytes.to_vec()),
+        Err(_) => bytes.to_vec(),
+    };
+    if let Err(err) = std::fs::write(&path, &payload) {
+        log::warn!(
+            "[prompt_dump] response write failed {}: {err}",
+            path.display()
+        );
+    } else {
+        log::info!(
+            "[prompt_dump] wrote response {} bytes -> {}",
+            payload.len(),
+            path.display()
+        );
+    }
+}
+
+/// Current sequence counter (the value that will be assigned on the next
+/// `dump_prompt_if_enabled` call). Callers that want to pair a response
+/// with its request should read this *before* calling the prompt dumper.
+fn peek_dump_seq() -> u64 {
+    PROMPT_DUMP_SEQ.load(Ordering::Relaxed)
+}
+
+fn dump_prompt_if_enabled<T: Serialize>(provider: &str, model: &str, body: &T) {
+    let Ok(dir) = std::env::var("OPENHUMAN_PROMPT_DUMP_DIR") else {
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    if let Err(err) = std::fs::create_dir_all(&dir) {
+        log::warn!(
+            "[prompt_dump] failed to create dir {}: {err}",
+            dir.display()
+        );
+        return;
+    }
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ");
+    let seq = PROMPT_DUMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let safe_model: String = model
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let filename = format!("{ts}_{seq:06}_{provider}_{safe_model}.json");
+    let path = dir.join(filename);
+    match serde_json::to_vec_pretty(body) {
+        Ok(bytes) => {
+            if let Err(err) = std::fs::write(&path, &bytes) {
+                log::warn!("[prompt_dump] write failed {}: {err}", path.display());
+            } else {
+                log::info!(
+                    "[prompt_dump] wrote {} bytes -> {}",
+                    bytes.len(),
+                    path.display()
+                );
+            }
+        }
+        Err(err) => {
+            log::warn!("[prompt_dump] serialize failed: {err}");
+        }
+    }
+}
 
 /// A provider that speaks the OpenAI-compatible chat completions API.
 /// Used by: Venice, Vercel AI Gateway, Cloudflare AI Gateway, Moonshot,
@@ -1182,6 +1294,7 @@ impl OpenAiCompatibleProvider {
         credential: &str,
         native_request: &NativeChatRequest,
         delta_tx: &tokio::sync::mpsc::Sender<crate::openhuman::providers::ProviderDelta>,
+        dump_seq: u64,
     ) -> anyhow::Result<ProviderChatResponse> {
         use futures_util::StreamExt;
 
@@ -1236,7 +1349,10 @@ impl OpenAiCompatibleProvider {
                 "[stream] {} upstream replied with non-SSE content-type; falling back to JSON parse",
                 self.name,
             );
-            let api_resp: ApiChatResponse = response.json().await?;
+            let response_bytes = response.bytes().await?;
+            dump_response_if_enabled(&self.name, &native_request.model, dump_seq, &response_bytes);
+            let api_resp: ApiChatResponse = serde_json::from_slice(&response_bytes)
+                .map_err(|err| anyhow::anyhow!("{} response parse error: {err}", self.name))?;
             return Self::parse_native_response(api_resp, &self.name);
         }
 
@@ -1498,6 +1614,48 @@ impl OpenAiCompatibleProvider {
             usage: last_usage,
             openhuman: last_openhuman,
         };
+
+        // Dump the aggregated final response (structured, diff-friendly,
+        // carries usage + openhuman cache meta from the last chunks).
+        // Hand-build a Value here because `ApiChatResponse` is
+        // Deserialize-only.
+        if std::env::var("OPENHUMAN_PROMPT_DUMP_DIR").is_ok() {
+            let msg = &api_resp.choices[0].message;
+            let aggregated = serde_json::json!({
+                "content": msg.content,
+                "reasoning_content": msg.reasoning_content,
+                "tool_calls": msg.tool_calls.as_ref().map(|calls| {
+                    calls.iter().map(|c| serde_json::json!({
+                        "id": c.id,
+                        "type": c.kind,
+                        "function": c.function.as_ref().map(|f| serde_json::json!({
+                            "name": f.name,
+                            "arguments": f.arguments,
+                        })),
+                    })).collect::<Vec<_>>()
+                }),
+                "usage": api_resp.usage.as_ref().map(|u| serde_json::json!({
+                    "prompt_tokens": u.prompt_tokens,
+                    "completion_tokens": u.completion_tokens,
+                    "total_tokens": u.total_tokens,
+                    "prompt_cached_tokens": u.prompt_tokens_details
+                        .as_ref().map(|d| d.cached_tokens),
+                })),
+                "openhuman": api_resp.openhuman.as_ref().map(|m| serde_json::json!({
+                    "usage": m.usage.as_ref().map(|u| serde_json::json!({
+                        "input_tokens": u.input_tokens,
+                        "output_tokens": u.output_tokens,
+                        "cached_input_tokens": u.cached_input_tokens,
+                    })),
+                    "billing": m.billing.as_ref().map(|b| serde_json::json!({
+                        "charged_amount_usd": b.charged_amount_usd,
+                    })),
+                })),
+            });
+            if let Ok(bytes) = serde_json::to_vec(&aggregated) {
+                dump_response_if_enabled(&self.name, &native_request.model, dump_seq, &bytes);
+            }
+        }
 
         Self::parse_native_response(api_resp, &self.name)
     }
@@ -1900,8 +2058,10 @@ impl Provider for OpenAiCompatibleProvider {
                 tool_choice: tools.as_ref().map(|_| "auto".to_string()),
                 tools: tools.clone(),
             };
+            let stream_dump_seq = peek_dump_seq();
+            dump_prompt_if_enabled(&self.name, model, &native_request);
             match self
-                .stream_native_chat(credential, &native_request, tx)
+                .stream_native_chat(credential, &native_request, tx, stream_dump_seq)
                 .await
             {
                 Ok(resp) => return Ok(resp),
@@ -1924,6 +2084,8 @@ impl Provider for OpenAiCompatibleProvider {
             tool_choice: tools.as_ref().map(|_| "auto".to_string()),
             tools,
         };
+        let dump_seq = peek_dump_seq();
+        dump_prompt_if_enabled(&self.name, model, &native_request);
 
         let url = self.chat_completions_url();
         let response = match self
@@ -1998,7 +2160,10 @@ impl Provider for OpenAiCompatibleProvider {
             anyhow::bail!("{} API error ({status}): {sanitized}", self.name);
         }
 
-        let native_response: ApiChatResponse = response.json().await?;
+        let response_bytes = response.bytes().await?;
+        dump_response_if_enabled(&self.name, model, dump_seq, &response_bytes);
+        let native_response: ApiChatResponse = serde_json::from_slice(&response_bytes)
+            .map_err(|err| anyhow::anyhow!("{} response parse error: {err}", self.name))?;
         Self::parse_native_response(native_response, &self.name)
     }
 


### PR DESCRIPTION
## Summary

- **JSONL as structured source-of-truth for session transcripts** — each turn persists the exact provider-facing `Vec<ChatMessage>` as `{workspace}/session_raw/DDMMYYYY/{agent}_{index}.jsonl`, with a `_meta` header line carrying cumulative tokens, cache boundary, and charged USD.
- **Human-readable `.md` companion re-rendered on every write** under `{workspace}/sessions/DDMMYYYY/{agent}_{index}.md` (humans only — never read back).
- **Per-message usage attribution**: the last assistant line on each turn carries `model`, `usage {input, output, cached_input, cost_usd}`, and `ts` pulled from the provider's `UsageInfo`.
- **Final assistant reply is now captured** in the transcript snapshot — previously the no-tool-call terminal branch persisted the pre-call prompt, dropping the reply.
- **Wire-level prompt + response dumps** gated by `OPENHUMAN_PROMPT_DUMP_DIR`. When set, every chat completion writes the outgoing `NativeChatRequest` and the aggregated `ApiChatResponse` (usage + cached_tokens + openhuman meta) to paired timestamped JSON files. Covers streaming and non-streaming paths.
- **Legacy `.md` fallback** in `find_latest_transcript` and `read_transcript` so pre-migration sessions resume cleanly for one release.

## Problem

Session transcripts were stored as HTML-comment-wrapped `.md` files, mixing structured state (messages, metadata, usage) with human-readable rendering. Diffing across turns to debug KV-cache instability was painful because escaping edge cases and prose formatting sat next to the actual prompt bytes. Separately, cache-hit accounting coming back from the backend (`prompt_tokens_details.cached_tokens`, `openhuman` meta) was only visible in logs — nothing persisted the wire payload for post-hoc diffing.

## Solution

1. **Split source-of-truth from readable view.** JSONL under `session_raw/`, markdown under `sessions/`. Structured diffs against `session_raw/*.jsonl`; readable review against `sessions/*.md`.
2. **Attach per-message usage at the exact site the response arrives** (`turn.rs`). Usage attributes to the last assistant message in the persisted snapshot.
3. **Dump at the HTTP layer**, not the dispatcher layer — catches the exact bytes the backend sees. Request and response share a `seq` prefix so pairs sort together.

Verified end-to-end against a real workspace: 5 turns across two threads, cache hits confirmed (`prompt_cached_tokens: 3696` consistently from the shared global prefix). Diff between consecutive JSONL transcripts shows byte-identical prefixes with only the assistant-reply and new-user-message appended — the KV-cache-stable shape.

## Submission Checklist

- [x] **Unit tests** — 17 transcript tests pass (`cargo test -p openhuman --lib transcript`), covering JSONL round-trip with usage, md-companion rendering, legacy-md fallback, `session_raw`/`sessions` path split, index-collision avoidance across dirs, and forward-compat on unknown JSONL fields
- [x] **Inline comments** — on the non-obvious bits (escape/legacy fallback rationale, `md_companion_path` component rewrite, why `last_provider_messages` gets mirrored at the terminal branch)
- [x] **Doc comments** — module-level `//!` doc on `transcript.rs` documents the JSONL schema, storage layout, and the `.md` companion contract
- [ ] **E2E / integration** — not added; KV-cache stability is hard to assert deterministically in E2E. Manual validation done against the real backend (see Summary).

## Impact

- **Storage migration**: existing `sessions/*.md` files remain readable via the legacy-`.md` fallback for one release; new sessions write JSONL under `session_raw/`. `next_index` scans both locations so indices don't collide.
- **No runtime overhead when `OPENHUMAN_PROMPT_DUMP_DIR` is unset** — the dump helper reads the env var once per call and short-circuits.
- **Platform**: desktop/CLI (core sidecar). No UI or Tauri changes.
- **Compatibility**: public `write_transcript` signature gained a `last_assistant_turn_usage: Option<&TurnUsage>` parameter; in-tree call sites updated (`turn.rs`, `subagent_runner.rs`).

## Related

- Issue(s): n/a
- Follow-up PR(s)/TODOs:
  - The `openhuman` custom meta block in responses is still `null` on the wire — if cache-hit accounting should also surface via the custom block (not just `prompt_tokens_details.cached_tokens`), that's a separate backend change.
  - The cached-token count observed in validation was pinned at the global prefix size across turns; extending the cache boundary to cover the per-conversation prefix is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional debug logging support to capture provider prompts and responses via environment configuration.
  * Enhanced per-turn usage tracking with model identification, token counts, and cost details with timestamps.

* **Improvements**
  * Upgraded transcript persistence to JSONL format for improved reliability and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->