### PR TITLE
test(e2e): channels smoke spec (Telegram + Discord) — first slice of #290

### DIFF
--- a/app/test/e2e/specs/channels-smoke.spec.ts
+++ b/app/test/e2e/specs/channels-smoke.spec.ts
@@ -85,9 +85,7 @@ describe('Channels page smoke (Telegram + Discord)', () => {
     // Switch to the Discord pill and assert it also exposes a Connect button.
     stepLog('switching to Discord panel');
     const clicked = await browser.execute(() => {
-      const buttons = Array.from(
-        document.querySelectorAll<HTMLButtonElement>('button')
-      );
+      const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('button'));
       const discordBtn = buttons.find(b => b.textContent?.includes('Discord'));
       if (discordBtn) {
         discordBtn.click();

--- a/app/test/e2e/specs/channels-smoke.spec.ts
+++ b/app/test/e2e/specs/channels-smoke.spec.ts
@@ -1,0 +1,103 @@
+import { waitForApp, waitForAppReady } from '../helpers/app-helpers';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { supportsExecuteScript } from '../helpers/platform';
+import { completeOnboardingIfVisible, navigateViaHash } from '../helpers/shared-flows';
+import { startMockServer, stopMockServer } from '../mock-server';
+
+/**
+ * Smoke spec for the Channels page (first slice of tinyhumansai/openhuman#290).
+ *
+ * Goal: verify the Channels page boots, renders both Telegram and Discord
+ * panels, and shows the "not connected" affordance (Connect button) for each.
+ *
+ * Deferred to follow-up PRs (do NOT add here):
+ *  - Telegram / Discord OAuth happy path
+ *  - Disconnect flow
+ *  - Message send + inbound webhook
+ *  - Auth edge cases and error states
+ *
+ * The channels page relies on core-RPC-backed definitions; when the mock
+ * sidecar does not respond, the UI falls back to `FALLBACK_DEFINITIONS` which
+ * includes both Telegram and Discord — that fallback path is exactly the
+ * "not_connected" state we want to assert here.
+ *
+ * Navigation uses `window.location.hash`. The sidebar has no "Channels" entry
+ * yet, so the Appium Mac2 branch of `navigateViaHash` has no label to click.
+ * Skip on Mac2 until a sidebar mapping (or testid) lands in a follow-up PR.
+ */
+function stepLog(message: string, context?: unknown): void {
+  const stamp = new Date().toISOString();
+  if (context === undefined) {
+    console.log(`[ChannelsSmokeE2E][${stamp}] ${message}`);
+    return;
+  }
+  console.log(`[ChannelsSmokeE2E][${stamp}] ${message}`, JSON.stringify(context, null, 2));
+}
+
+describe('Channels page smoke (Telegram + Discord)', () => {
+  before(async function beforeSuite() {
+    if (!supportsExecuteScript()) {
+      // Mac2 has no Channels sidebar label to click; skip cleanly.
+      stepLog('Skipping suite on Mac2 — no Channels sidebar mapping available');
+      this.skip();
+    }
+
+    stepLog('starting mock server');
+    await startMockServer();
+    stepLog('waiting for app');
+    await waitForApp();
+    stepLog('triggering auth bypass deep link');
+    await triggerAuthDeepLinkBypass('e2e-channels-smoke');
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await waitForAppReady(15_000);
+    await completeOnboardingIfVisible('[ChannelsSmokeE2E]');
+  });
+
+  after(async () => {
+    stepLog('stopping mock server');
+    await stopMockServer();
+  });
+
+  it('renders Telegram and Discord channel panels in not-connected state', async () => {
+    stepLog('navigating to /channels');
+    await navigateViaHash('/channels');
+
+    // Page header from ChannelSelector.
+    await waitForText('Channels', 15_000);
+
+    // Both channel pills render — their display names come from
+    // FALLBACK_DEFINITIONS when core RPC is unavailable in the mock env.
+    await waitForText('Telegram', 15_000);
+    await waitForText('Discord', 15_000);
+
+    // Default selected channel is Telegram; its config panel shows at least
+    // one auth mode ("Login with OpenHuman" = managed_dm) with a Connect
+    // button. Assert the Connect affordance is present.
+    expect(await textExists('Connect')).toBe(true);
+
+    // Switch to the Discord pill and assert it also exposes a Connect button.
+    stepLog('switching to Discord panel');
+    const clicked = await browser.execute(() => {
+      const buttons = Array.from(
+        document.querySelectorAll<HTMLButtonElement>('button')
+      );
+      const discordBtn = buttons.find(b => b.textContent?.includes('Discord'));
+      if (discordBtn) {
+        discordBtn.click();
+        return true;
+      }
+      return false;
+    });
+    expect(clicked).toBe(true);
+
+    await browser.pause(500);
+    expect(await textExists('Connect')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of #290 ([Channels] E2E verification and test coverage for Telegram + Discord). Adds a single smoke spec that verifies the Channels page boots and renders both Telegram and Discord panels in a not-connected state.

Full end-to-end coverage is genuinely multi-PR; this lands the boot-and-render baseline so later slices can assume the page works.

## Problem

Issue #290 calls for E2E verification of the Channels page plus Telegram/Discord integrations. No existing `app/test/e2e/specs/` spec touches channels. Before covering send/receive, OAuth, or disconnect flows, we need a stable smoke baseline that fails loudly if the page itself stops rendering.

## Solution

- New spec: `app/test/e2e/specs/channels-smoke.spec.ts`.
- Triggers the auth bypass deep link, completes onboarding if shown, navigates to `/channels` via hash, and asserts:
  - Page header "Channels" renders.
  - Both "Telegram" and "Discord" pills render (served by `FALLBACK_DEFINITIONS` when the core RPC methods are unavailable in the mock env — which is exactly the "not connected" state we want to assert).
  - A "Connect" affordance is visible on the default (Telegram) panel and on the Discord panel after switching to it.
- Skips cleanly on Appium Mac2 since the sidebar has no Channels entry to click (Mac2 cannot drive `window.location.hash`). Tauri-driver / Linux CI runs normally.
- No changes to production code. No changes to `scripts/mock-api-core.mjs` — the fallback-definitions path in `useChannelDefinitions` already covers the smoke state, so no new mock endpoints were required.

## Verification

- `yarn compile` — passes
- `yarn lint` — passes
- Prettier formatting applied
- Live E2E run not executed in this environment (no built app bundle available); spec typechecks and lints clean. Happy to re-run once CI picks it up.

## Deferred to follow-up PRs

This is the first slice of 5+ PRs. The following are explicitly **not** covered here and will land in follow-ups:

1. Telegram OAuth / managed-DM happy path (link-token issue → poll → connected).
2. Discord OAuth happy path (install bot → guild/channel picker → connected).
3. Disconnect flow for both channels (connected → disconnected, state in Redux + backend).
4. Message send + inbound webhook routing (outbound send via selected channel; inbound delivery surfaced in Conversations).
5. Auth edge cases: expired tokens, permission-check failures, credential validation errors, restart-required path.

Issue #290 remains open until the full suite lands.

cc @Al629176 — auto-drafted by a subagent, please review carefully.