### PR TITLE
feat(conversations): remove suggested-question prompt bubbles

### DIFF
--- a/app/schema.json
+++ b/app/schema.json
@@ -1457,34 +1457,6 @@
       ]
     },
     {
-      "description": "Suggest questions for provided context.",
-      "function": "suggest_questions",
-      "inputs": [
-        {
-          "comment": "Context text.",
-          "name": "context",
-          "required": false,
-          "ty": { "Option": "String" }
-        },
-        {
-          "comment": "Alternative context as lines.",
-          "name": "lines",
-          "required": false,
-          "ty": { "Option": { "Array": "String" } }
-        }
-      ],
-      "method": "openhuman.local_ai_suggest_questions",
-      "namespace": "local_ai",
-      "outputs": [
-        {
-          "comment": "Suggested questions payload.",
-          "name": "suggestions",
-          "required": true,
-          "ty": "Json"
-        }
-      ]
-    },
-    {
       "description": "Summarize text with local AI model.",
       "function": "summarize",
       "inputs": [

--- a/app/src/components/settings/panels/LocalModelDebugPanel.tsx
+++ b/app/src/components/settings/panels/LocalModelDebugPanel.tsx
@@ -13,7 +13,6 @@ import {
   type LocalAiEmbeddingResult,
   type LocalAiSpeechResult,
   type LocalAiStatus,
-  type LocalAiSuggestion,
   type LocalAiTtsResult,
   openhumanLocalAiAssetsStatus,
   openhumanLocalAiDiagnostics,
@@ -25,7 +24,6 @@ import {
   openhumanLocalAiPrompt,
   openhumanLocalAiSetOllamaPath,
   openhumanLocalAiStatus,
-  openhumanLocalAiSuggestQuestions,
   openhumanLocalAiSummarize,
   openhumanLocalAiTranscribe,
   openhumanLocalAiTts,
@@ -67,10 +65,6 @@ const LocalModelDebugPanel = () => {
   const [summaryInput, setSummaryInput] = useState('');
   const [summaryOutput, setSummaryOutput] = useState('');
   const [isSummaryLoading, setIsSummaryLoading] = useState(false);
-
-  const [suggestInput, setSuggestInput] = useState('');
-  const [suggestions, setSuggestions] = useState<LocalAiSuggestion[]>([]);
-  const [isSuggestLoading, setIsSuggestLoading] = useState(false);
 
   const [promptInput, setPromptInput] = useState('');
   const [promptOutput, setPromptOutput] = useState('');
@@ -191,22 +185,6 @@ const LocalModelDebugPanel = () => {
       setStatusError(err instanceof Error ? err.message : 'Summarization test failed');
     } finally {
       setIsSummaryLoading(false);
-    }
-  };
-
-  const runSuggestTest = async () => {
-    if (!suggestInput.trim()) return;
-    setIsSuggestLoading(true);
-    setSuggestions([]);
-    setStatusError('');
-    try {
-      const result = await openhumanLocalAiSuggestQuestions(suggestInput.trim());
-      setSuggestions(result.result);
-      await loadStatus();
-    } catch (err) {
-      setStatusError(err instanceof Error ? err.message : 'Suggestion test failed');
-    } finally {
-      setIsSuggestLoading(false);
     }
   };
 
@@ -405,11 +383,6 @@ const LocalModelDebugPanel = () => {
           isSummaryLoading={isSummaryLoading}
           onSetSummaryInput={setSummaryInput}
           onRunSummaryTest={() => void runSummaryTest()}
-          suggestInput={suggestInput}
-          suggestions={suggestions}
-          isSuggestLoading={isSuggestLoading}
-          onSetSuggestInput={setSuggestInput}
-          onRunSuggestTest={() => void runSuggestTest()}
           promptInput={promptInput}
           promptOutput={promptOutput}
           promptError={promptError}

--- a/app/src/components/settings/panels/local-model/ModelDownloadSection.tsx
+++ b/app/src/components/settings/panels/local-model/ModelDownloadSection.tsx
@@ -3,7 +3,6 @@ import type {
   LocalAiAssetsStatus,
   LocalAiEmbeddingResult,
   LocalAiSpeechResult,
-  LocalAiSuggestion,
   LocalAiTtsResult,
 } from '../../../../utils/tauriCommands';
 
@@ -18,12 +17,6 @@ interface ModelDownloadSectionProps {
   isSummaryLoading: boolean;
   onSetSummaryInput: (value: string) => void;
   onRunSummaryTest: () => void;
-
-  suggestInput: string;
-  suggestions: LocalAiSuggestion[];
-  isSuggestLoading: boolean;
-  onSetSuggestInput: (value: string) => void;
-  onRunSuggestTest: () => void;
 
   promptInput: string;
   promptOutput: string;
@@ -73,11 +66,6 @@ const ModelDownloadSection = ({
   isSummaryLoading,
   onSetSummaryInput,
   onRunSummaryTest,
-  suggestInput,
-  suggestions,
-  isSuggestLoading,
-  onSetSuggestInput,
-  onRunSuggestTest,
   promptInput,
   promptOutput,
   promptError,
@@ -172,43 +160,6 @@ const ModelDownloadSection = ({
             <pre className="whitespace-pre-wrap rounded-md bg-stone-50 border border-stone-200 p-3 text-xs text-stone-700">
               {summaryOutput}
             </pre>
-          )}
-        </div>
-      </section>
-
-      <section className="space-y-3">
-        <h3 className="text-sm font-semibold text-stone-900">Test Suggested Prompts</h3>
-        <div className="bg-stone-50 rounded-lg border border-stone-200 p-4 space-y-3">
-          <textarea
-            value={suggestInput}
-            onChange={e => onSetSuggestInput(e.target.value)}
-            placeholder="Paste conversation context to generate suggestions..."
-            className="w-full min-h-28 rounded-md bg-white border border-stone-200 px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:outline-none focus:ring-1 focus:ring-primary-500"
-          />
-          <div className="flex items-center justify-between">
-            <div className="text-xs text-stone-500">
-              Calls `openhuman.local_ai_suggest_questions` via Rust core
-            </div>
-            <button
-              onClick={onRunSuggestTest}
-              disabled={isSuggestLoading || !suggestInput.trim()}
-              className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 disabled:opacity-60 text-white">
-              {isSuggestLoading ? 'Running...' : 'Run Suggestion Test'}
-            </button>
-          </div>
-          {suggestions.length > 0 && (
-            <div className="space-y-2">
-              {suggestions.map(suggestion => (
-                <div
-                  key={`${suggestion.text}-${suggestion.confidence}`}
-                  className="rounded-md border border-stone-200 bg-stone-50 p-3">
-                  <div className="text-sm text-stone-800">{suggestion.text}</div>
-                  <div className="text-xs text-stone-400 mt-1">
-                    Confidence: {(suggestion.confidence * 100).toFixed(0)}%
-                  </div>
-                </div>
-              ))}
-            </div>
           )}
         </div>
       </section>

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -24,7 +24,6 @@ import {
   addMessageLocal,
   createNewThread,
   deleteThread,
-  fetchSuggestedQuestions,
   loadThreadMessages,
   loadThreads,
   persistReaction,
@@ -82,16 +81,8 @@ interface ConversationsProps {
 const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const {
-    threads,
-    selectedThreadId,
-    messages,
-    isLoadingMessages,
-    messagesError,
-    suggestedQuestions,
-    isLoadingSuggestions,
-    activeThreadId,
-  } = useAppSelector(state => state.thread);
+  const { threads, selectedThreadId, messages, isLoadingMessages, messagesError, activeThreadId } =
+    useAppSelector(state => state.thread);
 
   const { snapshot } = useCoreState();
   const welcomeLocked = isWelcomeLocked(snapshot);
@@ -232,12 +223,6 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
     // uses `dispatch`); the ref guards against duplicate fires.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatOnboardingCompleted]);
-
-  useEffect(() => {
-    if (selectedThreadId && messages.length === 0) {
-      dispatch(fetchSuggestedQuestions(selectedThreadId));
-    }
-  }, [selectedThreadId, messages.length, dispatch]);
 
   const location = useLocation();
   const { containerRef: messagesContainerRef, endRef: messagesEndRef } = useStickToBottom(
@@ -1217,25 +1202,6 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
             </div>
           )}
         </div>
-
-        {!hasVisibleMessages && suggestedQuestions.length > 0 && !isLoadingSuggestions && (
-          <div className="flex-shrink-0 px-4 py-3">
-            <div className="flex gap-2 overflow-x-auto scrollbar-hide">
-              {suggestedQuestions.map((s, i) => (
-                <button
-                  key={i}
-                  type="button"
-                  onClick={() => {
-                    void handleSendMessage(s.text);
-                  }}
-                  disabled={isSending || !rustChat}
-                  className="flex-shrink-0 px-3 py-1.5 rounded-lg text-[12px] whitespace-nowrap bg-white text-stone-500 border border-stone-200 hover:bg-stone-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-                  {s.text}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
 
         <div className="flex-shrink-0 border-t border-stone-200 px-4 py-3">
           {!welcomeLocked && (

--- a/app/src/store/__tests__/threadSlice.test.ts
+++ b/app/src/store/__tests__/threadSlice.test.ts
@@ -72,7 +72,6 @@ describe('threadSlice synchronous reducers', () => {
     expect(state.messages).toEqual([]);
     expect(state.isLoadingThreads).toBe(false);
     expect(state.isLoadingMessages).toBe(false);
-    expect(state.suggestedQuestions).toEqual([]);
   });
 
   it('setSelectedThread copies cached messages into the visible list', async () => {
@@ -90,7 +89,6 @@ describe('threadSlice synchronous reducers', () => {
     expect(state.selectedThreadId).toBe('t-1');
     expect(state.messages).toEqual(cached);
     expect(state.messagesError).toBeNull();
-    expect(state.suggestedQuestions).toEqual([]);
   });
 
   it('setSelectedThread resets messages when cache is empty', () => {

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -3,7 +3,6 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { threadApi } from '../services/api/threadApi';
 import type { Thread, ThreadMessage } from '../types/thread';
 import { IS_DEV } from '../utils/config';
-import { isTauri, openhumanLocalAiSuggestQuestions } from '../utils/tauriCommands';
 
 interface ThreadState {
   threads: Thread[];
@@ -14,8 +13,6 @@ interface ThreadState {
   isLoadingThreads: boolean;
   isLoadingMessages: boolean;
   messagesError: string | null;
-  suggestedQuestions: Array<{ text: string; confidence: number }>;
-  isLoadingSuggestions: boolean;
 }
 
 const initialState: ThreadState = {
@@ -27,8 +24,6 @@ const initialState: ThreadState = {
   isLoadingThreads: false,
   isLoadingMessages: false,
   messagesError: null,
-  suggestedQuestions: [],
-  isLoadingSuggestions: false,
 };
 
 function appendMessageToCache(
@@ -229,30 +224,6 @@ export const purgeThreads = createAsyncThunk(
   }
 );
 
-export const fetchSuggestedQuestions = createAsyncThunk(
-  'thread/fetchSuggestedQuestions',
-  async (conversationId: string | undefined, { getState, rejectWithValue }) => {
-    try {
-      const state = getState() as { thread: ThreadState };
-      const tid = conversationId ?? state.thread.selectedThreadId ?? undefined;
-      const msgs = tid ? (state.thread.messagesByThreadId[tid] ?? []) : [];
-
-      if (isTauri()) {
-        const lines = msgs
-          .slice(-24)
-          .map(m => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.content}`);
-        const local = await openhumanLocalAiSuggestQuestions(undefined, lines);
-        return local.result;
-      }
-      return [];
-    } catch (error) {
-      return rejectWithValue(
-        error instanceof Error ? error.message : 'Failed to load suggested questions'
-      );
-    }
-  }
-);
-
 // ── Slice ─────────────────────────────────────────────────────────
 
 const threadSlice = createSlice({
@@ -263,13 +234,11 @@ const threadSlice = createSlice({
       state.selectedThreadId = action.payload;
       state.messages = state.messagesByThreadId[action.payload] ?? [];
       state.messagesError = null;
-      state.suggestedQuestions = [];
     },
     clearSelectedThread: state => {
       state.selectedThreadId = null;
       state.messages = [];
       state.messagesError = null;
-      state.suggestedQuestions = [];
     },
     setActiveThread: (state, action: { payload: string | null }) => {
       state.activeThreadId = action.payload;
@@ -336,17 +305,6 @@ const threadSlice = createSlice({
       })
       .addCase(deleteThread.fulfilled, (state, action) => {
         delete state.messagesByThreadId[action.payload.threadId];
-      })
-      .addCase(fetchSuggestedQuestions.pending, state => {
-        state.isLoadingSuggestions = true;
-      })
-      .addCase(fetchSuggestedQuestions.fulfilled, (state, action) => {
-        state.isLoadingSuggestions = false;
-        state.suggestedQuestions = action.payload;
-      })
-      .addCase(fetchSuggestedQuestions.rejected, state => {
-        state.isLoadingSuggestions = false;
-        state.suggestedQuestions = [];
       });
   },
 });

--- a/app/src/types/thread.ts
+++ b/app/src/types/thread.ts
@@ -41,11 +41,6 @@ export interface SendMessageResponseData {
   [key: string]: unknown;
 }
 
-/** Response from GET /chat/autocomplete — suggested starter questions for a new thread */
-export interface SuggestQuestionsData {
-  suggestions: Array<{ text: string; confidence: number }>;
-}
-
 export interface PurgeRequestBody {
   messages: boolean;
   agentThreads: boolean;

--- a/app/src/utils/tauriCommands/localAi.ts
+++ b/app/src/utils/tauriCommands/localAi.ts
@@ -35,11 +35,6 @@ export interface LocalAiStatus {
   gen_toks_per_sec?: number | null;
 }
 
-export interface LocalAiSuggestion {
-  text: string;
-  confidence: number;
-}
-
 export interface LocalAiAssetStatus {
   state: string;
   id: string;
@@ -280,16 +275,6 @@ export async function openhumanLocalAiSummarize(
   return await callCoreRpc<CommandResponse<string>>({
     method: 'openhuman.local_ai_summarize',
     params: { text, max_tokens: maxTokens },
-  });
-}
-
-export async function openhumanLocalAiSuggestQuestions(
-  context?: string,
-  lines?: string[]
-): Promise<CommandResponse<LocalAiSuggestion[]>> {
-  return await callCoreRpc<CommandResponse<LocalAiSuggestion[]>>({
-    method: 'openhuman.local_ai_suggest_questions',
-    params: { context, lines },
   });
 }
 

--- a/src/openhuman/config/schema/local_ai.rs
+++ b/src/openhuman/config/schema/local_ai.rs
@@ -41,8 +41,6 @@ pub struct LocalAiConfig {
     pub download_url: Option<String>,
     #[serde(default = "default_autosummary_debounce_ms")]
     pub autosummary_debounce_ms: u64,
-    #[serde(default = "default_max_suggestions")]
-    pub max_suggestions: usize,
     #[serde(default)]
     pub selected_tier: Option<String>,
     /// Explicit MVP opt-in marker. Bootstrap disables local AI unless this is
@@ -145,10 +143,6 @@ fn default_autosummary_debounce_ms() -> u64 {
     2500
 }
 
-fn default_max_suggestions() -> usize {
-    5
-}
-
 fn default_whisper_in_process() -> bool {
     true
 }
@@ -178,7 +172,6 @@ impl Default for LocalAiConfig {
             preload_tts_voice: default_preload_tts_voice(),
             download_url: default_download_url(),
             autosummary_debounce_ms: default_autosummary_debounce_ms(),
-            max_suggestions: default_max_suggestions(),
             selected_tier: None,
             opt_in_confirmed: false,
             ollama_binary_path: None,

--- a/src/openhuman/local_ai/mod.rs
+++ b/src/openhuman/local_ai/mod.rs
@@ -36,5 +36,5 @@ pub(crate) use service::whisper_engine;
 pub use service::LocalAiService;
 pub use types::{
     LocalAiAssetStatus, LocalAiAssetsStatus, LocalAiDownloadProgressItem, LocalAiDownloadsProgress,
-    LocalAiEmbeddingResult, LocalAiSpeechResult, LocalAiStatus, LocalAiTtsResult, Suggestion,
+    LocalAiEmbeddingResult, LocalAiSpeechResult, LocalAiStatus, LocalAiTtsResult,
 };

--- a/src/openhuman/local_ai/ops.rs
+++ b/src/openhuman/local_ai/ops.rs
@@ -10,7 +10,7 @@ use crate::openhuman::agent::Agent;
 use crate::openhuman::config::Config;
 use crate::openhuman::local_ai::{
     self, LocalAiAssetsStatus, LocalAiDownloadsProgress, LocalAiEmbeddingResult,
-    LocalAiSpeechResult, LocalAiTtsResult, Suggestion,
+    LocalAiSpeechResult, LocalAiTtsResult,
 };
 use crate::openhuman::providers::{self, ProviderRuntimeOptions};
 use crate::rpc::RpcOutcome;
@@ -180,33 +180,6 @@ pub async fn local_ai_summarize(
     Ok(RpcOutcome::single_log(
         summary,
         "local ai summarize completed",
-    ))
-}
-
-/// Suggests relevant follow-up questions based on the provided context.
-pub async fn local_ai_suggest_questions(
-    config: &Config,
-    context: Option<String>,
-    lines: Option<Vec<String>>,
-) -> Result<RpcOutcome<Vec<Suggestion>>, String> {
-    let service = local_ai::global(config);
-    let status = service.status();
-    if !matches!(status.state.as_str(), "ready") {
-        service.bootstrap(config).await;
-    }
-    let mut context = context.unwrap_or_default();
-    if context.trim().is_empty() {
-        if let Some(lines) = lines {
-            context = lines.join("\n");
-        }
-    }
-    let suggestions = service
-        .suggest_questions(config, &context)
-        .await
-        .map_err(|e| e.to_string())?;
-    Ok(RpcOutcome::single_log(
-        suggestions,
-        "local ai suggestions generated",
     ))
 }
 
@@ -709,18 +682,6 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("local ai is disabled"));
-    }
-
-    #[tokio::test]
-    async fn local_ai_suggest_questions_returns_empty_without_local_ai() {
-        // With local_ai disabled suggestions should silently produce an empty
-        // list rather than erroring (graceful degradation).
-        let tmp = tempfile::tempdir().unwrap();
-        let config = test_config(&tmp);
-        let outcome = local_ai_suggest_questions(&config, Some("topic".into()), None)
-            .await
-            .expect("suggestions should not error when disabled");
-        assert!(outcome.value.is_empty());
     }
 
     #[tokio::test]

--- a/src/openhuman/local_ai/parse.rs
+++ b/src/openhuman/local_ai/parse.rs
@@ -1,21 +1,4 @@
-//! Parse model output into suggestions and inline completions.
-
-use super::types::Suggestion;
-
-pub(crate) fn parse_suggestions(raw: &str, limit: usize) -> Vec<Suggestion> {
-    raw.lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(|line| line.trim_start_matches(|c: char| c.is_ascii_digit() || c == '.' || c == '-'))
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .take(limit)
-        .map(|text| Suggestion {
-            text: text.to_string(),
-            confidence: 0.65,
-        })
-        .collect()
-}
+//! Parse model output into inline completions.
 
 fn normalize_inline_text(value: &str) -> String {
     value
@@ -163,16 +146,6 @@ pub(crate) fn sanitize_inline_completion(raw: &str, context: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_suggestions_strips_numbering_and_respects_limit() {
-        let raw = "1. First idea\n- Second idea\n3) Third idea\n";
-        let out = parse_suggestions(raw, 2);
-        assert_eq!(out.len(), 2);
-        assert_eq!(out[0].text, "First idea");
-        assert_eq!(out[1].text, "Second idea");
-        assert!((out[0].confidence - 0.65).abs() < f32::EPSILON);
-    }
 
     #[test]
     fn sanitize_inline_completion_handles_placeholders_and_clamps_length() {

--- a/src/openhuman/local_ai/schemas.rs
+++ b/src/openhuman/local_ai/schemas.rs
@@ -33,14 +33,6 @@ struct LocalAiPromptParams {
 }
 
 #[derive(Debug, Deserialize)]
-struct LocalAiSuggestParams {
-    #[serde(default)]
-    context: Option<String>,
-    #[serde(default)]
-    lines: Option<Vec<String>>,
-}
-
-#[derive(Debug, Deserialize)]
 struct LocalAiVisionPromptParams {
     prompt: String,
     image_refs: Vec<String>,
@@ -127,7 +119,6 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("local_ai_download"),
         schemas("local_ai_download_all_assets"),
         schemas("local_ai_summarize"),
-        schemas("local_ai_suggest_questions"),
         schemas("local_ai_prompt"),
         schemas("local_ai_vision_prompt"),
         schemas("local_ai_embed"),
@@ -175,10 +166,6 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("local_ai_summarize"),
             handler: handle_local_ai_summarize,
-        },
-        RegisteredController {
-            schema: schemas("local_ai_suggest_questions"),
-            handler: handle_local_ai_suggest_questions,
         },
         RegisteredController {
             schema: schemas("local_ai_prompt"),
@@ -313,23 +300,6 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 optional_u64("max_tokens", "Optional max output tokens."),
             ],
             outputs: vec![json_output("summary", "Summary text.")],
-        },
-        "local_ai_suggest_questions" => ControllerSchema {
-            namespace: "local_ai",
-            function: "suggest_questions",
-            description: "Suggest questions for provided context.",
-            inputs: vec![
-                optional_string("context", "Context text."),
-                FieldSchema {
-                    name: "lines",
-                    ty: TypeSchema::Option(Box::new(TypeSchema::Array(Box::new(
-                        TypeSchema::String,
-                    )))),
-                    comment: "Alternative context as lines.",
-                    required: false,
-                },
-            ],
-            outputs: vec![json_output("suggestions", "Suggested questions payload.")],
         },
         "local_ai_prompt" => ControllerSchema {
             namespace: "local_ai",
@@ -608,19 +578,6 @@ fn handle_local_ai_summarize(params: Map<String, Value>) -> ControllerFuture {
         to_json(
             crate::openhuman::local_ai::rpc::local_ai_summarize(&config, &p.text, p.max_tokens)
                 .await?,
-        )
-    })
-}
-
-fn handle_local_ai_suggest_questions(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let p = deserialize_params::<LocalAiSuggestParams>(params)?;
-        let config = config_rpc::load_config_with_timeout().await?;
-        to_json(
-            crate::openhuman::local_ai::rpc::local_ai_suggest_questions(
-                &config, p.context, p.lines,
-            )
-            .await?,
         )
     })
 }
@@ -1063,7 +1020,6 @@ mod tests {
             "local_ai_download",
             "local_ai_download_all_assets",
             "local_ai_summarize",
-            "local_ai_suggest_questions",
             "local_ai_prompt",
             "local_ai_vision_prompt",
             "local_ai_embed",

--- a/src/openhuman/local_ai/service/public_infer.rs
+++ b/src/openhuman/local_ai/service/public_infer.rs
@@ -3,8 +3,7 @@ use crate::openhuman::local_ai::model_ids;
 use crate::openhuman::local_ai::ollama_api::{
     ns_to_tps, ollama_base_url, OllamaGenerateOptions, OllamaGenerateRequest,
 };
-use crate::openhuman::local_ai::parse::{parse_suggestions, sanitize_inline_completion};
-use crate::openhuman::local_ai::types::Suggestion;
+use crate::openhuman::local_ai::parse::sanitize_inline_completion;
 
 use super::LocalAiService;
 
@@ -44,29 +43,6 @@ impl LocalAiService {
         };
         self.inference(config, system, prompt, max_tokens.or(Some(160)), no_think)
             .await
-    }
-
-    pub async fn suggest_questions(
-        &self,
-        config: &Config,
-        context: &str,
-    ) -> Result<Vec<Suggestion>, String> {
-        if !config.local_ai.enabled {
-            return Ok(Vec::new());
-        }
-        let system = "You create short suggested user prompts.";
-        let prompt = format!(
-            "Given this conversation context, produce up to {} short suggested next user prompts. Return one prompt per line with no numbering.\\n\\n{}",
-            config.local_ai.max_suggestions.max(1),
-            context
-        );
-        let raw = self
-            .inference(config, system, &prompt, Some(96), true)
-            .await?;
-        Ok(parse_suggestions(
-            &raw,
-            config.local_ai.max_suggestions.max(1),
-        ))
     }
 
     pub async fn inline_complete(
@@ -536,41 +512,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn suggest_questions_parses_line_separated_output() {
-        let _guard = crate::openhuman::local_ai::LOCAL_AI_TEST_MUTEX
-            .lock()
-            .expect("local ai test mutex");
-
-        let app = Router::new().route(
-            "/api/generate",
-            post(|| async {
-                Json(json!({
-                    "model": "test",
-                    "response": "What next?\nHow about this?\nTell me more.",
-                    "done": true
-                }))
-            }),
-        );
-        let base = spawn_mock(app).await;
-        unsafe {
-            std::env::set_var("OPENHUMAN_OLLAMA_BASE_URL", &base);
-        }
-
-        let mut config = enabled_config();
-        config.local_ai.max_suggestions = 3;
-        let service = ready_service(&config);
-        let suggestions = service
-            .suggest_questions(&config, "prior context")
-            .await
-            .expect("suggest_questions");
-        assert!(!suggestions.is_empty());
-
-        unsafe {
-            std::env::remove_var("OPENHUMAN_OLLAMA_BASE_URL");
-        }
-    }
-
-    #[tokio::test]
     async fn summarize_disabled_returns_error() {
         // When local_ai is disabled the summarize fn should short-circuit.
         let mut config = Config::default();
@@ -590,15 +531,6 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("local ai is disabled"));
-    }
-
-    #[tokio::test]
-    async fn suggest_questions_disabled_returns_empty() {
-        let mut config = Config::default();
-        config.local_ai.enabled = false;
-        let service = LocalAiService::new(&config);
-        let out = service.suggest_questions(&config, "ctx").await.unwrap();
-        assert!(out.is_empty());
     }
 
     #[tokio::test]

--- a/src/openhuman/local_ai/types.rs
+++ b/src/openhuman/local_ai/types.rs
@@ -77,12 +77,6 @@ impl LocalAiStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Suggestion {
-    pub text: String,
-    pub confidence: f32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalAiAssetStatus {
     pub state: String,
     pub id: String,


### PR DESCRIPTION
## Summary
- Drop the suggested-question prompt bubbles shown in an empty conversation.
- Remove the full Rust plumbing behind it: `local_ai_suggest_questions` controller/op/service method, `parse_suggestions`, `Suggestion` type, and the `max_suggestions` config knob.
- Strip the matching TS surface: `openhumanLocalAiSuggestQuestions`, `LocalAiSuggestion`, `SuggestQuestionsData`, the `fetchSuggestedQuestions` thunk + slice fields, and the suggestion test panel in Local Model Debug. `app/schema.json` regenerated to drop the method entry.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (906 passed)
- [x] `cargo check` (core)
- [x] `cargo test --lib openhuman::local_ai::` (155 passed)
- [ ] Manual: open a fresh conversation in the desktop app and confirm no suggestion bubbles render above the composer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features Removed**
  * Removed the auto-suggested questions feature that provided prompts when starting new conversations with the local AI model.
  * Removed the suggested prompts debug testing interface from the local model settings panel.

* **Chores**
  * Cleaned up related configuration and internal suggestion handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->