### PR TITLE
test(frontend): lock provider regression coverage

### DIFF
--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -1,0 +1,351 @@
+import { render } from '@testing-library/react';
+import { act } from 'react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as chatService from '../../services/chatService';
+import { threadApi } from '../../services/api/threadApi';
+import { store } from '../../store';
+import { setStatusForUser } from '../../store/socketSlice';
+import { setSelectedThread } from '../../store/threadSlice';
+import ChatRuntimeProvider from '../ChatRuntimeProvider';
+
+vi.mock('../../services/chatService', async () => {
+  const actual = await vi.importActual<typeof chatService>('../../services/chatService');
+  return { ...actual, subscribeChatEvents: vi.fn() };
+});
+
+vi.mock('../../services/api/threadApi', () => ({
+  threadApi: {
+    createNewThread: vi.fn(),
+    getThreads: vi.fn(),
+    getThreadMessages: vi.fn(),
+    appendMessage: vi.fn(),
+    generateTitleIfNeeded: vi.fn(),
+    updateMessage: vi.fn(),
+    deleteThread: vi.fn(),
+    purge: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/usageRefresh', () => ({ requestUsageRefresh: vi.fn() }));
+
+function renderProvider(): chatService.ChatEventListeners {
+  let captured: chatService.ChatEventListeners = {};
+  vi.mocked(chatService.subscribeChatEvents).mockImplementation(listeners => {
+    captured = listeners;
+    return () => {};
+  });
+
+  // Mark the pending user's socket as connected so the subscribe effect fires.
+  store.dispatch(setStatusForUser({ userId: '__pending__', status: 'connected' }));
+
+  render(
+    <Provider store={store}>
+      <ChatRuntimeProvider>
+        <div />
+      </ChatRuntimeProvider>
+    </Provider>
+  );
+
+  return captured;
+}
+
+function resetRuntimeState() {
+  // Reset chatRuntime + thread slices to clean state by dispatching a thread
+  // selection that clears ambient state.
+  store.dispatch({ type: 'thread/clearAllThreads' });
+  store.dispatch({ type: 'chatRuntime/clearAllChatRuntime' });
+  store.dispatch(setStatusForUser({ userId: '__pending__', status: 'disconnected' }));
+}
+
+describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invariants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRuntimeState();
+    vi.mocked(threadApi.appendMessage).mockImplementation(async (_tid, msg) => msg);
+    vi.mocked(threadApi.getThreads).mockResolvedValue({ threads: [], count: 0 });
+    vi.mocked(threadApi.generateTitleIfNeeded).mockResolvedValue({
+      id: 'tid',
+      title: 'new',
+    } as never);
+  });
+
+  describe('dedupe', () => {
+    it('drops duplicate tool_call events with the same thread/request/round/tool', () => {
+      const listeners = renderProvider();
+
+      const event: chatService.ChatToolCallEvent = {
+        thread_id: 't1',
+        request_id: 'r1',
+        round: 0,
+        tool_name: 'search',
+        skill_id: 'notion',
+        args: {},
+        tool_call_id: 'call-1',
+      };
+
+      act(() => {
+        listeners.onToolCall?.(event);
+        listeners.onToolCall?.(event);
+      });
+
+      const timeline = store.getState().chatRuntime.toolTimelineByThread['t1'] ?? [];
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0]?.name).toBe('search');
+      expect(timeline[0]?.status).toBe('running');
+    });
+
+    it('drops duplicate chat_done events with the same thread/request', () => {
+      const listeners = renderProvider();
+
+      const doneEvent: chatService.ChatDoneEvent = {
+        thread_id: 't-done',
+        request_id: 'r-done',
+        full_response: 'hello',
+        rounds_used: 1,
+        total_input_tokens: 5,
+        total_output_tokens: 7,
+      };
+
+      act(() => {
+        listeners.onDone?.(doneEvent);
+        listeners.onDone?.(doneEvent);
+      });
+
+      // Usage recorded exactly once despite duplicate dispatch.
+      const usage = store.getState().chatRuntime.sessionTokenUsage;
+      expect(usage.inputTokens).toBe(5);
+      expect(usage.outputTokens).toBe(7);
+      expect(usage.turns).toBe(1);
+    });
+
+    it('processes tool_call for different rounds as distinct events', () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onToolCall?.({
+          thread_id: 't1',
+          request_id: 'r1',
+          round: 0,
+          tool_name: 'search',
+          skill_id: 'notion',
+          args: {},
+          tool_call_id: 'call-1',
+        });
+        listeners.onToolCall?.({
+          thread_id: 't1',
+          request_id: 'r1',
+          round: 1,
+          tool_name: 'search',
+          skill_id: 'notion',
+          args: {},
+          tool_call_id: 'call-2',
+        });
+      });
+
+      const timeline = store.getState().chatRuntime.toolTimelineByThread['t1'] ?? [];
+      expect(timeline).toHaveLength(2);
+      expect(timeline.map(e => e.round)).toEqual([0, 1]);
+    });
+  });
+
+  describe('proactive thread resolution', () => {
+    it('reuses the selected thread when resolving a proactive: sender', async () => {
+      store.dispatch({
+        type: 'thread/loadThreads/fulfilled',
+        payload: { threads: [{ id: 'visible-thread', title: 'x' }] },
+      });
+      store.dispatch(setSelectedThread('visible-thread'));
+      const listeners = renderProvider();
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:worker-1',
+          request_id: 'req-p1',
+          full_response: 'ping',
+        });
+        // Allow the queued async proactive dispatch to flush.
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // createNewThread must NOT be invoked when a visible thread already exists.
+      expect(threadApi.createNewThread).not.toHaveBeenCalled();
+      expect(threadApi.appendMessage).toHaveBeenCalledWith(
+        'visible-thread',
+        expect.objectContaining({ content: 'ping', sender: 'agent' })
+      );
+    });
+
+    it('creates a new thread when no visible thread exists for proactive handoff', async () => {
+      vi.mocked(threadApi.createNewThread).mockResolvedValue({
+        id: 'created-thread',
+        title: 'new',
+      } as never);
+      vi.mocked(threadApi.getThreads).mockResolvedValue({
+        threads: [{ id: 'created-thread', title: 'new' }] as never,
+        count: 1,
+      });
+
+      const listeners = renderProvider();
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:worker-2',
+          request_id: 'req-p2',
+          full_response: 'bootstrap msg',
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(threadApi.createNewThread).toHaveBeenCalledTimes(1);
+      expect(threadApi.appendMessage).toHaveBeenCalledWith(
+        'created-thread',
+        expect.objectContaining({ content: 'bootstrap msg' })
+      );
+    });
+
+    it('deduplicates identical proactive messages from the same sender', async () => {
+      store.dispatch({
+        type: 'thread/loadThreads/fulfilled',
+        payload: { threads: [{ id: 'visible-thread', title: 'x' }] },
+      });
+      store.dispatch(setSelectedThread('visible-thread'));
+      const listeners = renderProvider();
+
+      const event: chatService.ProactiveMessageEvent = {
+        thread_id: 'proactive:worker-3',
+        request_id: 'req-dup',
+        full_response: 'ping',
+      };
+
+      await act(async () => {
+        listeners.onProactiveMessage?.(event);
+        listeners.onProactiveMessage?.(event);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(threadApi.appendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('mid-turn streaming invariants', () => {
+    it('accumulates text_delta chunks within the same request_id', () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onTextDelta?.({ thread_id: 't-mid', request_id: 'r1', round: 0, delta: 'Hel' });
+        listeners.onTextDelta?.({ thread_id: 't-mid', request_id: 'r1', round: 0, delta: 'lo!' });
+      });
+
+      const streaming = store.getState().chatRuntime.streamingAssistantByThread['t-mid'];
+      expect(streaming).toBeDefined();
+      expect(streaming?.requestId).toBe('r1');
+      expect(streaming?.content).toBe('Hello!');
+    });
+
+    it('replaces streaming state when request_id changes mid-turn', () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onTextDelta?.({ thread_id: 't-mid', request_id: 'r1', round: 0, delta: 'aaa' });
+        listeners.onTextDelta?.({ thread_id: 't-mid', request_id: 'r2', round: 0, delta: 'bbb' });
+      });
+
+      const streaming = store.getState().chatRuntime.streamingAssistantByThread['t-mid'];
+      expect(streaming?.requestId).toBe('r2');
+      expect(streaming?.content).toBe('bbb');
+    });
+
+    it('sets inference status to thinking on inference_start and clears it on chat_done', () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onInferenceStart?.({ thread_id: 't-inv', request_id: 'r1' });
+      });
+      expect(store.getState().chatRuntime.inferenceStatusByThread['t-inv']?.phase).toBe('thinking');
+
+      act(() => {
+        listeners.onDone?.({
+          thread_id: 't-inv',
+          request_id: 'r1',
+          full_response: '',
+          rounds_used: 1,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+        });
+      });
+      expect(store.getState().chatRuntime.inferenceStatusByThread['t-inv']).toBeUndefined();
+      expect(store.getState().chatRuntime.streamingAssistantByThread['t-inv']).toBeUndefined();
+    });
+
+    it('terminates running tool-timeline rows on chat_done', () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onToolCall?.({
+          thread_id: 't-inv',
+          request_id: 'r1',
+          round: 0,
+          tool_name: 'search',
+          skill_id: 'notion',
+          args: {},
+          tool_call_id: 'call-1',
+        });
+      });
+      expect(store.getState().chatRuntime.toolTimelineByThread['t-inv']?.[0]?.status).toBe(
+        'running'
+      );
+
+      act(() => {
+        listeners.onDone?.({
+          thread_id: 't-inv',
+          request_id: 'r1',
+          full_response: '',
+          rounds_used: 1,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+        });
+      });
+
+      const timeline = store.getState().chatRuntime.toolTimelineByThread['t-inv'] ?? [];
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0]?.status).toBe('success');
+    });
+
+    it('transitions running tool-timeline rows to error on chat_error', () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onToolCall?.({
+          thread_id: 't-err',
+          request_id: 'r1',
+          round: 0,
+          tool_name: 'search',
+          skill_id: 'notion',
+          args: {},
+          tool_call_id: 'call-err',
+        });
+      });
+
+      act(() => {
+        listeners.onError?.({
+          thread_id: 't-err',
+          request_id: 'r1',
+          message: 'timeout',
+          error_type: 'timeout',
+          round: 0,
+        });
+      });
+
+      const timeline = store.getState().chatRuntime.toolTimelineByThread['t-err'] ?? [];
+      expect(timeline[0]?.status).toBe('error');
+      expect(store.getState().chatRuntime.inferenceStatusByThread['t-err']).toBeUndefined();
+    });
+  });
+});

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { Provider } from 'react-redux';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -6,8 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as chatService from '../../services/chatService';
 import { threadApi } from '../../services/api/threadApi';
 import { store } from '../../store';
