### PR TITLE
chore(github): add CODEOWNERS to auto-request maintainer reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for openhuman.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# The @tinyhumansai/maintainers team is requested for review on every PR.
+# Team members must have at least "write" access on this repo for GitHub to
+# honour the assignment.
+
+*   @tinyhumansai/maintainers


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with a single catch-all entry requesting review from `@tinyhumansai/maintainers` on every PR.
- Complements the new `yarn review merge` gate (which requires `reviewDecision=APPROVED`) by making sure a maintainer is actually pinged when a PR opens.

## Why
Without a CODEOWNERS entry, GitHub never auto-requests maintainers on new PRs, so `reviewDecision` stays `REVIEW_REQUIRED` until someone is assigned manually — and our merge script will refuse to run. This fixes that.

## Prerequisites
- The `maintainers` team already exists on the org (verified: `role_name: maintain`, `push: true` on this repo), so GitHub will honour the assignment.
- To make the signal binding, the branch protection rule on `main` should toggle **Require review from Code Owners** under "Require a pull request before merging".

## Test plan
- [ ] After merge, open a throwaway PR and confirm `@tinyhumansai/maintainers` is automatically listed as a reviewer.
- [ ] Confirm `gh pr view <new-pr> --json reviewDecision` returns `REVIEW_REQUIRED` until a maintainer approves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->