### PR TITLE
test(rpc,core,billing,team): harden registry + RPC helpers with edge-case coverage

### DIFF
--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -642,4 +642,228 @@ mod tests {
             "duplicate RPC methods found in registry"
         );
     }
+
+    // --- validate_params edge cases -----------------------------------------
+
+    #[test]
+    fn validate_params_accepts_missing_optional_param() {
+        let s = schema(
+            "test",
+            "fn",
+            vec![FieldSchema {
+                name: "filter",
+                ty: TypeSchema::String,
+                comment: "optional filter",
+                required: false,
+            }],
+        );
+        assert!(validate_params(&s, &Map::new()).is_ok());
+    }
+
+    #[test]
+    fn validate_params_accepts_optional_param_when_present() {
+        let s = schema(
+            "test",
+            "fn",
+            vec![FieldSchema {
+                name: "filter",
+                ty: TypeSchema::String,
+                comment: "",
+                required: false,
+            }],
+        );
+        let mut p = Map::new();
+        p.insert("filter".into(), Value::String("abc".into()));
+        assert!(validate_params(&s, &p).is_ok());
+    }
+
+    #[test]
+    fn validate_params_missing_required_error_includes_comment() {
+        // The comment text helps callers (esp. the CLI/UI) understand what
+        // the missing field is for — lock this in so error messages don't
+        // regress to bare field names.
+        let s = schema(
+            "memory",
+            "doc_put",
+            vec![FieldSchema {
+                name: "namespace",
+                ty: TypeSchema::String,
+                comment: "namespace to write into",
+                required: true,
+            }],
+        );
+        let err = validate_params(&s, &Map::new()).unwrap_err();
+        assert!(err.contains("missing required param 'namespace'"));
+        assert!(err.contains("namespace to write into"));
+    }
+
+    #[test]
+    fn validate_params_unknown_error_includes_namespace_and_function() {
+        let s = schema("billing", "top_up", vec![]);
+        let mut p = Map::new();
+        p.insert("typo".into(), Value::Null);
+        let err = validate_params(&s, &p).unwrap_err();
+        assert!(err.contains("unknown param 'typo'"));
+        assert!(err.contains("billing.top_up"));
+    }
+
+    #[test]
+    fn validate_params_reports_missing_required_before_unknown() {
+        // If a call both omits a required param AND has an unknown one,
+        // the missing-required error fires first (it's strictly more
+        // actionable for callers).
+        let s = schema(
+            "test",
+            "fn",
+            vec![FieldSchema {
+                name: "key",
+                ty: TypeSchema::String,
+                comment: "",
+                required: true,
+            }],
+        );
+        let mut p = Map::new();
+        p.insert("unknown".into(), Value::Null);
+        let err = validate_params(&s, &p).unwrap_err();
+        assert!(err.contains("missing required param 'key'"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_params_null_for_required_is_acceptable() {
+        // JSON-RPC semantics: `null` is a valid value for an optional field
+        // sent explicitly. For a required field, presence (not value) is
+        // what we check — null does satisfy the "key present" check.
+        // Handlers enforce stronger type contracts downstream.
+        let s = schema(
+            "test",
+            "fn",
+            vec![FieldSchema {
+                name: "key",
+                ty: TypeSchema::String,
+                comment: "",
+                required: true,
+            }],
+        );
+        let mut p = Map::new();
+        p.insert("key".into(), Value::Null);
+        assert!(validate_params(&s, &p).is_ok());
+    }
+
+    // --- validate_registry edge cases ---------------------------------------
+
+    #[test]
+    fn validate_registry_rejects_empty_namespace() {
+        let declared = vec![schema("", "fn", vec![])];
+        let registered = vec![RegisteredController {
+            schema: declared[0].clone(),
+            handler: noop_handler,
+        }];
+        let err = validate_registry(&registered, &declared).unwrap_err();
+        assert!(err.contains("namespace must not be empty"));
+    }
+
+    #[test]
+    fn validate_registry_rejects_empty_function() {
+        let declared = vec![schema("ns", "", vec![])];
+        let registered = vec![RegisteredController {
+            schema: declared[0].clone(),
+            handler: noop_handler,
+        }];
+        let err = validate_registry(&registered, &declared).unwrap_err();
+        assert!(err.contains("function must not be empty"));
+    }
+
+    #[test]
+    fn validate_registry_rejects_whitespace_only_namespace() {
+        // `trim().is_empty()` is the invariant — a namespace of "   " must
+        // be rejected to prevent `openhuman.   _fn` nonsense RPC method names.
+        let declared = vec![schema("   ", "fn", vec![])];
+        let registered = vec![RegisteredController {
+            schema: declared[0].clone(),
+            handler: noop_handler,
+        }];
+        let err = validate_registry(&registered, &declared).unwrap_err();
+        assert!(err.contains("namespace must not be empty"));
+    }
+
+    #[test]
+    fn validate_registry_rejects_declared_without_registered() {
+        let declared = vec![schema("a", "b", vec![])];
+        let registered: Vec<RegisteredController> = vec![];
+        let err = validate_registry(&registered, &declared).unwrap_err();
+        assert!(err.contains("declared controller `a.b` has no registered handler"));
+    }
+
+    #[test]
+    fn validate_registry_rejects_registered_without_declared() {
+        let declared: Vec<ControllerSchema> = vec![];
+        let registered = vec![RegisteredController {
+            schema: schema("a", "b", vec![]),
+            handler: noop_handler,
+        }];
+        let err = validate_registry(&registered, &declared).unwrap_err();
+        assert!(err.contains("registered controller `a.b` has no declared schema"));
+    }
+
+    #[test]
+    fn validate_registry_rejects_duplicate_registered_controllers() {
+        let s = schema("a", "b", vec![]);
+        let declared = vec![s.clone()];
+        let registered = vec![
+            RegisteredController {
+                schema: s.clone(),
+                handler: noop_handler,
+            },
+            RegisteredController {
+                schema: s,
+                handler: noop_handler,
+            },
+        ];
+        let err = validate_registry(&registered, &declared).unwrap_err();
+        assert!(err.contains("duplicate registered controller `a.b`"));
+    }
+
+    // --- try_invoke_registered_rpc routing ---------------------------------
+
+    #[tokio::test]
+    async fn try_invoke_registered_rpc_returns_none_for_unknown_method() {
+        let out =
+            try_invoke_registered_rpc("openhuman.not_a_real_method_xyz_123", Map::new()).await;
+        assert!(out.is_none(), "unknown methods must return None");
+    }
+
+    #[tokio::test]
+    async fn try_invoke_registered_rpc_returns_some_for_known_method() {
+        // `openhuman.health_snapshot` is registered at startup and takes no
+        // required params — it must route and produce Some(_).
+        let out = try_invoke_registered_rpc("openhuman.health_snapshot", Map::new()).await;
+        assert!(out.is_some(), "known method must route");
+    }
+
+    #[test]
+    fn rpc_method_name_handles_multi_underscore_function() {
+        // Functions often contain underscores — the RPC method name must
+        // preserve them verbatim, separated from the namespace with `_`.
+        let s = schema("team", "change_member_role", vec![]);
+        assert_eq!(rpc_method_name(&s), "openhuman.team_change_member_role");
+    }
+
+    #[test]
+    fn every_registered_controller_has_matching_declared_schema() {
+        // Global invariant: the registry is consistent by construction.
+        // This test re-asserts the contract to catch drift.
+        use std::collections::BTreeSet;
+        let registered: BTreeSet<String> = all_registered_controllers()
+            .into_iter()
+            .map(|c| format!("{}.{}", c.schema.namespace, c.schema.function))
+            .collect();
+        let declared: BTreeSet<String> = all_controller_schemas()
+            .into_iter()
+            .map(|s| format!("{}.{}", s.namespace, s.function))
+            .collect();
+        assert_eq!(
+            registered, declared,
+            "registry/schema sets must be identical"
+        );
+    }
 }

--- a/src/core/dispatch.rs
+++ b/src/core/dispatch.rs
@@ -78,3 +78,97 @@ fn try_core_dispatch(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn test_state() -> AppState {
+        AppState {
+            core_version: "9.9.9-test".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_core_ping_returns_ok_true() {
+        let out = dispatch(test_state(), "core.ping", json!({}))
+            .await
+            .expect("core.ping should succeed");
+        assert_eq!(out, json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn dispatch_core_version_returns_state_version() {
+        let out = dispatch(test_state(), "core.version", json!({}))
+            .await
+            .expect("core.version should succeed");
+        assert_eq!(out, json!({ "version": "9.9.9-test" }));
+    }
+
+    #[tokio::test]
+    async fn dispatch_core_ignores_params() {
+        // Params must be tolerated even when the method takes none.
+        let out = dispatch(test_state(), "core.ping", json!({ "extra": 1 }))
+            .await
+            .expect("core.ping should ignore extra params");
+        assert_eq!(out, json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn dispatch_unknown_method_returns_error() {
+        let err = dispatch(test_state(), "does.not.exist", json!({}))
+            .await
+            .expect_err("unknown methods must error");
+        assert!(err.contains("unknown method"));
+        assert!(err.contains("does.not.exist"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_empty_method_returns_unknown_method_error() {
+        let err = dispatch(test_state(), "", json!({}))
+            .await
+            .expect_err("empty method must error");
+        assert!(err.contains("unknown method"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_delegates_to_tier2_for_domain_method() {
+        // Tier 2 dispatcher handles `openhuman.security_policy_info`, so
+        // it must succeed and return a policy object.
+        let out = dispatch(test_state(), "openhuman.security_policy_info", json!({}))
+            .await
+            .expect("security_policy_info should route via tier 2");
+        // With logs present, payload is wrapped as { result, logs }.
+        assert!(out.get("result").is_some() || out.get("autonomy").is_some());
+    }
+
+    #[test]
+    fn try_core_dispatch_returns_none_for_non_core_namespace() {
+        let state = test_state();
+        assert!(try_core_dispatch(&state, "openhuman.memory_list_namespaces", json!({})).is_none());
+        assert!(try_core_dispatch(&state, "corez.ping", json!({})).is_none());
+    }
+
+    #[test]
+    fn try_core_dispatch_matches_exact_ping_and_version() {
+        let state = test_state();
+        assert!(try_core_dispatch(&state, "core.ping", json!({})).is_some());
+        assert!(try_core_dispatch(&state, "core.version", json!({})).is_some());
+        // Prefix match alone must not count.
+        assert!(try_core_dispatch(&state, "core.pingz", json!({})).is_none());
+        assert!(try_core_dispatch(&state, "core", json!({})).is_none());
+    }
+
+    #[test]
+    fn try_core_dispatch_version_reflects_appstate() {
+        let state = AppState {
+            core_version: "0.0.0-abc".into(),
+        };
+        let result = try_core_dispatch(&state, "core.version", json!({}))
+            .expect("core.version must be routed")
+            .expect("core.version must produce InvocationResult");
+        assert_eq!(result.value, json!({ "version": "0.0.0-abc" }));
+        assert!(result.logs.is_empty());
+    }
+}

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -995,7 +995,10 @@ fn build_http_schema_dump() -> HttpSchemaDump {
 mod tests {
     use serde_json::json;
 
-    use super::{build_http_schema_dump, default_state, invoke_method};
+    use super::{
+        build_http_schema_dump, default_state, escape_html, invoke_method,
+        is_session_expired_error, params_to_object, parse_json_params, type_name,
+    };
 
     #[tokio::test]
     async fn invoke_health_snapshot_via_registry() {
@@ -1370,5 +1373,186 @@ mod tests {
                 "schema dump missing expected method: {expected}"
             );
         }
+    }
+
+    // --- helper coverage -----------------------------------------------------
+
+    #[test]
+    fn params_to_object_accepts_object() {
+        let map = params_to_object(json!({"a": 1, "b": "x"})).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("a"), Some(&json!(1)));
+    }
+
+    #[test]
+    fn params_to_object_accepts_null_as_empty_map() {
+        let map = params_to_object(json!(null)).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn params_to_object_rejects_array() {
+        let err = params_to_object(json!([1, 2, 3])).unwrap_err();
+        assert!(err.contains("invalid params"));
+        assert!(err.contains("array"));
+    }
+
+    #[test]
+    fn params_to_object_rejects_scalars() {
+        assert!(params_to_object(json!(42)).unwrap_err().contains("number"));
+        assert!(params_to_object(json!("hi"))
+            .unwrap_err()
+            .contains("string"));
+        assert!(params_to_object(json!(true)).unwrap_err().contains("bool"));
+    }
+
+    #[test]
+    fn type_name_labels_every_json_variant() {
+        assert_eq!(type_name(&json!(null)), "null");
+        assert_eq!(type_name(&json!(true)), "bool");
+        assert_eq!(type_name(&json!(3)), "number");
+        assert_eq!(type_name(&json!("s")), "string");
+        assert_eq!(type_name(&json!([])), "array");
+        assert_eq!(type_name(&json!({})), "object");
+    }
+
+    #[test]
+    fn parse_json_params_roundtrips_object() {
+        let v = parse_json_params(r#"{"k":1}"#).unwrap();
+        assert_eq!(v, json!({"k": 1}));
+    }
+
+    #[test]
+    fn parse_json_params_reports_error_message() {
+        let err = parse_json_params("{not json").unwrap_err();
+        assert!(err.contains("invalid JSON params"));
+    }
+
+    #[test]
+    fn is_session_expired_error_matches_401_unauthorized() {
+        assert!(is_session_expired_error(
+            "backend returned 401 Unauthorized"
+        ));
+        assert!(is_session_expired_error("401 UNAUTHORIZED"));
+        assert!(is_session_expired_error("got 401 and unauthorized body"));
+    }
+
+    #[test]
+    fn is_session_expired_error_requires_both_401_and_unauthorized() {
+        // 401 alone is not sufficient — could be HTTP/3.01 nonsense or
+        // unrelated text. We require the string "unauthorized" too.
+        assert!(!is_session_expired_error("server returned 401"));
+        assert!(!is_session_expired_error("unauthorized without code"));
+    }
+
+    #[test]
+    fn is_session_expired_error_matches_invalid_token_case_insensitive() {
+        assert!(is_session_expired_error("Invalid Token"));
+        assert!(is_session_expired_error("got an invalid token here"));
+    }
+
+    #[test]
+    fn is_session_expired_error_matches_session_expired_sentinel() {
+        // The SESSION_EXPIRED sentinel is case-sensitive by design.
+        assert!(is_session_expired_error("SESSION_EXPIRED: please re-auth"));
+        assert!(!is_session_expired_error("session_expired lowercase"));
+    }
+
+    #[test]
+    fn is_session_expired_error_does_not_match_unrelated_errors() {
+        assert!(!is_session_expired_error("network timeout"));
+        assert!(!is_session_expired_error("500 internal server error"));
+        assert!(!is_session_expired_error(""));
+    }
+
+    #[test]
+    fn escape_html_escapes_all_special_chars() {
+        let raw = r#"<script>alert("x&y'z")</script>"#;
+        let escaped = escape_html(raw);
+        assert!(!escaped.contains('<'));
+        assert!(!escaped.contains('>'));
+        assert!(!escaped.contains('"'));
+        assert!(!escaped.contains('\''));
+        assert!(escaped.contains("&lt;"));
+        assert!(escaped.contains("&gt;"));
+        assert!(escaped.contains("&quot;"));
+        assert!(escaped.contains("&#x27;"));
+        // `&` must be escaped first so later substitutions don't double-encode.
+        assert!(escaped.contains("&amp;y"));
+    }
+
+    #[test]
+    fn escape_html_is_noop_for_safe_text() {
+        assert_eq!(escape_html("safe text 123"), "safe text 123");
+        assert_eq!(escape_html(""), "");
+    }
+
+    // --- invoke_method parameter-shape errors ---------------------------------
+
+    #[tokio::test]
+    async fn invoke_method_rejects_array_params_for_registered_method() {
+        // Registered controllers expect named-argument style (JSON object).
+        // Passing an array must fail with a clear "invalid params" error
+        // instead of silently calling the handler with no args.
+        let err = invoke_method(
+            default_state(),
+            "openhuman.health_snapshot",
+            json!([1, 2, 3]),
+        )
+        .await
+        .expect_err("array params should be rejected");
+        assert!(err.contains("invalid params"));
+        assert!(err.contains("array"));
+    }
+
+    #[tokio::test]
+    async fn invoke_method_rejects_string_params_for_registered_method() {
+        let err = invoke_method(default_state(), "openhuman.health_snapshot", json!("oops"))
+            .await
+            .expect_err("string params should be rejected");
+        assert!(err.contains("invalid params"));
+        assert!(err.contains("string"));
+    }
+
+    #[tokio::test]
+    async fn invoke_method_accepts_null_params_for_registered_method() {
+        // JSON-RPC 2.0 allows omitting params; null must be treated like {}.
+        let result = invoke_method(default_state(), "openhuman.health_snapshot", json!(null)).await;
+        // Call should succeed or fail for domain reasons — but must NOT
+        // fail with the "invalid params" shape error.
+        if let Err(e) = result {
+            assert!(
+                !e.contains("invalid params"),
+                "null should be accepted as empty object, got: {e}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_method_unknown_method_returns_unknown_error() {
+        let err = invoke_method(default_state(), "openhuman.totally_made_up_xyz", json!({}))
+            .await
+            .expect_err("unknown methods must error");
+        assert!(err.contains("unknown method"));
+    }
+
+    #[tokio::test]
+    async fn invoke_method_core_ping_via_tier1() {
+        // core.* methods aren't in the registry; they route through tier 1.
+        let result = invoke_method(default_state(), "core.ping", json!({}))
+            .await
+            .expect("core.ping should succeed via tier 1");
+        assert_eq!(result, json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn invoke_method_core_version_via_tier1_reflects_state() {
+        let state = super::AppState {
+            core_version: "0.0.1-abc".into(),
+        };
+        let result = invoke_method(state, "core.version", json!({}))
+            .await
+            .expect("core.version should succeed");
+        assert_eq!(result, json!({ "version": "0.0.1-abc" }));
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -111,3 +111,122 @@ pub enum TypeSchema {
     /// Reference to a named shared/domain type defined elsewhere.
     Ref(&'static str),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(namespace: &'static str, function: &'static str) -> ControllerSchema {
+        ControllerSchema {
+            namespace,
+            function,
+            description: "",
+            inputs: vec![],
+            outputs: vec![],
+        }
+    }
+
+    #[test]
+    fn method_name_joins_namespace_and_function_with_dot() {
+        let s = mk("memory", "doc_put");
+        assert_eq!(s.method_name(), "memory.doc_put");
+    }
+
+    #[test]
+    fn method_name_is_not_an_rpc_method_name() {
+        // The dotted controller key and the `openhuman.<ns>_<fn>` RPC method
+        // name are intentionally different — guard against drift.
+        let s = mk("memory", "doc_put");
+        assert_eq!(s.method_name(), "memory.doc_put");
+        assert_eq!(
+            crate::core::all::rpc_method_name(&s),
+            "openhuman.memory_doc_put"
+        );
+    }
+
+    #[test]
+    fn method_name_preserves_underscores_in_function() {
+        let s = mk("team", "change_member_role");
+        assert_eq!(s.method_name(), "team.change_member_role");
+    }
+
+    #[test]
+    fn controller_schema_equality_considers_all_fields() {
+        let a = ControllerSchema {
+            namespace: "a",
+            function: "b",
+            description: "x",
+            inputs: vec![],
+            outputs: vec![],
+        };
+        let b = ControllerSchema {
+            namespace: "a",
+            function: "b",
+            description: "x",
+            inputs: vec![],
+            outputs: vec![],
+        };
+        let c = ControllerSchema {
+            namespace: "a",
+            function: "b",
+            description: "different",
+            inputs: vec![],
+            outputs: vec![],
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn type_schema_nesting_is_equality_comparable() {
+        let a = TypeSchema::Array(Box::new(TypeSchema::Option(Box::new(TypeSchema::String))));
+        let b = TypeSchema::Array(Box::new(TypeSchema::Option(Box::new(TypeSchema::String))));
+        let c = TypeSchema::Array(Box::new(TypeSchema::Option(Box::new(TypeSchema::I64))));
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn field_schema_required_flag_changes_equality() {
+        let a = FieldSchema {
+            name: "x",
+            ty: TypeSchema::Bool,
+            comment: "",
+            required: true,
+        };
+        let b = FieldSchema {
+            name: "x",
+            ty: TypeSchema::Bool,
+            comment: "",
+            required: false,
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn controller_schema_serializes_to_json() {
+        // Schema must be JSON-serializable: the /schema endpoint depends on it.
+        let s = ControllerSchema {
+            namespace: "health",
+            function: "snapshot",
+            description: "d",
+            inputs: vec![FieldSchema {
+                name: "limit",
+                ty: TypeSchema::U64,
+                comment: "cap",
+                required: false,
+            }],
+            outputs: vec![FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "",
+                required: true,
+            }],
+        };
+        let json = serde_json::to_value(&s).unwrap();
+        assert_eq!(json["namespace"], "health");
+        assert_eq!(json["function"], "snapshot");
+        assert_eq!(json["inputs"][0]["name"], "limit");
+        assert_eq!(json["outputs"][0]["required"], true);
+    }
+}

--- a/src/openhuman/billing/ops.rs
+++ b/src/openhuman/billing/ops.rs
@@ -344,5 +344,116 @@ mod tests {
             normalize_gateway(Some("paypal".to_string())),
             Err("gateway must be one of: stripe, coinbase".to_string())
         );
+        assert_eq!(
+            normalize_gateway(Some("".to_string())),
+            Ok("stripe".to_string()),
+            "empty string falls through to default, matching None"
+        );
+    }
+
+    // --- pre-HTTP input validation (no network) ---------------------------
+    //
+    // These tests only exercise the argument checks that run *before* any
+    // HTTP call. They must not depend on the backend, stored session token,
+    // or filesystem state — only on input shape.
+
+    fn cfg() -> Config {
+        Config::default()
+    }
+
+    #[tokio::test]
+    async fn purchase_plan_rejects_empty_plan() {
+        let err = purchase_plan(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "plan is required");
+    }
+
+    #[tokio::test]
+    async fn purchase_plan_rejects_whitespace_only_plan() {
+        // Whitespace must be trimmed and then rejected.
+        let err = purchase_plan(&cfg(), "   \t\n").await.unwrap_err();
+        assert_eq!(err, "plan is required");
+    }
+
+    #[tokio::test]
+    async fn create_coinbase_charge_rejects_empty_plan() {
+        let err = create_coinbase_charge(&cfg(), "", None).await.unwrap_err();
+        assert_eq!(err, "plan is required");
+    }
+
+    #[tokio::test]
+    async fn create_coinbase_charge_rejects_whitespace_plan() {
+        let err = create_coinbase_charge(&cfg(), "   ", Some("monthly".into()))
+            .await
+            .unwrap_err();
+        assert_eq!(err, "plan is required");
+    }
+
+    #[tokio::test]
+    async fn update_card_rejects_empty_payment_method_id() {
+        let err = update_card(&cfg(), "", json!({})).await.unwrap_err();
+        assert_eq!(err, "paymentMethodId is required");
+    }
+
+    #[tokio::test]
+    async fn update_card_rejects_whitespace_payment_method_id() {
+        let err = update_card(&cfg(), "  \t", json!({})).await.unwrap_err();
+        assert_eq!(err, "paymentMethodId is required");
+    }
+
+    #[tokio::test]
+    async fn delete_card_rejects_empty_payment_method_id() {
+        let err = delete_card(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "paymentMethodId is required");
+    }
+
+    #[tokio::test]
+    async fn redeem_coupon_rejects_empty_code() {
+        let err = redeem_coupon(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "code is required");
+    }
+
+    #[tokio::test]
+    async fn redeem_coupon_rejects_whitespace_code() {
+        let err = redeem_coupon(&cfg(), "   ").await.unwrap_err();
+        assert_eq!(err, "code is required");
+    }
+
+    #[tokio::test]
+    async fn top_up_rejects_zero_amount() {
+        let err = top_up_credits(&cfg(), 0.0, None).await.unwrap_err();
+        assert!(err.contains("amountUsd must be a finite number greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn top_up_rejects_negative_amount() {
+        let err = top_up_credits(&cfg(), -1.0, None).await.unwrap_err();
+        assert!(err.contains("amountUsd must be a finite number greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn top_up_rejects_nan_amount() {
+        let err = top_up_credits(&cfg(), f64::NAN, None).await.unwrap_err();
+        assert!(err.contains("amountUsd must be a finite number greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn top_up_rejects_infinity_amount() {
+        let err = top_up_credits(&cfg(), f64::INFINITY, None)
+            .await
+            .unwrap_err();
+        assert!(err.contains("amountUsd must be a finite number greater than 0"));
+        let err = top_up_credits(&cfg(), f64::NEG_INFINITY, None)
+            .await
+            .unwrap_err();
+        assert!(err.contains("amountUsd must be a finite number greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn top_up_rejects_invalid_gateway_after_amount_passes() {
+        // Amount validation passes → gateway validation kicks in and rejects.
+        let err = top_up_credits(&cfg(), 10.0, Some("paypal".into()))
+            .await
+            .unwrap_err();
+        assert_eq!(err, "gateway must be one of: stripe, coinbase");
     }
 }

--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -275,4 +275,183 @@ mod tests {
 
         assert_eq!(path, "/teams/team%2Fwith%3Freserved/members/user%23frag");
     }
+
+    #[test]
+    fn build_api_path_empty_segments_list_is_root() {
+        let path = build_api_path(&[]).expect("path should build");
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn build_api_path_preserves_segment_order() {
+        let path = build_api_path(&["a", "b", "c"]).expect("path should build");
+        assert_eq!(path, "/a/b/c");
+    }
+
+    #[test]
+    fn build_api_path_percent_encodes_spaces_and_unicode() {
+        let path = build_api_path(&["teams", "with space", "👥"]).expect("path should build");
+        assert!(path.contains("with%20space"));
+        // Unicode must be percent-encoded (UTF-8 bytes).
+        assert!(!path.contains('👥'));
+    }
+
+    #[test]
+    fn normalize_id_rejects_empty_with_field_name() {
+        let err = normalize_id("", "teamId").unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[test]
+    fn normalize_id_rejects_whitespace_only() {
+        let err = normalize_id("   \t\n", "userId").unwrap_err();
+        assert_eq!(err, "userId is required");
+    }
+
+    #[test]
+    fn normalize_id_trims_and_keeps_body() {
+        assert_eq!(normalize_id("  abc  ", "teamId").unwrap(), "abc");
+    }
+
+    #[test]
+    fn normalize_id_preserves_internal_whitespace() {
+        // Only leading/trailing whitespace is stripped — interior is preserved
+        // so we don't silently corrupt caller-provided identifiers.
+        assert_eq!(normalize_id("a b", "x").unwrap(), "a b");
+    }
+
+    // --- pre-HTTP input validation (no network) -----------------------------
+
+    fn cfg() -> Config {
+        Config::default()
+    }
+
+    #[tokio::test]
+    async fn list_members_rejects_empty_team_id() {
+        let err = list_members(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn list_members_rejects_whitespace_team_id() {
+        let err = list_members(&cfg(), "   ").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn get_team_rejects_empty_team_id() {
+        let err = get_team(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn create_team_rejects_empty_name() {
+        let err = create_team(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "name is required");
+    }
+
+    #[tokio::test]
+    async fn create_team_rejects_whitespace_name() {
+        let err = create_team(&cfg(), "   ").await.unwrap_err();
+        assert_eq!(err, "name is required");
+    }
+
+    #[tokio::test]
+    async fn update_team_rejects_empty_team_id() {
+        let err = update_team(&cfg(), "", Some("new")).await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn delete_team_rejects_empty_team_id() {
+        let err = delete_team(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn switch_team_rejects_empty_team_id() {
+        let err = switch_team(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn leave_team_rejects_empty_team_id() {
+        let err = leave_team(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn join_team_rejects_empty_code() {
+        let err = join_team(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "code is required");
+    }
+
+    #[tokio::test]
+    async fn join_team_rejects_whitespace_code() {
+        let err = join_team(&cfg(), "   ").await.unwrap_err();
+        assert_eq!(err, "code is required");
+    }
+
+    #[tokio::test]
+    async fn create_invite_rejects_empty_team_id() {
+        let err = create_invite(&cfg(), "", None, None).await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn remove_member_validates_team_id_before_user_id() {
+        // Failing input order must be deterministic: team_id is normalized
+        // first, so an empty team_id reports the teamId error regardless of
+        // the user_id.
+        let err = remove_member(&cfg(), "", "someone").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn remove_member_rejects_empty_user_id_when_team_id_valid() {
+        let err = remove_member(&cfg(), "t1", "").await.unwrap_err();
+        assert_eq!(err, "userId is required");
+    }
+
+    #[tokio::test]
+    async fn change_member_role_rejects_missing_role() {
+        let err = change_member_role(&cfg(), "t1", "u1", "")
+            .await
+            .unwrap_err();
+        assert_eq!(err, "role is required");
+    }
+
+    #[tokio::test]
+    async fn change_member_role_validates_team_id_first() {
+        let err = change_member_role(&cfg(), "", "u1", "admin")
+            .await
+            .unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn change_member_role_validates_user_id_before_role() {
+        let err = change_member_role(&cfg(), "t1", "", "admin")
+            .await
+            .unwrap_err();
+        assert_eq!(err, "userId is required");
+    }
+
+    #[tokio::test]
+    async fn list_invites_rejects_empty_team_id() {
+        let err = list_invites(&cfg(), "").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn revoke_invite_rejects_empty_team_id() {
+        let err = revoke_invite(&cfg(), "", "inv1").await.unwrap_err();
+        assert_eq!(err, "teamId is required");
+    }
+
+    #[tokio::test]
+    async fn revoke_invite_rejects_empty_invite_id() {
+        let err = revoke_invite(&cfg(), "t1", "").await.unwrap_err();
+        assert_eq!(err, "inviteId is required");
+    }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -61,3 +61,94 @@ impl<T: Serialize> RpcOutcome<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_preserves_value_and_logs() {
+        let outcome: RpcOutcome<i64> = RpcOutcome::new(7, vec!["a".into(), "b".into()]);
+        assert_eq!(outcome.value, 7);
+        assert_eq!(outcome.logs, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn single_log_stores_exactly_one_log() {
+        let outcome = RpcOutcome::single_log(json!({"ok": true}), "hello");
+        assert_eq!(outcome.logs.len(), 1);
+        assert_eq!(outcome.logs[0], "hello");
+        assert_eq!(outcome.value, json!({"ok": true}));
+    }
+
+    #[test]
+    fn single_log_accepts_string_and_str_via_into() {
+        let a = RpcOutcome::single_log(json!(1), "static str");
+        let b = RpcOutcome::single_log(json!(1), String::from("owned string"));
+        assert_eq!(a.logs[0], "static str");
+        assert_eq!(b.logs[0], "owned string");
+    }
+
+    #[test]
+    fn into_cli_compatible_json_no_logs_returns_bare_value() {
+        let outcome = RpcOutcome::<serde_json::Value>::new(json!({"x": 1}), vec![]);
+        let out = outcome.into_cli_compatible_json().unwrap();
+        assert_eq!(out, json!({"x": 1}));
+        assert!(out.get("logs").is_none());
+    }
+
+    #[test]
+    fn into_cli_compatible_json_with_logs_wraps_in_envelope() {
+        let outcome = RpcOutcome::single_log(json!(42), "did something");
+        let out = outcome.into_cli_compatible_json().unwrap();
+        assert_eq!(out["result"], json!(42));
+        assert_eq!(out["logs"], json!(["did something"]));
+        // And only those two keys exist.
+        assert_eq!(out.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn into_cli_compatible_json_serializes_typed_value() {
+        #[derive(serde::Serialize)]
+        struct Payload<'a> {
+            name: &'a str,
+            count: u32,
+        }
+        let outcome = RpcOutcome::new(
+            Payload {
+                name: "atlas",
+                count: 3,
+            },
+            vec![],
+        );
+        let out = outcome.into_cli_compatible_json().unwrap();
+        assert_eq!(out, json!({"name": "atlas", "count": 3}));
+    }
+
+    #[test]
+    fn into_cli_compatible_json_treats_null_value_as_bare_when_no_logs() {
+        let outcome: RpcOutcome<Option<i32>> = RpcOutcome::new(None, vec![]);
+        let out = outcome.into_cli_compatible_json().unwrap();
+        assert!(out.is_null());
+    }
+
+    #[test]
+    fn into_cli_compatible_json_preserves_log_order() {
+        let outcome = RpcOutcome::new(
+            json!({"ok": true}),
+            vec!["first".into(), "second".into(), "third".into()],
+        );
+        let out = outcome.into_cli_compatible_json().unwrap();
+        assert_eq!(out["logs"], json!(["first", "second", "third"]));
+    }
+
+    #[test]
+    fn into_cli_compatible_json_empty_string_logs_still_envelope() {
+        // An empty log string is still a log — envelope shape must kick in.
+        let outcome = RpcOutcome::new(json!("x"), vec!["".into()]);
+        let out = outcome.into_cli_compatible_json().unwrap();
+        assert!(out.get("result").is_some());
+        assert_eq!(out["logs"], json!([""]));
+    }
+}


### PR DESCRIPTION
## Summary

Test-only hardening for the Rust core RPC layer and two domain `ops` modules. No production code changes — every added line lives under `#[cfg(test)]` or a `mod tests` block.

Covers:
- `src/rpc/mod.rs` — `RpcOutcome<T>` constructor, log handling, and JSON serialization shape
- `src/core/mod.rs` — `ControllerSchema` / `FieldSchema` / `TypeSchema` metadata invariants
- `src/core/dispatch.rs` — core dispatch routing, unknown-method behavior
- `src/core/jsonrpc.rs` — helper contracts: `params_to_object`, `parse_json_params`, `escape_html`, `type_name`, `is_session_expired_error`
- `src/core/all.rs` — `validate_params` edge cases (missing optional, extra fields, type mismatches)
- `src/openhuman/billing/ops.rs` — pre-HTTP input validation (empty/whitespace plan, payment method id, coupon code; zero/NaN/±Inf top-up amount; gateway normalization)
- `src/openhuman/team/ops.rs` — `build_api_path` edge cases and registry coverage

## Why it matters

Locks in the current behavior of the JSON-RPC envelope and pre-HTTP input validation so future refactors of the core registry and adapters (`core_server::dispatch`, `core/jsonrpc`) can't silently regress input shape, error messages, or dispatch routing.

## Validation

- \`cargo test --lib\` → **4765 passed** (no failures, no ignored)
- \`cargo fmt --check\` → clean
- \`cargo check\` → clean

Pre-HTTP billing tests are explicitly documented to only exercise argument checks that run **before** any HTTP call — no network, no backend, no stored session token required.

## Risk

Minimal. Tests only. No runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests for input validation, parameter handling, and error reporting across core routing and RPC layers
  * Expanded coverage for JSON-RPC helper functions and schema validation
  * Added validation tests for billing operations and team management functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->