### PR TITLE
fix(agent): orchestrator never sends users to external dashboards for connect

### DIFF
--- a/src/openhuman/agent/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent/agents/orchestrator/prompt.md
@@ -55,6 +55,15 @@ or a manual fallback.
 - **Fail gracefully** — If a sub-agent fails after retries, explain what happened clearly.
 - **Escalate when appropriate** — If orchestration is the wrong mode or a specialist cannot make progress, hand control back to OpenHuman Core with a concise explanation and let Core handle general interactions.
 
+## Connecting external services
+
+When the user asks to connect a service (Gmail, Notion, WhatsApp, Calendar, Drive, etc.) or a sub-agent reports `Connection error, try to authenticate`:
+
+- **Never** paste external URLs (e.g. `app.composio.dev`, provider OAuth pages, dashboards).
+- **Never** explain OAuth, Composio, or any backend mechanic by name.
+- Reply with one short bubble pointing to the in-app path: **Settings → Connections → [Service]**. Example: `head to Settings → Connections → Gmail to hook it up, ping me when it's connected`.
+- If the user already said they connected it, call `composio_list_connections` to verify before continuing.
+
 ## Response Style
 
 Reply like you're texting a friend: casual, lowercase-ok, as few words as possible without losing meaning. No preamble, no recap, no "I'll now…".


### PR DESCRIPTION
## Why

Real chat output we caught the orchestrator producing when a user (no Gmail connected yet) asked about Gmail:

> no Gmail connections yet — your integration list is empty
>
> to connect Gmail, you'll need to go through the Composio OAuth flow. here's how:
>
> open your Composio dashboard (usually at https://app.composio.dev or wherever your instance is hosted)
> navigate to integrations → find Gmail
> click "connect" and follow the Google sign-in prompts
> grant the permissions you're comfortable with
> once that's done, I'll be able to see Gmail in your active connections and help you with email tasks

This is broken UX for the audience OpenHuman is built for:

- **Leaks backend internals** — names "Composio" and "OAuth flow", which mean nothing to a non-technical user.
- **Sends them to an external admin dashboard** the app already replaces with a first-class in-app surface (`Settings → Connections`, expanded in #743 to cover Gmail / Calendar / Drive / Notion).
- **"usually at https://app.composio.dev or wherever your instance is hosted"** — guessing a URL is worse than not giving one. A real user has no way to disambiguate "wherever your instance is hosted."
- **No actionable next step** — the user has to leave the app, find a dashboard, sign into a service they've never heard of, then come back.

The orchestrator was improvising this because nothing in its prompt told it how to handle "connect X" requests. Grep across `src/openhuman/agent/prompts/` and the orchestrator/integrations agents confirmed: zero guidance on integration onboarding. The model filled the gap with whatever Composio docs it had seen during training.

## What changed

Added a short **"Connecting external services"** section to `src/openhuman/agent/agents/orchestrator/prompt.md` with hard rules:

- **Never** paste external URLs (`app.composio.dev`, provider OAuth pages, dashboards).
- **Never** explain OAuth, Composio, or backend mechanics by name.
- Always route to the in-app path: **Settings → Connections → [Service]**.
- After the user says they connected something, call `composio_list_connections` to verify before continuing.

Also covers the `integrations_agent` escalation path — when a sub-agent reports `Connection error, try to authenticate`, the orchestrator now has explicit instructions instead of inventing dashboard guidance.

## Why a prompt fix instead of new tooling

Considered (and deferred): a chat-driven `open_connect(slug)` tool that would have the agent open the connect modal directly in-app. That's the right long-term answer, but:

- Requires a new tool registration, frontend listener, and end-to-end test coverage.
- The bad behavior in the screenshot above isn't a *missing* feature — it's the agent making up bad guidance because the prompt is silent. A prompt rule fixes the regression today.
- Once #743 (onboarding expansion to Gmail / Calendar / Drive / Notion) is live, the in-app path is fully built out for the most common toolkits.

We can revisit the agent-driven `open_connect` tool after watching real session logs to see how often users hit "connect from chat" vs "connect from settings."

## Test plan

- [ ] Manual: ask the agent *"connect gmail"* with no Gmail integration. Expect a single short bubble pointing to **Settings → Connections → Gmail**, no URLs, no mention of Composio or OAuth.
- [ ] Manual: trigger a Composio auth error from the integrations agent (e.g. attempt a Gmail send while disconnected). Expect orchestrator to surface the same in-app path instead of an external dashboard.
- [ ] Manual: after telling the agent *"ok I connected it"*, expect orchestrator to call `composio_list_connections` before resuming.