+import { clearAllChatRuntime } from '../../store/chatRuntimeSlice';
 import { setStatusForUser } from '../../store/socketSlice';
-import { setSelectedThread } from '../../store/threadSlice';
+import { clearAllThreads, loadThreads, setSelectedThread } from '../../store/threadSlice';
 import ChatRuntimeProvider from '../ChatRuntimeProvider';
 
 vi.mock('../../services/chatService', async () => {
@@ -54,8 +55,8 @@ function renderProvider(): chatService.ChatEventListeners {
 function resetRuntimeState() {
   // Reset chatRuntime + thread slices to clean state by dispatching a thread
   // selection that clears ambient state.
-  store.dispatch({ type: 'thread/clearAllThreads' });
-  store.dispatch({ type: 'chatRuntime/clearAllChatRuntime' });
+  store.dispatch(clearAllThreads());
+  store.dispatch(clearAllChatRuntime());
   store.dispatch(setStatusForUser({ userId: '__pending__', status: 'disconnected' }));
 }
 
@@ -152,10 +153,13 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
 
   describe('proactive thread resolution', () => {
     it('reuses the selected thread when resolving a proactive: sender', async () => {
-      store.dispatch({
-        type: 'thread/loadThreads/fulfilled',
-        payload: { threads: [{ id: 'visible-thread', title: 'x' }] },
-      });
+      store.dispatch(
+        loadThreads.fulfilled(
+          { threads: [{ id: 'visible-thread', title: 'x' }] as never, count: 1 },
+          'req-id',
+          undefined
+        )
+      );
       store.dispatch(setSelectedThread('visible-thread'));
       const listeners = renderProvider();
 
@@ -165,16 +169,15 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
           request_id: 'req-p1',
           full_response: 'ping',
         });
-        // Allow the queued async proactive dispatch to flush.
-        await Promise.resolve();
-        await Promise.resolve();
       });
 
       // createNewThread must NOT be invoked when a visible thread already exists.
       expect(threadApi.createNewThread).not.toHaveBeenCalled();
-      expect(threadApi.appendMessage).toHaveBeenCalledWith(
-        'visible-thread',
-        expect.objectContaining({ content: 'ping', sender: 'agent' })
+      await waitFor(() =>
+        expect(threadApi.appendMessage).toHaveBeenCalledWith(
+          'visible-thread',
+          expect.objectContaining({ content: 'ping', sender: 'agent' })
+        )
       );
     });
 
@@ -196,11 +199,9 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
           request_id: 'req-p2',
           full_response: 'bootstrap msg',
         });
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
       });
 
