### PR TITLE
feat(voice): in-place STT model download + retry in Voice Dictation panel

### DIFF
--- a/app/src/components/settings/panels/VoicePanel.tsx
+++ b/app/src/components/settings/panels/VoicePanel.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { formatBytes, formatEta, statusLabel } from '../../../utils/localAiHelpers';
 import {
+  type LocalAiAssetStatus,
+  type LocalAiDownloadProgressItem,
   openhumanGetVoiceServerSettings,
   openhumanLocalAiAssetsStatus,
+  openhumanLocalAiDownloadAsset,
+  openhumanLocalAiDownloadsProgress,
   openhumanUpdateVoiceServerSettings,
   openhumanVoiceServerStart,
   openhumanVoiceServerStatus,
@@ -15,6 +20,9 @@ import {
 import SettingsHeader from '../components/SettingsHeader';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
 
+const STT_DOWNLOADING_STATES = new Set(['downloading', 'installing', 'loading']);
+const STT_ERROR_STATES = new Set(['error', 'failed', 'degraded']);
+
 const VoicePanel = () => {
   const { navigateBack, navigateToSettings, breadcrumbs } = useSettingsNavigation();
   const [settings, setSettings] = useState<VoiceServerSettings | null>(null);
@@ -22,6 +30,10 @@ const VoicePanel = () => {
   const [serverStatus, setServerStatus] = useState<VoiceServerStatus | null>(null);
   const [, setVoiceStatus] = useState<VoiceStatus | null>(null);
   const [sttReady, setSttReady] = useState(false);
+  const [sttAsset, setSttAsset] = useState<LocalAiAssetStatus | null>(null);
+  const [sttDownload, setSttDownload] = useState<LocalAiDownloadProgressItem | null>(null);
+  const [sttDownloadError, setSttDownloadError] = useState<string | null>(null);
+  const [sttDownloadRequested, setSttDownloadRequested] = useState(false);
   const [, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
@@ -47,12 +59,14 @@ const VoicePanel = () => {
 
   const loadData = async (forceSettings = false) => {
     try {
-      const [settingsResponse, serverResponse, voiceResponse, assetsResponse] = await Promise.all([
-        openhumanGetVoiceServerSettings(),
-        openhumanVoiceServerStatus(),
-        openhumanVoiceStatus(),
-        openhumanLocalAiAssetsStatus(),
-      ]);
+      const [settingsResponse, serverResponse, voiceResponse, assetsResponse, downloadsResponse] =
+        await Promise.all([
+          openhumanGetVoiceServerSettings(),
+          openhumanVoiceServerStatus(),
+          openhumanVoiceStatus(),
+          openhumanLocalAiAssetsStatus(),
+          openhumanLocalAiDownloadsProgress().catch(() => null),
+        ]);
       const currentSettings = settingsRef.current;
       const currentSavedSettings = savedSettingsRef.current;
       if (
@@ -65,7 +79,9 @@ const VoicePanel = () => {
       setSavedSettings(settingsResponse.result);
       setServerStatus(serverResponse);
       setVoiceStatus(voiceResponse);
-      const sttAssetState = assetsResponse.result.stt?.state;
+      const sttAssetRaw = assetsResponse.result.stt ?? null;
+      setSttAsset(sttAssetRaw);
+      const sttAssetState = sttAssetRaw?.state;
       const sttAssetOk = sttAssetState === 'ready' || sttAssetState === 'ondemand';
       if (process.env.NODE_ENV !== 'production') {
         console.debug('[VoicePanel:stt] readiness decision', {
@@ -75,12 +91,34 @@ const VoicePanel = () => {
         });
       }
       setSttReady(sttAssetOk && voiceResponse.stt_available);
+      const sttDownloadRaw = downloadsResponse?.result?.stt ?? null;
+      setSttDownload(sttDownloadRaw);
+      // Clear transient "requested" once core reports an active download phase
+      // or the asset finished downloading (state becomes ready).
+      if (sttAssetOk || (sttDownloadRaw && STT_DOWNLOADING_STATES.has(sttDownloadRaw.state))) {
+        setSttDownloadRequested(false);
+      }
       setError(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load voice settings';
       setError(message);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const startSttDownload = async () => {
+    console.debug('[voice-intel] starting in-place STT download');
+    setSttDownloadError(null);
+    setSttDownloadRequested(true);
+    try {
+      await openhumanLocalAiDownloadAsset('stt');
+      await loadData(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start STT model download';
+      console.debug('[voice-intel] STT download failed', message);
+      setSttDownloadError(message);
+      setSttDownloadRequested(false);
     }
   };
 
@@ -322,17 +360,14 @@ const VoicePanel = () => {
             )}
 
             {disabled && (
-              <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 space-y-3">
-                <div>
-                  Voice dictation is disabled until the local STT model is downloaded and ready.
-                </div>
-                <button
-                  type="button"
-                  onClick={() => navigateToSettings('local-model')}
-                  className="px-3 py-1.5 text-xs rounded-md bg-amber-600 hover:bg-amber-700 text-white">
-                  Open Local AI Model
-                </button>
-              </div>
+              <SttSetupBlock
+                sttAsset={sttAsset}
+                sttDownload={sttDownload}
+                sttDownloadError={sttDownloadError}
+                sttDownloadRequested={sttDownloadRequested}
+                onStartDownload={() => void startSttDownload()}
+                onOpenAdvanced={() => navigateToSettings('local-model')}
+              />
             )}
 
             {error && (
@@ -380,6 +415,149 @@ const VoicePanel = () => {
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+interface SttSetupBlockProps {
+  sttAsset: LocalAiAssetStatus | null;
+  sttDownload: LocalAiDownloadProgressItem | null;
+  sttDownloadError: string | null;
+  sttDownloadRequested: boolean;
+  onStartDownload: () => void;
+  onOpenAdvanced: () => void;
+}
+
+const SttSetupBlock = ({
+  sttAsset,
+  sttDownload,
+  sttDownloadError,
+  sttDownloadRequested,
+  onStartDownload,
+  onOpenAdvanced,
+}: SttSetupBlockProps) => {
+  const assetState = sttAsset?.state ?? 'missing';
+  const downloadState = sttDownload?.state ?? 'idle';
+  const isDownloading = STT_DOWNLOADING_STATES.has(downloadState) || sttDownloadRequested;
+  const hasCoreError =
+    !sttDownloadError &&
+    (STT_ERROR_STATES.has(assetState) ||
+      STT_ERROR_STATES.has(downloadState) ||
+      !!sttDownload?.warning);
+  const coreErrorMessage =
+    sttDownload?.warning ??
+    sttAsset?.warning ??
+    (STT_ERROR_STATES.has(assetState) || STT_ERROR_STATES.has(downloadState)
+      ? 'The local STT model download did not complete.'
+      : null);
+  const progress =
+    sttDownload && typeof sttDownload.progress === 'number'
+      ? Math.max(0, Math.min(1, sttDownload.progress))
+      : null;
+  const percent = progress != null ? Math.round(progress * 100) : null;
+
+  // Priority: explicit frontend error > core-reported error > active progress > idle CTA.
+  if (sttDownloadError || hasCoreError) {
+    const message = sttDownloadError ?? coreErrorMessage ?? 'Unable to download the STT model.';
+    return (
+      <div
+        data-testid="voice-stt-setup-error"
+        className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 space-y-3">
+        <div className="space-y-1">
+          <div className="font-medium">STT model download didn’t complete.</div>
+          <div className="text-xs text-red-600">{message}</div>
+          <div className="text-xs text-red-500">
+            Check your internet connection and click Retry. The download resumes where it left off.
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onStartDownload}
+            className="px-3 py-1.5 text-xs rounded-md bg-red-600 hover:bg-red-700 text-white">
+            Retry download
+          </button>
+          <button
+            type="button"
+            onClick={onOpenAdvanced}
+            className="px-3 py-1.5 text-xs rounded-md border border-red-200 text-red-700 hover:border-red-300">
+            Advanced (Local AI)
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isDownloading) {
+    const downloaded = sttDownload?.downloaded_bytes ?? null;
+    const total = sttDownload?.total_bytes ?? null;
+    const speed = sttDownload?.speed_bps ?? null;
+    const eta = sttDownload?.eta_seconds ?? null;
+    return (
+      <div
+        data-testid="voice-stt-setup-progress"
+        className="rounded-md border border-primary-200 bg-primary-50 p-4 text-sm text-primary-900 space-y-3">
+        <div className="space-y-1">
+          <div className="font-medium">
+            {statusLabel(STT_DOWNLOADING_STATES.has(downloadState) ? downloadState : 'downloading')}
+            {' the local STT model…'}
+          </div>
+          <div className="text-xs text-primary-700">
+            You can keep this panel open — we’ll enable Voice Dictation the moment it’s ready.
+          </div>
+        </div>
+        <div className="h-1.5 w-full rounded-full bg-primary-100 overflow-hidden">
+          <div
+            className={`h-full rounded-full bg-primary-500 transition-all duration-500 ${
+              downloadState === 'installing' ? 'animate-pulse' : ''
+            }`}
+            style={{ width: downloadState === 'installing' ? '100%' : `${percent ?? 5}%` }}
+          />
+        </div>
+        <div className="flex items-center justify-between text-[11px] text-primary-700">
+          <span>
+            {downloadState === 'installing'
+              ? 'Installing…'
+              : downloaded != null && total != null
+                ? `${formatBytes(downloaded)} / ${formatBytes(total)}`
+                : percent != null
+                  ? `${percent}%`
+                  : 'Preparing…'}
+          </span>
+          <span>
+            {speed != null && speed > 0 ? `${formatBytes(speed)}/s` : ''}
+            {eta != null && eta > 0 ? ` · ${formatEta(eta)}` : ''}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="voice-stt-setup-idle"
+      className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 space-y-3">
+      <div className="space-y-1">
+        <div className="font-medium">Voice Dictation needs the local STT model.</div>
+        <div className="text-xs text-amber-700">
+          It’s a one-time download (~50–150 MB depending on your device). Everything stays on your
+          Mac.
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onStartDownload}
+          className="px-3 py-1.5 text-xs rounded-md bg-amber-600 hover:bg-amber-700 text-white">
+          Download STT model
+        </button>
+        <button
+          type="button"
+          onClick={onOpenAdvanced}
+          className="px-3 py-1.5 text-xs rounded-md border border-amber-300 text-amber-800 hover:border-amber-400">
+          Advanced (Local AI)
         </button>
       </div>
     </div>

--- a/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
@@ -5,8 +5,11 @@ import { renderWithProviders } from '../../../../test/test-utils';
 import {
   type CommandResponse,
   type ConfigSnapshot,
+  type LocalAiDownloadsProgress,
   openhumanGetVoiceServerSettings,
   openhumanLocalAiAssetsStatus,
+  openhumanLocalAiDownloadAsset,
+  openhumanLocalAiDownloadsProgress,
   openhumanUpdateVoiceServerSettings,
   openhumanVoiceServerStart,
   openhumanVoiceServerStatus,
@@ -21,12 +24,46 @@ import VoicePanel from '../VoicePanel';
 vi.mock('../../../../utils/tauriCommands', () => ({
   openhumanGetVoiceServerSettings: vi.fn(),
   openhumanLocalAiAssetsStatus: vi.fn(),
+  openhumanLocalAiDownloadAsset: vi.fn(),
+  openhumanLocalAiDownloadsProgress: vi.fn(),
   openhumanUpdateVoiceServerSettings: vi.fn(),
   openhumanVoiceServerStart: vi.fn(),
   openhumanVoiceServerStatus: vi.fn(),
   openhumanVoiceServerStop: vi.fn(),
   openhumanVoiceStatus: vi.fn(),
 }));
+
+const emptyDownloadsProgress = (): CommandResponse<LocalAiDownloadsProgress> => {
+  const blank = {
+    id: '',
+    provider: 'local',
+    state: 'idle',
+    progress: null,
+    downloaded_bytes: null,
+    total_bytes: null,
+    speed_bps: null,
+    eta_seconds: null,
+    warning: null,
+    path: null,
+  };
+  return {
+    result: {
+      state: 'idle',
+      progress: null,
+      downloaded_bytes: null,
+      total_bytes: null,
+      speed_bps: null,
+      eta_seconds: null,
+      warning: null,
+      chat: { ...blank },
+      vision: { ...blank },
+      embedding: { ...blank },
+      stt: { ...blank },
+      tts: { ...blank },
+    },
+    logs: [],
+  };
+};
 
 type RuntimeHarness = {
   settings: VoiceServerSettings;
@@ -97,6 +134,16 @@ describe('VoicePanel', () => {
       } as never,
       logs: [],
     }));
+    vi.mocked(openhumanLocalAiDownloadsProgress).mockImplementation(async () =>
+      emptyDownloadsProgress()
+    );
+    vi.mocked(openhumanLocalAiDownloadAsset).mockImplementation(async () => ({
+      result: {
+        quantization: 'q4',
+        stt: { id: 'ggml-tiny-q5_1.bin', state: 'downloading' },
+      } as never,
+      logs: [],
+    }));
     vi.mocked(openhumanUpdateVoiceServerSettings).mockImplementation(async update => {
       runtime.settings = { ...runtime.settings, ...update };
       return makeConfigSnapshot();
@@ -116,17 +163,86 @@ describe('VoicePanel', () => {
     });
   });
 
-  it('disables the panel when STT assets are not ready', async () => {
+  it('shows an inline Download STT model CTA when the STT asset is missing', async () => {
     runtime.sttState = 'missing';
     runtime.voiceStatus.stt_available = false;
 
     renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
 
     expect(await screen.findByText('Voice Dictation')).toBeInTheDocument();
-    expect(
-      screen.getByText(/Voice dictation is disabled until the local STT model is downloaded/)
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('voice-stt-setup-idle')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download STT model' })).toBeInTheDocument();
+    // Old redirect CTA is gone — the whole point of issue #632.
+    expect(screen.queryByRole('button', { name: 'Open Local AI Model' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Start Voice Server' })).toBeDisabled();
+  });
+
+  it('triggers an in-place STT download and shows progress without redirecting', async () => {
+    runtime.sttState = 'missing';
+    runtime.voiceStatus.stt_available = false;
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    const cta = await screen.findByRole('button', { name: 'Download STT model' });
+    fireEvent.click(cta);
+
+    await waitFor(() => {
+      expect(openhumanLocalAiDownloadAsset).toHaveBeenCalledWith('stt');
+    });
+
+    // Core starts reporting an active download on the next poll.
+    vi.mocked(openhumanLocalAiDownloadsProgress).mockImplementation(async () => {
+      const base = emptyDownloadsProgress();
+      base.result.state = 'downloading';
+      base.result.progress = 0.42;
+      base.result.downloaded_bytes = 42_000_000;
+      base.result.total_bytes = 100_000_000;
+      base.result.stt = {
+        id: 'ggml-tiny-q5_1.bin',
+        provider: 'local',
+        state: 'downloading',
+        progress: 0.42,
+        downloaded_bytes: 42_000_000,
+        total_bytes: 100_000_000,
+        speed_bps: 1_500_000,
+        eta_seconds: 40,
+        warning: null,
+        path: null,
+      };
+      return base;
+    });
+
+    expect(await screen.findByTestId('voice-stt-setup-progress')).toBeInTheDocument();
+  });
+
+  it('surfaces a retry button when the STT download fails and retries on click', async () => {
+    runtime.sttState = 'missing';
+    runtime.voiceStatus.stt_available = false;
+    vi.mocked(openhumanLocalAiDownloadAsset).mockRejectedValueOnce(new Error('network dropped'));
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download STT model' }));
+
+    const errorBlock = await screen.findByTestId('voice-stt-setup-error');
+    expect(errorBlock).toHaveTextContent('network dropped');
+    const retry = screen.getByRole('button', { name: 'Retry download' });
+
+    vi.mocked(openhumanLocalAiDownloadAsset).mockResolvedValueOnce({
+      result: {
+        quantization: 'q4',
+        stt: { id: 'ggml-tiny-q5_1.bin', state: 'downloading' },
+      } as never,
+      logs: [],
+    });
+    fireEvent.click(retry);
+
+    await waitFor(() => {
+      expect(openhumanLocalAiDownloadAsset).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('voice-stt-setup-error')).toBeNull();
+    });
   });
 
   it('starts the voice server with the edited form values', async () => {


### PR DESCRIPTION
## Summary

Replace the "Open Local AI Model" redirect in the Voice Dictation settings panel with an inline, in-place STT model setup: download CTA → live progress → actionable error with retry. Frontend-only, surgical, reuses existing core RPCs (`openhuman.local_ai_download_asset` and `openhuman.local_ai_downloads_progress`).

## Problem

Issue #632: when the local STT model is missing, the Voice Dictation panel shows an amber warning and a single **Open Local AI Model** button. That redirect drops the user out of the Voice Intelligence flow into a much larger debug/admin panel. There is no in-panel progress, no error copy, no recovery path if a download fails, and the user has to manually navigate back to verify Voice is ready.

## Solution

In `app/src/components/settings/panels/VoicePanel.tsx` the disabled-state block is replaced with a new `SttSetupBlock` that renders one of three states from the same data sources the panel already polls (`openhuman.local_ai_assets_status` + `openhuman.local_ai_downloads_progress`):

- **Idle** — "Voice Dictation needs the local STT model" card with a primary **Download STT model** button and a soft **Advanced (Local AI)** fallback link.
- **Progress** — live card showing percent, downloaded / total MB, speed, ETA, and a pulse while core is in the `installing` phase.
- **Error** — red card surfacing the error (either the thrown RPC error or `stt.warning` / `stt.state` from core) with a **Retry download** button that calls the same trigger RPC again — downloads resume because the core already supports resume.

Panel readiness still derives from the same source of truth (`assets.stt.state === "ready" && voiceStatus.stt_available`), so as soon as core finishes the download the voice form enables itself on the next 2s poll. No manual refresh, no redirect.

Three new Vitest cases added alongside the existing three:

- Idle CTA is shown and old "Open Local AI Model" redirect is gone.
- Clicking "Download STT model" calls `openhumanLocalAiDownloadAsset('stt')` and transitions to the progress card when core starts reporting an active download.
- When the trigger RPC rejects, the error card appears with a Retry button; clicking Retry fires the RPC again and clears the error state.

## Out of scope (intentionally deferred)

- **LocalAIStep (onboarding) / Home bootstrap / LocalModelPanel UX** — same class of fix, tracked separately. This PR only touches Voice Dictation settings.
- **Rust / core changes** — no new RPCs, no change to download resume semantics, no new schemas. If a follow-up wants cancel/pause it should add those to core first.
- **Cancel / pause controls** — not in scope for the first slice.
- **TTS model setup** — Voice Dictation only depends on STT today; TTS download still flows through the existing advanced panel.
- **Onboarding copy / trust messaging** — PR #759 owns that surface; no overlap with the files touched here.
- **E2E spec** — this slice is fully covered by the existing Vitest harness; an E2E is only worth adding once more Voice flows land on top.

## Submission Checklist

- [x] `yarn compile` (tsc --noEmit) clean
- [x] `yarn lint` clean
- [x] `yarn test:unit` — 466 passed, 2 skipped (5 in `VoicePanel.test.tsx`, all green)
- [x] Prettier clean on changed files
- [x] No Rust changes, no new dependencies, no CI changes
- [x] No overlap with PR #759 file list (different panel, different test file)
- [x] Debug logs namespaced `[voice-intel]` / `[VoicePanel:stt]`, no secrets/PII
- [ ] Manual smoke on a built `.app` bundle with a missing STT model — not performed in this subagent run; please verify before merging.

Addresses #632

cc @Al629176 — auto-drafted by a subagent, please review carefully.