### PR TITLE
feat(scripts/review): yarn review CLI for sync/review/fix/merge with LLM-summarised squash bodies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,5 +30,14 @@
 
 ## Related
 
-- Issue(s):
+<!--
+Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
+Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
+A bare "#123" reference is just a link — it does NOT close the issue.
+
+  Closes #123
+  Fixes  #456
+-->
+
+- Closes:
 - Follow-up PR(s)/TODOs:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:coverage": "yarn workspace openhuman-app test:coverage",
     "test:rust": "yarn workspace openhuman-app test:rust",
     "mock:api": "node scripts/mock-api-server.mjs",
+    "review": "bash scripts/review/cli.sh",
     "rust:check": "yarn workspace openhuman-app rust:check",
     "typecheck": "yarn workspace openhuman-app compile"
   },

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -3,12 +3,22 @@
 Helpers for working through PRs on this repo. Runnable directly — no zshrc
 integration needed.
 
-| Script       | What it does                                                                 |
-| ------------ | ---------------------------------------------------------------------------- |
-| `sync.sh`    | Fetch PR head, check out as `pr/<num>`, merge `main`, wire push/upstream.    |
-| `review.sh`  | `sync` + hand off to the `pr-reviewer` agent to review, comment, and approve.|
-| `fix.sh`     | `sync` + `pr-reviewer` (apply fixes) + `pr-manager-lite` (commit & push).    |
-| `merge.sh`   | Show PR status and merge via `gh pr merge` (default `--squash`).             |
+| Script       | What it does                                                                      |
+| ------------ | --------------------------------------------------------------------------------- |
+| `sync.sh`    | Fetch PR head, check out as `pr/<num>`, merge `main`, wire push/upstream.         |
+| `review.sh`  | `sync` + hand off to the `pr-reviewer` agent to review, comment, and approve.     |
+| `fix.sh`     | `sync` + `pr-reviewer` (apply fixes) + `pr-manager-lite` (commit & push).         |
+| `merge.sh`   | LLM-summarized squash body + filtered Co-authored-by trailers + `gh pr merge`.    |
+
+## LLM flags
+
+- `review` / `fix`: `--executor-llm <tool>` (default `claude`). Picks the CLI that
+  drives the agent prompt.
+- `merge`: `--summary-llm <tool>` (default `gemini`). The LLM that condenses the PR
+  body + commit messages into a concise squash commit body. Use `--summary-llm none`
+  to skip summarization and keep the raw PR body.
+
+Any tool that accepts `-p "<prompt>"` and prints its response to stdout works.
 
 ## Usage
 
@@ -36,4 +46,10 @@ scripts/review/merge.sh 123
 
 - Repo is derived from the `upstream` remote (falls back to `origin`). Override
   with `REVIEW_REPO=owner/name`.
-- Requires `git`, `gh`, `jq`. `review.sh` and `fix.sh` also require `claude`.
+- `REVIEW_BANNED_COAUTHOR_RE` overrides the substring regex used to drop
+  `Co-authored-by:` entries (default filters copilot / codex / cursor / claude /
+  anthropic / openai / chatgpt / `[bot]` / `noreply@github` /
+  `users.noreply.github.com`; matched case-insensitively on name or email).
+- Requires `git`, `gh`, `jq`. `review` / `fix` also require the executor LLM CLI
+  (default `claude`); `merge` also requires the summary LLM CLI (default `gemini`)
+  unless `--summary-llm none`.

--- a/scripts/review/README.md
+++ b/scripts/review/README.md
@@ -1,0 +1,39 @@
+# scripts/review
+
+Helpers for working through PRs on this repo. Runnable directly — no zshrc
+integration needed.
+
+| Script       | What it does                                                                 |
+| ------------ | ---------------------------------------------------------------------------- |
+| `sync.sh`    | Fetch PR head, check out as `pr/<num>`, merge `main`, wire push/upstream.    |
+| `review.sh`  | `sync` + hand off to the `pr-reviewer` agent to review, comment, and approve.|
+| `fix.sh`     | `sync` + `pr-reviewer` (apply fixes) + `pr-manager-lite` (commit & push).    |
+| `merge.sh`   | Show PR status and merge via `gh pr merge` (default `--squash`).             |
+
+## Usage
+
+Via yarn (preferred):
+
+```sh
+yarn review sync 123
+yarn review review 123
+yarn review fix 123
+yarn review merge 123              # --squash
+yarn review merge 123 --rebase
+yarn review --help
+```
+
+Or invoke the scripts directly:
+
+```sh
+scripts/review/sync.sh 123
+scripts/review/review.sh 123
+scripts/review/fix.sh 123
+scripts/review/merge.sh 123
+```
+
+## Config
+
+- Repo is derived from the `upstream` remote (falls back to `origin`). Override
+  with `REVIEW_REPO=owner/name`.
+- Requires `git`, `gh`, `jq`. `review.sh` and `fix.sh` also require `claude`.

--- a/scripts/review/cli.sh
+++ b/scripts/review/cli.sh
@@ -11,12 +11,19 @@ Usage: yarn review <command> <pr-number> [args]
 
 Commands:
   sync    <pr>                            Check out PR as pr/<num>, merge main, wire remotes
