### PR TITLE
fix(rewards): add retry on snapshot load failure + tab-switch logging

### DIFF
--- a/app/src/components/rewards/RewardsCommunityTab.tsx
+++ b/app/src/components/rewards/RewardsCommunityTab.tsx
@@ -68,12 +68,14 @@ function roleGlyph(index: number) {
 interface RewardsCommunityTabProps {
   error: string | null;
   isLoading: boolean;
+  onRetry?: () => void;
   snapshot: RewardsSnapshot | null;
 }
 
 export default function RewardsCommunityTab({
   error,
   isLoading,
+  onRetry,
   snapshot,
 }: RewardsCommunityTabProps) {
   const navigate = useNavigate();
@@ -136,9 +138,22 @@ export default function RewardsCommunityTab({
       {error ? (
         <div
           role="alert"
-          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-          Rewards sync is unavailable right now. The page is showing connection guidance without
-          claiming new unlocks. Details: {error}
+          data-testid="rewards-error"
+          className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <span>
+            Rewards sync is unavailable right now. The page is showing connection guidance without
+            claiming new unlocks. Details: {error}
+          </span>
+          {onRetry ? (
+            <button
+              type="button"
+              data-testid="rewards-retry"
+              onClick={onRetry}
+              disabled={isLoading}
+              className="rounded-full border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-800 shadow-sm transition-colors hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60">
+              {isLoading ? 'Retrying…' : 'Try again'}
+            </button>
+          ) : null}
         </div>
       ) : null}
 

--- a/app/src/pages/Rewards.tsx
+++ b/app/src/pages/Rewards.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import PillTabBar from '../components/PillTabBar';
 import RewardsCommunityTab from '../components/rewards/RewardsCommunityTab';
@@ -9,50 +9,64 @@ import type { RewardsSnapshot } from '../types/rewards';
 
 type RewardsTab = 'referrals' | 'redeem' | 'rewards';
 
+function errorMessage(err: unknown): string {
+  if (err && typeof err === 'object' && 'error' in err && typeof err.error === 'string') {
+    return err.error;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return 'Unable to load rewards';
+}
+
 const Rewards = () => {
   const [selectedTab, setSelectedTab] = useState<RewardsTab>('rewards');
   const [snapshot, setSnapshot] = useState<RewardsSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadRewards = async () => {
-      try {
-        const result = await rewardsApi.getMyRewards();
-        if (!cancelled) {
-          setSnapshot(result);
-          console.debug('[rewards] snapshot applied', {
-            unlockedCount: result.summary.unlockedCount,
-            totalCount: result.summary.totalCount,
-          });
-        }
-      } catch (err) {
-        const message =
-          err && typeof err === 'object' && 'error' in err && typeof err.error === 'string'
-            ? err.error
-            : err instanceof Error
-              ? err.message
-              : 'Unable to load rewards';
-        console.debug('[rewards] snapshot load failed', message);
-        if (!cancelled) {
-          setSnapshot(null);
-          setError(message);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
+  const loadRewards = useCallback(async (signal?: { cancelled: boolean }) => {
+    console.debug('[rewards] fetching snapshot');
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await rewardsApi.getMyRewards();
+      if (signal?.cancelled) return;
+      setSnapshot(result);
+      console.debug('[rewards] snapshot applied', {
+        unlockedCount: result.summary.unlockedCount,
+        totalCount: result.summary.totalCount,
+      });
+    } catch (err) {
+      const message = errorMessage(err);
+      console.debug('[rewards] snapshot load failed', message);
+      if (signal?.cancelled) return;
+      setSnapshot(null);
+      setError(message);
+    } finally {
+      if (!signal?.cancelled) {
+        setIsLoading(false);
       }
-    };
-
-    void loadRewards();
-
-    return () => {
-      cancelled = true;
-    };
+    }
   }, []);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    void loadRewards(signal);
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [loadRewards]);
+
+  const handleTabChange = useCallback((next: RewardsTab) => {
+    console.debug('[rewards] tab changed', { next });
+    setSelectedTab(next);
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    console.debug('[rewards] retry requested');
+    void loadRewards();
+  }, [loadRewards]);
 
   return (
     <div className="min-h-full px-4 pt-6 pb-10">
@@ -64,7 +78,7 @@ const Rewards = () => {
             { label: 'Redeem', value: 'redeem' },
           ]}
           selected={selectedTab}
-          onChange={setSelectedTab}
+          onChange={handleTabChange}
           activeClassName="border-primary-600 bg-primary-600 text-white"
         />
 
@@ -73,7 +87,12 @@ const Rewards = () => {
         ) : selectedTab === 'redeem' ? (
           <RewardsRedeemTab />
         ) : (
-          <RewardsCommunityTab error={error} isLoading={isLoading} snapshot={snapshot} />
+          <RewardsCommunityTab
+            error={error}
+            isLoading={isLoading}
+            onRetry={handleRetry}
+            snapshot={snapshot}
+          />
         )}
       </div>
     </div>

--- a/app/src/pages/__tests__/Rewards.test.tsx
+++ b/app/src/pages/__tests__/Rewards.test.tsx
@@ -97,6 +97,67 @@ describe('Rewards page', () => {
     expect(screen.queryByText('Unlocked')).not.toBeInTheDocument();
   });
 
+  it('retries the snapshot fetch when the user clicks Try again', async () => {
+    rewardsApi.getMyRewards
+      .mockRejectedValueOnce({ error: 'Backend offline' })
+      .mockResolvedValueOnce({
+        discord: {
+          linked: true,
+          discordId: 'discord-123',
+          inviteUrl: 'https://discord.gg/openhuman',
+          membershipStatus: 'member',
+        },
+        summary: {
+          unlockedCount: 1,
+          totalCount: 2,
+          assignedDiscordRoleCount: 1,
+          plan: 'PRO',
+          hasActiveSubscription: true,
+        },
+        metrics: {
+          currentStreakDays: 7,
+          longestStreakDays: 7,
+          cumulativeTokens: 12000000,
+          featuresUsedCount: 2,
+          trackedFeaturesCount: 6,
+          lastEvaluatedAt: '2026-04-09T00:00:00.000Z',
+          lastSyncedAt: '2026-04-09T01:00:00.000Z',
+        },
+        achievements: [
+          {
+            id: 'STREAK_7',
+            title: '7-Day Streak',
+            description: 'Use OpenHuman on seven consecutive active days.',
+            actionLabel: 'Keep your streak alive for 7 days',
+            unlocked: true,
+            progressLabel: 'Unlocked',
+            roleId: 'role-streak-7',
+            discordRoleStatus: 'assigned',
+            creditAmountUsd: null,
+          },
+        ],
+      });
+
+    render(
+      <MemoryRouter>
+        <Rewards />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rewards-error')).toBeInTheDocument();
+    });
+    expect(rewardsApi.getMyRewards).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('rewards-retry'));
+
+    await waitFor(() => {
+      expect(screen.getByText('7-Day Streak')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('rewards-error')).not.toBeInTheDocument();
+    expect(rewardsApi.getMyRewards).toHaveBeenCalledTimes(2);
+  });
+
   it('switches to the referrals tab content', async () => {
     rewardsApi.getMyRewards.mockResolvedValueOnce({
       discord: {


### PR DESCRIPTION
## Summary

First slice of #712 (Rewards stabilization). Tight, review-in-one-sitting change on the Rewards page shell so follow-up PRs can focus on per-tab flows and E2E.

- Retry button in the Community tab error banner — refetches the snapshot, re-enables on success, disabled while in flight.
- Tab-switch + retry logging under the `[rewards]` prefix.
- New unit test: fail → click Try again → refetch → success renders achievements + error banner clears.

cc @M3gA-Mind — you're the assignee on #712, happy to hand off or coordinate remaining slices. Scoped this PR to the page shell specifically so it doesn't block whatever you're doing on the individual tabs.

## Problem

`Rewards.tsx` had no retry path: if the `getMyRewards` call failed at mount, the user was stuck with a yellow banner and had to reload the whole app. The error string also wasn't easy to surface for E2E or Sentry.

## Solution

- Extract `loadRewards` into a `useCallback` so it can be invoked from both the mount `useEffect` and a user-triggered retry.
- Pass `onRetry` into `RewardsCommunityTab`; render a `Try again` pill inside the existing amber banner. Uses `data-testid="rewards-error"` / `data-testid="rewards-retry"` so the upcoming E2E slice of #712 has stable hooks.
- Reset `error` and set `isLoading` at the start of every fetch so retry visibly "goes back to loading" instead of lingering on the failed state.
- Log: `[rewards] fetching snapshot`, `[rewards] tab changed`, `[rewards] retry requested` for ops / Sentry breadcrumbs.

**Explicitly not in scope** (deferred to subsequent #712 slices):
- Referrals tab (ReferralRewardsSection) fixes.
- Redeem tab (RewardsCouponSection) fixes.
- Discord connect/join flow.
- E2E specs — hooks are in place (`rewards-error`, `rewards-retry`); specs will land in the E2E slice.

## Remaining #712 plan

1. This PR — shell + retry + logging + 1 new unit test. ✅
2. Next — Referrals tab characterization + fixes.
3. Then — Redeem / coupons.
4. Then — Community / Discord flow.
5. Finally — E2E smoke + per-flow specs.

Each slice is independent and passes CI on its own; #712 stays open until the E2E slice lands.

## Submission Checklist

- [x] **Unit tests** — `yarn test:unit src/pages/__tests__/Rewards.test.tsx` → 5 passed (1 new).
- [x] **Typecheck** — `yarn compile` clean.
- [x] **Lint / format** — `yarn lint` + Prettier clean.
- [ ] **E2E** — deferred to a later #712 slice; this PR adds the test IDs E2E will target.

## Impact

- **Runtime**: frontend only. No RPC / sidecar changes.
- **User-visible**: retry button appears in the existing error banner on the Rewards tab. Everything else unchanged.
- **Migration**: none.

## Related

- Part of #712 (first of ~5 slices)