### PR TITLE
feat(ui): hide TTS and autocomplete entry points (#717)

### DIFF
--- a/app/src/components/settings/SettingsHome.tsx
+++ b/app/src/components/settings/SettingsHome.tsx
@@ -96,7 +96,7 @@ const SettingsHome = () => {
     {
       id: 'features',
       title: 'Features',
-      description: 'Screen awareness, autocomplete, voice, messaging, and tools',
+      description: 'Screen awareness, messaging, and tools',
       icon: (
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path

--- a/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
+++ b/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
@@ -67,38 +67,7 @@ const developerItems = [
       </svg>
     ),
   },
-  {
-    id: 'autocomplete-debug',
-    title: 'Autocomplete Debug',
-    description: 'Timing, test harness, focus debug, activity logs, and history',
-    route: 'autocomplete-debug',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M4 7h16M4 12h10m-10 5h7m10 0l3 3m0 0l3-3m-3 3v-8"
-        />
-      </svg>
-    ),
-  },
-  {
-    id: 'voice-debug',
-    title: 'Voice Debug',
-    description: 'Runtime status, silence threshold, and recording diagnostics',
-    route: 'voice-debug',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M12 3a3 3 0 00-3 3v6a3 3 0 006 0V6a3 3 0 00-3-3zm-7 9a7 7 0 0014 0m-7 7v2m-4 0h8"
-        />
-      </svg>
-    ),
-  },
+  // Autocomplete Debug + Voice Debug hidden per #717 (routes retained for re-enable).
   {
     id: 'local-model-debug',
     title: 'Local Model Debug',

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1579,22 +1579,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                   disabled={isSending || !rustChat}
                   className="relative z-10 w-full resize-none border-0 bg-transparent pl-4 pr-10 py-2.5 text-sm leading-normal whitespace-pre-wrap break-words font-sans text-stone-900 placeholder:text-stone-400 outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0 max-h-32 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
-                {/* Mic icon inside input */}
-                <button
-                  type="button"
-                  onClick={() => setInputMode('voice')}
-                  disabled={isRecording || isTranscribing || !rustChat}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 z-20 text-stone-400 hover:text-stone-600 transition-colors disabled:opacity-40"
-                  title="Switch to voice input">
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.8}
-                      d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
-                    />
-                  </svg>
-                </button>
+                {/* Voice input mic hidden per #717 (inputMode='voice' path retained). */}
               </div>
               <button
                 onClick={() => {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -114,38 +114,7 @@ const featuresSettingsItems = [
       </svg>
     ),
   },
-  {
-    id: 'autocomplete',
-    title: 'Autocomplete',
-    description: 'Inline text completion style and app preferences',
-    route: 'autocomplete',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M4 7h16M4 12h10m-10 5h7m10 0l3 3m0 0l3-3m-3 3v-8"
-        />
-      </svg>
-    ),
-  },
-  {
-    id: 'voice',
-    title: 'Voice Dictation',
-    description: 'Hotkey, activation mode, writing style, and custom dictionary',
-    route: 'voice',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M12 3a3 3 0 00-3 3v6a3 3 0 006 0V6a3 3 0 00-3-3zm-7 9a7 7 0 0014 0m-7 7v2m-4 0h8"
-        />
-      </svg>
-    ),
-  },
+  // Autocomplete + Voice Dictation hidden per #717 (routes retained for re-enable).
   {
     id: 'messaging',
     title: 'Messaging Channels',
@@ -246,7 +215,7 @@ const Settings = () => {
           element={wrapSettingsPage(
             <SettingsSectionPage
               title="Features"
-              description="Screen awareness, autocomplete, voice, messaging, and tools."
+              description="Screen awareness, messaging, and tools."
               items={featuresSettingsItems}
             />
           )}

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -125,21 +125,7 @@ const BUILT_IN_SKILLS = [
     route: '/settings/screen-intelligence',
     icon: BUILT_IN_SKILL_ICONS.screenIntelligence,
   },
-  {
-    id: 'text-autocomplete',
-    title: 'Text Auto-Complete',
-    description:
-      'Suggest inline completions while you type and control where autocomplete is active.',
-    route: '/settings/autocomplete',
-    icon: BUILT_IN_SKILL_ICONS.textAutocomplete,
-  },
-  {
-    id: 'voice-stt',
-    title: 'Voice Intelligence',
-    description: 'Use the microphone for dictation and voice-driven chat with your AI.',
-    route: '/settings/voice',
-    icon: BUILT_IN_SKILL_ICONS.voiceStt,
-  },
+  // text-autocomplete + voice-stt hidden per #717 (modals/status hooks retained for re-enable).
 ];
 
 // ─── Item type for unified list ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Hides user-facing UI entry points for Voice Dictation/TTS and Autocomplete per product deprioritization
- Routes, panels, modals, and status hooks retained — re-enable is a revert of these hunks
- Closes #717, closes #706

## Hidden surfaces
- Features settings menu — Autocomplete + Voice Dictation cards
- Developer Options — Autocomplete Debug + Voice Debug cards
- Skills page — Text Auto-Complete + Voice Intelligence built-in cards
- Chat input — mic/voice mode toggle button

## Test plan
- [x] \`yarn compile\` (tsc --noEmit) clean
- [x] \`yarn lint\` clean
- [ ] Manual: Settings → Features no longer shows Autocomplete/Voice; Developer Options no longer shows debug panels; Skills page no longer shows those skill cards; chat input has no mic button