### PR TITLE
Feat: add email login auth

### DIFF
--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -64,18 +64,28 @@ const Welcome = () => {
           </p>
 
           {errorMessage ? (
-            <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            <div
+              role="alert"
+              className="mb-5 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
               {errorMessage}
             </div>
           ) : null}
 
           {isProcessing ? (
-            <div className="mb-5 flex flex-col items-center justify-center gap-3 py-2">
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="mb-5 flex flex-col items-center justify-center gap-3 py-2">
               <div className="h-6 w-6 animate-spin rounded-full border-2 border-stone-300 border-t-primary-500" />
               <p className="text-sm font-medium text-stone-700">Signing you in...</p>
             </div>
           ) : isSent ? (
-            <div className="flex flex-col items-center gap-3 py-2 text-center">
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="flex flex-col items-center gap-3 py-2 text-center">
               <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50">
                 <svg
                   className="h-6 w-6 text-primary-500"
@@ -129,7 +139,9 @@ const Welcome = () => {
 
               <form onSubmit={handleEmailSubmit} className="space-y-3">
                 {emailError ? (
-                  <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                  <div
+                    role="alert"
+                    className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
                     {emailError}
                   </div>
                 ) : null}
@@ -147,10 +159,10 @@ const Welcome = () => {
                   disabled={isSending || !email.trim()}
                   className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium text-sm rounded-xl transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2">
                   {isSending ? (
-                    <>
+                    <span role="status" aria-live="polite" aria-atomic="true" className="flex items-center justify-center gap-2">
                       <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
                       Sending link...
-                    </>
+                    </span>
                   ) : (
                     'Continue with email'
                   )}

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -28,14 +28,13 @@ const Welcome = () => {
     try {
       // Desktop: redirect back via openhuman:// deep link.
       // Web: redirect to the current origin so the app's hash router picks up the token.
-      const frontendRedirectUri = isTauri()
-        ? DESKTOP_FRONTEND_URI
-        : window.location.origin;
+      const frontendRedirectUri = isTauri() ? DESKTOP_FRONTEND_URI : window.location.origin;
 
       await sendEmailMagicLink(email.trim(), frontendRedirectUri);
       setIsSent(true);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Something went wrong. Please try again.';
+      const message =
+        err instanceof Error ? err.message : 'Something went wrong. Please try again.';
       setEmailError(message);
     } finally {
       setIsSending(false);
@@ -83,8 +82,7 @@ const Welcome = () => {
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
-                  strokeWidth={2}
-                >
+                  strokeWidth={2}>
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
@@ -94,14 +92,16 @@ const Welcome = () => {
               </div>
               <p className="text-sm font-medium text-stone-900">Check your email</p>
               <p className="text-xs text-stone-500">
-                We sent a sign-in link to <span className="font-medium text-stone-700">{email}</span>.
-                Click it to continue.
+                We sent a sign-in link to{' '}
+                <span className="font-medium text-stone-700">{email}</span>. Click it to continue.
               </p>
               <button
                 type="button"
-                onClick={() => { setIsSent(false); setEmail(''); }}
-                className="mt-1 text-xs text-primary-500 hover:underline"
-              >
+                onClick={() => {
+                  setIsSent(false);
+                  setEmail('');
+                }}
+                className="mt-1 text-xs text-primary-500 hover:underline">
                 Use a different email
               </button>
             </div>
@@ -145,8 +145,7 @@ const Welcome = () => {
                 <button
                   type="submit"
                   disabled={isSending || !email.trim()}
-                  className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium text-sm rounded-xl transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                >
+                  className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium text-sm rounded-xl transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2">
                   {isSending ? (
                     <>
                       <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -145,7 +145,11 @@ const Welcome = () => {
                     {emailError}
                   </div>
                 ) : null}
+                <label htmlFor="email-login-input" className="sr-only">
+                  Email address
+                </label>
                 <input
+                  id="email-login-input"
                   type="email"
                   value={email}
                   onChange={e => setEmail(e.target.value)}

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -1,10 +1,46 @@
+import { useState } from 'react';
+
 import OAuthProviderButton from '../components/oauth/OAuthProviderButton';
 import { oauthProviderConfigs } from '../components/oauth/providerConfigs';
 import RotatingTetrahedronCanvas from '../components/RotatingTetrahedronCanvas';
+import { sendEmailMagicLink } from '../services/api/authApi';
 import { useDeepLinkAuthState } from '../store/deepLinkAuthState';
+import { isTauri } from '../utils/tauriCommands';
+
+// Desktop deep-link scheme root; must match DESKTOP_FRONTEND_URI on the backend
+const DESKTOP_FRONTEND_URI = 'openhuman://';
 
 const Welcome = () => {
   const { isProcessing, errorMessage } = useDeepLinkAuthState();
+
+  const [email, setEmail] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [isSent, setIsSent] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim() || isSending) return;
+
+    setEmailError(null);
+    setIsSending(true);
+
+    try {
+      // Desktop: redirect back via openhuman:// deep link.
+      // Web: redirect to the current origin so the app's hash router picks up the token.
+      const frontendRedirectUri = isTauri()
+        ? DESKTOP_FRONTEND_URI
+        : window.location.origin;
+
+      await sendEmailMagicLink(email.trim(), frontendRedirectUri);
+      setIsSent(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Something went wrong. Please try again.';
+      setEmailError(message);
+    } finally {
+      setIsSending(false);
+    }
+  };
 
   return (
     <div className="min-h-full flex flex-col items-center justify-center p-4">
@@ -39,40 +75,90 @@ const Welcome = () => {
               <div className="h-6 w-6 animate-spin rounded-full border-2 border-stone-300 border-t-primary-500" />
               <p className="text-sm font-medium text-stone-700">Signing you in...</p>
             </div>
-          ) : (
-            /* OAuth buttons — horizontal row */
-            <div className="flex items-center justify-center gap-3 mb-5">
-              {oauthProviderConfigs
-                .filter(p => ['google', 'github', 'twitter'].includes(p.id))
-                .map(provider => (
-                  <OAuthProviderButton
-                    key={provider.id}
-                    provider={provider}
-                    className="!rounded-full !px-4 !py-2"
+          ) : isSent ? (
+            <div className="flex flex-col items-center gap-3 py-2 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50">
+                <svg
+                  className="h-6 w-6 text-primary-500"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
                   />
-                ))}
+                </svg>
+              </div>
+              <p className="text-sm font-medium text-stone-900">Check your email</p>
+              <p className="text-xs text-stone-500">
+                We sent a sign-in link to <span className="font-medium text-stone-700">{email}</span>.
+                Click it to continue.
+              </p>
+              <button
+                type="button"
+                onClick={() => { setIsSent(false); setEmail(''); }}
+                className="mt-1 text-xs text-primary-500 hover:underline"
+              >
+                Use a different email
+              </button>
             </div>
-          )}
+          ) : (
+            <>
+              {/* OAuth buttons — horizontal row */}
+              <div className="flex items-center justify-center gap-3 mb-5">
+                {oauthProviderConfigs
+                  .filter(p => ['google', 'github', 'twitter'].includes(p.id))
+                  .map(provider => (
+                    <OAuthProviderButton
+                      key={provider.id}
+                      provider={provider}
+                      className="!rounded-full !px-4 !py-2"
+                    />
+                  ))}
+              </div>
 
-          {/* Email login — disabled until backend auth flow is implemented
-          <div className="flex items-center gap-3 mb-5">
-            <div className="flex-1 h-px bg-stone-200" />
-            <span className="text-xs text-stone-400">Or</span>
-            <div className="flex-1 h-px bg-stone-200" />
-          </div>
-          <form className="space-y-3">
-            <input
-              type="email"
-              placeholder="Enter your email"
-              className="w-full rounded-xl border border-stone-200 bg-white px-4 py-3 text-sm text-stone-900 placeholder:text-stone-400 outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
-            />
-            <button
-              type="submit"
-              className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium text-sm rounded-xl transition-colors duration-200">
-              Continue with email
-            </button>
-          </form>
-          */}
+              {/* Email login */}
+              <div className="flex items-center gap-3 mb-5">
+                <div className="flex-1 h-px bg-stone-200" />
+                <span className="text-xs text-stone-400">Or</span>
+                <div className="flex-1 h-px bg-stone-200" />
+              </div>
+
+              <form onSubmit={handleEmailSubmit} className="space-y-3">
+                {emailError ? (
+                  <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                    {emailError}
+                  </div>
+                ) : null}
+                <input
+                  type="email"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  placeholder="Enter your email"
+                  required
+                  disabled={isSending}
+                  className="w-full rounded-xl border border-stone-200 bg-white px-4 py-3 text-sm text-stone-900 placeholder:text-stone-400 outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors disabled:opacity-60"
+                />
+                <button
+                  type="submit"
+                  disabled={isSending || !email.trim()}
+                  className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium text-sm rounded-xl transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                >
+                  {isSending ? (
+                    <>
+                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                      Sending link...
+                    </>
+                  ) : (
+                    'Continue with email'
+                  )}
+                </button>
+              </form>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -29,7 +29,6 @@ const Welcome = () => {
       // Desktop: redirect back via openhuman:// deep link.
       // Web: redirect to the current origin so the app's hash router picks up the token.
       const frontendRedirectUri = isTauri() ? DESKTOP_FRONTEND_URI : window.location.origin;
-
       await sendEmailMagicLink(email.trim(), frontendRedirectUri);
       setIsSent(true);
     } catch (err) {
@@ -163,7 +162,11 @@ const Welcome = () => {
                   disabled={isSending || !email.trim()}
                   className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium text-sm rounded-xl transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2">
                   {isSending ? (
-                    <span role="status" aria-live="polite" aria-atomic="true" className="flex items-center justify-center gap-2">
+                    <span
+                      role="status"
+                      aria-live="polite"
+                      aria-atomic="true"
+                      className="flex items-center justify-center gap-2">
                       <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
                       Sending link...
                     </span>

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Welcome from '../Welcome';
+import { sendEmailMagicLink } from '../../services/api/authApi';
+import { useDeepLinkAuthState } from '../../store/deepLinkAuthState';
+import { isTauri } from '../../utils/tauriCommands';
+
+vi.mock('../../components/RotatingTetrahedronCanvas', () => ({
+  default: () => <div data-testid="welcome-logo" />,
+}));
+
+vi.mock('../../components/oauth/OAuthProviderButton', () => ({
+  default: ({ provider }: { provider: { id: string } }) => <button>{provider.id}</button>,
+}));
+
+vi.mock('../../components/oauth/providerConfigs', () => ({
+  oauthProviderConfigs: [{ id: 'google' }, { id: 'github' }, { id: 'twitter' }],
+}));
+
+vi.mock('../../services/api/authApi', () => ({
+  sendEmailMagicLink: vi.fn(),
+}));
+
+vi.mock('../../store/deepLinkAuthState', () => ({
+  useDeepLinkAuthState: vi.fn(),
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('Welcome email login', () => {
+  beforeEach(() => {
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+    });
+    vi.mocked(isTauri).mockReturnValue(false);
+    vi.mocked(sendEmailMagicLink).mockReset();
+  });
+
+  it('uses the current origin for web email sign-in', async () => {
+    vi.mocked(sendEmailMagicLink).mockResolvedValue(undefined);
+
+    render(<Welcome />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    await waitFor(() => {
+      expect(sendEmailMagicLink).toHaveBeenCalledWith('user@example.com', window.location.origin);
+    });
+  });
+
+  it('uses the desktop deep-link URI for Tauri email sign-in', async () => {
+    vi.mocked(isTauri).mockReturnValue(true);
+    vi.mocked(sendEmailMagicLink).mockResolvedValue(undefined);
+
+    render(<Welcome />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    await waitFor(() => {
+      expect(sendEmailMagicLink).toHaveBeenCalledWith('user@example.com', 'openhuman://');
+    });
+  });
+
+  it('shows a pending state while the email request is in flight', async () => {
+    const deferred = createDeferred<void>();
+    vi.mocked(sendEmailMagicLink).mockReturnValue(deferred.promise);
+
+    render(<Welcome />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    expect(screen.getByRole('button', { name: /sending link/i })).toBeDisabled();
+    expect(screen.getByText('Sending link...')).toBeInTheDocument();
+
+    deferred.resolve();
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+    });
+  });
+
+  it('renders backend errors from the email request', async () => {
+    vi.mocked(sendEmailMagicLink).mockRejectedValue(new Error('Email service is down'));
+
+    render(<Welcome />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Email service is down')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the success confirmation after a magic link is sent', async () => {
+    vi.mocked(sendEmailMagicLink).mockResolvedValue(undefined);
+
+    render(<Welcome />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+  });
+
+  it('resets the success state when using a different email', async () => {
+    vi.mocked(sendEmailMagicLink).mockResolvedValue(undefined);
+
+    render(<Welcome />);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Check your email')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use a different email' }));
+
+    expect(screen.queryByText('Check your email')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter your email')).toHaveValue('');
+  });
+});

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -90,6 +90,7 @@ describe('Welcome email login', () => {
 
     expect(screen.getByRole('button', { name: /sending link/i })).toBeDisabled();
     expect(screen.getByText('Sending link...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Sending link...');
 
     deferred.resolve();
     await waitFor(() => {
@@ -108,7 +109,7 @@ describe('Welcome email login', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Email service is down')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent('Email service is down');
     });
   });
 
@@ -127,6 +128,7 @@ describe('Welcome email login', () => {
     });
 
     expect(screen.getByText('user@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Check your email');
   });
 
   it('resets the success state when using a different email', async () => {

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import Welcome from '../Welcome';
 import { sendEmailMagicLink } from '../../services/api/authApi';
 import { useDeepLinkAuthState } from '../../store/deepLinkAuthState';
 import { isTauri } from '../../utils/tauriCommands';
+import Welcome from '../Welcome';
 
 vi.mock('../../components/RotatingTetrahedronCanvas', () => ({
   default: () => <div data-testid="welcome-logo" />,
@@ -18,13 +18,9 @@ vi.mock('../../components/oauth/providerConfigs', () => ({
   oauthProviderConfigs: [{ id: 'google' }, { id: 'github' }, { id: 'twitter' }],
 }));
 
-vi.mock('../../services/api/authApi', () => ({
-  sendEmailMagicLink: vi.fn(),
-}));
+vi.mock('../../services/api/authApi', () => ({ sendEmailMagicLink: vi.fn() }));
 
-vi.mock('../../store/deepLinkAuthState', () => ({
-  useDeepLinkAuthState: vi.fn(),
-}));
+vi.mock('../../store/deepLinkAuthState', () => ({ useDeepLinkAuthState: vi.fn() }));
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -38,10 +34,7 @@ function createDeferred<T>() {
 
 describe('Welcome email login', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({
-      isProcessing: false,
-      errorMessage: null,
-    });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
     vi.mocked(isTauri).mockReturnValue(false);
     vi.mocked(sendEmailMagicLink).mockReset();
   });

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -51,7 +51,9 @@ describe('Welcome email login', () => {
 
     render(<Welcome />);
 
-    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+    expect(screen.getByLabelText('Email address')).toHaveAttribute('id', 'email-login-input');
+
+    fireEvent.change(screen.getByLabelText('Email address'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
@@ -67,7 +69,7 @@ describe('Welcome email login', () => {
 
     render(<Welcome />);
 
-    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+    fireEvent.change(screen.getByLabelText('Email address'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
@@ -83,7 +85,7 @@ describe('Welcome email login', () => {
 
     render(<Welcome />);
 
-    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+    fireEvent.change(screen.getByLabelText('Email address'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
@@ -103,7 +105,7 @@ describe('Welcome email login', () => {
 
     render(<Welcome />);
 
-    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+    fireEvent.change(screen.getByLabelText('Email address'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
@@ -118,7 +120,7 @@ describe('Welcome email login', () => {
 
     render(<Welcome />);
 
-    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+    fireEvent.change(screen.getByLabelText('Email address'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
@@ -136,7 +138,7 @@ describe('Welcome email login', () => {
 
     render(<Welcome />);
 
-    fireEvent.change(screen.getByPlaceholderText('Enter your email'), {
+    fireEvent.change(screen.getByLabelText('Email address'), {
       target: { value: 'user@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
@@ -148,6 +150,6 @@ describe('Welcome email login', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Use a different email' }));
 
     expect(screen.queryByText('Check your email')).not.toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Enter your email')).toHaveValue('');
+    expect(screen.getByLabelText('Email address')).toHaveValue('');
   });
 });

--- a/app/src/services/api/__tests__/authApi.test.ts
+++ b/app/src/services/api/__tests__/authApi.test.ts
@@ -18,10 +18,7 @@ describe('sendEmailMagicLink', () => {
     expect(fetchSpy).toHaveBeenCalledWith('http://localhost:5005/auth/email/send-link', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        email: 'user@example.com',
-        frontendRedirectUri: 'openhuman://',
-      }),
+      body: JSON.stringify({ email: 'user@example.com', frontendRedirectUri: 'openhuman://' }),
       signal: expect.any(AbortSignal),
     });
   });

--- a/app/src/services/api/__tests__/authApi.test.ts
+++ b/app/src/services/api/__tests__/authApi.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { sendEmailMagicLink } from '../authApi';
+
+describe('sendEmailMagicLink', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('posts the email and redirect URI to the backend', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }) as Response);
+
+    await sendEmailMagicLink('user@example.com', 'openhuman://');
+
+    expect(fetchSpy).toHaveBeenCalledWith('http://localhost:5005/auth/email/send-link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'user@example.com',
+        frontendRedirectUri: 'openhuman://',
+      }),
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('times out stalled requests and surfaces a retry message', async () => {
+    vi.useFakeTimers();
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+
+    const request = sendEmailMagicLink('user@example.com', 'openhuman://', 100);
+    const rejection = expect(request).rejects.toThrow('Request timed out. Please try again.');
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejection;
+  });
+});

--- a/app/src/services/api/authApi.ts
+++ b/app/src/services/api/authApi.ts
@@ -1,5 +1,5 @@
-import { callCoreRpc } from '../coreRpcClient';
 import { getBackendUrl } from '../backendUrl';
+import { callCoreRpc } from '../coreRpcClient';
 
 /**
  * Send a magic-link email for email-based login.

--- a/app/src/services/api/authApi.ts
+++ b/app/src/services/api/authApi.ts
@@ -1,6 +1,8 @@
 import { getBackendUrl } from '../backendUrl';
 import { callCoreRpc } from '../coreRpcClient';
 
+const EMAIL_MAGIC_LINK_TIMEOUT_MS = 15_000;
+
 /**
  * Send a magic-link email for email-based login.
  * POST /auth/email/send-link
@@ -10,17 +12,34 @@ import { callCoreRpc } from '../coreRpcClient';
  */
 export async function sendEmailMagicLink(
   email: string,
-  frontendRedirectUri: string
+  frontendRedirectUri: string,
+  timeoutMs = EMAIL_MAGIC_LINK_TIMEOUT_MS
 ): Promise<void> {
   const backendUrl = await getBackendUrl();
-  const response = await fetch(`${backendUrl}/auth/email/send-link`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, frontendRedirectUri }),
-  });
-  if (!response.ok) {
-    const body = (await response.json().catch(() => ({}))) as { error?: string };
-    throw new Error(body.error ?? `Failed to send magic link (${response.status})`);
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${backendUrl}/auth/email/send-link`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, frontendRedirectUri }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? `Failed to send magic link (${response.status})`);
+    }
+  } catch (error) {
+    if (
+      (error instanceof DOMException && error.name === 'AbortError') ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      throw new Error('Request timed out. Please try again.');
+    }
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
   }
 }
 

--- a/app/src/services/api/authApi.ts
+++ b/app/src/services/api/authApi.ts
@@ -1,4 +1,28 @@
 import { callCoreRpc } from '../coreRpcClient';
+import { getBackendUrl } from '../backendUrl';
+
+/**
+ * Send a magic-link email for email-based login.
+ * POST /auth/email/send-link
+ * @param email - The user's email address.
+ * @param frontendRedirectUri - Where the backend should redirect after verification
+ *   (e.g. "openhuman://" for desktop, or the web app origin for web).
+ */
+export async function sendEmailMagicLink(
+  email: string,
+  frontendRedirectUri: string
+): Promise<void> {
+  const backendUrl = await getBackendUrl();
+  const response = await fetch(`${backendUrl}/auth/email/send-link`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, frontendRedirectUri }),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Failed to send magic link (${response.status})`);
+  }
+}
 
 /**
  * Consume a verified login token and return the JWT.

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -422,6 +422,7 @@ mod tests {
     //! provider calls — they pin the behaviour of the branches that all of
     //! the async `ops::*` entry points rely on.
     use super::*;
+    use crate::openhuman::threads::title::collapse_whitespace;
     use serde_json::{json, Value};
 
     // ── request_id ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add email magic-link login to the `Welcome` screen alongside the existing OAuth buttons.
- Detect desktop vs web at submit time and send the appropriate `frontendRedirectUri` (`openhuman://` for Tauri, current origin for web).
- Add a dedicated `sendEmailMagicLink(...)` frontend API helper that calls the backend `/auth/email/send-link` endpoint.
- Show inline loading, error, and "check your email" success states so the new login path feels native instead of bolted on.
- Reuse the existing deep-link auth flow rather than inventing a second frontend callback path.

## Problem

- The app already supported OAuth-based sign-in, but users could not start login with email from the main welcome screen.
- The backend email-magic-link work needs a matching frontend entry point, otherwise the feature is effectively undiscoverable.
- Desktop and web need different post-verification redirect targets, so the UI has to choose the correct redirect URI before requesting a magic link.

## Solution

- Update [app/src/pages/Welcome.tsx](/Users/cardinal/Desktop/projects/main/openhuman/app/src/pages/Welcome.tsx) to add:
  - email input state
  - submit handling
  - pending/error/success UI states
  - desktop/web redirect URI selection
- Add [app/src/services/api/authApi.ts](/Users/cardinal/Desktop/projects/main/openhuman/app/src/services/api/authApi.ts) helper `sendEmailMagicLink(email, frontendRedirectUri)` to POST to the backend auth endpoint.
- Keep the frontend intentionally thin:
  - backend owns email sending, redirect validation, and verification
  - frontend only initiates the flow and explains the result to the user
- For desktop, send `openhuman://` so the backend can redirect back into the existing deep-link handler.
- For web, send `window.location.origin` so the SPA can continue handling auth in-browser.

## Submission Checklist

- [ ] **E2E / integration** — Where behavior is user-visible or crosses UI → Tauri → sidecar → JSON-RPC; use existing harnesses (`app/test/e2e`, mock backend, `tests/json_rpc_e2e.rs` as appropriate)
- [x]  **Manual test**  —   Manually tested the dev-backend and the openhuman tauri app , and performed the whole login flow
- [x] **N/A** — Backend-driven auth flow; this PR is a focused UI/API integration and does not add dedicated frontend tests in this branch
- [x] **Doc comments** — Added JSDoc for `sendEmailMagicLink(...)` and brief inline note for the desktop deep-link constant
- [x] **Inline comments** — Added where the desktop/web redirect split is non-obvious

(Any feature related checklist can go in here)

## Impact

- Runtime/platform impact: frontend welcome/login flow on desktop and web.
- Security: no new auth policy is implemented in this PR; it relies on backend validation of redirect URIs and token issuance.
- Compatibility: additive change to login options, with no change to the existing OAuth path.
- UX: users can start email login directly from the first screen and get immediate success/error feedback.

## Related

- Issue(s):  #455 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email magic-link sign-in with inline validation, disabled/spinner submit state, and a “Check your email” confirmation; OAuth sign-in remains available.
  * Backend email-link request support for the new flow.

* **Tests**
  * Added tests covering the email magic-link UI flow and backend request behavior (including timeout handling).
  * Enabled/updated whitespace-collapsing test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->