### PR TITLE
feat(e2e): agent-observable artifact capture slice

### DIFF
--- a/app/scripts/e2e-agent-review.sh
+++ b/app/scripts/e2e-agent-review.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Canonical "agent review" run: builds the app if needed, runs the
+# agent-review spec, and prints the artifact directory so agents (and
+# humans) can inspect screenshots, page-source dumps, and mock request
+# logs on disk.
+#
+# Usage:
+#   bash app/scripts/e2e-agent-review.sh [--skip-build] [--label <name>]
+#
+# Artifacts land in:
+#   app/test/e2e/artifacts/<timestamp>-<label>/
+# unless E2E_ARTIFACT_DIR is set.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$APP_DIR/.." && pwd)"
+
+SKIP_BUILD=0
+LABEL="agent-review"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --label) LABEL="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+export E2E_ARTIFACT_LABEL="$LABEL"
+
+cd "$REPO_ROOT"
+
+if [ "$SKIP_BUILD" -eq 0 ]; then
+  echo "[agent-review] building app + staging core sidecar"
+  yarn workspace openhuman-app test:e2e:build
+else
+  echo "[agent-review] --skip-build set; reusing existing build"
+fi
+
+echo "[agent-review] running spec test/e2e/specs/agent-review.spec.ts"
+bash "$APP_DIR/scripts/e2e-run-spec.sh" test/e2e/specs/agent-review.spec.ts agent-review
+
+# Find the most recent run dir for this label.
+ARTIFACT_ROOT="${E2E_ARTIFACT_ROOT:-$APP_DIR/test/e2e/artifacts}"
+if [ -d "$ARTIFACT_ROOT" ]; then
+  LATEST="$(ls -1dt "$ARTIFACT_ROOT"/*"-$LABEL" 2>/dev/null | head -n 1 || true)"
+  if [ -n "$LATEST" ]; then
+    echo
+    echo "[agent-review] ==========================================="
+    echo "[agent-review] artifact dir: $LATEST"
+    echo "[agent-review] ==========================================="
+    ls -1 "$LATEST" 2>/dev/null || true
+  else
+    echo "[agent-review] no artifact dir found under $ARTIFACT_ROOT"
+  fi
+else
+  echo "[agent-review] artifact root missing: $ARTIFACT_ROOT"
+fi

