### PR TITLE
fix(cef): expose CDP port in release builds so embedded webviews navigate

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -824,9 +824,15 @@ pub fn run() {
             // silently disappears and huddle/call buttons no-op.
             ("--enable-features", Some("SharedArrayBuffer")),
         ];
-        if cfg!(debug_assertions) {
-            args.push(("--remote-debugging-port", Some("19222")));
-        }
+        // Always expose the CDP port, not just in debug. The webview-accounts
+        // CDP session opener navigates each embedded provider webview from its
+        // `about:blank#openhuman-acct-...` placeholder to the real provider URL
+        // via `Page.navigate`. Without this port available in release builds,
+        // the CDP client can't attach (`browser_ws_url()` 404s on /json/version),
+        // the navigation never fires, and the embedded webview stays on
+        // `about:blank` (blank panel for Telegram / WhatsApp / Slack / Discord).
+        // Same port the `cdp::CDP_HOST`/`cdp::CDP_PORT` constants expect.
+        args.push(("--remote-debugging-port", Some("19222")));
         tauri::Builder::<tauri::Cef>::new().command_line_args::<&str, &str>(args)
     };
 


### PR DESCRIPTION
## Summary

Embedded provider webviews (Telegram / WhatsApp / Slack / Discord panels) ship as **blank panels** in every notarized release build. The webview opens, the React UI shows the side rail, but the panel where the third-party page should render stays on `about:blank`. Reproduces against any signed/notarized build of `main`.

## Root cause

`webview_accounts` opens each panel at an `about:blank#openhuman-acct-<id>` placeholder URL, then `cdp::session::run_session_cycle` is supposed to attach to CEF over the Chrome DevTools Protocol and call `Page.navigate` to the real provider URL. That cycle needs CEF's remote-debugging port reachable on `127.0.0.1:19222` (see `cdp::CDP_HOST` / `cdp::CDP_PORT` and the matching constants in `whatsapp_scanner` / `telegram_scanner` / `discord_scanner` / `slack_scanner`).

`app/src-tauri/src/lib.rs` was only passing `--remote-debugging-port=19222` to CEF inside `cfg!(debug_assertions)`. Release builds never exposed the port. The CDP client then 404'd on `/json/version`, `run_session_cycle` returned `Err`, the error was logged at `debug` level (silently lost in release), the webview never received `Page.navigate`, and the panel stayed on `about:blank`.

This has been broken since #629 introduced the `cfg!(debug_assertions)` gate — the multi-provider CEF webview accounts have never worked in shipped builds.

## Fix

Drop the gate. The flag is now passed unconditionally.

```rust
// before
if cfg!(debug_assertions) {
    args.push(("--remote-debugging-port", Some("19222")));
}
// after
args.push(("--remote-debugging-port", Some("19222")));
```

The CDP socket binds to `127.0.0.1` only and Chromium doesn't advertise it on the network, so the exposure is limited to local processes that already share the user's UID.

## Diagnosis

Launch log from a notarized release build, after clicking on Telegram in the sidebar:

```
[webview-accounts] open account_id=<id> provider=telegram label=acct_<id>
[webview-accounts] spawned label=acct_<id> initial_size=LogicalSize { width: 1.0, height: 1.0 }
[cdp-session][<id>] up real_url=https://web.telegram.org/k/  marker=openhuman-acct-<id>
[cef-helper-notify] on_context_created browser_id=3 origin=about:blank#openhuman-acct-<id>
[webview-accounts][<id>] revealed label=acct_<id> bounds={...} state=finished
[webview-accounts][<id>] load event state=finished url=about:blank   ← never navigates away from about:blank
```

`[cdp-session] up` fires but no subsequent `attaching to target` / `navigating to ...` follow — confirming `run_session_cycle` errored silently.

## Test plan

- [x] Local: rebuilt the OpenHuman shell with this fix, swapped into a re-signed + notarized release bundle, opened the app, clicked Telegram → embedded webview navigated to `https://web.telegram.org/k/` and rendered the page (previously: blank panel).
- [ ] Dispatch a staging release on GitHub Actions and confirm embedded panels render in the shipped notarized DMG.

## Out of scope (follow-up)

- `app/src-tauri/src/webview_accounts/mod.rs:615` — `teardown_account_scanners` calls `tokio::spawn` from `RunEvent::ExitRequested` (no current Tokio runtime), causing `thread 'main' panicked at ... there is no reactor running, must be called from the context of a Tokio 1.x runtime` on shutdown. Cosmetic (process is exiting anyway) but should be cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Remote debugging is now available in all builds, including production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->