### PR TITLE
chore(release): remove updater pubkey/endpoint override + gate signed artifacts

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -113,10 +113,11 @@ jobs:
             "${{ steps.core-paths.outputs.sidecar_base }}"
       - name: Define Tauri configuration overrides
         id: config-overrides
+        # `prepareTauriConfig.js` only emits the Windows DigiCert sign
+        # command at this point (`WITH_UPDATER` defaults to off here so
+        # this PR-build matrix doesn't try to mint signed updater
+        # artifacts it has no key for).
         uses: actions/github-script@v7
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          WITH_UPDATER: 'false'
         with:
           script: |
             const workspacePath = process.env.GITHUB_WORKSPACE.replace(/\\/g, '/');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,6 @@ jobs:
         shell: bash
         env:
           MATRIX_PLATFORM: ${{ matrix.settings.platform }}
-          UPDATER_PUBLIC_KEY: ${{ secrets.UPDATER_PUBLIC_KEY || vars.UPDATER_PUBLIC_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || secrets.UPDATER_PRIVATE_KEY }}
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -388,10 +387,9 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if [ -z "$UPDATER_PUBLIC_KEY" ]; then
-            echo "Missing UPDATER_PUBLIC_KEY (set as secret or repo/environment variable)."
-            exit 1
-          fi
+          # The minisign pubkey is now baked into the static
+          # `app/src-tauri/tauri.conf.json`, not injected from secrets.
+          # Only the private key still has to come from secrets.
           if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
             echo "Missing TAURI_SIGNING_PRIVATE_KEY (or fallback UPDATER_PRIVATE_KEY)."
             exit 1
@@ -406,12 +404,12 @@ jobs:
           fi
       - name: Define Tauri configuration overrides
         id: config-overrides
+        # `prepareTauriConfig.js` only reads `WITH_UPDATER` (flips
+        # `bundle.createUpdaterArtifacts` on for the release pipeline) and
+        # `KEYPAIR_ALIAS` (Windows DigiCert sign command). Pubkey + endpoint
+        # come from the static `app/src-tauri/tauri.conf.json`.
         uses: actions/github-script@v7
         env:
-          BASE_URL: ${{ needs.prepare-build.outputs.base_url }}
-          UPDATER_PUBLIC_KEY: ${{ secrets.UPDATER_PUBLIC_KEY || vars.UPDATER_PUBLIC_KEY }}
-          UPDATER_ENDPOINT: ${{ vars.UPDATER_ENDPOINT }}
-          UPDATER_REPO: tinyhumansai/openhuman
           WITH_UPDATER: "true"
         with:
           script: |