+      await waitFor(() => expect(threadApi.appendMessage).toHaveBeenCalled());
       expect(threadApi.createNewThread).toHaveBeenCalledTimes(1);
       expect(threadApi.appendMessage).toHaveBeenCalledWith(
         'created-thread',
@@ -209,10 +210,13 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
     });
 
     it('deduplicates identical proactive messages from the same sender', async () => {
-      store.dispatch({
-        type: 'thread/loadThreads/fulfilled',
-        payload: { threads: [{ id: 'visible-thread', title: 'x' }] },
-      });
+      store.dispatch(
+        loadThreads.fulfilled(
+          { threads: [{ id: 'visible-thread', title: 'x' }] as never, count: 1 },
+          'req-id',
+          undefined
+        )
+      );
       store.dispatch(setSelectedThread('visible-thread'));
       const listeners = renderProvider();
 
@@ -225,12 +229,9 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       await act(async () => {
         listeners.onProactiveMessage?.(event);
         listeners.onProactiveMessage?.(event);
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
       });
 
-      expect(threadApi.appendMessage).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(threadApi.appendMessage).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/app/src/providers/__tests__/CoreStateProvider.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.test.tsx
@@ -1,0 +1,212 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as coreStateApi from '../../services/coreStateApi';
+import { setCoreStateSnapshot } from '../../lib/coreState/store';
+import CoreStateProvider, { useCoreState } from '../CoreStateProvider';
+
+vi.mock('../../services/coreStateApi');
+vi.mock('../../services/analytics', () => ({ syncAnalyticsConsent: vi.fn() }));
+
+type Snapshot = Awaited<ReturnType<typeof coreStateApi.fetchCoreAppSnapshot>>;
+
+function makeSnapshot(overrides: {
+  userId?: string | null;
+  sessionToken?: string | null;
+  isAuthenticated?: boolean;
+}): Snapshot {
+  return {
+    auth: {
+      isAuthenticated: overrides.isAuthenticated ?? Boolean(overrides.userId),
+      userId: overrides.userId ?? null,
+      user: null,
+      profileId: null,
+    },
+    sessionToken: overrides.sessionToken ?? null,
+    currentUser: null,
+    onboardingCompleted: false,
+    analyticsEnabled: false,
+    localState: {},
+    runtime: {
+      screenIntelligence: null as never,
+      localAi: null as never,
+      autocomplete: null as never,
+      service: null as never,
+    },
+  };
+}
+
+type CoreStateContextValue = ReturnType<typeof useCoreState>;
+
+function Consumer({ captureCtx }: { captureCtx?: (ctx: CoreStateContextValue) => void }) {
+  const state = useCoreState();
+  useEffect(() => {
+    captureCtx?.(state);
+  });
+  return (
+    <div>
+      <span data-testid="user">{state.snapshot.auth.userId ?? 'none'}</span>
+      <span data-testid="token">{state.snapshot.sessionToken ?? 'none'}</span>
+      <span data-testid="teams">{state.teams.map(t => t.team._id).join(',')}</span>
+      <span data-testid="members">
+        {Object.entries(state.teamMembersById)
+          .map(([k, v]) => `${k}:${v.length}`)
+          .join(',')}
+      </span>
+      <span data-testid="invites">
+        {Object.entries(state.teamInvitesById)
+          .map(([k, v]) => `${k}:${v.length}`)
+          .join(',')}
+      </span>
+      <span data-testid="ready">{state.isReady ? 'ready' : 'boot'}</span>
+    </div>
+  );
+}
+
+function resetCoreStateStore() {
+  setCoreStateSnapshot({
+    isBootstrapping: true,
+    isReady: false,
+    snapshot: {
+      auth: { isAuthenticated: false, userId: null, user: null, profileId: null },
+      sessionToken: null,
+      currentUser: null,
+      onboardingCompleted: false,
+      analyticsEnabled: false,
+      localState: { encryptionKey: null, primaryWalletAddress: null, onboardingTasks: null },
+      runtime: { screenIntelligence: null, localAi: null, autocomplete: null, service: null },
+    },
+    teams: [],
+    teamMembersById: {},
+    teamInvitesById: {},
+  });
+}
+
+describe('CoreStateProvider — identity-change cache clearing', () => {
+  const fetchSnapshot = vi.mocked(coreStateApi.fetchCoreAppSnapshot);
+  const listTeams = vi.mocked(coreStateApi.listTeams);
+  const getTeamMembers = vi.mocked(coreStateApi.getTeamMembers);
+  const getTeamInvites = vi.mocked(coreStateApi.getTeamInvites);
+
+  beforeEach(() => {
+    fetchSnapshot.mockReset();
+    listTeams.mockReset();
+    getTeamMembers.mockReset();
+    getTeamInvites.mockReset();
+    resetCoreStateStore();
+  });
+
+  it('clears teams/members/invites when the userId changes between refreshes', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }));
+    listTeams.mockResolvedValue([{ team: { _id: 'team-u1' }, role: 'owner' } as never]);
+    getTeamMembers.mockResolvedValue([{ userId: 'u1' } as never]);
+    getTeamInvites.mockResolvedValue([{ id: 'invite-u1' } as never]);
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer
+          captureCtx={next => {
+            ctx = next;
+          }}
+        />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('u1'));
+    await waitFor(() => expect(screen.getByTestId('teams').textContent).toBe('team-u1'));
+
+    // Seed team-scoped caches we expect to be wiped on identity flip.
+    await act(async () => {
+      await ctx!.refreshTeamMembers('team-u1');
+      await ctx!.refreshTeamInvites('team-u1');
+    });
+    expect(screen.getByTestId('members').textContent).toBe('team-u1:1');
+    expect(screen.getByTestId('invites').textContent).toBe('team-u1:1');
+
+    // Flip identity: next refresh returns u2.
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u2', sessionToken: 'tok2' }));
+    listTeams.mockResolvedValue([]);
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('u2'));
+    expect(screen.getByTestId('teams').textContent).toBe('');
+    expect(screen.getByTestId('members').textContent).toBe('');
+    expect(screen.getByTestId('invites').textContent).toBe('');
+  });
+
+  it('clears scoped caches when transitioning authenticated → unauthenticated', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }));
+    listTeams.mockResolvedValue([{ team: { _id: 'team-a' }, role: 'owner' } as never]);
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer
+          captureCtx={next => {
+            ctx = next;
+          }}
+        />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('teams').textContent).toBe('team-a'));
+
+    fetchSnapshot.mockResolvedValue(
+      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('none'));
+    expect(screen.getByTestId('teams').textContent).toBe('');
+  });
+
+  it('preserves teams cache when identity is unchanged across refreshes', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }));
+    listTeams.mockResolvedValueOnce([
+      { team: { _id: 'team-x' }, role: 'owner' } as never,
+      { team: { _id: 'team-y' }, role: 'member' } as never,
+    ]);
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer
+          captureCtx={next => {
+            ctx = next;
+          }}
+        />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('teams').textContent).toBe('team-x,team-y'));
+
+    // Subsequent refresh returns same identity — team cache must be preserved
+    // because refreshTeams is not re-issued by normal refresh.
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    expect(screen.getByTestId('teams').textContent).toBe('team-x,team-y');
+    expect(listTeams).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets isReady=true once the first snapshot resolves', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: null, sessionToken: null }));
+    listTeams.mockResolvedValue([]);
+
+    render(
+      <CoreStateProvider>
+        <Consumer />
+      </CoreStateProvider>
+    );
+
+    expect(screen.getByTestId('ready').textContent).toBe('boot');
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('ready'));
+  });
+});

