### PR TITLE
chore(claude-md): slim CLAUDE.md, move deep-dives into docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,13 @@
 
 This file orients contributors and coding agents. Authoritative narrative architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Frontend layout: [`docs/src/README.md`](docs/src/README.md). Tauri shell: [`docs/src-tauri/README.md`](docs/src-tauri/README.md).
 
+## Detailed guides (read on demand)
+
+- **Testing** (unit + E2E + mock backend + Rust tests): [`docs/TESTING.md`](docs/TESTING.md)
+- **Feature workflow + debug logging + controller migration + platform notes**: [`docs/feature-workflow.md`](docs/feature-workflow.md)
+- **Event bus** (`DomainEvent` pub/sub and `NativeRegistry` typed in-process dispatch): [`docs/event-bus.md`](docs/event-bus.md)
+- **Design tokens**: [`docs/DESIGN_GUIDELINES.md`](docs/DESIGN_GUIDELINES.md)
+
 ---
 
 ## Repository layout
@@ -12,19 +19,19 @@ This file orients contributors and coding agents. Authoritative narrative archit
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`app/`**              | Yarn workspace **`openhuman-app`**: Vite + React (`app/src/`), Tauri desktop host (`app/src-tauri/`), Vitest tests                                                                                          |
 | **Repo root `src/`**    | Rust library **`openhuman_core`** and **`openhuman`** CLI binary entrypoint (`src/main.rs`) — `core_server`, `openhuman::*` domains, skills runtime (QuickJS / `rquickjs`), MCP routing in the core process |
