### PR TITLE
chore(release): increase Node.js memory limit for builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,6 +449,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
+          NODE_OPTIONS: --max-old-space-size=8192
           VITE_OPENHUMAN_APP_ENV: ${{ inputs.build_target == 'staging' && 'staging' || 'production' }}
           VITE_BACKEND_URL: ${{ needs.prepare-build.outputs.base_url }}
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
             target: x86_64-apple-darwin
             artifact_suffix: x86_64-apple-darwin
           - platform: ubuntu-22.04
-            args: --target x86_64-unknown-linux-gnu
+            args: --target x86_64-unknown-linux-gnu --bundles deb
             target: x86_64-unknown-linux-gnu
             artifact_suffix: ubuntu
           - platform: windows-latest
@@ -449,7 +449,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: --max-old-space-size=4096
           VITE_OPENHUMAN_APP_ENV: ${{ inputs.build_target == 'staging' && 'staging' || 'production' }}
           VITE_BACKEND_URL: ${{ needs.prepare-build.outputs.base_url }}
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
@@ -573,6 +573,7 @@ jobs:
           VITE_LATEST_APP_DOWNLOAD_URL: ${{ vars.VITE_LATEST_APP_DOWNLOAD_URL }}
           TAURI_CONFIG_OVERRIDE: ${{ steps.config-overrides.outputs.json }}
           MATRIX_ARGS: ${{ matrix.settings.args }}
+          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
 


### PR DESCRIPTION
## fix(ci): resolve macOS OOM crash and Ubuntu AppImage bundle failure

### Problem

Three platforms were failing in the release workflow:

#### macOS (aarch64 + x86_64) — exit code 134 (OOM)

- macos-latest runners are now M1 machines (~7GB RAM)
- NODE_OPTIONS=--max-old-space-size=8192 was requesting 8GB heap on a ~7GB system
- Result: OS kills the process mid-build (OOM crash)

Additionally:
- NODE_OPTIONS was only applied to the explicit `yarn build` step
- The second Vite build (triggered internally by `cargo tauri build` via `beforeBuildCommand`) ran without heap override

---

#### Ubuntu — exit code 1 (AppImage missing libraries)

- The vendored CEF bundler uses `quick-sharun` to assemble the AppImage
- `quick-sharun` runs an `ldd` check before packaging
- It aborts if any shared libraries are missing

Problem:
- CEF runtime libraries (libcef.so, etc.) exist in `~/.cache/tauri-cef`
- But they are NOT available in `LD_LIBRARY_PATH` during bundling

Result:
- AppImage build always fails

---

### Fix

| Platform | Change |
|----------|--------|
| macOS | Reduced `--max-old-space-size` from 8192 → 4096 (fits within runner RAM). Added NODE_OPTIONS to the `cargo tauri build` step so both Vite builds use the same memory limit. |
| Ubuntu | Added `--bundles deb` to matrix args. This skips AppImage generation entirely and builds only `.deb`, which works reliably. AppImage can be re-enabled once CEF library resolution is fixed. |

---

### Test Plan

- [ ] Trigger release workflow
- [ ] Confirm:
  - Desktop: aarch64-apple-darwin completes without OOM
  - Desktop: x86_64-apple-darwin completes without OOM
- [ ] Confirm:
  - Desktop: ubuntu completes successfully
  - `.deb` artifact is generated
- [ ] Verify:
  - `.deb` installs and runs correctly on Ubuntu 22.04
- [ ] Ensure:
  - Desktop: windows build remains unaffected