### PR TITLE
fix(chat): increase agent silence timeout from 2 to 10 minutes

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -536,18 +536,18 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
     if (sendingTimeoutRef.current) clearTimeout(sendingTimeoutRef.current);
     sendingThreadIdRef.current = threadId;
     sendingTimeoutRef.current = setTimeout(() => {
-      console.warn('[chat] silence timeout: no inference signal for 120s');
+      console.warn('[chat] silence timeout: no inference signal for 600s');
       setSendError(
         chatSendError(
           'safety_timeout',
-          'No response from the assistant after 2 minutes. Try again or check your connection.'
+          'No response from the assistant after 10 minutes. Try again or check your connection.'
         )
       );
       dispatch(clearRuntimeForThread({ threadId }));
       dispatch(setActiveThread(null));
       sendingTimeoutRef.current = null;
       sendingThreadIdRef.current = null;
-    }, 120_000);
+    }, 600_000);
   };
 
   // Rearm the silence timer on every inference status change for the
@@ -715,7 +715,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
     }
     setInputValue('');
     setSendError(null);
-    // Silence timer: fires only if 120s pass without ANY inference progress
+    // Silence timer: fires only if 600s pass without ANY inference progress
     // (tool call, tool result, iteration start, subagent event, text delta).
     // The effect below rearms this timer whenever `inferenceStatusByThread`
     // changes for `sendingThreadId`, so long-running agent turns stay alive


### PR DESCRIPTION
## Summary

- Increased the frontend silence timer in `Conversations.tsx` from `120_000ms` (2 min) to `600_000ms` (10 min)
- Updated log message and user-facing error string to reflect the new duration
- Updated inline comment referencing the old `120s` value

The silence timer fires only when **zero** inference progress signals (tool calls, tool results, iteration starts, text deltas) arrive for the full duration. It re-arms on every event, so this is an inactivity detector — not a wall-clock limit. Manual cancel remains the primary stop mechanism and is unchanged.

## Checklist

- [x] TypeScript compiles (`yarn typecheck`)
- [x] ESLint passes (`yarn lint`)
- [x] Prettier passes (`yarn format:check`)
- [x] Rust checks pass (`cargo check`)
- [x] No changes to cancel logic or tool timeouts
- [x] No regressions in normal short-response flows

Closes #715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended conversation timeout duration from 2 to 10 minutes, reducing premature disconnections during extended inactive periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->