-  review  <pr>                            Sync + pr-reviewer agent (review, comment, approve)
-  fix     <pr>                            Sync + pr-reviewer (apply fixes) + pr-manager-lite (push)
-  merge   <pr> [--squash|--merge|--rebase]  Merge via gh (default --squash, deletes branch)
+  review  <pr> [--executor-llm <tool>]    Sync + pr-reviewer agent (review, comment, approve)
+                                          Default executor: claude
+  fix     <pr> [--executor-llm <tool>]    Sync + pr-reviewer (apply fixes) + pr-manager-lite (push)
+                                          Default executor: claude
+  merge   <pr> [--squash|--merge|--rebase] [--dry-run] [--summary-llm <tool>]
+                                          Merge via gh (default --squash, deletes branch).
+                                          --dry-run prints the squash commit message and exits.
+                                          Default summary LLM: gemini (use 'none' to skip).
 
 Env:
-  REVIEW_REPO=owner/name  Override target repo (default: derived from upstream remote)
+  REVIEW_REPO=owner/name                  Override target repo (default: upstream remote)
+  REVIEW_BANNED_COAUTHOR_RE=<regex>       Substrings filtered from Co-authored-by lines
+                                          (default includes copilot/codex/cursor/claude/…)
 EOF
 }
 

--- a/scripts/review/cli.sh
+++ b/scripts/review/cli.sh
@@ -15,8 +15,12 @@ Commands:
                                           Default executor: claude
   fix     <pr> [--executor-llm <tool>]    Sync + pr-reviewer (apply fixes) + pr-manager-lite (push)
                                           Default executor: claude
-  merge   <pr> [--squash|--merge|--rebase] [--dry-run] [--summary-llm <tool>]
+  merge   <pr> [--squash|--merge|--rebase] [--dry-run] [--force] [--admin|--auto] [--summary-llm <tool>]
                                           Merge via gh (default --squash, deletes branch).
+                                          Requires reviewDecision=APPROVED and green required checks
+                                          (mergeStateStatus in CLEAN/UNSTABLE/HAS_HOOKS) — use --force to skip the local gate.
+                                          --admin bypasses branch protection (requires admin rights).
+                                          --auto queues the merge until checks/approvals are satisfied.
                                           --dry-run prints the squash commit message and exits.
                                           Default summary LLM: gemini (use 'none' to skip).
 

--- a/scripts/review/cli.sh
+++ b/scripts/review/cli.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Dispatcher for `yarn review <cmd> <args…>`.
+# Commands: sync | review | fix | merge
+
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: yarn review <command> <pr-number> [args]
+
+Commands:
+  sync    <pr>                            Check out PR as pr/<num>, merge main, wire remotes
+  review  <pr>                            Sync + pr-reviewer agent (review, comment, approve)
+  fix     <pr>                            Sync + pr-reviewer (apply fixes) + pr-manager-lite (push)
+  merge   <pr> [--squash|--merge|--rebase]  Merge via gh (default --squash, deletes branch)
+
+Env:
+  REVIEW_REPO=owner/name  Override target repo (default: derived from upstream remote)
+EOF
+}
+
+cmd="${1:-}"
+if [ -z "$cmd" ] || [ "$cmd" = "-h" ] || [ "$cmd" = "--help" ]; then
+  usage
+  exit 0
+fi
+shift
+
+case "$cmd" in
+  sync|review|fix|merge)
+    exec "$here/${cmd}.sh" "$@"
+    ;;
+  *)
+    echo "[review] unknown command: $cmd" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/review/fix.sh
+++ b/scripts/review/fix.sh
@@ -1,19 +1,34 @@
 #!/usr/bin/env bash
-# fix.sh <pr-number>
+# fix.sh <pr-number> [--executor-llm <tool>]
 # Sync the PR, run pr-reviewer to identify issues and apply fixes, then hand
 # off to pr-manager-lite to run the quality suite, commit, and push.
+#
+# --executor-llm picks the CLI that drives the agent. Default: claude.
 
 set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$here/lib.sh"
 
-require git gh jq claude
+require git gh jq
 require_pr_number "${1:-}"
-sync_pr "$1"
 
-claude "I've already checked out branch pr/$REVIEW_PR with main merged in and \
-upstream tracking set (repo: $REVIEW_REPO_RESOLVED). Use the pr-reviewer agent \
-to review PR #$REVIEW_PR and fix the issues it finds. Then use the \
-pr-manager-lite agent to run the quality suite, commit, and push the changes \
-back to the PR branch."
+pr="$1"
+executor_llm="claude"
+shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --executor-llm) executor_llm="${2:?--executor-llm requires a value}"; shift 2 ;;
+    --executor-llm=*) executor_llm="${1#*=}"; shift ;;
+    *) echo "[review] unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+require "$executor_llm"
+sync_pr "$pr"
+
+"$executor_llm" "I've already checked out branch pr/$REVIEW_PR with main \
+merged in and upstream tracking set (repo: $REVIEW_REPO_RESOLVED). Use the \
+pr-reviewer agent to review PR #$REVIEW_PR and fix the issues it finds. Then \
+use the pr-manager-lite agent to run the quality suite, commit, and push the \
+changes back to the PR branch."

