### PR TITLE
feat(ui,webview): compact tab bar, hide inactive tabs, harden CEF link handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,20 @@ Thin desktop host: window management, daemon health, **core process lifecycle** 
 
 Registered IPC (see [`docs/src-tauri/02-commands.md`](docs/src-tauri/02-commands.md)): `greet`, `write_ai_config_file`, `ai_get_config`, `ai_refresh_config`, `core_rpc_relay`, window commands, `openhuman_*` daemon helpers.
 
+### CEF child webviews — no new JS injection
+
+Embedded provider webviews (`acct_*`, loading third-party origins like `web.telegram.org`, `linkedin.com`, `slack.com`, …) **must not** grow any new JavaScript injection. Do not add new `.js` files under `app/src-tauri/src/webview_accounts/`, do not append new blocks to `build_init_script` / `RUNTIME_JS`, and do not dispatch scripts via CDP `Page.addScriptToEvaluateOnNewDocument` / `Runtime.evaluate` for these webviews. The migrated providers (whatsapp, telegram, slack, discord, browserscan) load with **zero** injected JS under CEF by design — all scraping and observability runs natively via CDP in the per-provider scanner modules, and anything host-controlled that runs inside a third-party origin is a scraping/attack-surface liability.
+
+New behavior for these webviews lives in:
+
+- **CEF handlers** — `on_navigation`, `on_new_window`, `LoadHandler::OnLoadStart`, `CefRequestHandler::*` (wired in `webview_accounts/mod.rs`).
+- **CDP from the scanner side** — `Network.*`, `Emulation.*`, `Input.*`, `Page.*` driven by the per-provider `*_scanner/` modules.
+- **Rust-side notification/IPC hooks** — never cross into the renderer.
+
+If a feature truly cannot be built this way (e.g. intercepting a click the page's JS preventDefaults), the correct answer is to **surface the limitation**, not to ship an init script. Legacy injection that already exists for non-migrated providers (`gmail`, `linkedin`, `google-meet` recipe files, `ua_spoof.js`, `runtime.js` bridge) is grandfathered but should shrink, not grow.
+
+Watch out for Tauri plugins that inject JS by default. `tauri-plugin-opener` ships `init-iife.js` (a global click listener that calls `plugin:opener|open_url` via HTTP-IPC) unless you build it with `.open_js_links_on_click(false)`. Any new plugin added to `app/src-tauri/src/lib.rs` must be audited for a `js_init_script` call — if found, opt out or configure around it.
+
 ---
 
 ## Rust core (`src/`)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 <p align="center">
   <a href="https://discord.tinyhumans.ai/">Discord</a> •
   <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
-  <a href="https://x.com/tinyhumansai">X/Twitter</a> •
+  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
   <a href="https://tinyhumans.gitbook.io/openhuman/">Docs</a>
+</p>
+<p align="center">
+  <a href="https://x.com/intent/follow?screen_name=senamakel">Follow @senamakel (Creator)</a>
 </p>
 
 <p align="center">
@@ -72,17 +75,17 @@ Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Contributor orient
 
 High-level comparison (products evolve—verify against each vendor). OpenHuman is built to **minimize vendor sprawl**, keep **workflow knowledge on-device**, and ship **deep desktop** features—not only chat.
 
-|                         | Claude Code/Cowork  | OpenClaw           | Hermes Agent       | OpenHuman                |
-| ----------------------- | ------------------- | ------------------ | ------------------ | ------------------------ |
-| **Open-source**         | 🚫 Proprietary      | ✅ MIT             | ✅ MIT             | ✅ GNU                   |
-| **Simple to start**     | ✅ Desktop + CLI    | ⚠️ Terminal-first  | ⚠️ Terminal-first  | ✅ Clean UI, minutes     |
-| **Cost**                | ⚠️ Sub + add-ons    | ⚠️ BYO models      | ⚠️ BYO models      | ✅ Local-friendly        |
-| **Memory & KB**         | ✅ Chat-scoped      | ⚠️ Plugin-reliant  | ✅ Self-learning   | 🚀 Local KB + learning   |
-| **API sprawl**          | 🚫 Extra keys       | 🚫 BYOK            | 🚫 Multi-vendor    | ✅ One account           |
-| **Extensibility**       | ✅ MCP              | ✅ SKILL.md        | ✅ SKILL.md        | 🚀 Rich Skills           |
-| **Desktop integration** | ⚠️ Basic            | ⚠️ Light           | ⚠️ Light           | ✅ STT/TTS/screen/more   |
+|                         | Claude Code/Cowork | OpenClaw          | Hermes Agent      | OpenHuman              |
+| ----------------------- | ------------------ | ----------------- | ----------------- | ---------------------- |
+| **Open-source**         | 🚫 Proprietary     | ✅ MIT            | ✅ MIT            | ✅ GNU                 |
+| **Simple to start**     | ✅ Desktop + CLI   | ⚠️ Terminal-first | ⚠️ Terminal-first | ✅ Clean UI, minutes   |
+| **Cost**                | ⚠️ Sub + add-ons   | ⚠️ BYO models     | ⚠️ BYO models     | ✅ Local-friendly      |
+| **Memory & KB**         | ✅ Chat-scoped     | ⚠️ Plugin-reliant | ✅ Self-learning  | 🚀 Local KB + learning |
+| **API sprawl**          | 🚫 Extra keys      | 🚫 BYOK           | 🚫 Multi-vendor   | ✅ One account         |
+| **Extensibility**       | ✅ MCP             | ✅ SKILL.md       | ✅ SKILL.md       | 🚀 Rich Skills         |
+| **Desktop integration** | ⚠️ Basic           | ⚠️ Light          | ⚠️ Light          | ✅ STT/TTS/screen/more |
 
-<!-- # Star us on GitHub
+# Star us on GitHub
 
 _Building toward AGI and artificial consciousness? Star the repo and help others find the path._
 
@@ -94,7 +97,7 @@ _Building toward AGI and artificial consciousness? Star the repo and help others
      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />
     </picture>
   </a>
-</p> -->
+</p>
 
 # Contributors Hall of Fame
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -598,7 +598,22 @@ pub fn run() {
     };
 
     let builder = builder
-        .plugin(tauri_plugin_opener::init())
+        // Explicitly disable `open_js_links_on_click`: tauri-plugin-opener
+        // defaults to injecting `init-iife.js` into *every* webview — a
+        // global click listener that invokes `plugin:opener|open_url` via
+        // HTTP-IPC. That violates our "no JS injection into CEF child
+        // webviews" rule (see CLAUDE.md) and also fails in practice
+        // because third-party origins (web.telegram.org, linkedin, …)
+        // trip Tauri's Origin header check and return 500. External link
+        // handling for `acct_*` webviews runs natively via
+        // `on_navigation` / `on_new_window` in webview_accounts/mod.rs;
+        // the main window uses `openUrl()` from `utils/openUrl.ts` when
+        // it needs to hand off a URL.
+        .plugin(
+            tauri_plugin_opener::Builder::default()
+                .open_js_links_on_click(false)
+                .build(),
+        )
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -191,13 +191,58 @@ fn popup_should_stay_in_app(provider: &str, url: &Url) -> bool {
         _ => false,
     }
 }
