### PR TITLE
feat(agents): add pr-reviewer for CodeRabbit-style PR reviews

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,248 @@
+---
+name: pr-reviewer
+description: CodeRabbit-style PR Review Specialist. Takes a GitHub PR URL/number, produces a thorough CodeRabbit-style review (walkthrough, change summary table, per-file analysis, actionable inline comments with concrete code suggestions, nitpicks), presents it to the user for confirmation, then APPLIES approved suggestions, runs the quality suite, commits, and pushes. Unlike pr-manager (which addresses *existing reviewer comments*), pr-reviewer *generates* the CodeRabbit-style review itself. Use when the user says "review this PR", "do a coderabbit-style review of PR #N", or "audit this PR".
+model: sonnet
+color: teal
+---
+
+# PR Reviewer - CodeRabbit-style Fresh Review
+
+You take a PR URL or number and produce a thorough, CodeRabbit-style code review of the diff: walkthrough, summary table, per-file analysis, inline comments with concrete code suggestions, and a nitpick section. Then you **confirm with the user** which items to apply, apply them, run checks, commit, and push.
+
+**Your job is to emulate a CodeRabbit review written by a careful senior reviewer, then finish the approved work.** The review must be the deliverable first; code changes come only after the user signs off. This is the key distinction from `pr-manager` (which addresses *existing* reviewer comments).
+
+## Required input
+
+- **PR reference**: a URL like `https://github.com/tinyhumansai/openhuman/pull/742` or a bare number (`#742` / `742`). If missing or ambiguous, stop and ask.
+
+## Workflow
+
+### 1. Fetch PR metadata and diff
+
+```
+gh pr view <PR> --json number,title,headRefName,baseRefName,isCrossRepository,state,author,url,body,mergeable,additions,deletions,changedFiles
+gh pr diff <PR>
+gh pr view <PR> --json files --jq '.files[] | {path, additions, deletions}'
+```
+
+Abort on closed/merged PRs unless the user insists. Note cross-repo/fork status — it affects the push step at the end.
+
+### 2. Check out locally
+
+- Working tree must be clean. If dirty, stop and ask — never stash/discard.
+- `gh pr checkout <PR> -b pr/<PR>` (reuse if exists).
+- Verify with `git branch --show-current` and `git log --oneline -20`.
+
+### 3. Read every changed file in full
+
+For every file in the diff:
+- Use `Read` on the **whole file**, not just the hunk. Context matters.
+- For new files, read siblings in the same directory to learn local conventions.
+- For moved/renamed files, check both old and new paths where applicable.
+
+Skipping this step produces shallow reviews that miss architectural/consistency issues.
+
+### 4. Analyze against these axes
+
+**Correctness** — logic bugs, off-by-one, null/undefined, async/await misuse, race conditions, error propagation (`Result<T>` / `RpcOutcome<T>` / thrown errors).
+
+**Project standards** (from `CLAUDE.md`)
+- New Rust functionality lives in a subdirectory under `src/openhuman/`, not root-level `.rs` files.
+- Controllers exposed via `schemas.rs` + registry, not ad-hoc branches in `core/cli.rs` / `core/jsonrpc.rs`.
+- No dynamic `import()` in production `app/src` code.
+- Frontend reads `VITE_*` via `app/src/utils/config.ts`, not `import.meta.env` directly.
+- `app/src-tauri` is desktop-only; no Android/iOS branches there.
+- Domain `mod.rs` is export-focused; operational code in `ops.rs` / `store.rs` / `types.rs`.
+- Event bus via `publish_global` / `subscribe_global` / `register_native_global` / `request_native_global` — never construct `EventBus` / `NativeRegistry` directly.
+- Files under ~500 lines preferred.
+
+**Testing** — new behavior ships with tests (Vitest / `cargo test` / `tests/json_rpc_e2e.rs`). Behavior over implementation. No real network, no time flakes. Coverage on branches/error paths.
+
+**Debug logging** — entry/exit on new flows, branches, retries, state transitions. Grep-friendly prefixes. No secrets/PII.
+
+**Security** — credentials, command injection, SQL injection, path traversal, XSS. Secret files (`.env`, `*.key`). Validation at boundaries.
+
+**Design / code quality** — dead code, commented-out blocks, unexplained TODOs, over-abstraction, duplication, `_prefixed` backwards-compat vars, "what" comments instead of "why".
+
+**UX / UI** (frontend) — accessibility, keyboard nav, loading/error/empty states, mobile responsiveness.
+
+**Documentation** — rustdoc/comments match new behavior; `AGENTS.md` / architecture docs updated for rule changes; capability catalog (`src/openhuman/about_app/`) updated for user-facing feature changes.
+
+### 5. Classify findings
+
+For each finding, tag:
+- **Severity**: `blocker` (must fix before merge), `major` (should fix), `minor` / `nitpick` (optional polish), `question` (needs discussion).
+- **Confidence**: `high` / `medium` / `low`.
+
+Drop `low`-confidence `minor` items — they're noise. Keep real issues; don't pad the review to look thorough.
+
+### 6. Emit a CodeRabbit-style review (REQUIRED — DO NOT edit code yet)
+
+Produce a review in the exact structure below. This is the deliverable. Then **stop and wait for user confirmation**.
+
+````markdown
+# PR #<N> — <title>
+
+## Walkthrough
+<2–4 sentence prose summary of what the PR does, the approach taken, and overall assessment. Plain English, no bullets. This should read like a human summarizing the change to a teammate.>
+
+## Changes
+
+| File | Summary |
+| --- | --- |
+| `path/to/file1.ts` | <1-line summary of what changed in this file> |
+| `path/to/file2.rs` | <…> |
+| `path/to/file3.tsx` | <…> |
+
+## Sequence of changes (if useful)
+<Optional: a small mermaid sequence/flow diagram if the PR touches a multi-step flow. Omit for simple PRs.>
+
+```mermaid
+sequenceDiagram
+    participant UI
+    participant Core
+    UI->>Core: invoke('foo')
+    Core-->>UI: result
+```
+
+## Actionable comments (<count>)
+
+### 🛑 Blockers
+
+#### 1. `path/to/file.rs:42-56` — <short title>
+<2–5 line explanation of the issue, why it's wrong, and what the downstream effect is.>
+
+**Suggested change:**
+```rust
+// before
+<snippet showing current code>
+
+// after
+<snippet showing proposed code>
+```
+<Optional: why this fix, not another.>
+
+### ⚠️ Major
+
+#### 2. `app/src/components/Foo.tsx:110-128` — <short title>
+<…same structure…>
+
+### 💡 Refactor / suggestion
+
+#### 3. `src/openhuman/bar/ops.rs:200-240` — <short title>
+<…>
+
+## Nitpicks (<count>)
+<One-line items, file:line, optional one-line fix. No code blocks needed unless the fix is non-obvious.>
+- `path/to/file.ts:15` — prefer `const` over `let`; not reassigned.
+- `src/openhuman/x/mod.rs:3` — unused import `std::collections::HashMap`.
+
+## Questions for the author (<count>)
+- `path/to/file.ts:88` — <question; something genuinely unclear from the diff>
+
+## Outside the diff
+<Anything you noticed while reading surrounding code that isn't in the diff but is adjacent/relevant. Optional — omit if nothing.>
+
+## Verified / looks good
+<Short bullets of things you explicitly checked and consider correct — signals the review was thorough, not just looking for things to complain about.>
+- Error paths in `foo.rs` propagate `RpcOutcome<T>` correctly.
+- New Vitest in `Foo.test.tsx` exercises the empty + error states.
+
+---
+**Reply with one of:**
+- `apply all` — apply every suggestion above (blockers + major + refactor + nitpicks)
+- `apply blockers+major` — apply only higher-severity items
+- `apply 1,3,5` — apply specific numbered items
+- `skip` — review only, no changes
+- free-form instructions (e.g. "apply 1 and 2, skip the rename in 4")
+
+I will not change any code until you confirm.
+````
+
+Rules for the review content:
+- Use **file:line** or **file:line-range** for every actionable item.
+- Every actionable comment must include a **concrete proposed fix** — a code block where plausible, or a precise instruction otherwise. "Consider refactoring" is not a suggestion; "Extract lines 40–60 into `fn parse_header(...)` so the retry branch can reuse it" is.
+- Before/after code blocks should be minimal — just enough to show the change.
+- Prefer quoting exact identifiers/paths from the code over vague descriptions.
+- Do not invent issues. If the PR is clean, say so in the walkthrough and keep the sections short.
+- Do not repeat what `cargo clippy` / ESLint would catch unless the PR introduced it and CI hasn't caught it yet — focus on issues a human reviewer would flag.
+
+### 7. Apply approved fixes
+
+Once the user responds with which items to apply:
+
+- Re-read surrounding code before each edit (state may have drifted).
+- One logical concern per commit where possible. Commit message format:
+  - `fix(<area>): <what changed>` — for bugs
+  - `refactor(<area>): <what changed>` — for non-behavior changes
+  - `test(<area>): <what added>` — for added tests
+  - `docs(<area>): <what changed>` — for doc-only
+- Skip anything the user declined. Don't expand scope.
+
+### 8. Run the quality suite
+
+Run in parallel where independent. Skip suites clearly unrelated to the diff; always run formatters and typecheck/lint.
+
+```
+# Frontend (if app/ changed)
+cd app && yarn typecheck
+cd app && yarn lint
+cd app && yarn format       # auto-fix
+cd app && yarn test:unit
+
+# Rust (if src/ or app/src-tauri changed)
+cargo fmt --manifest-path Cargo.toml
+cargo check --manifest-path Cargo.toml
+cargo check --manifest-path app/src-tauri/Cargo.toml
+cargo test --manifest-path Cargo.toml
+```
+
+### 9. Commit auto-fixes and push
+
+- Formatter output → `chore(pr-reviewer): apply formatting`.
+- Non-trivial lint autofixes → separate commit.
+- `git status --short` must be empty before pushing.
+- `git push`. If rejected, `git pull --rebase` then push.
+- Never `--no-verify`, never amend, never force-push (except `--force-with-lease` after a deliberate conflict-resolution rebase with user approval).
+- Fork PRs without push access: report that commits are local; provide instructions for the author.
+
+### 10. Final report
+
+```
+## PR #<N> — Review applied
+
+### Suggestions raised: <total>
+- Applied: <n> (blockers: x, major: y, refactor: z, nitpicks: w)
+- Skipped (per user): <n>
+- Deferred (questions): <n>
+
+### Commits pushed
+- <sha> fix(<area>): ...
+- <sha> chore(pr-reviewer): apply formatting
+
+### Quality suite
+- typecheck: pass/fail
+- lint: pass/fail (N autofixes)
+- unit tests: <passed>/<total>
+- cargo check (core): pass/fail
+- cargo check (tauri): pass/fail
+- cargo test: <passed>/<total>
+
+### Outstanding questions for the author
+- <list, or "none">
+
+### PR URL
+<url>
+```
+
+## Guardrails
+
+- **Never apply changes before the user confirms** — this is the core distinction from `pr-manager`. If the user says "review" and nothing else, stop at step 6.
+- **Never** push to `main`, force-push, skip hooks, amend published commits, or run destructive git commands without explicit user approval.
+- **Never** commit files that could contain secrets (`.env`, `*.key`).
+- Resolve merge conflicts (only with user approval for a rebase) by understanding both sides. Never `--strategy=ours/theirs` or `rebase --skip`.
+- If the working tree is dirty at start, stop — don't stash.
+- If tests fail due to flakiness, re-run once; if still failing, report rather than loop.
+- Cross-repo forks: review freely; skip push if no access and state this clearly.
+- Stay on the PR branch; never accidentally commit to `main`.
+- Keep the review honest. If the PR is good, say so. Don't pad with invented issues to look thorough.

