### PR TITLE
ci(release): drop duplicate vite build and raise node heap to 8GB

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,15 +78,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build frontend
-        run: yarn build
-        env:
-          NODE_ENV: production
-          VITE_BACKEND_URL: ${{ vars.BASE_URL }}
-          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_DEBUG: ${{ vars.VITE_DEBUG }}
-          VITE_MINIMUM_SUPPORTED_APP_VERSION: ${{ vars.VITE_MINIMUM_SUPPORTED_APP_VERSION }}
-          VITE_LATEST_APP_DOWNLOAD_URL: ${{ vars.VITE_LATEST_APP_DOWNLOAD_URL }}
+      # vite build runs via tauri.conf.json's beforeBuildCommand during the
+      # "Build Tauri app" step below — no separate frontend build needed.
 
       - name: Resolve core manifest and binary names
         id: core-paths
@@ -154,11 +147,14 @@ jobs:
         working-directory: app
         env:
           BASE_URL: ${{ vars.BASE_URL }}
+          VITE_BACKEND_URL: ${{ vars.BASE_URL }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_DEBUG: ${{ vars.VITE_DEBUG }}
           VITE_MINIMUM_SUPPORTED_APP_VERSION: ${{ vars.VITE_MINIMUM_SUPPORTED_APP_VERSION }}
           VITE_LATEST_APP_DOWNLOAD_URL: ${{ vars.VITE_LATEST_APP_DOWNLOAD_URL }}
           TAURI_CONFIG_OVERRIDE: ${{ steps.config-overrides.outputs.json }}
         run: |
-          cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" --target x86_64-pc-windows-msvc
+          NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" --target x86_64-pc-windows-msvc
 
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,26 +445,9 @@ jobs:
             const config = prepareTauriConfig();
             core.setOutput('json', JSON.stringify(config));
 
-      - name: Build frontend
-        run: yarn build
-        env:
-          NODE_ENV: production
-          NODE_OPTIONS: --max-old-space-size=4096
-          VITE_OPENHUMAN_APP_ENV: ${{ inputs.build_target == 'staging' && 'staging' || 'production' }}
-          VITE_BACKEND_URL: ${{ needs.prepare-build.outputs.base_url }}
-          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_DEBUG: ${{ vars.VITE_DEBUG }}
-          # OAuth guardrails (#365): block openhuman://oauth/success on outdated desktop builds.
-          VITE_MINIMUM_SUPPORTED_APP_VERSION: ${{ vars.VITE_MINIMUM_SUPPORTED_APP_VERSION }}
-          VITE_LATEST_APP_DOWNLOAD_URL: ${{ vars.VITE_LATEST_APP_DOWNLOAD_URL }}
-          # Sentry release tracking (#405): baked into the bundle so every event
-          # groups under the same release, and @sentry/vite-plugin uploads the
-          # matching source maps when SENTRY_AUTH_TOKEN is present.
-          VITE_BUILD_SHA: ${{ needs.prepare-build.outputs.sha }}
-          SENTRY_RELEASE: openhuman@${{ needs.prepare-build.outputs.version }}+${{ needs.prepare-build.outputs.sha }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_FRONTEND }}
+      # Note: vite build runs via tauri.conf.json's beforeBuildCommand during
+      # the "Build and package Tauri app" step below. A separate frontend build
+      # here would just double memory pressure (sentry-vite-plugin peaks hard).
 
       - name: Resolve core manifest and binary names
         id: core-paths
@@ -573,9 +556,11 @@ jobs:
           VITE_LATEST_APP_DOWNLOAD_URL: ${{ vars.VITE_LATEST_APP_DOWNLOAD_URL }}
           TAURI_CONFIG_OVERRIDE: ${{ steps.config-overrides.outputs.json }}
           MATRIX_ARGS: ${{ matrix.settings.args }}
-          NODE_OPTIONS: --max-old-space-size=4096
         run: |
-          cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
+          # Inline NODE_OPTIONS so it reaches the vite child spawned by
+          # beforeBuildCommand. Step-level env was observed not to propagate
+          # on macos-arm64 runners, causing OOM at node's ~2GB auto default.
+          NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
 
       # tauri-action previously uploaded non-macOS installer assets directly
       # to the release. Replicate that for Linux + Windows here (macOS goes


### PR DESCRIPTION
## Summary

- Release job was OOMing during `yarn build` on `macos-latest` (arm64) — v8 hit its ~2GB auto heap ceiling even though the step set `NODE_OPTIONS=4096`, because the env wasn't reaching the vite child.
- The explicit `yarn build` step was also redundant: `app/src-tauri/tauri.conf.json`'s `beforeBuildCommand` already runs vite during `cargo tauri build`, so every matrix job was running vite twice.
- Drop the redundant frontend build step in both `release.yml` and `build-windows.yml`, and inline `NODE_OPTIONS=--max-old-space-size=8192` on the `cargo tauri build` invocation so it actually propagates to the spawned node/vite process.
- Move `VITE_BACKEND_URL` / `VITE_SENTRY_DSN` / `VITE_DEBUG` onto the Windows tauri build step (they used to live only on the deleted frontend step).

## Test plan

- [ ] Dispatch `Release` with `build_target: staging` and confirm all four matrix entries succeed (previous run: https://github.com/tinyhumansai/openhuman/actions/runs/24768704213)
- [ ] Confirm the produced bundle still has the Sentry DSN baked in (DevTools → network / any Sentry event references the release tag)
- [ ] Dispatch `Build Windows` on `fix/windows` branch and confirm MSI + NSIS artifacts upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined and optimized build process for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->