@@ -524,7 +522,6 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.settings.platform == 'macos-latest' && '10.15' || '' }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || secrets.UPDATER_PRIVATE_KEY_PASSWORD }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY || secrets.UPDATER_PRIVATE_KEY }}
-          WITH_UPDATER: "true"
           VITE_MINIMUM_SUPPORTED_APP_VERSION: ${{ vars.VITE_MINIMUM_SUPPORTED_APP_VERSION }}
           VITE_LATEST_APP_DOWNLOAD_URL: ${{ vars.VITE_LATEST_APP_DOWNLOAD_URL }}
           TAURI_CONFIG_OVERRIDE: ${{ steps.config-overrides.outputs.json }}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -62,7 +62,7 @@
         ]
       }
     },
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "macOS": {
       "minimumSystemVersion": "10.15",
       "entitlements": "entitlements.sidecar.plist",

--- a/scripts/ci-secrets.example.json
+++ b/scripts/ci-secrets.example.json
@@ -7,7 +7,6 @@
     "APPLE_SIGNING_IDENTITY": "",
     "APPLE_TEAM_ID": "",
     "GITHUB_TOKEN": "",
-    "UPDATER_PUBLIC_KEY": "",
     "TAURI_SIGNING_PRIVATE_KEY_PASSWORD": "",
     "TAURI_SIGNING_PRIVATE_KEY": "",
     "XGH_TOKEN": "",
@@ -16,7 +15,6 @@
   },
   "vars": {
     "BASE_URL": "https://localhost",
-    "UPDATER_ENDPOINT": "",
     "VITE_BACKEND_URL": "https://localhost:5005",
     "VITE_SKILLS_GITHUB_REPO": "",
     "OPENHUMAN_SENTRY_DSN": "",

--- a/scripts/prepareTauriConfig.js
+++ b/scripts/prepareTauriConfig.js
@@ -1,44 +1,42 @@
+// Tauri config overrides applied at CI build time on top of the static
+// `app/src-tauri/tauri.conf.json`. Anything returned here is merged via
+// `tauri build --config <json>` and wins over the static file.
+//
+// History note: this file used to inject `plugins.updater.pubkey` and
+// `plugins.updater.endpoints` from `UPDATER_PUBLIC_KEY` / `UPDATER_ENDPOINT`
+// env vars sourced from GitHub secrets. That indirection caused a real
+// outage class — if the build-time pubkey ever drifted out of sync with the
+// `TAURI_SIGNING_PRIVATE_KEY` secret used to sign artifacts, every signed
+// installer was rejected by its own embedded pubkey at install time
+// ("bad keys"). The static `app/src-tauri/tauri.conf.json` is now the
+// single source of truth for the updater pubkey + endpoint; rotate via
+// commit + review instead of silent secret swaps.
+//
+// What's left at build time:
+//   - `WITH_UPDATER=true` → flip `bundle.createUpdaterArtifacts` on so
+//     the bundler emits signed `.app.tar.gz` / `.sig` artifacts. Only the
+//     release pipeline sets this; PR builds (`build.yml`,
+//     `build-windows.yml`, `test.yml`) leave it unset and skip artifact
+//     signing entirely (those jobs don't have `TAURI_SIGNING_PRIVATE_KEY`
+//     access by design).
+//   - `KEYPAIR_ALIAS` → Windows DigiCert SmartCard sign command. Has to
+//     stay build-time because the alias is a runner secret.
 export default function prepareTauriConfig() {
-  // Production frontend always ships from dist; BASE_URL is for updater URLs.
-  const frontendDist = '../dist';
-
-  const config = {
-    build: { frontendDist, devUrl: null },
-    bundle: { windows: {} },
-    identifier: 'com.openhuman.app',
-  };
+  const config = {};
+  const bundle = {};
 
   if (process.env.WITH_UPDATER === 'true') {
-    const repoSlug = process.env.UPDATER_REPO || 'tinyhumansai/openhuman';
-    const baseUrl =
-      process.env.BASE_URL ||
-      `https://github.com/${repoSlug}/releases/latest/download`;
-    const normalizedBaseUrl = String(baseUrl).replace(/\/+$/, '');
-    const updaterEndpoint =
-      process.env.UPDATER_ENDPOINT ||
-      process.env.UPDATER_GIST_URL ||
-      `${normalizedBaseUrl}/latest.json`;
-    const updaterPublicKey = process.env.UPDATER_PUBLIC_KEY;
-
-    if (!updaterPublicKey) {
-      throw new Error(
-        'WITH_UPDATER=true requires UPDATER_PUBLIC_KEY to be set',
-      );
-    }
-
-    config.plugins = {
-      updater: {
-        dialog: false,
-        endpoints: [updaterEndpoint],
-        pubkey: updaterPublicKey,
-      },
-    };
-
-    config.bundle.createUpdaterArtifacts = true;
+    bundle.createUpdaterArtifacts = true;
   }
 
   if (process.env.KEYPAIR_ALIAS) {
-    config.bundle.windows.signCommand = `smctl.exe sign --keypair-alias=${process.env.KEYPAIR_ALIAS} --input %1`;
+    bundle.windows = {
+      signCommand: `smctl.exe sign --keypair-alias=${process.env.KEYPAIR_ALIAS} --input %1`,
+    };
+  }
+
+  if (Object.keys(bundle).length > 0) {
+    config.bundle = bundle;
   }
 
   return config;


### PR DESCRIPTION
## Summary

Two related fixes to the release pipeline that together eliminate a real outage class ("bad keys" install failures) and stop PR/test builds from failing when they don't have signing secrets.

### 1. Drop the updater pubkey/endpoint override (the "bad keys" bug)

`scripts/prepareTauriConfig.js` was injecting `plugins.updater.pubkey` and `plugins.updater.endpoints` at build time from the `UPDATER_PUBLIC_KEY` / `UPDATER_ENDPOINT` / `UPDATER_REPO` env vars sourced from GitHub secrets/vars, on top of the static `app/src-tauri/tauri.conf.json`.

If the build-time `UPDATER_PUBLIC_KEY` ever drifted out of sync with `TAURI_SIGNING_PRIVATE_KEY` (e.g. one secret rotated, the other not) every signed installer was rejected by its own embedded pubkey at install time — surfacing as opaque "bad keys" errors.

The static `tauri.conf.json` already carries the canonical pubkey (`7494D291DAB5B3E1` after #910) and endpoint (`https://github.com/tinyhumansai/openhuman/releases/latest/download/latest.json`), so removing the override leaves the build pointed at the same place — just without the silent-drift risk. Key rotations now go through commit + review, which is also better auditability.

### 2. Gate signed artifact creation behind `WITH_UPDATER`

Static `bundle.createUpdaterArtifacts: false` is now the safe default. PR build matrices (`build.yml`, `build-windows.yml`) and `test.yml` don't have access to `TAURI_SIGNING_PRIVATE_KEY`, so without this gate the bundler would either fail or silently emit unsigned `.app.tar.gz` / `.sig` files. Only `release.yml` sets `WITH_UPDATER=true`, which `prepareTauriConfig.js` then translates into `bundle.createUpdaterArtifacts: true` for that one pipeline.

## Changes

- **`scripts/prepareTauriConfig.js`** — removes the `UPDATER_PUBLIC_KEY` / `UPDATER_ENDPOINT` / `UPDATER_REPO` block. Function now only flips `createUpdaterArtifacts` when `WITH_UPDATER=true` and emits the Windows DigiCert `signCommand` when `KEYPAIR_ALIAS` is set.
- **`app/src-tauri/tauri.conf.json`** — `bundle.createUpdaterArtifacts: true` → `false` (safe default).
- **`.github/workflows/release.yml`** — drops `UPDATER_PUBLIC_KEY` validation; drops the `UPDATER_PUBLIC_KEY` / `UPDATER_ENDPOINT` / `UPDATER_REPO` env vars from the config-overrides step; drops the redundant `WITH_UPDATER` env from the tauri-build step (only `prepareTauriConfig.js` reads it, and that runs in the config-overrides step).
- **`.github/workflows/build-windows.yml`** — drops the now-unused explicit `WITH_UPDATER='false'`.
- **`scripts/ci-secrets.example.json`** — drops `UPDATER_PUBLIC_KEY` (secret) and `UPDATER_ENDPOINT` (var) to match the pruned env-var surface.

## Action item for the repo owner before the next release

Confirm the GH Actions secret `TAURI_SIGNING_PRIVATE_KEY` (or legacy fallback `UPDATER_PRIVATE_KEY`) holds the private key matching the static pubkey `7494D291DAB5B3E1` (set by #910). If it still holds the old key, signing will succeed in CI but `update.download_and_install()` will fail signature verification on the user's machine.

You can safely delete these GH Actions secrets/vars too — nothing reads them anymore:

- `secrets.UPDATER_PUBLIC_KEY` / `vars.UPDATER_PUBLIC_KEY`
- `vars.UPDATER_ENDPOINT`

## Test plan

- [x] `node -e "import('./scripts/prepareTauriConfig.js').then(m => console.log(JSON.stringify(m.default(), null, 2)))"` with no env → `{}`.
- [x] Same with `WITH_UPDATER=true` → `{ bundle: { createUpdaterArtifacts: true } }`.
- [x] Same with `KEYPAIR_ALIAS=foo` → `{ bundle: { windows: { signCommand: '… --keypair-alias=foo …' } } }`.
- [x] No remaining references to `UPDATER_PUBLIC_KEY` / `UPDATER_ENDPOINT` / `UPDATER_REPO` / `UPDATER_GIST_URL` outside of comments / changelogs.

## Relationship to other open updater PRs

- **#909** (Tauri shell auto-updater plugin wiring + in-app prompt UI) — independent. Will need a small rebase if both land: #909 currently sets `createUpdaterArtifacts: true` in tauri.conf.json, which conflicts with this PR's flip to `false`. Resolution = take this PR's `false` (and let `WITH_UPDATER=true` from release.yml flip it on for releases as designed).
- **#910** (rotate pubkey to `7494D291DAB5B3E1`) — already merged on main; this PR builds on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured build configuration script to focus exclusively on bundler overrides for improved separation of concerns.

* **Chores**
  * Updated CI/CD workflows and reduced environment variable dependencies for improved maintainability.
  * Disabled automatic updater artifact creation in default builds.
  * Simplified example CI secrets configuration by removing deprecated updater-related entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->