### PR TITLE
fix(chat): size user message bubbles to fit text content

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -998,7 +998,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                     )}
                   <div
                     className={`group/msg flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
-                    <div className="relative w-full md:max-w-[75%]">
+                    <div className={`relative ${msg.sender === 'user' ? 'w-fit max-w-[75%]' : 'w-full md:max-w-[75%]'}`}>
                       {msg.sender === 'agent' ? (
                         <div className="space-y-1">
                           {splitAgentMessageIntoBubbles(msg.content).map(
@@ -1043,7 +1043,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                           )}
                         </div>
                       ) : (
-                        <div className="rounded-2xl px-4 py-2.5 bg-primary-500 text-white rounded-br-md">
+                        <div className="rounded-2xl px-4 py-2.5 bg-primary-500 text-white rounded-br-md break-words overflow-hidden">
                           <BubbleMarkdown content={msg.content} tone="user" />
                           {latestVisibleMessage?.id === msg.id && (
                             <p className="mt-1 text-[10px] text-white/60">

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -998,7 +998,8 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                     )}
                   <div
                     className={`group/msg flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
-                    <div className={`relative ${msg.sender === 'user' ? 'w-fit max-w-[75%]' : 'w-full md:max-w-[75%]'}`}>
+                    <div
+                      className={`relative ${msg.sender === 'user' ? 'w-fit max-w-[75%]' : 'w-full md:max-w-[75%]'}`}>
                       {msg.sender === 'agent' ? (
                         <div className="space-y-1">
                           {splitAgentMessageIntoBubbles(msg.content).map(


### PR DESCRIPTION
## Summary

- User-side chat bubbles now shrink to fit their text content instead of stretching to full width
- Long unbroken strings wrap properly instead of overflowing the bubble

## Changes

- `app/src/pages/Conversations.tsx`: use `w-fit max-w-[75%]` for user messages (agent bubbles unchanged), add `break-words overflow-hidden` to the user bubble div

## Test plan

- [ ] Send a short message — bubble should be narrow, fitting the text
- [ ] Send a long message — bubble should wrap at 75% max width
- [ ] Send a long unbroken string — text should wrap to next line, not overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented long words/strings from overflowing chat message bubbles.

* **Style**
  * User message bubbles now size to their content for a tighter fit while keeping layout caps.
  * Improved text wrapping and overflow handling in conversations for clearer, more consistent message display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->