### PR TITLE
Fix: release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,19 @@ jobs:
     container:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.XGITHUB_APP_ID }}
+          private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,12 +267,20 @@ jobs:
       OPENHUMAN_TELEGRAM_BOT_USERNAME: ${{ inputs.build_target == 'staging' && 'alphahumantest_bot' || 'openhumanaibot' }}
       VITE_TELEGRAM_BOT_USERNAME: ${{ inputs.build_target == 'staging' && 'alphahumantest_bot' || 'openhumanaibot' }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.XGITHUB_APP_ID }}
+          private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout build ref
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
           submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure staging app environment
         if: inputs.build_target == 'staging'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,8 +279,26 @@ jobs:
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
-          submodules: recursive
+          submodules: false
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Init submodules (with retry)
+        shell: bash
+        env:
+          SUBMODULE_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${SUBMODULE_TOKEN}@github.com/".insteadOf "https://github.com/"
+          for attempt in 1 2 3; do
+            echo "[submodules] attempt $attempt/3"
+            git submodule update --init --recursive --depth=1 && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "[submodules] all 3 attempts failed"
+              exit 1
+            fi
+            echo "[submodules] failed — waiting 30s before retry"
+            sleep 30
+          done
+          git config --global --unset-all url."https://x-access-token:${SUBMODULE_TOKEN}@github.com/".insteadOf || true
 
       - name: Configure staging app environment
         if: inputs.build_target == 'staging'


### PR DESCRIPTION
# Summary

Fixes intermittent Ubuntu and Windows release build failures caused by transient GitHub HTTP 500 errors during repository/submodule fetching.

---

# Problem

The `build-desktop` matrix jobs for Ubuntu and Windows were failing at the **Checkout build ref** step with HTTP 500 Internal Server Error from GitHub's backend:

- Windows → failure during main repo fetch  
- Ubuntu → failure during `tauri-cef` submodule clone  
- macOS → succeeded due to different execution timing  

The `tauri-cef` submodule is a ~400 MB private repo containing the CEF-aware Tauri CLI, making it particularly sensitive to transient fetch failures.

Additionally:

- The original checkout step had **no GitHub App token**
- `actions/checkout@v4` fell back to the default `GITHUB_TOKEN`
- `GITHUB_TOKEN` cannot authenticate against private org-owned submodules

---

# Solution

- Added GitHub App token generation as the first step in `build-desktop`
  - Ensures token is available for both main repo checkout and submodule authentication

- Split checkout into two steps:

  1. **Main repo checkout**
     - `actions/checkout@v4`
     - `submodules: false`
     - Uses GitHub App token

  2. **Submodule fetch (custom step)**
     - Runs:
       ```bash
       git submodule update --init --recursive --depth=1
       ```
     - Wrapped in a **3-attempt retry loop**
       - 30-second delay between attempts
     - Uses `url.insteadOf` to inject GitHub App token for private repo access
     - Cleans up config after execution

- Result:
  - Transient GitHub 500 errors during submodule fetch will **self-heal**
  - Prevents entire release pipeline from failing

---

# Submission Checklist

- Unit tests — N/A (workflow-only change)
- E2E / Integration — N/A (validated via next release run)
- Code changes — N/A (no Rust or TypeScript touched)
- Doc comments — N/A
- Inline comments — N/A

---

# Impact

- Affects **CI/CD only**
- No runtime, frontend, or backend changes
- Reduces flaky release failures caused by GitHub infrastructure issues
- `url.insteadOf` rewrite:
  - Scoped to runner's global git config for that step
  - Explicitly unset afterward
  - Does not persist beyond the step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to enhance authentication and repository access procedures for build and release processes.

---

**Note:** These are internal infrastructure updates with no impact on end-user features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->