### PR TITLE
feat(onboarding, ui): explicit context gathering + privacy surface

### DIFF
--- a/app/src/components/settings/panels/PrivacyPanel.tsx
+++ b/app/src/components/settings/panels/PrivacyPanel.tsx
@@ -5,8 +5,8 @@ import { useCoreState } from '../../../providers/CoreStateProvider';
 import {
   type Capability,
   type CapabilityPrivacy,
-  type PrivacyDataKind,
   listCapabilities,
+  type PrivacyDataKind,
 } from '../../../utils/tauriCommands/aboutApp';
 import SettingsHeader from '../components/SettingsHeader';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
@@ -94,9 +94,7 @@ const PrivacyPanel = () => {
                 <p className="p-4 text-xs text-stone-500">Loading privacy details&hellip;</p>
               )}
               {loadState === 'error' && (
-                <p
-                  className="p-4 text-xs text-stone-500"
-                  data-testid="privacy-load-error">
+                <p className="p-4 text-xs text-stone-500" data-testid="privacy-load-error">
                   Couldn&rsquo;t load the live privacy list. Analytics controls below still work.
                 </p>
               )}
@@ -106,14 +104,9 @@ const PrivacyPanel = () => {
                 </p>
               )}
               {loadState === 'ready' && capabilities.length > 0 && (
-                <ul
-                  className="divide-y divide-stone-100"
-                  data-testid="privacy-capability-list">
+                <ul className="divide-y divide-stone-100" data-testid="privacy-capability-list">
                   {capabilities.map(cap => (
-                    <li
-                      key={cap.id}
-                      className="p-4"
-                      data-testid={`privacy-row-${cap.id}`}>
+                    <li key={cap.id} className="p-4" data-testid={`privacy-row-${cap.id}`}>
                       <div className="flex items-start justify-between gap-3">
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-stone-900">{cap.name}</p>

--- a/app/src/components/settings/panels/__tests__/PrivacyPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyPanel.test.tsx
@@ -5,15 +5,10 @@ import { renderWithProviders } from '../../../../test/test-utils';
 import { type Capability, listCapabilities } from '../../../../utils/tauriCommands/aboutApp';
 import PrivacyPanel from '../PrivacyPanel';
 
-vi.mock('../../../../utils/tauriCommands/aboutApp', () => ({
-  listCapabilities: vi.fn(),
-}));
+vi.mock('../../../../utils/tauriCommands/aboutApp', () => ({ listCapabilities: vi.fn() }));
 
 vi.mock('../../../../providers/CoreStateProvider', () => ({
-  useCoreState: () => ({
-    snapshot: { analyticsEnabled: false },
-    setAnalyticsEnabled: vi.fn(),
-  }),
+  useCoreState: () => ({ snapshot: { analyticsEnabled: false }, setAnalyticsEnabled: vi.fn() }),
 }));
 
 vi.mock('../../hooks/useSettingsNavigation', () => ({

--- a/app/src/components/ui/Button.test.tsx
+++ b/app/src/components/ui/Button.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Button from './Button';
+
+describe('Button', () => {
+  it('renders children and defaults to primary/md with type=button', () => {
+    render(<Button>Send</Button>);
+    const btn = screen.getByRole('button', { name: 'Send' });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('type', 'button');
+    expect(btn.className).toMatch(/bg-primary-500/);
+    expect(btn.className).toMatch(/h-9/);
+    expect(btn.className).toMatch(/focus-visible:ring-primary-500\/25/);
+  });
+
+  it('applies secondary variant classes', () => {
+    render(<Button variant="secondary">Cancel</Button>);
+    const btn = screen.getByRole('button', { name: 'Cancel' });
+    expect(btn.className).toMatch(/border-neutral-300/);
+    expect(btn.className).toMatch(/bg-neutral-0/);
+  });
+
+  it('applies ghost variant classes', () => {
+    render(<Button variant="ghost">Skip</Button>);
+    const btn = screen.getByRole('button', { name: 'Skip' });
+    expect(btn.className).toMatch(/bg-transparent/);
+    expect(btn.className).toMatch(/text-neutral-700/);
+  });
+
+  it('applies danger variant classes', () => {
+    render(<Button variant="danger">Delete</Button>);
+    const btn = screen.getByRole('button', { name: 'Delete' });
+    expect(btn.className).toMatch(/text-coral-600/);
+    expect(btn.className).toMatch(/hover:bg-coral-50/);
+  });
+
+  it('honors size=xl classes', () => {
+    render(
+      <Button size="xl" variant="primary">
+        Open
+      </Button>
+    );
+    const btn = screen.getByRole('button', { name: 'Open' });
+    expect(btn.className).toMatch(/h-14/);
+    expect(btn.className).toMatch(/rounded-xl/);
+  });
+
+  it('honors size=xs classes', () => {
+    render(<Button size="xs">tiny</Button>);
+    const btn = screen.getByRole('button', { name: 'tiny' });
+    expect(btn.className).toMatch(/h-6/);
+    expect(btn.className).toMatch(/text-xs/);
+  });
+
+  it('merges extra className', () => {
+    render(<Button className="w-full">Wide</Button>);
+    const btn = screen.getByRole('button', { name: 'Wide' });
+    expect(btn.className).toMatch(/w-full/);
+  });
+
+  it('respects disabled: does not fire onClick and has disabled attr', () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        No
+      </Button>
+    );
+    const btn = screen.getByRole('button', { name: 'No' });
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(onClick).not.toHaveBeenCalled();
+    expect(btn.className).toMatch(/disabled:opacity-40/);
+  });
+
+  it('fires onClick when enabled', () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Go</Button>);
+    screen.getByRole('button', { name: 'Go' }).click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders leading and trailing icons', () => {
+    render(
+      <Button leadingIcon={<span data-testid="lead" />} trailingIcon={<span data-testid="trail" />}>
+        Label
+      </Button>
+    );
+    expect(screen.getByTestId('lead')).toBeInTheDocument();
+    expect(screen.getByTestId('trail')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/ui/Button.tsx
+++ b/app/src/components/ui/Button.tsx
@@ -1,0 +1,57 @@
+import { type ButtonHTMLAttributes, forwardRef, type ReactNode } from 'react';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+}
+
+const BASE =
+  'inline-flex items-center justify-center gap-2 font-medium transition-colors duration-150 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/25 ' +
+  'focus-visible:ring-offset-2 disabled:opacity-40 disabled:pointer-events-none';
+
+const VARIANTS: Record<ButtonVariant, string> = {
+  primary: 'bg-primary-500 text-white hover:bg-primary-600 active:bg-primary-700',
+  secondary: 'bg-neutral-0 text-neutral-900 border border-neutral-300 hover:bg-neutral-50',
+  ghost: 'bg-transparent text-neutral-700 hover:bg-neutral-100',
+  danger: 'bg-transparent text-coral-600 border border-coral-300/50 hover:bg-coral-50',
+};
+
+const SIZES: Record<ButtonSize, string> = {
+  xs: 'h-6 px-2 text-xs rounded-sm',
+  sm: 'h-[30px] px-3 text-sm rounded-md',
+  md: 'h-9 px-4 text-sm rounded-lg',
+  lg: 'h-11 px-5 text-base rounded-lg',
+  xl: 'h-14 px-7 text-base rounded-xl font-medium',
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  const {
+    variant = 'primary',
+    size = 'md',
+    leadingIcon,
+    trailingIcon,
+    className,
+    type,
+    children,
+    ...rest
+  } = props;
+
+  const classes = [BASE, VARIANTS[variant], SIZES[size], className ?? ''].filter(Boolean).join(' ');
+
+  return (
+    <button ref={ref} type={type ?? 'button'} className={classes} {...rest}>
+      {leadingIcon}
+      {children}
+      {trailingIcon}
+    </button>
+  );
+});
+Button.displayName = 'Button';
+
+export default Button;

--- a/app/src/features/privacy/WhatLeavesLink.tsx
+++ b/app/src/features/privacy/WhatLeavesLink.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+import WhatLeavesMyComputerSheet from './WhatLeavesMyComputerSheet';
+
+export interface WhatLeavesLinkProps {
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Inline "what leaves my computer?" trigger. Place near any screen that may
+ * cause a network call (model download, skill connect, provider selection).
+ * Invisible when not needed, one click away when it is.
+ */
+const WhatLeavesLink = ({ label = 'What leaves my computer?', className }: WhatLeavesLinkProps) => {
+  const [open, setOpen] = useState(false);
+  const base =
+    'text-sm text-neutral-500 underline underline-offset-2 hover:text-neutral-700 ' +
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/25 ' +
+    'focus-visible:ring-offset-2 rounded-sm';
+  return (
+    <>
+      <button
+        type="button"
+        className={[base, className ?? ''].filter(Boolean).join(' ')}
+        onClick={() => setOpen(true)}>
+        {label}
+      </button>
+      <WhatLeavesMyComputerSheet open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+export default WhatLeavesLink;

--- a/app/src/features/privacy/WhatLeavesMyComputerSheet.test.tsx
+++ b/app/src/features/privacy/WhatLeavesMyComputerSheet.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WHAT_LEAVES_ITEMS } from './whatLeavesItems';
+import WhatLeavesLink from './WhatLeavesLink';
+import WhatLeavesMyComputerSheet from './WhatLeavesMyComputerSheet';
+
+describe('WhatLeavesMyComputerSheet', () => {
+  it('renders nothing when closed', () => {
+    render(<WhatLeavesMyComputerSheet open={false} onClose={() => {}} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('lists all five honest leave items when open', () => {
+    render(<WhatLeavesMyComputerSheet open={true} onClose={() => {}} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    for (const item of WHAT_LEAVES_ITEMS) {
+      expect(screen.getByText(item.title)).toBeInTheDocument();
+    }
+    expect(WHAT_LEAVES_ITEMS).toHaveLength(5);
+  });
+
+  it('calls onClose when Got it is clicked', () => {
+    const onClose = vi.fn();
+    render(<WhatLeavesMyComputerSheet open={true} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Got it' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = vi.fn();
+    render(<WhatLeavesMyComputerSheet open={true} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WhatLeavesLink', () => {
+  it('opens the sheet when clicked', () => {
+    render(<WhatLeavesLink />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'What leaves my computer?' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('accepts a custom label', () => {
+    render(<WhatLeavesLink label="Network activity?" />);
+    expect(screen.getByRole('button', { name: 'Network activity?' })).toBeInTheDocument();
+  });
+});

--- a/app/src/features/privacy/WhatLeavesMyComputerSheet.tsx
+++ b/app/src/features/privacy/WhatLeavesMyComputerSheet.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import Button from '../../components/ui/Button';
+import { WHAT_LEAVES_HEADLINE, WHAT_LEAVES_ITEMS, WHAT_LEAVES_SUBHEAD } from './whatLeavesItems';
+
+export interface WhatLeavesMyComputerSheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const WhatLeavesMyComputerSheet = ({ open, onClose }: WhatLeavesMyComputerSheetProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    dialogRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-fade-in"
+      role="presentation">
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute inset-0 bg-neutral-900/40 backdrop-blur-sm cursor-default"
+      />
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="what-leaves-title"
+        className="relative w-full max-w-lg bg-neutral-0 rounded-2xl shadow-large border border-neutral-200 p-6 animate-fade-up outline-none">
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <p className="font-mono text-xs text-neutral-500 tracking-wider mb-1">
+              PRIVACY · WHAT LEAVES MY COMPUTER
+            </p>
+            <h2
+              id="what-leaves-title"
+              className="font-display text-2xl text-neutral-900 leading-tight">
+              {WHAT_LEAVES_HEADLINE}
+            </h2>
+          </div>
+        </div>
+        <p className="text-sm text-neutral-600 mb-5 max-w-md">{WHAT_LEAVES_SUBHEAD}</p>
+
+        <ul className="space-y-3 mb-6">
+          {WHAT_LEAVES_ITEMS.map(item => (
+            <li key={item.id} className="rounded-xl border border-neutral-200 bg-neutral-50 p-4">
+              <p className="text-sm font-medium text-neutral-900">{item.title}</p>
+              <p className="text-sm text-neutral-600 mt-1 leading-relaxed">{item.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-neutral-500">
+            Full controls live in Settings → Privacy & Security.
+          </p>
+          <Button variant="primary" size="md" onClick={onClose}>
+            Got it
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default WhatLeavesMyComputerSheet;

--- a/app/src/features/privacy/whatLeavesItems.ts
+++ b/app/src/features/privacy/whatLeavesItems.ts
@@ -1,0 +1,42 @@
+export interface PrivacyLeaveItem {
+  id: string;
+  title: string;
+  body: string;
+}
+
+/**
+ * The honest list of things that can leave the user's laptop.
+ * Copy source: repo README + handoff doc. Do not soften this list —
+ * the point is to not lie about "100% local".
+ */
+export const WHAT_LEAVES_ITEMS: PrivacyLeaveItem[] = [
+  {
+    id: 'model-downloads',
+    title: 'Model downloads & updates',
+    body: 'Local model weights are pulled from the model hub when you install or update them. After that, inference runs on your machine.',
+  },
+  {
+    id: 'cloud-providers',
+    title: 'Cloud AI providers — only when you pick one',
+    body: 'If you route a task to OpenAI, Anthropic, a search API, or any webhook target, that message goes to them. Your choice, per task.',
+  },
+  {
+    id: 'skill-integrations',
+    title: 'Skill integrations you connect',
+    body: "Skills like Gmail, Slack, or Notion talk to those services on your behalf — you authorized them. After each sync, a summary of that skill's state is sent to our memory service so the assistant can recall it across sessions.",
+  },
+  {
+    id: 'sentry',
+    title: 'Crash reports (opt-in)',
+    body: 'Anonymous crash reports help us fix bugs. Toggle anytime in Settings → Privacy & Security.',
+  },
+  {
+    id: 'auth-and-routing',
+    title: 'Account, billing, and chat routing',
+    body: 'Sign-in and billing go through our auth service. Chat messages are routed through our backend to the model you picked — local or cloud. Your files on disk stay on disk.',
+  },
+];
+
+export const WHAT_LEAVES_HEADLINE = 'Local by default. Cloud when you ask.';
+export const WHAT_LEAVES_SUBHEAD =
+  "We won't claim nothing ever leaves your computer — that would be a lie. Here's exactly what does, and when.";

--- a/app/src/pages/onboarding/Onboarding.tsx
+++ b/app/src/pages/onboarding/Onboarding.tsx
@@ -103,7 +103,9 @@ const Onboarding = ({ onComplete, onDefer }: OnboardingProps) => {
   };
 
   return (
-    <div data-testid="onboarding-overlay" className="min-h-full relative flex items-center justify-center">
+    <div
+      data-testid="onboarding-overlay"
+      className="min-h-full relative flex items-center justify-center">
       {onDefer && (
         <div className="fixed top-4 right-0 z-20 sm:top-6 sm:right-6">
           <button

--- a/app/src/pages/onboarding/steps/ContextGatheringStep.tsx
+++ b/app/src/pages/onboarding/steps/ContextGatheringStep.tsx
@@ -7,8 +7,10 @@
  * progress animation while the pipeline runs and displays the log when
  * it finishes.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
+import Button from '../../../components/ui/Button';
+import WhatLeavesLink from '../../../features/privacy/WhatLeavesLink';
 import { callCoreRpc } from '../../../services/coreRpcClient';
 import OnboardingNextButton from '../components/OnboardingNextButton';
 
@@ -88,30 +90,28 @@ const ContextGatheringStep = ({
   });
   const [stageDetails, setStageDetails] = useState<Record<string, string>>({});
   const [finished, setFinished] = useState(false);
+  const [started, setStarted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const ranRef = useRef(false);
 
   const hasGmail = connectedSources.some(s => s.includes('gmail'));
 
-  useEffect(() => {
+  const handleStart = () => {
     if (ranRef.current) return;
     ranRef.current = true;
+    setStarted(true);
 
     if (!hasGmail) {
-      // Derive skipped state asynchronously to avoid synchronous setState in effect.
-      setTimeout(() => {
-        const skipped: Record<string, StageStatus> = {};
-        for (const s of STAGES) skipped[s.id] = 'skipped';
-        setStageStatuses(skipped);
-        setStageDetails({ 'gmail-search': 'Gmail not connected' });
-        setFinished(true);
-      }, 0);
+      const skipped: Record<string, StageStatus> = {};
+      for (const s of STAGES) skipped[s.id] = 'skipped';
+      setStageStatuses(skipped);
+      setStageDetails({ 'gmail-search': 'Gmail not connected' });
+      setFinished(true);
       return;
     }
 
     void runPipeline();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  };
 
   async function runPipeline() {
     console.debug('[onboarding:context] runPipeline started');
@@ -205,16 +205,53 @@ const ContextGatheringStep = ({
     }
   };
 
+  if (!started) {
+    return (
+      <div
+        className="rounded-2xl border border-stone-200 bg-white p-8 shadow-soft animate-fade-up"
+        data-testid="context-gathering-intro">
+        <div className="text-center mb-5">
+          <h1 className="text-xl font-bold mb-2 text-stone-900">Getting to know you</h1>
+          <p className="text-stone-500 text-sm leading-relaxed max-w-sm mx-auto">
+            I can read what you've already connected and build a short profile so the first
+            conversation isn't cold. You're in charge — skip this and nothing is read.
+          </p>
+        </div>
+        <div className="rounded-xl border border-stone-100 bg-stone-50 p-4 mb-5 text-sm text-stone-600 leading-relaxed">
+          {hasGmail ? (
+            <>
+              Uses your <span className="font-medium text-stone-900">connected Gmail</span> to find
+              your LinkedIn URL, then pulls public profile info via a third-party LinkedIn scraper.
+              The resulting summary is saved to a local profile file.
+            </>
+          ) : (
+            <>You haven't connected Gmail. Nothing to read. You can skip this step.</>
+          )}
+        </div>
+        <OnboardingNextButton
+          label={hasGmail ? 'Start when ready' : 'Continue'}
+          onClick={handleStart}
+        />
+        <div className="mt-3 flex items-center justify-between gap-3">
+          <Button variant="ghost" size="sm" onClick={() => void onNext()}>
+            Skip for now
+          </Button>
+          <WhatLeavesLink />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-2xl border border-stone-200 bg-white p-8 shadow-soft animate-fade-up">
       <div className="text-center mb-5">
         <h1 className="text-xl font-bold mb-2 text-stone-900">
-          {finished ? 'Context Ready' : 'Preparing Your Context'}
+          {finished ? 'Context Ready' : 'Reading your connected accounts'}
         </h1>
         <p className="text-stone-500 text-sm">
           {finished
-            ? 'Your profile is ready. The assistant already knows who you are.'
-            : 'Learning about you from your connected accounts...'}
+            ? 'Short profile saved locally. Ready to chat.'
+            : 'Working from what you already connected…'}
         </p>
       </div>
 
@@ -317,6 +354,9 @@ const ContextGatheringStep = ({
       {error && <p className="text-coral-400 text-sm mb-3 text-center">{error}</p>}
 
       <OnboardingNextButton onClick={handleContinue} disabled={!finished} label="Continue" />
+      <div className="mt-3 flex justify-center">
+        <WhatLeavesLink />
+      </div>
     </div>
   );
 };

--- a/app/src/pages/onboarding/steps/WelcomeStep.tsx
+++ b/app/src/pages/onboarding/steps/WelcomeStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import ProgressIndicator from '../../../components/ProgressIndicator';
+import WhatLeavesLink from '../../../features/privacy/WhatLeavesLink';
 import OnboardingNextButton from '../components/OnboardingNextButton';
 
 interface WelcomeStepProps {
@@ -15,10 +16,20 @@ const AUTO_ADVANCE_MS = 5000;
 /* ------------------------------------------------------------------ */
 const WelcomeSlide = () => (
   <div className="flex flex-col items-center text-center">
-    <img src="/logo.png" alt="OpenHuman" className="w-24 h-24 rounded-2xl mb-6" />
-    <h1 className="text-2xl font-bold font-display text-stone-900 mb-3">Welcome On Board</h1>
-    <p className="text-stone-500 text-sm leading-relaxed">
-      All your tasks, tools, and conversations organized in one place.
+    <img src="/logo.png" alt="OpenHuman" className="w-20 h-20 rounded-2xl mb-5" />
+    <div className="flex items-center gap-2 mb-3">
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 rounded-full bg-primary-500 animate-glow-pulse"
+      />
+      <span className="font-mono text-[11px] tracking-[0.12em] text-stone-500">
+        OPENHUMAN · LOCAL BY DEFAULT
+      </span>
+    </div>
+    <h1 className="text-3xl font-display text-stone-900 mb-3 leading-tight">Hi. I'm OpenHuman.</h1>
+    <p className="text-stone-500 text-sm leading-relaxed max-w-sm">
+      A private assistant that runs on your computer and routes to the cloud when you pick a cloud
+      model. No hidden traffic — the full list is one click below.
     </p>
   </div>
 );
@@ -84,6 +95,9 @@ const WelcomeStep = ({ onNext }: WelcomeStepProps) => {
         <ProgressIndicator currentStep={slide} totalSteps={TOTAL_SLIDES} />
       </div>
       <OnboardingNextButton label="Let's Start" onClick={onNext} />
+      <div className="mt-4 flex justify-center">
+        <WhatLeavesLink />
+      </div>
     </div>
   );
 };

--- a/app/src/pages/onboarding/steps/WelcomeStep.tsx
+++ b/app/src/pages/onboarding/steps/WelcomeStep.tsx
@@ -85,7 +85,9 @@ const WelcomeStep = ({ onNext }: WelcomeStepProps) => {
   }, []);
 
   return (
-    <div data-testid="onboarding-welcome-step" className="rounded-2xl bg-white p-10 shadow-soft animate-fade-up">
+    <div
+      data-testid="onboarding-welcome-step"
+      className="rounded-2xl bg-white p-10 shadow-soft animate-fade-up">
       <div className="h-[340px] flex flex-col items-center justify-center">
         {slide === 0 && <WelcomeSlide />}
         {slide === 1 && <IntegrationsSlide />}

--- a/app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import ContextGatheringStep from '../ContextGatheringStep';
+
+const callCoreRpc = vi.hoisted(() => vi.fn());
+vi.mock('../../../../services/coreRpcClient', () => ({ callCoreRpc }));
+
+describe('ContextGatheringStep', () => {
+  beforeEach(() => {
+    callCoreRpc.mockReset();
+  });
+
+  it('renders user-driven intro gate with a Skip and privacy link, does NOT auto-run pipeline', () => {
+    renderWithProviders(
+      <ContextGatheringStep connectedSources={[]} onNext={() => Promise.resolve()} />
+    );
+
+    expect(screen.getByTestId('context-gathering-intro')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Getting to know you' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Skip for now' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'What leaves my computer?' })).toBeInTheDocument();
+    expect(callCoreRpc).not.toHaveBeenCalled();
+  });
+
+  it('no-Gmail branch: Start marks all stages skipped and surfaces Continue without any RPC', async () => {
+    renderWithProviders(
+      <ContextGatheringStep connectedSources={['notion']} onNext={() => Promise.resolve()} />
+    );
+
+    expect(screen.getByText(/haven't connected Gmail/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
+    });
+    expect(screen.getByText('Context Ready')).toBeInTheDocument();
+    expect(callCoreRpc).not.toHaveBeenCalled();
+  });
+
+  it('Skip for now invokes onNext without starting the pipeline', () => {
+    const onNext = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(<ContextGatheringStep connectedSources={['gmail']} onNext={onNext} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(callCoreRpc).not.toHaveBeenCalled();
+  });
+
+  it('with Gmail connected: Start when ready triggers the pipeline exactly once', async () => {
+    callCoreRpc.mockResolvedValue({ profile_url: null, profile_data: null, log: [] });
+    renderWithProviders(
+      <ContextGatheringStep connectedSources={['gmail']} onNext={() => Promise.resolve()} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start when ready' }));
+
+    await waitFor(() => {
+      expect(callCoreRpc).toHaveBeenCalledTimes(1);
+    });
+    expect(callCoreRpc).toHaveBeenCalledWith({ method: 'openhuman.learning_linkedin_enrichment' });
+  });
+});

--- a/app/src/pages/onboarding/steps/__tests__/WelcomeStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/WelcomeStep.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import WelcomeStep from '../WelcomeStep';
+
+describe('WelcomeStep', () => {
+  it('renders honest eyebrow + confident display title + subtitle', () => {
+    renderWithProviders(<WelcomeStep onNext={() => {}} />);
+    expect(screen.getByText(/OPENHUMAN · LOCAL BY DEFAULT/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: /Hi\. I'm OpenHuman\./ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/routes to the cloud when you pick a cloud model/i)
+    ).toBeInTheDocument();
+  });
+
+  it('exposes a "What leaves my computer?" link', () => {
+    renderWithProviders(<WelcomeStep onNext={() => {}} />);
+    expect(screen.getByRole('button', { name: 'What leaves my computer?' })).toBeInTheDocument();
+  });
+
+  it('fires onNext when the CTA is clicked', () => {
+    const onNext = vi.fn();
+    renderWithProviders(<WelcomeStep onNext={onNext} />);
+    fireEvent.click(screen.getByRole('button', { name: "Let's Start" }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables CTA when nextDisabled is set, and shows loading label when loading', () => {
+    const { rerender } = renderWithProviders(
+      <WelcomeStep
+        onNext={() => {}}
+        nextDisabled
+        nextLoading
+        nextLoadingLabel="Checking account…"
+      />
+    );
+    const btn = screen.getByRole('button', { name: /Checking account/ });
+    expect(btn).toBeDisabled();
+
+    rerender(<WelcomeStep onNext={() => {}} />);
+    expect(screen.getByRole('button', { name: "Let's Start" })).not.toBeDisabled();
+  });
+});

--- a/app/src/pages/onboarding/steps/__tests__/WelcomeStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/WelcomeStep.test.tsx
@@ -28,19 +28,8 @@ describe('WelcomeStep', () => {
     expect(onNext).toHaveBeenCalledTimes(1);
   });
 
-  it('disables CTA when nextDisabled is set, and shows loading label when loading', () => {
-    const { rerender } = renderWithProviders(
-      <WelcomeStep
-        onNext={() => {}}
-        nextDisabled
-        nextLoading
-        nextLoadingLabel="Checking account…"
-      />
-    );
-    const btn = screen.getByRole('button', { name: /Checking account/ });
-    expect(btn).toBeDisabled();
-
-    rerender(<WelcomeStep onNext={() => {}} />);
+  it("CTA is always enabled (WelcomeStep has no disabled/loading props)", () => {
+    renderWithProviders(<WelcomeStep onNext={() => {}} />);
     expect(screen.getByRole('button', { name: "Let's Start" })).not.toBeDisabled();
   });
 });

--- a/app/src/pages/onboarding/steps/__tests__/WelcomeStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/WelcomeStep.test.tsx
@@ -28,7 +28,7 @@ describe('WelcomeStep', () => {
     expect(onNext).toHaveBeenCalledTimes(1);
   });
 
-  it("CTA is always enabled (WelcomeStep has no disabled/loading props)", () => {
+  it('CTA is always enabled (WelcomeStep has no disabled/loading props)', () => {
     renderWithProviders(<WelcomeStep onNext={() => {}} />);
     expect(screen.getByRole('button', { name: "Let's Start" })).not.toBeDisabled();
   });

--- a/app/src/utils/tauriCommands/aboutApp.ts
+++ b/app/src/utils/tauriCommands/aboutApp.ts
@@ -6,7 +6,6 @@
  * the first consumer; future panels can reuse the same types.
  */
 import { callCoreRpc } from '../../services/coreRpcClient';
-
 import { CommandResponse } from './common';
 
 export type CapabilityCategory =
@@ -23,12 +22,7 @@ export type CapabilityCategory =
 
 export type CapabilityStatus = 'stable' | 'beta' | 'coming_soon' | 'deprecated';
 
-export type PrivacyDataKind =
-  | 'raw'
-  | 'derived'
-  | 'credentials'
-  | 'diagnostics'
-  | 'metadata';
+export type PrivacyDataKind = 'raw' | 'derived' | 'credentials' | 'diagnostics' | 'metadata';
 
 export interface CapabilityPrivacy {
   leaves_device: boolean;

--- a/app/test/e2e/helpers/artifacts.ts
+++ b/app/test/e2e/helpers/artifacts.ts
@@ -52,9 +52,7 @@ function nowStamp(): string {
 }
 
 function getRoot(): string {
-  return process.env.E2E_ARTIFACT_ROOT
-    ? path.resolve(process.env.E2E_ARTIFACT_ROOT)
-    : defaultRoot;
+  return process.env.E2E_ARTIFACT_ROOT ? path.resolve(process.env.E2E_ARTIFACT_ROOT) : defaultRoot;
 }
 
 /**
@@ -134,12 +132,7 @@ export async function captureCheckpoint(name: string): Promise<void> {
   if (await writeSource(xmlFile)) files.push(path.basename(xmlFile));
 
   if (meta) {
-    meta.checkpoints.push({
-      index: checkpointIndex,
-      name,
-      at: new Date().toISOString(),
-      files,
-    });
+    meta.checkpoints.push({ index: checkpointIndex, name, at: new Date().toISOString(), files });
     writeMeta();
   }
   // eslint-disable-next-line no-console
@@ -162,11 +155,7 @@ export async function captureFailureArtifacts(testName: string): Promise<void> {
     if (await writeSource(xmlFile)) files.push(path.basename(xmlFile));
 
     if (meta) {
-      meta.failures.push({
-        testName,
-        at: new Date().toISOString(),
-        files,
-      });
+      meta.failures.push({ testName, at: new Date().toISOString(), files });
       writeMeta();
     }
     // eslint-disable-next-line no-console

--- a/app/test/e2e/specs/agent-review.spec.ts
+++ b/app/test/e2e/specs/agent-review.spec.ts
@@ -17,11 +17,7 @@
  * UI assertion — we already have login-flow.spec.ts for that.
  */
 import { waitForApp, waitForAppReady, waitForAuthBootstrap } from '../helpers/app-helpers';
-import {
-  captureCheckpoint,
-  getArtifactDir,
-  saveMockRequestLog,
-} from '../helpers/artifacts';
+import { captureCheckpoint, getArtifactDir, saveMockRequestLog } from '../helpers/artifacts';
 import { triggerAuthDeepLink } from '../helpers/deep-link-helpers';
 import {
   clickText,
@@ -90,9 +86,7 @@ describe('Agent review — canonical onboarding + privacy flow', () => {
 
   it('02 advances past welcome step', async () => {
     const clicked =
-      (await tryClick("Let's Start")) ||
-      (await tryClick('Continue')) ||
-      (await tryClick('Skip'));
+      (await tryClick("Let's Start")) || (await tryClick('Continue')) || (await tryClick('Skip'));
     // eslint-disable-next-line no-console
     console.log(`[agent-review] welcome advance clicked=${clicked}`);
     await browser.pause(2_000);

--- a/app/test/e2e/specs/login-flow.spec.ts
+++ b/app/test/e2e/specs/login-flow.spec.ts
@@ -12,7 +12,8 @@
  *   Phase 2 — Onboarding steps (3 steps in Onboarding.tsx):
  *     Step 0: WelcomeStep            — "Continue"
  *     Step 1: SkillsStep             — "Continue" or "Skip for Now"
- *     Step 2: ContextGatheringStep   — "Continue" (skipped if no sources connected)
+ *     Step 2: ContextGatheringStep   — user-driven gate: "Start when ready" / "Continue" /
+ *                                       "Skip for now" (skipped entirely if no sources connected)
  *
  *   Phase 3 — Completion verification:
  *     - App calls POST /settings/onboarding-complete (from SkillsStep)
@@ -198,7 +199,9 @@ describe('Login flow — complete with mock data (Linux)', () => {
   // Steps in order:
   //   0: WelcomeStep            — "Continue" button
   //   1: SkillsStep             — "Continue" or "Skip for Now"
-  //   2: ContextGatheringStep   — "Continue" (skipped if no sources connected)
+  //   2: ContextGatheringStep   — user-driven gate: intro card with "Start when ready" /
+  //       "Continue" / "Skip for now". Step is skipped entirely when SkillsStep
+  //       produced zero connected sources (Onboarding.tsx → handleSkillsNext).
   // -----------------------------------------------------------------------
 
   it('onboarding overlay or home page is visible', async () => {
@@ -262,11 +265,22 @@ describe('Login flow — complete with mock data (Linux)', () => {
       }
     }
 
-    // Step 2: ContextGatheringStep — click "Continue" (skipped when no sources connected)
+    // Step 2: ContextGatheringStep — intro gate. Heading is "Getting to know you"
+    // (pre-start) or "Reading your connected accounts" / "Context Ready" (post-start).
+    // We don't actually want the real LinkedIn enrichment pipeline to run in E2E
+    // (it would hit the Rust core), so prefer "Skip for now" when present.
+    // "Continue" covers both the no-Gmail branch (skipped stages render Continue
+    // immediately after Start) and the completed-pipeline final state.
     {
-      const contextVisible = await textExists('Preparing Your Context');
+      const contextVisible =
+        (await textExists('Getting to know you')) ||
+        (await textExists('Reading your connected accounts')) ||
+        (await textExists('Context Ready'));
       if (contextVisible) {
-        const clicked = await clickFirstMatch(['Continue'], 10_000);
+        const clicked = await clickFirstMatch(
+          ['Skip for now', 'Continue', 'Start when ready'],
+          10_000
+        );
         if (clicked) {
           console.log(`[LoginFlow] ContextGatheringStep: clicked "${clicked}"`);
           await browser.pause(3_000);

--- a/app/test/wdio.conf.ts
+++ b/app/test/wdio.conf.ts
@@ -108,7 +108,7 @@ export const config: Options.Testrunner & Record<string, unknown> = {
   afterTest: async function (
     test: { title: string; parent?: string },
     _context: unknown,
-    result: { passed: boolean; error?: Error },
+    result: { passed: boolean; error?: Error }
   ) {
     if (result.passed) return;
     const name = [test.parent, test.title].filter(Boolean).join(' ').trim() || test.title;


### PR DESCRIPTION
**Opening as Draft — overlaps with existing onboarding; needs design reconciliation.**

## Changes
- Make onboarding context-gathering explicit and user-driven (vs implicit)
- New Button primitive in the UI kit
- "What leaves my computer" privacy surface during onboarding

+568 / −74 lines, 18 files.

## Open questions
- Does this replace or augment the current onboarding flow?
- Is the Button primitive needed given Headless UI + existing components?

38 commits behind main — rebase required before merge.

Close if the direction conflicts with the current onboarding stack.