### PR TITLE
fix(release): sign CEF framework as single bundle on macOS

### DIFF
--- a/scripts/release/sign-and-notarize-macos.sh
+++ b/scripts/release/sign-and-notarize-macos.sh
@@ -61,34 +61,32 @@ codesign_hardened() {
     "$@"
 }
 
+# Frameworks must be signed as a single bundle with no entitlements. codesign
+# recursively seals nested binaries (Versions/A/Libraries/*.dylib, the main
+# CEF binary, etc.) via _CodeSignature/CodeResources. Walking inside the
+# framework and signing inner *.dylib / *.so files individually corrupts the
+# seal — at runtime CEF's SecCodeCheckValidity self-check fails with -67030
+# (errSecCSReqFailed), helper processes can't host the URL request context
+# or remote debugger, and embedded webviews stay on about:blank.
+codesign_framework() {
+  codesign --force --options runtime \
+    --sign "$APPLE_SIGNING_IDENTITY" \
+    --timestamp \
+    "$@"
+}
+
 # ── Nested Frameworks/ (CEF + Helper apps) ──────────────────────────────────
 # Must be signed from the inside out, before the outer .app bundle.
 if [ -d "$APP_PATH/Contents/Frameworks" ]; then
-  # 1. Sign loose dylibs / binaries inside any *.framework
+  # 1. Sign each *.framework as a single bundle.
   while IFS= read -r -d '' fw; do
-    echo "[sign]   Scanning framework: $(basename "$fw")"
-    while IFS= read -r -d '' item; do
-      # Skip symlinks; codesign will sign the real file via Versions/Current
-      [ -L "$item" ] && continue
-      case "$item" in
-        *.dylib|*.so)
-          echo "[sign]     Signing lib: \"${item#${APP_PATH}/}\""
-          codesign_hardened "$item"
-          ;;
-      esac
-    done < <(find "$fw" -type f -print0)
-    # Sign the framework bundle itself
     echo "[sign]   Signing framework bundle: $(basename "$fw")"
-    codesign_hardened "$fw"
+    codesign_framework "$fw"
   done < <(find "$APP_PATH/Contents/Frameworks" -maxdepth 1 -type d -name '*.framework' -print0)
 
-  # 2. Sign each nested Helper.app (inner binary first, then the bundle)
+  # 2. Sign each nested Helper.app as a bundle. codesign signs the inner
+  # binary as part of sealing the bundle — don't pre-sign it separately.
   while IFS= read -r -d '' helper; do
-    HELPER_EXE="$(defaults read "$helper/Contents/Info.plist" CFBundleExecutable 2>/dev/null || true)"
-    if [ -n "$HELPER_EXE" ] && [ -f "$helper/Contents/MacOS/$HELPER_EXE" ]; then
-      echo "[sign]   Signing helper binary: $(basename "$helper")/$HELPER_EXE"
-      codesign_hardened "$helper/Contents/MacOS/$HELPER_EXE"
-    fi
     echo "[sign]   Signing helper bundle: $(basename "$helper")"
     codesign_hardened "$helper"
   done < <(find "$APP_PATH/Contents/Frameworks" -maxdepth 1 -type d -name '*.app' -print0)


### PR DESCRIPTION
## Summary

CI-built macOS `.app` bundles ship CEF + helpers but every embedded webview (Telegram, WhatsApp, Slack, Discord, ...) silently stays on `about:blank`. Locally-built `.app` works fine.

Repro: download `OpenHuman.app` from a release run, launch it, watch stderr:

```
[ERROR:base/mac/process_requirement.cc:165] Unable to derive validation category for current process. Signature validation of current process failed: NSOSStatusErrorDomain Code=-67030
[ERROR:base/mac/process_requirement.cc:560] ProcessIsSignedAndFulfillsRequirement: Code=-67030
...
[tg][...] idb scan failed: GET http://127.0.0.1:19222/json/version: error sending request
```

`-67030` = `errSecCSReqFailed`. Chromium calls `SecCodeCheckValidity()` against its own running process at startup; when that fails, helper processes can't host the URL request context or the remote debugger, so embedded webviews never navigate.

Root cause is in `scripts/release/sign-and-notarize-macos.sh`. The post-build re-sign step walks **into** `Chromium Embedded Framework.framework` and signs each `*.dylib` / `*.so` individually with hardened-runtime + the sidecar entitlements plist, then re-seals the framework as a whole. That corrupts the framework's `_CodeSignature/CodeResources` manifest — inner libs end up with their own designated requirement that doesn't match the categories Chromium expects in `process_requirement.cc`.

Local `cargo tauri build` (vendored CEF-aware CLI) signs the framework as a single bundle, which is the Apple-correct way: `codesign` recursively seals nested libs via the framework's `_CodeSignature`. That's why the local build passes the runtime self-check and the CI build doesn't.

### Fix

- Sign each `*.framework` as a single bundle, no `--entitlements` (frameworks don't carry entitlements).
- Sign each `Helper.app` as a bundle and let `codesign` handle the inner binary, instead of pre-signing the Mach-O separately and then re-signing the bundle around it.

### Out of scope (follow-up)

The shared `entitlements.sidecar.plist` is reused for the main `.app`, every helper, and the sidecar. It's broad enough to work but conceptually wrong (GPU/Plugin/Alerts helpers don't need `allow-jit`; the main app shouldn't share the sidecar plist). Splitting per-target plists is hygiene, not the bug — leaving for a follow-up to keep this change focused.

## Test plan

- [ ] Trigger Release workflow on this branch (production target)
- [ ] Download the macOS `.app` artifact, launch it, confirm no `process_requirement.cc` errors in stderr
- [ ] Open a Telegram account in the app, confirm `web.telegram.org` actually loads (CDP port 19222 reachable, page leaves `about:blank`)
- [ ] `codesign --verify --deep --strict --verbose=2 OpenHuman.app` passes
- [ ] `spctl -a -vv -t exec OpenHuman.app` reports notarized
- [ ] `xcrun stapler validate OpenHuman.app` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined macOS code signing and notarization process in the release workflow for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->