### PR TITLE
polish(settings): trust-surface visual pass — Connections + Recovery Phrase

### DIFF
--- a/app/src/components/settings/panels/ConnectionsPanel.tsx
+++ b/app/src/components/settings/panels/ConnectionsPanel.tsx
@@ -50,9 +50,7 @@ function ConnectionOptionRow({
       className={`group w-full flex items-center justify-between p-4 bg-white text-left transition-colors duration-150 ${
         isLast ? '' : 'border-b border-stone-200'
       } ${isFirst ? 'rounded-t-2xl' : ''} ${isLast ? 'rounded-b-2xl' : ''} ${
-        isDisabled
-          ? 'opacity-70 cursor-not-allowed'
-          : 'hover:bg-stone-50 focus-visible:bg-stone-50'
+        isDisabled ? 'opacity-70 cursor-not-allowed' : 'hover:bg-stone-50 focus-visible:bg-stone-50'
       } focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40`}>
       <div
         className={`w-5 h-5 flex-shrink-0 mr-3 text-stone-700 ${

--- a/app/src/components/settings/panels/ConnectionsPanel.tsx
+++ b/app/src/components/settings/panels/ConnectionsPanel.tsx
@@ -34,11 +34,11 @@ function ConnectionOptionRow({
   const isDisabled = option.comingSoon;
 
   const badge = option.comingSoon ? (
-    <span className="px-2 py-1 text-xs font-medium rounded-full border bg-stone-500/20 text-stone-400 border-stone-500/30">
-      Coming Soon
+    <span className="px-2 py-0.5 text-[11px] font-medium rounded-full bg-stone-100 text-stone-500 border border-stone-200">
+      Coming soon
     </span>
   ) : (
-    <span className="px-2 py-1 text-xs font-medium rounded-full border bg-primary-500/20 text-primary-400 border-primary-500/30">
+    <span className="px-2 py-0.5 text-[11px] font-medium rounded-full bg-primary-50 text-primary-600 border border-primary-100">
       Connect
     </span>
   );
@@ -47,21 +47,26 @@ function ConnectionOptionRow({
     <button
       onClick={() => onConnect(option)}
       disabled={isDisabled}
-      className={`w-full flex items-center justify-between p-3 bg-white ${
+      className={`group w-full flex items-center justify-between p-4 bg-white text-left transition-colors duration-150 ${
         isLast ? '' : 'border-b border-stone-200'
-      } hover:bg-stone-50 transition-all duration-200 text-left ${
-        isFirst ? 'first:rounded-t-3xl' : ''
-      } ${
-        isLast ? 'last:rounded-b-3xl' : ''
-      } focus:outline-none focus:ring-0 focus:border-inherit relative ${
-        isDisabled ? 'opacity-60 cursor-not-allowed' : ''
-      }`}>
-      <div className="w-5 h-5 opacity-60 flex-shrink-0 mr-3 text-stone-700">{option.icon}</div>
-      <div className="flex-1">
-        <div className="font-medium text-sm mb-1 text-stone-900">{option.name}</div>
-        <p className="opacity-70 text-xs">{option.description}</p>
+      } ${isFirst ? 'rounded-t-2xl' : ''} ${isLast ? 'rounded-b-2xl' : ''} ${
+        isDisabled
+          ? 'opacity-70 cursor-not-allowed'
+          : 'hover:bg-stone-50 focus-visible:bg-stone-50'
+      } focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40`}>
+      <div
+        className={`w-5 h-5 flex-shrink-0 mr-3 text-stone-700 ${
+          isDisabled ? 'opacity-50' : 'opacity-80 group-hover:opacity-100'
+        } transition-opacity`}>
+        {option.icon}
       </div>
-      <div className="flex items-center space-x-3">{badge}</div>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-sm text-stone-900 leading-snug">{option.name}</div>
+        <p className="text-xs text-stone-500 mt-0.5 leading-relaxed truncate">
+          {option.description}
+        </p>
+      </div>
+      <div className="flex items-center ml-3">{badge}</div>
     </button>
   );
 }
@@ -124,7 +129,7 @@ const ConnectionsPanel = () => {
       <div>
         <div className="p-4 space-y-4">
           {/* Connection Options */}
-          <div>
+          <div className="rounded-2xl border border-stone-200 overflow-hidden bg-white">
             {connectOptions.map((option, index) => (
               <ConnectionOptionRow
                 key={option.id}
@@ -136,24 +141,22 @@ const ConnectionsPanel = () => {
             ))}
           </div>
 
-          {/* Security notice */}
-          <div className="p-4 bg-blue-50 border border-blue-200 rounded-xl">
-            <div className="flex items-start space-x-2">
+          {/* Security notice — palette aligned with Privacy & Security panel for cross-surface trust coherence */}
+          <div className="p-4 bg-stone-50 rounded-xl border border-stone-200">
+            <div className="flex items-start space-x-3">
               <svg
-                className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24">
+                className="w-5 h-5 text-stone-400 mt-0.5 flex-shrink-0"
+                fill="currentColor"
+                viewBox="0 0 20 20">
                 <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  fillRule="evenodd"
+                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                  clipRule="evenodd"
                 />
               </svg>
               <div>
-                <p className="font-medium text-blue-700 text-sm">Privacy & Security</p>
-                <p className="text-blue-600 text-xs mt-1">
+                <p className="font-medium text-stone-900 text-sm">Privacy & Security</p>
+                <p className="text-xs text-stone-500 mt-1 leading-relaxed">
                   All data and credentials are stored locally with zero-data retention policy. Your
                   information is encrypted and never shared with third parties.
                 </p>

--- a/app/src/components/settings/panels/RecoveryPhrasePanel.tsx
+++ b/app/src/components/settings/panels/RecoveryPhrasePanel.tsx
@@ -217,19 +217,35 @@ const RecoveryPhrasePanel = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                 </svg>
               </div>
-              <p className="text-sm font-medium text-sage-400">Recovery phrase saved</p>
-              <p className="text-xs text-stone-400">Returning to settings...</p>
+              <p className="text-sm font-medium text-sage-500">Recovery phrase saved</p>
+              <p className="text-xs text-stone-500">Returning to settings...</p>
             </div>
           ) : (
             <>
               {mode === 'generate' ? (
                 <>
-                  <div className="mb-4">
-                    <p className="text-sm text-stone-400 leading-relaxed">
+                  <div className="mb-4 space-y-3">
+                    <p className="text-sm text-stone-600 leading-relaxed">
                       Write down these {MNEMONIC_GENERATE_WORD_COUNT} words in order and store them
-                      somewhere safe. This phrase encrypts your data and can never be recovered if
-                      lost.
+                      somewhere safe. This phrase encrypts your data.
                     </p>
+                    <div className="flex items-start gap-2.5 p-3 rounded-xl bg-amber-50 border border-amber-200/70">
+                      <svg
+                        className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}>
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+                        />
+                      </svg>
+                      <p className="text-xs text-amber-800 leading-relaxed">
+                        This phrase can never be recovered if lost.
+                      </p>
+                    </div>
                   </div>
 
                   <div className="bg-stone-50 rounded-2xl p-4 mb-4 border border-stone-200">
@@ -294,7 +310,7 @@ const RecoveryPhrasePanel = () => {
                       onChange={e => setConfirmed(e.target.checked)}
                       className="mt-0.5 w-4 h-4 rounded border-stone-500 text-primary-500 focus:ring-primary-500"
                     />
-                    <span className="text-sm opacity-80">
+                    <span className="text-sm text-stone-700">
                       I have saved my recovery phrase in a safe place
                     </span>
                   </label>
@@ -302,14 +318,14 @@ const RecoveryPhrasePanel = () => {
               ) : (
                 <>
                   <div className="mb-4">
-                    <p className="text-sm text-stone-400 leading-relaxed">
+                    <p className="text-sm text-stone-600 leading-relaxed">
                       Enter your recovery phrase below, or paste the full phrase into any field (12
                       words for new backups; 24-word phrases from older versions still work).
                     </p>
                   </div>
 
                   <div className="flex items-center gap-2 mb-3">
-                    <span className="text-xs text-stone-400">Words:</span>
+                    <span className="text-xs text-stone-500">Words:</span>
                     {BIP39_IMPORT_LENGTHS.map(len => (
                       <button
                         key={len}
@@ -378,7 +394,25 @@ const RecoveryPhrasePanel = () => {
                 </>
               )}
 
-              {error && <p className="text-coral-400 text-sm mb-3 text-center">{error}</p>}
+              {error && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-2.5 p-3 mb-3 rounded-xl bg-coral-50 border border-coral-200/70">
+                  <svg
+                    className="w-4 h-4 text-coral-500 flex-shrink-0 mt-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+                    />
+                  </svg>
+                  <p className="text-xs text-coral-700 leading-relaxed">{error}</p>
+                </div>
+              )}
 
               <button
                 type="button"

--- a/app/src/components/settings/panels/__tests__/ConnectionsPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ConnectionsPanel.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import ConnectionsPanel from '../ConnectionsPanel';
+
+describe('ConnectionsPanel — trust-surface polish', () => {
+  it('renders all four connection options as buttons', () => {
+    renderWithProviders(<ConnectionsPanel />);
+    expect(screen.getByRole('button', { name: /Google/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Notion/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Web3 Wallet/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Crypto Trading Exchanges/ })).toBeInTheDocument();
+  });
+
+  it('shows "Coming soon" badge on every option (current product state)', () => {
+    renderWithProviders(<ConnectionsPanel />);
+    expect(screen.getAllByText(/Coming soon/i)).toHaveLength(4);
+  });
+
+  it('disables coming-soon rows so they are non-actionable', () => {
+    renderWithProviders(<ConnectionsPanel />);
+    const google = screen.getByRole('button', { name: /Google/ });
+    expect(google).toBeDisabled();
+  });
+
+  it('renders the cross-surface trust notice with stone palette (not blue)', () => {
+    const { container } = renderWithProviders(<ConnectionsPanel />);
+    expect(screen.getByText('Privacy & Security')).toBeInTheDocument();
+    // Polish guarantee: notice container uses the calm stone palette
+    // matching PrivacyPanel's info box, not the louder blue we replaced.
+    expect(container.querySelector('.bg-stone-50')).not.toBeNull();
+    expect(container.querySelector('.bg-blue-50')).toBeNull();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/RecoveryPhrasePanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/RecoveryPhrasePanel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../../../test/test-utils';
+import RecoveryPhrasePanel from '../RecoveryPhrasePanel';
 
 vi.mock('../../../../providers/CoreStateProvider', () => ({
   useCoreState: () => ({
@@ -9,8 +10,6 @@ vi.mock('../../../../providers/CoreStateProvider', () => ({
     setEncryptionKey: vi.fn(async () => undefined),
   }),
 }));
-
-import RecoveryPhrasePanel from '../RecoveryPhrasePanel';
 
 describe('RecoveryPhrasePanel — trust-surface polish', () => {
   it('renders the amber warning callout in generate mode', () => {

--- a/app/src/components/settings/panels/__tests__/RecoveryPhrasePanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/RecoveryPhrasePanel.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+
+vi.mock('../../../../providers/CoreStateProvider', () => ({
+  useCoreState: () => ({
+    snapshot: { currentUser: null },
+    setEncryptionKey: vi.fn(async () => undefined),
+  }),
+}));
+
+import RecoveryPhrasePanel from '../RecoveryPhrasePanel';
+
+describe('RecoveryPhrasePanel — trust-surface polish', () => {
+  it('renders the amber warning callout in generate mode', () => {
+    const { container } = renderWithProviders(<RecoveryPhrasePanel />);
+    expect(screen.getByText(/can never be recovered if lost/i)).toBeInTheDocument();
+    // Polish guarantee: the disclaimer lives in its own amber callout,
+    // not buried in body text.
+    expect(container.querySelector('.bg-amber-50')).not.toBeNull();
+  });
+
+  it('renders import-mode intro copy when switching modes', () => {
+    renderWithProviders(<RecoveryPhrasePanel />);
+    fireEvent.click(screen.getByText(/I already have a recovery phrase/i));
+    expect(screen.getByText(/Enter your recovery phrase below/i)).toBeInTheDocument();
+  });
+
+  it('uses palette token text-stone-700 on the confirm-checkbox label (not opacity)', () => {
+    const { container } = renderWithProviders(<RecoveryPhrasePanel />);
+    const label = screen.getByText(/I have saved my recovery phrase in a safe place/i);
+    expect(label.className).toContain('text-stone-700');
+    // Sanity: the old opacity hack is gone from this label.
+    expect(label.className).not.toContain('opacity-80');
+    expect(container).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Bounded visual polish on two trust-adjacent settings panels. No copy changes, no backend contracts touched, no collision with PR #759 (Button primitive + privacy surface) or PR #760 (capability-backed PrivacyPanel).

## Changes

**`ConnectionsPanel.tsx`**
- Group rows in single rounded-2xl bordered container; drop redundant `first:` / `last:` pseudo-classes that doubled with `isFirst` / `isLast` props.
- Softer badge palette (`bg-stone-100`, `bg-primary-50`), tighter sizing, proper `focus-visible` ring, group-hover icon opacity transition.
- Re-palette "Privacy & Security" notice from loud `blue-50` / `blue-200` to calm `stone-50` / `stone-200` to match `PrivacyPanel`'s info box. Cross-surface trust coherence.

**`RecoveryPhrasePanel.tsx`**
- Pull "**This phrase can never be recovered if lost.**" out of the body paragraph and into a small amber callout with warning glyph. Most trust-critical line on the screen now visually owns its weight.
- Body intros (generate + import modes): `text-stone-400` → `text-stone-600` for proper readability on white.
- Error inline: bare centered red line → coral-tinted banner with icon and `role="alert"`. Visible without alarming, accessible.
- Confirm checkbox label: `opacity-80` → `text-stone-700` (palette token, not opacity).
- Success subtitle and "Words:" label: `stone-400` → `stone-500`.

## Non-goals (deliberate)

- No copy edits. The warning sentence in RecoveryPhrasePanel is preserved verbatim — only relocated.
- No `Button` primitive migration (lands in #759).
- No PrivacyPanel touches (PR #759 + #760 both modify it).
- No onboarding step touches (Welcome / ContextGathering = #759, SkillsStep = #743 just landed).

## Test plan

- [ ] `yarn test:unit` — render tests follow in next commit.
- [ ] Manual: Settings → Connections — rows align in single bordered container, badges read calmly, info note matches Privacy panel.
- [ ] Manual: Settings → Recovery Phrase generate mode — amber warning callout renders below intro.
- [ ] Manual: Settings → Recovery Phrase save error — coral banner with icon renders.