### PR TITLE
fix(security): command injection in npm postinstall + weak RNG fallback

### DIFF
--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -18,6 +18,12 @@ import { AgentChatPanel } from './Conversations';
 function makeAccountId(): string {
   const c = globalThis.crypto;
   if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  if (c && typeof c.getRandomValues === 'function') {
+    const bytes = new Uint8Array(4);
+    c.getRandomValues(bytes);
+    const suffix = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+    return `acct-${Date.now().toString(36)}-${suffix}`;
+  }
   return `acct-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 

--- a/packages/npm/install.js
+++ b/packages/npm/install.js
@@ -132,6 +132,8 @@ async function main() {
     execFileSync(
       'powershell',
       [
+        '-NoProfile',
+        '-NonInteractive',
         '-Command',
         `Expand-Archive -Path $env:TC_SRC -DestinationPath $env:TC_DEST -Force`,
       ],

--- a/packages/npm/install.js
+++ b/packages/npm/install.js
@@ -10,7 +10,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 const REPO = 'tinyhumansai/openhuman';
 const pkg = require('./package.json');
@@ -125,17 +125,22 @@ async function main() {
   }
   console.log('[openhuman] Checksum verified.');
 
-  // Extract
+  // Extract — use execFileSync (no shell interpolation) so paths with spaces
+  // or shell metacharacters in `tmpTarball` / `binDir` can't be injected.
   if (isWin) {
     // PowerShell is available on Windows runners
-    execSync(
-      `powershell -Command "Expand-Archive -Path '${tmpTarball}' -DestinationPath '${binDir}' -Force"`,
-      { stdio: 'inherit' }
+    execFileSync(
+      'powershell',
+      [
+        '-Command',
+        `Expand-Archive -Path $env:TC_SRC -DestinationPath $env:TC_DEST -Force`,
+      ],
+      { stdio: 'inherit', env: { ...process.env, TC_SRC: tmpTarball, TC_DEST: binDir } }
     );
     const extracted = path.join(binDir, 'openhuman-core.exe');
     if (fs.existsSync(extracted)) fs.renameSync(extracted, binDest);
   } else {
-    execSync(`tar -xzf "${tmpTarball}" -C "${binDir}"`, { stdio: 'inherit' });
+    execFileSync('tar', ['-xzf', tmpTarball, '-C', binDir], { stdio: 'inherit' });
     const extracted = path.join(binDir, 'openhuman-core');
     if (fs.existsSync(extracted)) {
       fs.renameSync(extracted, binDest);

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -16,9 +16,9 @@ use crate::openhuman::memory::{
 };
 use crate::openhuman::providers::{self, ProviderRuntimeOptions};
 use crate::openhuman::threads::title::{
-    build_title_prompt, is_auto_generated_thread_title, sanitize_generated_title,
-    title_log_fingerprint, THREAD_TITLE_LOG_PREFIX, THREAD_TITLE_MODEL_HINT,
-    THREAD_TITLE_SYSTEM_PROMPT,
+    build_title_prompt, collapse_whitespace, is_auto_generated_thread_title,
+    sanitize_generated_title, title_log_fingerprint, THREAD_TITLE_LOG_PREFIX,
+    THREAD_TITLE_MODEL_HINT, THREAD_TITLE_SYSTEM_PROMPT,
 };
 use crate::rpc::RpcOutcome;
 use serde::Serialize;


### PR DESCRIPTION
## Summary
Two low-blast-radius security fixes surfaced by running [TrueCourse](https://github.com/truecourse-ai/truecourse) against the repo:

- **`packages/npm/install.js`** — swap `execSync(\`tar ... \"${'$'}{tmpTarball}\" ...\`)` / `execSync(\`powershell -Command \"Expand-Archive -Path '${'$'}{tmpTarball}' ...\"\`)` for `execFileSync` with argv arrays. Shell metacharacters in `tmpTarball` / `binDir` paths (controlled by npm install location + release version) can no longer be interpreted. PowerShell path passes values via env vars to avoid any interpolation.
- **`app/src/pages/Accounts.tsx`** — `makeAccountId()` now prefers `crypto.getRandomValues` before falling back to `Math.random()` for the suffix. Primary path is still `crypto.randomUUID()`; this just hardens the fallback chain.

Both findings are low-probability exploits (install dir would need to be attacker-controlled; Math.random suffix is behind a UUID availability check), but the fixes are zero-cost.

TrueCourse flagged two other \"critical\"s I skipped:
- `desktopDeepLinkListener.ts:17` — false positive (event name string, not a secret).
- `app/test/e2e/helpers/deep-link-helpers.ts:28` — `exec` in an e2e helper; test-only, local-only. Not worth churn.

## Test plan
- [x] `yarn compile` passes (Accounts.tsx)
- [x] `node -e \"require('./packages/npm/install.js')\"` parses
- [ ] CI (Build Tauri App + Rust tests + TS typecheck + Installer Smoke) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account identifiers now use cryptographic randomness when available for more reliable, less predictable IDs.
  * Improved installation/extraction behavior on Windows and non-Windows systems for more robust installs.

* **Refactor**
  * Minor internal import cleanup in thread title handling (no user-facing change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->