+/// Unwrap provider-side "link safety" redirects so the system browser
+/// lands on the real destination.
+///
+/// These wrappers (LinkedIn's `/safety/go/?url=…`, etc.) require the
+/// user to be logged into the provider in the destination browser. In
+/// our setup the session lives inside the embedded CEF webview's cookie
+/// jar, not the user's default browser — opening the wrapper URL there
+/// shows a broken safety page instead of completing the redirect.
+/// Extract the `url` query param and return the resolved destination.
+fn unwrap_provider_redirect(url: &Url) -> Option<Url> {
+    let host = url.host_str()?;
+    let path = url.path();
+    let matches_linkedin = (host == "www.linkedin.com" || host == "linkedin.com")
+        && (path == "/safety/go/" || path == "/safety/go" || path == "/redir/redirect");
+    if !matches_linkedin {
+        return None;
+    }
+    let (_, raw) = url.query_pairs().find(|(k, _)| k == "url")?;
+    Url::parse(&raw).ok()
+}
+
 /// Fire-and-forget handoff to the OS default URL handler. Any error is
 /// logged but not propagated — we've already cancelled the in-app
 /// navigation so there's nowhere to surface a failure to.
+///
+/// On macOS we shell out to `/usr/bin/open` directly rather than via
+/// `tauri_plugin_opener::open_url`: the plugin returned Ok but no browser
+/// actually launched in the CEF runtime (suspected sandbox/launch-service
+/// interaction with the `open` crate's detached spawn). The direct
+/// Command call is equivalent to what a user would type in Terminal and
+/// works reliably.
 fn open_in_system_browser(url: &str) {
-    match tauri_plugin_opener::open_url(url, None::<&str>) {
-        Ok(()) => log::info!("[webview-accounts] opened externally: {}", url),
-        Err(e) => log::warn!("[webview-accounts] open_url({}) failed: {}", url, e),
+    #[cfg(target_os = "macos")]
+    {
+        match std::process::Command::new("/usr/bin/open")
+            .arg(url)
+            .spawn()
+        {
+            Ok(_) => log::info!("[webview-accounts] opened externally (macos open): {}", url),
+            Err(e) => log::warn!(
+                "[webview-accounts] /usr/bin/open {} failed: {} — falling back to opener plugin",
+                url,
+                e
+            ),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        match tauri_plugin_opener::open_url(url, None::<&str>) {
+            Ok(()) => log::info!("[webview-accounts] opened externally: {}", url),
+            Err(e) => log::warn!("[webview-accounts] open_url({}) failed: {}", url, e),
+        }
     }
 }
 
@@ -552,9 +597,6 @@ fn build_init_script(account_id: &str, provider: &str) -> String {
     } else {
         ""
     };
-    // Migrated providers have no recipe under wry either (recipe.js
-    // files were deleted with the cef migration), but the UA shim is
-    // still worth shipping so fingerprint gates pass.
     let Some(recipe_js) = provider_recipe_js(provider) else {
         return spoof.to_string();
     };
@@ -686,11 +728,22 @@ pub async fn webview_account_open<R: Runtime>(
         if url_is_internal(&nav_provider, url) {
             true
         } else {
-            log::info!(
-                "[webview-accounts] external navigation {} → system browser",
-                url
-            );
-            open_in_system_browser(url.as_str());
+            let target = unwrap_provider_redirect(url)
+                .map(|u| u.to_string())
+                .unwrap_or_else(|| url.to_string());
+            if target != url.as_str() {
+                log::info!(
+                    "[webview-accounts] external navigation {} → (unwrapped) {} → system browser",
+                    url,
+                    target
+                );
+            } else {
+                log::info!(
+                    "[webview-accounts] external navigation {} → system browser",
+                    url
+                );
+            }
+            open_in_system_browser(&target);
             false
         }
     });
@@ -714,12 +767,60 @@ pub async fn webview_account_open<R: Runtime>(
             );
             NewWindowResponse::Allow
         } else {
-            log::info!(
-                "[webview-accounts] new-window request {} → system browser",
-                url
-            );
-            open_in_system_browser(url.as_str());
+            let target = unwrap_provider_redirect(&url)
+                .map(|u| u.to_string())
+                .unwrap_or_else(|| url.to_string());
+            if target != url.as_str() {
+                log::info!(
+                    "[webview-accounts] new-window request {} → (unwrapped) {} → system browser",
+                    url,
+                    target
+                );
+            } else {
+                log::info!(
+                    "[webview-accounts] new-window request {} → system browser",
+                    url
+                );
+            }
+            open_in_system_browser(&target);
             NewWindowResponse::Deny
+        }
+    });
+
+    // Emit a main-frame load-state event to the React side so it can
+    // hide the loading overlay once the provider's UI is ready. Only
+    // fires for top-level navigations; sub-frame loads are ignored.
+    let load_app = app.clone();
+    let load_account_id = args.account_id.clone();
+    let load_provider = args.provider.clone();
+    builder = builder.on_page_load(move |webview, payload| {
+        // Ignore sub-frame events — the webview argument is always the
+        // top-level one from the builder, but `payload.url()` reflects
+        // whichever frame triggered. We filter by checking the URL is
+        // http(s) (sub-frames are commonly data:/about:blank/chrome://).
+        let url = payload.url().to_string();
+        let state = match payload.event() {
+            tauri::webview::PageLoadEvent::Started => "started",
+            tauri::webview::PageLoadEvent::Finished => "finished",
+        };
+        let _ = webview;
+        let event = serde_json::json!({
+            "account_id": load_account_id,
+            "provider": load_provider,
+            "state": state,
+            "url": url,
+        });
+        log::debug!(
+            "[webview-accounts] page_load account={} state={} url={}",
+            load_account_id,
+            state,
+            payload.url()
+        );
+        if let Err(e) = load_app.emit("webview-account:load", &event) {
+            log::warn!(
+                "[webview-accounts] emit webview-account:load failed: {}",
+                e
+            );
         }
     });
 

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -787,43 +787,6 @@ pub async fn webview_account_open<R: Runtime>(
         }
     });
 