--- a/app/src/components/settings/panels/PrivacyPanel.tsx
+++ b/app/src/components/settings/panels/PrivacyPanel.tsx
@@ -17,7 +17,7 @@ const PrivacyPanel = () => {
   };
 
   return (
-    <div>
+    <div data-testid="settings-privacy-panel">
       <SettingsHeader
         title="Privacy & Security"
         showBackButton={true}

--- a/app/src/pages/onboarding/Onboarding.tsx
+++ b/app/src/pages/onboarding/Onboarding.tsx
@@ -198,11 +198,12 @@ const Onboarding = ({ onComplete, onDefer }: OnboardingProps) => {
   };
 
   return (
-    <div className="min-h-full relative flex items-center justify-center">
+    <div data-testid="onboarding-overlay" className="min-h-full relative flex items-center justify-center">
       {onDefer && (
         <div className="fixed top-4 right-0 z-20 sm:top-6 sm:right-6">
           <button
             type="button"
+            data-testid="onboarding-skip-button"
             onClick={onDefer}
             className="text-sm text-stone-600 hover:text-stone-900 transition-colors">
             Skip

--- a/app/src/pages/onboarding/components/OnboardingNextButton.tsx
+++ b/app/src/pages/onboarding/components/OnboardingNextButton.tsx
@@ -15,6 +15,7 @@ const OnboardingNextButton = ({
 }: OnboardingNextButtonProps) => (
   <button
     type="button"
+    data-testid="onboarding-next-button"
     onClick={onClick}
     disabled={disabled || loading}
     className="w-full py-2.5 bg-primary-500 hover:bg-primary-600 active:bg-primary-700 text-white text-sm font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed">

--- a/app/src/pages/onboarding/steps/WelcomeStep.tsx
+++ b/app/src/pages/onboarding/steps/WelcomeStep.tsx
@@ -82,7 +82,7 @@ const WelcomeStep = ({
   }, []);
 
   return (
-    <div className="rounded-2xl bg-white p-10 shadow-soft animate-fade-up">
+    <div data-testid="onboarding-welcome-step" className="rounded-2xl bg-white p-10 shadow-soft animate-fade-up">
       <div className="h-[340px] flex flex-col items-center justify-center">
         {slide === 0 && <WelcomeSlide />}
         {slide === 1 && <IntegrationsSlide />}

--- a/app/test/e2e/helpers/artifacts.ts
+++ b/app/test/e2e/helpers/artifacts.ts
@@ -1,0 +1,201 @@
+// @ts-nocheck
+/**
+ * Agent-observable artifact capture for E2E specs.
+ *
+ * Creates a per-run directory under app/test/e2e/artifacts/ and provides
+ * helpers to drop screenshots, page-source dumps, mock request-log snapshots,
+ * and a meta.json that agents (and humans) can inspect from disk.
+ *
+ * Layout:
+ *   app/test/e2e/artifacts/
+ *     2026-04-21T23-15-10Z-agent-review/
+ *       01-welcome.png
+ *       01-welcome.source.xml
+ *       02-privacy-sheet.png
+ *       02-privacy-sheet.source.xml
+ *       failure-<test>.png
+ *       failure-<test>.source.xml
+ *       mock-requests-<checkpoint>.json
+ *       meta.json
+ *
+ * Env:
+ *   E2E_ARTIFACT_DIR — overrides the auto-generated run dir.
+ *   E2E_ARTIFACT_ROOT — overrides the artifacts/ parent dir.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { dumpAccessibilityTree } from './element-helpers';
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultRoot = path.resolve(thisDir, '..', 'artifacts');
+
+type Meta = {
+  runId: string;
+  startedAt: string;
+  platform: NodeJS.Platform;
+  checkpoints: { index: number; name: string; at: string; files: string[] }[];
+  failures: { testName: string; at: string; files: string[] }[];
+};
+
+let runDir: string | null = null;
+let meta: Meta | null = null;
+let checkpointIndex = 0;
+
+function sanitize(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_.-]+/g, '-').slice(0, 80) || 'unnamed';
+}
+
+function nowStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-').replace('Z', 'Z');
+}
+
+function getRoot(): string {
+  return process.env.E2E_ARTIFACT_ROOT
+    ? path.resolve(process.env.E2E_ARTIFACT_ROOT)
+    : defaultRoot;
+}
+
+/**
+ * Compute + create the per-run artifact directory. Idempotent.
+ * Returns the absolute path.
+ */
+export function getArtifactDir(): string {
+  if (runDir) return runDir;
+
+  if (process.env.E2E_ARTIFACT_DIR) {
+    runDir = path.resolve(process.env.E2E_ARTIFACT_DIR);
+  } else {
+    const label = sanitize(process.env.E2E_ARTIFACT_LABEL || 'run');
+    runDir = path.join(getRoot(), `${nowStamp()}-${label}`);
+  }
+
+  fs.mkdirSync(runDir, { recursive: true });
+
+  meta = {
+    runId: path.basename(runDir),
+    startedAt: new Date().toISOString(),
+    platform: process.platform,
+    checkpoints: [],
+    failures: [],
+  };
+  writeMeta();
+
+  // eslint-disable-next-line no-console
+  console.log(`[artifacts] run dir: ${runDir}`);
+  return runDir;
+}
+
+function writeMeta(): void {
+  if (!runDir || !meta) return;
+  fs.writeFileSync(path.join(runDir, 'meta.json'), JSON.stringify(meta, null, 2));
+}
+
+async function writeScreenshot(file: string): Promise<boolean> {
+  try {
+    const png = await browser.takeScreenshot();
+    fs.writeFileSync(file, Buffer.from(png, 'base64'));
+    return true;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`[artifacts] screenshot failed: ${err}`);
+    return false;
+  }
+}
+
+async function writeSource(file: string): Promise<boolean> {
+  try {
+    const source = await dumpAccessibilityTree();
+    fs.writeFileSync(file, source);
+    return true;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`[artifacts] source dump failed: ${err}`);
+    return false;
+  }
+}
+
+/**
+ * Capture a named checkpoint: screenshot + page source.
+ * Numbered so agents can read the flow chronologically.
+ */
+export async function captureCheckpoint(name: string): Promise<void> {
+  const dir = getArtifactDir();
+  checkpointIndex += 1;
+  const idx = String(checkpointIndex).padStart(2, '0');
+  const base = `${idx}-${sanitize(name)}`;
+
+  const pngFile = path.join(dir, `${base}.png`);
+  const xmlFile = path.join(dir, `${base}.source.xml`);
+
+  const files: string[] = [];
+  if (await writeScreenshot(pngFile)) files.push(path.basename(pngFile));
+  if (await writeSource(xmlFile)) files.push(path.basename(xmlFile));
+
+  if (meta) {
+    meta.checkpoints.push({
+      index: checkpointIndex,
+      name,
+      at: new Date().toISOString(),
+      files,
+    });
+    writeMeta();
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[artifacts] checkpoint ${idx} "${name}" → ${files.join(', ')}`);
+}
+
+/**
+ * Always-on failure hook: screenshot + source named after the failing test.
+ * Safe to call from wdio afterTest without crashing the runner.
+ */
+export async function captureFailureArtifacts(testName: string): Promise<void> {
+  try {
+    const dir = getArtifactDir();
+    const base = `failure-${sanitize(testName)}`;
+    const pngFile = path.join(dir, `${base}.png`);
+    const xmlFile = path.join(dir, `${base}.source.xml`);
+
+    const files: string[] = [];
+    if (await writeScreenshot(pngFile)) files.push(path.basename(pngFile));
+    if (await writeSource(xmlFile)) files.push(path.basename(xmlFile));
+
+    if (meta) {
+      meta.failures.push({
+        testName,
+        at: new Date().toISOString(),
+        files,
+      });
+      writeMeta();
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[artifacts] FAILURE "${testName}" → ${files.join(', ')}`);
+  } catch (err) {
+    // Never let artifact capture break the runner.
+    // eslint-disable-next-line no-console
+    console.warn(`[artifacts] captureFailureArtifacts swallow: ${err}`);
+  }
+}
+
+/**
+ * Persist the current mock-server request log next to the checkpoints.
+ * Accepts the log array from getRequestLog() to avoid coupling to mock-server here.
+ */
+export function saveMockRequestLog(label: string, log: unknown[]): string {
+  const dir = getArtifactDir();
+  const file = path.join(dir, `mock-requests-${sanitize(label)}.json`);
+  fs.writeFileSync(file, JSON.stringify(log, null, 2));
+  // eslint-disable-next-line no-console
+  console.log(`[artifacts] mock log "${label}" (${log.length} req) → ${path.basename(file)}`);
+  return file;
+}
+
+/**
+ * Reset helper for tests that create multiple runs in one process.
+ */
+export function resetArtifactRun(): void {
+  runDir = null;
+  meta = null;
+  checkpointIndex = 0;
+}

--- a/app/test/e2e/specs/agent-review.spec.ts
+++ b/app/test/e2e/specs/agent-review.spec.ts
@@ -1,0 +1,138 @@
+// @ts-nocheck
+/**
+ * Canonical "agent review" E2E flow.
+ *
+ * Goal: one deterministic, mock-backed path through onboarding + the privacy
+ * settings panel that produces a readable artifact trail on disk so coding
+ * agents can:
+ *   - launch the app into a known state,
+ *   - navigate via automation,
+ *   - inspect screenshots + page source at each checkpoint,
+ *   - inspect mock backend request evidence.
+ *
+ * See docs/AGENT-OBSERVABILITY.md for how artifacts are laid out.
+ *
+ * This spec intentionally keeps assertions loose: its primary contract is
+ * "the flow reaches each checkpoint and captures artifacts", not a strict
+ * UI assertion — we already have login-flow.spec.ts for that.
+ */
+import { waitForApp, waitForAppReady, waitForAuthBootstrap } from '../helpers/app-helpers';
+import {
+  captureCheckpoint,
+  getArtifactDir,
+  saveMockRequestLog,
+} from '../helpers/artifacts';
+import { triggerAuthDeepLink } from '../helpers/deep-link-helpers';
+import {
+  clickText,
+  textExists,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+async function tryClick(text: string, timeout = 5_000): Promise<boolean> {
+  if (!(await textExists(text))) return false;
+  try {
+    await clickText(text, timeout);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForAny(texts: string[], timeout = 10_000): Promise<string | null> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const t of texts) {
+      if (await textExists(t)) return t;
+    }
+    await browser.pause(500);
+  }
+  return null;
+}
+
+describe('Agent review — canonical onboarding + privacy flow', () => {
+  before(async () => {
+    // Force label so the run dir is predictable: "<ts>-agent-review".
+    process.env.E2E_ARTIFACT_LABEL = process.env.E2E_ARTIFACT_LABEL || 'agent-review';
+    getArtifactDir();
+
+    await startMockServer();
+    await waitForApp();
+    clearRequestLog();
+  });
+
+  after(async () => {
+    resetMockBehavior();
+    await stopMockServer();
+    // eslint-disable-next-line no-console
+    console.log(`[agent-review] artifacts: ${getArtifactDir()}`);
+  });
+
+  it('01 launches and reaches welcome', async () => {
+    await triggerAuthDeepLink('e2e-agent-review-token');
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await waitForAppReady(15_000);
+    await waitForAuthBootstrap(15_000);
+
+    await waitForAny(['Welcome', 'Continue', "Let's Start", 'Home'], 15_000);
+    await captureCheckpoint('welcome');
+    saveMockRequestLog('after-welcome', getRequestLog());
+  });
+
+  it('02 advances past welcome step', async () => {
+    const clicked =
+      (await tryClick("Let's Start")) ||
+      (await tryClick('Continue')) ||
+      (await tryClick('Skip'));
+    // eslint-disable-next-line no-console
+    console.log(`[agent-review] welcome advance clicked=${clicked}`);
+    await browser.pause(2_000);
+    await captureCheckpoint('post-welcome');
+  });
+
+  it('03 walks remaining onboarding steps or lands on home', async () => {
+    // Referral
+    if (await textExists('Referral code')) {
+      await tryClick('Skip for now');
+      await browser.pause(1_500);
+    }
+    // Skills
+    if (await textExists('Connect Gmail')) {
+      await tryClick('Skip for Now');
+      await browser.pause(2_000);
+    }
+    // Context gathering (may auto-skip)
+    if (await textExists('Context')) {
+      await tryClick('Continue');
+      await browser.pause(1_500);
+    }
+
+    await waitForAny(['Home', 'Skills', 'Conversations', 'Settings'], 15_000);
+    await captureCheckpoint('post-onboarding');
+    saveMockRequestLog('after-onboarding', getRequestLog());
+  });
+
+  it('04 opens settings privacy panel', async () => {
+    // Navigate via hash route — works on tauri-driver and Mac2 WebView.
+    try {
+      await browser.execute(() => {
+        window.location.hash = '#/settings/privacy';
+      });
+    } catch {
+      // Non-fatal: if hash nav is unavailable, we still capture what we see.
+    }
+    await browser.pause(2_000);
+    await waitForAny(['Privacy', 'Analytics'], 10_000);
+    await captureCheckpoint('privacy-panel');
+    saveMockRequestLog('after-privacy', getRequestLog());
+  });
+});

--- a/app/test/wdio.conf.ts
+++ b/app/test/wdio.conf.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { captureFailureArtifacts } from './e2e/helpers/artifacts';
+
 const configDir = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(configDir, '..');
 const repoRoot = path.resolve(projectRoot, '..');
@@ -99,4 +101,17 @@ export const config: Options.Testrunner & Record<string, unknown> = {
     timeout: 120_000, // Billing/settings tests need extra time for API polling
   },
   autoCompileOpts: { tsNodeOpts: { project: tsconfigE2ePath } },
+  /**
+   * Always capture screenshot + page source on failure so agents can
+   * inspect what the app looked like the moment the assertion failed.
+   */
+  afterTest: async function (
+    test: { title: string; parent?: string },
+    _context: unknown,
+    result: { passed: boolean; error?: Error },
+  ) {
+    if (result.passed) return;
+    const name = [test.parent, test.title].filter(Boolean).join(' ').trim() || test.title;
+    await captureFailureArtifacts(name);
+  },
 };

--- a/docs/AGENT-OBSERVABILITY.md
+++ b/docs/AGENT-OBSERVABILITY.md
@@ -1,0 +1,81 @@
+# Agent Observability for E2E
+
+This doc describes the artifact-capture layer that makes the desktop app
+inspectable by coding agents (Codex, Claude Code, Cursor) through the
+existing WDIO/Appium/tauri-driver harness.
+
+It is intentionally narrow: one canonical onboarding + privacy flow with
+on-disk screenshots, page-source dumps, and mock backend request logs.
+See `AGENT_OBSERVABILITY_PLAN.md` at the repo root for the broader plan.
+
+## TL;DR
+
+```bash
+bash app/scripts/e2e-agent-review.sh
+```
+
+Artifacts land under:
+
+```
+app/test/e2e/artifacts/<ISO-timestamp>-agent-review/
+  01-welcome.png
+  01-welcome.source.xml
+  02-post-welcome.png
+  02-post-welcome.source.xml
+  03-post-onboarding.png
+  03-post-onboarding.source.xml
+  04-privacy-panel.png
+  04-privacy-panel.source.xml
+  mock-requests-after-welcome.json
+  mock-requests-after-onboarding.json
+  mock-requests-after-privacy.json
+  failure-<test>.png              # only on failure
+  failure-<test>.source.xml       # only on failure
+  meta.json                       # run metadata + checkpoint index
+```
+
+The script prints the resolved artifact directory at the end.
+
+## Pieces
+
+| Piece | Path | Role |
+|-------|------|------|
+| Helper | `app/test/e2e/helpers/artifacts.ts` | Run dir, `captureCheckpoint`, `captureFailureArtifacts`, `saveMockRequestLog` |
+| WDIO hook | `app/test/wdio.conf.ts` (`afterTest`) | Always dumps screenshot + source on any failing test |
+| Canonical spec | `app/test/e2e/specs/agent-review.spec.ts` | Welcome → onboarding → privacy panel with named checkpoints |
+| Wrapper script | `app/scripts/e2e-agent-review.sh` | Build + run + print artifact dir |
+| Stable selectors | `data-testid` on `OnboardingNextButton`, `Onboarding` overlay + skip button, `WelcomeStep`, `PrivacyPanel` | Agent-reliable navigation anchors |
+
+## Environment overrides
+
+| Variable | Effect |
+|----------|--------|
+| `E2E_ARTIFACT_DIR` | Force a specific run dir (skips auto-timestamped name) |
+| `E2E_ARTIFACT_ROOT` | Parent dir for auto-generated run dirs (default: `app/test/e2e/artifacts`) |
+| `E2E_ARTIFACT_LABEL` | Label used in the auto-generated run dir name (default: `run`; wrapper sets `agent-review`) |
+
+## Using the helper from new specs
+
+```ts
+import {
+  captureCheckpoint,
+  saveMockRequestLog,
+} from '../helpers/artifacts';
+import { getRequestLog } from '../mock-server';
+
+await captureCheckpoint('after-connect-click');
+saveMockRequestLog('after-connect-click', getRequestLog());
+```
+
+`captureCheckpoint` numbers captures so the run dir reads chronologically.
+`captureFailureArtifacts` is wired into `wdio.conf.ts` and fires
+automatically on any failing test — specs should not call it directly.
+
+## What is intentionally out of scope
+
+- Visual baselines / image diffs across every component state.
+- Screenshot capture on every click (too noisy).
+- Live integrations (Gmail, Notion, Telegram); mock server only.
+- New test framework / reporter.
+
+Widen to more flows only after this loop proves out.

--- a/docs/E2E-TESTING.md
+++ b/docs/E2E-TESTING.md
@@ -173,3 +173,14 @@ Deep links require a `.app` bundle. Use `yarn tauri build --debug --bundles app`
 ### Docker: Build is slow on first run
 
 The first Docker build compiles Rust + tauri-driver from source. Subsequent runs use cached layers. Cargo registry and git sources are cached via Docker volumes.
+
+## Agent-observable artifact flow
+
+For a canonical, inspectable run that drops screenshots, page-source dumps, and mock request logs on disk:
+
+```bash
+bash app/scripts/e2e-agent-review.sh
+```
+
+Artifacts land in `app/test/e2e/artifacts/<timestamp>-agent-review/`. Full details + helper API: [`AGENT-OBSERVABILITY.md`](AGENT-OBSERVABILITY.md). Any failing test triggers `wdio.conf.ts`'s `afterTest` hook, which writes `failure-*.png` + `failure-*.source.xml` into the same run dir.
+


### PR DESCRIPTION
## Summary

- New canonical WDIO spec (`test/e2e/specs/agent-review.spec.ts`) walks welcome → onboarding → privacy panel and drops screenshots + page-source dumps + mock request logs at named checkpoints.
- `afterTest` hook in `wdio.conf.ts` captures failure artifacts on any spec failure, app-wide.
- Wrapper `app/scripts/e2e-agent-review.sh` builds, runs the spec, and prints the artifact directory for agents/humans to inspect.
- Minimal stable `data-testid` selectors added to onboarding + privacy surfaces.
- Docs: new `docs/AGENT-OBSERVABILITY.md`, link added from `docs/E2E-TESTING.md`.

## How to run locally

```bash
bash app/scripts/e2e-agent-review.sh              # build + run + print artifact dir
bash app/scripts/e2e-agent-review.sh --skip-build # reuse existing build
```

Artifacts land under `app/test/e2e/artifacts/<timestamp>-agent-review/`.

## CI status — not yet wired

- **No active Linux E2E workflow runs this spec today.** The `e2e-linux` job in `.github/workflows/test.yml` is currently commented out; this PR intentionally does not enable it.
- **Artifact upload is not wired.** CI has no step that uploads `app/test/e2e/artifacts/**` — agents can only read artifacts from local runs for now.
- CI activation (enabling the workflow + adding artifact upload + registering the spec in the run list) is a separate infra PR, tracked as a follow-up.

## Test plan

- [ ] Run `bash app/scripts/e2e-agent-review.sh` on macOS/Linux with the E2E stack set up; verify 4 checkpoint screenshots + 3 mock logs + `meta.json` land in the timestamped dir
- [ ] Force a failure (e.g. tweak a selector) and verify `failure-*.png` + `failure-*.source.xml` appear in the run dir
- [ ] Typecheck passes: `cd app && npx tsc --noEmit -p .`

🧙 Built with [WOZCODE](https://wozcode.com)