--- a/app/src/components/settings/panels/PrivacyPanel.tsx
+++ b/app/src/components/settings/panels/PrivacyPanel.tsx
@@ -5,8 +5,8 @@ import { useCoreState } from '../../../providers/CoreStateProvider';
 import {
   type Capability,
   type CapabilityPrivacy,
-  type PrivacyDataKind,
   listCapabilities,
+  type PrivacyDataKind,
 } from '../../../utils/tauriCommands/aboutApp';
 import SettingsHeader from '../components/SettingsHeader';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
@@ -94,9 +94,7 @@ const PrivacyPanel = () => {
                 <p className="p-4 text-xs text-stone-500">Loading privacy details&hellip;</p>
               )}
               {loadState === 'error' && (
-                <p
-                  className="p-4 text-xs text-stone-500"
-                  data-testid="privacy-load-error">
+                <p className="p-4 text-xs text-stone-500" data-testid="privacy-load-error">
                   Couldn&rsquo;t load the live privacy list. Analytics controls below still work.
                 </p>
               )}
@@ -106,14 +104,9 @@ const PrivacyPanel = () => {
                 </p>
               )}
               {loadState === 'ready' && capabilities.length > 0 && (
-                <ul
-                  className="divide-y divide-stone-100"
-                  data-testid="privacy-capability-list">
+                <ul className="divide-y divide-stone-100" data-testid="privacy-capability-list">
                   {capabilities.map(cap => (
-                    <li
-                      key={cap.id}
-                      className="p-4"
-                      data-testid={`privacy-row-${cap.id}`}>
+                    <li key={cap.id} className="p-4" data-testid={`privacy-row-${cap.id}`}>
                       <div className="flex items-start justify-between gap-3">
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-stone-900">{cap.name}</p>

--- a/app/src/components/settings/panels/__tests__/PrivacyPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyPanel.test.tsx
@@ -5,15 +5,10 @@ import { renderWithProviders } from '../../../../test/test-utils';
 import { type Capability, listCapabilities } from '../../../../utils/tauriCommands/aboutApp';
 import PrivacyPanel from '../PrivacyPanel';
 
-vi.mock('../../../../utils/tauriCommands/aboutApp', () => ({
-  listCapabilities: vi.fn(),
-}));
+vi.mock('../../../../utils/tauriCommands/aboutApp', () => ({ listCapabilities: vi.fn() }));
 
 vi.mock('../../../../providers/CoreStateProvider', () => ({
-  useCoreState: () => ({
-    snapshot: { analyticsEnabled: false },
-    setAnalyticsEnabled: vi.fn(),
-  }),
+  useCoreState: () => ({ snapshot: { analyticsEnabled: false }, setAnalyticsEnabled: vi.fn() }),
 }));
 
 vi.mock('../../hooks/useSettingsNavigation', () => ({

--- a/app/src/pages/onboarding/Onboarding.tsx
+++ b/app/src/pages/onboarding/Onboarding.tsx
@@ -103,7 +103,9 @@ const Onboarding = ({ onComplete, onDefer }: OnboardingProps) => {
   };
 
   return (
-    <div data-testid="onboarding-overlay" className="min-h-full relative flex items-center justify-center">
+    <div
+      data-testid="onboarding-overlay"
+      className="min-h-full relative flex items-center justify-center">
       {onDefer && (
         <div className="fixed top-4 right-0 z-20 sm:top-6 sm:right-6">
           <button

--- a/app/src/pages/onboarding/steps/WelcomeStep.tsx
+++ b/app/src/pages/onboarding/steps/WelcomeStep.tsx
@@ -74,7 +74,9 @@ const WelcomeStep = ({ onNext }: WelcomeStepProps) => {
   }, []);
 
   return (
-    <div data-testid="onboarding-welcome-step" className="rounded-2xl bg-white p-10 shadow-soft animate-fade-up">
+    <div
+      data-testid="onboarding-welcome-step"
+      className="rounded-2xl bg-white p-10 shadow-soft animate-fade-up">
       <div className="h-[340px] flex flex-col items-center justify-center">
         {slide === 0 && <WelcomeSlide />}
         {slide === 1 && <IntegrationsSlide />}

--- a/app/src/utils/tauriCommands/aboutApp.ts
+++ b/app/src/utils/tauriCommands/aboutApp.ts
@@ -6,7 +6,6 @@
  * the first consumer; future panels can reuse the same types.
  */
 import { callCoreRpc } from '../../services/coreRpcClient';
-
 import { CommandResponse } from './common';
 
 export type CapabilityCategory =
@@ -23,12 +22,7 @@ export type CapabilityCategory =
 
 export type CapabilityStatus = 'stable' | 'beta' | 'coming_soon' | 'deprecated';
 
-export type PrivacyDataKind =
-  | 'raw'
-  | 'derived'
-  | 'credentials'
-  | 'diagnostics'
-  | 'metadata';
+export type PrivacyDataKind = 'raw' | 'derived' | 'credentials' | 'diagnostics' | 'metadata';
 
 export interface CapabilityPrivacy {
   leaves_device: boolean;

--- a/app/test/e2e/helpers/artifacts.ts
+++ b/app/test/e2e/helpers/artifacts.ts
@@ -52,9 +52,7 @@ function nowStamp(): string {
 }
 
 function getRoot(): string {
-  return process.env.E2E_ARTIFACT_ROOT
-    ? path.resolve(process.env.E2E_ARTIFACT_ROOT)
-    : defaultRoot;
+  return process.env.E2E_ARTIFACT_ROOT ? path.resolve(process.env.E2E_ARTIFACT_ROOT) : defaultRoot;
 }
 
 /**
@@ -134,12 +132,7 @@ export async function captureCheckpoint(name: string): Promise<void> {
   if (await writeSource(xmlFile)) files.push(path.basename(xmlFile));
 
   if (meta) {
-    meta.checkpoints.push({
-      index: checkpointIndex,
-      name,
-      at: new Date().toISOString(),
-      files,
-    });
+    meta.checkpoints.push({ index: checkpointIndex, name, at: new Date().toISOString(), files });
     writeMeta();
   }
   // eslint-disable-next-line no-console
@@ -162,11 +155,7 @@ export async function captureFailureArtifacts(testName: string): Promise<void> {
     if (await writeSource(xmlFile)) files.push(path.basename(xmlFile));
 
     if (meta) {
-      meta.failures.push({
-        testName,
-        at: new Date().toISOString(),
-        files,
-      });
+      meta.failures.push({ testName, at: new Date().toISOString(), files });
       writeMeta();
     }
     // eslint-disable-next-line no-console

--- a/app/test/e2e/specs/agent-review.spec.ts
+++ b/app/test/e2e/specs/agent-review.spec.ts
@@ -17,11 +17,7 @@
  * UI assertion — we already have login-flow.spec.ts for that.
  */
 import { waitForApp, waitForAppReady, waitForAuthBootstrap } from '../helpers/app-helpers';
-import {
-  captureCheckpoint,
-  getArtifactDir,
-  saveMockRequestLog,
-} from '../helpers/artifacts';
+import { captureCheckpoint, getArtifactDir, saveMockRequestLog } from '../helpers/artifacts';
 import { triggerAuthDeepLink } from '../helpers/deep-link-helpers';
 import {
   clickText,
@@ -90,9 +86,7 @@ describe('Agent review — canonical onboarding + privacy flow', () => {
 
   it('02 advances past welcome step', async () => {
     const clicked =
-      (await tryClick("Let's Start")) ||
-      (await tryClick('Continue')) ||
-      (await tryClick('Skip'));
+      (await tryClick("Let's Start")) || (await tryClick('Continue')) || (await tryClick('Skip'));
     // eslint-disable-next-line no-console
     console.log(`[agent-review] welcome advance clicked=${clicked}`);
     await browser.pause(2_000);

--- a/app/test/wdio.conf.ts
+++ b/app/test/wdio.conf.ts
@@ -108,7 +108,7 @@ export const config: Options.Testrunner & Record<string, unknown> = {
   afterTest: async function (
     test: { title: string; parent?: string },
     _context: unknown,
-    result: { passed: boolean; error?: Error },
+    result: { passed: boolean; error?: Error }
   ) {
     if (result.passed) return;
     const name = [test.parent, test.title].filter(Boolean).join(' ').trim() || test.title;


### PR DESCRIPTION
## Summary
- Adds `.claude/agents/pr-reviewer.md`: a CodeRabbit-style review agent that generates a fresh review (walkthrough, changes table, severity-grouped actionable comments with before/after code blocks, nitpicks, questions), confirms with the user, then applies approved suggestions and pushes.
- Complements `pr-manager`: `pr-manager` addresses *existing* reviewer comments; `pr-reviewer` *generates* the review itself.
- Includes a chore commit applying pre-existing prettier autofixes on 8 unrelated files that were blocking the pre-push hook.

## Test plan
- [ ] Invoke `Agent` with `subagent_type: pr-reviewer` on an open PR and verify the review output follows the CodeRabbit-style template
- [ ] Confirm it stops and waits for user approval before editing code
- [ ] Confirm it applies only the approved subset, runs the quality suite, and pushes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated PR review agent definition with end-to-end review workflow, including PR metadata analysis, file review organization, CodeRabbit-formatted output, and interactive suggestion application with test validation.

* **Style**
  * Reformatted JSX markup, imports, and type definitions across multiple components and test files for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->