--- a/app/src/providers/__tests__/SocketProvider.test.tsx
+++ b/app/src/providers/__tests__/SocketProvider.test.tsx
@@ -1,0 +1,131 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCoreState } from '../CoreStateProvider';
+import SocketProvider from '../SocketProvider';
+
+vi.mock('../CoreStateProvider', () => ({ useCoreState: vi.fn() }));
+
+vi.mock('../../services/socketService', () => ({
+  socketService: { connect: vi.fn(), disconnect: vi.fn() },
+}));
+
+vi.mock('../../services/coreRpcClient', () => ({ callCoreRpc: vi.fn().mockResolvedValue({}) }));
+
+vi.mock('../../hooks/useDaemonLifecycle', () => ({
+  useDaemonLifecycle: () => ({
+    isAutoStartEnabled: false,
+    connectionAttempts: 0,
+    isRecovering: false,
+    maxAttemptsReached: false,
+  }),
+}));
+
+type SnapshotShape = { sessionToken: string | null };
+
+function setToken(token: string | null) {
+  vi.mocked(useCoreState).mockReturnValue({
+    snapshot: { sessionToken: token } as SnapshotShape,
+  } as unknown as ReturnType<typeof useCoreState>);
+}
+
+describe('SocketProvider — token transitions', () => {
+  let socketService: { connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> };
+  let callCoreRpc: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    socketService = (await import('../../services/socketService'))
+      .socketService as unknown as typeof socketService;
+    callCoreRpc = (await import('../../services/coreRpcClient'))
+      .callCoreRpc as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('does not connect when mounted with a null token', () => {
+    setToken(null);
+    render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+
+    expect(socketService.connect).not.toHaveBeenCalled();
+    expect(socketService.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('connects socket and triggers sidecar RPC when a token first appears', () => {
+    setToken('jwt-abc');
+    render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+
+    expect(socketService.connect).toHaveBeenCalledTimes(1);
+    expect(socketService.connect).toHaveBeenCalledWith('jwt-abc');
+    expect(callCoreRpc).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'openhuman.socket_connect_with_session' })
+    );
+  });
+
+  it('does not reconnect when the same token re-renders', () => {
+    setToken('jwt-abc');
+    const { rerender } = render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+    expect(socketService.connect).toHaveBeenCalledTimes(1);
+
+    // Same token on re-render — should not trigger another connect.
+    setToken('jwt-abc');
+    rerender(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+
+    expect(socketService.connect).toHaveBeenCalledTimes(1);
+    expect(socketService.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('disconnects when the token is cleared after being set', () => {
+    setToken('jwt-abc');
+    const { rerender } = render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+    expect(socketService.connect).toHaveBeenCalledTimes(1);
+
+    setToken(null);
+    rerender(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+
+    expect(socketService.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconnects when the token rotates to a new value', () => {
+    setToken('jwt-first');
+    const { rerender } = render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+    expect(socketService.connect).toHaveBeenCalledTimes(1);
+    expect(socketService.connect).toHaveBeenLastCalledWith('jwt-first');
+
+    setToken('jwt-second');
+    rerender(
+      <SocketProvider>
+        <div />
+      </SocketProvider>
+    );
+
+    expect(socketService.connect).toHaveBeenCalledTimes(2);
+    expect(socketService.connect).toHaveBeenLastCalledWith('jwt-second');
+  });
+});

--- a/app/src/providers/__tests__/SocketProvider.test.tsx
+++ b/app/src/providers/__tests__/SocketProvider.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { callCoreRpc } from '../../services/coreRpcClient';
+import { socketService } from '../../services/socketService';
 import { useCoreState } from '../CoreStateProvider';
 import SocketProvider from '../SocketProvider';
 
@@ -30,15 +32,8 @@ function setToken(token: string | null) {
 }
 
 describe('SocketProvider — token transitions', () => {
-  let socketService: { connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> };
-  let callCoreRpc: ReturnType<typeof vi.fn>;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    socketService = (await import('../../services/socketService'))
-      .socketService as unknown as typeof socketService;
-    callCoreRpc = (await import('../../services/coreRpcClient'))
-      .callCoreRpc as unknown as ReturnType<typeof vi.fn>;
   });
 
   it('does not connect when mounted with a null token', () => {
@@ -49,8 +44,8 @@ describe('SocketProvider — token transitions', () => {
       </SocketProvider>
     );
 
-    expect(socketService.connect).not.toHaveBeenCalled();
-    expect(socketService.disconnect).not.toHaveBeenCalled();
+    expect(vi.mocked(socketService.connect)).not.toHaveBeenCalled();
+    expect(vi.mocked(socketService.disconnect)).not.toHaveBeenCalled();
   });
 
   it('connects socket and triggers sidecar RPC when a token first appears', () => {
@@ -61,9 +56,9 @@ describe('SocketProvider — token transitions', () => {
       </SocketProvider>
     );
 
-    expect(socketService.connect).toHaveBeenCalledTimes(1);
-    expect(socketService.connect).toHaveBeenCalledWith('jwt-abc');
-    expect(callCoreRpc).toHaveBeenCalledWith(
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledWith('jwt-abc');
+    expect(vi.mocked(callCoreRpc)).toHaveBeenCalledWith(
       expect.objectContaining({ method: 'openhuman.socket_connect_with_session' })
     );
   });
@@ -75,7 +70,7 @@ describe('SocketProvider — token transitions', () => {
         <div />
       </SocketProvider>
     );
-    expect(socketService.connect).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledTimes(1);
 
     // Same token on re-render — should not trigger another connect.
     setToken('jwt-abc');
@@ -85,8 +80,8 @@ describe('SocketProvider — token transitions', () => {
       </SocketProvider>
     );
 
-    expect(socketService.connect).toHaveBeenCalledTimes(1);
-    expect(socketService.disconnect).not.toHaveBeenCalled();
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(socketService.disconnect)).not.toHaveBeenCalled();
   });
 
   it('disconnects when the token is cleared after being set', () => {
@@ -96,7 +91,7 @@ describe('SocketProvider — token transitions', () => {
         <div />
       </SocketProvider>
     );
-    expect(socketService.connect).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledTimes(1);
 
     setToken(null);
     rerender(
@@ -105,7 +100,7 @@ describe('SocketProvider — token transitions', () => {
       </SocketProvider>
     );
 
-    expect(socketService.disconnect).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(socketService.disconnect)).toHaveBeenCalledTimes(1);
   });
 
   it('reconnects when the token rotates to a new value', () => {
@@ -115,8 +110,8 @@ describe('SocketProvider — token transitions', () => {
         <div />
       </SocketProvider>
     );
-    expect(socketService.connect).toHaveBeenCalledTimes(1);
-    expect(socketService.connect).toHaveBeenLastCalledWith('jwt-first');
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(socketService.connect)).toHaveBeenLastCalledWith('jwt-first');
 
     setToken('jwt-second');
     rerender(
@@ -125,7 +120,7 @@ describe('SocketProvider — token transitions', () => {
       </SocketProvider>
     );
 
-    expect(socketService.connect).toHaveBeenCalledTimes(2);
-    expect(socketService.connect).toHaveBeenLastCalledWith('jwt-second');
+    expect(vi.mocked(socketService.connect)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(socketService.connect)).toHaveBeenLastCalledWith('jwt-second');
   });
 });


### PR DESCRIPTION
## Summary

- Add focused provider regression tests for `CoreStateProvider`, `SocketProvider`, and `ChatRuntimeProvider`.
- Cover identity transitions, socket reconnect/disconnect behavior, and chat runtime dedupe/state-machine rules.
- Keep the change test-only with no production code edits.

## Problem

- Recent frontend regressions affected provider and runtime behavior that was not deterministically locked by tests.
- Those flows are stateful and easy to break silently when adjacent code changes.

## Solution

- Add targeted tests under `app/src/providers/__tests__/` for the highest-risk transitions and invariants.
- Cover cache clearing/preservation, token-driven socket lifecycle, and chat/tool timeline dedupe and status clearing.
- Validate with the focused provider suite plus full frontend test, lint, typecheck, and format passes.

## Submission Checklist

- [x] **Unit tests** — Vitest coverage added and full frontend suite passed
- [ ] **E2E / integration** — Not applicable; this PR is test-only unit coverage for existing provider behavior
- [x] **N/A** — E2E is not applicable because no user-visible flow changed in production code
- [ ] **Doc comments** — Not applicable; no public API or non-obvious module surface was added
- [ ] **Inline comments** — Not applicable; test-only change and assertions are direct

## Impact

- No runtime behavior change expected; this is frontend test coverage only.
- Reduces regression risk around provider bootstrapping, socket lifecycle, and chat runtime event handling.

## Related

- Issue(s):
- Follow-up PR(s)/TODOs: `useDaemonLifecycle` deterministic regression coverage