### PR TITLE
feat(invites): viral share hub with hero card + one-tap social share

### DIFF
--- a/app/src/components/rewards/ReferralRewardsSection.tsx
+++ b/app/src/components/rewards/ReferralRewardsSection.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useUser } from '../../hooks/useUser';
 import { useCoreState } from '../../providers/CoreStateProvider';
 import { referralApi } from '../../services/api/referralApi';
 import type { ReferralRelationshipStatus, ReferralStats } from '../../types/referral';
+import { defaultInviteMessage } from '../../utils/share';
+import SocialShareRow from '../share/SocialShareRow';
+import ViralInviteCard from '../share/ViralInviteCard';
 
 function formatUsd(n: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n);
@@ -44,7 +47,6 @@ const ReferralRewardsSection = () => {
   const [applyLoading, setApplyLoading] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
   const [applySuccess, setApplySuccess] = useState(false);
-  const [copyHint, setCopyHint] = useState<string | null>(null);
 
   const latestRequestIdRef = useRef(0);
 
@@ -87,41 +89,14 @@ const ReferralRewardsSection = () => {
     void loadStats();
   }, [loadStats]);
 
-  const shareOrCopyTarget = stats?.referralLink?.trim() || stats?.referralCode || '';
-
-  const handleCopy = async () => {
-    if (!shareOrCopyTarget) return;
-    try {
-      await navigator.clipboard.writeText(shareOrCopyTarget);
-      setCopyHint('Copied');
-      setTimeout(() => setCopyHint(null), 2000);
-    } catch {
-      setCopyHint('Copy failed');
-      setTimeout(() => setCopyHint(null), 2500);
-    }
-  };
-
-  const handleShare = async () => {
-    if (!shareOrCopyTarget) return;
-    try {
-      if (navigator.share) {
-        const url = stats?.referralLink?.trim();
-        await navigator.share({
-          title: 'OpenHuman',
-          text: url
-            ? 'Join me on OpenHuman'
-            : `Join me on OpenHuman — referral code: ${stats?.referralCode ?? ''}`,
-          ...(url ? { url } : {}),
-        });
-      } else {
-        await handleCopy();
-      }
-    } catch (e) {
-      if ((e as Error)?.name !== 'AbortError') {
-        await handleCopy();
-      }
-    }
-  };
+  const shareUrl = useMemo(
+    () => stats?.referralLink?.trim() || stats?.referralCode?.trim() || '',
+    [stats?.referralLink, stats?.referralCode]
+  );
+  const shareMessage = useMemo(
+    () => defaultInviteMessage(stats?.referralCode?.trim() || 'OPENHUMAN', shareUrl),
+    [stats?.referralCode, shareUrl]
+  );
 
   const handleApply = async () => {
     const trimmed = applyCode.trim();
@@ -163,17 +138,21 @@ const ReferralRewardsSection = () => {
 
   return (
     <div className="space-y-4">
-      <div className="bg-white rounded-2xl shadow-soft border border-stone-200 p-6 space-y-6">
-        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-          <div className="space-y-2">
-            <h2 className="text-2xl font-semibold text-stone-900">Invite friends, earn credits</h2>
-            <p className="text-sm text-stone-600 max-w-xl">
-              Share your personal link. When a friend subscribes to a monthly plan, you both get $5
-              in account credit. Self-referrals and duplicate rewards are blocked on the server.
-            </p>
-          </div>
-        </div>
+      {stats && stats.referralCode ? (
+        <ViralInviteCard
+          code={stats.referralCode}
+          url={shareUrl || stats.referralCode}
+          firstName={user?.firstName ?? undefined}
+          headline={
+            user?.firstName
+              ? `${user.firstName}, turn your network into credits.`
+              : 'Turn your network into credits.'
+          }
+          subheadline="Share your link. When a friend subscribes, you both earn $5 in credit."
+        />
+      ) : null}
 
+      <div className="bg-white rounded-2xl shadow-soft border border-stone-200 p-6 space-y-5">
         {loading && !stats ? (
           <p className="text-sm text-stone-500">Loading referral program…</p>
         ) : null}
@@ -191,15 +170,18 @@ const ReferralRewardsSection = () => {
 
         {stats ? (
           <>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
-                <div className="text-xs font-medium uppercase tracking-wide text-stone-400">
-                  Your code
-                </div>
-                <div className="mt-2 font-mono text-lg font-semibold text-stone-900 break-all">
-                  {stats.referralCode || '—'}
-                </div>
-              </div>
+            <div>
+              <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-stone-400">
+                Share with one tap
+              </p>
+              <SocialShareRow
+                url={shareUrl || stats.referralCode}
+                message={shareMessage}
+                variant="spacious"
+              />
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
               <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
                 <div className="text-xs font-medium uppercase tracking-wide text-stone-400">
                   Total earned
@@ -210,7 +192,7 @@ const ReferralRewardsSection = () => {
               </div>
               <div className="rounded-xl border border-stone-200 bg-stone-50 p-4">
                 <div className="text-xs font-medium uppercase tracking-wide text-stone-400">
-                  Pending referrals
+                  Pending
                 </div>
                 <div className="mt-2 text-2xl font-semibold text-stone-900">
                   {stats.totals.pendingCount}
@@ -225,30 +207,6 @@ const ReferralRewardsSection = () => {
                 </div>
               </div>
             </div>
-
-            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-              <button
-                type="button"
-                onClick={() => void handleCopy()}
-                disabled={!shareOrCopyTarget}
-                className="inline-flex items-center justify-center gap-2 rounded-xl bg-stone-900 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-stone-800 disabled:opacity-50">
-                Copy link or code
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleShare()}
-                disabled={!shareOrCopyTarget}
-                className="inline-flex items-center justify-center rounded-xl border border-stone-200 bg-white px-4 py-3 text-sm font-medium text-stone-700 transition-colors hover:bg-stone-50 disabled:opacity-50">
-                Share
-              </button>
-              {copyHint ? (
-                <span className="self-center text-sm text-sage-600">{copyHint}</span>
-              ) : null}
-            </div>
-
-            {stats.referralLink ? (
-              <p className="text-xs text-stone-500 break-all font-mono">{stats.referralLink}</p>
-            ) : null}
           </>
         ) : null}
       </div>

--- a/app/src/components/share/InviteProgressBar.tsx
+++ b/app/src/components/share/InviteProgressBar.tsx
@@ -1,0 +1,50 @@
+interface InviteProgressBarProps {
+  /** Number of invites the user has successfully converted. */
+  converted: number;
+  /** Total capacity (usually the number of invite codes the user owns). */
+  total: number;
+  /** Optional cap for how far the progress bar fills (defaults to `total`). */
+  goal?: number;
+}
+
+/**
+ * Horizontal progress indicator that turns the abstract "5 invite codes"
+ * into a visible, gamified goal. Users get a dopamine nudge as the bar
+ * fills, which empirically lifts referral conversion.
+ */
+export default function InviteProgressBar({ converted, total, goal }: InviteProgressBarProps) {
+  const cap = Math.max(1, goal ?? total);
+  const clamped = Math.max(0, Math.min(converted, cap));
+  const pct = Math.min(100, Math.round((clamped / cap) * 100));
+  const remaining = Math.max(0, cap - clamped);
+
+  const message =
+    clamped === 0
+      ? 'Invite your first friend to unlock your first reward.'
+      : clamped >= cap
+        ? 'You maxed out your invite rewards — thank you!'
+        : `${remaining} more ${remaining === 1 ? 'invite' : 'invites'} to go.`;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-stone-400">
+        <span>Your invite streak</span>
+        <span>
+          {clamped}/{cap}
+        </span>
+      </div>
+      <div
+        className="h-2.5 w-full rounded-full bg-stone-100"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={cap}
+        aria-valuenow={clamped}>
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-primary-500 via-primary-400 to-sage-500 transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-xs text-stone-500">{message}</p>
+    </div>
+  );
+}

--- a/app/src/components/share/SocialShareRow.tsx
+++ b/app/src/components/share/SocialShareRow.tsx
@@ -1,0 +1,282 @@
+import debugFactory from 'debug';
+import { useCallback, useState } from 'react';
+
+import { copyToClipboard, shareOn, type SharePlatform, tryNativeShare } from '../../utils/share';
+
+const log = debugFactory('share:row');
+
+interface SocialShareRowProps {
+  /** Share URL (typically the invite or referral link). */
+  url: string;
+  /** Text blurb to prefill each social intent. */
+  message: string;
+  /** Dense (icon-only) vs spacious (icon + label) rendering. */
+  variant?: 'dense' | 'spacious';
+  /** Platforms to render, in the order shown. Defaults to the full set. */
+  platforms?: SharePlatform[];
+  /** Called after a share intent opens (analytics hook). */
+  onShare?: (platform: SharePlatform | 'native' | 'copy') => void;
+}
+
+interface PlatformMeta {
+  id: SharePlatform;
+  label: string;
+  bg: string;
+  hover: string;
+  icon: React.ReactNode;
+}
+
+const PLATFORMS: Record<SharePlatform, PlatformMeta> = {
+  twitter: {
+    id: 'twitter',
+    label: 'X',
+    bg: 'bg-stone-900 text-white',
+    hover: 'hover:bg-black',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 fill-current">
+        <path d="M17.53 3H20.5l-6.48 7.4L22 21h-6.03l-4.71-6.16L5.86 21H2.88l6.94-7.93L2 3h6.17l4.27 5.64L17.53 3Zm-1.06 16.2h1.67L7.62 4.7H5.83l10.64 14.5Z" />
+      </svg>
+    ),
+  },
+  telegram: {
+    id: 'telegram',
+    label: 'Telegram',
+    bg: 'bg-[#229ED9] text-white',
+    hover: 'hover:bg-[#1B8BC0]',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 fill-current">
+        <path d="M9.78 18.65l.28-4.23 7.68-6.92c.34-.31-.07-.46-.52-.19L7.74 13.3 3.64 12c-.88-.25-.89-.86.2-1.3l15.97-6.16c.73-.33 1.43.18 1.15 1.3l-2.72 12.81c-.19.91-.74 1.13-1.5.71L12.6 16.3l-1.99 1.93c-.23.23-.42.42-.83.42z" />
+      </svg>
+    ),
+  },
+  whatsapp: {
+    id: 'whatsapp',
+    label: 'WhatsApp',
+    bg: 'bg-[#25D366] text-white',
+    hover: 'hover:bg-[#1DB954]',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 fill-current">
+        <path d="M12.04 2C6.58 2 2.14 6.44 2.14 11.89c0 2.09.64 4.03 1.76 5.64L2 22l4.66-1.83c1.55.85 3.33 1.34 5.22 1.34h.01c5.46 0 9.89-4.44 9.89-9.9 0-2.64-1.03-5.13-2.9-7-1.88-1.87-4.37-2.9-7-2.9zm0 1.88c2.13 0 4.13.83 5.64 2.34 1.51 1.51 2.34 3.51 2.34 5.64 0 4.42-3.59 8.01-8.02 8.01-1.58 0-3.11-.47-4.42-1.36l-.32-.19-2.77 1.09.94-2.72-.21-.34c-.98-1.46-1.5-3.17-1.5-4.94 0-4.42 3.59-8.02 8.02-8.02zm4.64 9.19c-.25-.13-1.48-.73-1.71-.81-.23-.09-.4-.13-.57.13-.17.25-.65.81-.8.98-.15.17-.3.19-.55.06-.25-.13-1.07-.39-2.04-1.25-.75-.67-1.26-1.5-1.41-1.76-.15-.25-.02-.39.11-.52.12-.12.25-.3.38-.46.13-.15.17-.25.25-.42.09-.17.04-.32-.02-.45-.06-.13-.57-1.37-.78-1.88-.2-.49-.42-.43-.57-.43H8.8c-.17 0-.45.06-.68.32-.23.25-.89.87-.89 2.12 0 1.25.91 2.45 1.04 2.62.13.17 1.79 2.74 4.34 3.85.61.26 1.08.42 1.44.54.61.19 1.16.17 1.6.1.49-.07 1.48-.6 1.69-1.18.21-.58.21-1.08.15-1.18-.06-.1-.23-.17-.48-.3z" />
+      </svg>
+    ),
+  },
+  linkedin: {
+    id: 'linkedin',
+    label: 'LinkedIn',
+    bg: 'bg-[#0A66C2] text-white',
+    hover: 'hover:bg-[#08528B]',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 fill-current">
+        <path d="M4.98 3.5a2.5 2.5 0 1 1 .01 5 2.5 2.5 0 0 1-.01-5zM3 9.25h4V21H3V9.25zM9.25 9.25h3.84v1.6h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21h-4v-5.28c0-1.26-.02-2.88-1.75-2.88-1.75 0-2.02 1.36-2.02 2.78V21h-4V9.25z" />
+      </svg>
+    ),
+  },
+  facebook: {
+    id: 'facebook',
+    label: 'Facebook',
+    bg: 'bg-[#1877F2] text-white',
+    hover: 'hover:bg-[#1463C9]',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 fill-current">
+        <path d="M13.5 21v-7.5h2.53l.38-2.93H13.5V8.87c0-.85.24-1.43 1.46-1.43H16.5V4.83c-.27-.04-1.2-.12-2.29-.12-2.27 0-3.82 1.38-3.82 3.91v2.18H8v2.93h2.39V21h3.11z" />
+      </svg>
+    ),
+  },
+  reddit: {
+    id: 'reddit',
+    label: 'Reddit',
+    bg: 'bg-[#FF4500] text-white',
+    hover: 'hover:bg-[#E03E00]',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className="h-4 w-4 fill-current">
+        <path d="M22 12.1a2.11 2.11 0 0 0-3.57-1.52c-1.35-.94-3.16-1.54-5.16-1.61l.98-3.54 2.83.6a1.44 1.44 0 1 0 .15-1.42l-3.52-.75-1.16 4.2c-2.08.04-3.97.65-5.37 1.62a2.11 2.11 0 1 0-2.37 3.44 4.06 4.06 0 0 0-.06.7C4.75 16.43 8.03 19 12.02 19c3.98 0 7.25-2.57 7.25-5.77 0-.24-.02-.47-.06-.7A2.11 2.11 0 0 0 22 12.1zM8.38 13.67a1.18 1.18 0 1 1 0-2.36 1.18 1.18 0 0 1 0 2.36zm7.24 0a1.18 1.18 0 1 1 0-2.36 1.18 1.18 0 0 1 0 2.36zm-.66 3.05c-.74.74-2.15 1.08-3.54 1.08s-2.8-.34-3.54-1.08a.35.35 0 0 1 .5-.5c.59.6 1.78.88 3.04.88s2.45-.29 3.04-.88a.35.35 0 0 1 .5.5z" />
+      </svg>
+    ),
+  },
+  email: {
+    id: 'email',
+    label: 'Email',
+    bg: 'bg-stone-200 text-stone-900',
+    hover: 'hover:bg-stone-300',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 8l8.5 5.5a2 2 0 0 0 2 0L22 8M5 20h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2z"
+        />
+      </svg>
+    ),
+  },
+  sms: {
+    id: 'sms',
+    label: 'SMS',
+    bg: 'bg-sage-500 text-white',
+    hover: 'hover:bg-sage-600',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M8 10h.01M12 10h.01M16 10h.01M21 12a8 8 0 0 1-11.7 7.1L3 21l1.9-6.3A8 8 0 1 1 21 12z"
+        />
+      </svg>
+    ),
+  },
+};
+
+const DEFAULT_PLATFORMS: SharePlatform[] = [
+  'twitter',
+  'telegram',
+  'whatsapp',
+  'linkedin',
+  'reddit',
+  'email',
+];
+
+/**
+ * A row of one-tap share buttons plus "Copy" and (when supported) a native
+ * share sheet trigger. Drop this in anywhere you want users to spread the
+ * word.
+ */
+export default function SocialShareRow({
+  url,
+  message,
+  variant = 'dense',
+  platforms = DEFAULT_PLATFORMS,
+  onShare,
+}: SocialShareRowProps) {
+  const [copied, setCopied] = useState(false);
+  const [nativeShareAvailable] = useState(
+    () => typeof navigator !== 'undefined' && typeof navigator.share === 'function'
+  );
+
+  const handleCopy = useCallback(async () => {
+    const ok = await copyToClipboard(url);
+    if (ok) {
+      setCopied(true);
+      onShare?.('copy');
+      setTimeout(() => setCopied(false), 1800);
+      log('copied link');
+    }
+  }, [url, onShare]);
+
+  const handleNativeShare = useCallback(async () => {
+    const ok = await tryNativeShare({ title: 'OpenHuman', text: message, url });
+    if (ok) {
+      onShare?.('native');
+    } else {
+      await handleCopy();
+    }
+  }, [message, url, onShare, handleCopy]);
+
+  const handlePlatform = useCallback(
+    async (platform: SharePlatform) => {
+      await shareOn(platform, message, url);
+      onShare?.(platform);
+    },
+    [message, url, onShare]
+  );
+
+  const dense = variant === 'dense';
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {platforms.map(id => {
+        const meta = PLATFORMS[id];
+        if (!meta) return null;
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => void handlePlatform(id)}
+            title={`Share on ${meta.label}`}
+            aria-label={`Share on ${meta.label}`}
+            className={`inline-flex items-center justify-center gap-1.5 rounded-full transition-colors ${meta.bg} ${meta.hover} ${
+              dense ? 'h-9 w-9' : 'h-9 px-3 text-xs font-medium'
+            }`}>
+            {meta.icon}
+            {!dense ? <span>{meta.label}</span> : null}
+          </button>
+        );
+      })}
+
+      {nativeShareAvailable ? (
+        <button
+          type="button"
+          onClick={() => void handleNativeShare()}
+          title="Share via your device"
+          aria-label="Share via your device"
+          className={`inline-flex items-center justify-center gap-1.5 rounded-full border border-stone-200 bg-white text-stone-700 transition-colors hover:bg-stone-50 ${
+            dense ? 'h-9 w-9' : 'h-9 px-3 text-xs font-medium'
+          }`}>
+          <svg
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7M16 6l-4-4m0 0L8 6m4-4v13"
+            />
+          </svg>
+          {!dense ? <span>More</span> : null}
+        </button>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => void handleCopy()}
+        className={`inline-flex items-center justify-center gap-1.5 rounded-full transition-colors ${
+          copied ? 'bg-sage-500 text-white' : 'bg-stone-900 text-white hover:bg-stone-800'
+        } ${dense ? 'h-9 px-3 text-xs font-medium' : 'h-9 px-3 text-xs font-medium'}`}>
+        {copied ? (
+          <>
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <span>Copied!</span>
+          </>
+        ) : (
+          <>
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8 16H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v2m-6 12h8a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2h-8a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2z"
+              />
+            </svg>
+            <span>Copy link</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/share/ViralInviteCard.tsx
+++ b/app/src/components/share/ViralInviteCard.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { copyToClipboard } from '../../utils/share';
+
+interface ViralInviteCardProps {
+  /** The user-facing invite or referral code (e.g. "ABC123"). */
+  code: string;
+  /** Shareable URL for the code (deep-link-friendly). */
+  url: string;
+  /** Headline copy override. */
+  headline?: string;
+  /** Subheadline / reward description override. */
+  subheadline?: string;
+  /** Friendly first name for personalization. */
+  firstName?: string;
+}
+
+/**
+ * Beautiful, high-contrast "hero" card that showcases the user's invite
+ * code and link. Designed to be screenshotted — the gradient mesh, star
+ * motif, and personalized headline make it feel worth sharing.
+ */
+export default function ViralInviteCard({
+  code,
+  url,
+  headline,
+  subheadline = 'Both of you earn credits when your friend joins.',
+  firstName,
+}: ViralInviteCardProps) {
+  const [copiedTarget, setCopiedTarget] = useState<'code' | 'url' | null>(null);
+
+  const displayHeadline =
+    headline ??
+    (firstName ? `${firstName}, pass the torch.` : 'Invite your people. Earn together.');
+
+  const copy = useCallback(async (target: 'code' | 'url', text: string) => {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopiedTarget(target);
+      setTimeout(() => setCopiedTarget(null), 1800);
+    }
+  }, []);
+
+  const shortUrl = useMemo(() => url.replace(/^https?:\/\//, ''), [url]);
+
+  return (
+    <div className="relative overflow-hidden rounded-3xl bg-stone-900 p-6 text-white shadow-strong sm:p-8">
+      {/* Decorative gradient + soft noise */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-80"
+        style={{
+          background:
+            'radial-gradient(circle at 20% 0%, #4A83DD 0%, transparent 45%), radial-gradient(circle at 100% 100%, #9B8AFB 0%, transparent 45%), radial-gradient(circle at 70% 30%, #4DC46F 0%, transparent 40%)',
+        }}
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background: 'linear-gradient(180deg, rgba(28,25,23,0.15) 0%, rgba(28,25,23,0.65) 100%)',
+        }}
+      />
+
+      <div className="relative z-10 space-y-5">
+        <div className="flex items-center justify-between">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[11px] font-medium uppercase tracking-wider backdrop-blur-sm">
+            <span className="h-1.5 w-1.5 rounded-full bg-sage-500 animate-pulse" />
+            OpenHuman · Invite
+          </div>
+          <div className="hidden sm:flex items-center gap-1 text-[11px] text-white/60">
+            <svg className="h-3 w-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 2L15 9L22 9.25L16.5 14L18.5 21L12 17.25L5.5 21L7.5 14L2 9.25L9 9L12 2Z" />
+            </svg>
+            Limited codes
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
+            {displayHeadline}
+          </h2>
+          <p className="max-w-md text-sm text-white/70">{subheadline}</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+          <button
+            type="button"
+            onClick={() => void copy('code', code)}
+            className="group flex items-center justify-between rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-left backdrop-blur-md transition-colors hover:bg-white/15"
+            aria-label="Copy invite code">
+            <div>
+              <div className="text-[10px] font-medium uppercase tracking-widest text-white/60">
+                Your code
+              </div>
+              <div className="font-mono text-xl font-semibold tracking-[0.25em] text-white">
+                {code || '—'}
+              </div>
+            </div>
+            <span className="ml-3 rounded-full bg-white/10 px-3 py-1 text-[11px] font-medium">
+              {copiedTarget === 'code' ? 'Copied!' : 'Tap to copy'}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => void copy('url', url)}
+            className="group flex items-center justify-between rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-left backdrop-blur-md transition-colors hover:bg-white/15 sm:w-64"
+            aria-label="Copy invite link">
+            <div className="min-w-0">
+              <div className="text-[10px] font-medium uppercase tracking-widest text-white/60">
+                Share link
+              </div>
+              <div className="truncate font-mono text-sm text-white/90">{shortUrl}</div>
+            </div>
+            <span className="ml-3 rounded-full bg-white/10 px-3 py-1 text-[11px] font-medium">
+              {copiedTarget === 'url' ? 'Copied!' : 'Copy'}
+            </span>
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2 text-[11px] text-white/60">
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            aria-hidden="true">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
+            />
+          </svg>
+          Both you and your friend get credit when they join. No limit on earnings.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -272,6 +272,39 @@ const Home = () => {
           </button>
         </div>
 
+        {/* Invite nudge — compact viral nudge that cheaply links to the full invite flow */}
+        <button
+          onClick={() => navigate('/invites')}
+          className="group mt-3 w-full overflow-hidden rounded-2xl border border-stone-200 bg-gradient-to-r from-primary-500 via-primary-400 to-sage-500 p-[1px] text-left shadow-soft transition-transform hover:scale-[1.01]"
+          aria-label="Invite a friend to OpenHuman">
+          <div className="flex items-center justify-between gap-3 rounded-[15px] bg-white px-4 py-3">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary-500 to-sage-500 text-white">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                </svg>
+              </div>
+              <div className="min-w-0">
+                <div className="text-sm font-semibold text-stone-900">
+                  Give OpenHuman to a friend
+                </div>
+                <div className="truncate text-[11px] text-stone-500">
+                  You both earn credits. Takes 5 seconds.
+                </div>
+              </div>
+            </div>
+            <span className="shrink-0 rounded-full bg-stone-900 px-3 py-1 text-[11px] font-medium text-white transition-colors group-hover:bg-stone-800">
+              Share
+            </span>
+          </div>
+        </button>
+
         {/* Next steps — compact directory of where to go next */}
         <div className="mt-3 bg-white rounded-2xl shadow-soft border border-stone-200 p-4">
           <div className="text-[11px] uppercase tracking-wide text-stone-400 mb-2">Next steps</div>

--- a/app/src/pages/Invites.tsx
+++ b/app/src/pages/Invites.tsx
@@ -1,77 +1,71 @@
 import debugFactory from 'debug';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
+import InviteProgressBar from '../components/share/InviteProgressBar';
+import SocialShareRow from '../components/share/SocialShareRow';
+import ViralInviteCard from '../components/share/ViralInviteCard';
 import { useUser } from '../hooks/useUser';
 import { inviteApi } from '../services/api/inviteApi';
 import type { InviteCode } from '../types/invite';
+import { buildInviteUrl, copyToClipboard, defaultInviteMessage } from '../utils/share';
 
 const log = debugFactory('invites');
 
 type RedeemStatus = 'idle' | 'loading' | 'success' | 'error';
 
-const CodeRow = ({ invite }: { invite: InviteCode }) => {
+function CodeRow({ invite }: { invite: InviteCode }) {
   const [copied, setCopied] = useState(false);
+  const url = buildInviteUrl(invite.code);
   const claimed = invite.currentUses >= invite.maxUses;
   const claimedUser = invite.usageHistory[0]?.userId;
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(invite.code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   const displayName = claimedUser?.username
     ? `@${claimedUser.username}`
-    : claimedUser?.firstName || 'Someone';
+    : claimedUser?.firstName || 'a friend';
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(url);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    }
+  };
 
   return (
-    <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/5 hover:bg-white/[0.07] transition-colors">
-      <div className="flex-1 min-w-0">
-        <span className="font-mono text-sm tracking-wider">{invite.code}</span>
-        {claimed && <p className="text-xs text-stone-500 mt-0.5">Claimed by {displayName}</p>}
-      </div>
-      <div className="flex items-center gap-2 ml-3">
-        {claimed ? (
-          <span className="text-xs px-2 py-1 rounded-full bg-stone-700/50 text-stone-400">
-            Used
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-stone-200 bg-white/60 px-4 py-3 transition-colors hover:bg-white">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm font-semibold tracking-[0.25em] text-stone-900">
+            {invite.code}
           </span>
-        ) : (
-          <span className="text-xs px-2 py-1 rounded-full bg-sage-500/20 text-sage-500">
-            Available
-          </span>
-        )}
-        <button
-          onClick={handleCopy}
-          className="p-1.5 rounded-lg hover:bg-white/10 transition-colors text-stone-400 hover:text-stone-200"
-          title="Copy code">
-          {copied ? (
-            <svg
-              className="w-4 h-4 text-sage-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
+          {claimed ? (
+            <span className="rounded-full bg-sage-100 px-2 py-0.5 text-[10px] font-medium text-sage-700">
+              Joined
+            </span>
           ) : (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-              />
-            </svg>
+            <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">
+              Unused
+            </span>
           )}
-        </button>
+        </div>
+        <p className="mt-0.5 truncate text-[11px] text-stone-500">
+          {claimed ? `Redeemed by ${displayName}` : url.replace(/^https?:\/\//, '')}
+        </p>
       </div>
+      {!claimed ? (
+        <button
+          type="button"
+          onClick={() => void handleCopy()}
+          className={`whitespace-nowrap rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
+            copied ? 'bg-sage-500 text-white' : 'bg-stone-900 text-white hover:bg-stone-800'
+          }`}>
+          {copied ? 'Link copied' : 'Copy link'}
+        </button>
+      ) : (
+        <span className="text-[11px] text-stone-400">Thanks for sharing!</span>
+      )}
     </div>
   );
-};
+}
 
 const Invites = () => {
   const { user, refetch: refetchUser } = useUser();
@@ -146,72 +140,132 @@ const Invites = () => {
     }
   };
 
+  const availableCode = useMemo(
+    () => codes.find(c => c.currentUses < c.maxUses) ?? codes[0],
+    [codes]
+  );
+
+  const convertedCount = useMemo(
+    () => codes.filter(c => c.currentUses >= c.maxUses).length,
+    [codes]
+  );
+
+  const heroCode = availableCode?.code ?? '';
+  const heroUrl = useMemo(() => buildInviteUrl(heroCode), [heroCode]);
+  const heroMessage = useMemo(
+    () => defaultInviteMessage(heroCode || 'OPENHUMAN', heroUrl),
+    [heroCode, heroUrl]
+  );
+
   return (
-    <div className="min-h-full flex items-center justify-center p-4 pt-6">
-      <div className="max-w-md w-full space-y-4">
-        <div>
-          <div className="space-y-4">
-            {/* Redeem Section — shown only if user hasn't redeemed yet */}
-            {!hasBeenInvited && (
-              <div className="bg-white rounded-2xl shadow-soft border border-stone-200 p-6 animate-fade-up">
-                <h2 className="text-lg font-bold mb-1">Redeem an Invite Code</h2>
-                <p className="text-xs opacity-70 mb-4">
-                  Got a code from a friend? Enter it below to unlock free credits.
-                </p>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    value={redeemInput}
-                    onChange={e => setRedeemInput(e.target.value.toUpperCase())}
-                    onKeyDown={e => e.key === 'Enter' && handleRedeem()}
-                    placeholder="Enter code"
-                    className="flex-1 px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl font-mono text-sm tracking-wider placeholder:text-stone-500 placeholder:tracking-normal placeholder:font-sans focus:outline-none focus:ring-2 focus:ring-primary-500/50 focus:border-primary-500/50 transition-all"
-                    disabled={redeemStatus === 'loading'}
-                  />
-                  <button
-                    onClick={handleRedeem}
-                    disabled={redeemStatus === 'loading' || !redeemInput.trim()}
-                    className="btn-primary px-5 py-2.5 text-sm font-medium rounded-xl disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap">
-                    {redeemStatus === 'loading' ? '...' : 'Redeem'}
-                  </button>
-                </div>
-                {redeemStatus === 'success' && (
-                  <p className="text-sage-500 text-xs mt-2">Invite code redeemed successfully!</p>
-                )}
-                {redeemStatus === 'error' && redeemError && (
-                  <p className="text-coral-500 text-xs mt-2">{redeemError}</p>
-                )}
-              </div>
+    <div className="min-h-full p-4 pt-6 pb-10">
+      <div className="mx-auto max-w-xl space-y-4">
+        {/* Hero — shareable invite card */}
+        {heroCode ? (
+          <div className="animate-fade-up space-y-3">
+            <ViralInviteCard
+              code={heroCode}
+              url={heroUrl}
+              firstName={user?.firstName ?? undefined}
+            />
+            <div className="rounded-2xl border border-stone-200 bg-white p-4 shadow-soft">
+              <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-stone-400">
+                Share with one tap
+              </p>
+              <SocialShareRow url={heroUrl} message={heroMessage} variant="spacious" />
+            </div>
+          </div>
+        ) : null}
+
+        {/* Redeem Section — shown only if user hasn't redeemed yet */}
+        {!hasBeenInvited && (
+          <div className="animate-fade-up rounded-2xl border border-stone-200 bg-white p-6 shadow-soft">
+            <h2 className="mb-1 text-lg font-bold">Got a code from a friend?</h2>
+            <p className="mb-4 text-xs text-stone-500">
+              Enter it below to unlock free credits — welcome to the inner circle.
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={redeemInput}
+                onChange={e => setRedeemInput(e.target.value.toUpperCase())}
+                onKeyDown={e => e.key === 'Enter' && void handleRedeem()}
+                placeholder="Enter code"
+                className="flex-1 rounded-xl border border-stone-200 bg-white px-4 py-2.5 font-mono text-sm tracking-wider text-stone-900 placeholder:font-sans placeholder:tracking-normal placeholder:text-stone-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/40"
+                disabled={redeemStatus === 'loading'}
+              />
+              <button
+                onClick={() => void handleRedeem()}
+                disabled={redeemStatus === 'loading' || !redeemInput.trim()}
+                className="whitespace-nowrap rounded-xl bg-primary-500 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50">
+                {redeemStatus === 'loading' ? '...' : 'Redeem'}
+              </button>
+            </div>
+            {redeemStatus === 'success' && (
+              <p className="mt-2 text-xs text-sage-600">Invite code redeemed successfully!</p>
             )}
+            {redeemStatus === 'error' && redeemError && (
+              <p className="mt-2 text-xs text-coral-500">{redeemError}</p>
+            )}
+          </div>
+        )}
 
-            {/* Your Invite Codes */}
-            <div className="bg-white rounded-2xl shadow-soft border border-stone-200 p-6 animate-fade-up">
-              <div className="mb-4">
-                <h2 className="text-lg font-bold mb-1">Your Invite Codes</h2>
-                <p className="text-xs opacity-70">
-                  Share these codes with friends. Each code can be used once.
-                </p>
-              </div>
+        {/* Your Invite Codes */}
+        <div className="animate-fade-up rounded-2xl border border-stone-200 bg-white p-6 shadow-soft">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-bold">Your invite codes</h2>
+              <p className="text-xs text-stone-500">
+                Each code is one magic seat. They go fast — share today.
+              </p>
+            </div>
+          </div>
 
-              {loadError && <p className="text-coral-500 text-xs text-center py-2">{loadError}</p>}
+          {codes.length > 0 ? (
+            <div className="mb-4">
+              <InviteProgressBar converted={convertedCount} total={codes.length} />
+            </div>
+          ) : null}
 
-              {isLoading ? (
-                <div className="space-y-3">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={i} className="h-12 bg-white/5 rounded-xl animate-pulse" />
-                  ))}
-                </div>
-              ) : codes.length > 0 ? (
-                <div className="space-y-2">
-                  {codes.map(invite => (
-                    <CodeRow key={invite._id} invite={invite} />
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-stone-500 text-center py-6">
-                  No invite codes available yet.
-                </p>
-              )}
+          {loadError && <p className="text-center text-xs text-coral-500">{loadError}</p>}
+
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-12 animate-pulse rounded-xl bg-stone-100" />
+              ))}
+            </div>
+          ) : codes.length > 0 ? (
+            <div className="space-y-2">
+              {codes.map(invite => (
+                <CodeRow key={invite._id} invite={invite} />
+              ))}
+            </div>
+          ) : (
+            <p className="py-6 text-center text-sm text-stone-500">
+              No invite codes available yet.
+            </p>
+          )}
+        </div>
+
+        {/* Social proof / trust row */}
+        <div className="animate-fade-up rounded-2xl border border-stone-200 bg-gradient-to-br from-primary-50 via-white to-sage-50 p-5 shadow-soft">
+          <div className="flex items-center gap-3">
+            <div className="flex -space-x-2">
+              <span className="h-8 w-8 rounded-full border-2 border-white bg-primary-500" />
+              <span className="h-8 w-8 rounded-full border-2 border-white bg-sage-500" />
+              <span className="h-8 w-8 rounded-full border-2 border-white bg-amber-500" />
+              <span className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-stone-900 text-[10px] font-semibold text-white">
+                +
+              </span>
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-stone-900">
+                Join builders shipping with OpenHuman
+              </p>
+              <p className="text-xs text-stone-500">
+                Every invite you send helps more humans reclaim their time.
+              </p>
             </div>
           </div>
         </div>

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -53,14 +53,27 @@ const Welcome = () => {
 
           {/* Heading */}
           <h1 className="text-2xl font-bold text-stone-900 text-center mb-2">
-            Sign in! Let's Cook
+            Your AI, actually yours.
           </h1>
 
           {/* Subtitle */}
-          <p className="text-sm text-stone-500 text-center mb-6 leading-relaxed">
-            Welcome to <span className="font-medium text-stone-900">OpenHuman</span>! Your Personal
-            AI Super Intelligence. Private, Simple and extremely powerful.
+          <p className="text-sm text-stone-500 text-center mb-4 leading-relaxed">
+            <span className="font-medium text-stone-900">OpenHuman</span> — a private AI super
+            assistant that remembers, reasons, and runs on your rules.
           </p>
+
+          {/* Social proof row */}
+          <div className="flex items-center justify-center gap-2 mb-6">
+            <div className="flex -space-x-1.5">
+              <span className="h-5 w-5 rounded-full border border-white bg-primary-500" />
+              <span className="h-5 w-5 rounded-full border border-white bg-sage-500" />
+              <span className="h-5 w-5 rounded-full border border-white bg-amber-500" />
+              <span className="h-5 w-5 rounded-full border border-white bg-stone-900" />
+            </div>
+            <span className="text-[11px] font-medium text-stone-500">
+              Trusted by builders worldwide
+            </span>
+          </div>
 
           {errorMessage ? (
             <div

--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -65,6 +65,7 @@ vi.mock('../utils/config', () => ({
   BACKEND_URL: 'http://localhost:5005',
   TELEGRAM_BOT_USERNAME: 'openhuman_bot',
   DEV_JWT_TOKEN: undefined,
+  SHARE_BASE_URL: 'https://openhuman.ai',
 }));
 
 vi.mock('../services/backendUrl', () => ({

--- a/app/src/utils/__tests__/share.test.ts
+++ b/app/src/utils/__tests__/share.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildInviteUrl, buildShareUrl, copyToClipboard, tryNativeShare } from '../share';
+
+vi.mock('../openUrl', () => ({ openUrl: vi.fn() }));
+
+describe('buildInviteUrl', () => {
+  it('appends the invite code to the share base URL', () => {
+    expect(buildInviteUrl('ABC123')).toBe('https://openhuman.ai/i/ABC123');
+  });
+
+  it('trims whitespace', () => {
+    expect(buildInviteUrl('  HELLO  ')).toBe('https://openhuman.ai/i/HELLO');
+  });
+
+  it('url-encodes special characters', () => {
+    expect(buildInviteUrl('a/b c')).toBe('https://openhuman.ai/i/a%2Fb%20c');
+  });
+
+  it('falls back to the base URL for empty codes', () => {
+    expect(buildInviteUrl('')).toBe('https://openhuman.ai');
+    expect(buildInviteUrl('   ')).toBe('https://openhuman.ai');
+  });
+});
+
+describe('buildShareUrl', () => {
+  const text = 'Try OpenHuman';
+  const url = 'https://openhuman.ai/i/XYZ';
+
+  it('builds twitter intent', () => {
+    const result = buildShareUrl('twitter', text, url);
+    expect(result).toContain('https://twitter.com/intent/tweet');
+    expect(result).toContain(encodeURIComponent(text));
+    expect(result).toContain(encodeURIComponent(url));
+  });
+
+  it('builds telegram share url', () => {
+    const result = buildShareUrl('telegram', text, url);
+    expect(result).toContain('https://t.me/share/url');
+    expect(result).toContain(encodeURIComponent(url));
+  });
+
+  it('builds whatsapp share url', () => {
+    const result = buildShareUrl('whatsapp', text, url);
+    expect(result).toContain('https://wa.me/?text=');
+    expect(result).toContain(encodeURIComponent(`${text} ${url}`));
+  });
+
+  it('builds a mailto: email link', () => {
+    const result = buildShareUrl('email', text, url);
+    expect(result.startsWith('mailto:')).toBe(true);
+    expect(result).toContain('subject=');
+    expect(result).toContain('body=');
+  });
+});
+
+describe('copyToClipboard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses navigator.clipboard when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    await expect(copyToClipboard('hello')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('returns false when no copy mechanism works', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockRejectedValue(new Error('blocked')) },
+      configurable: true,
+    });
+    const originalExecCommand = document.execCommand;
+    document.execCommand = vi.fn().mockImplementation(() => {
+      throw new Error('nope');
+    }) as typeof document.execCommand;
+    try {
+      await expect(copyToClipboard('hello')).resolves.toBe(false);
+    } finally {
+      document.execCommand = originalExecCommand;
+    }
+  });
+});
+
+describe('tryNativeShare', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns false when navigator.share is missing', async () => {
+    const original = (navigator as Navigator & { share?: unknown }).share;
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+    try {
+      await expect(tryNativeShare({ url: 'x' })).resolves.toBe(false);
+    } finally {
+      Object.defineProperty(navigator, 'share', { value: original, configurable: true });
+    }
+  });
+
+  it('treats AbortError as a completed share', async () => {
+    const err = new Error('cancelled');
+    err.name = 'AbortError';
+    const share = vi.fn().mockRejectedValue(err);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    await expect(tryNativeShare({ url: 'x' })).resolves.toBe(true);
+    expect(share).toHaveBeenCalled();
+  });
+});

--- a/app/src/utils/config.ts
+++ b/app/src/utils/config.ts
@@ -100,3 +100,14 @@ export const MINIMUM_SUPPORTED_APP_VERSION =
 export const LATEST_APP_DOWNLOAD_URL =
   (import.meta.env.VITE_LATEST_APP_DOWNLOAD_URL as string | undefined)?.trim() ||
   'https://github.com/tinyhumansai/openhuman/releases/latest';
+
+/**
+ * Public base URL used to build shareable invite/referral links.
+ *
+ * Friends who click the link from a social post land on a web page that
+ * routes them into the app (or the download page). Override with
+ * `VITE_SHARE_BASE_URL` to point at a staging/marketing host.
+ */
+export const SHARE_BASE_URL = (
+  (import.meta.env.VITE_SHARE_BASE_URL as string | undefined)?.trim() || 'https://openhuman.ai'
+).replace(/\/+$/, '');

--- a/app/src/utils/share.ts
+++ b/app/src/utils/share.ts
@@ -1,0 +1,125 @@
+import debugFactory from 'debug';
+
+import { SHARE_BASE_URL } from './config';
+import { openUrl } from './openUrl';
+
+const log = debugFactory('share');
+
+export type SharePlatform =
+  | 'twitter'
+  | 'telegram'
+  | 'whatsapp'
+  | 'linkedin'
+  | 'facebook'
+  | 'reddit'
+  | 'email'
+  | 'sms';
+
+/**
+ * Build a public invite URL that friends can click from anywhere.
+ *
+ * Routes to the web onboarding flow with `?invite=CODE`; the desktop/mobile
+ * app also handles `openhuman://invite/CODE` for deep linking.
+ */
+export function buildInviteUrl(code: string): string {
+  const trimmed = code.trim();
+  if (!trimmed) return SHARE_BASE_URL;
+  return `${SHARE_BASE_URL}/i/${encodeURIComponent(trimmed)}`;
+}
+
+/** Short, social-optimized default copy for invite posts. */
+export function defaultInviteMessage(code: string, url: string): string {
+  return `I'm using OpenHuman — a private AI super-assistant that actually gets me. Join with my code ${code}: ${url}`;
+}
+
+const SHARE_URL_BUILDERS: Record<SharePlatform, (text: string, url: string) => string> = {
+  twitter: (text, url) =>
+    `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
+  telegram: (text, url) =>
+    `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`,
+  whatsapp: (text, url) => `https://wa.me/?text=${encodeURIComponent(`${text} ${url}`)}`,
+  linkedin: (_text, url) =>
+    `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+  facebook: (_text, url) =>
+    `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+  reddit: (text, url) =>
+    `https://www.reddit.com/submit?title=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
+  email: (text, url) =>
+    `mailto:?subject=${encodeURIComponent('Try OpenHuman with me')}&body=${encodeURIComponent(
+      `${text}\n\n${url}`
+    )}`,
+  sms: (text, url) => `sms:?&body=${encodeURIComponent(`${text} ${url}`)}`,
+};
+
+/** Construct the platform-specific share URL for a given message + target URL. */
+export function buildShareUrl(platform: SharePlatform, text: string, url: string): string {
+  return SHARE_URL_BUILDERS[platform](text, url);
+}
+
+/** Open the share intent for the given platform in the default browser / app. */
+export async function shareOn(platform: SharePlatform, text: string, url: string): Promise<void> {
+  const target = buildShareUrl(platform, text, url);
+  log('opening share intent', { platform });
+  await openUrl(target);
+}
+
+/**
+ * Copy text to the clipboard. Returns `true` on success.
+ *
+ * Uses the async Clipboard API when available; falls back to a hidden
+ * textarea + `document.execCommand` for older surfaces (e.g. webviews
+ * without navigator.clipboard).
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (error) {
+    log('navigator.clipboard.writeText failed', error);
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch (error) {
+    log('textarea fallback failed', error);
+    return false;
+  }
+}
+
+/**
+ * Invoke the native OS share sheet when supported (mobile browsers, modern
+ * desktop). Returns `true` if the share sheet was shown (or accepted), or
+ * `false` if the platform lacks support so the caller can show a fallback UI.
+ */
+export async function tryNativeShare(payload: {
+  title?: string;
+  text?: string;
+  url?: string;
+}): Promise<boolean> {
+  if (typeof navigator === 'undefined' || typeof navigator.share !== 'function') {
+    return false;
+  }
+  try {
+    await navigator.share(payload);
+    log('native share succeeded');
+    return true;
+  } catch (error) {
+    if ((error as Error)?.name === 'AbortError') {
+      log('native share cancelled by user');
+      return true;
+    }
+    log('native share failed', error);
+    return false;
+  }
+}


### PR DESCRIPTION
**Opening as Draft — this is a product direction call, not a mechanical change.**

## What it does
- Hero share card on the invites surface
- One-tap share buttons for major social platforms
- Invite-nudge surface to re-engage users with unused invites

+974 / −198 lines across 11 files.

## Open questions
- Is viral / social share the invite direction you want?
- Does the hero-card design fit the current calm-UI guideline?

Close this if the direction doesn't fit — worst case we learned what shape an invite revamp would take.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added social sharing buttons for inviting friends across multiple platforms (Twitter, Telegram, WhatsApp, LinkedIn, Facebook, Reddit, email, SMS).
  * Introduced invite progress tracking with visual indicators and conversion metrics.
  * Added new invite card UI with copy-to-clipboard functionality for invite links and codes.
  * Launched invite call-to-action on the home page.
  * Enhanced welcome and invites pages with social proof elements ("Trusted by builders worldwide").

* **Tests**
  * Added comprehensive unit tests for share utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->