### PR TITLE
feat(composio): inject connected identities into agent prompts

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -102,6 +102,14 @@ Quick reference for anyone starting with Claude on this project. Updated by the 
 - **UnifiedSkillCard** — All skill types (built-in, channels, 3rd party) use `UnifiedSkillCard` from `app/src/components/skills/SkillCard.tsx`. Secondary actions use an overflow menu. `data-testid` attributes (`skill-sync-button-*`, `skill-debug-button-*`) must be preserved.
 - **SkillSearchBar + SkillCategoryFilter** — New components in `app/src/components/skills/` for search and category filtering on the Skills page.
 
+## Composio Identity (Issue #691)
+
+- **`ProviderUserProfile.profile_url`** — New optional field on the struct in `src/openhuman/composio/providers/types.rs`. Providers should populate it when available from upstream profile payloads.
+- **`identity_set` callback in default flow** — `ComposioProvider::on_connection_created()` in `src/openhuman/composio/providers/traits.rs` now calls `identity_set(&profile)` after profile fetch. `composio_get_user_profile` in `src/openhuman/composio/ops.rs` also routes persistence through `identity_set`.
+- **Facet key format for connected identities** — `skill:{toolkit}:{identifier}:{field}` (e.g. `skill:gmail:user@example.com:profile_url`). Use `FacetType::Skill` when storing. Toolkit and identifier together form the unique identity; field is the attribute name.
+- **Connected identities loader/renderer** — `src/openhuman/composio/providers/profile.rs` contains `load_connected_identities()` (reads `skill:*` facets) and `render_connected_identities_section()` (formats markdown for prompt injection). Keep rendering logic there, not in prompt modules.
+- **Prompt injection helper** — `render_connected_identities` is imported and called in `welcome/prompt.rs`, `orchestrator/prompt.rs`, and `integrations_agent/prompt.rs` to inject a "Connected accounts:" block. Add it to any new agent prompt that needs Composio context.
+
 ## Agent Timeout & Cancellation (Issue #715)
 
 - **Frontend silence timer, not a wall-clock limit** — `armSilenceTimer` in `app/src/pages/Conversations.tsx` fires if 120s (fixed to 600s) pass with zero inference progress events. It re-arms on every `tool_call`, `tool_result`, `iteration_start`, etc., so long-running tool chains that keep emitting events are not cut off.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,7 +4420,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.52.27"
+version = "0.52.28"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -293,6 +293,11 @@ if resolve_from_latest_json; then
 else
   log_warn "latest.json lookup failed. Falling back to releases API."
   if ! resolve_from_release_api; then
+    if [ "${DRY_RUN}" = true ]; then
+      log_warn "No compatible release asset found for ${OS}/${ARCH} (dry-run mode, skipping download)."
+      echo "DRY RUN: no compatible artifact available yet for ${OS}/${ARCH}"
+      exit 0
+    fi
     log_err "Could not resolve a compatible asset for ${OS}/${ARCH}."
     exit 1
   fi

--- a/src/core/event_bus/events.rs
+++ b/src/core/event_bus/events.rs
@@ -225,6 +225,11 @@ pub enum DomainEvent {
         connection_id: String,
         connect_url: String,
     },
