### PR TITLE
ci: enable sccache and disable incremental in rust test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,15 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+    env:
+      # Incremental compilation is pointless on fresh CI runners and just wastes
+      # disk and IO. Swatinem/rust-cache already handles cross-run warmup.
+      CARGO_INCREMENTAL: "0"
+      # Route rustc through sccache, backed by the GitHub Actions cache. This
+      # layers on top of Swatinem/rust-cache (which caches target/) by caching
+      # individual compilation units across branches.
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -102,6 +111,9 @@ jobs:
 
       - name: Install system dependencies (cmake, ALSA, X11)
         run: apt-get update && apt-get install -y --no-install-recommends cmake libasound2-dev libxdo-dev libxtst-dev libx11-dev libevdev-dev && rm -rf /var/lib/apt/lists/*
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Check formatting (cargo fmt)
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

Two stacked wins on the Rust test job (`.github/workflows/test.yml`):

- **`CARGO_INCREMENTAL=0`** — incremental compilation is for warm local dev, pointless on fresh CI runners. Saves disk + a few % wall-clock.
- **`RUSTC_WRAPPER=sccache`** via `mozilla-actions/sccache-action@v0.0.9` with `SCCACHE_GHA_ENABLED=true`. Layers cleanly on top of the existing `Swatinem/rust-cache@v2`: rust-cache warms `target/` per branch; sccache caches individual compilation units across branches. Expected 30–60% off cold Rust builds on fresh PRs.

No changes to `build-windows.yml` (triggers only on `workflow_dispatch` / `fix/windows` branch) or release workflows — those can follow if this proves clean.

## Test plan

- [ ] First CI run on this PR: sccache step installs cleanly inside the `openhuman_ci:rust-1.93.0` container
- [ ] Subsequent runs: confirm sccache cache hits in the job log (`sccache --show-stats` appears at job end from the action)
- [ ] No regression in Rust test runtime (Swatinem + sccache should layer, not fight)

If sccache-in-container turns out flaky, the fallback is to revert the sccache step and keep only the `CARGO_INCREMENTAL=0` line.