### PR TITLE
feat(skills): SKILL.md skills UI — browse, create, install from URL (#681)

### DIFF
--- a/app/src/components/skills/CreateSkillModal.tsx
+++ b/app/src/components/skills/CreateSkillModal.tsx
@@ -1,0 +1,416 @@
+/**
+ * CreateSkillModal
+ * ----------------
+ *
+ * Centered white modal that scaffolds a new SKILL.md skill via the
+ * `openhuman.skills_create` JSON-RPC method. Matches the settings-modal
+ * design rules (clean white, 520px desktop, 16px radius, backdrop + blur,
+ * Escape/click-out to close, focus capture) — see
+ * `.claude/rules/15-settings-modal-system.md`.
+ *
+ * Form fields mirror `SkillsCreateParams` on the Rust side:
+ *   - name          (required) — display name; also slugified into the
+ *                   on-disk skill directory. A live preview surfaces the
+ *                   slug so users can see what will hit the filesystem.
+ *   - description   (required) — short prose; persisted as the
+ *                   `description:` field in the generated YAML frontmatter.
+ *   - scope         (user | project) — where SKILL.md is written. The UI
+ *                   hides the `legacy` scope since that layout is read-only
+ *                   and being phased out.
+ *   - license       (optional) — free-form SPDX string (e.g. `MIT`,
+ *                   `Apache-2.0`). Forwarded verbatim.
+ *   - tags          (optional, CSV) — normalized client-side into an array;
+ *                   empty entries are dropped.
+ *   - allowedTools  (optional, CSV) — rekeyed to `allowed-tools` on the
+ *                   wire by `skillsApi.createSkill`.
+ *
+ * On success `onCreated(skill)` fires with the freshly-discovered
+ * `SkillSummary` so the parent grid can insert the new row without a
+ * full refetch. On failure the Rust error string is surfaced verbatim
+ * at the bottom of the form and the submit button re-enables.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import debug from 'debug';
+
+import {
+  skillsApi,
+  type CreateSkillInput,
+  type SkillScope,
+  type SkillSummary,
+} from '../../services/api/skillsApi';
+
+const log = debug('skills:create-modal');
+
+interface Props {
+  onClose: () => void;
+  onCreated: (skill: SkillSummary) => void;
+}
+
+const INITIAL_SCOPE: SkillScope = 'user';
+
+/**
+ * Client-side slug preview — mirrors the Rust `slugify_skill_name`
+ * heuristic (lowercase, ASCII alphanumerics + `-`, collapse repeats,
+ * trim hyphens at the edges). The preview is advisory only; the Rust
+ * side is authoritative when the skill is persisted.
+ */
+function previewSlug(name: string): string {
+  const lower = name.normalize('NFKD').toLowerCase();
+  let out = '';
+  let prevHyphen = false;
+  for (const ch of lower) {
+    // ASCII alnum pass-through
+    if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
+      out += ch;
+      prevHyphen = false;
+      continue;
+    }
+    if ((ch === '-' || ch === '_' || /\s/.test(ch)) && !prevHyphen) {
+      out += '-';
+      prevHyphen = true;
+    }
+  }
+  // Trim leading/trailing hyphens
+  return out.replace(/^-+|-+$/g, '');
+}
+
+function splitCsv(raw: string): string[] {
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
+export default function CreateSkillModal({ onClose, onCreated }: Props) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [scope, setScope] = useState<SkillScope>(INITIAL_SCOPE);
+  const [license, setLicense] = useState('');
+  const [author, setAuthor] = useState('');
+  const [tagsCsv, setTagsCsv] = useState('');
+  const [allowedToolsCsv, setAllowedToolsCsv] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const slug = useMemo(() => previewSlug(name), [name]);
+
+  const nameValid = slug.length > 0;
+  const descriptionValid = description.trim().length > 0;
+  const formValid = nameValid && descriptionValid && !submitting;
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const raf = window.requestAnimationFrame(() => {
+      firstFieldRef.current?.focus();
+    });
+    log('mount');
+    return () => {
+      window.cancelAnimationFrame(raf);
+      previousFocusRef.current?.focus?.();
+      log('unmount');
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) {
+        log('escape-key close');
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose, submitting]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!formValid) {
+        return;
+      }
+      const payload: CreateSkillInput = {
+        name: name.trim(),
+        description: description.trim(),
+        scope,
+      };
+      if (license.trim()) payload.license = license.trim();
+      if (author.trim()) payload.author = author.trim();
+      const tags = splitCsv(tagsCsv);
+      if (tags.length > 0) payload.tags = tags;
+      const allowedTools = splitCsv(allowedToolsCsv);
+      if (allowedTools.length > 0) payload.allowedTools = allowedTools;
+
+      log('submit name=%s scope=%s', payload.name, payload.scope);
+      setSubmitting(true);
+      setError(null);
+      try {
+        const created = await skillsApi.createSkill(payload);
+        log('submit-ok id=%s', created.id);
+        onCreated(created);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log('submit-err %s', message);
+        setError(message);
+        setSubmitting(false);
+      }
+    },
+    [allowedToolsCsv, author, description, formValid, license, name, onCreated, scope, tagsCsv]
+  );
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={e => {
+        if (e.target === e.currentTarget && !submitting) {
+          log('backdrop-click close');
+          onClose();
+        }
+      }}>
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
+        onClick={() => {
+          if (!submitting) {
+            log('backdrop-direct close');
+            onClose();
+          }
+        }}
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-skill-title"
+        className="relative w-full max-w-[520px] rounded-2xl bg-white shadow-2xl animate-fade-in">
+        <form onSubmit={handleSubmit}>
+          {/* Header */}
+          <div className="flex items-start justify-between gap-3 border-b border-stone-100 px-5 py-4">
+            <div className="min-w-0 flex-1">
+              <h2
+                id="create-skill-title"
+                className="text-base font-semibold text-stone-900 font-sans">
+                New skill
+              </h2>
+              <p className="mt-0.5 text-xs text-stone-500">
+                Scaffolds a <code className="font-mono">SKILL.md</code> with the supplied
+                frontmatter.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                if (!submitting) {
+                  log('close-button');
+                  onClose();
+                }
+              }}
+              disabled={submitting}
+              aria-label="Close"
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:opacity-40">
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="max-h-[70vh] space-y-4 overflow-y-auto px-5 py-4">
+            {/* Name */}
+            <div>
+              <label
+                htmlFor="create-skill-name"
+                className="block text-xs font-medium text-stone-600">
+                Name<span className="text-coral-500"> *</span>
+              </label>
+              <input
+                id="create-skill-name"
+                ref={firstFieldRef}
+                type="text"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                required
+                maxLength={128}
+                className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                placeholder="e.g. Trade Journal"
+              />
+              <p className="mt-1 text-[11px] text-stone-500">
+                Slug:{' '}
+                <code className="rounded bg-stone-100 px-1 py-[1px] font-mono text-stone-700">
+                  {slug || '—'}
+                </code>
+              </p>
+            </div>
+
+            {/* Description */}
+            <div>
+              <label
+                htmlFor="create-skill-description"
+                className="block text-xs font-medium text-stone-600">
+                Description<span className="text-coral-500"> *</span>
+              </label>
+              <textarea
+                id="create-skill-description"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                required
+                rows={3}
+                maxLength={500}
+                className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                placeholder="What does this skill do?"
+              />
+            </div>
+
+            {/* Scope */}
+            <fieldset>
+              <legend className="block text-xs font-medium text-stone-600">Scope</legend>
+              <div className="mt-1 flex gap-2">
+                {(['user', 'project'] as const).map(s => {
+                  const selected = scope === s;
+                  return (
+                    <label
+                      key={s}
+                      className={`flex flex-1 cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                        selected
+                          ? 'border-primary-500 bg-primary-50 text-primary-900'
+                          : 'border-stone-200 bg-white text-stone-700 hover:border-stone-300'
+                      }`}>
+                      <input
+                        type="radio"
+                        name="create-skill-scope"
+                        value={s}
+                        checked={selected}
+                        onChange={() => setScope(s)}
+                        className="h-3 w-3 accent-primary-500"
+                      />
+                      <span className="capitalize">{s}</span>
+                    </label>
+                  );
+                })}
+              </div>
+              <p className="mt-1 text-[11px] text-stone-500">
+                {scope === 'user'
+                  ? 'Written to ~/.openhuman/skills/<slug>/SKILL.md — available across all workspaces.'
+                  : 'Written to <workspace>/.openhuman/skills/<slug>/SKILL.md — requires workspace trust.'}
+              </p>
+            </fieldset>
+
+            {/* License / Author */}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div>
+                <label
+                  htmlFor="create-skill-license"
+                  className="block text-xs font-medium text-stone-600">
+                  License
+                </label>
+                <input
+                  id="create-skill-license"
+                  type="text"
+                  value={license}
+                  onChange={e => setLicense(e.target.value)}
+                  maxLength={64}
+                  className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                  placeholder="MIT"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="create-skill-author"
+                  className="block text-xs font-medium text-stone-600">
+                  Author
+                </label>
+                <input
+                  id="create-skill-author"
+                  type="text"
+                  value={author}
+                  onChange={e => setAuthor(e.target.value)}
+                  maxLength={128}
+                  className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                  placeholder="Your name"
+                />
+              </div>
+            </div>
+
+            {/* Tags */}
+            <div>
+              <label
+                htmlFor="create-skill-tags"
+                className="block text-xs font-medium text-stone-600">
+                Tags
+                <span className="ml-1 font-normal text-stone-400">(comma-separated)</span>
+              </label>
+              <input
+                id="create-skill-tags"
+                type="text"
+                value={tagsCsv}
+                onChange={e => setTagsCsv(e.target.value)}
+                maxLength={256}
+                className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                placeholder="trading, research"
+              />
+            </div>
+
+            {/* Allowed tools */}
+            <div>
+              <label
+                htmlFor="create-skill-tools"
+                className="block text-xs font-medium text-stone-600">
+                Allowed tools
+                <span className="ml-1 font-normal text-stone-400">(comma-separated)</span>
+              </label>
+              <input
+                id="create-skill-tools"
+                type="text"
+                value={allowedToolsCsv}
+                onChange={e => setAllowedToolsCsv(e.target.value)}
+                maxLength={512}
+                className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm font-mono text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                placeholder="node_exec, fetch"
+              />
+              <p className="mt-1 text-[11px] text-stone-500">
+                Rendered into the SKILL.md frontmatter as{' '}
+                <code className="font-mono">allowed-tools:</code>.
+              </p>
+            </div>
+
+            {/* Error */}
+            {error ? (
+              <div
+                role="alert"
+                className="rounded-xl border border-coral-200 bg-coral-50 p-3 text-xs text-coral-900">
+                <p className="font-semibold">Could not create skill</p>
+                <p className="mt-1 whitespace-pre-wrap font-mono">{error}</p>
+              </div>
+            ) : null}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-2 border-t border-stone-100 px-5 py-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:opacity-40">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!formValid}
+              className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">
+              {submitting ? 'Creating…' : 'Create skill'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/src/components/skills/InstallSkillDialog.tsx
+++ b/app/src/components/skills/InstallSkillDialog.tsx
@@ -1,0 +1,361 @@
+/**
+ * InstallSkillDialog
+ * ------------------
+ *
+ * Centered white modal that installs a published skill package via
+ * `openhuman.skills_install_from_url`. The Rust side shells out to
+ * `npx --yes skills add <url>` under the managed Node toolchain, with
+ * an allow-list on the URL (https only, no private/loopback/link-local/
+ * multicast/cloud-metadata hosts) and a wall-clock timeout (default 60s,
+ * max 600s).
+ *
+ * UI contract:
+ *   - Single URL input (https only) + optional timeout in seconds.
+ *   - While the RPC is in flight we show a "Installing…" indicator and
+ *     disable close / backdrop-dismiss so we don't orphan a subprocess.
+ *   - On success we surface the list of `newSkills` (ids that appeared
+ *     post-install) plus captured stdout/stderr panes, then hand the
+ *     first new skill id back to the caller via `onInstalled` so the
+ *     parent can refetch the list and auto-select the row.
+ *   - On failure the Rust error string is rendered verbatim in a coral
+ *     alert and the submit button re-enables.
+ *
+ * Design mirrors `CreateSkillModal` — see `.claude/rules/15-settings-modal-system.md`.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import debug from 'debug';
+
+import {
+  skillsApi,
+  type InstallSkillFromUrlResult,
+  type SkillSummary,
+} from '../../services/api/skillsApi';
+
+const log = debug('skills:install-dialog');
+
+interface Props {
+  onClose: () => void;
+  /**
+   * Fires when the backend reports the install succeeded. The parent is
+   * responsible for refetching the skills list (the RPC already returns
+   * the freshly-added ids, but the caller may want full `SkillSummary`
+   * rows). `newSkills` lists ids that appeared post-install.
+   */
+  onInstalled: (result: InstallSkillFromUrlResult) => void;
+  /**
+   * Optional: used only for symmetry with `CreateSkillModal`. When
+   * supplied and the caller wants to auto-open the detail drawer for a
+   * specific skill, they can resolve the full `SkillSummary` and call
+   * this directly. Not invoked by the dialog itself.
+   */
+  onSelectSkill?: (skill: SkillSummary) => void;
+}
+
+/**
+ * Cheap pre-flight URL shape check — mirrors the hard rules the Rust
+ * side enforces so we can fail fast without a round-trip. The Rust
+ * side is still authoritative.
+ */
+function isLikelyValidUrl(raw: string): boolean {
+  if (!raw.trim()) return false;
+  try {
+    const u = new URL(raw.trim());
+    return u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
+  const [url, setUrl] = useState('');
+  const [timeoutSecs, setTimeoutSecs] = useState<string>('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<InstallSkillFromUrlResult | null>(null);
+
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const urlValid = useMemo(() => isLikelyValidUrl(url), [url]);
+  const timeoutValid = useMemo(() => {
+    if (!timeoutSecs.trim()) return true;
+    const n = Number(timeoutSecs);
+    return Number.isInteger(n) && n > 0 && n <= 600;
+  }, [timeoutSecs]);
+  const formValid = urlValid && timeoutValid && !submitting && !result;
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const raf = window.requestAnimationFrame(() => {
+      firstFieldRef.current?.focus();
+    });
+    log('mount');
+    return () => {
+      window.cancelAnimationFrame(raf);
+      previousFocusRef.current?.focus?.();
+      log('unmount');
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) {
+        log('escape-key close');
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose, submitting]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!formValid) return;
+
+      const payload = {
+        url: url.trim(),
+        ...(timeoutSecs.trim() ? { timeoutSecs: Number(timeoutSecs) } : {}),
+      };
+      log('submit url=%s timeout=%s', payload.url, payload.timeoutSecs ?? 'default');
+      setSubmitting(true);
+      setError(null);
+      try {
+        const installed = await skillsApi.installSkillFromUrl(payload);
+        log(
+          'submit-ok new=%d stdout=%d stderr=%d',
+          installed.newSkills.length,
+          installed.stdout.length,
+          installed.stderr.length
+        );
+        setResult(installed);
+        onInstalled(installed);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log('submit-err %s', message);
+        setError(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [formValid, onInstalled, timeoutSecs, url]
+  );
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={e => {
+        if (e.target === e.currentTarget && !submitting) {
+          log('backdrop-click close');
+          onClose();
+        }
+      }}>
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 animate-fade-in bg-black/50 backdrop-blur-sm"
+        onClick={() => {
+          if (!submitting) {
+            log('backdrop-direct close');
+            onClose();
+          }
+        }}
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="install-skill-title"
+        className="relative w-full max-w-[560px] animate-fade-in rounded-2xl bg-white shadow-2xl">
+        <form onSubmit={handleSubmit}>
+          {/* Header */}
+          <div className="flex items-start justify-between gap-3 border-b border-stone-100 px-5 py-4">
+            <div className="min-w-0 flex-1">
+              <h2
+                id="install-skill-title"
+                className="font-sans text-base font-semibold text-stone-900">
+                Install skill from URL
+              </h2>
+              <p className="mt-0.5 text-xs text-stone-500">
+                Runs <code className="font-mono">npx --yes skills add &lt;url&gt;</code> under the
+                managed Node toolchain. HTTPS only; private and loopback hosts are blocked.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                if (!submitting) {
+                  log('close-button');
+                  onClose();
+                }
+              }}
+              disabled={submitting}
+              aria-label="Close"
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:opacity-40">
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="max-h-[70vh] space-y-4 overflow-y-auto px-5 py-4">
+            {/* URL */}
+            <div>
+              <label
+                htmlFor="install-skill-url"
+                className="block text-xs font-medium text-stone-600">
+                Skill URL<span className="text-coral-500"> *</span>
+              </label>
+              <input
+                id="install-skill-url"
+                ref={firstFieldRef}
+                type="url"
+                inputMode="url"
+                autoComplete="off"
+                value={url}
+                onChange={e => setUrl(e.target.value)}
+                disabled={submitting || result !== null}
+                required
+                maxLength={2048}
+                className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 font-mono text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 disabled:bg-stone-50 disabled:text-stone-500"
+                placeholder="https://example.com/my-skill.tgz"
+              />
+              {url.trim() && !urlValid ? (
+                <p className="mt-1 text-[11px] text-coral-600">
+                  URL must be a well-formed <code className="font-mono">https://</code> link.
+                </p>
+              ) : (
+                <p className="mt-1 text-[11px] text-stone-500">
+                  Points to anything <code className="font-mono">npx skills add</code> accepts — a
+                  tarball, a published npm package, or a git URL.
+                </p>
+              )}
+            </div>
+
+            {/* Timeout */}
+            <div>
+              <label
+                htmlFor="install-skill-timeout"
+                className="block text-xs font-medium text-stone-600">
+                Timeout
+                <span className="ml-1 font-normal text-stone-400">(seconds, optional)</span>
+              </label>
+              <input
+                id="install-skill-timeout"
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={600}
+                value={timeoutSecs}
+                onChange={e => setTimeoutSecs(e.target.value)}
+                disabled={submitting || result !== null}
+                className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 disabled:bg-stone-50 disabled:text-stone-500"
+                placeholder="60"
+              />
+              {!timeoutValid ? (
+                <p className="mt-1 text-[11px] text-coral-600">Must be an integer between 1 and 600.</p>
+              ) : (
+                <p className="mt-1 text-[11px] text-stone-500">
+                  Defaults to 60 seconds. Values outside 1–600 are clamped server-side.
+                </p>
+              )}
+            </div>
+
+            {/* In-flight indicator */}
+            {submitting ? (
+              <div
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-3 rounded-xl border border-primary-200 bg-primary-50 p-3 text-xs text-primary-900">
+                <span
+                  aria-hidden="true"
+                  className="h-3 w-3 flex-shrink-0 animate-spin rounded-full border-2 border-primary-300 border-t-primary-600"
+                />
+                <span>
+                  Running <code className="font-mono">npx skills add</code>… this can take up to
+                  the timeout you configured.
+                </span>
+              </div>
+            ) : null}
+
+            {/* Success panel */}
+            {result ? (
+              <div
+                role="status"
+                aria-live="polite"
+                className="space-y-3 rounded-xl border border-sage-200 bg-sage-50 p-3 text-xs text-sage-900">
+                <div>
+                  <p className="font-semibold">Install complete</p>
+                  <p className="mt-1">
+                    {result.newSkills.length > 0
+                      ? `Discovered ${result.newSkills.length} new skill${result.newSkills.length === 1 ? '' : 's'}.`
+                      : 'No new skill ids appeared — the package may have updated an existing skill or failed silently. Check stderr below.'}
+                  </p>
+                  {result.newSkills.length > 0 ? (
+                    <ul className="mt-1 list-disc pl-5 font-mono">
+                      {result.newSkills.map(id => (
+                        <li key={id}>{id}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+                {result.stdout ? (
+                  <details>
+                    <summary className="cursor-pointer font-semibold">stdout</summary>
+                    <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-sage-100 bg-white p-2 font-mono text-[11px] text-stone-800">
+                      {result.stdout}
+                    </pre>
+                  </details>
+                ) : null}
+                {result.stderr ? (
+                  <details>
+                    <summary className="cursor-pointer font-semibold">stderr</summary>
+                    <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-sage-100 bg-white p-2 font-mono text-[11px] text-stone-800">
+                      {result.stderr}
+                    </pre>
+                  </details>
+                ) : null}
+              </div>
+            ) : null}
+
+            {/* Error panel */}
+            {error ? (
+              <div
+                role="alert"
+                className="rounded-xl border border-coral-200 bg-coral-50 p-3 text-xs text-coral-900">
+                <p className="font-semibold">Could not install skill</p>
+                <p className="mt-1 whitespace-pre-wrap font-mono">{error}</p>
+              </div>
+            ) : null}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-2 border-t border-stone-100 px-5 py-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:opacity-40">
+              {result ? 'Done' : 'Cancel'}
+            </button>
+            {result ? null : (
+              <button
+                type="submit"
+                disabled={!formValid}
+                className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50">
+                {submitting ? 'Installing…' : 'Install'}
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/src/components/skills/InstallSkillDialog.tsx
+++ b/app/src/components/skills/InstallSkillDialog.tsx
@@ -2,23 +2,29 @@
  * InstallSkillDialog
  * ------------------
  *
- * Centered white modal that installs a published skill package via
- * `openhuman.skills_install_from_url`. The Rust side shells out to
- * `npx --yes skills add <url>` under the managed Node toolchain, with
- * an allow-list on the URL (https only, no private/loopback/link-local/
- * multicast/cloud-metadata hosts) and a wall-clock timeout (default 60s,
- * max 600s).
+ * Centered white modal that installs a skill via
+ * `openhuman.skills_install_from_url`. The Rust side fetches a single
+ * `SKILL.md` file over HTTPS and writes it into
+ * `<workspace>/.openhuman/skills/<slug>/SKILL.md`. URLs are allow-listed
+ * (https only, no private/loopback/link-local/multicast/cloud-metadata
+ * hosts) and a wall-clock timeout applies (default 60s, max 600s).
+ * `github.com/<o>/<r>/blob/<b>/<p>.md` URLs are auto-rewritten to their
+ * `raw.githubusercontent.com` equivalents.
  *
  * UI contract:
- *   - Single URL input (https only) + optional timeout in seconds.
- *   - While the RPC is in flight we show a "Installing…" indicator and
- *     disable close / backdrop-dismiss so we don't orphan a subprocess.
+ *   - Single URL input (https only, must point at a `.md` file) +
+ *     optional timeout in seconds.
+ *   - While the RPC is in flight we show a "Fetching…" indicator and
+ *     disable close / backdrop-dismiss so the caller sees the outcome.
  *   - On success we surface the list of `newSkills` (ids that appeared
- *     post-install) plus captured stdout/stderr panes, then hand the
- *     first new skill id back to the caller via `onInstalled` so the
+ *     post-install) plus captured fetch log / parse-warning panes, then
+ *     hand the result back to the caller via `onInstalled` so the
  *     parent can refetch the list and auto-select the row.
- *   - On failure the Rust error string is rendered verbatim in a coral
- *     alert and the submit button re-enables.
+ *   - On failure we map the Rust error prefix (`invalid url:`,
+ *     `unsupported url form:`, `fetch failed:`, `fetch too large:`,
+ *     `fetch timed out`, `invalid SKILL.md:`, `skill already installed`,
+ *     `write failed:`) to a short human title + hint, and show the raw
+ *     message below it for debugging.
  *
  * Design mirrors `CreateSkillModal` — see `.claude/rules/15-settings-modal-system.md`.
  */
@@ -65,6 +71,73 @@ function isLikelyValidUrl(raw: string): boolean {
   } catch {
     return false;
   }
+}
+
+interface CategorizedError {
+  title: string;
+  hint: string;
+}
+
+/**
+ * Map the stable Rust error prefixes from `install_skill_from_url` to a
+ * short human-readable title + hint. See
+ * `src/openhuman/skills/ops.rs::install_skill_from_url` for the full list.
+ */
+function categorizeInstallError(raw: string): CategorizedError {
+  const msg = raw.trim();
+  const lower = msg.toLowerCase();
+  if (lower.startsWith('invalid url:')) {
+    return {
+      title: 'URL rejected',
+      hint: 'Only public HTTPS URLs are allowed. Private, loopback, and metadata hosts are blocked.',
+    };
+  }
+  if (lower.startsWith('unsupported url form:')) {
+    return {
+      title: 'URL form not supported',
+      hint: 'Only direct `.md` links work. For GitHub, link to a file (github.com/owner/repo/blob/…/SKILL.md) — tree and repo roots are not installed.',
+    };
+  }
+  if (lower.startsWith('fetch too large:')) {
+    return {
+      title: 'SKILL.md too large',
+      hint: 'The SKILL.md must be under 1 MiB. Split bundled resources into `references/` or `scripts/` files instead of inlining them.',
+    };
+  }
+  if (lower.startsWith('fetch timed out')) {
+    return {
+      title: 'Fetch timed out',
+      hint: 'The remote host did not respond in time. Try again or raise the timeout (1–600 s).',
+    };
+  }
+  if (lower.startsWith('fetch failed:')) {
+    return {
+      title: 'Fetch failed',
+      hint: 'The request did not complete successfully. Check the URL points at a reachable public file, and that the host returned a 2xx response.',
+    };
+  }
+  if (lower.startsWith('invalid skill.md:')) {
+    return {
+      title: 'SKILL.md did not parse',
+      hint: 'The frontmatter must be valid YAML with non-empty `name` and `description` fields, terminated by `---`.',
+    };
+  }
+  if (lower.startsWith('skill already installed')) {
+    return {
+      title: 'Skill already installed',
+      hint: 'A skill with this slug already exists in the workspace. Remove it first or change the frontmatter `metadata.id` / `name`.',
+    };
+  }
+  if (lower.startsWith('write failed:')) {
+    return {
+      title: 'Could not write SKILL.md',
+      hint: 'The workspace skills directory was not writable. Check filesystem permissions for `<workspace>/.openhuman/skills/`.',
+    };
+  }
+  return {
+    title: 'Could not install skill',
+    hint: 'The backend returned an error. The raw message is shown below.',
+  };
 }
 
 export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
@@ -177,8 +250,9 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                 Install skill from URL
               </h2>
               <p className="mt-0.5 text-xs text-stone-500">
-                Runs <code className="font-mono">npx --yes skills add &lt;url&gt;</code> under the
-                managed Node toolchain. HTTPS only; private and loopback hosts are blocked.
+                Fetches a single <code className="font-mono">SKILL.md</code> over HTTPS and installs
+                it under <code className="font-mono">.openhuman/skills/</code>. HTTPS only; private
+                and loopback hosts are blocked.
               </p>
             </div>
             <button
@@ -224,7 +298,7 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                 required
                 maxLength={2048}
                 className="mt-1 w-full rounded-lg border border-stone-200 bg-white px-3 py-2 font-mono text-sm text-stone-900 shadow-sm transition-colors focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 disabled:bg-stone-50 disabled:text-stone-500"
-                placeholder="https://example.com/my-skill.tgz"
+                placeholder="https://raw.githubusercontent.com/owner/repo/main/SKILL.md"
               />
               {url.trim() && !urlValid ? (
                 <p className="mt-1 text-[11px] text-coral-600">
@@ -232,8 +306,9 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                 </p>
               ) : (
                 <p className="mt-1 text-[11px] text-stone-500">
-                  Points to anything <code className="font-mono">npx skills add</code> accepts — a
-                  tarball, a published npm package, or a git URL.
+                  Direct link to a <code className="font-mono">.md</code> file.{' '}
+                  <code className="font-mono">github.com/…/blob/…</code> URLs auto-rewrite to
+                  <code className="font-mono"> raw.githubusercontent.com</code>.
                 </p>
               )}
             </div>
@@ -278,8 +353,8 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                   className="h-3 w-3 flex-shrink-0 animate-spin rounded-full border-2 border-primary-300 border-t-primary-600"
                 />
                 <span>
-                  Running <code className="font-mono">npx skills add</code>… this can take up to
-                  the timeout you configured.
+                  Fetching <code className="font-mono">SKILL.md</code>… this can take up to the
+                  timeout you configured.
                 </span>
               </div>
             ) : null}
@@ -295,7 +370,7 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                   <p className="mt-1">
                     {result.newSkills.length > 0
                       ? `Discovered ${result.newSkills.length} new skill${result.newSkills.length === 1 ? '' : 's'}.`
-                      : 'No new skill ids appeared — the package may have updated an existing skill or failed silently. Check stderr below.'}
+                      : 'Skill installed, but no new skill ids appeared — the catalog may already contain a skill with the same slug.'}
                   </p>
                   {result.newSkills.length > 0 ? (
                     <ul className="mt-1 list-disc pl-5 font-mono">
@@ -307,7 +382,7 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                 </div>
                 {result.stdout ? (
                   <details>
-                    <summary className="cursor-pointer font-semibold">stdout</summary>
+                    <summary className="cursor-pointer font-semibold">Fetch log</summary>
                     <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-sage-100 bg-white p-2 font-mono text-[11px] text-stone-800">
                       {result.stdout}
                     </pre>
@@ -315,7 +390,7 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
                 ) : null}
                 {result.stderr ? (
                   <details>
-                    <summary className="cursor-pointer font-semibold">stderr</summary>
+                    <summary className="cursor-pointer font-semibold">Parse warnings</summary>
                     <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-sage-100 bg-white p-2 font-mono text-[11px] text-stone-800">
                       {result.stderr}
                     </pre>
@@ -328,9 +403,22 @@ export default function InstallSkillDialog({ onClose, onInstalled }: Props) {
             {error ? (
               <div
                 role="alert"
-                className="rounded-xl border border-coral-200 bg-coral-50 p-3 text-xs text-coral-900">
-                <p className="font-semibold">Could not install skill</p>
-                <p className="mt-1 whitespace-pre-wrap font-mono">{error}</p>
+                className="space-y-2 rounded-xl border border-coral-200 bg-coral-50 p-3 text-xs text-coral-900">
+                {(() => {
+                  const cat = categorizeInstallError(error);
+                  return (
+                    <>
+                      <p className="font-semibold">{cat.title}</p>
+                      <p>{cat.hint}</p>
+                      <details>
+                        <summary className="cursor-pointer font-semibold">Raw error</summary>
+                        <pre className="mt-1 whitespace-pre-wrap rounded border border-coral-200 bg-white p-2 font-mono text-[11px] text-stone-800">
+                          {error}
+                        </pre>
+                      </details>
+                    </>
+                  );
+                })()}
               </div>
             ) : null}
           </div>

--- a/app/src/components/skills/SkillDetailDrawer.tsx
+++ b/app/src/components/skills/SkillDetailDrawer.tsx
@@ -1,0 +1,270 @@
+/**
+ * SkillDetailDrawer
+ * -----------------
+ *
+ * Right-side slide-in drawer that surfaces metadata for a discovered SKILL.md
+ * skill plus a browsable tree of bundled resources (`scripts/`, `references/`,
+ * `assets/`). Clicking a resource loads its contents via
+ * `skillsApi.readSkillResource` and renders it in a size-gated preview pane.
+ *
+ * Accessibility / UX rules (per `.claude/rules/15-settings-modal-system.md`):
+ * - Rendered via `createPortal` on `document.body` so it overlays everything.
+ * - Backdrop click or Escape closes the drawer.
+ * - `role="dialog"` / `aria-modal="true"` / labelled heading.
+ * - Focus is captured on open and returned on close.
+ * - 520px wide on desktop, slides in from the right in 200ms ease-out.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import debug from 'debug';
+
+import type { SkillSummary } from '../../services/api/skillsApi';
+import SkillResourcePreview from './SkillResourcePreview';
+import SkillResourceTree from './SkillResourceTree';
+
+const log = debug('skills:drawer');
+
+interface Props {
+  skill: SkillSummary;
+  onClose: () => void;
+}
+
+function scopePill(scope: SkillSummary['scope'], legacy: boolean): { label: string; cls: string } {
+  if (legacy) {
+    return {
+      label: 'Legacy',
+      cls: 'bg-stone-100 text-stone-700 border-stone-200',
+    };
+  }
+  switch (scope) {
+    case 'user':
+      return {
+        label: 'User',
+        // Sage tones for user-scope per design system.
+        cls: 'bg-sage-50 text-sage-700 border-sage-200',
+      };
+    case 'project':
+      return {
+        label: 'Project',
+        // Amber tones for project-scope (trust-gated surface).
+        cls: 'bg-amber-50 text-amber-700 border-amber-200',
+      };
+    case 'legacy':
+    default:
+      return {
+        label: 'Legacy',
+        cls: 'bg-stone-100 text-stone-700 border-stone-200',
+      };
+  }
+}
+
+export default function SkillDetailDrawer({ skill, onClose }: Props) {
+  const [selectedResource, setSelectedResource] = useState<string | null>(null);
+  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Capture focus on mount, restore on unmount.
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    // Defer focus grab to next frame so the portal content is attached.
+    const raf = window.requestAnimationFrame(() => {
+      closeBtnRef.current?.focus();
+    });
+    log('mount skillId=%s', skill.id);
+    return () => {
+      window.cancelAnimationFrame(raf);
+      previousFocusRef.current?.focus?.();
+      log('unmount skillId=%s', skill.id);
+    };
+  }, [skill.id]);
+
+  // Close on Escape key.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        log('escape-key close skillId=%s', skill.id);
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose, skill.id]);
+
+  const pill = useMemo(() => scopePill(skill.scope, skill.legacy), [skill.scope, skill.legacy]);
+
+  const handleSelect = useCallback(
+    (path: string) => {
+      log('select-resource skillId=%s path=%s', skill.id, path);
+      setSelectedResource(path);
+    },
+    [skill.id]
+  );
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex"
+      onClick={e => {
+        if (e.target === e.currentTarget) {
+          log('backdrop-click close skillId=%s', skill.id);
+          onClose();
+        }
+      }}>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
+        onClick={() => {
+          log('backdrop-direct close skillId=%s', skill.id);
+          onClose();
+        }}
+      />
+
+      {/* Drawer */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="skill-drawer-title"
+        className="relative ml-auto flex h-full w-full max-w-[520px] flex-col bg-white shadow-2xl animate-slide-in-right">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 border-b border-stone-100 px-5 py-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2
+                id="skill-drawer-title"
+                className="truncate text-base font-semibold text-stone-900 font-sans">
+                {skill.name}
+              </h2>
+              <span
+                className={`inline-flex flex-shrink-0 items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${pill.cls}`}>
+                {pill.label}
+              </span>
+            </div>
+            {skill.version ? (
+              <p className="mt-1 text-xs text-stone-500 font-mono">v{skill.version}</p>
+            ) : null}
+          </div>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={() => {
+              log('close-button skillId=%s', skill.id);
+              onClose();
+            }}
+            aria-label="Close skill details"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1">
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="px-5 py-4 space-y-4">
+            {/* Description */}
+            {skill.description ? (
+              <p className="text-sm leading-relaxed text-stone-700 font-sans">
+                {skill.description}
+              </p>
+            ) : null}
+
+            {/* Metadata grid */}
+            <dl className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-2 text-xs">
+              {skill.author ? (
+                <>
+                  <dt className="font-medium text-stone-500">Author</dt>
+                  <dd className="text-stone-800">{skill.author}</dd>
+                </>
+              ) : null}
+              {skill.tags.length > 0 ? (
+                <>
+                  <dt className="font-medium text-stone-500">Tags</dt>
+                  <dd className="flex flex-wrap gap-1">
+                    {skill.tags.map(tag => (
+                      <span
+                        key={tag}
+                        className="inline-flex items-center rounded-md border border-stone-200 bg-stone-50 px-1.5 py-0.5 text-[10px] text-stone-700">
+                        {tag}
+                      </span>
+                    ))}
+                  </dd>
+                </>
+              ) : null}
+              {skill.tools.length > 0 ? (
+                <>
+                  <dt className="font-medium text-stone-500">Allowed tools</dt>
+                  <dd className="flex flex-wrap gap-1">
+                    {skill.tools.map(tool => (
+                      <span
+                        key={tool}
+                        className="inline-flex items-center rounded-md border border-primary-100 bg-primary-50 px-1.5 py-0.5 font-mono text-[10px] text-primary-700">
+                        {tool}
+                      </span>
+                    ))}
+                  </dd>
+                </>
+              ) : null}
+              {skill.location ? (
+                <>
+                  <dt className="font-medium text-stone-500">Location</dt>
+                  <dd className="truncate font-mono text-[11px] text-stone-600" title={skill.location}>
+                    {skill.location}
+                  </dd>
+                </>
+              ) : null}
+            </dl>
+
+            {/* Warnings */}
+            {skill.warnings.length > 0 ? (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-amber-900">
+                  Warnings
+                </p>
+                <ul className="mt-1.5 list-disc space-y-1 pl-4 text-xs text-amber-800">
+                  {skill.warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {/* Resources */}
+            <div>
+              <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-stone-500">
+                Bundled resources ({skill.resources.length})
+              </h3>
+              {skill.resources.length === 0 ? (
+                <p className="text-xs text-stone-400 italic">No bundled resources.</p>
+              ) : (
+                <SkillResourceTree
+                  resources={skill.resources}
+                  selectedPath={selectedResource}
+                  onSelect={handleSelect}
+                />
+              )}
+            </div>
+
+            {/* Preview pane */}
+            {selectedResource ? (
+              <SkillResourcePreview
+                key={`${skill.id}:${selectedResource}`}
+                skillId={skill.id}
+                relativePath={selectedResource}
+                onDismiss={() => {
+                  log('dismiss-preview skillId=%s', skill.id);
+                  setSelectedResource(null);
+                }}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/src/components/skills/SkillResourcePreview.tsx
+++ b/app/src/components/skills/SkillResourcePreview.tsx
@@ -1,0 +1,147 @@
+/**
+ * SkillResourcePreview
+ * --------------------
+ *
+ * Size-gated text viewer for a single SKILL bundled resource. Fetches content
+ * via `skillsApi.readSkillResource`. The backend caps payloads at 128 KB, emits
+ * a traversal/symlink error as a plain string, and never streams — so the
+ * preview pane only has three visual states: loading, error, success.
+ *
+ * Errors (e.g. "path escape", ">128KB") are surfaced verbatim in a coral
+ * panel per the crypto-community design system.
+ */
+import { useEffect, useState } from 'react';
+import debug from 'debug';
+
+import { skillsApi } from '../../services/api/skillsApi';
+
+const log = debug('skills:resource-preview');
+
+interface Props {
+  skillId: string;
+  relativePath: string;
+  onDismiss: () => void;
+}
+
+interface LoadState {
+  status: 'loading' | 'success' | 'error';
+  content?: string;
+  bytes?: number;
+  error?: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export default function SkillResourcePreview({ skillId, relativePath, onDismiss }: Props) {
+  const [state, setState] = useState<LoadState>({ status: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    log('fetch skillId=%s path=%s', skillId, relativePath);
+    skillsApi
+      .readSkillResource({ skillId, relativePath })
+      .then(result => {
+        if (cancelled) return;
+        log('success bytes=%d', result.bytes);
+        setState({
+          status: 'success',
+          content: result.content,
+          bytes: result.bytes,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        log('error message=%s', message);
+        setState({ status: 'error', error: message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skillId, relativePath]);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-stone-200 bg-white shadow-soft">
+      <div className="flex items-center justify-between gap-2 border-b border-stone-200 bg-stone-50 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <p
+            className="truncate font-mono text-[11px] text-stone-700"
+            title={relativePath}>
+            {relativePath}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            log('dismiss skillId=%s path=%s', skillId, relativePath);
+            onDismiss();
+          }}
+          aria-label="Close preview"
+          className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1">
+          <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {state.status === 'loading' ? (
+        <div className="flex items-center justify-center gap-2 px-3 py-6 text-xs text-stone-500">
+          <svg
+            className="h-4 w-4 animate-spin text-primary-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            role="status"
+            aria-label="Loading">
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+          <span>Loading preview…</span>
+        </div>
+      ) : null}
+
+      {state.status === 'error' ? (
+        <div className="border-t border-coral-200 bg-coral-50 px-3 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-coral-900">
+            Preview failed
+          </p>
+          <p className="mt-1 break-words font-mono text-[11px] leading-relaxed text-coral-800">
+            {state.error}
+          </p>
+        </div>
+      ) : null}
+
+      {state.status === 'success' ? (
+        <>
+          <pre className="max-h-[320px] overflow-auto px-3 py-3 font-mono text-[11px] leading-relaxed text-stone-900 whitespace-pre-wrap break-words">
+            {state.content}
+          </pre>
+          <div className="flex items-center justify-end border-t border-stone-200 bg-stone-50 px-3 py-1.5">
+            <span className="text-[10px] font-mono text-stone-500">
+              {typeof state.bytes === 'number' ? formatBytes(state.bytes) : ''}
+            </span>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/components/skills/SkillResourceTree.tsx
+++ b/app/src/components/skills/SkillResourceTree.tsx
@@ -1,0 +1,118 @@
+/**
+ * SkillResourceTree
+ * -----------------
+ *
+ * Groups a flat list of skill resource paths by their top-level directory
+ * (`scripts/`, `references/`, `assets/`) with a catch-all "Other" bucket so
+ * anything unexpected still renders. Items are rendered as clickable rows in
+ * JetBrains Mono for path clarity. Selected item uses primary-50 background.
+ */
+import { useMemo } from 'react';
+import debug from 'debug';
+
+const log = debug('skills:resource-tree');
+
+interface Props {
+  resources: string[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+}
+
+interface ResourceGroup {
+  label: string;
+  key: string;
+  items: string[];
+}
+
+const KNOWN_GROUPS: Array<{ prefix: string; label: string; key: string }> = [
+  { prefix: 'scripts/', label: 'Scripts', key: 'scripts' },
+  { prefix: 'references/', label: 'References', key: 'references' },
+  { prefix: 'assets/', label: 'Assets', key: 'assets' },
+];
+
+function groupResources(resources: string[]): ResourceGroup[] {
+  const buckets = new Map<string, ResourceGroup>();
+  for (const known of KNOWN_GROUPS) {
+    buckets.set(known.key, { label: known.label, key: known.key, items: [] });
+  }
+  const other: ResourceGroup = { label: 'Other', key: 'other', items: [] };
+
+  for (const resource of resources) {
+    let matched = false;
+    for (const known of KNOWN_GROUPS) {
+      if (resource.startsWith(known.prefix)) {
+        buckets.get(known.key)!.items.push(resource);
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      other.items.push(resource);
+    }
+  }
+
+  for (const bucket of buckets.values()) {
+    bucket.items.sort((a, b) => a.localeCompare(b));
+  }
+  other.items.sort((a, b) => a.localeCompare(b));
+
+  const result: ResourceGroup[] = [];
+  for (const known of KNOWN_GROUPS) {
+    const bucket = buckets.get(known.key)!;
+    if (bucket.items.length > 0) {
+      result.push(bucket);
+    }
+  }
+  if (other.items.length > 0) {
+    result.push(other);
+  }
+  return result;
+}
+
+export default function SkillResourceTree({ resources, selectedPath, onSelect }: Props) {
+  const groups = useMemo(() => groupResources(resources), [resources]);
+
+  if (groups.length === 0) {
+    return <p className="text-xs text-stone-400 italic">No bundled resources.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {groups.map(group => (
+        <div
+          key={group.key}
+          className="rounded-xl border border-stone-200 bg-stone-50/50 overflow-hidden">
+          <div className="flex items-center justify-between border-b border-stone-200 bg-stone-50 px-3 py-1.5">
+            <h4 className="text-[11px] font-semibold uppercase tracking-wide text-stone-600">
+              {group.label}
+            </h4>
+            <span className="text-[10px] text-stone-400 font-mono">{group.items.length}</span>
+          </div>
+          <ul className="divide-y divide-stone-100">
+            {group.items.map(path => {
+              const isSelected = selectedPath === path;
+              return (
+                <li key={path}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      log('click path=%s', path);
+                      onSelect(path);
+                    }}
+                    className={`w-full truncate px-3 py-2 text-left text-[11px] font-mono transition-colors focus:outline-none focus:ring-1 focus:ring-inset focus:ring-primary-500 ${
+                      isSelected
+                        ? 'bg-primary-50 text-primary-700'
+                        : 'text-stone-700 hover:bg-white'
+                    }`}
+                    title={path}>
+                    {path}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/skills/__tests__/CreateSkillModal.test.tsx
+++ b/app/src/components/skills/__tests__/CreateSkillModal.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * CreateSkillModal — vitest coverage
+ *
+ * Verifies:
+ * - Renders title + required fields.
+ * - Escape key closes (but not while submitting).
+ * - Backdrop click closes (but not while submitting).
+ * - Submit is disabled when name or description is empty.
+ * - Submit rekeys `allowedTools` → `'allowed-tools'` via skillsApi.createSkill.
+ * - Submit calls `onCreated` with the returned skill.
+ * - Submit failure surfaces an error banner and re-enables the button.
+ * - Slug preview updates as the name changes.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SkillSummary } from '../../../services/api/skillsApi';
+import CreateSkillModal from '../CreateSkillModal';
+
+vi.mock('../../../services/api/skillsApi', () => ({
+  skillsApi: {
+    createSkill: vi.fn(),
+  },
+}));
+
+function builtSkill(overrides: Partial<SkillSummary> = {}): SkillSummary {
+  return {
+    id: 'my-skill',
+    name: 'My Skill',
+    description: 'does stuff',
+    version: '',
+    author: null,
+    tags: [],
+    tools: [],
+    prompts: [],
+    location: '/home/u/.openhuman/skills/my-skill/SKILL.md',
+    resources: [],
+    scope: 'user',
+    legacy: false,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('CreateSkillModal', () => {
+  beforeEach(async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.createSkill).mockReset();
+  });
+
+  it('renders title and required fields', () => {
+    render(<CreateSkillModal onClose={vi.fn()} onCreated={vi.fn()} />);
+    expect(screen.getByText('New skill')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Description/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Create skill/ })).toBeInTheDocument();
+  });
+
+  it('updates slug preview as the user types the name', () => {
+    render(<CreateSkillModal onClose={vi.fn()} onCreated={vi.fn()} />);
+    const name = screen.getByLabelText(/Name/) as HTMLInputElement;
+    fireEvent.change(name, { target: { value: 'My Trade Journal!' } });
+    expect(screen.getByText('my-trade-journal')).toBeInTheDocument();
+  });
+
+  it('disables submit when name or description is empty', () => {
+    render(<CreateSkillModal onClose={vi.fn()} onCreated={vi.fn()} />);
+    const submit = screen.getByRole('button', { name: /Create skill/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/Name/), { target: { value: 'demo' } });
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/Description/), { target: { value: 'what it does' } });
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<CreateSkillModal onClose={onClose} onCreated={vi.fn()} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('rekeys allowedTools to allowed-tools on submit and calls onCreated', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    const created = builtSkill();
+    vi.mocked(skillsApi.createSkill).mockResolvedValueOnce(created);
+
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    render(<CreateSkillModal onClose={onClose} onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByLabelText(/Name/), { target: { value: 'My Skill' } });
+    fireEvent.change(screen.getByLabelText(/Description/), { target: { value: 'does stuff' } });
+    fireEvent.change(screen.getByLabelText(/Tags/), { target: { value: 'alpha, beta' } });
+    fireEvent.change(screen.getByLabelText(/Allowed tools/), {
+      target: { value: 'mcp/fs, fetch' },
+    });
+
+    const submit = screen.getByRole('button', { name: /Create skill/ });
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    expect(vi.mocked(skillsApi.createSkill)).toHaveBeenCalledWith({
+      name: 'My Skill',
+      description: 'does stuff',
+      scope: 'user',
+      tags: ['alpha', 'beta'],
+      allowedTools: ['mcp/fs', 'fetch'],
+    });
+    expect(onCreated).toHaveBeenCalledWith(created);
+  });
+
+  it('surfaces error and re-enables submit on failure', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.createSkill).mockRejectedValueOnce(new Error('slug already exists'));
+
+    render(<CreateSkillModal onClose={vi.fn()} onCreated={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Name/), { target: { value: 'dup' } });
+    fireEvent.change(screen.getByLabelText(/Description/), { target: { value: 'x' } });
+
+    const submit = screen.getByRole('button', { name: /Create skill/ }) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('slug already exists');
+    });
+    expect(submit.disabled).toBe(false);
+  });
+});

--- a/app/src/components/skills/__tests__/InstallSkillDialog.test.tsx
+++ b/app/src/components/skills/__tests__/InstallSkillDialog.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * InstallSkillDialog — vitest coverage
+ *
+ * Verifies:
+ * - Renders title + url input + install button.
+ * - Submit disabled until a well-formed https URL is entered.
+ * - Shows inline error for non-https URLs.
+ * - Rejects timeout outside 1–600.
+ * - Submit forwards timeoutSecs to skillsApi.installSkillFromUrl.
+ * - Success panel renders newSkills list + calls onInstalled.
+ * - Error panel renders verbatim on failure and submit re-enables.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InstallSkillDialog from '../InstallSkillDialog';
+
+vi.mock('../../../services/api/skillsApi', () => ({
+  skillsApi: {
+    installSkillFromUrl: vi.fn(),
+  },
+}));
+
+describe('InstallSkillDialog', () => {
+  beforeEach(async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.installSkillFromUrl).mockReset();
+  });
+
+  it('renders title and URL input', () => {
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    expect(screen.getByText('Install skill from URL')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Skill URL/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Install/ })).toBeInTheDocument();
+  });
+
+  it('disables submit until a well-formed https URL is entered', () => {
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    const submit = screen.getByRole('button', { name: /Install/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/Skill URL/), { target: { value: 'not-a-url' } });
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'http://example.com/pkg.tgz' },
+    });
+    expect(submit.disabled).toBe(true);
+    expect(screen.getByText(/must be a well-formed/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://example.com/pkg.tgz' },
+    });
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('rejects out-of-range timeout values', () => {
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://example.com/pkg.tgz' },
+    });
+
+    const submit = screen.getByRole('button', { name: /Install/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+
+    fireEvent.change(screen.getByLabelText(/Timeout/), { target: { value: '9999' } });
+    expect(submit.disabled).toBe(true);
+    expect(screen.getByText(/Must be an integer between 1 and 600/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Timeout/), { target: { value: '120' } });
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('forwards timeoutSecs to skillsApi and fires onInstalled on success', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.installSkillFromUrl).mockResolvedValueOnce({
+      url: 'https://example.com/pkg.tgz',
+      stdout: 'added my-skill',
+      stderr: '',
+      newSkills: ['my-skill'],
+    });
+
+    const onInstalled = vi.fn();
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={onInstalled} />);
+
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://example.com/pkg.tgz' },
+    });
+    fireEvent.change(screen.getByLabelText(/Timeout/), { target: { value: '120' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Install/ }));
+    });
+
+    expect(vi.mocked(skillsApi.installSkillFromUrl)).toHaveBeenCalledWith({
+      url: 'https://example.com/pkg.tgz',
+      timeoutSecs: 120,
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Install complete')).toBeInTheDocument();
+    });
+    expect(screen.getByText('my-skill')).toBeInTheDocument();
+    expect(onInstalled).toHaveBeenCalledWith(
+      expect.objectContaining({ newSkills: ['my-skill'] })
+    );
+  });
+
+  it('omits timeoutSecs when field is blank', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.installSkillFromUrl).mockResolvedValueOnce({
+      url: 'https://example.com/pkg.tgz',
+      stdout: '',
+      stderr: '',
+      newSkills: [],
+    });
+
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://example.com/pkg.tgz' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Install/ }));
+    });
+
+    expect(vi.mocked(skillsApi.installSkillFromUrl)).toHaveBeenCalledWith({
+      url: 'https://example.com/pkg.tgz',
+    });
+  });
+
+  it('surfaces error verbatim and re-enables submit', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.installSkillFromUrl).mockRejectedValueOnce(
+      new Error('host blocked: localhost')
+    );
+
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://localhost/pkg.tgz' },
+    });
+
+    const submit = screen.getByRole('button', { name: /Install/ }) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('host blocked: localhost');
+    });
+    expect(submit.disabled).toBe(false);
+  });
+});

--- a/app/src/components/skills/__tests__/InstallSkillDialog.test.tsx
+++ b/app/src/components/skills/__tests__/InstallSkillDialog.test.tsx
@@ -8,7 +8,8 @@
  * - Rejects timeout outside 1–600.
  * - Submit forwards timeoutSecs to skillsApi.installSkillFromUrl.
  * - Success panel renders newSkills list + calls onInstalled.
- * - Error panel renders verbatim on failure and submit re-enables.
+ * - Error panel categorizes known prefixes and shows the raw error in
+ *   a details expander; unknown errors fall back to a generic title.
  */
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -43,13 +44,13 @@ describe('InstallSkillDialog', () => {
     expect(submit.disabled).toBe(true);
 
     fireEvent.change(screen.getByLabelText(/Skill URL/), {
-      target: { value: 'http://example.com/pkg.tgz' },
+      target: { value: 'http://example.com/SKILL.md' },
     });
     expect(submit.disabled).toBe(true);
     expect(screen.getByText(/must be a well-formed/)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Skill URL/), {
-      target: { value: 'https://example.com/pkg.tgz' },
+      target: { value: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md' },
     });
     expect(submit.disabled).toBe(false);
   });
@@ -57,7 +58,7 @@ describe('InstallSkillDialog', () => {
   it('rejects out-of-range timeout values', () => {
     render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
     fireEvent.change(screen.getByLabelText(/Skill URL/), {
-      target: { value: 'https://example.com/pkg.tgz' },
+      target: { value: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md' },
     });
 
     const submit = screen.getByRole('button', { name: /Install/ }) as HTMLButtonElement;
@@ -74,7 +75,7 @@ describe('InstallSkillDialog', () => {
   it('forwards timeoutSecs to skillsApi and fires onInstalled on success', async () => {
     const { skillsApi } = await import('../../../services/api/skillsApi');
     vi.mocked(skillsApi.installSkillFromUrl).mockResolvedValueOnce({
-      url: 'https://example.com/pkg.tgz',
+      url: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md',
       stdout: 'added my-skill',
       stderr: '',
       newSkills: ['my-skill'],
@@ -84,7 +85,7 @@ describe('InstallSkillDialog', () => {
     render(<InstallSkillDialog onClose={vi.fn()} onInstalled={onInstalled} />);
 
     fireEvent.change(screen.getByLabelText(/Skill URL/), {
-      target: { value: 'https://example.com/pkg.tgz' },
+      target: { value: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md' },
     });
     fireEvent.change(screen.getByLabelText(/Timeout/), { target: { value: '120' } });
 
@@ -93,7 +94,7 @@ describe('InstallSkillDialog', () => {
     });
 
     expect(vi.mocked(skillsApi.installSkillFromUrl)).toHaveBeenCalledWith({
-      url: 'https://example.com/pkg.tgz',
+      url: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md',
       timeoutSecs: 120,
     });
     await waitFor(() => {
@@ -108,7 +109,7 @@ describe('InstallSkillDialog', () => {
   it('omits timeoutSecs when field is blank', async () => {
     const { skillsApi } = await import('../../../services/api/skillsApi');
     vi.mocked(skillsApi.installSkillFromUrl).mockResolvedValueOnce({
-      url: 'https://example.com/pkg.tgz',
+      url: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md',
       stdout: '',
       stderr: '',
       newSkills: [],
@@ -116,7 +117,7 @@ describe('InstallSkillDialog', () => {
 
     render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
     fireEvent.change(screen.getByLabelText(/Skill URL/), {
-      target: { value: 'https://example.com/pkg.tgz' },
+      target: { value: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md' },
     });
 
     await act(async () => {
@@ -124,19 +125,19 @@ describe('InstallSkillDialog', () => {
     });
 
     expect(vi.mocked(skillsApi.installSkillFromUrl)).toHaveBeenCalledWith({
-      url: 'https://example.com/pkg.tgz',
+      url: 'https://raw.githubusercontent.com/owner/repo/main/SKILL.md',
     });
   });
 
-  it('surfaces error verbatim and re-enables submit', async () => {
+  it('shows generic title with raw error text on unknown error and re-enables submit', async () => {
     const { skillsApi } = await import('../../../services/api/skillsApi');
     vi.mocked(skillsApi.installSkillFromUrl).mockRejectedValueOnce(
-      new Error('host blocked: localhost')
+      new Error('unexpected: something weird happened')
     );
 
     render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
     fireEvent.change(screen.getByLabelText(/Skill URL/), {
-      target: { value: 'https://localhost/pkg.tgz' },
+      target: { value: 'https://example.com/SKILL.md' },
     });
 
     const submit = screen.getByRole('button', { name: /Install/ }) as HTMLButtonElement;
@@ -145,8 +146,54 @@ describe('InstallSkillDialog', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('host blocked: localhost');
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not install skill');
     });
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'unexpected: something weird happened'
+    );
     expect(submit.disabled).toBe(false);
+  });
+
+  it('categorizes "invalid SKILL.md:" errors with a friendly title and hint', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.installSkillFromUrl).mockRejectedValueOnce(
+      new Error('invalid SKILL.md: missing required field `description`')
+    );
+
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://example.com/SKILL.md' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Install/ }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('SKILL.md did not parse');
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(/frontmatter must be valid YAML/i);
+    expect(screen.getByRole('alert')).toHaveTextContent('missing required field');
+  });
+
+  it('categorizes "unsupported url form:" errors', async () => {
+    const { skillsApi } = await import('../../../services/api/skillsApi');
+    vi.mocked(skillsApi.installSkillFromUrl).mockRejectedValueOnce(
+      new Error('unsupported url form: path must end in .md, got "https://example.com/foo"')
+    );
+
+    render(<InstallSkillDialog onClose={vi.fn()} onInstalled={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Skill URL/), {
+      target: { value: 'https://example.com/SKILL.md' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Install/ }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('URL form not supported');
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(/direct `?\.md`? links/i);
   });
 });

--- a/app/src/components/skills/__tests__/SkillDetailDrawer.test.tsx
+++ b/app/src/components/skills/__tests__/SkillDetailDrawer.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * SkillDetailDrawer — vitest coverage
+ *
+ * Verifies:
+ * - Renders skill name, description, version, tags, allowed tools, warnings.
+ * - Escape key closes the drawer.
+ * - Close button click triggers onClose.
+ * - Backdrop click closes the drawer.
+ * - Resource list empty-state message shows when no resources.
+ * - Selecting a resource from the tree mounts the preview.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SkillSummary } from '../../../services/api/skillsApi';
+import SkillDetailDrawer from '../SkillDetailDrawer';
+
+// Mock skillsApi so <SkillResourcePreview /> doesn't hit the network
+vi.mock('../../../services/api/skillsApi', () => ({
+  skillsApi: {
+    listSkills: vi.fn().mockResolvedValue([]),
+    readSkillResource: vi.fn().mockResolvedValue({
+      skillId: 'demo',
+      relativePath: 'scripts/run.sh',
+      content: '#!/bin/sh\necho hi',
+      bytes: 18,
+    }),
+  },
+}));
+
+function buildSkill(overrides: Partial<SkillSummary> = {}): SkillSummary {
+  return {
+    id: 'demo',
+    name: 'demo',
+    description: 'A demonstration skill.',
+    version: '1.2.3',
+    author: 'Acme Labs',
+    tags: ['alpha', 'beta'],
+    tools: ['bash', 'python'],
+    prompts: [],
+    location: '/tmp/skills/demo/SKILL.md',
+    resources: ['scripts/run.sh', 'references/README.md', 'assets/logo.png'],
+    scope: 'user',
+    legacy: false,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('SkillDetailDrawer', () => {
+  it('renders core metadata and scope pill', () => {
+    const onClose = vi.fn();
+    render(<SkillDetailDrawer skill={buildSkill()} onClose={onClose} />);
+    expect(screen.getByText('demo')).toBeInTheDocument();
+    expect(screen.getByText('A demonstration skill.')).toBeInTheDocument();
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('Acme Labs')).toBeInTheDocument();
+    // User scope pill
+    expect(screen.getByText('User')).toBeInTheDocument();
+    // Tools
+    expect(screen.getByText('bash')).toBeInTheDocument();
+    expect(screen.getByText('python')).toBeInTheDocument();
+  });
+
+  it('shows Project pill for project-scope skills', () => {
+    render(<SkillDetailDrawer skill={buildSkill({ scope: 'project' })} onClose={vi.fn()} />);
+    expect(screen.getByText('Project')).toBeInTheDocument();
+  });
+
+  it('shows Legacy pill when legacy=true regardless of scope', () => {
+    render(
+      <SkillDetailDrawer
+        skill={buildSkill({ scope: 'user', legacy: true })}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
+  });
+
+  it('renders warnings in an amber panel', () => {
+    render(
+      <SkillDetailDrawer
+        skill={buildSkill({ warnings: ['unknown frontmatter field: foo'] })}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Warnings')).toBeInTheDocument();
+    expect(screen.getByText('unknown frontmatter field: foo')).toBeInTheDocument();
+  });
+
+  it('invokes onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(<SkillDetailDrawer skill={buildSkill()} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('invokes onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<SkillDetailDrawer skill={buildSkill()} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close skill details/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the empty-state hint when there are no bundled resources', () => {
+    render(<SkillDetailDrawer skill={buildSkill({ resources: [] })} onClose={vi.fn()} />);
+    expect(screen.getByText(/No bundled resources/i)).toBeInTheDocument();
+  });
+
+  it('mounts the preview when a resource is clicked', () => {
+    render(<SkillDetailDrawer skill={buildSkill()} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTitle('scripts/run.sh'));
+    // Loading state from preview
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+});

--- a/app/src/components/skills/__tests__/SkillResourcePreview.test.tsx
+++ b/app/src/components/skills/__tests__/SkillResourcePreview.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * SkillResourcePreview — vitest coverage
+ *
+ * Verifies:
+ * - Loading state renders a spinner.
+ * - Success path renders `content` in a <pre> and shows the size footer.
+ * - Error path surfaces the backend error string verbatim (e.g. "path escape").
+ * - Close button triggers onDismiss.
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { skillsApi } from '../../../services/api/skillsApi';
+import SkillResourcePreview from '../SkillResourcePreview';
+
+vi.mock('../../../services/api/skillsApi', () => ({
+  skillsApi: {
+    listSkills: vi.fn(),
+    readSkillResource: vi.fn(),
+  },
+}));
+
+const mockedReadSkillResource = skillsApi.readSkillResource as ReturnType<typeof vi.fn>;
+
+describe('SkillResourcePreview', () => {
+  beforeEach(() => {
+    mockedReadSkillResource.mockReset();
+  });
+
+  it('renders a loading spinner while the RPC is pending', () => {
+    mockedReadSkillResource.mockImplementation(() => new Promise(() => {}));
+    render(
+      <SkillResourcePreview skillId="demo" relativePath="scripts/run.sh" onDismiss={vi.fn()} />
+    );
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('renders content and a size footer on success', async () => {
+    mockedReadSkillResource.mockResolvedValueOnce({
+      skillId: 'demo',
+      relativePath: 'scripts/run.sh',
+      content: '#!/bin/sh\necho hello',
+      bytes: 20,
+    });
+    render(
+      <SkillResourcePreview skillId="demo" relativePath="scripts/run.sh" onDismiss={vi.fn()} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('#!/bin/sh echo hello')).toBeInTheDocument();
+    });
+    // Size footer ("20 B")
+    expect(screen.getByText('20 B')).toBeInTheDocument();
+  });
+
+  it('surfaces the backend error string verbatim on failure', async () => {
+    mockedReadSkillResource.mockRejectedValueOnce(new Error('path escape'));
+    render(
+      <SkillResourcePreview
+        skillId="demo"
+        relativePath="../../etc/passwd"
+        onDismiss={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Preview failed')).toBeInTheDocument();
+    });
+    expect(screen.getByText('path escape')).toBeInTheDocument();
+  });
+
+  it('surfaces size-cap errors verbatim', async () => {
+    mockedReadSkillResource.mockRejectedValueOnce(
+      new Error('resource exceeds maximum size of 131072 bytes')
+    );
+    render(
+      <SkillResourcePreview skillId="demo" relativePath="assets/huge.bin" onDismiss={vi.fn()} />
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/resource exceeds maximum size of 131072 bytes/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('calls onDismiss when the close button is clicked', async () => {
+    mockedReadSkillResource.mockResolvedValueOnce({
+      skillId: 'demo',
+      relativePath: 'scripts/run.sh',
+      content: 'ok',
+      bytes: 2,
+    });
+    const onDismiss = vi.fn();
+    render(
+      <SkillResourcePreview
+        skillId="demo"
+        relativePath="scripts/run.sh"
+        onDismiss={onDismiss}
+      />
+    );
+    await act(async () => {
+      // allow promise to settle
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /close preview/i }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -9,6 +9,8 @@ import {
   KNOWN_COMPOSIO_TOOLKITS,
 } from '../components/composio/toolkitMeta';
 import AutocompleteSetupModal from '../components/skills/AutocompleteSetupModal';
+import CreateSkillModal from '../components/skills/CreateSkillModal';
+import InstallSkillDialog from '../components/skills/InstallSkillDialog';
 import ScreenIntelligenceSetupModal from '../components/skills/ScreenIntelligenceSetupModal';
 import UnifiedSkillCard from '../components/skills/SkillCard';
 import { SKILL_CATEGORY_ORDER, type SkillCategory } from '../components/skills/skillCategories';
@@ -181,6 +183,8 @@ export default function Skills() {
   const [selectedCategory, setSelectedCategory] = useState<SkillCategory>('All');
   const [discoveredSkills, setDiscoveredSkills] = useState<SkillSummary[]>([]);
   const [selectedSkill, setSelectedSkill] = useState<SkillSummary | null>(null);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [installDialogOpen, setInstallDialogOpen] = useState(false);
   const pendingEscalationId =
     location.state &&
     typeof location.state === 'object' &&
@@ -221,24 +225,37 @@ export default function Skills() {
 
   // Discover SKILL.md skills via the core RPC. Ignore failures — the rest of
   // the page still works when the sidecar is unreachable or no skills exist.
+  // Extracted so create/install flows can trigger a refresh on success.
+  const refreshDiscoveredSkills = useCallback(async (): Promise<SkillSummary[]> => {
+    try {
+      const skills = await skillsApi.listSkills();
+      console.debug('[skills][discovered] listSkills ok', { count: skills.length });
+      setDiscoveredSkills(skills);
+      return skills;
+    } catch (err) {
+      console.debug('[skills][discovered] listSkills error', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    skillsApi
-      .listSkills()
-      .then(skills => {
-        if (cancelled) return;
-        console.debug('[skills][discovered] listSkills ok', { count: skills.length });
-        setDiscoveredSkills(skills);
-      })
-      .catch((err: unknown) => {
-        console.debug('[skills][discovered] listSkills error', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+    void (async () => {
+      const skills = await refreshDiscoveredSkills();
+      if (cancelled) {
+        // If the effect was cancelled mid-fetch, the state update still
+        // fired inside `refreshDiscoveredSkills`. That's fine — React
+        // will bail on the unmounted update; no retry needed.
+        return;
+      }
+      void skills;
+    })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [refreshDiscoveredSkills]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -392,6 +409,30 @@ export default function Skills() {
       <div className="min-h-full flex flex-col">
         <div className="flex-1 flex items-start justify-center p-4 pt-6">
           <div className="max-w-lg w-full space-y-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0">
+                <h1 className="text-base font-semibold text-stone-900">Skills</h1>
+                <p className="text-xs text-stone-500">
+                  Scaffold a new <code className="font-mono">SKILL.md</code> or install a published
+                  package.
+                </p>
+              </div>
+              <div className="flex flex-shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setInstallDialogOpen(true)}
+                  className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-xs font-medium text-stone-700 shadow-soft transition-colors hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1">
+                  Install from URL
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCreateModalOpen(true)}
+                  className="rounded-lg bg-primary-500 px-3 py-2 text-xs font-semibold text-white shadow-soft transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1">
+                  New skill
+                </button>
+              </div>
+            </div>
+
             <SkillSearchBar value={searchQuery} onChange={setSearchQuery} />
 
             <SkillCategoryFilter
@@ -685,6 +726,48 @@ export default function Skills() {
 
       {selectedSkill && (
         <SkillDetailDrawer skill={selectedSkill} onClose={() => setSelectedSkill(null)} />
+      )}
+
+      {createModalOpen && (
+        <CreateSkillModal
+          onClose={() => setCreateModalOpen(false)}
+          onCreated={skill => {
+            console.debug('[skills][create] created', { id: skill.id, scope: skill.scope });
+            setCreateModalOpen(false);
+            // Optimistically append; then reconcile against a fresh list so
+            // version/author/warnings picked up by the Rust discoverer end
+            // up in state too.
+            setDiscoveredSkills(prev =>
+              prev.some(s => s.id === skill.id) ? prev : [...prev, skill]
+            );
+            setSelectedSkill(skill);
+            void refreshDiscoveredSkills();
+          }}
+        />
+      )}
+
+      {installDialogOpen && (
+        <InstallSkillDialog
+          onClose={() => setInstallDialogOpen(false)}
+          onInstalled={result => {
+            console.debug('[skills][install] complete', {
+              url: result.url,
+              newSkills: result.newSkills.length,
+            });
+            void (async () => {
+              const skills = await refreshDiscoveredSkills();
+              // Auto-select the first newly-installed skill, if any — matches
+              // the create flow's UX of landing the user in the detail view.
+              const firstNewId = result.newSkills[0];
+              if (firstNewId) {
+                const match = skills.find(s => s.id === firstNewId);
+                if (match) {
+                  setSelectedSkill(match);
+                }
+              }
+            })();
+          }}
+        />
       )}
     </div>
   );

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -13,6 +13,7 @@ import ScreenIntelligenceSetupModal from '../components/skills/ScreenIntelligenc
 import UnifiedSkillCard from '../components/skills/SkillCard';
 import { SKILL_CATEGORY_ORDER, type SkillCategory } from '../components/skills/skillCategories';
 import SkillCategoryFilter from '../components/skills/SkillCategoryFilter';
+import SkillDetailDrawer from '../components/skills/SkillDetailDrawer';
 import {
   BUILT_IN_SKILL_ICONS,
   CHANNEL_ICONS,
@@ -28,6 +29,7 @@ import { useChannelDefinitions } from '../hooks/useChannelDefinitions';
 import { useComposioIntegrations } from '../lib/composio/hooks';
 import { canonicalizeComposioToolkitSlug } from '../lib/composio/toolkitSlug';
 import { type ComposioConnection, deriveComposioState } from '../lib/composio/types';
+import { skillsApi, type SkillSummary } from '../services/api/skillsApi';
 import { useAppSelector } from '../store/hooks';
 import type { ChannelConnectionStatus, ChannelDefinition, ChannelType } from '../types/channels';
 import { subconsciousEscalationsDismiss } from '../utils/tauriCommands';
@@ -135,7 +137,7 @@ interface SkillItem {
   name: string;
   description: string;
   category: SkillCategory;
-  kind: 'builtin' | 'channel' | 'composio';
+  kind: 'builtin' | 'channel' | 'composio' | 'discovered';
   // For built-in
   route?: string;
   icon?: React.ReactNode;
@@ -145,6 +147,8 @@ interface SkillItem {
   // For composio
   composioToolkit?: ComposioToolkitMeta;
   composioConnection?: ComposioConnection;
+  // For discovered SKILL.md skills
+  discoveredSkill?: SkillSummary;
 }
 
 // ─── Main Skills Page ──────────────────────────────────────────────────────────
@@ -175,6 +179,8 @@ export default function Skills() {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<SkillCategory>('All');
+  const [discoveredSkills, setDiscoveredSkills] = useState<SkillSummary[]>([]);
+  const [selectedSkill, setSelectedSkill] = useState<SkillSummary | null>(null);
   const pendingEscalationId =
     location.state &&
     typeof location.state === 'object' &&
@@ -212,6 +218,27 @@ export default function Skills() {
     },
     [clearPendingEscalationState, pendingEscalationId]
   );
+
+  // Discover SKILL.md skills via the core RPC. Ignore failures — the rest of
+  // the page still works when the sidecar is unreachable or no skills exist.
+  useEffect(() => {
+    let cancelled = false;
+    skillsApi
+      .listSkills()
+      .then(skills => {
+        if (cancelled) return;
+        console.debug('[skills][discovered] listSkills ok', { count: skills.length });
+        setDiscoveredSkills(skills);
+      })
+      .catch((err: unknown) => {
+        console.debug('[skills][discovered] listSkills error', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -304,6 +331,21 @@ export default function Skills() {
       });
     }
 
+    // Discovered SKILL.md skills — surface each as a card whose CTA opens
+    // the detail drawer. They live under the generic "Other" category so
+    // they don't displace hand-curated built-ins or Channels.
+    for (const skill of discoveredSkills) {
+      items.push({
+        id: `discovered-${skill.id}`,
+        name: skill.name,
+        description: skill.description,
+        category: 'Other',
+        kind: 'discovered',
+        icon: BUILT_IN_SKILL_ICONS.screenIntelligence,
+        discoveredSkill: skill,
+      });
+    }
+
     return items;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -311,6 +353,7 @@ export default function Skills() {
     channelConnections,
     composioCatalogToolkits,
     composioConnectionByToolkit,
+    discoveredSkills,
   ]);
 
   const availableCategories: SkillCategory[] = useMemo(() => {
@@ -510,6 +553,48 @@ export default function Skills() {
                           />
                         );
                       }
+                      if (item.kind === 'discovered') {
+                        const skill = item.discoveredSkill!;
+                        const scopeLabel = skill.legacy
+                          ? 'Legacy'
+                          : skill.scope === 'user'
+                            ? 'User'
+                            : skill.scope === 'project'
+                              ? 'Project'
+                              : 'Legacy';
+                        const scopeDot = skill.legacy
+                          ? 'bg-stone-300'
+                          : skill.scope === 'user'
+                            ? 'bg-sage-500'
+                            : skill.scope === 'project'
+                              ? 'bg-amber-500'
+                              : 'bg-stone-300';
+                        const scopeColor = skill.legacy
+                          ? 'text-stone-600'
+                          : skill.scope === 'user'
+                            ? 'text-sage-600'
+                            : skill.scope === 'project'
+                              ? 'text-amber-600'
+                              : 'text-stone-600';
+                        return (
+                          <UnifiedSkillCard
+                            key={item.id}
+                            icon={item.icon}
+                            title={item.name}
+                            description={item.description}
+                            statusDot={scopeDot}
+                            statusLabel={scopeLabel}
+                            statusColor={scopeColor}
+                            ctaLabel="View"
+                            onCtaClick={() => {
+                              console.debug('[skills][discovered] open drawer', {
+                                skillId: skill.id,
+                              });
+                              setSelectedSkill(skill);
+                            }}
+                          />
+                        );
+                      }
                       if (item.kind === 'composio') {
                         const meta = item.composioToolkit!;
                         const connection = item.composioConnection;
@@ -596,6 +681,10 @@ export default function Skills() {
           }}
           onClose={() => setComposioModalToolkit(null)}
         />
+      )}
+
+      {selectedSkill && (
+        <SkillDetailDrawer skill={selectedSkill} onClose={() => setSelectedSkill(null)} />
       )}
     </div>
   );

--- a/app/src/services/api/__tests__/skillsApi.test.ts
+++ b/app/src/services/api/__tests__/skillsApi.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { skillsApi } from '../skillsApi';
+
+vi.mock('../../coreRpcClient', () => ({ callCoreRpc: vi.fn() }));
+
+describe('skillsApi.createSkill', () => {
+  beforeEach(async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockReset();
+  });
+
+  it('forwards inputs to skills_create and rekeys allowedTools', async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      skill: {
+        id: 'my-skill',
+        name: 'my-skill',
+        description: 'does stuff',
+        version: '',
+        author: null,
+        tags: ['alpha'],
+        tools: ['mcp/fs'],
+        prompts: [],
+        location: '/home/u/.openhuman/skills/my-skill/SKILL.md',
+        resources: [],
+        scope: 'user',
+        legacy: false,
+        warnings: [],
+      },
+    });
+
+    const result = await skillsApi.createSkill({
+      name: 'My Skill',
+      description: 'does stuff',
+      scope: 'user',
+      tags: ['alpha'],
+      allowedTools: ['mcp/fs'],
+    });
+
+    expect(callCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.skills_create',
+      params: {
+        name: 'My Skill',
+        description: 'does stuff',
+        scope: 'user',
+        tags: ['alpha'],
+        'allowed-tools': ['mcp/fs'],
+      },
+    });
+    expect(result.id).toBe('my-skill');
+    expect(result.scope).toBe('user');
+  });
+
+  it('omits optional fields when not provided', async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      skill: {
+        id: 'minimal',
+        name: 'minimal',
+        description: 'd',
+        version: '',
+        author: null,
+        tags: [],
+        tools: [],
+        prompts: [],
+        location: null,
+        resources: [],
+        scope: 'user',
+        legacy: false,
+        warnings: [],
+      },
+    });
+
+    await skillsApi.createSkill({ name: 'minimal', description: 'd' });
+
+    const call = vi.mocked(callCoreRpc).mock.calls[0][0];
+    expect(call.params).toEqual({ name: 'minimal', description: 'd' });
+  });
+
+  it('unwraps an envelope response', async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      data: {
+        skill: {
+          id: 'env',
+          name: 'env',
+          description: 'e',
+          version: '',
+          author: null,
+          tags: [],
+          tools: [],
+          prompts: [],
+          location: null,
+          resources: [],
+          scope: 'project',
+          legacy: false,
+          warnings: [],
+        },
+      },
+    });
+    const result = await skillsApi.createSkill({ name: 'env', description: 'e' });
+    expect(result.id).toBe('env');
+    expect(result.scope).toBe('project');
+  });
+});
+
+describe('skillsApi.installSkillFromUrl', () => {
+  beforeEach(async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockReset();
+  });
+
+  it('forwards url and rekeys timeoutSecs to timeout_secs', async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      url: 'https://example.com/my-skill.tgz',
+      stdout: 'added my-skill',
+      stderr: '',
+      new_skills: ['my-skill'],
+    });
+
+    const result = await skillsApi.installSkillFromUrl({
+      url: 'https://example.com/my-skill.tgz',
+      timeoutSecs: 120,
+    });
+
+    expect(callCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.skills_install_from_url',
+      params: { url: 'https://example.com/my-skill.tgz', timeout_secs: 120 },
+    });
+    expect(result.newSkills).toEqual(['my-skill']);
+    expect(result.stdout).toBe('added my-skill');
+  });
+
+  it('omits timeout_secs when not provided and normalizes missing new_skills', async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      url: 'https://example.com/x',
+      stdout: '',
+      stderr: '',
+      new_skills: undefined,
+    });
+
+    const result = await skillsApi.installSkillFromUrl({ url: 'https://example.com/x' });
+
+    const call = vi.mocked(callCoreRpc).mock.calls[0][0];
+    expect(call.params).toEqual({ url: 'https://example.com/x' });
+    expect(result.newSkills).toEqual([]);
+  });
+
+  it('unwraps an envelope response', async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      data: { url: 'https://example.com/y', stdout: 'ok', stderr: 'warn', new_skills: ['y-skill'] },
+    });
+    const result = await skillsApi.installSkillFromUrl({ url: 'https://example.com/y' });
+    expect(result.newSkills).toEqual(['y-skill']);
+    expect(result.stderr).toBe('warn');
+  });
+});

--- a/app/src/services/api/skillsApi.ts
+++ b/app/src/services/api/skillsApi.ts
@@ -73,6 +73,60 @@ interface RawSkillsReadResourceResult {
   bytes: number;
 }
 
+/**
+ * Parameters accepted by `openhuman.skills_create`.
+ *
+ * Matches the wire shape defined in `src/openhuman/skills/schemas.rs`
+ * (`SkillsCreateParams`) — `allowedTools` is rekeyed to `allowed-tools` on
+ * the JSON-RPC envelope per SKILL.md frontmatter convention (with
+ * `allowed_tools` accepted as an alias by the Rust deserializer).
+ */
+export interface CreateSkillInput {
+  name: string;
+  description: string;
+  scope?: SkillScope;
+  license?: string;
+  author?: string;
+  tags?: string[];
+  allowedTools?: string[];
+}
+
+interface RawSkillsCreateResult {
+  skill: SkillSummary;
+}
+
+/**
+ * Parameters accepted by `openhuman.skills_install_from_url`.
+ *
+ * `timeoutSecs` is optional — the Rust side defaults to 60s and caps at
+ * 600s. Values outside that range are clamped server-side.
+ */
+export interface InstallSkillFromUrlInput {
+  url: string;
+  timeoutSecs?: number;
+}
+
+/**
+ * Result of `openhuman.skills_install_from_url`.
+ *
+ * `newSkills` lists skill ids that appeared post-install (diff vs the
+ * pre-install snapshot). `stdout` and `stderr` are captured verbatim from
+ * the `npx skills add …` subprocess so the UI can surface progress/errors.
+ */
+export interface InstallSkillFromUrlResult {
+  url: string;
+  stdout: string;
+  stderr: string;
+  newSkills: string[];
+}
+
+interface RawInstallSkillFromUrlResult {
+  url: string;
+  stdout: string;
+  stderr: string;
+  new_skills: string[];
+}
+
 interface Envelope<T> {
   data?: T;
 }
@@ -127,6 +181,69 @@ export const skillsApi = {
       bytes: raw.bytes,
     };
     log('readSkillResource: response bytes=%d', normalized.bytes);
+    return normalized;
+  },
+
+  /**
+   * Scaffold a new SKILL.md skill via `openhuman.skills_create`.
+   *
+   * The Rust side slugifies the name, writes `SKILL.md` with the supplied
+   * frontmatter, and returns the freshly-discovered `SkillSummary` so the
+   * caller can insert the new row into the grid without a full refetch.
+   */
+  createSkill: async (input: CreateSkillInput): Promise<SkillSummary> => {
+    log('createSkill: request name=%s scope=%s', input.name, input.scope ?? 'default');
+    const response = await callCoreRpc<Envelope<RawSkillsCreateResult> | RawSkillsCreateResult>({
+      method: 'openhuman.skills_create',
+      params: {
+        name: input.name,
+        description: input.description,
+        ...(input.scope !== undefined ? { scope: input.scope } : {}),
+        ...(input.license !== undefined ? { license: input.license } : {}),
+        ...(input.author !== undefined ? { author: input.author } : {}),
+        ...(input.tags !== undefined ? { tags: input.tags } : {}),
+        ...(input.allowedTools !== undefined ? { 'allowed-tools': input.allowedTools } : {}),
+      },
+    });
+    const raw = unwrapEnvelope(response);
+    log('createSkill: response id=%s', raw.skill.id);
+    return raw.skill;
+  },
+
+  /**
+   * Install a published skill package by URL via `openhuman.skills_install_from_url`.
+   *
+   * The Rust side shells out to `npx --yes skills add <url>` under the
+   * managed Node toolchain, with an allow-list on the URL (https only,
+   * no private/loopback/link-local/multicast/cloud-metadata hosts) and a
+   * wall-clock timeout (default 60s, max 600s).
+   */
+  installSkillFromUrl: async (
+    input: InstallSkillFromUrlInput
+  ): Promise<InstallSkillFromUrlResult> => {
+    log('installSkillFromUrl: request url=%s', input.url);
+    const response = await callCoreRpc<
+      Envelope<RawInstallSkillFromUrlResult> | RawInstallSkillFromUrlResult
+    >({
+      method: 'openhuman.skills_install_from_url',
+      params: {
+        url: input.url,
+        ...(input.timeoutSecs !== undefined ? { timeout_secs: input.timeoutSecs } : {}),
+      },
+    });
+    const raw = unwrapEnvelope(response);
+    const normalized: InstallSkillFromUrlResult = {
+      url: raw.url,
+      stdout: raw.stdout,
+      stderr: raw.stderr,
+      newSkills: raw.new_skills ?? [],
+    };
+    log(
+      'installSkillFromUrl: response new=%d stdout=%d stderr=%d',
+      normalized.newSkills.length,
+      normalized.stdout.length,
+      normalized.stderr.length
+    );
     return normalized;
   },
 };

--- a/app/src/services/api/skillsApi.ts
+++ b/app/src/services/api/skillsApi.ts
@@ -110,8 +110,10 @@ export interface InstallSkillFromUrlInput {
  * Result of `openhuman.skills_install_from_url`.
  *
  * `newSkills` lists skill ids that appeared post-install (diff vs the
- * pre-install snapshot). `stdout` and `stderr` are captured verbatim from
- * the `npx skills add …` subprocess so the UI can surface progress/errors.
+ * pre-install snapshot). `stdout` holds a human-readable diagnostic summary
+ * (bytes fetched, target path); `stderr` holds non-fatal frontmatter parse
+ * warnings joined by newlines. There is no subprocess — the Rust side fetches
+ * SKILL.md directly over HTTPS.
  */
 export interface InstallSkillFromUrlResult {
   url: string;
@@ -211,12 +213,14 @@ export const skillsApi = {
   },
 
   /**
-   * Install a published skill package by URL via `openhuman.skills_install_from_url`.
+   * Install a remote SKILL.md by URL via `openhuman.skills_install_from_url`.
    *
-   * The Rust side shells out to `npx --yes skills add <url>` under the
-   * managed Node toolchain, with an allow-list on the URL (https only,
-   * no private/loopback/link-local/multicast/cloud-metadata hosts) and a
-   * wall-clock timeout (default 60s, max 600s).
+   * The Rust side fetches the SKILL.md directly over HTTPS (no subprocess,
+   * no Node toolchain required), validates the frontmatter, and writes it
+   * into the user-scope skills directory. URL must be https, resolve to a
+   * public host, and point at a single `.md` file; `github.com/.../blob/...`
+   * is normalised to its `raw.githubusercontent.com` equivalent. Size is
+   * capped at 1 MiB; timeout default 60s, max 600s.
    */
   installSkillFromUrl: async (
     input: InstallSkillFromUrlInput

--- a/app/src/services/api/skillsApi.ts
+++ b/app/src/services/api/skillsApi.ts
@@ -1,0 +1,132 @@
+import debug from 'debug';
+
+import { callCoreRpc } from '../coreRpcClient';
+
+const log = debug('skillsApi');
+
+/**
+ * Scope a skill was discovered in.
+ *
+ * Mirrors `openhuman::skills::ops::SkillScope` on the Rust side — serialized
+ * as a lowercase string (`"user" | "project" | "legacy"`).
+ */
+export type SkillScope = 'user' | 'project' | 'legacy';
+
+/**
+ * Wire-format representation of a discovered skill returned by
+ * `openhuman.skills_list`.
+ *
+ * Paths are intentionally serialized as strings (not URLs) to avoid lossy
+ * conversions on non-UTF-8 filesystems.
+ */
+export interface SkillSummary {
+  /** Stable identifier — equal to `name` on the Rust side. */
+  id: string;
+  /** Display name, from frontmatter or directory. */
+  name: string;
+  /** Short prose summary from frontmatter / `description`. */
+  description: string;
+  /** Version string, if declared (empty otherwise). */
+  version: string;
+  /** Author string, if declared. */
+  author: string | null;
+  /** Tags declared in frontmatter metadata. */
+  tags: string[];
+  /** Tool hint from `allowed-tools`. */
+  tools: string[];
+  /** Prompt files declared in the legacy manifest. */
+  prompts: string[];
+  /** Path to `SKILL.md` (or `skill.json`) on disk, or null if unknown. */
+  location: string | null;
+  /** Bundled resource files, relative to the skill root. */
+  resources: string[];
+  /** Where the skill came from. */
+  scope: SkillScope;
+  /** True when loaded from the legacy `skills/` layout. */
+  legacy: boolean;
+  /** Non-fatal parse warnings to surface in the UI. */
+  warnings: string[];
+}
+
+interface SkillsListResult {
+  skills: SkillSummary[];
+}
+
+/**
+ * Result of `openhuman.skills_read_resource`.
+ */
+export interface SkillResourceContent {
+  /** Echo of the requested skill id. */
+  skillId: string;
+  /** Echo of the requested relative path. */
+  relativePath: string;
+  /** UTF-8 file contents (<= 128 KB). */
+  content: string;
+  /** Size of the file on disk, in bytes. */
+  bytes: number;
+}
+
+interface RawSkillsReadResourceResult {
+  skill_id: string;
+  relative_path: string;
+  content: string;
+  bytes: number;
+}
+
+interface Envelope<T> {
+  data?: T;
+}
+
+function unwrapEnvelope<T>(response: Envelope<T> | T): T {
+  if (response && typeof response === 'object' && 'data' in response) {
+    const envelope = response as Envelope<T>;
+    if (envelope.data !== undefined) {
+      return envelope.data as T;
+    }
+  }
+  return response as T;
+}
+
+export const skillsApi = {
+  /** Enumerate SKILL.md / legacy skills visible in the active workspace. */
+  listSkills: async (): Promise<SkillSummary[]> => {
+    log('listSkills: request');
+    const response = await callCoreRpc<Envelope<SkillsListResult> | SkillsListResult>({
+      method: 'openhuman.skills_list',
+    });
+    const result = unwrapEnvelope(response);
+    const skills = result?.skills ?? [];
+    log('listSkills: response count=%d', skills.length);
+    return skills;
+  },
+
+  /**
+   * Read a single bundled resource file from a discovered skill. Rejects on
+   * traversal, symlink escape, non-UTF-8 payloads, or files larger than
+   * 128 KB — the caller surfaces the error string verbatim in the drawer.
+   */
+  readSkillResource: async ({
+    skillId,
+    relativePath,
+  }: {
+    skillId: string;
+    relativePath: string;
+  }): Promise<SkillResourceContent> => {
+    log('readSkillResource: request skillId=%s path=%s', skillId, relativePath);
+    const response = await callCoreRpc<
+      Envelope<RawSkillsReadResourceResult> | RawSkillsReadResourceResult
+    >({
+      method: 'openhuman.skills_read_resource',
+      params: { skill_id: skillId, relative_path: relativePath },
+    });
+    const raw = unwrapEnvelope(response);
+    const normalized: SkillResourceContent = {
+      skillId: raw.skill_id,
+      relativePath: raw.relative_path,
+      content: raw.content,
+      bytes: raw.bytes,
+    };
+    log('readSkillResource: response bytes=%d', normalized.bytes);
+    return normalized;
+  },
+};

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -110,6 +110,8 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     );
     // Bridge to external skill runtimes
     controllers.extend(crate::openhuman::socket::all_socket_registered_controllers());
+    // Discovered SKILL.md skills and their bundled resources
+    controllers.extend(crate::openhuman::skills::all_skills_registered_controllers());
     // User workspace and file management
     controllers.extend(crate::openhuman::workspace::all_workspace_registered_controllers());
     // Skill tool registry
@@ -177,6 +179,7 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
         crate::openhuman::screen_intelligence::all_screen_intelligence_controller_schemas(),
     );
     schemas.extend(crate::openhuman::socket::all_socket_controller_schemas());
+    schemas.extend(crate::openhuman::skills::all_skills_controller_schemas());
     schemas.extend(crate::openhuman::workspace::all_workspace_controller_schemas());
     schemas.extend(crate::openhuman::tools::all_tools_controller_schemas());
     schemas.extend(crate::openhuman::memory::all_memory_controller_schemas());
@@ -239,6 +242,7 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         "migrate" => Some("Data migration utilities."),
         "screen_intelligence" => Some("Screen capture, permissions, and accessibility automation."),
         "service" => Some("Desktop service lifecycle management."),
+        "skills" => Some("Discovered SKILL.md skills and their bundled resources."),
         "socket" => Some("Skills runtime socket bridge controls."),
         "memory" => Some("Document storage, vector search, key-value store, and knowledge graph."),
         "memory_tree" => Some(

--- a/src/openhuman/skills/mod.rs
+++ b/src/openhuman/skills/mod.rs
@@ -2,6 +2,10 @@
 
 pub mod bus;
 pub mod ops;
+pub mod schemas;
 pub mod types;
 
 pub use ops::*;
+pub use schemas::{
+    all_skills_controller_schemas, all_skills_registered_controllers, skills_schemas,
+};

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -571,11 +571,19 @@ fn load_from_legacy_manifest(
 /// placeholder.
 pub fn parse_skill_md(path: &Path) -> Option<(SkillFrontmatter, String, Vec<String>)> {
     let content = std::fs::read_to_string(path).ok()?;
+    parse_skill_md_str(&content)
+}
+
+/// Content-only variant of [`parse_skill_md`] used when the SKILL.md has been
+/// fetched over HTTPS (see [`install_skill_from_url`]) and has not yet landed
+/// on disk. Returns `None` when the frontmatter block is opened with `---` but
+/// never terminated — the same failure mode the file-based parser rejects.
+pub fn parse_skill_md_str(content: &str) -> Option<(SkillFrontmatter, String, Vec<String>)> {
     let mut lines = content.lines();
     let first = lines.next()?;
     if first.trim() != "---" {
         // No frontmatter — treat whole file as body.
-        return Some((SkillFrontmatter::default(), content, Vec::new()));
+        return Some((SkillFrontmatter::default(), content.to_string(), Vec::new()));
     }
 
     let mut yaml = String::new();
@@ -603,10 +611,7 @@ pub fn parse_skill_md(path: &Path) -> Option<(SkillFrontmatter, String, Vec<Stri
     let frontmatter = match serde_yaml::from_str::<SkillFrontmatter>(&yaml) {
         Ok(fm) => fm,
         Err(err) => {
-            log::warn!(
-                "[skills] failed to parse frontmatter in {}: {err}",
-                path.display()
-            );
+            log::warn!("[skills] failed to parse frontmatter: {err}");
             parse_warnings.push(format!("frontmatter parse error: {err}"));
             SkillFrontmatter::default()
         }
@@ -1124,19 +1129,24 @@ fn yaml_scalar(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 
-/// Default wall-clock budget for the `npx skills add` install path.
+/// Default wall-clock budget for the SKILL.md fetch.
 pub const DEFAULT_INSTALL_TIMEOUT_SECS: u64 = 60;
 /// Hard ceiling callers can request via `timeout_secs`.
 pub const MAX_INSTALL_TIMEOUT_SECS: u64 = 600;
 /// Upper bound on raw URL length accepted by [`validate_install_url`].
 pub const MAX_INSTALL_URL_LEN: usize = 2048;
+/// Upper bound on the fetched SKILL.md body. Single-file skills rarely exceed
+/// a few KB; the 1 MiB cap here is a defensive limit against a hostile or
+/// misconfigured host streaming an unbounded response into memory.
+pub const MAX_SKILL_MD_BYTES: usize = 1024 * 1024;
 
 /// Input for [`install_skill_from_url`]. Mirrors the `skills.install_from_url`
 /// JSON-RPC payload.
 #[derive(Debug, Clone, Deserialize)]
 pub struct InstallSkillFromUrlParams {
-    /// Remote skill package URL. Must be `https://` and resolve to a
-    /// non-private host (see [`validate_install_url`]).
+    /// Remote SKILL.md URL. Must be `https://`, resolve to a non-private host
+    /// (see [`validate_install_url`]), and point at a `.md` file after
+    /// github.com `/blob/` normalization.
     pub url: String,
     /// Optional wall-clock budget override, in seconds. Defaults to
     /// [`DEFAULT_INSTALL_TIMEOUT_SECS`] and is capped at
@@ -1146,54 +1156,80 @@ pub struct InstallSkillFromUrlParams {
 }
 
 /// Outcome of a successful install. `new_skills` is the set of skill slugs
-/// that appeared in the catalog as a result of the CLI run (post-discovery
+/// that appeared in the catalog since the start of the call (post-discovery
 /// minus pre-discovery).
 #[derive(Debug, Clone, Serialize)]
 pub struct InstallSkillFromUrlOutcome {
+    /// The URL the caller submitted, trimmed.
     pub url: String,
+    /// Human-readable install log — typically `Fetched N bytes from <url>\n
+    /// Installed to <path>`. Repurposed from the old npx stdout field so the
+    /// UI success panel keeps the same `<details>` layout.
     pub stdout: String,
+    /// Non-fatal warnings surfaced during parse (e.g. deprecated top-level
+    /// `version`/`author`/`tags`). Empty on the happy path. Repurposed from
+    /// the old npx stderr field.
     pub stderr: String,
+    /// Slugs that appeared in the workspace skill catalog as a result of the
+    /// install. Usually one, empty only when the SKILL.md could not be
+    /// enumerated by discovery (rare — indicates workspace trust mismatch).
     pub new_skills: Vec<String>,
 }
 
-/// Install a skill from a remote registry URL by shelling out to
-/// `npx --yes skills add <url>` through the managed Node.js toolchain.
+/// Install a skill by fetching its `SKILL.md` directly over HTTPS and writing
+/// it to `<workspace>/.openhuman/skills/<slug>/SKILL.md`.
 ///
-/// Validation applied before spawning anything:
+/// Design rationale: openhuman's skill discovery scans
+/// `<workspace>/.openhuman/skills/` (plus `~/.openhuman/skills/` and legacy
+/// paths), **not** the per-agent subdirectories that the vercel-labs `skills`
+/// CLI writes to (`./claude-code/skills/`, `./cursor/skills/`, …). The CLI's
+/// agent ecosystem is incompatible with openhuman's skill layout, so we fetch
+/// the SKILL.md file directly and install it into a layout discovery sees.
+///
+/// Validation applied before any network I/O:
 /// * URL length, scheme (`https` only), and host safety via
 ///   [`validate_install_url`] — rejects loopback, private, link-local,
 ///   multicast, shared-address ranges, `localhost`, and `.local` / `.localhost`
 ///   mDNS-style hostnames.
+/// * `github.com/<o>/<r>/blob/<b>/<p>` is rewritten to the raw
+///   `raw.githubusercontent.com/<o>/<r>/<b>/<p>` equivalent so humans can
+///   paste the URL they see in the browser.
+/// * The path must end in `.md` (case-insensitive). Repo/tree URLs and
+///   tarballs are rejected with `unsupported url form:`.
 /// * `timeout_secs` is clamped to [`MAX_INSTALL_TIMEOUT_SECS`].
 ///
 /// Runtime:
-/// * Reuses [`NodeBootstrap`] for toolchain resolution (same code path as
-///   `npm_exec`), so the user sees the same bootstrap / download behavior.
-/// * Clears the host env before spawn and rebuilds `PATH` with
-///   `resolved.bin_dir` prepended — `npx`, `node`, and anything the CLI
-///   shells out to stay on the managed toolchain.
-/// * Child runs in `workspace_dir` so the installer lands packages in the
-///   current project by default.
+/// * Body size is capped by [`MAX_SKILL_MD_BYTES`] (1 MiB). The advertised
+///   `Content-Length` is checked up front; the buffered body length is
+///   checked again after the download as defense against a lying header.
+/// * Frontmatter is validated — `name` and `description` are required per
+///   the agentskills.io spec.
+/// * The slug is derived from `metadata.id` when present, otherwise the
+///   sanitized `name` field. Collision with an existing directory is fatal
+///   (no silent overwrite).
+/// * Write is atomic: `SKILL.md.tmp` in the target dir, then `rename` on
+///   success.
 ///
 /// On success the full post-install skills catalog is re-discovered and the
 /// outcome includes the list of skill slugs that appeared since the start of
-/// the call (i.e. the skill(s) produced by `skills add`).
+/// the call.
 pub async fn install_skill_from_url(
     workspace_dir: &Path,
-    node_config: crate::openhuman::config::schema::NodeConfig,
     params: InstallSkillFromUrlParams,
 ) -> Result<InstallSkillFromUrlOutcome, String> {
-    let url = params.url.trim();
-    validate_install_url(url)?;
+    let raw_url = params.url.trim().to_string();
+    validate_install_url(&raw_url)?;
 
     let timeout_secs = params
         .timeout_secs
         .unwrap_or(DEFAULT_INSTALL_TIMEOUT_SECS)
-        .min(MAX_INSTALL_TIMEOUT_SECS)
-        .max(1);
+        .clamp(1, MAX_INSTALL_TIMEOUT_SECS);
+
+    let fetch_url = normalize_install_url(&raw_url)?;
 
     tracing::debug!(
-        url = %url,
+        raw_url = %raw_url,
+        fetch_url = %fetch_url,
         workspace = %workspace_dir.display(),
         timeout_secs = timeout_secs,
         "[skills] install_skill_from_url: entry"
@@ -1207,85 +1243,110 @@ pub async fn install_skill_from_url(
             .map(|s| s.name)
             .collect();
 
-    let bootstrap = crate::openhuman::node_runtime::NodeBootstrap::new(
-        node_config,
-        workspace_dir.to_path_buf(),
-        reqwest::Client::new(),
-    );
-    let resolved = bootstrap
-        .resolve()
-        .await
-        .map_err(|e| format!("node runtime unavailable: {e}"))?;
-
-    let npx_bin = if cfg!(windows) {
-        resolved.bin_dir.join("npx.cmd")
-    } else {
-        resolved.bin_dir.join("npx")
-    };
-    if !npx_bin.exists() {
-        return Err(format!(
-            "npx binary not found at {} (resolved toolchain {} is missing the npx launcher)",
-            npx_bin.display(),
-            resolved.version,
-        ));
-    }
-
-    let mut cmd = tokio::process::Command::new(&npx_bin);
-    cmd.arg("--yes").arg("skills").arg("add").arg(url);
-    cmd.current_dir(workspace_dir);
-    cmd.env_clear();
-
-    let host_path = std::env::var("PATH").unwrap_or_default();
-    let sep = if cfg!(windows) { ";" } else { ":" };
-    let new_path = if host_path.is_empty() {
-        resolved.bin_dir.to_string_lossy().into_owned()
-    } else {
-        format!("{}{}{}", resolved.bin_dir.display(), sep, host_path)
-    };
-    cmd.env("PATH", &new_path);
-    for var in &[
-        "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
-    ] {
-        if let Ok(v) = std::env::var(var) {
-            cmd.env(var, v);
-        }
-    }
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|e| format!("fetch failed: build http client: {e}"))?;
 
     tracing::info!(
-        version = %resolved.version,
-        source = ?resolved.source,
-        npx = %npx_bin.display(),
-        url = %url,
-        "[skills] install_skill_from_url: spawning `npx --yes skills add <url>`"
+        fetch_url = %fetch_url,
+        "[skills] install_skill_from_url: fetching SKILL.md"
     );
 
-    let spawn_result =
-        tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), cmd.output()).await;
-
-    let output = match spawn_result {
-        Ok(Ok(out)) => out,
-        Ok(Err(e)) => return Err(format!("failed to execute npx: {e}")),
-        Err(_) => {
-            return Err(format!(
-                "install timed out after {timeout_secs}s and was killed"
-            ));
+    let response = match client.get(&fetch_url).send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            if e.is_timeout() {
+                return Err(format!("fetch timed out after {timeout_secs}s"));
+            }
+            return Err(format!("fetch failed: {e}"));
         }
     };
 
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-
-    if !output.status.success() {
-        let trimmed = stderr.trim();
-        let detail = if trimmed.is_empty() {
-            stdout.trim().to_string()
-        } else {
-            trimmed.to_string()
-        };
+    let status = response.status();
+    if !status.is_success() {
         return Err(format!(
-            "`npx skills add {url}` exited with status {}: {detail}",
-            output.status
+            "fetch failed: {fetch_url} returned status {}",
+            status.as_u16()
         ));
+    }
+
+    if let Some(len) = response.content_length() {
+        if len > MAX_SKILL_MD_BYTES as u64 {
+            return Err(format!(
+                "fetch too large: {} bytes exceeds {MAX_SKILL_MD_BYTES} limit",
+                len
+            ));
+        }
+    }
+
+    let bytes = match response.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            if e.is_timeout() {
+                return Err(format!("fetch timed out after {timeout_secs}s"));
+            }
+            return Err(format!("fetch failed: reading body: {e}"));
+        }
+    };
+
+    if bytes.len() > MAX_SKILL_MD_BYTES {
+        return Err(format!(
+            "fetch too large: {} bytes exceeds {MAX_SKILL_MD_BYTES} limit",
+            bytes.len()
+        ));
+    }
+
+    let content = String::from_utf8(bytes.to_vec())
+        .map_err(|e| format!("invalid SKILL.md: body is not valid utf-8: {e}"))?;
+
+    let (frontmatter, _body, parse_warnings) = parse_skill_md_str(&content).ok_or_else(|| {
+        "invalid SKILL.md: frontmatter block opened with `---` but never terminated".to_string()
+    })?;
+
+    if frontmatter.name.trim().is_empty() {
+        return Err("invalid SKILL.md: missing required field 'name'".to_string());
+    }
+    if frontmatter.description.trim().is_empty() {
+        return Err("invalid SKILL.md: missing required field 'description'".to_string());
+    }
+
+    let slug = derive_install_slug(&frontmatter)?;
+
+    let skills_root = workspace_dir.join(".openhuman").join("skills");
+    let target_dir = skills_root.join(&slug);
+    if target_dir.exists() {
+        return Err(format!(
+            "skill already installed as {slug:?} at {}",
+            target_dir.display()
+        ));
+    }
+
+    std::fs::create_dir_all(&target_dir).map_err(|e| {
+        format!(
+            "write failed: create directory {}: {e}",
+            target_dir.display()
+        )
+    })?;
+
+    let target_file = target_dir.join(SKILL_MD);
+    let temp_file = target_dir.join("SKILL.md.tmp");
+    std::fs::write(&temp_file, &content)
+        .map_err(|e| format!("write failed: {}: {e}", temp_file.display()))?;
+    std::fs::rename(&temp_file, &target_file)
+        .map_err(|e| format!("write failed: rename {}: {e}", target_file.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o644);
+        if let Err(e) = std::fs::set_permissions(&target_file, perms) {
+            tracing::warn!(
+                target = %target_file.display(),
+                error = %e,
+                "[skills] install_skill_from_url: chmod 0644 failed (non-fatal)"
+            );
+        }
     }
 
     let trusted_after = is_workspace_trusted(workspace_dir);
@@ -1297,17 +1358,131 @@ pub async fn install_skill_from_url(
         .collect();
 
     tracing::info!(
-        url = %url,
+        raw_url = %raw_url,
+        fetch_url = %fetch_url,
+        slug = %slug,
+        bytes = content.len(),
         new_count = new_skills.len(),
         "[skills] install_skill_from_url: completed"
     );
 
+    let stdout = format!(
+        "Fetched {} bytes from {fetch_url}\nInstalled to {}",
+        content.len(),
+        target_file.display()
+    );
+    let stderr = parse_warnings.join("\n");
+
     Ok(InstallSkillFromUrlOutcome {
-        url: url.to_string(),
+        url: raw_url,
         stdout,
         stderr,
         new_skills,
     })
+}
+
+/// Rewrite `github.com/<o>/<r>/blob/<branch>/<path>` into its raw counterpart
+/// so a URL copied from a browser's GitHub page resolves to the file body
+/// instead of the HTML wrapper. Any other host is returned unchanged.
+///
+/// Also enforces that the final path ends in `.md` (case-insensitive). Tree,
+/// commit, and whole-repo URLs are rejected here — they require a
+/// fundamentally different install path (recursive fetch / tarball) that is
+/// out of scope for single-file SKILL.md installs.
+fn normalize_install_url(raw: &str) -> Result<String, String> {
+    let parsed =
+        url::Url::parse(raw).map_err(|e| format!("unsupported url form: parse {raw:?}: {e}"))?;
+    let host = parsed.host_str().unwrap_or("").to_ascii_lowercase();
+
+    let normalized = if host == "github.com" {
+        let segments: Vec<&str> = parsed
+            .path_segments()
+            .map(|it| it.collect())
+            .unwrap_or_default();
+        if segments.len() >= 5 && segments[2] == "blob" {
+            let owner = segments[0];
+            let repo = segments[1];
+            let branch = segments[3];
+            let rest = segments[4..].join("/");
+            format!("https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{rest}")
+        } else if segments.len() >= 3 && (segments[2] == "tree" || segments[2] == "raw") {
+            return Err(format!(
+                "unsupported url form: only direct SKILL.md links are supported, got {raw:?} (tree/dir URLs are not yet supported)"
+            ));
+        } else if segments.len() <= 2 {
+            return Err(format!(
+                "unsupported url form: only direct SKILL.md links are supported, got {raw:?} (whole-repo URLs are not yet supported)"
+            ));
+        } else {
+            raw.to_string()
+        }
+    } else {
+        raw.to_string()
+    };
+
+    let check = url::Url::parse(&normalized)
+        .map_err(|e| format!("unsupported url form: parse normalized {normalized:?}: {e}"))?;
+    let path_lower = check.path().to_ascii_lowercase();
+    if !path_lower.ends_with(".md") {
+        return Err(format!(
+            "unsupported url form: path must end in .md, got {normalized:?}"
+        ));
+    }
+
+    Ok(normalized)
+}
+
+/// Derive the install directory slug from the SKILL.md frontmatter.
+///
+/// Prefers `metadata.id` (the spec-aligned identifier) when present. Falls
+/// back to a sanitized form of `name`:
+///   * lowercase ASCII
+///   * non-alphanumeric runs collapsed to a single `-`
+///   * leading/trailing `-` trimmed
+///
+/// Rejects the empty string and paths that would escape the skills root
+/// (`..`, `/`, `\`). Max length is [`MAX_NAME_LEN`].
+fn derive_install_slug(fm: &SkillFrontmatter) -> Result<String, String> {
+    let candidate = fm
+        .metadata
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| fm.name.clone());
+
+    let mut out = String::with_capacity(candidate.len());
+    let mut last_dash = false;
+    for ch in candidate.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+
+    if out.is_empty() {
+        return Err(
+            "invalid SKILL.md: cannot derive slug from empty name/id — set a value in frontmatter"
+                .to_string(),
+        );
+    }
+    if out.len() > MAX_NAME_LEN {
+        return Err(format!(
+            "invalid SKILL.md: derived slug {out:?} exceeds {MAX_NAME_LEN} chars"
+        ));
+    }
+    if out.contains("..") || out.contains('/') || out.contains('\\') {
+        return Err(format!(
+            "invalid SKILL.md: derived slug {out:?} contains forbidden path components"
+        ));
+    }
+
+    Ok(out)
 }
 
 /// Validate a remote skill install URL. Returns `Ok(())` when the URL is
@@ -2216,5 +2391,170 @@ mod tests {
         assert!(validate_install_url("ftp://example.com/x").is_err());
         // unparseable bracketed host
         assert!(validate_install_url("https://[not-an-ip]/x").is_err());
+    }
+
+    #[test]
+    fn normalize_install_url_rewrites_github_blob_to_raw() {
+        let out = normalize_install_url("https://github.com/owner/repo/blob/main/path/to/SKILL.md")
+            .unwrap();
+        assert_eq!(
+            out,
+            "https://raw.githubusercontent.com/owner/repo/main/path/to/SKILL.md"
+        );
+    }
+
+    #[test]
+    fn normalize_install_url_rewrites_github_blob_nested_path() {
+        let out =
+            normalize_install_url("https://github.com/owner/repo/blob/feat/x/dir/sub/SKILL.md")
+                .unwrap();
+        assert_eq!(
+            out,
+            "https://raw.githubusercontent.com/owner/repo/feat/x/dir/sub/SKILL.md"
+        );
+    }
+
+    #[test]
+    fn normalize_install_url_passes_raw_github_through() {
+        let raw = "https://raw.githubusercontent.com/owner/repo/main/SKILL.md";
+        assert_eq!(normalize_install_url(raw).unwrap(), raw);
+    }
+
+    #[test]
+    fn normalize_install_url_rejects_tree_urls() {
+        let err =
+            normalize_install_url("https://github.com/owner/repo/tree/main/path").unwrap_err();
+        assert!(err.contains("unsupported url form"), "{err}");
+        assert!(err.contains("tree/dir"), "{err}");
+    }
+
+    #[test]
+    fn normalize_install_url_rejects_whole_repo() {
+        let err = normalize_install_url("https://github.com/owner/repo").unwrap_err();
+        assert!(err.contains("unsupported url form"), "{err}");
+        assert!(err.contains("whole-repo"), "{err}");
+    }
+
+    #[test]
+    fn normalize_install_url_rejects_non_md_suffix() {
+        let err = normalize_install_url("https://example.com/skill.txt").unwrap_err();
+        assert!(err.contains("unsupported url form"), "{err}");
+        assert!(err.contains(".md"), "{err}");
+    }
+
+    #[test]
+    fn normalize_install_url_accepts_uppercase_md_suffix() {
+        let raw = "https://example.com/SKILL.MD";
+        assert_eq!(normalize_install_url(raw).unwrap(), raw);
+    }
+
+    #[test]
+    fn derive_install_slug_prefers_metadata_id() {
+        let mut fm = SkillFrontmatter {
+            name: "My Skill".to_string(),
+            description: "x".to_string(),
+            ..Default::default()
+        };
+        fm.metadata.insert(
+            "id".to_string(),
+            serde_yaml::Value::String("canonical-id".to_string()),
+        );
+        assert_eq!(derive_install_slug(&fm).unwrap(), "canonical-id");
+    }
+
+    #[test]
+    fn derive_install_slug_sanitizes_name_fallback() {
+        let fm = SkillFrontmatter {
+            name: "My Cool Skill!!".to_string(),
+            description: "x".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(derive_install_slug(&fm).unwrap(), "my-cool-skill");
+    }
+
+    #[test]
+    fn derive_install_slug_collapses_runs_and_trims_edges() {
+        let fm = SkillFrontmatter {
+            name: "---foo__bar  baz---".to_string(),
+            description: "x".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(derive_install_slug(&fm).unwrap(), "foo-bar-baz");
+    }
+
+    #[test]
+    fn derive_install_slug_rejects_empty_after_sanitize() {
+        let fm = SkillFrontmatter {
+            name: "!!!".to_string(),
+            description: "x".to_string(),
+            ..Default::default()
+        };
+        let err = derive_install_slug(&fm).unwrap_err();
+        assert!(err.contains("invalid SKILL.md"), "{err}");
+    }
+
+    #[test]
+    fn derive_install_slug_rejects_oversized() {
+        let fm = SkillFrontmatter {
+            name: "a".repeat(MAX_NAME_LEN + 1),
+            description: "x".to_string(),
+            ..Default::default()
+        };
+        let err = derive_install_slug(&fm).unwrap_err();
+        assert!(err.contains("invalid SKILL.md"), "{err}");
+        assert!(err.contains("exceeds"), "{err}");
+    }
+
+    #[test]
+    fn derive_install_slug_sanitizes_path_escape_attempts() {
+        // `..` and `/` are non-alphanumeric so they collapse to `-` during
+        // sanitization — verify no path-escape characters survive.
+        let fm = SkillFrontmatter {
+            name: "../etc/passwd".to_string(),
+            description: "x".to_string(),
+            ..Default::default()
+        };
+        let slug = derive_install_slug(&fm).unwrap();
+        assert!(!slug.contains(".."), "slug leaked ..: {slug}");
+        assert!(!slug.contains('/'), "slug leaked /: {slug}");
+        assert!(!slug.contains('\\'), "slug leaked \\: {slug}");
+    }
+
+    #[test]
+    fn parse_skill_md_str_happy_path() {
+        let content = "---\nname: demo\ndescription: a demo skill\n---\n\n# Body\n";
+        let (fm, body, warnings) = parse_skill_md_str(content).unwrap();
+        assert_eq!(fm.name, "demo");
+        assert_eq!(fm.description, "a demo skill");
+        assert!(body.contains("# Body"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn parse_skill_md_str_unterminated_frontmatter_returns_none() {
+        let content = "---\nname: demo\ndescription: missing close\n# Body\n";
+        assert!(parse_skill_md_str(content).is_none());
+    }
+
+    #[test]
+    fn parse_skill_md_str_no_frontmatter_treats_whole_as_body() {
+        let content = "# Just a body\nno frontmatter here\n";
+        let (fm, body, warnings) = parse_skill_md_str(content).unwrap();
+        assert!(fm.name.is_empty());
+        assert_eq!(body, content);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn parse_skill_md_str_bad_yaml_returns_empty_frontmatter_with_warning() {
+        let content = "---\nname: [unterminated\ndescription: also bad\n---\n";
+        let (fm, _body, warnings) = parse_skill_md_str(content).unwrap();
+        assert!(fm.name.is_empty());
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("frontmatter parse error")),
+            "expected warning, got {warnings:?}"
+        );
     }
 }

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -28,6 +28,15 @@ const MAX_NAME_LEN: usize = 64;
 const MAX_DESCRIPTION_LEN: usize = 1024;
 const RESOURCE_DIRS: &[&str] = &["scripts", "references", "assets"];
 
+/// Upper bound on resource payload size (in bytes) returned by
+/// [`read_skill_resource`]. 128 KB is large enough for a typical SKILL-bundled
+/// script or reference doc but small enough to keep the JSON-RPC payload and
+/// UI memory footprint bounded even when a skill author bundles something
+/// unusually chonky (e.g. a minified binary fixture). Requests for files
+/// larger than this limit are rejected outright — callers must stream or
+/// download the file via another mechanism.
+pub const MAX_SKILL_RESOURCE_BYTES: u64 = 128 * 1024;
+
 /// Where the skill was discovered. Determines precedence on name collision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -632,6 +641,153 @@ pub fn inventory_resources(dir: &Path) -> Vec<PathBuf> {
     out
 }
 
+/// Read a bundled skill resource as UTF-8 text, hardened against directory
+/// traversal, symlink escape, and oversized payloads.
+///
+/// `skill_id` identifies the skill by its discovered `name` — the same field
+/// surfaced on [`Skill::name`]. The skill is resolved by running the standard
+/// discovery pipeline (`dirs::home_dir()` + `workspace_dir`, honoring the
+/// `.openhuman/trust` marker) and locating the matching entry; this keeps the
+/// read scoped to legitimately installed skills and reuses all the symlink /
+/// traversal hardening already baked into discovery.
+///
+/// `relative_path` is resolved relative to the skill's on-disk directory
+/// (the parent of its `SKILL.md` / `skill.json`). All of the following are
+/// rejected with an error:
+///
+/// * paths that canonicalize outside the skill root (traversal),
+/// * paths whose final component or any intermediate component is a symlink
+///   (link-follow escape),
+/// * non-file targets (directories, sockets, fifos),
+/// * files larger than [`MAX_SKILL_RESOURCE_BYTES`],
+/// * non-UTF-8 byte contents (binary files must be surfaced some other way —
+///   no lossy replacement).
+///
+/// On success returns the file's contents as an owned `String`.
+pub fn read_skill_resource(
+    workspace_dir: &Path,
+    skill_id: &str,
+    relative_path: &Path,
+) -> Result<String, String> {
+    tracing::debug!(
+        skill_id = %skill_id,
+        relative_path = %relative_path.display(),
+        workspace = %workspace_dir.display(),
+        "[skills] read_skill_resource: entry"
+    );
+
+    if skill_id.trim().is_empty() {
+        return Err("skill_id must not be empty".to_string());
+    }
+
+    let relative_str = relative_path.to_string_lossy();
+    if relative_str.trim().is_empty() {
+        return Err("relative_path must not be empty".to_string());
+    }
+    if relative_path.is_absolute() {
+        return Err("relative_path must be relative, not absolute".to_string());
+    }
+    // Reject any component that is `..`, is empty, starts with `.`, or is the
+    // root. `..` is the obvious traversal vector; the others are defense in
+    // depth against unusual path inputs (e.g. `./`, `//foo`, Windows `C:`).
+    for component in relative_path.components() {
+        use std::path::Component;
+        match component {
+            Component::Normal(_) => {}
+            Component::ParentDir => {
+                return Err("relative_path must not contain '..' components".to_string());
+            }
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("relative_path must be a plain relative path".to_string());
+            }
+        }
+    }
+
+    // Resolve the skill by running the standard discovery pipeline. We reuse
+    // `load_skills` (which honors both user and workspace roots plus the
+    // trust marker) so the resource read is scoped to the exact same set of
+    // skills the UI would already have shown the user.
+    let skills = load_skills(workspace_dir);
+    let skill = skills
+        .into_iter()
+        .find(|s| s.name == skill_id)
+        .ok_or_else(|| format!("skill '{skill_id}' not found"))?;
+    let skill_root = skill
+        .location
+        .as_deref()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| format!("skill '{skill_id}' has no on-disk location"))?
+        .to_path_buf();
+
+    // Canonicalize the root first. The root must itself be a real directory
+    // on disk (not a symlink). Reject early if this fails.
+    let canonical_root = std::fs::canonicalize(&skill_root).map_err(|e| {
+        format!(
+            "failed to canonicalize skill root {}: {e}",
+            skill_root.display()
+        )
+    })?;
+
+    let requested = canonical_root.join(relative_path);
+
+    // Pre-check the immediate target with `symlink_metadata` so we catch
+    // symlinked leaves before `canonicalize` silently follows them.
+    let leaf_meta = std::fs::symlink_metadata(&requested)
+        .map_err(|e| format!("failed to stat resource {}: {e}", requested.display()))?;
+    if leaf_meta.file_type().is_symlink() {
+        return Err("resource path is a symlink".to_string());
+    }
+    if !leaf_meta.is_file() {
+        return Err("resource path is not a regular file".to_string());
+    }
+
+    // Size gate — check via metadata before reading so we never allocate the
+    // buffer for an oversized file.
+    let size = leaf_meta.len();
+    if size > MAX_SKILL_RESOURCE_BYTES {
+        return Err(format!(
+            "resource file is {size} bytes, exceeds limit of {MAX_SKILL_RESOURCE_BYTES}"
+        ));
+    }
+
+    // Canonicalize the full path and verify it stays within the skill root.
+    // This catches any symlink reachable via an intermediate path component
+    // that was created after our initial checks (race-ish, but the
+    // `is_symlink` check above makes the obvious attack infeasible).
+    let canonical_requested = std::fs::canonicalize(&requested).map_err(|e| {
+        format!(
+            "failed to canonicalize resource {}: {e}",
+            requested.display()
+        )
+    })?;
+    if !canonical_requested.starts_with(&canonical_root) {
+        return Err(format!(
+            "resource path escapes skill root: {}",
+            canonical_requested.display()
+        ));
+    }
+
+    // Read the bytes and enforce strict UTF-8 (no lossy replacement — we
+    // would rather refuse a binary file than silently mangle it).
+    let bytes = std::fs::read(&canonical_requested).map_err(|e| {
+        format!(
+            "failed to read resource {}: {e}",
+            canonical_requested.display()
+        )
+    })?;
+    let content = std::str::from_utf8(&bytes)
+        .map_err(|e| format!("resource is not valid UTF-8 text: {e}"))?
+        .to_string();
+
+    tracing::debug!(
+        skill_id = %skill_id,
+        bytes = bytes.len(),
+        "[skills] read_skill_resource: success"
+    );
+
+    Ok(content)
+}
+
 fn walk_files(current: &Path, base: &Path, out: &mut Vec<PathBuf>) {
     let entries = match std::fs::read_dir(current) {
         Ok(e) => e,
@@ -1024,5 +1180,184 @@ mod tests {
         );
         let skills = load_skills_ws(ws);
         assert!(skills.is_empty());
+    }
+
+    // -- read_skill_resource -------------------------------------------------
+    //
+    // These tests exercise the resource-read path via legacy-scope skills
+    // (`<ws>/skills/<name>/`) because that scope doesn't require the trust
+    // marker, is fully workspace-scoped, and avoids touching the user's home
+    // directory. The guarantees tested here apply equally to user- and
+    // project-scope skills since they all flow through the same
+    // `canonicalize` + `symlink_metadata` + size check gauntlet.
+
+    fn make_legacy_skill(ws: &Path, name: &str) -> PathBuf {
+        let skill_dir = ws.join("skills").join(name);
+        write(
+            &skill_dir.join("SKILL.md"),
+            &format!("---\nname: {name}\ndescription: test skill\n---\n# {name}\n"),
+        );
+        skill_dir
+    }
+
+    #[test]
+    fn read_skill_resource_happy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let skill_dir = make_legacy_skill(ws, "demo");
+        write(
+            &skill_dir.join("scripts").join("hello.sh"),
+            "#!/bin/sh\necho hi\n",
+        );
+
+        let got = read_skill_resource(ws, "demo", Path::new("scripts/hello.sh"))
+            .expect("read should succeed");
+        assert_eq!(got, "#!/bin/sh\necho hi\n");
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let skill_dir = make_legacy_skill(ws, "demo");
+        // Put a secret *outside* the skill root.
+        write(&ws.join("secret.txt"), "top secret");
+        // Put a resource file inside so the skill has at least one bundled
+        // asset (makes the test realistic).
+        write(&skill_dir.join("scripts").join("ok.sh"), "ok");
+
+        let err = read_skill_resource(ws, "demo", Path::new("../../secret.txt"))
+            .expect_err("parent-dir traversal must be rejected");
+        assert!(
+            err.contains("..") || err.to_lowercase().contains("escape"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_absolute_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        make_legacy_skill(ws, "demo");
+
+        let err = read_skill_resource(ws, "demo", Path::new("/etc/passwd"))
+            .expect_err("absolute path must be rejected");
+        assert!(
+            err.to_lowercase().contains("absolute"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_skill_resource_rejects_symlinked_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let skill_dir = make_legacy_skill(ws, "demo");
+
+        // Target lives outside the skill root.
+        let external = tempfile::tempdir().unwrap();
+        write(&external.path().join("leaked.txt"), "leaked content");
+
+        // Symlink <skill>/scripts/leak.txt -> external/leaked.txt
+        std::fs::create_dir_all(skill_dir.join("scripts")).unwrap();
+        symlink(
+            external.path().join("leaked.txt"),
+            skill_dir.join("scripts/leak.txt"),
+        )
+        .unwrap();
+
+        let err = read_skill_resource(ws, "demo", Path::new("scripts/leak.txt"))
+            .expect_err("symlinked leaf must be rejected");
+        assert!(
+            err.to_lowercase().contains("symlink") || err.to_lowercase().contains("escape"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let skill_dir = make_legacy_skill(ws, "demo");
+        // Write MAX + 1 bytes.
+        let oversize = vec![b'a'; (MAX_SKILL_RESOURCE_BYTES as usize) + 1];
+        let target = skill_dir.join("references").join("big.txt");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, &oversize).unwrap();
+
+        let err = read_skill_resource(ws, "demo", Path::new("references/big.txt"))
+            .expect_err("oversized file must be rejected");
+        assert!(
+            err.to_lowercase().contains("exceeds") || err.to_lowercase().contains("limit"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_non_utf8_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let skill_dir = make_legacy_skill(ws, "demo");
+        // 0xFF is never valid UTF-8 (invalid start byte in any multi-byte
+        // sequence).
+        let target = skill_dir.join("assets").join("binary.bin");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, [0xFFu8, 0xFE, 0xFD, 0xFC]).unwrap();
+
+        let err = read_skill_resource(ws, "demo", Path::new("assets/binary.bin"))
+            .expect_err("non-UTF-8 content must be rejected");
+        assert!(
+            err.to_lowercase().contains("utf-8"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_unknown_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+
+        let err = read_skill_resource(ws, "does-not-exist", Path::new("scripts/x.sh"))
+            .expect_err("unknown skill must be rejected");
+        assert!(
+            err.to_lowercase().contains("not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_directory_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let skill_dir = make_legacy_skill(ws, "demo");
+        std::fs::create_dir_all(skill_dir.join("scripts").join("nested")).unwrap();
+
+        let err = read_skill_resource(ws, "demo", Path::new("scripts/nested"))
+            .expect_err("directory target must be rejected");
+        assert!(
+            err.to_lowercase().contains("not a regular file"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_skill_resource_rejects_empty_inputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        make_legacy_skill(ws, "demo");
+
+        let err = read_skill_resource(ws, "", Path::new("scripts/x.sh"))
+            .expect_err("empty skill_id must be rejected");
+        assert!(err.to_lowercase().contains("skill_id"), "unexpected: {err}");
+
+        let err = read_skill_resource(ws, "demo", Path::new(""))
+            .expect_err("empty relative_path must be rejected");
+        assert!(
+            err.to_lowercase().contains("relative_path"),
+            "unexpected: {err}"
+        );
     }
 }

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -1593,7 +1593,11 @@ pub async fn validate_resolved_host(raw_url: &str) -> Result<(), String> {
     let port = parsed.port_or_known_default().unwrap_or(443);
     // IPv6 literal hosts come back bracketed from `url::Url`; `lookup_host`
     // needs the bracketed form for IPv6 to parse correctly.
-    let lookup_target = if parsed.host().map(|h| matches!(h, url::Host::Ipv6(_))).unwrap_or(false) {
+    let lookup_target = if parsed
+        .host()
+        .map(|h| matches!(h, url::Host::Ipv6(_)))
+        .unwrap_or(false)
+    {
         format!("[{host}]:{port}")
     } else {
         format!("{host}:{port}")

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -827,6 +827,302 @@ fn first_body_line(body: &str) -> Option<String> {
     None
 }
 
+/// Input for [`create_skill`]. Mirrors the `skills.create` JSON-RPC payload.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct CreateSkillParams {
+    /// Human-readable name — slugified into the on-disk folder.
+    pub name: String,
+    /// One-line description written into the frontmatter.
+    pub description: String,
+    /// Where to install: `user`, `project`, or `legacy`. Defaults to `user`.
+    #[serde(default)]
+    pub scope: SkillScope,
+    /// Optional SPDX license (written to frontmatter `license`).
+    #[serde(default)]
+    pub license: Option<String>,
+    /// Optional author name (written under frontmatter `metadata.author`).
+    #[serde(default)]
+    pub author: Option<String>,
+    /// Optional tags (written under frontmatter `metadata.tags`).
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Optional tool hints (written to frontmatter `allowed-tools`).
+    #[serde(default, rename = "allowed-tools", alias = "allowed_tools")]
+    pub allowed_tools: Vec<String>,
+}
+
+/// Scaffold a new SKILL.md-based skill on disk.
+///
+/// Writes `<scope-root>/<slug>/SKILL.md` with frontmatter derived from
+/// `params` and creates empty `scripts/`, `references/`, `assets/` subdirs
+/// so the author has somewhere to drop bundled resources.
+///
+/// Scope resolution:
+/// * [`SkillScope::User`] → `~/.openhuman/skills/`
+/// * [`SkillScope::Project`] → `<workspace>/.openhuman/skills/`. Requires the
+///   trust marker at `<workspace>/.openhuman/trust` to be present; otherwise
+///   rejected with an error.
+/// * [`SkillScope::Legacy`] → rejected. Callers must pick one of the
+///   above; the legacy `<workspace>/skills/` layout is read-only going
+///   forward.
+///
+/// Name hardening:
+/// * Slug is derived from `params.name` (lowercased, `[a-z0-9-]` only,
+///   non-alphanumeric runs collapsed to a single `-`).
+/// * Empty / non-alphanumeric-only names are rejected.
+/// * Slug is length-bounded by [`MAX_NAME_LEN`].
+/// * The resolved `<scope-root>/<slug>` path is canonicalized and verified
+///   to stay inside the canonical scope root (same `starts_with` guard used
+///   by [`read_skill_resource`]) to defeat `..` or absolute-path inputs.
+/// * Collisions with an existing directory are rejected outright — this
+///   function never overwrites.
+///
+/// On success the freshly created skill is re-discovered through the standard
+/// pipeline and returned so callers can drop it straight into the UI list.
+pub fn create_skill(workspace_dir: &Path, params: CreateSkillParams) -> Result<Skill, String> {
+    let home = dirs::home_dir();
+    create_skill_inner(home.as_deref(), workspace_dir, params)
+}
+
+fn create_skill_inner(
+    home_dir: Option<&Path>,
+    workspace_dir: &Path,
+    params: CreateSkillParams,
+) -> Result<Skill, String> {
+    tracing::debug!(
+        name = %params.name,
+        scope = ?params.scope,
+        workspace = %workspace_dir.display(),
+        "[skills] create_skill: entry"
+    );
+
+    let display_name = params.name.trim();
+    if display_name.is_empty() {
+        return Err("name must not be empty".to_string());
+    }
+    if display_name.len() > MAX_NAME_LEN {
+        return Err(format!("name exceeds max {MAX_NAME_LEN} chars"));
+    }
+
+    let description = params.description.trim();
+    if description.is_empty() {
+        return Err("description must not be empty".to_string());
+    }
+    if description.len() > MAX_DESCRIPTION_LEN {
+        return Err(format!(
+            "description exceeds max {MAX_DESCRIPTION_LEN} chars"
+        ));
+    }
+
+    let slug = slugify_skill_name(display_name)?;
+
+    let scope_root = match params.scope {
+        SkillScope::User => {
+            let home =
+                home_dir.ok_or_else(|| "could not resolve user home directory".to_string())?;
+            home.join(".openhuman").join("skills")
+        }
+        SkillScope::Project => {
+            if !is_workspace_trusted(workspace_dir) {
+                return Err(format!(
+                    "workspace {} is not trusted; create {}/.openhuman/trust to enable project-scope skills",
+                    workspace_dir.display(),
+                    workspace_dir.display(),
+                ));
+            }
+            workspace_dir.join(".openhuman").join("skills")
+        }
+        SkillScope::Legacy => {
+            return Err(
+                "cannot create skill in legacy scope; choose 'user' or 'project'".to_string(),
+            );
+        }
+    };
+
+    std::fs::create_dir_all(&scope_root)
+        .map_err(|e| format!("failed to create skills root {}: {e}", scope_root.display()))?;
+
+    let canonical_root = std::fs::canonicalize(&scope_root).map_err(|e| {
+        format!(
+            "failed to canonicalize skills root {}: {e}",
+            scope_root.display()
+        )
+    })?;
+
+    let skill_dir = canonical_root.join(&slug);
+    if !skill_dir.starts_with(&canonical_root) {
+        return Err(format!(
+            "resolved skill dir {} escapes scope root {}",
+            skill_dir.display(),
+            canonical_root.display(),
+        ));
+    }
+
+    if skill_dir.exists() {
+        return Err(format!(
+            "skill '{slug}' already exists at {}",
+            skill_dir.display()
+        ));
+    }
+
+    std::fs::create_dir_all(&skill_dir)
+        .map_err(|e| format!("failed to create skill dir {}: {e}", skill_dir.display()))?;
+
+    let skill_md_path = skill_dir.join(SKILL_MD);
+    let skill_md = render_skill_md(
+        &slug,
+        description,
+        params.license.as_deref(),
+        params.author.as_deref(),
+        &params.tags,
+        &params.allowed_tools,
+    );
+    std::fs::write(&skill_md_path, skill_md)
+        .map_err(|e| format!("failed to write {}: {e}", skill_md_path.display()))?;
+
+    for sub in RESOURCE_DIRS {
+        let sub_path = skill_dir.join(sub);
+        std::fs::create_dir_all(&sub_path)
+            .map_err(|e| format!("failed to create {}: {e}", sub_path.display()))?;
+    }
+
+    tracing::info!(
+        slug = %slug,
+        scope = ?params.scope,
+        location = %skill_md_path.display(),
+        "[skills] create_skill: wrote SKILL.md"
+    );
+
+    let trusted = is_workspace_trusted(workspace_dir);
+    let created = discover_skills_inner(home_dir, Some(workspace_dir), trusted)
+        .into_iter()
+        .find(|s| s.name == slug)
+        .ok_or_else(|| format!("created skill '{slug}' but failed to re-discover"))?;
+    Ok(created)
+}
+
+/// Convert a human-readable skill name to a filesystem-safe slug.
+///
+/// Rules:
+/// * ASCII alphanumeric characters are lowercased and kept.
+/// * Whitespace, `-`, and `_` collapse to a single `-`.
+/// * Any other character is dropped.
+/// * Leading / trailing `-` are trimmed.
+/// * The empty slug (i.e. the name had no `[a-z0-9]` characters) is rejected.
+fn slugify_skill_name(name: &str) -> Result<String, String> {
+    let mut out = String::new();
+    let mut prev_hyphen = true;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_hyphen = false;
+        } else if (ch == '-' || ch == '_' || ch.is_whitespace()) && !prev_hyphen {
+            out.push('-');
+            prev_hyphen = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        return Err(format!(
+            "name '{name}' has no alphanumeric characters; cannot derive slug"
+        ));
+    }
+    if out.len() > MAX_NAME_LEN {
+        return Err(format!("slug '{out}' exceeds max {MAX_NAME_LEN} chars"));
+    }
+    Ok(out)
+}
+
+/// Render a minimal SKILL.md body for a freshly scaffolded skill.
+fn render_skill_md(
+    slug: &str,
+    description: &str,
+    license: Option<&str>,
+    author: Option<&str>,
+    tags: &[String],
+    allowed_tools: &[String],
+) -> String {
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("name: {slug}\n"));
+    out.push_str(&format!("description: {}\n", yaml_scalar(description)));
+    if let Some(v) = license {
+        out.push_str(&format!("license: {}\n", yaml_scalar(v)));
+    }
+    let has_metadata = author.is_some() || !tags.is_empty();
+    if has_metadata {
+        out.push_str("metadata:\n");
+        if let Some(v) = author {
+            out.push_str(&format!("  author: {}\n", yaml_scalar(v)));
+        }
+        if !tags.is_empty() {
+            out.push_str("  tags:\n");
+            for t in tags {
+                out.push_str(&format!("    - {}\n", yaml_scalar(t)));
+            }
+        }
+    }
+    if !allowed_tools.is_empty() {
+        out.push_str("allowed-tools:\n");
+        for t in allowed_tools {
+            out.push_str(&format!("  - {}\n", yaml_scalar(t)));
+        }
+    }
+    out.push_str("---\n\n");
+    out.push_str(&format!("# {slug}\n\n"));
+    out.push_str(description);
+    if !description.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str("\n## Instructions\n\n");
+    out.push_str("_Describe when and how this skill should be used._\n");
+    out
+}
+
+/// Best-effort YAML scalar encoder: pass plain-safe strings through,
+/// double-quote anything with structure / whitespace / control chars.
+fn yaml_scalar(s: &str) -> String {
+    let needs_quote = s.is_empty()
+        || s.chars().any(|c| {
+            matches!(
+                c,
+                ':' | '#'
+                    | '\''
+                    | '"'
+                    | '\n'
+                    | '\r'
+                    | '\t'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | ','
+                    | '&'
+                    | '*'
+                    | '!'
+                    | '|'
+                    | '>'
+                    | '%'
+                    | '@'
+                    | '`'
+            )
+        })
+        || s.starts_with(|c: char| c.is_ascii_whitespace() || c == '-' || c == '?')
+        || s.ends_with(|c: char| c.is_ascii_whitespace());
+    if !needs_quote {
+        return s.to_string();
+    }
+    let escaped = s
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t");
+    format!("\"{escaped}\"")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1359,5 +1655,197 @@ mod tests {
             err.to_lowercase().contains("relative_path"),
             "unexpected: {err}"
         );
+    }
+
+    // -- create_skill --------------------------------------------------------
+
+    #[test]
+    fn create_skill_user_scope_scaffolds_skill_md_and_resource_dirs() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+
+        let params = CreateSkillParams {
+            name: "My Demo Skill".to_string(),
+            description: "Send a friendly greeting to the user.".to_string(),
+            scope: SkillScope::User,
+            license: Some("MIT".to_string()),
+            author: Some("Jane Dev".to_string()),
+            tags: vec!["demo".to_string(), "greeting".to_string()],
+            allowed_tools: vec!["shell".to_string()],
+        };
+
+        let created = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect("create_skill should succeed");
+
+        assert_eq!(created.name, "my-demo-skill");
+        assert_eq!(created.scope, SkillScope::User);
+        assert_eq!(created.description, "Send a friendly greeting to the user.");
+        assert_eq!(created.author.as_deref(), Some("Jane Dev"));
+        assert_eq!(
+            created.tags,
+            vec!["demo".to_string(), "greeting".to_string()]
+        );
+        assert_eq!(created.tools, vec!["shell".to_string()]);
+
+        let skill_root = home
+            .path()
+            .join(".openhuman")
+            .join("skills")
+            .join("my-demo-skill");
+        assert!(skill_root.join(SKILL_MD).is_file());
+        for sub in RESOURCE_DIRS {
+            assert!(skill_root.join(sub).is_dir(), "missing scaffold dir: {sub}");
+        }
+
+        // Frontmatter round-trips through the parser.
+        let on_disk = std::fs::read_to_string(skill_root.join(SKILL_MD)).unwrap();
+        assert!(on_disk.contains("name: my-demo-skill"));
+        assert!(on_disk.contains("license: MIT"));
+        assert!(on_disk.contains("author: Jane Dev"));
+    }
+
+    #[test]
+    fn create_skill_rejects_slug_collision() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+
+        let params = CreateSkillParams {
+            name: "collider".to_string(),
+            description: "first".to_string(),
+            scope: SkillScope::User,
+            ..Default::default()
+        };
+        create_skill_inner(Some(home.path()), ws.path(), params.clone()).unwrap();
+
+        let err = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect_err("second create with same name must fail");
+        assert!(
+            err.to_lowercase().contains("already exists"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn create_skill_rejects_non_alphanumeric_name() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+
+        let params = CreateSkillParams {
+            name: "   ///   ".to_string(),
+            description: "nothing useful".to_string(),
+            scope: SkillScope::User,
+            ..Default::default()
+        };
+        let err = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect_err("non-alphanumeric name must be rejected");
+        // Either the empty-name guard or the slugify guard catches this.
+        assert!(
+            err.to_lowercase().contains("alphanumeric") || err.to_lowercase().contains("empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn create_skill_rejects_project_scope_without_trust_marker() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        // Intentionally no trust marker.
+
+        let params = CreateSkillParams {
+            name: "project-skill".to_string(),
+            description: "scoped to ws".to_string(),
+            scope: SkillScope::Project,
+            ..Default::default()
+        };
+        let err = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect_err("untrusted workspace must reject project scope");
+        assert!(
+            err.to_lowercase().contains("trust"),
+            "unexpected error: {err}"
+        );
+
+        // Confirm nothing was written.
+        assert!(!ws
+            .path()
+            .join(".openhuman")
+            .join("skills")
+            .join("project-skill")
+            .exists());
+    }
+
+    #[test]
+    fn create_skill_project_scope_writes_under_workspace_when_trusted() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        write(&ws.path().join(".openhuman").join(TRUST_MARKER), "");
+
+        let params = CreateSkillParams {
+            name: "ws-skill".to_string(),
+            description: "project-scoped".to_string(),
+            scope: SkillScope::Project,
+            ..Default::default()
+        };
+        let created = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect("trusted project-scope create should succeed");
+
+        assert_eq!(created.name, "ws-skill");
+        assert_eq!(created.scope, SkillScope::Project);
+        assert!(ws
+            .path()
+            .join(".openhuman")
+            .join("skills")
+            .join("ws-skill")
+            .join(SKILL_MD)
+            .is_file());
+    }
+
+    #[test]
+    fn create_skill_rejects_legacy_scope() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+
+        let params = CreateSkillParams {
+            name: "legacy-skill".to_string(),
+            description: "no".to_string(),
+            scope: SkillScope::Legacy,
+            ..Default::default()
+        };
+        let err = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect_err("legacy scope must be rejected");
+        assert!(
+            err.to_lowercase().contains("legacy"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn create_skill_rejects_empty_description() {
+        let home = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+
+        let params = CreateSkillParams {
+            name: "ok-name".to_string(),
+            description: "   ".to_string(),
+            scope: SkillScope::User,
+            ..Default::default()
+        };
+        let err = create_skill_inner(Some(home.path()), ws.path(), params)
+            .expect_err("empty description must be rejected");
+        assert!(
+            err.to_lowercase().contains("description"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn slugify_collapses_separators_and_trims() {
+        assert_eq!(slugify_skill_name("Hello  World").unwrap(), "hello-world");
+        assert_eq!(slugify_skill_name("--foo__bar--").unwrap(), "foo-bar");
+        assert_eq!(
+            slugify_skill_name("ALL CAPS skill!").unwrap(),
+            "all-caps-skill"
+        );
+        assert!(slugify_skill_name("   ").is_err());
+        assert!(slugify_skill_name("!!!").is_err());
     }
 }

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -1313,7 +1313,15 @@ pub async fn install_skill_from_url(
 
     let slug = derive_install_slug(&frontmatter)?;
 
-    let skills_root = workspace_dir.join(".openhuman").join("skills");
+    // Install to user scope (`~/.openhuman/skills/<slug>`), which `discover_skills`
+    // scans unconditionally. Project scope (`<ws>/.openhuman/skills/`) is gated on
+    // a `<ws>/.openhuman/trust` marker and would render the install invisible to the
+    // skills list until the user opts the workspace into trust.
+    let skills_root = home
+        .as_deref()
+        .ok_or_else(|| "write failed: unable to resolve home directory".to_string())?
+        .join(".openhuman")
+        .join("skills");
     let target_dir = skills_root.join(&slug);
     if target_dir.exists() {
         return Err(format!(

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -19,6 +19,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 
 const TRUST_MARKER: &str = "trust";
@@ -1123,6 +1124,295 @@ fn yaml_scalar(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 
+/// Default wall-clock budget for the `npx skills add` install path.
+pub const DEFAULT_INSTALL_TIMEOUT_SECS: u64 = 60;
+/// Hard ceiling callers can request via `timeout_secs`.
+pub const MAX_INSTALL_TIMEOUT_SECS: u64 = 600;
+/// Upper bound on raw URL length accepted by [`validate_install_url`].
+pub const MAX_INSTALL_URL_LEN: usize = 2048;
+
+/// Input for [`install_skill_from_url`]. Mirrors the `skills.install_from_url`
+/// JSON-RPC payload.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstallSkillFromUrlParams {
+    /// Remote skill package URL. Must be `https://` and resolve to a
+    /// non-private host (see [`validate_install_url`]).
+    pub url: String,
+    /// Optional wall-clock budget override, in seconds. Defaults to
+    /// [`DEFAULT_INSTALL_TIMEOUT_SECS`] and is capped at
+    /// [`MAX_INSTALL_TIMEOUT_SECS`].
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
+/// Outcome of a successful install. `new_skills` is the set of skill slugs
+/// that appeared in the catalog as a result of the CLI run (post-discovery
+/// minus pre-discovery).
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallSkillFromUrlOutcome {
+    pub url: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub new_skills: Vec<String>,
+}
+
+/// Install a skill from a remote registry URL by shelling out to
+/// `npx --yes skills add <url>` through the managed Node.js toolchain.
+///
+/// Validation applied before spawning anything:
+/// * URL length, scheme (`https` only), and host safety via
+///   [`validate_install_url`] — rejects loopback, private, link-local,
+///   multicast, shared-address ranges, `localhost`, and `.local` / `.localhost`
+///   mDNS-style hostnames.
+/// * `timeout_secs` is clamped to [`MAX_INSTALL_TIMEOUT_SECS`].
+///
+/// Runtime:
+/// * Reuses [`NodeBootstrap`] for toolchain resolution (same code path as
+///   `npm_exec`), so the user sees the same bootstrap / download behavior.
+/// * Clears the host env before spawn and rebuilds `PATH` with
+///   `resolved.bin_dir` prepended — `npx`, `node`, and anything the CLI
+///   shells out to stay on the managed toolchain.
+/// * Child runs in `workspace_dir` so the installer lands packages in the
+///   current project by default.
+///
+/// On success the full post-install skills catalog is re-discovered and the
+/// outcome includes the list of skill slugs that appeared since the start of
+/// the call (i.e. the skill(s) produced by `skills add`).
+pub async fn install_skill_from_url(
+    workspace_dir: &Path,
+    node_config: crate::openhuman::config::schema::NodeConfig,
+    params: InstallSkillFromUrlParams,
+) -> Result<InstallSkillFromUrlOutcome, String> {
+    let url = params.url.trim();
+    validate_install_url(url)?;
+
+    let timeout_secs = params
+        .timeout_secs
+        .unwrap_or(DEFAULT_INSTALL_TIMEOUT_SECS)
+        .min(MAX_INSTALL_TIMEOUT_SECS)
+        .max(1);
+
+    tracing::debug!(
+        url = %url,
+        workspace = %workspace_dir.display(),
+        timeout_secs = timeout_secs,
+        "[skills] install_skill_from_url: entry"
+    );
+
+    let home = dirs::home_dir();
+    let trusted_before = is_workspace_trusted(workspace_dir);
+    let before: std::collections::HashSet<String> =
+        discover_skills_inner(home.as_deref(), Some(workspace_dir), trusted_before)
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+
+    let bootstrap = crate::openhuman::node_runtime::NodeBootstrap::new(
+        node_config,
+        workspace_dir.to_path_buf(),
+        reqwest::Client::new(),
+    );
+    let resolved = bootstrap
+        .resolve()
+        .await
+        .map_err(|e| format!("node runtime unavailable: {e}"))?;
+
+    let npx_bin = if cfg!(windows) {
+        resolved.bin_dir.join("npx.cmd")
+    } else {
+        resolved.bin_dir.join("npx")
+    };
+    if !npx_bin.exists() {
+        return Err(format!(
+            "npx binary not found at {} (resolved toolchain {} is missing the npx launcher)",
+            npx_bin.display(),
+            resolved.version,
+        ));
+    }
+
+    let mut cmd = tokio::process::Command::new(&npx_bin);
+    cmd.arg("--yes").arg("skills").arg("add").arg(url);
+    cmd.current_dir(workspace_dir);
+    cmd.env_clear();
+
+    let host_path = std::env::var("PATH").unwrap_or_default();
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let new_path = if host_path.is_empty() {
+        resolved.bin_dir.to_string_lossy().into_owned()
+    } else {
+        format!("{}{}{}", resolved.bin_dir.display(), sep, host_path)
+    };
+    cmd.env("PATH", &new_path);
+    for var in &[
+        "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+    ] {
+        if let Ok(v) = std::env::var(var) {
+            cmd.env(var, v);
+        }
+    }
+
+    tracing::info!(
+        version = %resolved.version,
+        source = ?resolved.source,
+        npx = %npx_bin.display(),
+        url = %url,
+        "[skills] install_skill_from_url: spawning `npx --yes skills add <url>`"
+    );
+
+    let spawn_result =
+        tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), cmd.output()).await;
+
+    let output = match spawn_result {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => return Err(format!("failed to execute npx: {e}")),
+        Err(_) => {
+            return Err(format!(
+                "install timed out after {timeout_secs}s and was killed"
+            ));
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    if !output.status.success() {
+        let trimmed = stderr.trim();
+        let detail = if trimmed.is_empty() {
+            stdout.trim().to_string()
+        } else {
+            trimmed.to_string()
+        };
+        return Err(format!(
+            "`npx skills add {url}` exited with status {}: {detail}",
+            output.status
+        ));
+    }
+
+    let trusted_after = is_workspace_trusted(workspace_dir);
+    let after = discover_skills_inner(home.as_deref(), Some(workspace_dir), trusted_after);
+    let new_skills: Vec<String> = after
+        .into_iter()
+        .map(|s| s.name)
+        .filter(|name| !before.contains(name))
+        .collect();
+
+    tracing::info!(
+        url = %url,
+        new_count = new_skills.len(),
+        "[skills] install_skill_from_url: completed"
+    );
+
+    Ok(InstallSkillFromUrlOutcome {
+        url: url.to_string(),
+        stdout,
+        stderr,
+        new_skills,
+    })
+}
+
+/// Validate a remote skill install URL. Returns `Ok(())` when the URL is
+/// well-formed, uses `https`, and points at a public host.
+///
+/// Rejects:
+/// * empty string or > [`MAX_INSTALL_URL_LEN`] bytes
+/// * non-`https` schemes (including `http`, `ftp`, `file`, `git+ssh`)
+/// * missing or empty host
+/// * `localhost`, `*.localhost`, `*.local`
+/// * IPv4 literals in loopback (127.0.0.0/8), private (10/8, 172.16/12,
+///   192.168/16), link-local (169.254/16), shared-address (100.64/10),
+///   multicast, broadcast, or unspecified (0.0.0.0) ranges
+/// * IPv6 literals in loopback (::1), unspecified (::), unique-local
+///   (fc00::/7), link-local (fe80::/10), or multicast (ff00::/8)
+pub fn validate_install_url(raw: &str) -> Result<(), String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("url must not be empty".to_string());
+    }
+    if trimmed.len() > MAX_INSTALL_URL_LEN {
+        return Err(format!(
+            "url exceeds max {MAX_INSTALL_URL_LEN} chars (got {})",
+            trimmed.len()
+        ));
+    }
+    let parsed = url::Url::parse(trimmed).map_err(|e| format!("invalid url {trimmed:?}: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err(format!(
+            "url scheme {:?} not allowed; https only",
+            parsed.scheme()
+        ));
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| format!("url {trimmed:?} has no host"))?;
+    if host.is_empty() {
+        return Err(format!("url {trimmed:?} has empty host"));
+    }
+    if is_blocked_install_host(host) {
+        return Err(format!(
+            "host {host:?} not allowed (loopback/private/link-local/multicast)"
+        ));
+    }
+    Ok(())
+}
+
+fn is_blocked_install_host(host: &str) -> bool {
+    let lower = host.to_ascii_lowercase();
+    // url::Url::host_str returns IPv6 literals wrapped in brackets (e.g. "[::1]").
+    // Strip them before attempting Ipv6Addr parse.
+    let stripped = lower
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(&lower);
+    if stripped == "localhost" || stripped.ends_with(".localhost") || stripped.ends_with(".local") {
+        return true;
+    }
+    if let Ok(v4) = stripped.parse::<Ipv4Addr>() {
+        return is_private_v4(&v4);
+    }
+    if let Ok(v6) = stripped.parse::<Ipv6Addr>() {
+        return is_private_v6(&v6);
+    }
+    false
+}
+
+fn is_private_v4(ip: &Ipv4Addr) -> bool {
+    if ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+    {
+        return true;
+    }
+    let [a, b, _, _] = ip.octets();
+    // 100.64.0.0/10 shared address (CGN)
+    if a == 100 && (64..=127).contains(&b) {
+        return true;
+    }
+    // 0.0.0.0/8
+    if a == 0 {
+        return true;
+    }
+    false
+}
+
+fn is_private_v6(ip: &Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+        return true;
+    }
+    let first = ip.segments()[0];
+    // fc00::/7 unique-local
+    if (first & 0xfe00) == 0xfc00 {
+        return true;
+    }
+    // fe80::/10 link-local
+    if (first & 0xffc0) == 0xfe80 {
+        return true;
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1847,5 +2137,84 @@ mod tests {
         );
         assert!(slugify_skill_name("   ").is_err());
         assert!(slugify_skill_name("!!!").is_err());
+    }
+
+    #[test]
+    fn validate_install_url_accepts_public_https() {
+        for url in &[
+            "https://registry.npmjs.org/@acme/skill",
+            "https://example.com/skill.tar.gz",
+            "https://github.com/acme/skill/releases/download/v1/skill.tgz",
+            "https://8.8.8.8/x",
+        ] {
+            validate_install_url(url).unwrap_or_else(|e| panic!("{url} rejected: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_install_url_rejects_non_https_scheme() {
+        for url in &[
+            "http://example.com/x",
+            "ftp://example.com/x",
+            "file:///etc/passwd",
+            "git+ssh://git@example.com/repo",
+            "javascript:alert(1)",
+        ] {
+            assert!(
+                validate_install_url(url).is_err(),
+                "{url} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_install_url_rejects_empty_and_oversized() {
+        assert!(validate_install_url("").is_err());
+        assert!(validate_install_url("   ").is_err());
+        let huge = format!("https://example.com/{}", "a".repeat(MAX_INSTALL_URL_LEN));
+        assert!(validate_install_url(&huge).is_err());
+    }
+
+    #[test]
+    fn validate_install_url_rejects_private_and_loopback() {
+        for url in &[
+            "https://localhost/x",
+            "https://foo.localhost/x",
+            "https://foo.local/x",
+            "https://127.0.0.1/x",
+            "https://127.42.1.1/x",
+            "https://10.0.0.5/x",
+            "https://172.16.0.1/x",
+            "https://172.31.255.255/x",
+            "https://192.168.1.1/x",
+            "https://169.254.169.254/x", // cloud metadata IP
+            "https://100.64.0.1/x",      // CGN
+            "https://0.0.0.0/x",
+            "https://255.255.255.255/x",
+            "https://224.0.0.1/x", // multicast
+            "https://[::1]/x",
+            "https://[::]/x",
+            "https://[fe80::1]/x",
+            "https://[fc00::1]/x",
+            "https://[fd12:3456:789a::1]/x",
+            "https://[ff02::1]/x",
+        ] {
+            assert!(
+                validate_install_url(url).is_err(),
+                "{url} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_install_url_rejects_malformed() {
+        // missing scheme -> parse error
+        assert!(validate_install_url("not-a-url").is_err());
+        // special scheme with empty host -> parse error
+        assert!(validate_install_url("https://").is_err());
+        // non-https scheme rejected even when otherwise well-formed
+        assert!(validate_install_url("ftp://example.com/x").is_err());
+        // unparseable bracketed host
+        assert!(validate_install_url("https://[not-an-ip]/x").is_err());
     }
 }

--- a/src/openhuman/skills/ops.rs
+++ b/src/openhuman/skills/ops.rs
@@ -1227,6 +1227,15 @@ pub async fn install_skill_from_url(
 
     let fetch_url = normalize_install_url(&raw_url)?;
 
+    // Second-layer SSRF guard: a public-looking hostname can still resolve
+    // to a loopback / private / link-local address (DNS-to-private-IP). We
+    // resolve the host up-front and reject if any returned IP is private.
+    // Known caveat: this does not fully prevent DNS rebinding — reqwest's
+    // resolver may see different answers than ours. Closing that gap requires
+    // pinning a `SocketAddr` and passing it to reqwest via a custom resolver,
+    // tracked separately.
+    validate_resolved_host(&fetch_url).await?;
+
     tracing::debug!(
         raw_url = %raw_url,
         fetch_url = %fetch_url,
@@ -1339,10 +1348,33 @@ pub async fn install_skill_from_url(
 
     let target_file = target_dir.join(SKILL_MD);
     let temp_file = target_dir.join("SKILL.md.tmp");
-    std::fs::write(&temp_file, &content)
-        .map_err(|e| format!("write failed: {}: {e}", temp_file.display()))?;
-    std::fs::rename(&temp_file, &target_file)
-        .map_err(|e| format!("write failed: rename {}: {e}", target_file.display()))?;
+
+    // Roll the partial install back if either filesystem op fails so the
+    // next retry isn't blocked by a leftover empty directory. Cleanup is
+    // best-effort — if it fails, we surface the original write error.
+    let write_result: Result<(), String> = std::fs::write(&temp_file, &content)
+        .map_err(|e| format!("write failed: {}: {e}", temp_file.display()))
+        .and_then(|_| {
+            std::fs::rename(&temp_file, &target_file)
+                .map_err(|e| format!("write failed: rename {}: {e}", target_file.display()))
+        });
+
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&temp_file);
+        if let Err(rm_err) = std::fs::remove_dir(&target_dir) {
+            tracing::warn!(
+                target_dir = %target_dir.display(),
+                error = %rm_err,
+                "[skills] install_skill_from_url: rollback remove_dir failed (non-fatal)"
+            );
+        } else {
+            tracing::warn!(
+                target_dir = %target_dir.display(),
+                "[skills] install_skill_from_url: rolled back partial install after write failure"
+            );
+        }
+        return Err(e);
+    }
 
     #[cfg(unix)]
     {
@@ -1534,6 +1566,80 @@ pub fn validate_install_url(raw: &str) -> Result<(), String> {
         return Err(format!(
             "host {host:?} not allowed (loopback/private/link-local/multicast)"
         ));
+    }
+    Ok(())
+}
+
+/// Resolve the host in the given URL and reject if any returned IP falls in
+/// loopback / private / link-local / multicast / unspecified ranges.
+///
+/// Covers the DNS-to-private-IP SSRF vector: a public-looking hostname can
+/// still resolve to 127.0.0.1 / 169.254.x / fc00::/7 etc., which
+/// [`validate_install_url`] alone cannot detect because it only inspects
+/// literal IP hosts.
+///
+/// Caveat: does **not** close the DNS-rebinding gap. `reqwest` performs its
+/// own DNS lookup on the GET below, and a rebinding server can answer the
+/// check with a public IP and answer reqwest with a private one. Full
+/// mitigation requires resolving to a `SocketAddr` here and passing it to
+/// reqwest via a custom resolver that only honours the pinned address.
+pub async fn validate_resolved_host(raw_url: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(raw_url)
+        .map_err(|e| format!("invalid url {raw_url:?} during DNS guard: {e}"))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| format!("url {raw_url:?} has no host (DNS guard)"))?;
+    // `tokio::net::lookup_host` wants "host:port". Default https → 443.
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    // IPv6 literal hosts come back bracketed from `url::Url`; `lookup_host`
+    // needs the bracketed form for IPv6 to parse correctly.
+    let lookup_target = if parsed.host().map(|h| matches!(h, url::Host::Ipv6(_))).unwrap_or(false) {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
+
+    tracing::debug!(
+        host = %host,
+        port = port,
+        "[skills] validate_resolved_host: resolving"
+    );
+
+    let mut addrs = tokio::net::lookup_host(&lookup_target)
+        .await
+        .map_err(|e| format!("dns lookup failed for {host:?}: {e}"))?
+        .peekable();
+    if addrs.peek().is_none() {
+        return Err(format!("host {host:?} resolved to no IP addresses"));
+    }
+    for addr in addrs {
+        let ip = addr.ip();
+        match ip {
+            std::net::IpAddr::V4(v4) => {
+                if is_private_v4(&v4) {
+                    tracing::warn!(
+                        host = %host,
+                        resolved = %v4,
+                        "[skills] validate_resolved_host: rejected private IPv4"
+                    );
+                    return Err(format!(
+                        "host {host:?} resolved to non-public IPv4 {v4} (loopback/private/link-local)"
+                    ));
+                }
+            }
+            std::net::IpAddr::V6(v6) => {
+                if is_private_v6(&v6) {
+                    tracing::warn!(
+                        host = %host,
+                        resolved = %v6,
+                        "[skills] validate_resolved_host: rejected private IPv6"
+                    );
+                    return Err(format!(
+                        "host {host:?} resolved to non-public IPv6 {v6} (loopback/ula/link-local)"
+                    ));
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/src/openhuman/skills/schemas.rs
+++ b/src/openhuman/skills/schemas.rs
@@ -1,0 +1,319 @@
+//! JSON-RPC / CLI controller surface for the skills domain.
+//!
+//! Exposes:
+//! * `skills.list` — enumerate SKILL.md / legacy skills discovered in the
+//!   current user home and workspace.
+//! * `skills.read_resource` — read a single bundled resource file, with path
+//!   traversal, symlink, size and UTF-8 guards.
+//!
+//! Both controllers resolve the active workspace via the persisted config
+//! layer (`config::load_config_with_timeout`) so the CLI and UI see the same
+//! skills catalog without the caller having to thread a workspace path.
+
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use crate::openhuman::config::Config;
+use crate::openhuman::skills::ops::{
+    discover_skills, is_workspace_trusted, read_skill_resource, Skill, SkillScope,
+};
+use crate::rpc::RpcOutcome;
+
+#[derive(Debug, Deserialize, Default)]
+struct SkillsListParams {
+    // No params today. Kept as an empty struct so future filters (scope,
+    // search, etc.) can slot in without breaking older clients.
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillsReadResourceParams {
+    skill_id: String,
+    relative_path: String,
+}
+
+/// Wire-format representation of a discovered skill. Mirrors the fields in
+/// [`Skill`] that are useful to the UI while hiding the
+/// `frontmatter` blob (which includes a flatten'd forward-compat hatch and
+/// can balloon with arbitrary YAML).
+#[derive(Debug, Serialize)]
+struct SkillSummary {
+    id: String,
+    name: String,
+    description: String,
+    version: String,
+    author: Option<String>,
+    tags: Vec<String>,
+    tools: Vec<String>,
+    prompts: Vec<String>,
+    location: Option<String>,
+    resources: Vec<String>,
+    scope: SkillScope,
+    legacy: bool,
+    warnings: Vec<String>,
+}
+
+impl From<Skill> for SkillSummary {
+    fn from(s: Skill) -> Self {
+        SkillSummary {
+            id: s.name.clone(),
+            name: s.name,
+            description: s.description,
+            version: s.version,
+            author: s.author,
+            tags: s.tags,
+            tools: s.tools,
+            prompts: s.prompts,
+            location: s.location.as_ref().map(|p| p.display().to_string()),
+            resources: s
+                .resources
+                .into_iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            scope: s.scope,
+            legacy: s.legacy,
+            warnings: s.warnings,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SkillsListResult {
+    skills: Vec<SkillSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct SkillsReadResourceResult {
+    skill_id: String,
+    relative_path: String,
+    content: String,
+    bytes: usize,
+}
+
+pub fn all_skills_controller_schemas() -> Vec<ControllerSchema> {
+    vec![
+        skills_schemas("skills_list"),
+        skills_schemas("skills_read_resource"),
+    ]
+}
+
+pub fn all_skills_registered_controllers() -> Vec<RegisteredController> {
+    vec![
+        RegisteredController {
+            schema: skills_schemas("skills_list"),
+            handler: handle_skills_list,
+        },
+        RegisteredController {
+            schema: skills_schemas("skills_read_resource"),
+            handler: handle_skills_read_resource,
+        },
+    ]
+}
+
+pub fn skills_schemas(function: &str) -> ControllerSchema {
+    match function {
+        "skills_list" => ControllerSchema {
+            namespace: "skills",
+            function: "list",
+            description: "List SKILL.md and legacy skills discovered in the user home and workspace.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "skills",
+                ty: TypeSchema::Array(Box::new(TypeSchema::Ref("SkillSummary"))),
+                comment: "Discovered skills (sorted by name, project-scope shadows user-scope).",
+                required: true,
+            }],
+        },
+        "skills_read_resource" => ControllerSchema {
+            namespace: "skills",
+            function: "read_resource",
+            description: "Read a single bundled SKILL resource file, hardened against traversal, symlink escape, and oversized payloads.",
+            inputs: vec![
+                FieldSchema {
+                    name: "skill_id",
+                    ty: TypeSchema::String,
+                    comment: "Name of the skill (matches SkillSummary.id / Skill.name).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "relative_path",
+                    ty: TypeSchema::String,
+                    comment: "Path to the resource file, relative to the skill root (e.g. 'scripts/foo.sh').",
+                    required: true,
+                },
+            ],
+            outputs: vec![
+                FieldSchema {
+                    name: "skill_id",
+                    ty: TypeSchema::String,
+                    comment: "Echo of the requested skill id.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "relative_path",
+                    ty: TypeSchema::String,
+                    comment: "Echo of the requested relative path.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "content",
+                    ty: TypeSchema::String,
+                    comment: "File contents (UTF-8, <= 128 KB).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "bytes",
+                    ty: TypeSchema::U64,
+                    comment: "Size of the file on disk, in bytes.",
+                    required: true,
+                },
+            ],
+        },
+        _ => ControllerSchema {
+            namespace: "skills",
+            function: "unknown",
+            description: "Unknown skills controller.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "error",
+                ty: TypeSchema::String,
+                comment: "Lookup error details.",
+                required: true,
+            }],
+        },
+    }
+}
+
+fn handle_skills_list(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let _ = deserialize_params::<SkillsListParams>(params)?;
+        tracing::debug!("[skills][rpc] list skills");
+        let workspace = resolve_workspace_dir().await;
+        let trusted = is_workspace_trusted(&workspace);
+        let home = dirs::home_dir();
+        let skills = discover_skills(home.as_deref(), Some(workspace.as_path()), trusted);
+        tracing::debug!(
+            count = skills.len(),
+            workspace = %workspace.display(),
+            trusted,
+            "[skills][rpc] list result"
+        );
+        let summaries = skills.into_iter().map(SkillSummary::from).collect();
+        to_json(RpcOutcome::new(
+            SkillsListResult { skills: summaries },
+            Vec::new(),
+        ))
+    })
+}
+
+fn handle_skills_read_resource(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = deserialize_params::<SkillsReadResourceParams>(params)?;
+        tracing::debug!(
+            skill_id = %payload.skill_id,
+            relative_path = %payload.relative_path,
+            "[skills][rpc] read_resource"
+        );
+        let workspace = resolve_workspace_dir().await;
+        let relative = Path::new(&payload.relative_path);
+        match read_skill_resource(workspace.as_path(), &payload.skill_id, relative) {
+            Ok(content) => {
+                let bytes = content.len();
+                to_json(RpcOutcome::new(
+                    SkillsReadResourceResult {
+                        skill_id: payload.skill_id,
+                        relative_path: payload.relative_path,
+                        content,
+                        bytes,
+                    },
+                    Vec::new(),
+                ))
+            }
+            Err(err) => {
+                tracing::debug!(
+                    error = %err,
+                    "[skills][rpc] read_resource: rejected"
+                );
+                Err(err)
+            }
+        }
+    })
+}
+
+/// Resolve the active workspace directory. Falls back to the runtime default
+/// if the persisted config fails to load so the CLI and headless diagnostics
+/// still work in partially-initialized environments.
+async fn resolve_workspace_dir() -> PathBuf {
+    match tokio::time::timeout(std::time::Duration::from_secs(30), Config::load_or_init()).await {
+        Ok(Ok(cfg)) => cfg.workspace_dir,
+        Ok(Err(err)) => {
+            tracing::debug!(
+                error = %err,
+                "[skills][rpc] config load failed; falling back to default workspace"
+            );
+            fallback_workspace_dir()
+        }
+        Err(_) => {
+            tracing::debug!(
+                "[skills][rpc] config load timed out; falling back to default workspace"
+            );
+            fallback_workspace_dir()
+        }
+    }
+}
+
+fn fallback_workspace_dir() -> PathBuf {
+    crate::openhuman::config::default_root_openhuman_dir()
+        .unwrap_or_else(|_| PathBuf::from(".openhuman"))
+        .join("workspace")
+}
+
+fn deserialize_params<T: DeserializeOwned>(params: Map<String, Value>) -> Result<T, String> {
+    serde_json::from_value(Value::Object(params)).map_err(|e| format!("invalid params: {e}"))
+}
+
+fn to_json<T: serde::Serialize>(outcome: RpcOutcome<T>) -> Result<Value, String> {
+    outcome.into_cli_compatible_json()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_names_are_stable() {
+        let list = skills_schemas("skills_list");
+        assert_eq!(list.namespace, "skills");
+        assert_eq!(list.function, "list");
+
+        let read = skills_schemas("skills_read_resource");
+        assert_eq!(read.namespace, "skills");
+        assert_eq!(read.function, "read_resource");
+    }
+
+    #[test]
+    fn controller_lists_match_lengths() {
+        assert_eq!(
+            all_skills_controller_schemas().len(),
+            all_skills_registered_controllers().len()
+        );
+    }
+
+    #[test]
+    fn skill_summary_round_trip_minimum_fields() {
+        let skill = Skill {
+            name: "demo".to_string(),
+            description: "desc".to_string(),
+            version: "".to_string(),
+            ..Default::default()
+        };
+        let summary: SkillSummary = skill.into();
+        assert_eq!(summary.id, "demo");
+        assert_eq!(summary.name, "demo");
+        assert_eq!(summary.description, "desc");
+    }
+}

--- a/src/openhuman/skills/schemas.rs
+++ b/src/openhuman/skills/schemas.rs
@@ -460,9 +460,8 @@ fn handle_skills_install_from_url(params: Map<String, Value>) -> ControllerFutur
         );
         let config = resolve_config().await;
         let workspace = config.workspace_dir.clone();
-        let node_config = config.node.clone();
         let payload: InstallSkillFromUrlParams = wire.into();
-        match install_skill_from_url(workspace.as_path(), node_config, payload).await {
+        match install_skill_from_url(workspace.as_path(), payload).await {
             Ok(outcome) => {
                 tracing::debug!(
                     url = %outcome.url,

--- a/src/openhuman/skills/schemas.rs
+++ b/src/openhuman/skills/schemas.rs
@@ -7,9 +7,10 @@
 //!   traversal, symlink, size and UTF-8 guards.
 //! * `skills.create` — scaffold a new SKILL.md skill under the user or
 //!   workspace scope.
-//! * `skills.install_from_url` — install a remote skill by shelling out to
-//!   `npx --yes skills add <url>` through the managed Node.js toolchain,
-//!   with https-only / private-IP URL guards and a timeout.
+//! * `skills.install_from_url` — install a remote skill by fetching its
+//!   `SKILL.md` over HTTPS (size-capped, timeout-clamped) and writing it into
+//!   the user-scope skills directory. Rejects non-https, private-IP, and
+//!   non-SKILL.md URLs; normalises `github.com/.../blob/...` → raw.
 //!
 //! All controllers resolve the active workspace via the persisted config
 //! layer (`config::load_config_with_timeout`) so the CLI and UI see the same
@@ -306,7 +307,7 @@ pub fn skills_schemas(function: &str) -> ControllerSchema {
         "skills_install_from_url" => ControllerSchema {
             namespace: "skills",
             function: "install_from_url",
-            description: "Install a remote skill by shelling out to `npx --yes skills add <url>`. URL must be https and resolve to a public host; default 60s timeout (max 600s).",
+            description: "Install a remote skill by fetching its SKILL.md over HTTPS and writing it into the user-scope skills directory. URL must be https, resolve to a public host, and point at a single `.md` file (`github.com/.../blob/...` auto-rewrites to raw). Default 60s timeout, max 600s.",
             inputs: vec![
                 FieldSchema {
                     name: "url",
@@ -331,13 +332,13 @@ pub fn skills_schemas(function: &str) -> ControllerSchema {
                 FieldSchema {
                     name: "stdout",
                     ty: TypeSchema::String,
-                    comment: "Captured stdout from the `npx skills add` invocation.",
+                    comment: "Human-readable diagnostic summary (bytes fetched, target path).",
                     required: true,
                 },
                 FieldSchema {
                     name: "stderr",
                     ty: TypeSchema::String,
-                    comment: "Captured stderr from the `npx skills add` invocation.",
+                    comment: "Non-fatal frontmatter parse warnings, joined by newlines.",
                     required: true,
                 },
                 FieldSchema {

--- a/src/openhuman/skills/schemas.rs
+++ b/src/openhuman/skills/schemas.rs
@@ -5,8 +5,10 @@
 //!   current user home and workspace.
 //! * `skills.read_resource` — read a single bundled resource file, with path
 //!   traversal, symlink, size and UTF-8 guards.
+//! * `skills.create` — scaffold a new SKILL.md skill under the user or
+//!   workspace scope.
 //!
-//! Both controllers resolve the active workspace via the persisted config
+//! All controllers resolve the active workspace via the persisted config
 //! layer (`config::load_config_with_timeout`) so the CLI and UI see the same
 //! skills catalog without the caller having to thread a workspace path.
 
@@ -20,7 +22,8 @@ use crate::core::all::{ControllerFuture, RegisteredController};
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
 use crate::openhuman::config::Config;
 use crate::openhuman::skills::ops::{
-    discover_skills, is_workspace_trusted, read_skill_resource, Skill, SkillScope,
+    create_skill, discover_skills, is_workspace_trusted, read_skill_resource, CreateSkillParams,
+    Skill, SkillScope,
 };
 use crate::rpc::RpcOutcome;
 
@@ -34,6 +37,36 @@ struct SkillsListParams {
 struct SkillsReadResourceParams {
     skill_id: String,
     relative_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillsCreateParams {
+    name: String,
+    description: String,
+    #[serde(default)]
+    scope: SkillScope,
+    #[serde(default)]
+    license: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default, rename = "allowed-tools", alias = "allowed_tools")]
+    allowed_tools: Vec<String>,
+}
+
+impl From<SkillsCreateParams> for CreateSkillParams {
+    fn from(p: SkillsCreateParams) -> Self {
+        CreateSkillParams {
+            name: p.name,
+            description: p.description,
+            scope: p.scope,
+            license: p.license,
+            author: p.author,
+            tags: p.tags,
+            allowed_tools: p.allowed_tools,
+        }
+    }
 }
 
 /// Wire-format representation of a discovered skill. Mirrors the fields in
@@ -94,10 +127,16 @@ struct SkillsReadResourceResult {
     bytes: usize,
 }
 
+#[derive(Debug, Serialize)]
+struct SkillsCreateResult {
+    skill: SkillSummary,
+}
+
 pub fn all_skills_controller_schemas() -> Vec<ControllerSchema> {
     vec![
         skills_schemas("skills_list"),
         skills_schemas("skills_read_resource"),
+        skills_schemas("skills_create"),
     ]
 }
 
@@ -110,6 +149,10 @@ pub fn all_skills_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: skills_schemas("skills_read_resource"),
             handler: handle_skills_read_resource,
+        },
+        RegisteredController {
+            schema: skills_schemas("skills_create"),
+            handler: handle_skills_create,
         },
     ]
 }
@@ -172,6 +215,61 @@ pub fn skills_schemas(function: &str) -> ControllerSchema {
                     required: true,
                 },
             ],
+        },
+        "skills_create" => ControllerSchema {
+            namespace: "skills",
+            function: "create",
+            description: "Scaffold a new SKILL.md skill under the user or workspace scope.",
+            inputs: vec![
+                FieldSchema {
+                    name: "name",
+                    ty: TypeSchema::String,
+                    comment: "Human-readable name (slugified into the on-disk directory).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "description",
+                    ty: TypeSchema::String,
+                    comment: "One-line description written into SKILL.md frontmatter.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "scope",
+                    ty: TypeSchema::String,
+                    comment: "Target scope: 'user' (default) or 'project' (requires trust marker).",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "license",
+                    ty: TypeSchema::String,
+                    comment: "Optional SPDX license identifier.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "author",
+                    ty: TypeSchema::String,
+                    comment: "Optional author name (written under frontmatter.metadata.author).",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "tags",
+                    ty: TypeSchema::Array(Box::new(TypeSchema::String)),
+                    comment: "Optional tags for the skill.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "allowed_tools",
+                    ty: TypeSchema::Array(Box::new(TypeSchema::String)),
+                    comment: "Optional tool hints (maps to frontmatter.allowed-tools).",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "skill",
+                ty: TypeSchema::Ref("SkillSummary"),
+                comment: "The newly created skill, re-discovered through the standard pipeline.",
+                required: true,
+            }],
         },
         _ => ControllerSchema {
             namespace: "skills",
@@ -238,6 +336,37 @@ fn handle_skills_read_resource(params: Map<String, Value>) -> ControllerFuture {
                     error = %err,
                     "[skills][rpc] read_resource: rejected"
                 );
+                Err(err)
+            }
+        }
+    })
+}
+
+fn handle_skills_create(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload = deserialize_params::<SkillsCreateParams>(params)?;
+        tracing::debug!(
+            name = %payload.name,
+            scope = ?payload.scope,
+            "[skills][rpc] create"
+        );
+        let workspace = resolve_workspace_dir().await;
+        match create_skill(workspace.as_path(), payload.into()) {
+            Ok(skill) => {
+                tracing::debug!(
+                    skill = %skill.name,
+                    location = ?skill.location,
+                    "[skills][rpc] create: ok"
+                );
+                to_json(RpcOutcome::new(
+                    SkillsCreateResult {
+                        skill: SkillSummary::from(skill),
+                    },
+                    Vec::new(),
+                ))
+            }
+            Err(err) => {
+                tracing::debug!(error = %err, "[skills][rpc] create: rejected");
                 Err(err)
             }
         }

--- a/src/openhuman/skills/schemas.rs
+++ b/src/openhuman/skills/schemas.rs
@@ -7,6 +7,9 @@
 //!   traversal, symlink, size and UTF-8 guards.
 //! * `skills.create` — scaffold a new SKILL.md skill under the user or
 //!   workspace scope.
+//! * `skills.install_from_url` — install a remote skill by shelling out to
+//!   `npx --yes skills add <url>` through the managed Node.js toolchain,
+//!   with https-only / private-IP URL guards and a timeout.
 //!
 //! All controllers resolve the active workspace via the persisted config
 //! layer (`config::load_config_with_timeout`) so the CLI and UI see the same
@@ -22,8 +25,8 @@ use crate::core::all::{ControllerFuture, RegisteredController};
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
 use crate::openhuman::config::Config;
 use crate::openhuman::skills::ops::{
-    create_skill, discover_skills, is_workspace_trusted, read_skill_resource, CreateSkillParams,
-    Skill, SkillScope,
+    create_skill, discover_skills, install_skill_from_url, is_workspace_trusted,
+    read_skill_resource, CreateSkillParams, InstallSkillFromUrlParams, Skill, SkillScope,
 };
 use crate::rpc::RpcOutcome;
 
@@ -132,11 +135,36 @@ struct SkillsCreateResult {
     skill: SkillSummary,
 }
 
+#[derive(Debug, Deserialize)]
+struct SkillsInstallFromUrlParamsWire {
+    url: String,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+}
+
+impl From<SkillsInstallFromUrlParamsWire> for InstallSkillFromUrlParams {
+    fn from(p: SkillsInstallFromUrlParamsWire) -> Self {
+        InstallSkillFromUrlParams {
+            url: p.url,
+            timeout_secs: p.timeout_secs,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SkillsInstallFromUrlResult {
+    url: String,
+    stdout: String,
+    stderr: String,
+    new_skills: Vec<String>,
+}
+
 pub fn all_skills_controller_schemas() -> Vec<ControllerSchema> {
     vec![
         skills_schemas("skills_list"),
         skills_schemas("skills_read_resource"),
         skills_schemas("skills_create"),
+        skills_schemas("skills_install_from_url"),
     ]
 }
 
@@ -153,6 +181,10 @@ pub fn all_skills_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: skills_schemas("skills_create"),
             handler: handle_skills_create,
+        },
+        RegisteredController {
+            schema: skills_schemas("skills_install_from_url"),
+            handler: handle_skills_install_from_url,
         },
     ]
 }
@@ -271,6 +303,51 @@ pub fn skills_schemas(function: &str) -> ControllerSchema {
                 required: true,
             }],
         },
+        "skills_install_from_url" => ControllerSchema {
+            namespace: "skills",
+            function: "install_from_url",
+            description: "Install a remote skill by shelling out to `npx --yes skills add <url>`. URL must be https and resolve to a public host; default 60s timeout (max 600s).",
+            inputs: vec![
+                FieldSchema {
+                    name: "url",
+                    ty: TypeSchema::String,
+                    comment: "Remote skill package URL (https only; loopback / private / link-local hosts rejected).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "timeout_secs",
+                    ty: TypeSchema::U64,
+                    comment: "Optional wall-clock override in seconds. Default 60, capped at 600.",
+                    required: false,
+                },
+            ],
+            outputs: vec![
+                FieldSchema {
+                    name: "url",
+                    ty: TypeSchema::String,
+                    comment: "Echo of the installed URL.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "stdout",
+                    ty: TypeSchema::String,
+                    comment: "Captured stdout from the `npx skills add` invocation.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "stderr",
+                    ty: TypeSchema::String,
+                    comment: "Captured stderr from the `npx skills add` invocation.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "new_skills",
+                    ty: TypeSchema::Array(Box::new(TypeSchema::String)),
+                    comment: "Slugs of skills that appeared in the catalog as a result of the install.",
+                    required: true,
+                },
+            ],
+        },
         _ => ControllerSchema {
             namespace: "skills",
             function: "unknown",
@@ -371,6 +448,70 @@ fn handle_skills_create(params: Map<String, Value>) -> ControllerFuture {
             }
         }
     })
+}
+
+fn handle_skills_install_from_url(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let wire = deserialize_params::<SkillsInstallFromUrlParamsWire>(params)?;
+        tracing::debug!(
+            url = %wire.url,
+            timeout_secs = ?wire.timeout_secs,
+            "[skills][rpc] install_from_url"
+        );
+        let config = resolve_config().await;
+        let workspace = config.workspace_dir.clone();
+        let node_config = config.node.clone();
+        let payload: InstallSkillFromUrlParams = wire.into();
+        match install_skill_from_url(workspace.as_path(), node_config, payload).await {
+            Ok(outcome) => {
+                tracing::debug!(
+                    url = %outcome.url,
+                    new_count = outcome.new_skills.len(),
+                    "[skills][rpc] install_from_url: ok"
+                );
+                to_json(RpcOutcome::new(
+                    SkillsInstallFromUrlResult {
+                        url: outcome.url,
+                        stdout: outcome.stdout,
+                        stderr: outcome.stderr,
+                        new_skills: outcome.new_skills,
+                    },
+                    Vec::new(),
+                ))
+            }
+            Err(err) => {
+                tracing::debug!(error = %err, "[skills][rpc] install_from_url: rejected");
+                Err(err)
+            }
+        }
+    })
+}
+
+/// Resolve the active [`Config`]. Falls back to `Config::default()` with a
+/// best-effort workspace directory if the persisted load times out or errors,
+/// so headless diagnostics still work in partially-initialized environments.
+async fn resolve_config() -> Config {
+    match tokio::time::timeout(std::time::Duration::from_secs(30), Config::load_or_init()).await {
+        Ok(Ok(cfg)) => cfg,
+        Ok(Err(err)) => {
+            tracing::debug!(
+                error = %err,
+                "[skills][rpc] config load failed; falling back to default config"
+            );
+            fallback_config()
+        }
+        Err(_) => {
+            tracing::debug!("[skills][rpc] config load timed out; falling back to default config");
+            fallback_config()
+        }
+    }
+}
+
+fn fallback_config() -> Config {
+    Config {
+        workspace_dir: fallback_workspace_dir(),
+        ..Default::default()
+    }
 }
 
 /// Resolve the active workspace directory. Falls back to the runtime default


### PR DESCRIPTION
## Summary

- Adds the skills catalog panel with detail drawer, resource tree, and size-gated resource preview so users can browse installed SKILL.md skills from the app.
- Adds two authoring flows: **New skill** scaffolds a local SKILL.md, **Install from URL** fetches a remote SKILL.md directly into the skills directory.
- Introduces three new core RPCs — `skills.read_resource`, `skills.create`, and `skills.install_from_url` — under the `skills` namespace, wired through the controller registry.
- **Install is direct HTTPS fetch**, not a shell-out. Validates YAML frontmatter, enforces a 1 MiB size cap and 1–600s timeout, normalizes GitHub blob→raw URLs, and rejects path traversal.
- Frontend error copy is user-friendly — backend error prefixes are categorized into titles like "URL rejected", "SKILL.md too large", "Fetch timed out", "SKILL.md did not parse". Raw backend text is preserved under a details disclosure.

## Problem

Issue #681 asks for a skills UI so users can view, create, and install SKILL.md-format skills without leaving the app. Before this change the app had no skills panel and no authoring surface — skills could only be managed by editing files under `~/.openhuman/skills/` manually. The install story in particular needed to work for "any normie" with a GitHub URL, not require a Node toolchain for first-time install.

## Solution

**Core (Rust)**
- `src/openhuman/skills/ops.rs` gained `install_skill_from_url`, which fetches a single SKILL.md over HTTPS using the existing `reqwest` client, parses frontmatter with `serde_yaml`, derives a slug, and writes into the resolved skills directory. Helpers: `normalize_install_url` (GitHub blob→raw rewriting), `derive_install_slug` (filesystem-safe slug from frontmatter `name`), `parse_skill_md_str` (frontmatter + body validation). Size cap `MAX_SKILL_MD_BYTES = 1 MiB`; timeout clamp `[1, 600]s`; 12 unit tests.
- `src/openhuman/skills/schemas.rs` registers the new RPCs in the controller registry — no domain branches in `core/jsonrpc.rs` or `core/cli.rs`.
- `skills.read_resource` and `skills.create` follow the same pattern for browsing bundled resources and scaffolding.

**App (React/Tauri)**
- `SkillsGrid` → click → `SkillDetailDrawer` (right-side panel) with `SkillResourceTree` (grouped by top-level directory) and `SkillResourcePreview` (size-gated text/image preview).
- `CreateSkillModal` scaffolds SKILL.md via `skills.create`.
- `InstallSkillDialog` calls `skills.install_from_url`. Errors from the core are funneled through `categorizeInstallError(raw)` which maps Rust error prefixes (`invalid url:`, `unsupported url form:`, `fetch too large:`, `fetch timed out`, `invalid SKILL.md:`, `skill already installed`, `write failed:`, …) to friendly titles + hints; unknown errors show a generic title with the raw message tucked under `<details>`.
- Typed client wrappers in `app/src/api/skillsApi.ts`.

**Design tradeoffs**
- Chose direct HTTPS fetch over shelling out to `npx skills add`. The CLI writes to `./claude-code/skills/` / `./cursor/skills/` which do not match openhuman's discovery paths, and requiring Node on first install blocks non-technical users. Direct fetch covers the common "paste a GitHub URL" path with zero prerequisites.
- Install is unconditional — no feature gate — per the product direction that any user should be able to install a skill.
- Full package/tarball install (`npm install` + fallback to `npx skills add`) is intentionally deferred to a follow-up; this PR ships the SKILL.md path that issue #681 actually exercises.

## Submission Checklist

- [x] **Unit tests** — 12 new `cargo test` cases in `skills/ops.rs` (URL normalization, slug derivation, frontmatter parsing, path traversal). 8 Vitest cases in `InstallSkillDialog.test.tsx` cover the direct-fetch fixtures and error categorization branches. Tests for `SkillDetailDrawer`, `SkillResourceTree`, `SkillResourcePreview`, `CreateSkillModal` also included.
- [ ] **E2E / integration** — Not added in this PR; relying on unit + component coverage while the drawer and install dialog stabilize. Can be added in a follow-up once the UX settles.
- [ ] **N/A**
- [x] **Doc comments** — `///` on new public functions in `ops.rs` (`install_skill_from_url`, helpers) and new types in `schemas.rs`. Component files carry brief JSDoc headers.
- [x] **Inline comments** — Added where the logic is non-obvious (GitHub URL rewriting, size-cap enforcement, error-prefix categorization mapping).

## Impact

- **Runtime**: Desktop only (skills browsing + install are surfaced through the Tauri app). No mobile impact.
- **Security**: Install path restricted to `https://` URLs, single-file SKILL.md only, 1 MiB hard cap, timeout cap at 600s, path-traversal guard on the derived slug. No arbitrary code execution — SKILL.md is data, not executed on install.
- **Performance**: One HTTP GET per install; fire-and-forget filesystem write. `cargo check` / clippy pass (one pre-existing `derivable_impls` warning on `SkillScope` unrelated to this PR).
- **Migration / compatibility**: Additive. New RPCs under `skills.*` namespace; no existing RPC or UI route changed.

## Related

- Issue(s): Closes #681
- Follow-up PR(s)/TODOs:
  - Full package install (`npm install` + `npx skills add` fallback) for skills that need a Node runtime at install time
  - E2E spec for the install + detail drawer flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Skills system: discover, create, install, list, and view discovered SKILL.md skills via Skills page with “New skill” and “Install from URL” controls.
  * Skill detail drawer with metadata, warnings, bundled-resource tree and in-app file preview (with sizes).
  * Create-skill modal with slug preview, validation, focus/close handling.
  * Install-from-URL dialog with HTTPS validation, timeout, progress, diagnostics and categorized error messaging.

* **Tests**
  * Added comprehensive UI and API tests covering create, install, listing, drawer, resource preview, and API behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->