+    /// A Composio connection was removed.
+    ComposioConnectionDeleted {
+        toolkit: String,
+        connection_id: String,
+    },
     /// A Composio action was executed (success or failure) via the backend.
     ComposioActionExecuted {
         tool: String,
@@ -355,6 +360,7 @@ impl DomainEvent {
 
             Self::ComposioTriggerReceived { .. }
             | Self::ComposioConnectionCreated { .. }
+            | Self::ComposioConnectionDeleted { .. }
             | Self::ComposioActionExecuted { .. } => "composio",
 
             Self::TriggerEvaluated { .. }

--- a/src/openhuman/agent/agents/archivist/prompt.rs
+++ b/src/openhuman/agent/agents/archivist/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/code_executor/prompt.rs
+++ b/src/openhuman/agent/agents/code_executor/prompt.rs
@@ -62,6 +62,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/critic/prompt.rs
+++ b/src/openhuman/agent/agents/critic/prompt.rs
@@ -57,6 +57,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -15,8 +15,8 @@
 //! isn't a branch on `agent_id` somewhere else.
 
 use crate::openhuman::context::prompt::{
-    render_safety, render_tools, render_user_files, render_workspace, ConnectedIntegration,
-    PromptContext,
+    render_connected_identities, render_safety, render_tools, render_user_files, render_workspace,
+    ConnectedIntegration, PromptContext,
 };
 use crate::openhuman::skills::Skill;
 use anyhow::Result;
@@ -33,6 +33,12 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
     let user_files = render_user_files(ctx)?;
     if !user_files.trim().is_empty() {
         out.push_str(user_files.trim_end());
+        out.push_str("\n\n");
+    }
+
+    let identities = render_connected_identities();
+    if !identities.trim().is_empty() {
+        out.push_str(identities.trim_end());
         out.push_str("\n\n");
     }
 

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -15,8 +15,8 @@
 //! isn't a branch on `agent_id` somewhere else.
 
 use crate::openhuman::context::prompt::{
-    render_connected_identities, render_safety, render_tools, render_user_files, render_workspace,
-    ConnectedIntegration, PromptContext,
+    render_safety, render_tools, render_user_files, render_workspace, ConnectedIntegration,
+    PromptContext,
 };
 use crate::openhuman::skills::Skill;
 use anyhow::Result;
@@ -36,7 +36,7 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
         out.push_str("\n\n");
     }
 
-    let identities = render_connected_identities();
+    let identities = ctx.connected_identities_md.as_str();
     if !identities.trim().is_empty() {
         out.push_str(identities.trim_end());
         out.push_str("\n\n");
@@ -165,6 +165,7 @@ mod tests {
             visible_tool_names: EMPTY_VISIBLE.get_or_init(HashSet::new),
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: integrations,
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         }

--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -258,6 +258,7 @@ mod tests {
                         visible_tool_names: &empty_visible,
                         tool_call_format: ToolCallFormat::PFormat,
                         connected_integrations: &empty_integrations,
+                        connected_identities_md: String::new(),
                         include_profile: false,
                         include_memory_md: false,
                     };

--- a/src/openhuman/agent/agents/morning_briefing/prompt.rs
+++ b/src/openhuman/agent/agents/morning_briefing/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -9,7 +9,8 @@
 //! `agent_id` in a shared section impl.
 
 use crate::openhuman::context::prompt::{
-    render_tools, render_user_files, render_workspace, ConnectedIntegration, PromptContext,
+    render_connected_identities, render_tools, render_user_files, render_workspace,
+    ConnectedIntegration, PromptContext,
 };
 use anyhow::Result;
 use std::fmt::Write;
@@ -24,6 +25,12 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
     let user_files = render_user_files(ctx)?;
     if !user_files.trim().is_empty() {
         out.push_str(user_files.trim_end());
+        out.push_str("\n\n");
+    }
+
+    let identities = render_connected_identities();
+    if !identities.trim().is_empty() {
+        out.push_str(identities.trim_end());
         out.push_str("\n\n");
     }
 

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -9,8 +9,7 @@
 //! `agent_id` in a shared section impl.
 
 use crate::openhuman::context::prompt::{
-    render_connected_identities, render_tools, render_user_files, render_workspace,
-    ConnectedIntegration, PromptContext,
+    render_tools, render_user_files, render_workspace, ConnectedIntegration, PromptContext,
 };
 use anyhow::Result;
 use std::fmt::Write;
@@ -28,7 +27,7 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
         out.push_str("\n\n");
     }
 
-    let identities = render_connected_identities();
+    let identities = ctx.connected_identities_md.as_str();
     if !identities.trim().is_empty() {
         out.push_str(identities.trim_end());
         out.push_str("\n\n");
@@ -108,6 +107,7 @@ mod tests {
             visible_tool_names: EMPTY_VISIBLE.get_or_init(HashSet::new),
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: integrations,
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         }

--- a/src/openhuman/agent/agents/planner/prompt.rs
+++ b/src/openhuman/agent/agents/planner/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/researcher/prompt.rs
+++ b/src/openhuman/agent/agents/researcher/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/summarizer/prompt.rs
+++ b/src/openhuman/agent/agents/summarizer/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/tool_maker/prompt.rs
+++ b/src/openhuman/agent/agents/tool_maker/prompt.rs
@@ -62,6 +62,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/tools_agent/prompt.rs
+++ b/src/openhuman/agent/agents/tools_agent/prompt.rs
@@ -59,6 +59,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/trigger_reactor/prompt.rs
+++ b/src/openhuman/agent/agents/trigger_reactor/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/trigger_triage/prompt.rs
+++ b/src/openhuman/agent/agents/trigger_triage/prompt.rs
@@ -58,6 +58,7 @@ mod tests {
             visible_tool_names: &visible,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/agents/welcome/prompt.rs
+++ b/src/openhuman/agent/agents/welcome/prompt.rs
@@ -8,7 +8,8 @@
 //! skill-executor wording stays scoped to `integrations_agent/prompt.rs`).
 
 use crate::openhuman::context::prompt::{
-    render_tools, render_user_files, render_workspace, ConnectedIntegration, PromptContext,
+    render_connected_identities, render_tools, render_user_files, render_workspace,
+    ConnectedIntegration, PromptContext,
 };
 use anyhow::Result;
 use std::fmt::Write;
@@ -23,6 +24,12 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
     let user_files = render_user_files(ctx)?;
     if !user_files.trim().is_empty() {
         out.push_str(user_files.trim_end());
+        out.push_str("\n\n");
+    }
+
+    let identities = render_connected_identities();
+    if !identities.trim().is_empty() {
+        out.push_str(identities.trim_end());
         out.push_str("\n\n");
     }
 

--- a/src/openhuman/agent/agents/welcome/prompt.rs
+++ b/src/openhuman/agent/agents/welcome/prompt.rs
@@ -8,8 +8,7 @@
 //! skill-executor wording stays scoped to `integrations_agent/prompt.rs`).
 
 use crate::openhuman::context::prompt::{
-    render_connected_identities, render_tools, render_user_files, render_workspace,
-    ConnectedIntegration, PromptContext,
+    render_tools, render_user_files, render_workspace, ConnectedIntegration, PromptContext,
 };
 use anyhow::Result;
 use std::fmt::Write;
@@ -27,7 +26,7 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
         out.push_str("\n\n");
     }
 
-    let identities = render_connected_identities();
+    let identities = ctx.connected_identities_md.as_str();
     if !identities.trim().is_empty() {
         out.push_str(identities.trim_end());
         out.push_str("\n\n");
@@ -121,6 +120,7 @@ mod tests {
             visible_tool_names: EMPTY_VISIBLE.get_or_init(HashSet::new),
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: integrations,
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         }

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -1147,8 +1147,8 @@ impl Agent {
             visible_tool_names: &self.visible_tool_names,
             tool_call_format: self.tool_dispatcher.tool_call_format(),
             connected_integrations: &self.connected_integrations,
-            connected_identities_md:
-                crate::openhuman::agent::prompts::render_connected_identities(),
+            connected_identities_md: crate::openhuman::agent::prompts::render_connected_identities(
+            ),
             include_profile: !self.omit_profile,
             include_memory_md: !self.omit_memory_md,
         };

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -1147,6 +1147,8 @@ impl Agent {
             visible_tool_names: &self.visible_tool_names,
             tool_call_format: self.tool_dispatcher.tool_call_format(),
             connected_integrations: &self.connected_integrations,
+            connected_identities_md:
+                crate::openhuman::agent::prompts::render_connected_identities(),
             include_profile: !self.omit_profile,
             include_memory_md: !self.omit_memory_md,
         };

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -527,6 +527,7 @@ async fn run_typed_mode(
         visible_tool_names: &visible_tool_names,
         tool_call_format: parent.tool_call_format,
         connected_integrations: &narrowed_integrations,
+        connected_identities_md: crate::openhuman::agent::prompts::render_connected_identities(),
         include_profile: !definition.omit_profile,
         include_memory_md: !definition.omit_memory_md,
     };

--- a/src/openhuman/agent/prompts/connected_identities.rs
+++ b/src/openhuman/agent/prompts/connected_identities.rs
@@ -1,0 +1,12 @@
+//! Connected identity prompt helper.
+//!
+//! Kept in a dedicated sibling module so `mod.rs` remains mostly
+//! export-focused while the runtime fetch logic lives in a small,
+//! testable unit.
+
+/// Render persisted provider identities (if available) as a compact
+/// `## Connected Identities` section.
+pub fn render_connected_identities() -> String {
+    let identities = crate::openhuman::composio::providers::profile::load_connected_identities();
+    crate::openhuman::composio::providers::profile::render_connected_identities_section(&identities)
+}

--- a/src/openhuman/agent/prompts/mod.rs
+++ b/src/openhuman/agent/prompts/mod.rs
@@ -514,6 +514,13 @@ pub fn render_user_files(ctx: &PromptContext<'_>) -> Result<String> {
     UserFilesSection.build(ctx)
 }
 
+/// Render persisted provider identities (if available) as a compact
+/// `## Connected Identities` section.
+pub fn render_connected_identities() -> String {
+    let identities = crate::openhuman::composio::providers::profile::load_connected_identities();
+    crate::openhuman::composio::providers::profile::render_connected_identities_section(&identities)
+}
+
 /// Render the tree-summariser user-memory block.
 pub fn render_user_memory(ctx: &PromptContext<'_>) -> Result<String> {
     UserMemorySection.build(ctx)

--- a/src/openhuman/agent/prompts/mod.rs
+++ b/src/openhuman/agent/prompts/mod.rs
@@ -1,5 +1,7 @@
 pub mod types;
 pub use types::*;
+mod connected_identities;
+pub use connected_identities::render_connected_identities;
 
 use crate::openhuman::skills::Skill;
 use crate::openhuman::tools::Tool;
@@ -514,13 +516,6 @@ pub fn render_user_files(ctx: &PromptContext<'_>) -> Result<String> {
     UserFilesSection.build(ctx)
 }
 
-/// Render persisted provider identities (if available) as a compact
-/// `## Connected Identities` section.
-pub fn render_connected_identities() -> String {
-    let identities = crate::openhuman::composio::providers::profile::load_connected_identities();
-    crate::openhuman::composio::providers::profile::render_connected_identities_section(&identities)
-}
-
 /// Render the tree-summariser user-memory block.
 pub fn render_user_memory(ctx: &PromptContext<'_>) -> Result<String> {
     UserMemorySection.build(ctx)
@@ -588,6 +583,7 @@ fn empty_prompt_context_for_static_sections() -> PromptContext<'static> {
         visible_tool_names: visible,
         tool_call_format: ToolCallFormat::PFormat,
         connected_integrations: EMPTY_INTEGRATIONS,
+        connected_identities_md: String::new(),
         include_profile: false,
         include_memory_md: false,
     }
@@ -1064,6 +1060,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -1092,6 +1089,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -1129,6 +1127,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -1186,6 +1185,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -1229,6 +1229,7 @@ mod tests {
                 visible_tool_names: &NO_FILTER,
                 tool_call_format: format,
                 connected_integrations: &[],
+                connected_identities_md: String::new(),
                 include_profile: false,
                 include_memory_md: false,
             };
@@ -1268,6 +1269,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -1295,6 +1297,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -1941,6 +1944,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: true,
             include_memory_md: true,
         };
@@ -1981,6 +1985,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };
@@ -2058,6 +2063,7 @@ mod tests {
             visible_tool_names: &NO_FILTER,
             tool_call_format: ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         };

--- a/src/openhuman/agent/prompts/types.rs
+++ b/src/openhuman/agent/prompts/types.rs
@@ -173,6 +173,10 @@ pub struct PromptContext<'a> {
     pub tool_call_format: ToolCallFormat,
     /// Active Composio integrations the user has connected.
     pub connected_integrations: &'a [ConnectedIntegration],
+    /// Pre-rendered `## Connected Identities` markdown block loaded once
+    /// by the caller so prompt builders remain deterministic and avoid
+    /// hidden global reads during `build(ctx)`.
+    pub connected_identities_md: String,
     /// When `true`, inject `PROFILE.md` (onboarding enrichment output).
     pub include_profile: bool,
     /// When `true`, inject `MEMORY.md` (archivist-curated long-term

--- a/src/openhuman/agent/triage/evaluator.rs
+++ b/src/openhuman/agent/triage/evaluator.rs
@@ -340,6 +340,7 @@ fn extract_inline_prompt(def: &AgentDefinition) -> Option<String> {
                 visible_tool_names: &empty_visible,
                 tool_call_format: ToolCallFormat::PFormat,
                 connected_integrations: &empty_integrations,
+                connected_identities_md: String::new(),
                 include_profile: false,
                 include_memory_md: false,
             };

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -365,11 +365,11 @@ pub async fn composio_get_user_profile(
 
     // Side-effect: persist profile fields into the local user_profile
     // facet table so any RPC call also refreshes the local store.
-    let facets = super::providers::profile::persist_provider_profile(&profile);
+    let facets = provider.identity_set(&profile);
     tracing::debug!(
         toolkit = %toolkit,
         facets_written = facets,
-        "[composio] profile facets persisted from get_user_profile"
+        "[composio] identity_set persisted profile facets from get_user_profile"
     );
 
     Ok(RpcOutcome::new(

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -122,10 +122,27 @@ pub async fn composio_delete_connection(
 ) -> OpResult<RpcOutcome<ComposioDeleteResponse>> {
     tracing::debug!(connection_id = %connection_id, "[composio] rpc delete_connection");
     let client = resolve_client(config)?;
+    let toolkit = resolve_toolkit_for_connection(&client, connection_id).await.ok();
     let resp = client
         .delete_connection(connection_id)
         .await
         .map_err(|e| format!("[composio] delete_connection failed: {e:#}"))?;
+    if let Some(toolkit) = toolkit.as_deref() {
+        let deleted =
+            super::providers::profile::delete_connected_identity_facets(toolkit, connection_id);
+        tracing::debug!(
+            toolkit = %toolkit,
+            connection_id = %connection_id,
+            facets_deleted = deleted,
+            "[composio] deleted connected identity facets after connection removal"
+        );
+    }
+    crate::core::event_bus::publish_global(
+        crate::core::event_bus::DomainEvent::ComposioConnectionDeleted {
+            toolkit: toolkit.unwrap_or_else(|| "unknown".to_string()),
+            connection_id: connection_id.to_string(),
+        },
+    );
     // Bust the integrations cache so the next prompt reflects the removal.
     invalidate_connected_integrations_cache();
     Ok(RpcOutcome::new(

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -122,7 +122,9 @@ pub async fn composio_delete_connection(
 ) -> OpResult<RpcOutcome<ComposioDeleteResponse>> {
     tracing::debug!(connection_id = %connection_id, "[composio] rpc delete_connection");
     let client = resolve_client(config)?;
-    let toolkit = resolve_toolkit_for_connection(&client, connection_id).await.ok();
+    let toolkit = resolve_toolkit_for_connection(&client, connection_id)
+        .await
+        .ok();
     let resp = client
         .delete_connection(connection_id)
         .await

--- a/src/openhuman/composio/providers/gmail/provider.rs
+++ b/src/openhuman/composio/providers/gmail/provider.rs
@@ -142,6 +142,16 @@ impl ComposioProvider for GmailProvider {
             ],
         )
         .or_else(|| email.clone());
+        let profile_url = pick_str(
+            data,
+            &[
+                "data.profileUrl",
+                "data.profile_url",
+                "data.profile.url",
+                "profileUrl",
+                "profile_url",
+            ],
+        );
 
         let profile = ProviderUserProfile {
             toolkit: "gmail".to_string(),
@@ -150,6 +160,7 @@ impl ComposioProvider for GmailProvider {
             email,
             username: None,
             avatar_url: None,
+            profile_url,
             extras: data.clone(),
         };
         let has_email = profile.email.is_some();

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -275,6 +275,7 @@ mod tests {
         assert!(p.email.is_none());
         assert!(p.username.is_none());
         assert!(p.avatar_url.is_none());
+        assert!(p.profile_url.is_none());
         assert!(p.extras.is_null());
     }
 }

--- a/src/openhuman/composio/providers/notion/provider.rs
+++ b/src/openhuman/composio/providers/notion/provider.rs
@@ -128,6 +128,16 @@ impl ComposioProvider for NotionProvider {
             data,
             &["data.avatar_url", "data.user.avatar_url", "avatar_url"],
         );
+        let profile_url = pick_str(
+            data,
+            &[
+                "data.url",
+                "data.profile_url",
+                "data.profile.url",
+                "url",
+                "profile_url",
+            ],
+        );
 
         Ok(ProviderUserProfile {
             toolkit: "notion".to_string(),
@@ -136,6 +146,7 @@ impl ComposioProvider for NotionProvider {
             email,
             username,
             avatar_url,
+            profile_url,
             extras: data.clone(),
         })
     }

--- a/src/openhuman/composio/providers/profile.rs
+++ b/src/openhuman/composio/providers/profile.rs
@@ -4,7 +4,7 @@
 //! alongside conversation-extracted preferences.
 //!
 //! Each non-`None` field becomes a [`FacetType::Context`] facet keyed
-//! as `composio:{toolkit}:{field}`. Confidence is set to 0.95 because
+//! as `skill:{toolkit}:{identifier}:{field}`. Confidence is set to 0.95 because
 //! this data comes directly from the upstream provider API — it's
 //! authoritative, not inferred from conversation.
 //!
@@ -15,6 +15,7 @@
 
 use super::ProviderUserProfile;
 use crate::openhuman::memory::store::profile::{self, FacetType};
+use std::collections::BTreeMap;
 
 /// Confidence level assigned to provider-sourced profile data.
 ///
@@ -39,13 +40,20 @@ pub fn persist_provider_profile(profile: &ProviderUserProfile) -> usize {
     let conn = client.profile_conn();
 
     let now = now_secs();
-    let toolkit = &profile.toolkit;
+    let toolkit = normalize_token(&profile.toolkit);
+    let identifier = profile
+        .connection_id
+        .as_deref()
+        .map(normalize_token)
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "default".to_string());
 
     let fields: &[(&str, &Option<String>)] = &[
         ("display_name", &profile.display_name),
         ("email", &profile.email),
         ("username", &profile.username),
         ("avatar_url", &profile.avatar_url),
+        ("profile_url", &profile.profile_url),
     ];
 
     let mut written = 0usize;
@@ -55,13 +63,13 @@ pub fn persist_provider_profile(profile: &ProviderUserProfile) -> usize {
             continue;
         }
 
-        let key = format!("composio:{toolkit}:{field_name}");
-        let facet_id = format!("composio-{toolkit}-{field_name}");
+        let key = format!("skill:{toolkit}:{identifier}:{field_name}");
+        let facet_id = format!("skill-{toolkit}-{identifier}-{field_name}");
 
         if let Err(e) = profile::profile_upsert(
             &conn,
             &facet_id,
-            &FacetType::Context,
+            &FacetType::Skill,
             &key,
             val,
             PROVIDER_CONFIDENCE,
@@ -70,6 +78,7 @@ pub fn persist_provider_profile(profile: &ProviderUserProfile) -> usize {
         ) {
             tracing::warn!(
                 toolkit = %toolkit,
+                identifier = %identifier,
                 field = %field_name,
                 error = %e,
                 "[composio:profile] profile_upsert failed (non-fatal)"
@@ -82,11 +91,132 @@ pub fn persist_provider_profile(profile: &ProviderUserProfile) -> usize {
     if written > 0 {
         tracing::debug!(
             toolkit = %toolkit,
+            identifier = %identifier,
             facets_written = written,
             "[composio:profile] persisted provider profile facets"
         );
     }
     written
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectedIdentity {
+    pub source: String,
+    pub identifier: String,
+    pub display_name: Option<String>,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    pub profile_url: Option<String>,
+}
+
+/// Load provider-sourced identity fragments from profile facets and
+/// group them by `source + identifier`.
+pub fn load_connected_identities() -> Vec<ConnectedIdentity> {
+    let Some(client) = crate::openhuman::memory::global::client_if_ready() else {
+        return Vec::new();
+    };
+    let conn = client.profile_conn();
+    let Ok(facets) = profile::profile_facets_by_type(&conn, &FacetType::Skill) else {
+        return Vec::new();
+    };
+
+    let mut grouped: BTreeMap<(String, String), ConnectedIdentity> = BTreeMap::new();
+    for facet in facets {
+        let Some((source, identifier, field)) = parse_skill_identity_key(&facet.key) else {
+            continue;
+        };
+        let entry = grouped
+            .entry((source.clone(), identifier.clone()))
+            .or_insert_with(|| ConnectedIdentity {
+                source,
+                identifier,
+                display_name: None,
+                email: None,
+                username: None,
+                profile_url: None,
+            });
+        match field.as_str() {
+            "display_name" => entry.display_name = Some(facet.value.clone()),
+            "email" => entry.email = Some(facet.value.clone()),
+            "username" => entry.username = Some(facet.value.clone()),
+            "profile_url" => entry.profile_url = Some(facet.value.clone()),
+            _ => {}
+        }
+    }
+    grouped.into_values().collect()
+}
+
+/// Render a compact markdown section for prompt injection.
+pub fn render_connected_identities_section(identities: &[ConnectedIdentity]) -> String {
+    if identities.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("## Connected Identities\n\n");
+    for identity in identities {
+        let mut fields = Vec::new();
+        if let Some(display_name) = identity.display_name.as_deref() {
+            fields.push(display_name.to_string());
+        }
+        if let Some(email) = identity.email.as_deref() {
+            fields.push(email.to_string());
+        }
+        if let Some(username) = identity.username.as_deref() {
+            fields.push(format!("@{username}"));
+        }
+        if let Some(profile_url) = identity.profile_url.as_deref() {
+            fields.push(profile_url.to_string());
+        }
+        if fields.is_empty() {
+            continue;
+        }
+        out.push_str(&format!(
+            "- {} ({}): {}\n",
+            title_case(&identity.source),
+            identity.identifier,
+            fields.join(" | ")
+        ));
+    }
+    if out.trim() == "## Connected Identities" {
+        return String::new();
+    }
+    out
+}
+
+fn parse_skill_identity_key(key: &str) -> Option<(String, String, String)> {
+    let mut parts = key.split(':');
+    let prefix = parts.next()?;
+    let source = parts.next()?;
+    let identifier = parts.next()?;
+    let field = parts.next()?;
+    if prefix != "skill" || parts.next().is_some() {
+        return None;
+    }
+    Some((
+        source.to_string(),
+        identifier.to_string(),
+        field.to_string(),
+    ))
+}
+
+fn normalize_token(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() || lower == '-' || lower == '_' {
+            out.push(lower);
+        } else {
+            out.push('_');
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+fn title_case(raw: &str) -> String {
+    let mut chars = raw.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
 }
 
 fn now_secs() -> f64 {
@@ -121,9 +251,9 @@ mod tests {
         // Simulate what persist_provider_profile does internally.
         profile::profile_upsert(
             &conn,
-            "composio-gmail-email",
-            &FacetType::Context,
-            "composio:gmail:email",
+            "skill-gmail-conn-1-email",
+            &FacetType::Skill,
+            "skill:gmail:conn-1:email",
             "user@example.com",
             PROVIDER_CONFIDENCE,
             None,
@@ -133,9 +263,9 @@ mod tests {
 
         profile::profile_upsert(
             &conn,
-            "composio-gmail-display_name",
-            &FacetType::Context,
-            "composio:gmail:display_name",
+            "skill-gmail-conn-1-display_name",
+            &FacetType::Skill,
+            "skill:gmail:conn-1:display_name",
             "Jane Doe",
             PROVIDER_CONFIDENCE,
             None,
@@ -146,7 +276,7 @@ mod tests {
         let facets = profile_load_all(&conn).unwrap();
         assert_eq!(facets.len(), 2);
 
-        let email_facet = facets.iter().find(|f| f.key == "composio:gmail:email");
+        let email_facet = facets.iter().find(|f| f.key == "skill:gmail:conn-1:email");
         assert!(email_facet.is_some());
         let email_facet = email_facet.unwrap();
         assert_eq!(email_facet.value, "user@example.com");
@@ -161,9 +291,9 @@ mod tests {
         // First write.
         profile::profile_upsert(
             &conn,
-            "composio-notion-email",
-            &FacetType::Context,
-            "composio:notion:email",
+            "skill-notion-default-email",
+            &FacetType::Skill,
+            "skill:notion:default:email",
             "user@workspace.com",
             PROVIDER_CONFIDENCE,
             None,
@@ -174,9 +304,9 @@ mod tests {
         // Second write — same key, same value (periodic re-sync).
         profile::profile_upsert(
             &conn,
-            "composio-notion-email-2",
-            &FacetType::Context,
-            "composio:notion:email",
+            "skill-notion-default-email-2",
+            &FacetType::Skill,
+            "skill:notion:default:email",
             "user@workspace.com",
             PROVIDER_CONFIDENCE,
             None,
@@ -210,6 +340,7 @@ mod tests {
             email: Some("jane@example.com".into()),
             username: None,
             avatar_url: None,
+            profile_url: None,
             extras: serde_json::Value::Null,
         };
         let _written = persist_provider_profile(&profile);
@@ -224,6 +355,7 @@ mod tests {
             email: None,
             username: Some("".into()), // empty string — should be skipped
             avatar_url: Some("  ".into()), // whitespace — should be skipped
+            profile_url: Some("https://mail.google.com".into()),
             extras: serde_json::Value::Null,
         };
 
@@ -235,11 +367,43 @@ mod tests {
             ("email", &profile.email),
             ("username", &profile.username),
             ("avatar_url", &profile.avatar_url),
+            ("profile_url", &profile.profile_url),
         ];
         let non_empty_count = fields
             .iter()
             .filter(|(_, v)| v.as_deref().is_some_and(|s| !s.trim().is_empty()))
             .count();
-        assert_eq!(non_empty_count, 1, "only display_name should pass");
+        assert_eq!(
+            non_empty_count, 2,
+            "display_name and profile_url should pass"
+        );
+    }
+
+    #[test]
+    fn parse_skill_identity_key_accepts_valid_key() {
+        let parsed = parse_skill_identity_key("skill:gmail:conn_1:email");
+        assert_eq!(
+            parsed,
+            Some((
+                "gmail".to_string(),
+                "conn_1".to_string(),
+                "email".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn render_connected_identities_section_formats_lines() {
+        let rendered = render_connected_identities_section(&[ConnectedIdentity {
+            source: "gmail".into(),
+            identifier: "default".into(),
+            display_name: Some("Jane Doe".into()),
+            email: Some("jane@example.com".into()),
+            username: None,
+            profile_url: Some("https://mail.google.com".into()),
+        }]);
+        assert!(rendered.contains("## Connected Identities"));
+        assert!(rendered
+            .contains("- Gmail (default): Jane Doe | jane@example.com | https://mail.google.com"));
     }
 }

--- a/src/openhuman/composio/providers/profile.rs
+++ b/src/openhuman/composio/providers/profile.rs
@@ -15,6 +15,7 @@
 
 use super::ProviderUserProfile;
 use crate::openhuman::memory::store::profile::{self, FacetType};
+use rusqlite::params;
 use std::collections::BTreeMap;
 
 /// Confidence level assigned to provider-sourced profile data.
@@ -113,11 +114,22 @@ pub struct ConnectedIdentity {
 /// group them by `source + identifier`.
 pub fn load_connected_identities() -> Vec<ConnectedIdentity> {
     let Some(client) = crate::openhuman::memory::global::client_if_ready() else {
+        tracing::debug!(
+            "[composio:profile] load_connected_identities: memory client not ready"
+        );
         return Vec::new();
     };
     let conn = client.profile_conn();
-    let Ok(facets) = profile::profile_facets_by_type(&conn, &FacetType::Skill) else {
-        return Vec::new();
+    let facets = match profile::profile_facets_by_type(&conn, &FacetType::Skill) {
+        Ok(facets) => facets,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                facet_type = ?FacetType::Skill,
+                "[composio:profile] load_connected_identities: profile_facets_by_type failed"
+            );
+            return Vec::new();
+        }
     };
 
     let mut grouped: BTreeMap<(String, String), ConnectedIdentity> = BTreeMap::new();
@@ -155,24 +167,37 @@ pub fn render_connected_identities_section(identities: &[ConnectedIdentity]) -> 
     for identity in identities {
         let mut fields = Vec::new();
         if let Some(display_name) = identity.display_name.as_deref() {
-            fields.push(display_name.to_string());
+            let cleaned = sanitize_prompt_value(display_name);
+            if !cleaned.is_empty() {
+                fields.push(cleaned);
+            }
         }
         if let Some(email) = identity.email.as_deref() {
-            fields.push(email.to_string());
+            let cleaned = sanitize_prompt_value(email);
+            if !cleaned.is_empty() {
+                fields.push(cleaned);
+            }
         }
         if let Some(username) = identity.username.as_deref() {
-            fields.push(format!("@{username}"));
+            let cleaned = sanitize_prompt_value(username);
+            if !cleaned.is_empty() {
+                fields.push(format!("@{cleaned}"));
+            }
         }
         if let Some(profile_url) = identity.profile_url.as_deref() {
-            fields.push(profile_url.to_string());
+            let cleaned = sanitize_prompt_value(profile_url);
+            if !cleaned.is_empty() {
+                fields.push(cleaned);
+            }
         }
         if fields.is_empty() {
             continue;
         }
+        let identifier = sanitize_prompt_value(&identity.identifier);
         out.push_str(&format!(
             "- {} ({}): {}\n",
             title_case(&identity.source),
-            identity.identifier,
+            identifier,
             fields.join(" | ")
         ));
     }
@@ -217,6 +242,48 @@ fn title_case(raw: &str) -> String {
         Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
         None => String::new(),
     }
+}
+
+fn sanitize_prompt_value(raw: &str) -> String {
+    let replaced = raw.replace(['\n', '\r', '\t'], " ").replace('|', "/");
+    replaced.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Delete provider-sourced skill facets for one connection identifier.
+pub fn delete_connected_identity_facets(source: &str, identifier: &str) -> usize {
+    let Some(client) = crate::openhuman::memory::global::client_if_ready() else {
+        tracing::debug!(
+            source = %source,
+            identifier = %identifier,
+            "[composio:profile] delete_connected_identity_facets: memory client not ready"
+        );
+        return 0;
+    };
+    let conn = client.profile_conn();
+    let Ok(facets) = profile::profile_facets_by_type(&conn, &FacetType::Skill) else {
+        return 0;
+    };
+    let mut deleted = 0usize;
+    for facet in facets {
+        let Some((facet_source, facet_identifier, _field)) = parse_skill_identity_key(&facet.key)
+        else {
+            continue;
+        };
+        if facet_source == source && facet_identifier == identifier {
+            let conn_guard = conn.lock();
+            if conn_guard
+                .execute(
+                    "DELETE FROM user_profile WHERE facet_id = ?1",
+                    params![facet.facet_id],
+                )
+                .unwrap_or(0)
+                > 0
+            {
+                deleted += 1;
+            }
+        }
+    }
+    deleted
 }
 
 fn now_secs() -> f64 {

--- a/src/openhuman/composio/providers/profile.rs
+++ b/src/openhuman/composio/providers/profile.rs
@@ -114,9 +114,7 @@ pub struct ConnectedIdentity {
 /// group them by `source + identifier`.
 pub fn load_connected_identities() -> Vec<ConnectedIdentity> {
     let Some(client) = crate::openhuman::memory::global::client_if_ready() else {
-        tracing::debug!(
-            "[composio:profile] load_connected_identities: memory client not ready"
-        );
+        tracing::debug!("[composio:profile] load_connected_identities: memory client not ready");
         return Vec::new();
     };
     let conn = client.profile_conn();

--- a/src/openhuman/composio/providers/traits.rs
+++ b/src/openhuman/composio/providers/traits.rs
@@ -52,6 +52,16 @@ pub trait ComposioProvider: Send + Sync {
     /// the memory layer via [`ProviderContext::memory_client`]).
     async fn sync(&self, ctx: &ProviderContext, reason: SyncReason) -> Result<SyncOutcome, String>;
 
+    /// Standardized identity callback for provider implementations.
+    ///
+    /// Providers can override this to customize how identity fragments
+    /// are persisted. Default behavior stores a normalized identity
+    /// fragment in profile facets via `skill:{source}:{identifier}:{field}`
+    /// keys and returns the number of facets written.
+    fn identity_set(&self, profile: &ProviderUserProfile) -> usize {
+        super::profile::persist_provider_profile(profile)
+    }
+
     /// Hook fired when an OAuth handoff completes
     /// ([`crate::core::event_bus::DomainEvent::ComposioConnectionCreated`]).
     ///
@@ -91,11 +101,11 @@ pub trait ComposioProvider: Send + Sync {
                 // facet table so display_name / email / avatar are
                 // available to the agent context and UI without a
                 // round-trip to the upstream provider.
-                let facets = super::profile::persist_provider_profile(&profile);
+                let facets = self.identity_set(&profile);
                 tracing::debug!(
                     toolkit = %toolkit,
                     facets_written = facets,
-                    "[composio:provider] profile facets persisted"
+                    "[composio:provider] identity_set persisted profile facets"
                 );
             }
             Err(e) => {

--- a/src/openhuman/composio/providers/types.rs
+++ b/src/openhuman/composio/providers/types.rs
@@ -31,7 +31,8 @@ impl SyncReason {
 
 /// Normalized user profile shape returned by every provider.
 ///
-/// The shared fields (`display_name`, `email`, `username`, `avatar_url`)
+/// The shared fields (`display_name`, `email`, `username`, `avatar_url`,
+/// `profile_url`)
 /// cover what the desktop UI actually needs to render a connected
 /// account card. Anything provider-specific (Gmail's `messagesTotal`,
 /// Notion's workspace ids, …) goes into [`extras`](Self::extras) so
@@ -45,6 +46,7 @@ pub struct ProviderUserProfile {
     pub email: Option<String>,
     pub username: Option<String>,
     pub avatar_url: Option<String>,
+    pub profile_url: Option<String>,
     /// Provider-specific extras (raw JSON object).
     #[serde(default)]
     pub extras: serde_json::Value,

--- a/src/openhuman/context/debug_dump.rs
+++ b/src/openhuman/context/debug_dump.rs
@@ -386,6 +386,7 @@ async fn render_integrations_agent(config: &Config, toolkit: &str) -> Result<Dum
         visible_tool_names: &empty_visible,
         tool_call_format: ToolCallFormat::PFormat,
         connected_integrations: &narrow_integrations,
+        connected_identities_md: crate::openhuman::agent::prompts::render_connected_identities(),
         include_profile: !definition.omit_profile,
         include_memory_md: !definition.omit_memory_md,
     };

--- a/src/openhuman/learning/prompt_sections.rs
+++ b/src/openhuman/learning/prompt_sections.rs
@@ -157,6 +157,7 @@ mod tests {
             visible_tool_names,
             tool_call_format: crate::openhuman::context::prompt::ToolCallFormat::PFormat,
             connected_integrations: &[],
+            connected_identities_md: String::new(),
             include_profile: false,
             include_memory_md: false,
         }


### PR DESCRIPTION
## Summary
- implement issue #691 (Composio-only) with a standardized `identity_set` callback in the provider lifecycle and `ProviderUserProfile.profile_url` support
- persist connected identity fragments as durable `FacetType::Skill` profile facets using deterministic keys (`skill:{toolkit}:{identifier}:{field}`), and add loaders/renderers for merged identity context
- inject a unified `Connected Identities` section into welcome, orchestrator, and integrations agent system prompts so inference can reference cross-platform identity
- include related tests and memory notes updates; branch also includes existing vendor bump commit `0eb58a37`

## Linked issue
Closes #691

## Test plan
- [x] `cargo test --manifest-path Cargo.toml composio::providers::profile -- --nocapture`
- [x] `cargo test --manifest-path Cargo.toml prompt::tests -- --nocapture`
- [x] `cargo fmt --manifest-path Cargo.toml`
- [x] `cargo check --manifest-path Cargo.toml`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn format:check`
- [x] `yarn build`
- [x] `yarn tauri dev` (smoke start)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompts now include a “Connected Identities” section showing linked provider accounts; provider profile URLs are surfaced when available.
  * Can list and remove connected identity entries; connection-deleted events are emitted.

* **Refactor**
  * Unified identity persistence path and migrated stored identity keys to a new skill-oriented schema.

* **Tests**
  * Updated tests and fixtures for the new prompt context field.

* **Chores**
  * Updated vendored Tauri CEF and installer DRY_RUN handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->