-| **Skills registry**     | **[`tinyhumansai/openhuman-skills`](https://github.com/tinyhumansai/openhuman-skills)** on GitHub — canonical skill packages and TS build; not vendored in this tree (see blurb below).                     |
-| **`Cargo.toml`** (root) | Core crate; `cargo build --bin openhuman` produces the sidecar the UI stages via `app`’s `core:stage`                                                                                                       |
+| **Skills registry**     | **[`tinyhumansai/openhuman-skills`](https://github.com/tinyhumansai/openhuman-skills)** on GitHub — canonical skill packages and TS build; not vendored in this tree.                                       |
+| **`Cargo.toml`** (root) | Core crate; `cargo build --bin openhuman` produces the sidecar the UI stages via `app`'s `core:stage`                                                                                                       |
 | **`docs/`**             | Architecture and module guides (numbered pages under `docs/src/`, `docs/src-tauri/`)                                                                                                                        |
 
 Commands in documentation assume the **repo root** unless noted: `yarn dev` runs the `app` workspace.
 
-**Skills registry:** Skill sources and the bundler live in **[github.com/tinyhumansai/openhuman-skills](https://github.com/tinyhumansai/openhuman-skills)**. Clone that repository to author or change skills (`yarn install`, `yarn build`). The desktop app’s skills catalog defaults to that GitHub slug; override with `VITE_SKILLS_GITHUB_REPO` (see [`app/src/utils/config.ts`](app/src/utils/config.ts)).
+**Skills registry:** Skill sources and the bundler live in **[github.com/tinyhumansai/openhuman-skills](https://github.com/tinyhumansai/openhuman-skills)**. Clone that repository to author or change skills (`yarn install`, `yarn build`). The desktop app's skills catalog defaults to that GitHub slug; override with `VITE_SKILLS_GITHUB_REPO` (see [`app/src/utils/config.ts`](app/src/utils/config.ts)).
 
 ---
 
 ## Runtime scope
 
-- **Shipped product**: desktop — Windows, macOS, Linux (see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) “Platform reach”).
+- **Shipped product**: desktop — Windows, macOS, Linux (see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) "Platform reach").
 - **Tauri host** (`app/src-tauri`): **desktop-only** (`compile_error!` for non-desktop targets). Do not add Android/iOS branches inside `app/src-tauri`.
 - **Core binary** (`openhuman`): spawned/staged as a **sidecar**; the Web UI talks to it over HTTP (`core_rpc_relay` + `core_rpc` client), not by re-implementing domain logic in the shell.
 
@@ -69,7 +76,7 @@ cargo build --manifest-path Cargo.toml --bin openhuman
 cargo check --manifest-path app/src-tauri/Cargo.toml
 ```
 
-**Tests**: Vitest in `app/` (`yarn test`, `yarn test:coverage`). Rust tests via `cargo test` at repo root as wired in `app/package.json`.
+**Tests**: Vitest in `app/` (`yarn test`, `yarn test:coverage`). Rust tests via `cargo test` at repo root as wired in `app/package.json`. See [`docs/TESTING.md`](docs/TESTING.md) for the full guide.
 
 **Quality**: ESLint + Prettier + Husky in the `app` workspace.
 
@@ -88,164 +95,14 @@ Environment variables are documented in two `.env.example` files:
 
 ---
 
-## Testing Guide (Unit + E2E)
+## Frontend (`app/src/`) — quick map
 
-### Unit tests (Vitest)
-
-- **Where tests live**: co-locate as `*.test.ts` / `*.test.tsx` under `app/src/**`.
-- **Runner/config**: Vitest with `app/test/vitest.config.ts` and shared setup in `app/src/test/setup.ts`.
-- **Run**:
-
-```bash
-yarn test:unit
-yarn test:coverage
-```
-
-- **Authoring rules**:
-  - Prefer testing behavior over implementation details.
-  - Use existing helpers from `app/src/test/` (`test-utils.tsx`, shared mock backend) before adding new harness code.
-  - Keep tests deterministic: avoid real network calls, time-sensitive flakes, or hidden global state.
-
-### Shared mock backend (app + Rust tests)
-
-- **Core implementation**: `scripts/mock-api-core.mjs`
-- **Standalone server entrypoint**: `scripts/mock-api-server.mjs`
-- **E2E wrapper**: `app/test/e2e/mock-server.ts`
-- **Vitest unit setup**: `app/src/test/setup.ts` starts the shared mock server by default on `http://127.0.0.1:5005`.
-
-Key admin endpoints:
-
-- `GET /__admin/health`
-- `POST /__admin/reset`
-- `POST /__admin/behavior`
-- `GET /__admin/requests`
-
-Run manually:
-
-```bash
-yarn mock:api
-curl -s http://127.0.0.1:18473/__admin/health
-```
-
-### E2E tests (WDIO — dual platform)
-
-Full guide: [`docs/E2E-TESTING.md`](docs/E2E-TESTING.md).
-
-Two automation backends:
-- **Linux (CI default)**: `tauri-driver` (WebDriver, port 4444) — drives the debug binary directly
-- **macOS (local dev)**: Appium Mac2 (XCUITest, port 4723) — drives the `.app` bundle
-
-- **Where specs live**: `app/test/e2e/specs/*.spec.ts`
-- **Shared harness**:
-  - Platform detection: `app/test/e2e/helpers/platform.ts`
-  - Element helpers: `app/test/e2e/helpers/element-helpers.ts`
-  - Deep link helpers: `app/test/e2e/helpers/deep-link-helpers.ts`
-  - App lifecycle: `app/test/e2e/helpers/app-helpers.ts`
-  - Mock backend: `app/test/e2e/mock-server.ts`
-  - WDIO config: `app/test/wdio.conf.ts` (auto-detects platform)
-
-- **Build + run**:
-
-```bash
-# Build app + stage core sidecar (detects macOS vs Linux automatically)
-yarn test:e2e:build
-
-# Run one spec
-bash app/scripts/e2e-run-spec.sh test/e2e/specs/smoke.spec.ts smoke
-
-# Run all flow specs
-yarn test:e2e:all:flows
-
-# Docker on macOS (run Linux E2E locally)
-docker compose -f e2e/docker-compose.yml run --rm e2e
-```
-
-- **Authoring rules**:
-  - Ensure each spec is runnable in isolation.
-  - Use helpers from `element-helpers.ts` — never use raw `XCUIElementType*` selectors in specs.
-  - Use `clickNativeButton()`, `hasAppChrome()`, `waitForWebView()`, `clickToggle()` for cross-platform element interaction.
-  - Assert both UI outcomes and backend/mock effects when relevant.
-  - Add failure diagnostics (request logs, `dumpAccessibilityTree()`) for faster debugging by agents.
-
-### Deterministic core-sidecar reset
-
-By default, `app/scripts/e2e-run-spec.sh` creates and cleans a temp `OPENHUMAN_WORKSPACE`
-automatically when the variable is not provided.
-
-If you need a fixed workspace for debugging, provide one explicitly:
-
-```bash
-export OPENHUMAN_WORKSPACE="$(mktemp -d)"
-yarn test:e2e:build
-bash app/scripts/e2e-run-spec.sh test/e2e/specs/smoke.spec.ts smoke
-rm -rf "$OPENHUMAN_WORKSPACE"
-```
-
-- `OPENHUMAN_WORKSPACE` redirects core config + workspace storage away from `~/.openhuman`.
-- Default reset strategy:
-  - Rebuild/stage sidecar once per E2E run (`yarn test:e2e:build`).
-  - Isolate state per test case with a fresh temp workspace (default behavior in `e2e-run-spec.sh`).
-
-### Rust tests with mock backend
-
-Use the shared mock backend runner so Rust unit/integration tests get deterministic API behavior:
-
-```bash
-yarn test:rust
-# or targeted
-bash scripts/test-rust-with-mock.sh --test json_rpc_e2e
-```
-
-Example per-test-case pattern inside a harness script:
-
-```bash
-run_case() {
-  export OPENHUMAN_WORKSPACE="$(mktemp -d)"
-  bash app/scripts/e2e-run-spec.sh "$1" "$2"
-  rm -rf "$OPENHUMAN_WORKSPACE"
-}
-```
-
-### Test authoring checklist
-
-- Add/update unit tests for logic changes before stacking additional features.
-- Add/update E2E coverage for user-visible flows and cross-process integration behavior.
-- Keep new tests independent, deterministic, and debuggable from logs alone.
-- When touching core/sidecar behavior, validate both:
-  - `yarn test:unit`
-  - targeted E2E spec(s) via `app/scripts/e2e-run-spec.sh`
-
----
-
-## Frontend (`app/src/`)
-
-### Provider chain (`app/src/App.tsx`)
-
-Order matters for auth and realtime:
-
-`Redux Provider` → `PersistGate` → **`UserProvider`** → **`SocketProvider`** → **`AIProvider`** → **`SkillProvider`** → **`HashRouter`** → `AppRoutes`.
-
-There is **no** `TelegramProvider` in the current tree; Telegram may appear in UI copy or legacy settings, but MTProto is not an active provider here.
-
-### State (`app/src/store/`)
-
-Redux Toolkit slices include **auth**, **user**, **socket**, **ai**, **skills**, **team**, and related modules. Prefer Redux (and persist where configured) over ad hoc `localStorage` for app state; see project rules for exceptions.
-
-### Services (`app/src/services/`)
-
-Singleton-style modules include **`apiClient`**, **`socketService`**, **`coreRpcClient`** (HTTP bridge to the core process), and domain **`api/*`** clients. There is **no** `mtprotoService` in this tree.
-
-### MCP (`app/src/lib/mcp/`)
-
-Transport, validation, and types for JSON-RPC-style messaging over Socket.io — **not** a large Telegram tool pack. Tooling for agents is driven by the **skills** system and backend; see `agentToolRegistry.ts` and core RPC.
-
-### Routing (`app/src/AppRoutes.tsx`)
-
-Hash routes include `/`, `/onboarding`, `/mnemonic`, `/home`, `/intelligence`, `/skills`, `/conversations`, `/invites`, `/agents`, `/settings/*`, plus `DefaultRedirect`. **No** dedicated `/login` route in `AppRoutes` (auth flows use the welcome/onboarding paths).
-
-### AI configuration
-
-Bundled prompts live under **`src/openhuman/agent/prompts/`** at the **repository root** (also bundled via `app/src-tauri/tauri.conf.json` `resources`). Loaders under `app/src/lib/ai/` use `?raw` imports, optional remote fetch, and in Tauri **`ai_get_config` / `ai_refresh_config`** for packaged content.
+- **Provider chain** (`App.tsx`, order matters for auth and realtime): `Redux Provider` → `PersistGate` → **`UserProvider`** → **`SocketProvider`** → **`AIProvider`** → **`SkillProvider`** → **`HashRouter`** → `AppRoutes`. There is **no** `TelegramProvider`; MTProto is not an active provider here.
+- **State** (`store/`): Redux Toolkit slices — **auth**, **user**, **socket**, **ai**, **skills**, **team**. Prefer Redux (and persist where configured) over ad hoc `localStorage`.
+- **Services** (`services/`): singleton-style — **`apiClient`**, **`socketService`**, **`coreRpcClient`** (HTTP bridge to the core process), domain **`api/*`** clients. No `mtprotoService`.
+- **MCP** (`lib/mcp/`): transport/validation/types for JSON-RPC-style messaging over Socket.io — **not** a Telegram tool pack. Agent tooling is driven by the **skills** system and backend.
+- **Routes** (`AppRoutes.tsx`): hash routes `/`, `/onboarding`, `/mnemonic`, `/home`, `/intelligence`, `/skills`, `/conversations`, `/invites`, `/agents`, `/settings/*`, plus `DefaultRedirect`. **No** dedicated `/login` route.
+- **AI configuration**: bundled prompts live under **`src/openhuman/agent/prompts/`** at the **repository root** (also bundled via `app/src-tauri/tauri.conf.json` `resources`). Loaders under `app/src/lib/ai/` use `?raw` imports, optional remote fetch, and in Tauri **`ai_get_config` / `ai_refresh_config`** for packaged content.
 
 ---
 
@@ -255,238 +112,56 @@ Thin desktop host: window management, daemon health bridging, **core process lif
 
 Registered IPC commands (see [`docs/src-tauri/02-commands.md`](docs/src-tauri/02-commands.md)) include **`greet`**, **`write_ai_config_file`**, **`ai_get_config`**, **`ai_refresh_config`**, **`core_rpc_relay`**, **window** commands, and **OpenHuman service / daemon host** helpers (`openhuman_*`).
 
-Deep link plugin is registered where supported; behavior is platform-specific (see platform notes below).
+Deep link plugin is registered where supported; behavior is platform-specific (see [`docs/feature-workflow.md`](docs/feature-workflow.md) platform notes).
 
 ---
 
-## Rust core (repo root `src/`)
+## Rust core (repo root `src/`) — key rules
 
 - **`openhuman/`** — Domain logic (skills, memory, channels, config, …). RPC controllers live in **`rpc.rs`** files per domain; use **`RpcOutcome<T>`** pattern per [`AGENTS.md`](AGENTS.md) / internal rules.
-- **`src/openhuman/` module layout**: **New** functionality must live in a **dedicated subdirectory** (its own folder/module, e.g. `openhuman/my_domain/mod.rs` plus related files, or a new subfolder under an existing domain). Do **not** add new standalone `*.rs` files directly at `src/openhuman/` root; place new code in a module directory and declare it from `mod.rs` (or merge into an existing domain folder).
-- **Controller schema contract**: Shared controller metadata types live in **`src/core/mod.rs`** (`ControllerSchema`, `FieldSchema`, `TypeSchema`) and are consumed by adapters (RPC/CLI) in different ways.
-- **Domain schema files**: For each domain, define controller schema metadata in a dedicated module inside the domain folder (example: **`src/openhuman/cron/schemas.rs`**) and export from the domain `mod.rs`.
-- **Controller-only exposure rule**: Expose domain functionality to **CLI and JSON-RPC through the controller registry** (`schemas.rs` + registered handlers). Do **not** add domain-specific branches or one-off transport logic in `src/core/cli.rs` or `src/core/jsonrpc.rs` just to expose a feature.
+- **`src/openhuman/` module layout**: **New** functionality must live in a **dedicated subdirectory** (its own folder/module, e.g. `openhuman/my_domain/mod.rs` plus related files, or a new subfolder under an existing domain). Do **not** add new standalone `*.rs` files directly at `src/openhuman/` root.
+- **Controller schema contract**: Shared types live in **`src/core/mod.rs`** (`ControllerSchema`, `FieldSchema`, `TypeSchema`); domain metadata in a dedicated module inside the domain folder (example: **`src/openhuman/cron/schemas.rs`**), exported from the domain `mod.rs`.
+- **Controller-only exposure rule**: Expose domain functionality to **CLI and JSON-RPC through the controller registry** (`schemas.rs` + registered handlers). Do **not** add domain-specific branches or one-off transport logic in `src/core/cli.rs` or `src/core/jsonrpc.rs`.
 - **Light `mod.rs` rule**: Keep domain `mod.rs` files light and export-focused. Put operational code in sibling files (example: `ops.rs`, `store.rs`, `schedule.rs`, `types.rs`), then re-export the public API from `mod.rs`.
 - **`core_server/`** — Transport only: Axum/HTTP, JSON-RPC envelope, CLI parsing, **dispatch** (`core_server::dispatch`) — **no** heavy business logic here.
 - **Layering**: Implementation in `openhuman::<domain>/`, controllers in `openhuman::<domain>/rpc.rs`, routes in `core_server/`.
 
 Skills runtime uses **QuickJS** (`rquickjs`) in **`src/openhuman/skills/`** (e.g. `qjs_skill_instance.rs`, `qjs_engine.rs`), not V8/deno_core in this repository.
 
-### Controller migration checklist
-
-- `src/openhuman/<domain>/mod.rs`: keep export-focused, add `mod schemas;` and re-export:
-  - `all_controller_schemas as all_<domain>_controller_schemas`
-  - `all_registered_controllers as all_<domain>_registered_controllers`
-- `src/openhuman/<domain>/schemas.rs` must define:
-  - `schemas(function: &str) -> ControllerSchema`
-  - `all_controller_schemas() -> Vec<ControllerSchema>`
-  - `all_registered_controllers() -> Vec<RegisteredController>`
-  - domain handler fns `fn handle_*(_: Map<String, Value>) -> ControllerFuture`
-- Handlers should delegate to existing domain `rpc.rs` functions during migration.
-- Wire domain exports into `src/core/all.rs` for both declared schemas and registered handlers.
-- Keep adapters generic: do not add domain-specific logic to `src/core/cli.rs` or `src/core/jsonrpc.rs`.
-- Remove migrated method branches from `src/rpc/dispatch.rs` once registry coverage is in place.
-
-### Event bus (`src/core/event_bus/`)
-
-A typed pub/sub event bus for **decoupled cross-module communication** plus a **native, in-process typed request/response** surface. Both are singletons — one instance each for the whole application. Do **not** construct `EventBus` or `NativeRegistry` directly; use the module-level functions.
-
-**When to use which surface:**
-
-- **Broadcast events** (`publish_global` / `subscribe_global`) — fire-and-forget notification. One publisher, many subscribers, no return value. Use when a module needs to _announce_ something happened and other modules may react independently.
-- **Native request/response** (`register_native_global` / `request_native_global`) — one-to-one typed Rust dispatch keyed by a method string. **Zero serialization**: trait objects (`Arc<dyn Provider>`), streaming channels (`mpsc::Sender<T>`), oneshot senders, and anything else `Send + 'static` all pass through unchanged. Use when a module needs a typed return value from another module in-process. This is **internal-only** — anything that needs to be callable over JSON-RPC should register against `src/core/all.rs` instead.
-
-**Core types** (all in `src/core/event_bus/`):
-
-| Type | File | Purpose |
-|------|------|---------|
-| `DomainEvent` | `events.rs` | `#[non_exhaustive]` enum — all cross-module events live here, grouped by domain |
-| `EventBus` | `bus.rs` | Singleton backed by `tokio::sync::broadcast`. Construction is `pub(crate)` — tests only |
-| `NativeRegistry` / `NativeRequestError` | `native_request.rs` | In-process typed request/response registry keyed by method name. Rust types only — passes trait objects, `mpsc::Sender`, and `oneshot::Sender` through without serialization |
-| `EventHandler` | `subscriber.rs` | Async trait with optional `domains()` filter for selective subscription |
-| `SubscriptionHandle` | `subscriber.rs` | RAII handle — subscriber task is cancelled on drop |
-| `TracingSubscriber` | `tracing.rs` | Built-in debug logger for all events (registered at startup) |
-
-**Singleton API** (all modules use these — never hold or pass `EventBus` / `NativeRegistry` instances):
-
-| Function | Purpose |
-|----------|---------|
-| `event_bus::init_global(capacity)` | Initialize both singletons (broadcast bus + native registry) at startup (once) |
-| `event_bus::publish_global(event)` | Publish a broadcast event from anywhere (no-op if not yet initialized) |
-| `event_bus::subscribe_global(handler)` | Subscribe to broadcast events from anywhere (returns `None` if not yet initialized) |
-| `event_bus::register_native_global(method, handler)` | Register a typed native request handler for a method name — called at startup by each domain's `bus.rs` |
-| `event_bus::request_native_global(method, req)` | Dispatch a typed native request to the registered handler — zero serialization |
-| `event_bus::global()` / `event_bus::native_registry()` | Get the underlying singleton for advanced use |
-
-**Domains:** `agent`, `memory`, `channel`, `cron`, `skill`, `tool`, `webhook`, `system`. See `events.rs` for the full variant list — events carry rich payloads so subscribers have everything they need.
-
-**Domain subscriber files** — each domain owns its `bus.rs` with `EventHandler` impls:
-- `cron/bus.rs` — `CronDeliverySubscriber` (delivers job output to channels)
-- `webhooks/bus.rs` — `WebhookRequestSubscriber` (routes incoming requests to skills, emits responses via socket)
-- `channels/bus.rs` — `ChannelInboundSubscriber` (runs agent loop for inbound socket messages)
-- `skills/bus.rs` — stub for future subscribers
-
-**Adding events for a new domain:**
-
-1. Add variants to `DomainEvent` in `events.rs` (prefix with domain name, e.g. `BillingInvoiceCreated { ... }`).
-2. Add the domain string to the `domain()` match arm.
-3. Create a `bus.rs` file **inside your domain module** (e.g. `src/openhuman/billing/bus.rs`) for subscriber implementations — each domain owns its handlers.
-4. Register subscribers in startup (e.g. `channels/runtime/startup.rs`) via the singleton.
-5. Publish events with `event_bus::publish_global(DomainEvent::YourEvent { ... })`.
-
-**Example — publishing:**
-```rust
-use crate::core::event_bus::{publish_global, DomainEvent};
-
-publish_global(DomainEvent::CronDeliveryRequested {
-    job_id: job.id.clone(),
-    channel: "telegram".into(),
-    target: "chat-123".into(),
-    output: "Job completed".into(),
-});
-```
-
-**Example — subscribing (trait-based, in `<domain>/bus.rs`):**
-```rust
-use crate::core::event_bus::{DomainEvent, EventHandler};
-use async_trait::async_trait;
-
-pub struct MyDomainSubscriber { /* dependencies */ }
-
-#[async_trait]
-impl EventHandler for MyDomainSubscriber {
-    fn name(&self) -> &str { "my_domain::handler" }
-    fn domains(&self) -> Option<&[&str]> { Some(&["cron"]) } // filter by domain
-    async fn handle(&self, event: &DomainEvent) {
-        if let DomainEvent::CronJobCompleted { job_id, success } = event {
-            // react to the event
-        }
-    }
-}
-```
-
-**Convention:** Name the handler struct `<Purpose>Subscriber` (e.g. `CronDeliverySubscriber`) and the `name()` return value `"<domain>::<purpose>"` for grep-friendly tracing output.
-
-**Adding a native request handler for a new domain:**
-
-1. Define the **request and response types** in the domain (e.g. `src/openhuman/billing/bus.rs`). Use owned fields, `Arc`s, and channels — not borrows. Types only need `Send + 'static`, not `Serialize`.
-2. Register the handler at startup from the same `bus.rs`, keyed by a stable method name prefixed with the domain (e.g. `"billing.charge_invoice"`).
-3. Callers import the request/response types from the domain's public surface and dispatch via `request_native_global`.
-4. Method name convention: `"<domain>.<verb>"` — same naming scheme as JSON-RPC method roots for consistency, but these are **not** exposed over JSON-RPC.
-
-**Example — native request (typed request/response, in `<domain>/bus.rs`):**
-```rust
-use crate::core::event_bus::{register_native_global, request_native_global};
-use std::sync::Arc;
-use tokio::sync::mpsc;
-
-// Request carries non-serializable state directly — trait objects and
-// streaming channels all pass through unchanged.
-pub struct BillingChargeRequest {
-    pub provider: Arc<dyn BillingProvider>,
-    pub amount_cents: u64,
-    pub progress_tx: Option<mpsc::Sender<String>>,
-}
-pub struct BillingChargeResponse {
-    pub charge_id: String,
-}
-
-// At startup:
-pub async fn register_billing_handlers() {
-    register_native_global::<BillingChargeRequest, BillingChargeResponse, _, _>(
-        "billing.charge",
-        |req| async move {
-            let id = req.provider.charge(req.amount_cents).await
-                .map_err(|e| e.to_string())?;
-            Ok(BillingChargeResponse { charge_id: id })
-        },
-    ).await;
-}
-
-// From another module:
-let resp: BillingChargeResponse = request_native_global(
-    "billing.charge",
-    BillingChargeRequest { provider, amount_cents: 500, progress_tx: None },
-).await?;
-```
-
-**Tests:** override production handlers by calling `register_native_global` again for the same method before exercising the code under test — the most recent registration wins. For full isolation, construct a fresh `NativeRegistry` directly via `NativeRegistry::new()` and use its `register` / `request` methods.
+Event bus and controller migration details: [`docs/event-bus.md`](docs/event-bus.md), [`docs/feature-workflow.md`](docs/feature-workflow.md).
 
 ---
-
-## App theme & design system
-
-**Design intent**: Premium, calm visual language — ocean primary (`#4A83DD`), sage / amber / coral semantic colors, Inter + Cabinet Grotesk + JetBrains Mono, Tailwind with custom radii/spacing/shadows. Details: [`docs/DESIGN_GUIDELINES.md`](docs/DESIGN_GUIDELINES.md).
 
 ## Desktop shell (Tauri) vs application code
 
 In the parent **OpenHuman** desktop app, **Tauri / Rust is a delivery vehicle**: windowing, process lifecycle, IPC to the core sidecar, and other host concerns. **Keep as much UI behavior and product logic as practical in TypeScript/React** (`app/`). Avoid growing Rust in the shell for flows that belong in the web layer unless there is a hard platform or security reason.
 
+---
+
 ## Git workflow
 
-- **GitHub issues on upstream** — File and track issues on **[tinyhumansai/openhuman](https://github.com/tinyhumansai/openhuman/)** ([Issues](https://github.com/tinyhumansai/openhuman/issues)), not only a fork’s tracker, unless the workflow explicitly says otherwise.
-- **GitHub issue templates** — Use **[`.github/ISSUE_TEMPLATE/feature.md`](.github/ISSUE_TEMPLATE/feature.md)** for new features and **[`.github/ISSUE_TEMPLATE/bug.md`](.github/ISSUE_TEMPLATE/bug.md)** for bugs; keep the same section structure and fill every required part. AI-authored issues should follow those templates verbatim.
-- **Open pull requests on upstream** — Always create PRs against **[tinyhumansai/openhuman](https://github.com/tinyhumansai/openhuman)** ([pull requests](https://github.com/tinyhumansai/openhuman/pulls)), not only a fork’s default remote, unless the workflow explicitly says otherwise.
+- **GitHub issues + PRs on upstream** — File on **[tinyhumansai/openhuman](https://github.com/tinyhumansai/openhuman/)** ([Issues](https://github.com/tinyhumansai/openhuman/issues), [PRs](https://github.com/tinyhumansai/openhuman/pulls)), not only a fork's tracker, unless the workflow explicitly says otherwise.
+- **Templates** — Use [`.github/ISSUE_TEMPLATE/feature.md`](.github/ISSUE_TEMPLATE/feature.md) / [`bug.md`](.github/ISSUE_TEMPLATE/bug.md) for issues and [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) for PRs. AI-generated text should follow them verbatim.
 - **Public repo**; push to your working branch; PRs target **`main`**.
-- Use [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md); AI-generated PR text should follow its sections and checklist.
 
 ---
 
 ## Coding philosophy
 
-- **Unix-style modules**: Prefer **individual modules** with a **single, sharp responsibility**—each should do one thing really well. Compose behavior through small, well-named units and clear boundaries instead of monolithic code.
-- **Tests before the next layer**: Ship **enough unit tests and coverage** for the behavior you are adding or changing **before** building additional features on top of it. Treat untested code as incomplete; do not accumulate depth on a shaky base.
-- **Documentation with code**: New or changed behavior must ship with matching documentation. At minimum, add concise rustdoc / code comments where the flow is not obvious, and update `AGENTS.md`, architecture docs, or feature docs when repository rules or user-visible behavior change.
+- **Unix-style modules**: individual modules with a single, sharp responsibility. Compose via small, well-named units.
+- **Tests before the next layer**: ship enough unit tests for new behavior before stacking more on top. Treat untested code as incomplete.
+- **Documentation with code**: new or changed behavior ships with matching docs. Update `AGENTS.md`, architecture docs, or feature docs when repository rules or user-visible behavior change.
 
 ---
 
-## Debug logging rule (must follow)
+## Key patterns
 
-- **Default to verbose diagnostics on new/changed flows**: Add substantial, development-oriented logs while implementing features or fixes so issues are easy to trace end-to-end.
-- **Log critical checkpoints**: Include logs at entry/exit points, branch decisions, external calls, retries/timeouts, state transitions, and error handling paths.
-- **Use structured, grep-friendly context**: Prefer stable prefixes (for example `[domain]`, `[rpc]`, `[ui-flow]`) and include correlation fields such as request IDs, method names, and entity IDs when available.
-- **Platform conventions**: In Rust, use `log` / `tracing` at `debug` or `trace`; in `app/`, use namespaced `debug` logs and dev-only detail as needed.
-- **Keep logs safe**: Never log secrets or sensitive payloads (API keys, JWTs, credentials, full PII). Redact or omit sensitive fields.
-- **Treat debuggability as a deliverable**: Changes lacking sufficient logging for diagnosis are incomplete and should be updated before handoff.
-
----
-
-## Feature design workflow (new capabilities)
-
-Follow this order so behavior is **specified**, **proven in Rust**, **proven over RPC**, then **surfaced in the UI** with matching tests.
-
-1. **Specify against the current codebase** — Ground the design in **existing** domains, controller/registry patterns, and JSON-RPC naming (`openhuman.<namespace>_<function>`). Reuse or extend documented flows in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and sibling guides; avoid parallel architectures.
-2. **Implement in Rust** — Add domain logic under `src/openhuman/<domain>/`, wire **schemas + registered handlers** into the shared registry, and land **unit tests** in the crate (`cargo test -p openhuman`, focused modules) until the feature is correct in isolation.
-3. **JSON-RPC E2E** — Add or extend **integration-style tests** that call the real HTTP JSON-RPC surface (e.g. [`tests/json_rpc_e2e.rs`](tests/json_rpc_e2e.rs), mock backend / [`scripts/test-rust-with-mock.sh`](scripts/test-rust-with-mock.sh) as appropriate) so methods, params, and outcomes match what the UI will call.
-4. **UI in the Tauri app** — Build **React** screens, state, and **`core_rpc_relay` / `coreRpcClient`** usage in `app/`; keep **business rules** in the core, not duplicated in the shell.
-5. **App unit tests** — Cover components, hooks, and clients with **Vitest** (`yarn test` / `yarn test:unit` in `app/`).
-6. **App E2E** — Add **desktop E2E** specs where the feature is user-visible (`yarn test:e2e*`, isolated workspace — see [Testing Guide (Unit + E2E)](#testing-guide-unit--e2e)) so the full stack (UI → Tauri → sidecar) behaves as intended.
-
-**Capability catalog** — When a change adds, removes, renames, relocates, or materially changes a user-facing feature, update **`src/openhuman/about_app/`** in the same work so the runtime capability catalog remains the source of truth for what the app can do.
-
-**Debug logging (throughout)** — Add **lots of development-oriented logging** as you build, not as an afterthought. In **Rust**, use `log` / `tracing` at **`debug`** or **`trace`** on RPC entry and exit, error paths, state transitions, and any branch that is hard to infer from tests alone. In **`app/`**, follow existing patterns (e.g. the **`debug`** npm package with a **namespace** per area) plus **dev-only** detail where useful. Prefer **grep-friendly prefixes** (`[feature]`, domain name, or JSON-RPC method) so terminal output from **sidecar**, **Tauri**, and **WebView** can be correlated during `yarn dev` / `tauri dev`. **Never** log secrets, raw JWTs, API keys, or full PII—redact or omit.
-
-**Planning rule:** When scoping a feature, define the **E2E scenarios (core RPC + app)** up front. Those scenarios should **cover the full intended scope**—happy paths, failure modes, auth or policy gates, and regressions you care about. If a scenario is not testable end-to-end, the spec is incomplete or the cut is too large; split or add harness support first.
-
----
-
-## Key patterns (concise)
-
-- **Debug logging**: Ship **heavy `debug`/`trace` (Rust)** and **namespaced `debug` / dev logs (`app/`)** on new flows so sidecar + WebView output is easy to grep; see [Feature design workflow](#feature-design-workflow-new-capabilities). Never log secrets or raw tokens.
-- **`src/openhuman/`**: New features go in a **folder/module**, not new root-level `src/openhuman/*.rs` files (see Rust core section).
-- **File size**: Prefer ≤ ~500 lines per source file; split modules when growing.
-- **Pre-merge checks** (when touching code): Prettier, ESLint, `tsc --noEmit` in `app/`; `cargo fmt` + `cargo check` for changed Rust (`Cargo.toml` at root and/or `app/src-tauri/Cargo.toml` as appropriate).
-- **No dynamic imports** in production **`app/src`** code — use **static** `import` / `import type` at the top of the module. Do **not** use `import()` (async dynamic import), `React.lazy(() => import(...))`, or `await import('…')` to load app modules, Tauri APIs, or RPC clients. **Why:** predictable chunk graph, simpler static analysis, fewer surprises in Tauri + Vite, and easier code review. **If a module must not run at load time** (e.g. heavy optional path), use a static import and **guard the call site** with `try/catch` or an explicit runtime check instead of deferring module load via dynamic import. **Exceptions:** Vitest harness patterns (`vi.importActual`, dynamic imports **only** inside `*.test.ts` / `__tests__` / `test/setup.ts` when required by the runner); ambient `typeof import('…')` in `.d.ts`; config files (e.g. `tailwind.config.js` JSDoc).- **Type-only imports**: `import type` where appropriate.
-- **Dual socket / tool sync**: If you change realtime protocol, keep **frontend** (`socketService` / MCP transport) and **core** socket behavior aligned (see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) dual-socket section).
-
----
-
-## Platform notes
-
-- **Vendored CEF-aware `tauri-cli` (required)**: The default runtime is **CEF**, and only the **vendored** `tauri-cli` at `app/src-tauri/vendor/tauri-cef/crates/tauri-cli` knows how to bundle the Chromium Embedded Framework into the app's `Contents/Frameworks/`. The stock `@tauri-apps/cli` / upstream `cargo-tauri` produces a bundle **without** `Frameworks/` and the app panics at startup inside `cef::library_loader::LibraryLoader::new` with `No such file or directory`. `yarn dev:app` (and every other `cargo tauri` script in `app/package.json`) now calls **`yarn tauri:ensure`** which runs [`scripts/ensure-tauri-cli.sh`](scripts/ensure-tauri-cli.sh) to install the vendored CLI into `~/.cargo/bin/cargo-tauri` on first use. If you ever install a different `tauri-cli` over it (e.g. `npm i -g @tauri-apps/cli`) you'll need to re-run the ensure script / `cargo install --locked --path app/src-tauri/vendor/tauri-cef/crates/tauri-cli`.
-- **macOS deep links**: Often require a built **`.app`** bundle; not only `tauri dev`. See [`docs/telegram-login-desktop.md`](docs/telegram-login-desktop.md) if applicable.
-- **`window.__TAURI__`**: Not assumed at module load; guard Tauri usage accordingly.
-- **Core sidecar**: Must be staged/built so `core_rpc` can reach the `openhuman` binary (see `scripts/stage-core-sidecar.mjs`).
+- **`src/openhuman/`**: new features go in a folder/module, not new root-level `src/openhuman/*.rs` files (see Rust core rules above).
+- **File size**: prefer ≤ ~500 lines per source file; split modules when growing.
+- **Pre-merge checks** (when touching code): Prettier, ESLint, `tsc --noEmit` in `app/`; `cargo fmt` + `cargo check` for changed Rust.
+- **No dynamic imports** in production **`app/src`** code — use static `import` / `import type` at the top of the module. Do **not** use `import()`, `React.lazy(() => import(...))`, or `await import('…')`. Guard optional code paths with `try/catch` or runtime checks instead of deferring module load. **Exceptions:** Vitest harness patterns in `*.test.ts` / `test/setup.ts`; ambient `typeof import('…')` in `.d.ts`; config files.
+- **Debug logging on new flows**: heavy `debug`/`trace` (Rust) and namespaced `debug` / dev logs (`app/`) so sidecar + WebView output is easy to grep. Never log secrets or raw tokens. Full rule: [`docs/feature-workflow.md`](docs/feature-workflow.md).
+- **Dual socket / tool sync**: if you change realtime protocol, keep **frontend** (`socketService` / MCP transport) and **core** socket behavior aligned (see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) dual-socket section).
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,126 @@
+# Testing Guide (Unit + E2E)
+
+## Unit tests (Vitest)
+
+- **Where tests live**: co-locate as `*.test.ts` / `*.test.tsx` under `app/src/**`.
+- **Runner/config**: Vitest with `app/test/vitest.config.ts` and shared setup in `app/src/test/setup.ts`.
+- **Run**:
+
+```bash
+yarn test:unit
+yarn test:coverage
+```
+
+- **Authoring rules**:
+  - Prefer testing behavior over implementation details.
+  - Use existing helpers from `app/src/test/` (`test-utils.tsx`, shared mock backend) before adding new harness code.
+  - Keep tests deterministic: avoid real network calls, time-sensitive flakes, or hidden global state.
+
+## Shared mock backend (app + Rust tests)
+
+- **Core implementation**: `scripts/mock-api-core.mjs`
+- **Standalone server entrypoint**: `scripts/mock-api-server.mjs`
+- **E2E wrapper**: `app/test/e2e/mock-server.ts`
+- **Vitest unit setup**: `app/src/test/setup.ts` starts the shared mock server by default on `http://127.0.0.1:5005`.
+
+Key admin endpoints:
+
+- `GET /__admin/health`
+- `POST /__admin/reset`
+- `POST /__admin/behavior`
+- `GET /__admin/requests`
+
+Run manually:
+
+```bash
+yarn mock:api
+curl -s http://127.0.0.1:18473/__admin/health
+```
+
+## E2E tests (WDIO — dual platform)
+
+Full guide: [`E2E-TESTING.md`](E2E-TESTING.md).
+
+Two automation backends:
+- **Linux (CI default)**: `tauri-driver` (WebDriver, port 4444) — drives the debug binary directly
+- **macOS (local dev)**: Appium Mac2 (XCUITest, port 4723) — drives the `.app` bundle
+
+- **Where specs live**: `app/test/e2e/specs/*.spec.ts`
+- **Shared harness**:
+  - Platform detection: `app/test/e2e/helpers/platform.ts`
+  - Element helpers: `app/test/e2e/helpers/element-helpers.ts`
+  - Deep link helpers: `app/test/e2e/helpers/deep-link-helpers.ts`
+  - App lifecycle: `app/test/e2e/helpers/app-helpers.ts`
+  - Mock backend: `app/test/e2e/mock-server.ts`
+  - WDIO config: `app/test/wdio.conf.ts` (auto-detects platform)
+
+- **Build + run**:
+
+```bash
+# Build app + stage core sidecar (detects macOS vs Linux automatically)
+yarn test:e2e:build
+
+# Run one spec
+bash app/scripts/e2e-run-spec.sh test/e2e/specs/smoke.spec.ts smoke
+
+# Run all flow specs
+yarn test:e2e:all:flows
+
+# Docker on macOS (run Linux E2E locally)
+docker compose -f e2e/docker-compose.yml run --rm e2e
+```
+
+- **Authoring rules**:
+  - Ensure each spec is runnable in isolation.
+  - Use helpers from `element-helpers.ts` — never use raw `XCUIElementType*` selectors in specs.
+  - Use `clickNativeButton()`, `hasAppChrome()`, `waitForWebView()`, `clickToggle()` for cross-platform element interaction.
+  - Assert both UI outcomes and backend/mock effects when relevant.
+  - Add failure diagnostics (request logs, `dumpAccessibilityTree()`) for faster debugging by agents.
+
+## Deterministic core-sidecar reset
+
+By default, `app/scripts/e2e-run-spec.sh` creates and cleans a temp `OPENHUMAN_WORKSPACE`
+automatically when the variable is not provided.
+
+If you need a fixed workspace for debugging, provide one explicitly:
+
+```bash
+export OPENHUMAN_WORKSPACE="$(mktemp -d)"
+yarn test:e2e:build
+bash app/scripts/e2e-run-spec.sh test/e2e/specs/smoke.spec.ts smoke
+rm -rf "$OPENHUMAN_WORKSPACE"
+```
+
+- `OPENHUMAN_WORKSPACE` redirects core config + workspace storage away from `~/.openhuman`.
+- Default reset strategy:
+  - Rebuild/stage sidecar once per E2E run (`yarn test:e2e:build`).
+  - Isolate state per test case with a fresh temp workspace (default behavior in `e2e-run-spec.sh`).
+
+## Rust tests with mock backend
+
+Use the shared mock backend runner so Rust unit/integration tests get deterministic API behavior:
+
+```bash
+yarn test:rust
+# or targeted
+bash scripts/test-rust-with-mock.sh --test json_rpc_e2e
+```
+
+Example per-test-case pattern inside a harness script:
+
+```bash
+run_case() {
+  export OPENHUMAN_WORKSPACE="$(mktemp -d)"
+  bash app/scripts/e2e-run-spec.sh "$1" "$2"
+  rm -rf "$OPENHUMAN_WORKSPACE"
+}
+```
+
+## Test authoring checklist
+
+- Add/update unit tests for logic changes before stacking additional features.
+- Add/update E2E coverage for user-visible flows and cross-process integration behavior.
+- Keep new tests independent, deterministic, and debuggable from logs alone.
+- When touching core/sidecar behavior, validate both:
+  - `yarn test:unit`
+  - targeted E2E spec(s) via `app/scripts/e2e-run-spec.sh`

--- a/docs/event-bus.md
+++ b/docs/event-bus.md
@@ -1,0 +1,124 @@
+# Event bus (`src/core/event_bus/`)
+
+A typed pub/sub event bus for **decoupled cross-module communication** plus a **native, in-process typed request/response** surface. Both are singletons — one instance each for the whole application. Do **not** construct `EventBus` or `NativeRegistry` directly; use the module-level functions.
+
+**When to use which surface:**
+
+- **Broadcast events** (`publish_global` / `subscribe_global`) — fire-and-forget notification. One publisher, many subscribers, no return value. Use when a module needs to _announce_ something happened and other modules may react independently.
+- **Native request/response** (`register_native_global` / `request_native_global`) — one-to-one typed Rust dispatch keyed by a method string. **Zero serialization**: trait objects (`Arc<dyn Provider>`), streaming channels (`mpsc::Sender<T>`), oneshot senders, and anything else `Send + 'static` all pass through unchanged. Use when a module needs a typed return value from another module in-process. This is **internal-only** — anything that needs to be callable over JSON-RPC should register against `src/core/all.rs` instead.
+
+**Core types** (all in `src/core/event_bus/`):
+
+| Type | File | Purpose |
+|------|------|---------|
+| `DomainEvent` | `events.rs` | `#[non_exhaustive]` enum — all cross-module events live here, grouped by domain |
+| `EventBus` | `bus.rs` | Singleton backed by `tokio::sync::broadcast`. Construction is `pub(crate)` — tests only |
+| `NativeRegistry` / `NativeRequestError` | `native_request.rs` | In-process typed request/response registry keyed by method name. Rust types only — passes trait objects, `mpsc::Sender`, and `oneshot::Sender` through without serialization |
+| `EventHandler` | `subscriber.rs` | Async trait with optional `domains()` filter for selective subscription |
+| `SubscriptionHandle` | `subscriber.rs` | RAII handle — subscriber task is cancelled on drop |
+| `TracingSubscriber` | `tracing.rs` | Built-in debug logger for all events (registered at startup) |
+
+**Singleton API** (all modules use these — never hold or pass `EventBus` / `NativeRegistry` instances):
+
+| Function | Purpose |
+|----------|---------|
+| `event_bus::init_global(capacity)` | Initialize both singletons (broadcast bus + native registry) at startup (once) |
+| `event_bus::publish_global(event)` | Publish a broadcast event from anywhere (no-op if not yet initialized) |
+| `event_bus::subscribe_global(handler)` | Subscribe to broadcast events from anywhere (returns `None` if not yet initialized) |
+| `event_bus::register_native_global(method, handler)` | Register a typed native request handler for a method name — called at startup by each domain's `bus.rs` |
+| `event_bus::request_native_global(method, req)` | Dispatch a typed native request to the registered handler — zero serialization |
+| `event_bus::global()` / `event_bus::native_registry()` | Get the underlying singleton for advanced use |
+
+**Domains:** `agent`, `memory`, `channel`, `cron`, `skill`, `tool`, `webhook`, `system`. See `events.rs` for the full variant list — events carry rich payloads so subscribers have everything they need.
+
+**Domain subscriber files** — each domain owns its `bus.rs` with `EventHandler` impls:
+- `cron/bus.rs` — `CronDeliverySubscriber` (delivers job output to channels)
+- `webhooks/bus.rs` — `WebhookRequestSubscriber` (routes incoming requests to skills, emits responses via socket)
+- `channels/bus.rs` — `ChannelInboundSubscriber` (runs agent loop for inbound socket messages)
+- `skills/bus.rs` — stub for future subscribers
+
+**Adding events for a new domain:**
+
+1. Add variants to `DomainEvent` in `events.rs` (prefix with domain name, e.g. `BillingInvoiceCreated { ... }`).
+2. Add the domain string to the `domain()` match arm.
+3. Create a `bus.rs` file **inside your domain module** (e.g. `src/openhuman/billing/bus.rs`) for subscriber implementations — each domain owns its handlers.
+4. Register subscribers in startup (e.g. `channels/runtime/startup.rs`) via the singleton.
+5. Publish events with `event_bus::publish_global(DomainEvent::YourEvent { ... })`.
+
+**Example — publishing:**
+```rust
+use crate::core::event_bus::{publish_global, DomainEvent};
+
+publish_global(DomainEvent::CronDeliveryRequested {
+    job_id: job.id.clone(),
+    channel: "telegram".into(),
+    target: "chat-123".into(),
+    output: "Job completed".into(),
+});
+```
+
+**Example — subscribing (trait-based, in `<domain>/bus.rs`):**
+```rust
+use crate::core::event_bus::{DomainEvent, EventHandler};
+use async_trait::async_trait;
+
+pub struct MyDomainSubscriber { /* dependencies */ }
+
+#[async_trait]
+impl EventHandler for MyDomainSubscriber {
+    fn name(&self) -> &str { "my_domain::handler" }
+    fn domains(&self) -> Option<&[&str]> { Some(&["cron"]) } // filter by domain
+    async fn handle(&self, event: &DomainEvent) {
+        if let DomainEvent::CronJobCompleted { job_id, success } = event {
+            // react to the event
+        }
+    }
+}
+```
+
+**Convention:** Name the handler struct `<Purpose>Subscriber` (e.g. `CronDeliverySubscriber`) and the `name()` return value `"<domain>::<purpose>"` for grep-friendly tracing output.
+
+**Adding a native request handler for a new domain:**
+
+1. Define the **request and response types** in the domain (e.g. `src/openhuman/billing/bus.rs`). Use owned fields, `Arc`s, and channels — not borrows. Types only need `Send + 'static`, not `Serialize`.
+2. Register the handler at startup from the same `bus.rs`, keyed by a stable method name prefixed with the domain (e.g. `"billing.charge_invoice"`).
+3. Callers import the request/response types from the domain's public surface and dispatch via `request_native_global`.
+4. Method name convention: `"<domain>.<verb>"` — same naming scheme as JSON-RPC method roots for consistency, but these are **not** exposed over JSON-RPC.
+
+**Example — native request (typed request/response, in `<domain>/bus.rs`):**
+```rust
+use crate::core::event_bus::{register_native_global, request_native_global};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+// Request carries non-serializable state directly — trait objects and
+// streaming channels all pass through unchanged.
+pub struct BillingChargeRequest {
+    pub provider: Arc<dyn BillingProvider>,
+    pub amount_cents: u64,
+    pub progress_tx: Option<mpsc::Sender<String>>,
+}
+pub struct BillingChargeResponse {
+    pub charge_id: String,
+}
+
+// At startup:
+pub async fn register_billing_handlers() {
+    register_native_global::<BillingChargeRequest, BillingChargeResponse, _, _>(
+        "billing.charge",
+        |req| async move {
+            let id = req.provider.charge(req.amount_cents).await
+                .map_err(|e| e.to_string())?;
+            Ok(BillingChargeResponse { charge_id: id })
+        },
+    ).await;
+}
+
+// From another module:
+let resp: BillingChargeResponse = request_native_global(
+    "billing.charge",
+    BillingChargeRequest { provider, amount_cents: 500, progress_tx: None },
+).await?;
+```
+
+**Tests:** override production handlers by calling `register_native_global` again for the same method before exercising the code under test — the most recent registration wins. For full isolation, construct a fresh `NativeRegistry` directly via `NativeRegistry::new()` and use its `register` / `request` methods.

--- a/docs/feature-workflow.md
+++ b/docs/feature-workflow.md
@@ -1,0 +1,47 @@
+# Feature design workflow (new capabilities)
+
+Follow this order so behavior is **specified**, **proven in Rust**, **proven over RPC**, then **surfaced in the UI** with matching tests.
+
+1. **Specify against the current codebase** — Ground the design in **existing** domains, controller/registry patterns, and JSON-RPC naming (`openhuman.<namespace>_<function>`). Reuse or extend documented flows in [`ARCHITECTURE.md`](ARCHITECTURE.md) and sibling guides; avoid parallel architectures.
+2. **Implement in Rust** — Add domain logic under `src/openhuman/<domain>/`, wire **schemas + registered handlers** into the shared registry, and land **unit tests** in the crate (`cargo test -p openhuman`, focused modules) until the feature is correct in isolation.
+3. **JSON-RPC E2E** — Add or extend **integration-style tests** that call the real HTTP JSON-RPC surface (e.g. [`tests/json_rpc_e2e.rs`](../tests/json_rpc_e2e.rs), mock backend / [`scripts/test-rust-with-mock.sh`](../scripts/test-rust-with-mock.sh) as appropriate) so methods, params, and outcomes match what the UI will call.
+4. **UI in the Tauri app** — Build **React** screens, state, and **`core_rpc_relay` / `coreRpcClient`** usage in `app/`; keep **business rules** in the core, not duplicated in the shell.
+5. **App unit tests** — Cover components, hooks, and clients with **Vitest** (`yarn test` / `yarn test:unit` in `app/`).
+6. **App E2E** — Add **desktop E2E** specs where the feature is user-visible (`yarn test:e2e*`, isolated workspace — see [`TESTING.md`](TESTING.md)) so the full stack (UI → Tauri → sidecar) behaves as intended.
+
+**Capability catalog** — When a change adds, removes, renames, relocates, or materially changes a user-facing feature, update **`src/openhuman/about_app/`** in the same work so the runtime capability catalog remains the source of truth for what the app can do.
+
+**Debug logging (throughout)** — Add **lots of development-oriented logging** as you build, not as an afterthought. In **Rust**, use `log` / `tracing` at **`debug`** or **`trace`** on RPC entry and exit, error paths, state transitions, and any branch that is hard to infer from tests alone. In **`app/`**, follow existing patterns (e.g. the **`debug`** npm package with a **namespace** per area) plus **dev-only** detail where useful. Prefer **grep-friendly prefixes** (`[feature]`, domain name, or JSON-RPC method) so terminal output from **sidecar**, **Tauri**, and **WebView** can be correlated during `yarn dev` / `tauri dev`. **Never** log secrets, raw JWTs, API keys, or full PII—redact or omit.
+
+**Planning rule:** When scoping a feature, define the **E2E scenarios (core RPC + app)** up front. Those scenarios should **cover the full intended scope**—happy paths, failure modes, auth or policy gates, and regressions you care about. If a scenario is not testable end-to-end, the spec is incomplete or the cut is too large; split or add harness support first.
+
+## Debug logging rule
+
+- **Default to verbose diagnostics on new/changed flows**: Add substantial, development-oriented logs while implementing features or fixes so issues are easy to trace end-to-end.
+- **Log critical checkpoints**: Include logs at entry/exit points, branch decisions, external calls, retries/timeouts, state transitions, and error handling paths.
+- **Use structured, grep-friendly context**: Prefer stable prefixes (for example `[domain]`, `[rpc]`, `[ui-flow]`) and include correlation fields such as request IDs, method names, and entity IDs when available.
+- **Platform conventions**: In Rust, use `log` / `tracing` at `debug` or `trace`; in `app/`, use namespaced `debug` logs and dev-only detail as needed.
+- **Keep logs safe**: Never log secrets or sensitive payloads (API keys, JWTs, credentials, full PII). Redact or omit sensitive fields.
+- **Treat debuggability as a deliverable**: Changes lacking sufficient logging for diagnosis are incomplete and should be updated before handoff.
+
+## Controller migration checklist
+
+- `src/openhuman/<domain>/mod.rs`: keep export-focused, add `mod schemas;` and re-export:
+  - `all_controller_schemas as all_<domain>_controller_schemas`
+  - `all_registered_controllers as all_<domain>_registered_controllers`
+- `src/openhuman/<domain>/schemas.rs` must define:
+  - `schemas(function: &str) -> ControllerSchema`
+  - `all_controller_schemas() -> Vec<ControllerSchema>`
+  - `all_registered_controllers() -> Vec<RegisteredController>`
+  - domain handler fns `fn handle_*(_: Map<String, Value>) -> ControllerFuture`
+- Handlers should delegate to existing domain `rpc.rs` functions during migration.
+- Wire domain exports into `src/core/all.rs` for both declared schemas and registered handlers.
+- Keep adapters generic: do not add domain-specific logic to `src/core/cli.rs` or `src/core/jsonrpc.rs`.
+- Remove migrated method branches from `src/rpc/dispatch.rs` once registry coverage is in place.
+
+## Platform notes
+
+- **Vendored CEF-aware `tauri-cli` (required)**: The default runtime is **CEF**, and only the **vendored** `tauri-cli` at `app/src-tauri/vendor/tauri-cef/crates/tauri-cli` knows how to bundle the Chromium Embedded Framework into the app's `Contents/Frameworks/`. The stock `@tauri-apps/cli` / upstream `cargo-tauri` produces a bundle **without** `Frameworks/` and the app panics at startup inside `cef::library_loader::LibraryLoader::new` with `No such file or directory`. `yarn dev:app` (and every other `cargo tauri` script in `app/package.json`) now calls **`yarn tauri:ensure`** which runs [`../scripts/ensure-tauri-cli.sh`](../scripts/ensure-tauri-cli.sh) to install the vendored CLI into `~/.cargo/bin/cargo-tauri` on first use. If you ever install a different `tauri-cli` over it (e.g. `npm i -g @tauri-apps/cli`) you'll need to re-run the ensure script / `cargo install --locked --path app/src-tauri/vendor/tauri-cef/crates/tauri-cli`.
+- **macOS deep links**: Often require a built **`.app`** bundle; not only `tauri dev`. See [`telegram-login-desktop.md`](telegram-login-desktop.md) if applicable.
+- **`window.__TAURI__`**: Not assumed at module load; guard Tauri usage accordingly.
+- **Core sidecar**: Must be staged/built so `core_rpc` can reach the `openhuman` binary (see `scripts/stage-core-sidecar.mjs`).


### PR DESCRIPTION
## Summary

Extracts three long reference sections from \`CLAUDE.md\` into dedicated docs so they load on-demand instead of on every Claude Code session start. **No content changes** — same prose, new location.

## Moved

- **Testing guide** (unit + E2E + mock backend + Rust tests) → [\`docs/TESTING.md\`](../blob/chore/claude-md-slim/docs/TESTING.md)
- **Event bus deep-dive** (\`DomainEvent\` + \`NativeRegistry\`) → [\`docs/event-bus.md\`](../blob/chore/claude-md-slim/docs/event-bus.md)
- **Feature workflow + debug logging + controller migration + platform notes** → [\`docs/feature-workflow.md\`](../blob/chore/claude-md-slim/docs/feature-workflow.md)

## Kept in CLAUDE.md

Still useful as always-loaded overview:

- Repo layout, commands, runtime scope, configuration
- Frontend quick map (provider chain, state, services, routes)
- Tauri shell overview
- Rust core key rules (controller-only exposure, light \`mod.rs\`, subdir layout) — brief form, pointer to full detail
- Coding philosophy, key patterns, git workflow

## Size impact

- \`CLAUDE.md\`: 32.8k → 13.3k chars (~8.2k → ~3.3k tokens)
- **Session context saving for contributors using Claude Code**: ~5k tokens per session
- Contributors reading the repo in a normal editor lose nothing — pointers at the top link to the extracted docs.

## Relation to other PRs

Complements #804 (\`paths:\` frontmatter for \`.claude/rules/\`) and issue #805 (rules audit). Together they target ~30-40k token savings per Claude Code session startup.

## Test plan

- [ ] \`docs/TESTING.md\`, \`docs/event-bus.md\`, \`docs/feature-workflow.md\` render correctly on GitHub
- [ ] All cross-references in the new docs resolve (relative paths)
- [ ] Links from \`CLAUDE.md\` to the new docs resolve
- [ ] No content was dropped — search \`git log -p main..HEAD -- CLAUDE.md\` to confirm every removed paragraph landed in one of the three new docs