### PR TITLE
chore(updater): rotate signing pubkey to working key 7494D291DAB5B3E1

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -75,7 +75,7 @@
   "plugins": {
     "updater": {
       "active": false,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdDNDNENzk3QzVCN0MwNDcKUldSSHdMZkZsOWREZkpicit5c2ZWTDJtcDVhT25WMXkzbUJqcW5ucVBDdU1kN29GbUwwRDFkTkoK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc0OTREMjkxREFCNUIzRTEKUldUaHM3WGFrZEtVZEJzZWtMTlc5dGxnT0R2Q3hUTWVaclJWSm9JUFpPcVFUV2RBSG5oNFN6UjQK",
       "endpoints": [
         "https://github.com/tinyhumansai/openhuman/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary

Rotate the Tauri shell updater pubkey from `7C43D797C5B7C047` to `7494D291DAB5B3E1`.

The previous private key's passphrase appears to be lost — neither I nor the repo owner could unlock it locally with any of the candidates we tried. The new pubkey matches a private key we *can* unlock, which means signed `latest.json` / `.sig` artifacts can actually be produced (locally and in CI) going forward.

## Why now

The updater plugin is wired up in #909, which (modulo signing) is otherwise ready to land. Without a working private key the build it produces is signing-blocked — CI release jobs would either skip the manifest publish or generate signatures the embedded pubkey rejects. Switching to the key we control unblocks the whole pipeline.

## Functional impact

**On `main` today**: zero. `plugins.updater.active` is still `false` — the runtime never even consults the pubkey. This commit is a no-op until the wiring PR (#909) flips `active: true`.

**Once #909 lands**: the first build with the active updater will only verify `.sig` files signed by the matching `7494…` private key.

## Backwards-compatibility

Any release artifact previously signed with the `7C43…` key (e.g. some of the existing `.sig` files attached to `v0.52.26`) will no longer validate against builds carrying this pubkey. Per the wiring PR's notes, **no installs out in the wild today have the updater plugin compiled in**, so nothing existing would have validated against either pubkey regardless. Net compatibility cost: zero.

## Action item for the repo owner (not blocking merge)

Before the first release after #909 + this PR land, please confirm:

- GitHub Actions secret `TAURI_SIGNING_PRIVATE_KEY` (or the legacy fallback `UPDATER_PRIVATE_KEY`) contains the contents of the **matching** minisign secret key.
- GitHub Actions secret `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (or `UPDATER_PRIVATE_KEY_PASSWORD`) is set to its passphrase.

If the secrets still hold the old `7C43…` key, the next release with `createUpdaterArtifacts: true` will produce signatures the embedded pubkey rejects and `update.download_and_install()` will fail at the verification step.

## Test plan

- [x] `cargo check --manifest-path app/src-tauri/Cargo.toml --no-default-features --features cef` — clean (config-only change).
- [x] Verified locally that the new pubkey corresponds to a private key we can sign with: `cargo tauri signer sign /tmp/test.txt` succeeds with the matching passphrase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the public key used by the application's updater.
  * No other updater settings or endpoints were changed; end-user update behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->