--- a/scripts/review/fix.sh
+++ b/scripts/review/fix.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# fix.sh <pr-number>
+# Sync the PR, run pr-reviewer to identify issues and apply fixes, then hand
+# off to pr-manager-lite to run the quality suite, commit, and push.
+
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+
+require git gh jq claude
+require_pr_number "${1:-}"
+sync_pr "$1"
+
+claude "I've already checked out branch pr/$REVIEW_PR with main merged in and \
+upstream tracking set (repo: $REVIEW_REPO_RESOLVED). Use the pr-reviewer agent \
+to review PR #$REVIEW_PR and fix the issues it finds. Then use the \
+pr-manager-lite agent to run the quality suite, commit, and push the changes \
+back to the PR branch."

--- a/scripts/review/lib.sh
+++ b/scripts/review/lib.sh
@@ -28,6 +28,39 @@ require() {
   done
 }
 
+# Summarize free-form text via a local LLM CLI (expects `-p <prompt>`).
+# Usage: summarize_text <tool> <input>
+# Tools used here: gemini (default for summaries), claude, or any CLI that
+# accepts `-p "<prompt>"` and prints the response to stdout.
+# Special value `none` echoes input unchanged.
+summarize_text() {
+  local tool="$1"
+  local input="$2"
+  if [ "$tool" = "none" ] || [ "$tool" = "raw" ]; then
+    printf '%s' "$input"
+    return
+  fi
+  require "$tool"
+  local prompt
+  prompt=$(cat <<'EOF'
+You are writing the body of a squash-merge commit.
+Summarize the PR changes below into 3-6 short bullet points.
+Rules:
+- Start each bullet with "- " and use imperative mood ("Add…", "Fix…", "Rename…").
+- One line per bullet, under ~100 chars.
+- No headers, no code fences, no sign-offs, no Co-authored-by lines.
+- Do not include the PR number or title.
+- Output only the bullets, nothing else.
+
+PR content:
+---
+EOF
+)
+  "$tool" -p "${prompt}
+${input}
+---"
+}
+
 require_pr_number() {
   if [ -z "${1:-}" ]; then
     echo "Usage: $(basename "$0") <pr-number>" >&2
@@ -48,7 +81,7 @@ sync_pr() {
   local repo
   repo=$(resolve_repo)
 
-  echo "[review] syncing main from upstream…"
+  echo "[review] syncing main from upstream..."
   git checkout main
   git pull origin main
   git fetch upstream
@@ -68,7 +101,7 @@ sync_pr() {
     "+${head_branch}:${local_branch}"
   git checkout "$local_branch"
 
-  echo "[review] merging main into $local_branch (conflicts will not abort)…"
+  echo "[review] merging main into $local_branch (conflicts will not abort)..."
   git merge main || echo "[review] ! conflicts detected in PR #$pr, continuing."
 
   # Prefer an existing SSH remote pointing at this fork to avoid https auth prompts.

--- a/scripts/review/lib.sh
+++ b/scripts/review/lib.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Shared helpers for scripts/review/*.sh
+# Source this file; do not execute directly.
+
+set -euo pipefail
+
+# Repo that hosts the PR. Override with REVIEW_REPO=owner/name if needed;
+# otherwise we derive it from the `upstream` remote, falling back to `origin`.
+resolve_repo() {
+  if [ -n "${REVIEW_REPO:-}" ]; then
+    echo "$REVIEW_REPO"
+    return
+  fi
+  local url
+  url=$(git remote get-url upstream 2>/dev/null || git remote get-url origin)
+  # Accept git@github.com:owner/name(.git) and https://github.com/owner/name(.git)
+  echo "$url" \
+    | sed -E 's#^git@github\.com:##; s#^https?://github\.com/##; s#\.git$##'
+}
+
+require() {
+  local bin
+  for bin in "$@"; do
+    command -v "$bin" >/dev/null 2>&1 || {
+      echo "[review] missing required tool: $bin" >&2
+      exit 1
+    }
+  done
+}
+
+require_pr_number() {
+  if [ -z "${1:-}" ]; then
+    echo "Usage: $(basename "$0") <pr-number>" >&2
+    exit 1
+  fi
+  case "$1" in
+    ''|*[!0-9]*)
+      echo "[review] pr-number must be numeric, got: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Fetch PR head into local branch pr/<num>, merge main in, wire upstream +
+# pushRemote so `git push` lands on the contributor's fork.
+sync_pr() {
+  local pr="$1"
+  local repo
+  repo=$(resolve_repo)
+
+  echo "[review] syncing main from upstream…"
+  git checkout main
+  git pull origin main
+  git fetch upstream
+  git merge upstream/main
+  git submodule update --init --recursive
+
+  local info head_repo head_branch local_branch
+  info=$(gh pr view "$pr" -R "$repo" \
+    --json headRefName,headRepository,headRepositoryOwner)
+  head_repo=$(echo "$info" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
+  head_branch=$(echo "$info" | jq -r '.headRefName')
+  local_branch="pr/$pr"
+
+  echo "[review] PR #$pr -> $head_repo:$head_branch (local: $local_branch)"
+
+  git fetch "https://github.com/${head_repo}.git" \
+    "+${head_branch}:${local_branch}"
+  git checkout "$local_branch"
+
+  echo "[review] merging main into $local_branch (conflicts will not abort)…"
+  git merge main || echo "[review] ! conflicts detected in PR #$pr, continuing."
+
+  # Prefer an existing SSH remote pointing at this fork to avoid https auth prompts.
+  local remote_name="remote-$pr"
+  local existing_ssh
+  existing_ssh=$(git remote -v \
+    | awk -v repo="$head_repo" '$2 ~ ("[:/]" repo "(\\.git)?$") && $3 == "(fetch)" {print $1; exit}')
+  if [ -n "$existing_ssh" ]; then
+    remote_name="$existing_ssh"
+    echo "[review] reusing remote '$remote_name' -> $(git remote get-url "$remote_name")"
+  else
+    local remote_url="https://github.com/${head_repo}.git"
+    git remote add "$remote_name" "$remote_url" 2>/dev/null \
+      || git remote set-url "$remote_name" "$remote_url"
+  fi
+
+  git fetch "$remote_name" \
+    "+refs/heads/${head_branch}:refs/remotes/${remote_name}/${head_branch}"
+
+  git branch --set-upstream-to="$remote_name/$head_branch" "$local_branch"
+  git config "branch.${local_branch}.pushRemote" "$remote_name"
+  git config "branch.${local_branch}.merge" "refs/heads/${head_branch}"
+
+  echo "[review] upstream + pushRemote set to $remote_name/$head_branch"
+
+  # Export for callers.
+  REVIEW_PR="$pr"
+  REVIEW_REPO_RESOLVED="$repo"
+  REVIEW_LOCAL_BRANCH="$local_branch"
+  REVIEW_HEAD_REPO="$head_repo"
+  REVIEW_HEAD_BRANCH="$head_branch"
+}

--- a/scripts/review/merge.sh
+++ b/scripts/review/merge.sh
@@ -1,26 +1,42 @@
 #!/usr/bin/env bash
-# merge.sh <pr-number> [--squash|--merge|--rebase]
-# Merge a PR via gh. Defaults to --squash to match the usual workflow.
-# Waits for required checks (gh's --auto is not used here; we block explicitly
-# so you see the outcome before the script exits).
+# merge.sh <pr-number> [--squash|--merge|--rebase] [--dry-run] [--summary-llm <tool>]
+# Merge a PR via gh. Defaults to --squash.
+#
+# For --squash we rewrite the commit body:
+#   - summarize the PR body + commit messages with the summary LLM
+#     (default: gemini; use `none` to skip and keep the raw PR body)
+#   - drop any Co-authored-by lines mentioning copilot / codex / cursor / claude
+#   - add the current `git config user.name <user.email>` as a co-author
+# --merge and --rebase keep the original commits as-is.
+#
+# --dry-run prints the squash subject + body that would be used and exits
+# without calling `gh pr merge`. Ignored for --merge / --rebase.
 
 set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$here/lib.sh"
 
-require git gh
+require git gh jq
 require_pr_number "${1:-}"
 
 pr="$1"
-strategy="${2:---squash}"
-case "$strategy" in
-  --squash|--merge|--rebase) ;;
-  *)
-    echo "[review] unknown merge strategy: $strategy (expected --squash|--merge|--rebase)" >&2
-    exit 1
-    ;;
-esac
+strategy="--squash"
+dry_run=0
+summary_llm="gemini"
+shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --squash|--merge|--rebase) strategy="$1"; shift ;;
+    --dry-run|-n) dry_run=1; shift ;;
+    --summary-llm) summary_llm="${2:?--summary-llm requires a value}"; shift 2 ;;
+    --summary-llm=*) summary_llm="${1#*=}"; shift ;;
+    *)
+      echo "[review] unknown arg: $1 (expected --squash|--merge|--rebase|--dry-run|--summary-llm)" >&2
+      exit 1
+      ;;
+  esac
+done
 
 repo=$(resolve_repo)
 
@@ -30,6 +46,135 @@ gh pr view "$pr" -R "$repo" \
   | jq '{state, mergeable, mergeStateStatus, reviewDecision,
          checks: [.statusCheckRollup[]? | {name: (.name // .context), status, conclusion}]}'
 
-echo "[review] merging PR #$pr with $strategy…"
-gh pr merge "$pr" -R "$repo" "$strategy" --delete-branch
+# Substring patterns (case-insensitive) matched against co-author name OR email.
+# Override via REVIEW_BANNED_COAUTHOR_RE env var.
+BANNED_RE="${REVIEW_BANNED_COAUTHOR_RE:-copilot|codex|cursor|claude|anthropic|openai|chatgpt|\[bot\]|noreply@github|users\.noreply\.github\.com}"
+
+build_squash_body() {
+  local pr="$1" repo="$2" summary_llm="$3"
+  local data body title me_name me_email
+  data=$(gh pr view "$pr" -R "$repo" --json title,body,commits)
+  title=$(jq -r '.title' <<<"$data")
+  body=$(jq -r '.body // ""' <<<"$data")
+
+  me_name=$(git config --get user.name || true)
+  me_email=$(git config --get user.email || true)
+  if [ -z "$me_name" ] || [ -z "$me_email" ]; then
+    echo "[review] git config user.name/user.email not set; cannot add self as co-author" >&2
+    exit 1
+  fi
+
+  # Strip any existing Co-authored-by trailers from the PR body.
+  local body_clean
+  body_clean=$(printf '%s\n' "$body" | grep -viE '^co-authored-by:' || true)
+  # Trim trailing blank lines.
+  body_clean=$(printf '%s\n' "$body_clean" | awk 'NF {p=1} p {lines[NR]=$0; last=NR} END {for (i=1;i<=last;i++) print lines[i]}')
+
+  # Build input for the summary LLM: title + PR body + commit list.
+  local summary_input
+  summary_input=$(jq -r '
+      "Title: " + .title + "\n\n" +
+      "PR body:\n" + (.body // "(empty)") + "\n\n" +
+      "Commits:\n" +
+      ((.commits // [])
+        | map("- " + .messageHeadline
+              + (if (.messageBody // "") != ""
+                 then "\n  " + ((.messageBody) | gsub("\n"; "\n  "))
+                 else "" end))
+        | join("\n"))
+    ' <<<"$data")
+
+  local summary_body
+  if [ "$summary_llm" = "none" ] || [ "$summary_llm" = "raw" ]; then
+    summary_body="$body_clean"
+  else
+    echo "[review] summarizing with ${summary_llm}..." >&2
+    summary_body=$(summarize_text "$summary_llm" "$summary_input")
+    if [ -z "$summary_body" ]; then
+      echo "[review] ! summary LLM returned empty output; falling back to PR body" >&2
+      summary_body="$body_clean"
+    fi
+  fi
+
+  # Collect co-authors from commit authors + Co-authored-by trailers, then
+  # filter. tolower()-based match is portable (BSD awk has no IGNORECASE).
+  local coauthors
+  coauthors=$(jq -r '
+      .commits[]
+      | (
+          (.authors[]? | "\(.name // "")\t\(.email // "")"),
+          (.messageBody // "" | split("\n")[]
+            | select(test("^[Cc]o-authored-by:"))
+            | sub("^[Cc]o-authored-by:\\s*"; "")
+            | capture("^(?<n>.+?)\\s*<(?<e>[^>]+)>\\s*$")?
+            | "\(.n)\t\(.e)"
+          )
+        )
+    ' <<<"$data" \
+    | awk -F'\t' -v me="$me_email" -v banned="$BANNED_RE" '
+        NF < 2 { next }
+        $1 == "" || $2 == "" { next }
+        tolower($2) == tolower(me) { next }
+        {
+          nl = tolower($1); el = tolower($2);
+          if (nl ~ banned || el ~ banned) next;
+          key = el;
+          if (!(key in seen)) {
+            seen[key] = 1
+            printf "Co-authored-by: %s <%s>\n", $1, $2
+          }
+        }
+      ')
+
+  {
+    if [ -n "$summary_body" ]; then
+      printf '%s\n\n' "$summary_body"
+    fi
+    if [ -n "$coauthors" ]; then
+      printf '%s\n' "$coauthors"
+    fi
+    printf 'Co-authored-by: %s <%s>\n' "$me_name" "$me_email"
+  }
+  : "$title"  # reserved for future subject overrides
+}
+
+if [ "$strategy" = "--squash" ]; then
+  title=$(gh pr view "$pr" -R "$repo" --json title -q .title)
+
+  # Append any linked "Closes #N" issues that aren't already referenced in the
+  # title (skip issue numbers already mentioned as #N).
+  closing=$(gh pr view "$pr" -R "$repo" \
+    --json closingIssuesReferences \
+    --jq '.closingIssuesReferences[].number' 2>/dev/null || true)
+  missing=()
+  for n in $closing; do
+    if ! grep -qE "#${n}([^0-9]|$)" <<<"$title"; then
+      missing+=("#${n}")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    joined=$(printf ', %s' "${missing[@]}")
+    joined=${joined:2}
+    title="${title} (closes ${joined})"
+  fi
+
+  body=$(build_squash_body "$pr" "$repo" "$summary_llm")
+  echo "[review] squash commit message:"
+  printf -- '----\n%s (#%s)\n\n%s\n----\n' "$title" "$pr" "$body"
+  if [ "$dry_run" = "1" ]; then
+    echo "[review] --dry-run: not merging."
+    exit 0
+  fi
+  echo "[review] merging PR #$pr with --squash..."
+  gh pr merge "$pr" -R "$repo" --squash --delete-branch \
+    --subject "$title (#$pr)" \
+    --body "$body"
+else
+  if [ "$dry_run" = "1" ]; then
+    echo "[review] --dry-run: $strategy does not rewrite the commit message; nothing to preview."
+    exit 0
+  fi
+  echo "[review] merging PR #$pr with $strategy..."
+  gh pr merge "$pr" -R "$repo" "$strategy" --delete-branch
+fi
 echo "[review] merged."

--- a/scripts/review/merge.sh
+++ b/scripts/review/merge.sh
@@ -23,28 +23,104 @@ require_pr_number "${1:-}"
 pr="$1"
 strategy="--squash"
 dry_run=0
+force=0
+admin=0
+auto=0
 summary_llm="gemini"
 shift
 while [ $# -gt 0 ]; do
   case "$1" in
     --squash|--merge|--rebase) strategy="$1"; shift ;;
     --dry-run|-n) dry_run=1; shift ;;
+    --force|-f) force=1; shift ;;
+    --admin) admin=1; shift ;;
+    --auto) auto=1; shift ;;
     --summary-llm) summary_llm="${2:?--summary-llm requires a value}"; shift 2 ;;
     --summary-llm=*) summary_llm="${1#*=}"; shift ;;
     *)
-      echo "[review] unknown arg: $1 (expected --squash|--merge|--rebase|--dry-run|--summary-llm)" >&2
+      echo "[review] unknown arg: $1 (expected --squash|--merge|--rebase|--dry-run|--force|--admin|--auto|--summary-llm)" >&2
       exit 1
       ;;
   esac
 done
 
+if [ "$admin" = "1" ] && [ "$auto" = "1" ]; then
+  echo "[review] --admin and --auto are mutually exclusive" >&2
+  exit 1
+fi
+
 repo=$(resolve_repo)
 
 echo "[review] PR #$pr status on $repo:"
-gh pr view "$pr" -R "$repo" \
-  --json state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup \
-  | jq '{state, mergeable, mergeStateStatus, reviewDecision,
-         checks: [.statusCheckRollup[]? | {name: (.name // .context), status, conclusion}]}'
+pr_status_json=$(gh pr view "$pr" -R "$repo" \
+  --json state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup)
+jq '{state, mergeable, mergeStateStatus, reviewDecision,
+     checks: [.statusCheckRollup[]? | {name: (.name // .context), status, conclusion}]}' \
+  <<<"$pr_status_json"
+
+# Merge gate: all required checks green + at least one maintainer approval.
+# GitHub already folds both into mergeStateStatus:
+#   CLEAN    — approved, required checks pass, mergeable
+#   UNSTABLE — approved, required pass, non-required failing (OK to merge)
+#   BLOCKED  — missing review, failing required check, or branch-protection block
+#   DIRTY    — merge conflicts
+# We require reviewDecision=APPROVED too, so a repo without branch protection
+# (which would leave mergeStateStatus=CLEAN even without a review) still blocks.
+ensure_merge_ready() {
+  local state review merge_state
+  state=$(jq -r '.state' <<<"$pr_status_json")
+  review=$(jq -r '.reviewDecision // "NONE"' <<<"$pr_status_json")
+  merge_state=$(jq -r '.mergeStateStatus' <<<"$pr_status_json")
+
+  local ok=1
+  if [ "$state" != "OPEN" ]; then
+    echo "[review] ! PR state is $state (expected OPEN)" >&2
+    ok=0
+  fi
+  case "$review" in
+    APPROVED) ;;
+    *)
+      echo "[review] ! reviewDecision is $review (expected APPROVED — need a maintainer approval)" >&2
+      ok=0
+      ;;
+  esac
+  case "$merge_state" in
+    CLEAN|UNSTABLE|HAS_HOOKS) ;;
+    *)
+      echo "[review] ! mergeStateStatus is $merge_state (expected CLEAN/UNSTABLE — required checks may still be pending or failing)" >&2
+      ok=0
+      ;;
+  esac
+
+  # Enumerate any required-looking checks that aren't SUCCESS/NEUTRAL/SKIPPED
+  # for a clearer error. mergeStateStatus already covers this; this is just UX.
+  local bad_checks
+  bad_checks=$(jq -r '
+      .statusCheckRollup[]?
+      | select(
+          (.conclusion // "") as $c
+          | (.status // "") as $s
+          | ($c | IN("SUCCESS","NEUTRAL","SKIPPED","")) as $okConc
+          | ($s | IN("COMPLETED","")) as $okStatus
+          | (($okConc and $okStatus) | not)
+        )
+      | "  - \((.name // .context)): status=\(.status // "?"), conclusion=\(.conclusion // "?")"
+    ' <<<"$pr_status_json")
+  if [ -n "$bad_checks" ]; then
+    echo "[review] ! checks not green:" >&2
+    printf '%s\n' "$bad_checks" >&2
+    ok=0
+  fi
+
+  if [ "$ok" != "1" ]; then
+    if [ "$force" = "1" ]; then
+      echo "[review] --force: proceeding despite merge gate failures." >&2
+      return 0
+    fi
+    echo "[review] refusing to merge. Re-run with --force to override." >&2
+    exit 1
+  fi
+}
 
 # Substring patterns (case-insensitive) matched against co-author name OR email.
 # Override via REVIEW_BANNED_COAUTHOR_RE env var.
@@ -165,16 +241,37 @@ if [ "$strategy" = "--squash" ]; then
     echo "[review] --dry-run: not merging."
     exit 0
   fi
+  extra_flags=()
+  if [ "$admin" = "1" ]; then
+    echo "[review] --admin: bypassing local gate and using branch-protection override"
+    extra_flags+=(--admin)
+  elif [ "$auto" = "1" ]; then
+    echo "[review] --auto: queueing merge once checks/approvals are satisfied"
+    extra_flags+=(--auto)
+  else
+    ensure_merge_ready
+  fi
   echo "[review] merging PR #$pr with --squash..."
   gh pr merge "$pr" -R "$repo" --squash --delete-branch \
     --subject "$title (#$pr)" \
-    --body "$body"
+    --body "$body" \
+    "${extra_flags[@]}"
 else
   if [ "$dry_run" = "1" ]; then
     echo "[review] --dry-run: $strategy does not rewrite the commit message; nothing to preview."
     exit 0
   fi
+  extra_flags=()
+  if [ "$admin" = "1" ]; then
+    echo "[review] --admin: bypassing local gate and using branch-protection override"
+    extra_flags+=(--admin)
+  elif [ "$auto" = "1" ]; then
+    echo "[review] --auto: queueing merge once checks/approvals are satisfied"
+    extra_flags+=(--auto)
+  else
+    ensure_merge_ready
+  fi
   echo "[review] merging PR #$pr with $strategy..."
-  gh pr merge "$pr" -R "$repo" "$strategy" --delete-branch
+  gh pr merge "$pr" -R "$repo" "$strategy" --delete-branch "${extra_flags[@]}"
 fi
 echo "[review] merged."

--- a/scripts/review/merge.sh
+++ b/scripts/review/merge.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# merge.sh <pr-number> [--squash|--merge|--rebase]
+# Merge a PR via gh. Defaults to --squash to match the usual workflow.
+# Waits for required checks (gh's --auto is not used here; we block explicitly
+# so you see the outcome before the script exits).
+
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+
+require git gh
+require_pr_number "${1:-}"
+
+pr="$1"
+strategy="${2:---squash}"
+case "$strategy" in
+  --squash|--merge|--rebase) ;;
+  *)
+    echo "[review] unknown merge strategy: $strategy (expected --squash|--merge|--rebase)" >&2
+    exit 1
+    ;;
+esac
+
+repo=$(resolve_repo)
+
+echo "[review] PR #$pr status on $repo:"
+gh pr view "$pr" -R "$repo" \
+  --json state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup \
+  | jq '{state, mergeable, mergeStateStatus, reviewDecision,
+         checks: [.statusCheckRollup[]? | {name: (.name // .context), status, conclusion}]}'
+
+echo "[review] merging PR #$pr with $strategy…"
+gh pr merge "$pr" -R "$repo" "$strategy" --delete-branch
+echo "[review] merged."

--- a/scripts/review/merge.sh
+++ b/scripts/review/merge.sh
@@ -127,7 +127,7 @@ ensure_merge_ready() {
 BANNED_RE="${REVIEW_BANNED_COAUTHOR_RE:-copilot|codex|cursor|claude|anthropic|openai|chatgpt|\[bot\]|noreply@github|users\.noreply\.github\.com}"
 
 build_squash_body() {
-  local pr="$1" repo="$2" summary_llm="$3"
+  local pr="$1" repo="$2" summary_llm="$3" closing_issues="${4:-}"
   local data body title me_name me_email
   data=$(gh pr view "$pr" -R "$repo" --json title,body,commits)
   title=$(jq -r '.title' <<<"$data")
@@ -202,9 +202,29 @@ build_squash_body() {
         }
       ')
 
+  # Strip any stray closing-keyword lines the LLM or PR body may have
+  # emitted — we'll append a canonical block below so GitHub sees one
+  # `Closes #N` per linked issue (its regex only matches one ref per keyword,
+  # so `Closes #1, #2` would only close #1).
+  local summary_clean
+  summary_clean=$(printf '%s\n' "$summary_body" \
+    | grep -viE '^[[:space:]]*(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(#|[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#)[0-9]+' \
+    || true)
+
+  local closes_block=""
+  if [ -n "$closing_issues" ]; then
+    local n
+    for n in $closing_issues; do
+      closes_block+="Closes #${n}"$'\n'
+    done
+  fi
+
   {
-    if [ -n "$summary_body" ]; then
-      printf '%s\n\n' "$summary_body"
+    if [ -n "$summary_clean" ]; then
+      printf '%s\n\n' "$summary_clean"
+    fi
+    if [ -n "$closes_block" ]; then
+      printf '%s\n' "$closes_block"
     fi
     if [ -n "$coauthors" ]; then
       printf '%s\n' "$coauthors"
@@ -234,7 +254,7 @@ if [ "$strategy" = "--squash" ]; then
     title="${title} (closes ${joined})"
   fi
 
-  body=$(build_squash_body "$pr" "$repo" "$summary_llm")
+  body=$(build_squash_body "$pr" "$repo" "$summary_llm" "$closing")
   echo "[review] squash commit message:"
   printf -- '----\n%s (#%s)\n\n%s\n----\n' "$title" "$pr" "$body"
   if [ "$dry_run" = "1" ]; then

--- a/scripts/review/review.sh
+++ b/scripts/review/review.sh
@@ -1,20 +1,38 @@
 #!/usr/bin/env bash
-# review.sh <pr-number>
+# review.sh <pr-number> [--executor-llm <tool>]
 # Sync the PR locally, then hand off to the pr-reviewer agent to produce a
 # CodeRabbit-style review, post it, and approve the PR if it looks good.
+#
+# --executor-llm picks the CLI that drives the agent. Default: claude.
+# (Note: the pr-reviewer / pr-manager-lite agents are Claude Code constructs;
+# switching executors only makes sense if the alternate CLI understands them.)
 
 set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$here/lib.sh"
 
-require git gh jq claude
+require git gh jq
 require_pr_number "${1:-}"
-sync_pr "$1"
 
-claude "I've already checked out branch pr/$REVIEW_PR with main merged in and \
-upstream tracking set (repo: $REVIEW_REPO_RESOLVED). Use the pr-reviewer agent \
-to produce a CodeRabbit-style review of PR #$REVIEW_PR and publish review \
-comments. After the review is posted and if the changes look acceptable \
-overall, approve the PR with \`gh pr review $REVIEW_PR -R $REVIEW_REPO_RESOLVED --approve\`. \
-If blocking issues remain, request changes instead of approving."
+pr="$1"
+executor_llm="claude"
+shift
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --executor-llm) executor_llm="${2:?--executor-llm requires a value}"; shift 2 ;;
+    --executor-llm=*) executor_llm="${1#*=}"; shift ;;
+    *) echo "[review] unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+require "$executor_llm"
+sync_pr "$pr"
+
+"$executor_llm" "I've already checked out branch pr/$REVIEW_PR with main \
+merged in and upstream tracking set (repo: $REVIEW_REPO_RESOLVED). Use the \
+pr-reviewer agent to produce a CodeRabbit-style review of PR #$REVIEW_PR and \
+publish review comments. After the review is posted and if the changes look \
+acceptable overall, approve the PR with \`gh pr review $REVIEW_PR -R \
+$REVIEW_REPO_RESOLVED --approve\`. If blocking issues remain, request changes \
+instead of approving."

--- a/scripts/review/review.sh
+++ b/scripts/review/review.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# review.sh <pr-number>
+# Sync the PR locally, then hand off to the pr-reviewer agent to produce a
+# CodeRabbit-style review, post it, and approve the PR if it looks good.
+
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+
+require git gh jq claude
+require_pr_number "${1:-}"
+sync_pr "$1"
+
+claude "I've already checked out branch pr/$REVIEW_PR with main merged in and \
+upstream tracking set (repo: $REVIEW_REPO_RESOLVED). Use the pr-reviewer agent \
+to produce a CodeRabbit-style review of PR #$REVIEW_PR and publish review \
+comments. After the review is posted and if the changes look acceptable \
+overall, approve the PR with \`gh pr review $REVIEW_PR -R $REVIEW_REPO_RESOLVED --approve\`. \
+If blocking issues remain, request changes instead of approving."

--- a/scripts/review/sync.sh
+++ b/scripts/review/sync.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# sync.sh <pr-number>
+# Check out the PR as local branch pr/<num>, merge main in, wire upstream
+# tracking + pushRemote to the contributor's fork. No agent invocation.
+
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$here/lib.sh"
+
+require git gh jq
+require_pr_number "${1:-}"
+sync_pr "$1"
+
+echo "[review] done. current branch: $(git branch --show-current)"


### PR DESCRIPTION
## Summary
Adds a \`scripts/review/\` toolkit, wired up as \`yarn review <cmd>\`, for end-to-end PR handling:

- \`sync <pr>\`   — fetch PR head as \`pr/<num>\`, merge \`main\`, set upstream + pushRemote on the contributor's fork.
- \`review <pr>\` — sync + hand off to the \`pr-reviewer\` agent (review, comment, approve). Executor defaults to \`claude\`.
- \`fix <pr>\`    — sync + \`pr-reviewer\` (apply fixes) + \`pr-manager-lite\` (run quality suite, commit, push).
- \`merge <pr>\`  — LLM-summarised squash body + filtered co-authors + safety gate + \`gh pr merge\`.

## Merge gate
\`yarn review merge\` refuses to merge unless:
- \`reviewDecision == APPROVED\` (a maintainer actually signed off), and
- \`mergeStateStatus ∈ {CLEAN, UNSTABLE, HAS_HOOKS}\` (required checks green / no branch-protection block), and
- no check in \`statusCheckRollup\` is pending or failing.

Overrides: \`--force\` (skip local gate), \`--admin\` (bypass branch protection server-side), \`--auto\` (queue until requirements met). \`--dry-run\` prints the would-be squash message and exits without touching the PR.

## LLM-summarised squash body
On \`--squash\` (default) we pipe \`title + PR body + commit list\` through a summary LLM (default \`gemini\`, configurable via \`--summary-llm\`), producing 3-6 imperative bullets. We then:
- strip any \`Co-authored-by:\` lines from the PR body,
- collect co-authors from commit authors and \`Co-authored-by:\` trailers,
- drop any matching \`copilot | codex | cursor | claude | anthropic | openai | chatgpt | [bot] | noreply@github | users.noreply.github.com\` (case-insensitive, via \`tolower()\` — BSD awk ignores \`IGNORECASE\`, which had let entries like "Claude Opus" through),
- append the remaining co-authors plus your current \`git config user.name <user.email>\`.

Any \`Closes #N\` issues referenced by the PR but not already mentioned in the title get appended as \`(closes #N[, #M])\` on the squash subject.

## Test plan
- [x] \`yarn review --help\` prints the new usage block.
- [x] \`yarn review merge 839 --dry-run\` produces a clean 6-bullet body with banned co-authors removed.
- [x] \`yarn review merge 839\` (un-approved, IN_PROGRESS checks) correctly refuses with the three distinct reasons logged.
- [ ] \`yarn review merge <approved-pr>\` on a real merge passes the gate and lands a clean squash commit.
- [ ] \`yarn review merge <pr> --admin\` bypasses protection for the admin workflow.

## Follow-ups
- Depends on #848 (CODEOWNERS) to make \`reviewDecision=APPROVED\` actually require a maintainer. Merge that first for the gate to bite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a suite of automated PR workflow utilities accessible via a new `review` command to sync, review, fix, and merge pull requests.

* **Documentation**
  * Added usage docs describing the PR workflow tools, configuration options, CLI flags, and examples.

* **Chores**
  * Updated the pull request template to replace the generic Issue(s) placeholder with a "Closes" section and guidance on auto-closing keywords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->