### PR TITLE
feat(onboarding): expand SkillsStep to Gmail+Calendar+Drive+Notion with fallback

### DIFF
--- a/app/src/pages/onboarding/steps/SkillsStep.test.tsx
+++ b/app/src/pages/onboarding/steps/SkillsStep.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../../../test/mockDefaultSkillStatusHooks';
+import { renderWithProviders } from '../../../test/test-utils';
+import SkillsStep from './SkillsStep';
+
+const refreshComposio = vi.fn();
+let composioToolkits: string[] = [];
+let composioConnections = new Map();
+let composioLoading = false;
+let composioError: string | null = null;
+
+vi.mock('../../../lib/composio/hooks', () => ({
+  useComposioIntegrations: () => ({
+    toolkits: composioToolkits,
+    connectionByToolkit: composioConnections,
+    loading: composioLoading,
+    error: composioError,
+    refresh: refreshComposio,
+  }),
+}));
+
+vi.mock('../../../components/composio/ComposioConnectModal', () => ({
+  default: ({ toolkit, onClose }: { toolkit: { name: string }; onClose: () => void }) => (
+    <div>
+      <h2>Connect {toolkit.name}</h2>
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+describe('Onboarding SkillsStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    composioToolkits = [];
+    composioConnections = new Map();
+    composioLoading = false;
+    composioError = null;
+  });
+
+  it('falls back to the curated composio catalog when the backend allowlist is empty', () => {
+    const onNext = vi.fn();
+    renderWithProviders(<SkillsStep onNext={onNext} />);
+
+    expect(screen.getByText('Gmail')).toBeInTheDocument();
+    expect(screen.getByText('Google Calendar')).toBeInTheDocument();
+    expect(screen.getByText('Google Drive')).toBeInTheDocument();
+    expect(screen.getByText('Notion')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Skip for Now' })).toBeInTheDocument();
+  });
+
+  it('only surfaces the onboarding subset when the backend returns a larger toolkit allowlist', () => {
+    composioToolkits = ['gmail', 'github', 'slack', 'notion'];
+
+    renderWithProviders(<SkillsStep onNext={vi.fn()} />);
+
+    expect(screen.getByText('Gmail')).toBeInTheDocument();
+    expect(screen.getByText('Notion')).toBeInTheDocument();
+    expect(screen.queryByText('GitHub')).not.toBeInTheDocument();
+    expect(screen.queryByText('Slack')).not.toBeInTheDocument();
+  });
+
+  it('passes connected composio sources through on continue', async () => {
+    composioToolkits = ['gmail', 'notion'];
+    composioConnections = new Map([
+      ['gmail', { id: 'conn_gmail', toolkit: 'gmail', status: 'ACTIVE' }],
+      ['notion', { id: 'conn_notion', toolkit: 'notion', status: 'ACTIVE' }],
+    ]);
+    const onNext = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(<SkillsStep onNext={onNext} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(onNext).toHaveBeenCalledWith(['composio:gmail', 'composio:notion']);
+  });
+});

--- a/app/src/pages/onboarding/steps/SkillsStep.tsx
+++ b/app/src/pages/onboarding/steps/SkillsStep.tsx
@@ -4,8 +4,10 @@ import ComposioConnectModal from '../../../components/composio/ComposioConnectMo
 import {
   composioToolkitMeta,
   type ComposioToolkitMeta,
+  KNOWN_COMPOSIO_TOOLKITS,
 } from '../../../components/composio/toolkitMeta';
 import { useComposioIntegrations } from '../../../lib/composio/hooks';
+import { canonicalizeComposioToolkitSlug } from '../../../lib/composio/toolkitSlug';
 import { type ComposioConnection, deriveComposioState } from '../../../lib/composio/types';
 import OnboardingNextButton from '../components/OnboardingNextButton';
 
@@ -68,13 +70,19 @@ const SkillsStep = ({ onNext, onBack: _onBack }: SkillsStepProps) => {
     refresh: refreshComposio,
   } = useComposioIntegrations();
 
-  // Only show Gmail during onboarding — but only if the backend allowlist
-  // includes it. Fall back to showing it from the static catalog when the
-  // allowlist hasn't loaded yet (composioLoading is true).
-  const ONBOARDING_SLUGS = ['gmail'] as const;
-  const displayToolkits: ComposioToolkitMeta[] = ONBOARDING_SLUGS.filter(
-    slug => composioLoading || backendToolkits.map(t => t.toLowerCase()).includes(slug)
-  ).map(slug => composioToolkitMeta(slug));
+  // Keep onboarding opinionated: show a small curated set of high-value
+  // integrations, but never hide them just because the live Composio allowlist
+  // hasn't loaded yet or temporarily returns an empty list.
+  const ONBOARDING_SLUGS = ['gmail', 'googlecalendar', 'googledrive', 'notion'] as const;
+  const normalizedBackendToolkits = backendToolkits.map(canonicalizeComposioToolkitSlug);
+  const fallbackToolkits = ONBOARDING_SLUGS.filter(slug => KNOWN_COMPOSIO_TOOLKITS.includes(slug));
+  const effectiveToolkits =
+    normalizedBackendToolkits.length > 0
+      ? ONBOARDING_SLUGS.filter(slug => normalizedBackendToolkits.includes(slug))
+      : fallbackToolkits;
+  const displayToolkits: ComposioToolkitMeta[] = effectiveToolkits.map(slug =>
+    composioToolkitMeta(slug)
+  );
 
   // Only count connections for the displayed toolkits.
   const connectedCount = displayToolkits.filter(t => {
@@ -103,10 +111,10 @@ const SkillsStep = ({ onNext, onBack: _onBack }: SkillsStepProps) => {
   return (
     <div className="rounded-2xl border border-stone-200 bg-white p-8 shadow-soft animate-fade-up">
       <div className="text-center mb-4">
-        <h1 className="text-xl font-bold mb-2 text-stone-900">Connect Gmail</h1>
+        <h1 className="text-xl font-bold mb-2 text-stone-900">Connect your tools</h1>
         <p className="text-stone-600 text-sm">
-          Connect your Gmail so OpenHuman can learn about you and build context for your agent. Your
-          data is saved locally and never leaves your device.
+          Connect the tools you already use so OpenHuman can build context for your agent. Your data
+          is saved locally and never leaves your device.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Broaden onboarding integration step from Gmail-only to four high-value toolkits (Gmail, Google Calendar, Google Drive, Notion).
- Canonicalize the backend Composio allowlist slugs and fall back to the curated static catalog when the allowlist is empty or hasn't loaded, so users always see actionable connect targets.
- Update copy from "Connect Gmail" to "Connect your tools" to match the broader set.

## Test plan
- [x] `yarn test:unit src/pages/onboarding/steps/SkillsStep.test.tsx` — 3/3 passing (fallback, allowlist subset, connected-source forwarding on continue).
- [ ] Manual: walk through onboarding with empty backend allowlist → all 4 toolkits render.
- [ ] Manual: walk through onboarding with allowlist containing extra slugs → only the 4 onboarding slugs render.