### PR TITLE
fix(voice): friendly STT error with direct settings link

### DIFF
--- a/app/src/chat/chatSendError.ts
+++ b/app/src/chat/chatSendError.ts
@@ -5,6 +5,7 @@ export type ChatSendErrorCode =
   | 'local_model_failed'
   | 'cloud_send_failed'
   | 'voice_transcription'
+  | 'stt_not_ready'
   | 'microphone_unavailable'
   | 'microphone_recording'
   | 'microphone_access'

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -342,7 +342,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
         if (cancelled) return;
         if (!status.stt_available) {
           setVoiceStatus(
-            'Speech-to-text unavailable: whisper-cli binary or STT model not found. Check Settings > Local Models.'
+            'Voice input needs a speech model to work. Go to Settings > Local AI Models to set it up.'
           );
         } else {
           setVoiceStatus('Ready — tap "Start Talking" to record.');
@@ -490,7 +490,16 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
     } catch (err) {
       notifyOverlaySttState('error');
       const message = err instanceof Error ? err.message : String(err);
-      setSendError(chatSendError('voice_transcription', `Voice transcription failed: ${message}`));
+      const isSetupIssue =
+        message.includes('whisper') || message.includes('binary not found') || message.includes('STT model');
+      setSendError(
+        chatSendError(
+          isSetupIssue ? 'stt_not_ready' : 'voice_transcription',
+          isSetupIssue
+            ? 'Voice input needs a speech model. Go to Settings to download one.'
+            : `Voice transcription failed: ${message}`
+        )
+      );
       setVoiceStatus(null);
     } finally {
       setIsTranscribing(false);
@@ -1252,11 +1261,23 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
               <p className="text-xs text-coral-500" data-chat-send-error-code={sendError.code}>
                 {sendError.message}
               </p>
-              <button
-                onClick={() => setSendError(null)}
-                className="text-xs text-stone-500 hover:text-stone-700 transition-colors ml-2 flex-shrink-0">
-                Dismiss
-              </button>
+              <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                {(sendError.code === 'stt_not_ready' || sendError.code === 'voice_transcription') && (
+                  <button
+                    onClick={() => {
+                      setSendError(null);
+                      navigate('/settings/local-model');
+                    }}
+                    className="text-xs text-primary-500 hover:text-primary-600 font-medium transition-colors">
+                    Set up
+                  </button>
+                )}
+                <button
+                  onClick={() => setSendError(null)}
+                  className="text-xs text-stone-500 hover:text-stone-700 transition-colors">
+                  Dismiss
+                </button>
+              </div>
             </div>
           )}
 

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -491,7 +491,9 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
       notifyOverlaySttState('error');
       const message = err instanceof Error ? err.message : String(err);
       const isSetupIssue =
-        message.includes('whisper') || message.includes('binary not found') || message.includes('STT model');
+        message.includes('whisper') ||
+        message.includes('binary not found') ||
+        message.includes('STT model');
       setSendError(
         chatSendError(
           isSetupIssue ? 'stt_not_ready' : 'voice_transcription',
@@ -1262,7 +1264,8 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                 {sendError.message}
               </p>
               <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                {(sendError.code === 'stt_not_ready' || sendError.code === 'voice_transcription') && (
+                {(sendError.code === 'stt_not_ready' ||
+                  sendError.code === 'voice_transcription') && (
                   <button
                     onClick={() => {
                       setSendError(null);


### PR DESCRIPTION
## Summary
- Replace technical "whisper.cpp binary not found. Set WHISPER_BIN or install whisper-cli" error with user-friendly message: "Voice input needs a speech model. Go to Settings to download one."
- Add a **"Set up"** button in the error banner that navigates directly to `/settings/local-model` so users can download the STT model in one click
- Detect whisper/binary-related transcription failures and map them to the friendly `stt_not_ready` error code

## Test plan
- [ ] Trigger voice transcription without whisper/STT model installed (via dictation hotkey)
- [ ] Verify friendly error message appears instead of technical whisper.cpp error
- [ ] Click "Set up" link — should navigate to `/settings/local-model`
- [ ] Click "Dismiss" — error clears normally
- [ ] `yarn typecheck` passes
- [ ] `yarn lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for voice transcription failures and unavailable speech-to-text services with clearer setup guidance
  * Added "Set Up" button to voice-related error notifications, allowing users to quickly navigate to speech model configuration
  * Improved error categorization for better identification and communication of setup-related voice feature issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->