### PR TITLE
fix(release): convert UDZO to temp path + compact (DMG repackage)

### DIFF
--- a/scripts/release/repackage-dmg.sh
+++ b/scripts/release/repackage-dmg.sh
@@ -78,21 +78,35 @@ MOUNT_DIR=""
 sync
 sleep 2
 
-# 3. Convert back to compressed format (UDZO).
-# `hdiutil convert` is occasionally flaky on macOS even after a clean detach
-# ("internal error" with no further detail). Retry a couple of times before
-# failing the release.
+# 3. Compact the writable image to reclaim the empty space left over from
+# the 1GB resize. Without this the UDZO output carries hundreds of MB of
+# zero blocks and `hdiutil convert` is more likely to fail.
+echo "[dmg] Compacting writable image before recompression..."
+hdiutil compact "$DMG_RW" || echo "[dmg] hdiutil compact returned non-zero (continuing)"
+
+# 4. Convert back to compressed format (UDZO).
+# Convert to a TEMPORARY path and `mv` over the original instead of
+# `-ov`-overwriting the input. On macOS GitHub runners the in-place
+# overwrite fails immediately with "hdiutil: convert failed - internal
+# error" — the source DMG handle is still held by the imaging engine when
+# the same path is reopened for write. A separate output path sidesteps
+# the issue entirely.
+DMG_OUT="$(mktemp /tmp/OpenHuman-UDZO-XXXXXX).dmg"
+rm -f "$DMG_OUT"  # mktemp created an empty file; hdiutil refuses to overwrite without -ov.
 convert_attempts=0
-until hdiutil convert "$DMG_RW" -format UDZO -ov -o "$DMG_PATH"; do
+until hdiutil convert "$DMG_RW" -format UDZO -o "$DMG_OUT"; do
   convert_attempts=$((convert_attempts + 1))
   if [ "$convert_attempts" -ge 3 ]; then
     echo "[dmg] ERROR: hdiutil convert to UDZO failed after $convert_attempts attempts" >&2
+    rm -f "$DMG_OUT"
     exit 1
   fi
   echo "[dmg] hdiutil convert failed (attempt $convert_attempts) — retrying after settle..." >&2
+  rm -f "$DMG_OUT"
   sync
   sleep $((convert_attempts * 5))
 done
+mv -f "$DMG_OUT" "$DMG_PATH"
 rm -f "$DMG_RW"
 DMG_RW=""
 


### PR DESCRIPTION
## Summary

Supersedes the retry-only approach in #952. The macOS release pipeline kept failing on `Re-package DMG after notarization` with:

```
Preparing imaging engine…
hdiutil: convert failed - internal error
```

Investigation against actual GitHub macOS runner logs confirmed the failure is **structural, not transient** — it fires in ~6ms, every attempt, before any real work. Root cause: `hdiutil convert -ov -o "$DMG_PATH"` reopens the source path for write while the imaging engine still holds a handle on the input DMG, producing the unspecific "internal error".

- Convert UDZO to a temporary output path, then `mv` over the original. The in-place overwrite is what trips the engine; a separate output path sidesteps it.
- `hdiutil compact` the writable image first to discard the zero blocks left over from the 1GB resize, so the UDZO output isn't carrying hundreds of MB of empty space.
- Retry loop preserved (now cleans up the temp file between attempts) — it never helped against the structural bug, but it's still the right belt-and-braces for genuine flakes.

Reference failing run: https://github.com/tinyhumansai/openhuman/actions/runs/24970255766/job/73111881422

## Test plan

- [ ] Dispatch a staging release; confirm `Re-package DMG after notarization` succeeds and the resulting DMG is correctly compressed (not the bloated 1GB writable layout).
- [ ] Confirm the final DMG mounts, contains `OpenHuman.app` plus the `Applications` symlink, and stapled validation still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build process by optimizing disk image creation. Enhanced compaction and conversion procedures to reduce file sizes and increase reliability, with better cleanup handling during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->