### PR TITLE
chore: commit .mcp.json + gitignore .truecourse/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ workflow
 .fastembed_cache
 overlay/src-tauri/target/
 .claude/*.lock
+
+# Local tooling state
+.truecourse/
+solo.yml

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "digitalocean": {
+      "command": "npx",
+      "args": ["-y", "@digitalocean/mcp"],
+      "env": { "DIGITALOCEAN_API_TOKEN": "${DIGITALOCEAN_API_TOKEN}" }
+    },
+    "daytona": {
+      "command": "daytona",
+      "args": ["mcp", "start"],
+      "env": { "DAYTONA_API_KEY": "${DAYTONA_API_KEY}" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Commits `.mcp.json` (DigitalOcean + Daytona MCP server config using `\${ENV_VAR}` refs — no secrets).
- Adds `.truecourse/` to `.gitignore` (local tooling state dir that was appearing as untracked noise).

## Test plan
- [ ] `git status` on main worktree no longer shows `.mcp.json` or `.truecourse/` as untracked after merge.