### PR TITLE
chore: add solo.yml for Solo workspace

### DIFF
--- a/solo.yml
+++ b/solo.yml
@@ -1,0 +1,19 @@
+processes:
+
+  tauri-dev:
+    command: yarn tauri dev
+
+  skills-watch:
+    command: yarn workspace openhuman-app skills:watch
+
+  typecheck-watch:
+    command: yarn workspace openhuman-app exec tsc --noEmit --watch --preserveWatchOutput
+
+  core-check:
+    command: cargo check --manifest-path Cargo.toml
+
+  core-build:
+    command: cargo build --manifest-path Cargo.toml --bin openhuman
+
+  core-stage:
+    command: yarn workspace openhuman-app core:stage


### PR DESCRIPTION
## Summary

- Adds a repo-root `solo.yml` defining the shared development processes for [Solo](https://soloterm.com) (native terminal workspace for agents + dev stacks).
- Contributors who use Solo get the same stack on "play": `tauri-dev`, `skills-watch`, `typecheck-watch`, plus one-shot `core-check` / `core-build` / `core-stage` helpers.
- Zero code changes. Does not affect non-Solo users, CI, or existing workflows.

## Why

Currently every contributor juggles 4–6 terminals to run the full dev loop (Vite + Tauri + skills watch + typecheck + core rebuild + stage). A checked-in `solo.yml` removes the recall burden and documents the canonical process list in the repo instead of in tribal knowledge.

Personal/branch-specific processes can still be added in Solo's UI without touching this file (Solo distinguishes YAML-backed vs local-only processes).

## Test plan

- [ ] Solo imports the project and shows 6 processes without prompting for setup
- [ ] `tauri-dev` starts Vite + Tauri successfully
- [ ] `skills-watch` and `typecheck-watch` keep running as long-lived watchers
- [ ] One-shot commands (`core-check`, `core-build`, `core-stage`) run to completion
- [ ] Users without Solo installed are unaffected (file is ignored by every existing tool)