### PR TITLE
fix(windows): hide conhost window spawned with core sidecar

### DIFF
--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -25,6 +25,21 @@ fn apply_core_color_env(cmd: &mut Command) {
     }
 }
 
+/// Hide the console window that Windows would otherwise allocate for the
+/// core sidecar. The core binary is a console-subsystem executable so that
+/// `openhuman core run` in a terminal behaves normally, but when the GUI
+/// shell spawns it as a child a stray conhost window pops up on top of the
+/// app. `CREATE_NO_WINDOW` suppresses that while leaving stdout/stderr
+/// piping intact for our log forwarding.
+#[cfg(windows)]
+fn apply_core_no_window(cmd: &mut Command) {
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn apply_core_no_window(_cmd: &mut Command) {}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CoreRunMode {
     InProcess,
@@ -142,6 +157,7 @@ impl CoreProcessHandle {
                         cmd
                     };
                     apply_core_color_env(&mut cmd);
+                    apply_core_no_window(&mut cmd);
                     let child = cmd
                         .spawn()
                         .map_err(|e| format!("failed to spawn core process: {e}"))?;
@@ -180,6 +196,7 @@ impl CoreProcessHandle {
                     };
 
                     apply_core_color_env(&mut cmd);
+                    apply_core_no_window(&mut cmd);
                     let child = cmd
                         .spawn()
                         .map_err(|e| format!("failed to spawn core process: {e}"))?;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -222,6 +222,13 @@ async fn run_core_cli(args: Vec<String>) -> Result<String, String> {
         }
         cmd.args(&args);
 
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         log::info!(
             "[service-direct] running {:?} {}{}",
             bin,


### PR DESCRIPTION
## Summary

On Windows, launching the installed `OpenHuman.exe` pops a stray conhost (terminal) window on top of the app. The GUI shell is built with `windows_subsystem = "windows"` (no console), but the `openhuman-core` sidecar is a **console-subsystem** executable — kept that way intentionally so that `openhuman core run` works as a normal CLI in a terminal. When the GUI shell spawns the console sidecar as a child without `CREATE_NO_WINDOW`, Windows allocates a fresh console window for it.

Fix: pass `CREATE_NO_WINDOW` (`0x08000000`) at every site where the GUI launches a core subprocess. Non-Windows platforms get a no-op helper so the call sites stay identical.

## Changes

- `app/src-tauri/src/core_process.rs`
  - New `apply_core_no_window(&mut Command)` helper — sets `CREATE_NO_WINDOW` on Windows, no-op elsewhere.
  - Applied at both sidecar spawn paths (`CoreRunMode::InProcess` fallback and `CoreRunMode::ChildProcess`).
- `app/src-tauri/src/lib.rs`
  - Same flag applied to the short-lived `run_core_cli` subprocess used by `service_install_direct` / `service_start_direct` / `service_stop_direct` / `service_status_direct`.

Stdout/stderr piping (used for our log forwarding) is unaffected — `CREATE_NO_WINDOW` only suppresses the window, not the handles.

## Why the core binary stays console-subsystem

The core binary at `src/main.rs` is intentionally **not** marked `windows_subsystem = "windows"` so that running it directly from a terminal (`openhuman core run`, service CLI, etc.) behaves like a normal CLI tool with visible stdout/stderr. Flipping the subsystem would break that UX. Suppressing the window at the spawner is the right layer.

## Test plan

- [ ] Build a Windows installer from this branch and launch the installed app — verify **no** conhost window appears on top.
- [ ] Run `openhuman core run` directly from a Windows terminal — CLI output still visible (unchanged).
- [ ] Trigger a service CLI command from the app UI (`service_install_direct` etc.) — no window flash; command still returns expected output.
- [ ] macOS / Linux regression check: `yarn tauri dev` still starts the sidecar and RPC becomes ready as before.
- [ ] Log forwarding from the sidecar to the shell's logs is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary console window appearing on Windows when running the core process in the background. The window is now suppressed while maintaining all logging and output functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->