-    // Emit a main-frame load-state event to the React side so it can
-    // hide the loading overlay once the provider's UI is ready. Only
-    // fires for top-level navigations; sub-frame loads are ignored.
-    let load_app = app.clone();
-    let load_account_id = args.account_id.clone();
-    let load_provider = args.provider.clone();
-    builder = builder.on_page_load(move |webview, payload| {
-        // Ignore sub-frame events — the webview argument is always the
-        // top-level one from the builder, but `payload.url()` reflects
-        // whichever frame triggered. We filter by checking the URL is
-        // http(s) (sub-frames are commonly data:/about:blank/chrome://).
-        let url = payload.url().to_string();
-        let state = match payload.event() {
-            tauri::webview::PageLoadEvent::Started => "started",
-            tauri::webview::PageLoadEvent::Finished => "finished",
-        };
-        let _ = webview;
-        let event = serde_json::json!({
-            "account_id": load_account_id,
-            "provider": load_provider,
-            "state": state,
-            "url": url,
-        });
-        log::debug!(
-            "[webview-accounts] page_load account={} state={} url={}",
-            load_account_id,
-            state,
-            payload.url()
-        );
-        if let Err(e) = load_app.emit("webview-account:load", &event) {
-            log::warn!(
-                "[webview-accounts] emit webview-account:load failed: {}",
-                e
-            );
-        }
-    });
-
     // Enable devtools on child webviews in debug builds only so recipe
     // diagnostics and IndexedDB state can be inspected. Access on macOS is via
     //   Safari → Develop → <App name> → <webview label>

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -225,10 +225,7 @@ fn unwrap_provider_redirect(url: &Url) -> Option<Url> {
 fn open_in_system_browser(url: &str) {
     #[cfg(target_os = "macos")]
     {
-        match std::process::Command::new("/usr/bin/open")
-            .arg(url)
-            .spawn()
-        {
+        match std::process::Command::new("/usr/bin/open").arg(url).spawn() {
             Ok(_) => log::info!("[webview-accounts] opened externally (macos open): {}", url),
             Err(e) => log::warn!(
                 "[webview-accounts] /usr/bin/open {} failed: {} — falling back to opener plugin",

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -14,8 +14,8 @@
       {
         "label": "main",
         "title": "OpenHuman",
-        "width": 800,
-        "height": 720,
+        "width": 1000,
+        "height": 800,
         "visible": true,
         "decorations": true,
         "resizable": true,

--- a/app/src/components/BottomTabBar.tsx
+++ b/app/src/components/BottomTabBar.tsx
@@ -183,7 +183,7 @@ const BottomTabBar = () => {
         onBlur={e => {
           if (!e.currentTarget.contains(e.relatedTarget as Node)) setRevealed(false);
         }}>
-        <nav className="pointer-events-auto inline-flex items-center gap-2 rounded-sm border border-stone-300 bg-stone-200 shadow-soft px-1 py-1">
+        <nav className="pointer-events-auto inline-flex items-center gap-1 rounded-sm border border-stone-300 bg-stone-200 shadow-soft px-1 py-1">
           {tabs.map(tab => {
             const active = isActive(tab.path);
             const showBadge = tab.id === 'notifications' && unreadCount > 0;
@@ -191,7 +191,7 @@ const BottomTabBar = () => {
               <button
                 key={tab.id}
                 onClick={() => navigate(tab.path)}
-                className={`relative flex items-center gap-2 px-4 py-2 rounded-sm text-sm transition-colors duration-150 cursor-pointer ${
+                className={`group relative flex items-center px-2 py-2 rounded-sm text-sm transition-colors duration-200 ease-out cursor-pointer ${
                   active
                     ? 'bg-white text-stone-900 font-semibold shadow-sm'
                     : 'bg-transparent text-stone-500 hover:bg-stone-300/50 hover:text-stone-700'
@@ -201,7 +201,7 @@ const BottomTabBar = () => {
                     ? `${tab.label} (${unreadCount} unread)`
                     : tab.label
                 }>
-                <span className="relative inline-flex">
+                <span className="relative inline-flex flex-shrink-0">
                   {tab.icon}
                   {showBadge && (
                     <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-1 rounded-full bg-coral-500 text-[9px] font-bold text-white flex items-center justify-center leading-none">
@@ -209,7 +209,14 @@ const BottomTabBar = () => {
                     </span>
                   )}
                 </span>
-                <span>{tab.label}</span>
+                <span
+                  className={`overflow-hidden whitespace-nowrap transition-[max-width,margin-left,opacity] duration-300 ease-out ${
+                    active
+                      ? 'max-w-[160px] ml-2 opacity-100'
+                      : 'max-w-0 ml-0 opacity-0 group-hover:max-w-[160px] group-hover:ml-2 group-hover:opacity-100 group-focus-visible:max-w-[160px] group-focus-visible:ml-2 group-focus-visible:opacity-100'
+                  }`}>
+                  {tab.label}
+                </span>
               </button>
             );
           })}

--- a/app/src/components/BottomTabBar.tsx
+++ b/app/src/components/BottomTabBar.tsx
@@ -7,22 +7,21 @@ import { selectUnreadCount } from '../store/notificationSlice';
 import { isAccountsFullscreen } from '../utils/accountsFullscreen';
 
 const tabs = [
-  // Hidden — not active yet. Uncomment to re-enable.
-  // {
-  //   id: 'home',
-  //   label: 'Home',
-  //   path: '/home',
-  //   icon: (
-  //     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-  //       <path
-  //         strokeLinecap="round"
-  //         strokeLinejoin="round"
-  //         strokeWidth={1.8}
-  //         d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a2 2 0 01-2-2v-4a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z"
-  //       />
-  //     </svg>
-  //   ),
-  // },
+  {
+    id: 'home',
+    label: 'Home',
+    path: '/home',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.8}
+          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a2 2 0 01-2-2v-4a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z"
+        />
+      </svg>
+    ),
+  },
   {
     id: 'chat',
     label: 'Chat',
@@ -53,22 +52,21 @@ const tabs = [
       </svg>
     ),
   },
-  // Hidden — not active yet. Uncomment to re-enable.
-  // {
-  //   id: 'intelligence',
-  //   label: 'Intelligence',
-  //   path: '/intelligence',
-  //   icon: (
-  //     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-  //       <path
-  //         strokeLinecap="round"
-  //         strokeLinejoin="round"
-  //         strokeWidth={1.8}
-  //         d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-  //       />
-  //     </svg>
-  //   ),
-  // },
+  {
+    id: 'intelligence',
+    label: 'Memory',
+    path: '/intelligence',
+    icon: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.8}
+          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+        />
+      </svg>
+    ),
+  },
   {
     id: 'notifications',
     label: 'Alerts',
@@ -191,7 +189,7 @@ const BottomTabBar = () => {
               <button
                 key={tab.id}
                 onClick={() => navigate(tab.path)}
-                className={`group relative flex items-center px-2 py-2 rounded-sm text-sm transition-colors duration-200 ease-out cursor-pointer ${
+                className={`group relative flex items-center px-2 py-2 rounded-sm text-sm transition-colors duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] cursor-pointer ${
                   active
                     ? 'bg-white text-stone-900 font-semibold shadow-sm'
                     : 'bg-transparent text-stone-500 hover:bg-stone-300/50 hover:text-stone-700'
@@ -210,7 +208,7 @@ const BottomTabBar = () => {
                   )}
                 </span>
                 <span
-                  className={`overflow-hidden whitespace-nowrap transition-[max-width,margin-left,opacity] duration-300 ease-out ${
+                  className={`overflow-hidden whitespace-nowrap transition-[max-width,margin-left,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] ${
                     active
                       ? 'max-w-[160px] ml-2 opacity-100'
                       : 'max-w-0 ml-0 opacity-0 group-hover:max-w-[160px] group-hover:ml-2 group-hover:opacity-100 group-focus-visible:max-w-[160px] group-focus-visible:ml-2 group-focus-visible:opacity-100'

--- a/app/src/components/BottomTabBar.tsx
+++ b/app/src/components/BottomTabBar.tsx
@@ -7,21 +7,22 @@ import { selectUnreadCount } from '../store/notificationSlice';
 import { isAccountsFullscreen } from '../utils/accountsFullscreen';
 
 const tabs = [
-  {
-    id: 'home',
-    label: 'Home',
-    path: '/home',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.8}
-          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a2 2 0 01-2-2v-4a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z"
-        />
-      </svg>
-    ),
-  },
+  // Hidden — not active yet. Uncomment to re-enable.
+  // {
+  //   id: 'home',
+  //   label: 'Home',
+  //   path: '/home',
+  //   icon: (
+  //     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //         strokeWidth={1.8}
+  //         d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a2 2 0 01-2-2v-4a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z"
+  //       />
+  //     </svg>
+  //   ),
+  // },
   {
     id: 'chat',
     label: 'Chat',
@@ -52,21 +53,22 @@ const tabs = [
       </svg>
     ),
   },
-  {
-    id: 'intelligence',
-    label: 'Intelligence',
-    path: '/intelligence',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.8}
-          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-        />
-      </svg>
-    ),
-  },
+  // Hidden — not active yet. Uncomment to re-enable.
+  // {
+  //   id: 'intelligence',
+  //   label: 'Intelligence',
+  //   path: '/intelligence',
+  //   icon: (
+  //     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //         strokeWidth={1.8}
+  //         d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+  //       />
+  //     </svg>
+  //   ),
+  // },
   {
     id: 'notifications',
     label: 'Alerts',

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -122,15 +122,22 @@ function composioStatusColor(connection: ComposioConnection | undefined): string
 
 // ─── Built-in skill definitions ────────────────────────────────────────────────
 
-const BUILT_IN_SKILLS = [
-  {
-    id: 'screen-intelligence',
-    title: 'Screen Intelligence',
-    description:
-      'Capture windows, summarize what is on screen, and feed useful context into memory.',
-    route: '/settings/screen-intelligence',
-    icon: BUILT_IN_SKILL_ICONS.screenIntelligence,
-  },
+const BUILT_IN_SKILLS: Array<{
+  id: string;
+  title: string;
+  description: string;
+  route: string;
+  icon: React.ReactNode;
+}> = [
+  // Hidden — not active yet. Uncomment to re-enable.
+  // {
+  //   id: 'screen-intelligence',
+  //   title: 'Screen Intelligence',
+  //   description:
+  //     'Capture windows, summarize what is on screen, and feed useful context into memory.',
+  //   route: '/settings/screen-intelligence',
+  //   icon: BUILT_IN_SKILL_ICONS.screenIntelligence,
+  // },
   // text-autocomplete + voice-stt hidden per #717 (modals/status hooks retained for re-enable).
 ];
 


### PR DESCRIPTION
## Summary

- **Bottom tab bar**: compact icon-only by default; labels animate in on hover/focus/active. Hides tabs for unreleased features (Home, Memory/Intelligence, Screen Intelligence built-in skill). Home + Memory (relabeled from Intelligence) restored after the trim.
- **CEF child webview hardening**: opts out of `tauri-plugin-opener`'s default JS injection (`init-iife.js`), adds a CLAUDE.md rule forbidding new JS injection into \`acct_*\` webviews, and unwraps LinkedIn's \`/safety/go/?url=...\` redirect in Rust so the system browser lands on the real destination (was breaking because the safety page requires LinkedIn session which lives only inside the embedded webview).
- **macOS opener fix**: \`open_in_system_browser\` now shells out to \`/usr/bin/open\` directly instead of \`tauri_plugin_opener::open_url\`, which returned Ok but no browser actually launched under CEF.
- **Window default**: 1000×800 instead of 800×720.

## Known follow-up
- Loading-overlay work for first-time account opens is deferred to #867 — on_page_load doesn't fire for our CDP-driven navigation and CEF's set_visible races with async browser creation. Captured that context in the issue.

## Test plan

- [ ] \`yarn typecheck\` passes (verified locally).
- [ ] \`cargo check --manifest-path app/src-tauri/Cargo.toml\` passes.
- [ ] Bottom tab bar shows icon-only at rest; labels slide in on hover and stay on active with the 500ms ease-out-quint.
- [ ] Skills page no longer lists Screen Intelligence.
- [ ] Click external link (e.g. \`https://example.com\`) from LinkedIn message → opens in default browser at the real URL, not the \`linkedin.com/safety/go\` wrapper.
- [ ] Click external link from Slack / Gmail / Discord → opens in default browser.
- [ ] No \`plugin:opener|open_url\` IPC calls from \`acct_*\` webviews (verify in DevTools Network tab; previously they 500'd with "Origin header is not a valid URL").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab labels now animate and reveal on hover/focus for a refined UI experience.

* **UI/UX Improvements**
  * Renamed "Intelligence" tab to "Memory."
  * Increased default window size for better visibility.
  * Optimized tab bar spacing and layout.

* **Bug Fixes**
  * Fixed LinkedIn redirect link handling to resolve actual destinations.
  * Improved macOS system browser navigation.

* **Documentation**
  * Updated README with GitHub star section and social follow links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->