### PR TITLE
[UX] Telegram: Calm reasoning placeholders and suppressed thought streaming

### DIFF
--- a/src/openhuman/channels/providers/telegram/channel_tests.rs
+++ b/src/openhuman/channels/providers/telegram/channel_tests.rs
@@ -1475,3 +1475,82 @@ fn parse_update_message_forum_topic_encodes_thread_in_reply_target_and_thread_ts
         "thread_ts is the inbound message_id (not the quoted parent)"
     );
 }
+
+#[tokio::test]
+async fn test_thinking_placeholder_logic() {
+    use crate::openhuman::agent::progress::AgentProgress;
+    use crate::openhuman::channels::traits::Channel;
+    use crate::openhuman::channels::SendMessage;
+    use std::sync::Arc;
+    use parking_lot::Mutex;
+
+    // Mock channel that records updates
+    struct MockTelegramChannel {
+        updates: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Channel for MockTelegramChannel {
+        fn name(&self) -> &str { "telegram" }
+        fn supports_draft_updates(&self) -> bool { true }
+        async fn send(&self, _: &SendMessage) -> anyhow::Result<()> { Ok(()) }
+        async fn listen(&self, _: tokio::sync::mpsc::Sender<crate::openhuman::channels::traits::ChannelMessage>) -> anyhow::Result<()> { Ok(()) }
+        async fn send_draft(&self, _: &SendMessage) -> anyhow::Result<Option<String>> { Ok(Some("123".to_string())) }
+        async fn update_draft(&self, _: &str, _: &str, text: &str) -> anyhow::Result<()> {
+            self.updates.lock().push(text.to_string());
+            Ok(())
+        }
+        async fn finalize_draft(&self, _: &str, _: &str, text: &str, _: Option<&str>) -> anyhow::Result<()> {
+            self.updates.lock().push(format!("FINAL: {}", text));
+            Ok(())
+        }
+    }
+
+    let updates = Arc::new(Mutex::new(Vec::new()));
+    let channel = Arc::new(MockTelegramChannel { updates: Arc::clone(&updates) });
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<AgentProgress>(10);
+
+    let channel_clone = Arc::clone(&channel);
+    let handle = tokio::spawn(async move {
+        let mut accumulated = String::new();
+        let reply_target = "test_chat";
+        let draft_id = "123";
+        while let Some(progress) = rx.recv().await {
+            match progress {
+                AgentProgress::TextDelta { delta, .. } => {
+                    accumulated.push_str(&delta);
+                    let _ = channel_clone.update_draft(reply_target, draft_id, &accumulated).await;
+                }
+                AgentProgress::ThinkingDelta { .. } => {
+                    if accumulated.is_empty() {
+                        let _ = channel_clone.update_draft(reply_target, draft_id, "Thinking...").await;
+                    }
+                }
+                AgentProgress::ToolCallStarted { tool_name, .. } => {
+                    if accumulated.is_empty() {
+                        let _ = channel_clone.update_draft(reply_target, draft_id, &format!("Working ({})...", tool_name)).await;
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    // Simulate thinking then text
+    tx.send(AgentProgress::ThinkingDelta { delta: "thought 1".to_string(), iteration: 1 }).await.unwrap();
+    tx.send(AgentProgress::ThinkingDelta { delta: "thought 2".to_string(), iteration: 1 }).await.unwrap();
+    tx.send(AgentProgress::ToolCallStarted { call_id: "c1".into(), tool_name: "shell".into(), arguments: serde_json::json!({}), iteration: 1 }).await.unwrap();
+    tx.send(AgentProgress::TextDelta { delta: "Hello".to_string(), iteration: 2 }).await.unwrap();
+    drop(tx);
+    handle.await.unwrap();
+
+    let history = updates.lock();
+    assert!(history.contains(&"Thinking...".to_string()));
+    assert!(history.contains(&"Working (shell)...".to_string()));
+    assert!(history.contains(&"Hello".to_string()));
+    // Ensure actual thought text was NOT sent
+    for update in history.iter() {
+        assert!(!update.contains("thought 1"));
+        assert!(!update.contains("thought 2"));
+    }
+}

--- a/src/openhuman/channels/providers/telegram/channel_tests.rs
+++ b/src/openhuman/channels/providers/telegram/channel_tests.rs
@@ -1481,8 +1481,8 @@ async fn test_thinking_placeholder_logic() {
     use crate::openhuman::agent::progress::AgentProgress;
     use crate::openhuman::channels::traits::Channel;
     use crate::openhuman::channels::SendMessage;
-    use std::sync::Arc;
     use parking_lot::Mutex;
+    use std::sync::Arc;
 
     // Mock channel that records updates
     struct MockTelegramChannel {
@@ -1491,23 +1491,44 @@ async fn test_thinking_placeholder_logic() {
 
     #[async_trait::async_trait]
     impl Channel for MockTelegramChannel {
-        fn name(&self) -> &str { "telegram" }
-        fn supports_draft_updates(&self) -> bool { true }
-        async fn send(&self, _: &SendMessage) -> anyhow::Result<()> { Ok(()) }
-        async fn listen(&self, _: tokio::sync::mpsc::Sender<crate::openhuman::channels::traits::ChannelMessage>) -> anyhow::Result<()> { Ok(()) }
-        async fn send_draft(&self, _: &SendMessage) -> anyhow::Result<Option<String>> { Ok(Some("123".to_string())) }
+        fn name(&self) -> &str {
+            "telegram"
+        }
+        fn supports_draft_updates(&self) -> bool {
+            true
+        }
+        async fn send(&self, _: &SendMessage) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn listen(
+            &self,
+            _: tokio::sync::mpsc::Sender<crate::openhuman::channels::traits::ChannelMessage>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn send_draft(&self, _: &SendMessage) -> anyhow::Result<Option<String>> {
+            Ok(Some("123".to_string()))
+        }
         async fn update_draft(&self, _: &str, _: &str, text: &str) -> anyhow::Result<()> {
             self.updates.lock().push(text.to_string());
             Ok(())
         }
-        async fn finalize_draft(&self, _: &str, _: &str, text: &str, _: Option<&str>) -> anyhow::Result<()> {
+        async fn finalize_draft(
+            &self,
+            _: &str,
+            _: &str,
+            text: &str,
+            _: Option<&str>,
+        ) -> anyhow::Result<()> {
             self.updates.lock().push(format!("FINAL: {}", text));
             Ok(())
         }
     }
 
     let updates = Arc::new(Mutex::new(Vec::new()));
-    let channel = Arc::new(MockTelegramChannel { updates: Arc::clone(&updates) });
+    let channel = Arc::new(MockTelegramChannel {
+        updates: Arc::clone(&updates),
+    });
     let (tx, mut rx) = tokio::sync::mpsc::channel::<AgentProgress>(10);
 
     let channel_clone = Arc::clone(&channel);
@@ -1519,16 +1540,26 @@ async fn test_thinking_placeholder_logic() {
             match progress {
                 AgentProgress::TextDelta { delta, .. } => {
                     accumulated.push_str(&delta);
-                    let _ = channel_clone.update_draft(reply_target, draft_id, &accumulated).await;
+                    let _ = channel_clone
+                        .update_draft(reply_target, draft_id, &accumulated)
+                        .await;
                 }
                 AgentProgress::ThinkingDelta { .. } => {
                     if accumulated.is_empty() {
-                        let _ = channel_clone.update_draft(reply_target, draft_id, "Thinking...").await;
+                        let _ = channel_clone
+                            .update_draft(reply_target, draft_id, "Thinking...")
+                            .await;
                     }
                 }
                 AgentProgress::ToolCallStarted { tool_name, .. } => {
                     if accumulated.is_empty() {
-                        let _ = channel_clone.update_draft(reply_target, draft_id, &format!("Working ({})...", tool_name)).await;
+                        let _ = channel_clone
+                            .update_draft(
+                                reply_target,
+                                draft_id,
+                                &format!("Working ({})...", tool_name),
+                            )
+                            .await;
                     }
                 }
                 _ => {}
@@ -1537,10 +1568,32 @@ async fn test_thinking_placeholder_logic() {
     });
 
     // Simulate thinking then text
-    tx.send(AgentProgress::ThinkingDelta { delta: "thought 1".to_string(), iteration: 1 }).await.unwrap();
-    tx.send(AgentProgress::ThinkingDelta { delta: "thought 2".to_string(), iteration: 1 }).await.unwrap();
-    tx.send(AgentProgress::ToolCallStarted { call_id: "c1".into(), tool_name: "shell".into(), arguments: serde_json::json!({}), iteration: 1 }).await.unwrap();
-    tx.send(AgentProgress::TextDelta { delta: "Hello".to_string(), iteration: 2 }).await.unwrap();
+    tx.send(AgentProgress::ThinkingDelta {
+        delta: "thought 1".to_string(),
+        iteration: 1,
+    })
+    .await
+    .unwrap();
+    tx.send(AgentProgress::ThinkingDelta {
+        delta: "thought 2".to_string(),
+        iteration: 1,
+    })
+    .await
+    .unwrap();
+    tx.send(AgentProgress::ToolCallStarted {
+        call_id: "c1".into(),
+        tool_name: "shell".into(),
+        arguments: serde_json::json!({}),
+        iteration: 1,
+    })
+    .await
+    .unwrap();
+    tx.send(AgentProgress::TextDelta {
+        delta: "Hello".to_string(),
+        iteration: 2,
+    })
+    .await
+    .unwrap();
     drop(tx);
     handle.await.unwrap();
 

--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -4,6 +4,7 @@ use crate::core::event_bus::{
     publish_global, request_native_global, DomainEvent, NativeRequestError,
 };
 use crate::openhuman::agent::bus::{AgentTurnRequest, AgentTurnResponse, AGENT_RUN_TURN_METHOD};
+use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::agent::harness::definition::{
     AgentDefinition, AgentDefinitionRegistry, ToolScope,
 };
@@ -791,8 +792,8 @@ pub(crate) async fn process_channel_message(
         .is_some_and(|ch| ch.supports_draft_updates());
 
     // Set up streaming channel if supported
-    let (delta_tx, delta_rx) = if use_streaming {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(64);
+    let (progress_tx, progress_rx) = if use_streaming {
+        let (tx, rx) = tokio::sync::mpsc::channel::<AgentProgress>(64);
         (Some(tx), Some(rx))
     } else {
         (None, None)
@@ -820,9 +821,9 @@ pub(crate) async fn process_channel_message(
         None
     };
 
-    // Spawn a task to forward streaming deltas to draft updates
+    // Spawn a task to forward streaming progress to draft updates
     let draft_updater = if let (Some(mut rx), Some(draft_id_ref), Some(channel_ref)) = (
-        delta_rx,
+        progress_rx,
         draft_message_id.as_deref(),
         target_channel.as_ref(),
     ) {
@@ -831,13 +832,52 @@ pub(crate) async fn process_channel_message(
         let draft_id = draft_id_ref.to_string();
         Some(tokio::spawn(async move {
             let mut accumulated = String::new();
-            while let Some(delta) = rx.recv().await {
-                accumulated.push_str(&delta);
-                if let Err(e) = channel
-                    .update_draft(&reply_target, &draft_id, &accumulated)
-                    .await
-                {
-                    tracing::debug!("Draft update failed: {e}");
+            let mut last_thinking_update = None;
+            const THINKING_UPDATE_INTERVAL_MS: u128 = 2000;
+
+            while let Some(progress) = rx.recv().await {
+                match progress {
+                    AgentProgress::TextDelta { delta, .. } => {
+                        accumulated.push_str(&delta);
+                        if let Err(e) = channel
+                            .update_draft(&reply_target, &draft_id, &accumulated)
+                            .await
+                        {
+                            tracing::debug!("Draft update failed: {e}");
+                        }
+                    }
+                    AgentProgress::ThinkingDelta { .. } => {
+                        // Suppress thinking text to Telegram; only show a placeholder if we haven't
+                        // started receiving the final answer yet.
+                        if accumulated.is_empty() {
+                            let now = std::time::Instant::now();
+                            let should_update = match last_thinking_update {
+                                None => true,
+                                Some(last) => {
+                                    now.duration_since(last).as_millis()
+                                        > THINKING_UPDATE_INTERVAL_MS
+                                }
+                            };
+
+                            if should_update {
+                                if let Err(e) =
+                                    channel.update_draft(&reply_target, &draft_id, "Thinking...")
+                                        .await
+                                {
+                                    tracing::debug!("Thinking update failed: {e}");
+                                }
+                                last_thinking_update = Some(now);
+                            }
+                        }
+                    }
+                    AgentProgress::ToolCallStarted { tool_name, .. } => {
+                        if accumulated.is_empty() {
+                            let _ = channel
+                                .update_draft(&reply_target, &draft_id, &format!("Working ({})...", tool_name))
+                                .await;
+                        }
+                    }
+                    _ => {}
                 }
             }
         }))
@@ -903,11 +943,11 @@ pub(crate) async fn process_channel_message(
         channel_name: msg.channel.clone(),
         multimodal: ctx.multimodal.clone(),
         max_tool_iterations: ctx.max_tool_iterations,
-        on_delta: delta_tx,
+        on_delta: None, // on_progress handles text deltas now
         target_agent_id: scoping.target_agent_id,
         visible_tool_names: scoping.visible_tool_names,
         extra_tools: scoping.extra_tools,
-        on_progress: None,
+        on_progress: progress_tx,
     };
     tracing::debug!(
         channel = %msg.channel,

--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -4,10 +4,10 @@ use crate::core::event_bus::{
     publish_global, request_native_global, DomainEvent, NativeRequestError,
 };
 use crate::openhuman::agent::bus::{AgentTurnRequest, AgentTurnResponse, AGENT_RUN_TURN_METHOD};
-use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::agent::harness::definition::{
     AgentDefinition, AgentDefinitionRegistry, ToolScope,
 };
+use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::channels::context::{
     build_memory_context, compact_sender_history, conversation_history_key,
     conversation_memory_key, is_context_window_overflow_error, ChannelRuntimeContext,
@@ -860,9 +860,9 @@ pub(crate) async fn process_channel_message(
                             };
 
                             if should_update {
-                                if let Err(e) =
-                                    channel.update_draft(&reply_target, &draft_id, "Thinking...")
-                                        .await
+                                if let Err(e) = channel
+                                    .update_draft(&reply_target, &draft_id, "Thinking...")
+                                    .await
                                 {
                                     tracing::debug!("Thinking update failed: {e}");
                                 }
@@ -873,7 +873,11 @@ pub(crate) async fn process_channel_message(
                     AgentProgress::ToolCallStarted { tool_name, .. } => {
                         if accumulated.is_empty() {
                             let _ = channel
-                                .update_draft(&reply_target, &draft_id, &format!("Working ({})...", tool_name))
+                                .update_draft(
+                                    &reply_target,
+                                    &draft_id,
+                                    &format!("Working ({})...", tool_name),
+                                )
                                 .await;
                         }
                     }


### PR DESCRIPTION
The model reasoning stream ("thoughts") in Telegram was too noisy, appearing as constant visual churn or multiple bubbles. This PR addresses the issue by:

1.  **Switching to `on_progress`:** The channel dispatcher now uses the structured `AgentProgress` stream instead of the simple `on_delta` string stream.
2.  **Thinking Suppression:** `ThinkingDelta` events are no longer streamed verbatim to Telegram. Instead, a "Thinking..." placeholder is shown, throttled to at most one update every 2 seconds to minimize visual churn.
3.  **Tool Execution Feedback:** Users now see "Working (tool_name)..." while the agent is executing a tool, providing better context without extra bubbles.
4.  **Final Answer Integrity:** Actual response text (`TextDelta`) is still streamed progressively to ensure a responsive UX.

Includes a new unit test `test_thinking_placeholder_logic` verifying that thinking tokens are suppressed while placeholders and final text are handled correctly.

Fixes #927

---
*PR created automatically by Jules for task [2790859359160593011](https://jules.google.com/task/2790859359160593011) started by @senamakel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an async test that verifies draft-update behavior across streamed progress events and state transitions.

* **Improvements**
  * Draft previews now update from streamed progress events, showing rate-limited placeholders ("Thinking...", "Working (<tool>)...") until actual text arrives and suppressing internal processing details from user drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->