### PR TITLE
feat(onboarding): remove referral step, drop welcome network gate

### DIFF
--- a/app/src/pages/onboarding/Onboarding.tsx
+++ b/app/src/pages/onboarding/Onboarding.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useCoreState } from '../../providers/CoreStateProvider';
-import { referralApi } from '../../services/api/referralApi';
 import { userApi } from '../../services/api/userApi';
 import { getDefaultEnabledTools } from '../../utils/toolDefinitions';
 import BetaBanner from './components/BetaBanner';
 import ContextGatheringStep from './steps/ContextGatheringStep';
-import ReferralApplyStep from './steps/ReferralApplyStep';
 import SkillsStep from './steps/SkillsStep';
 import WelcomeStep from './steps/WelcomeStep';
 
@@ -19,103 +17,20 @@ interface OnboardingDraft {
   connectedSources: string[];
 }
 
-function hasReferralFromProfile(
-  user:
-    | { referral?: { invitedBy?: string | null; invitedByCode?: string | null } }
-    | null
-    | undefined
-): boolean {
-  return !!(user?.referral?.invitedBy || user?.referral?.invitedByCode);
-}
-
-/** When referral is skipped, step index 1 (apply) is not shown — treat as skills (2). */
-function resolveOnboardingStep(currentStep: number, skipReferralStep: boolean): number {
-  if (skipReferralStep && currentStep === 1) {
-    return 2;
-  }
-  return currentStep;
-}
-
 const Onboarding = ({ onComplete, onDefer }: OnboardingProps) => {
   const { setOnboardingCompletedFlag, setOnboardingTasks, snapshot } = useCoreState();
   const [currentStep, setCurrentStep] = useState(0);
   const [draft, setDraft] = useState<OnboardingDraft>({ connectedSources: [] });
-  /** Last session token for which referral stats prefetch finished (async path only). */
-  const [referralStatsToken, setReferralStatsToken] = useState<string | null>(null);
-  const [skipReferralFromStats, setSkipReferralFromStats] = useState(false);
-  const [referralAppliedThisSession, setReferralAppliedThisSession] = useState(false);
-
-  const token = snapshot.sessionToken;
-  const currentUser = snapshot.currentUser;
-
-  const profileAlreadyReferred = useMemo(() => hasReferralFromProfile(currentUser), [currentUser]);
-  const needsReferralStatsPrefetch = !!(token && !profileAlreadyReferred);
-
-  useEffect(() => {
-    if (!needsReferralStatsPrefetch) {
-      return;
-    }
-
-    let cancelled = false;
-    (async () => {
-      try {
-        const stats = await referralApi.getStats();
-        const applied =
-          typeof stats.appliedReferralCode === 'string' && stats.appliedReferralCode.trim() !== '';
-        if (!cancelled) {
-          setSkipReferralFromStats(applied);
-          setReferralStatsToken(token);
-        }
-      } catch {
-        console.debug('[onboarding] referral preflight failed; showing referral step');
-        if (!cancelled) {
-          setSkipReferralFromStats(false);
-          setReferralStatsToken(token);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [needsReferralStatsPrefetch, token, profileAlreadyReferred]);
-
-  const referralGateReady = !token || profileAlreadyReferred || referralStatsToken === token;
-
-  const skipReferralStep = !token
-    ? false
-    : profileAlreadyReferred
-      ? true
-      : referralStatsToken === token && skipReferralFromStats;
-
-  const resolvedStep = resolveOnboardingStep(currentStep, skipReferralStep);
-
-  const handleWelcomeNext = () => {
-    if (skipReferralStep) {
-      setCurrentStep(2);
-    } else {
-      setCurrentStep(1);
-    }
-  };
 
   const handleNext = () => {
-    const logical = resolveOnboardingStep(currentStep, skipReferralStep);
-    if (logical < 3) {
-      setCurrentStep(logical + 1);
+    if (currentStep < 2) {
+      setCurrentStep(currentStep + 1);
     }
   };
 
   const handleBack = () => {
-    const logical = resolveOnboardingStep(currentStep, skipReferralStep);
-    if (logical <= 0) return;
-    if (
-      logical === 2 &&
-      (skipReferralStep || profileAlreadyReferred || referralAppliedThisSession)
-    ) {
-      setCurrentStep(0);
-      return;
-    }
-    setCurrentStep(logical - 1);
+    if (currentStep <= 0) return;
+    setCurrentStep(currentStep - 1);
   };
 
   const handleSkillsNext = async (connectedSources: string[]) => {
@@ -164,27 +79,12 @@ const Onboarding = ({ onComplete, onDefer }: OnboardingProps) => {
   };
 
   const renderStep = () => {
-    switch (resolvedStep) {
+    switch (currentStep) {
       case 0:
-        return (
-          <WelcomeStep
-            onNext={handleWelcomeNext}
-            nextDisabled={!referralGateReady}
-            nextLoading={!!token && !referralGateReady}
-            nextLoadingLabel="Checking account…"
-          />
-        );
+        return <WelcomeStep onNext={handleNext} />;
       case 1:
-        return (
-          <ReferralApplyStep
-            onNext={handleNext}
-            onBack={handleBack}
-            onApplied={() => setReferralAppliedThisSession(true)}
-          />
-        );
-      case 2:
         return <SkillsStep onNext={handleSkillsNext} onBack={handleBack} />;
-      case 3:
+      case 2:
         return (
           <ContextGatheringStep
             connectedSources={draft.connectedSources}


### PR DESCRIPTION
## Summary

- Remove the referral code step from the onboarding flow. New path: **Welcome → Skills → Context Gathering**.
- Drop the `referralApi.getStats()` prefetch that was disabling Welcome's Next button with "Checking account…" — the main perceived-load gate on signed-in first-open.
- `ReferralApplyStep.tsx` is preserved on disk, just no longer imported, so the step can return later without a rewrite.
- `referralApi` is untouched; still consumed by Rewards, Invites, and Billing.

## Problem

1. **#752** — Referral step adds friction to onboarding and should be disabled.
2. **#692** — First-open onboarding feels slow. The Welcome step's Next button was gated on an async `referralApi.getStats()` round-trip ("Checking account…"), which is exactly the perceived-load hit users noticed.

## Solution

Single-file change in `app/src/pages/onboarding/Onboarding.tsx`:

- Strip `referralApi` / `ReferralApplyStep` imports.
- Remove `hasReferralFromProfile`, `resolveOnboardingStep`, `skipReferralStep`, `referralStatsToken`, `skipReferralFromStats`, `referralAppliedThisSession`, and `referralGateReady`.
- Drop the prefetch `useEffect`.
- Renumber steps: `0` Welcome → `1` Skills → `2` Context.
- Welcome no longer receives `nextDisabled` / `nextLoading` / `nextLoadingLabel` — Next is immediately interactive.
- `handleBack` simplified; back/forward navigation through the 3-step flow works as expected.

## Overlap with #759

None at the file level — #759 touches `WelcomeStep.tsx`, `ContextGatheringStep.tsx`, and privacy components; this PR only edits `Onboarding.tsx`. The only interaction is that Welcome's optional `nextDisabled` / `nextLoading` props are no longer passed. Merge order doesn't matter.

## Submission Checklist

- [x] **Unit tests** — `yarn test:unit src/pages/onboarding` green (9/9 across `SkillsStep.test.tsx` and `LocalAIStep.test.tsx`). No referral-specific unit test existed; none removed.
- [x] **Typecheck / lint / format** — `yarn compile`, `yarn lint`, `prettier --check` all clean.
- [ ] **E2E** — `login-flow.spec.ts` (touched by #759) does not assert on the referral step. Manual verification pending on a built bundle; deferring to CI.
- [x] **Doc comments** — Behavior is self-evident from the simplified switch and navigation helpers.

## Impact

- **Runtime**: frontend only. No Tauri / core / JSON-RPC changes.
- **User-visible**: (1) referral step no longer appears during onboarding; (2) Welcome's Next is instantly interactive on first open — no "Checking account…" delay.
- **Migration**: none. Users who already applied a referral keep their state (`referralApi` is still wired everywhere else).
- **Follow-ups**: deeper first-open wins (bootstrap snapshot fetch, 3s profile-load timeout in `OnboardingOverlay`) left for a separate PR to keep this cut minimal.

## Related

- Closes #752
- Addresses #692 for the signed-in first-open path
- Adjacent: #759 (trust-first onboarding + Button primitive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the onboarding flow by removing the referral application step, resulting in a simplified 3-step process with improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->