### PR TITLE
build(sidecar): enable whatsapp-web,channel-matrix features when staging core

### DIFF
--- a/scripts/stage-core-sidecar.mjs
+++ b/scripts/stage-core-sidecar.mjs
@@ -65,7 +65,15 @@ const binName = isWindows ? "openhuman-core.exe" : "openhuman-core";
 console.log(
   `[core:stage] Building openhuman-core standalone binary for ${triple}...`,
 );
-run("cargo", ["build", "--manifest-path", "Cargo.toml", "--bin", "openhuman-core"]);
+run("cargo", [
+  "build",
+  "--manifest-path",
+  "Cargo.toml",
+  "--bin",
+  "openhuman-core",
+  "--features",
+  "whatsapp-web,channel-matrix",
+]);
 
 const targetDir = cargoTargetDir();
 const source = join(targetDir, "debug", binName);


### PR DESCRIPTION
## Summary
- Staging script built `openhuman-core` without the `whatsapp-web` and `channel-matrix` features, so the bundled sidecar shipped the feature-gated stubs and failed at runtime with `requires 'whatsapp-web' feature`.
- Wire both features into `scripts/stage-core-sidecar.mjs` so the staged binary matches what the rest of the build expects.

## Test plan
- [ ] `cd app && yarn core:stage` produces a sidecar that starts without the `whatsapp-web` runtime error.
- [ ] WhatsApp Web and Matrix channel registry paths exercise without missing-feature errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled support for WhatsApp Web and Matrix channel integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->