### PR TITLE
fix(ui): refetch snapshot on turn boundary so progress UI re-syncs (#924)

### DIFF
--- a/app/src/hooks/__tests__/useRefetchSnapshotOnTurnEnd.test.ts
+++ b/app/src/hooks/__tests__/useRefetchSnapshotOnTurnEnd.test.ts
@@ -93,4 +93,22 @@ describe('useRefetchSnapshotOnTurnEnd', () => {
     });
     expect(mockPatchSnapshot).toHaveBeenLastCalledWith({ currentUser: mockUser2 });
   });
+
+  it('clears the pending debounce timer on unmount so getMe never fires', async () => {
+    vi.mocked(userApi.getMe).mockResolvedValue({ _id: 'user1' } as any);
+
+    const { result, unmount } = renderHook(() => useRefetchSnapshotOnTurnEnd());
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(750);
+    });
+
+    expect(userApi.getMe).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/hooks/__tests__/useRefetchSnapshotOnTurnEnd.test.ts
+++ b/app/src/hooks/__tests__/useRefetchSnapshotOnTurnEnd.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCoreState } from '../../providers/CoreStateProvider';
+import { userApi } from '../../services/api/userApi';
+import { useRefetchSnapshotOnTurnEnd } from '../useRefetchSnapshotOnTurnEnd';
+
+vi.mock('../../providers/CoreStateProvider', () => ({ useCoreState: vi.fn() }));
+
+vi.mock('../../services/api/userApi', () => ({ userApi: { getMe: vi.fn() } }));
+
+describe('useRefetchSnapshotOnTurnEnd', () => {
+  const mockPatchSnapshot = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(useCoreState).mockReturnValue({ patchSnapshot: mockPatchSnapshot } as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('refetches and patches snapshot after 750ms', async () => {
+    const mockUser1 = { _id: 'user1', firstName: 'Jules' };
+    vi.mocked(userApi.getMe).mockResolvedValue(mockUser1 as any);
+
+    const { result } = renderHook(() => useRefetchSnapshotOnTurnEnd());
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    expect(userApi.getMe).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(750);
+    });
+
+    expect(userApi.getMe).toHaveBeenCalledTimes(1);
+    expect(mockPatchSnapshot).toHaveBeenCalledWith({ currentUser: mockUser1 });
+  });
+
+  it('three rapid finalize events → one getMe call', async () => {
+    const mockUser1 = { _id: 'user1', firstName: 'Jules' };
+    vi.mocked(userApi.getMe).mockResolvedValue(mockUser1 as any);
+
+    const { result } = renderHook(() => useRefetchSnapshotOnTurnEnd());
+
+    act(() => {
+      result.current.refetch();
+      vi.advanceTimersByTime(300);
+      result.current.refetch();
+      vi.advanceTimersByTime(300);
+      result.current.refetch();
+    });
+
+    expect(userApi.getMe).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(750);
+    });
+
+    expect(userApi.getMe).toHaveBeenCalledTimes(1);
+  });
+
+  it('two sequential payloads → second value lands in snapshot', async () => {
+    const mockUser1 = { _id: 'user1', firstName: 'Jules', hasAccess: false };
+    const mockUser2 = { _id: 'user1', firstName: 'Jules', hasAccess: true };
+
+    vi.mocked(userApi.getMe)
+      .mockResolvedValueOnce(mockUser1 as any)
+      .mockResolvedValueOnce(mockUser2 as any);
+
+    const { result } = renderHook(() => useRefetchSnapshotOnTurnEnd());
+
+    // First refetch
+    act(() => {
+      result.current.refetch();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(750);
+    });
+    expect(mockPatchSnapshot).toHaveBeenLastCalledWith({ currentUser: mockUser1 });
+
+    // Second refetch
+    act(() => {
+      result.current.refetch();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(750);
+    });
+    expect(mockPatchSnapshot).toHaveBeenLastCalledWith({ currentUser: mockUser2 });
+  });
+});

--- a/app/src/hooks/useRefetchSnapshotOnTurnEnd.ts
+++ b/app/src/hooks/useRefetchSnapshotOnTurnEnd.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef } from 'react';
+
+import { useCoreState } from '../providers/CoreStateProvider';
+import { userApi } from '../services/api/userApi';
+
+/**
+ * Hook to refetch the authoritative user state from the backend after a chat
+ * turn finishes. Updates the global snapshot in CoreStateProvider.
+ *
+ * Includes a 750ms debounce to collapse multiple rapid turn-finalized events.
+ */
+export function useRefetchSnapshotOnTurnEnd() {
+  const { patchSnapshot } = useCoreState();
+  const debounceTimerRef = useRef<number | null>(null);
+
+  const refetch = useCallback(() => {
+    if (debounceTimerRef.current !== null) {
+      window.clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = window.setTimeout(() => {
+      debounceTimerRef.current = null;
+
+      // Fire-and-forget on a microtask
+      void (async () => {
+        try {
+          const user = await userApi.getMe();
+          patchSnapshot({ currentUser: user });
+        } catch (error) {
+          console.warn('[useRefetchSnapshotOnTurnEnd] failed to refetch user state:', error);
+        }
+      })();
+    }, 750);
+  }, [patchSnapshot]);
+
+  return { refetch };
+}

--- a/app/src/hooks/useRefetchSnapshotOnTurnEnd.ts
+++ b/app/src/hooks/useRefetchSnapshotOnTurnEnd.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useCoreState } from '../providers/CoreStateProvider';
 import { userApi } from '../services/api/userApi';
@@ -12,6 +12,15 @@ import { userApi } from '../services/api/userApi';
 export function useRefetchSnapshotOnTurnEnd() {
   const { patchSnapshot } = useCoreState();
   const debounceTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current !== null) {
+        window.clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const refetch = useCallback(() => {
     if (debounceTimerRef.current !== null) {

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -558,6 +558,12 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
               reason: 'chat_done',
             });
             requestUsageRefresh();
+            rtLog('snapshot_refetch_queued', {
+              thread: event.thread_id,
+              request: event.request_id,
+              reason: 'chat_done',
+              path: 'proactive',
+            });
             refetchSnapshot();
             dispatch(endInferenceTurn({ threadId: event.thread_id }));
             dispatch(setActiveThread(null));
@@ -577,6 +583,12 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
           reason: 'chat_done',
         });
         requestUsageRefresh();
+        rtLog('snapshot_refetch_queued', {
+          thread: event.thread_id,
+          request: event.request_id,
+          reason: 'chat_done',
+          path: 'ordinary',
+        });
         refetchSnapshot();
         dispatch(endInferenceTurn({ threadId: event.thread_id }));
         dispatch(setActiveThread(null));

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -2,6 +2,7 @@ import debug from 'debug';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { requestUsageRefresh } from '../hooks/usageRefresh';
+import { useRefetchSnapshotOnTurnEnd } from '../hooks/useRefetchSnapshotOnTurnEnd';
 import {
   type ChatInferenceStartEvent,
   type ChatIterationStartEvent,
@@ -56,6 +57,7 @@ function rtLog(message: string, fields?: Record<string, string | number | null |
 
 const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
   const dispatch = useAppDispatch();
+  const { refetch: refetchSnapshot } = useRefetchSnapshotOnTurnEnd();
   const socketStatus = useAppSelector(selectSocketStatus);
   const toolTimelineByThread = useAppSelector(state => state.chatRuntime.toolTimelineByThread);
   const inferenceStatusByThread = useAppSelector(
@@ -556,6 +558,7 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
               reason: 'chat_done',
             });
             requestUsageRefresh();
+            refetchSnapshot();
             dispatch(endInferenceTurn({ threadId: event.thread_id }));
             dispatch(setActiveThread(null));
           })();
@@ -574,6 +577,7 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
           reason: 'chat_done',
         });
         requestUsageRefresh();
+        refetchSnapshot();
         dispatch(endInferenceTurn({ threadId: event.thread_id }));
         dispatch(setActiveThread(null));
       },
@@ -636,7 +640,7 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
       rtLog('unsubscribe_chat_events');
       cleanup();
     };
-  }, [dispatch, resolveVisibleThreadForProactive, socketStatus]);
+  }, [dispatch, resolveVisibleThreadForProactive, socketStatus, refetchSnapshot]);
 
   return <>{children}</>;
 };

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -64,6 +64,7 @@ interface CoreStateContextValue extends CoreState {
   setOnboardingCompletedFlag: (value: boolean) => Promise<void>;
   setEncryptionKey: (value: string | null) => Promise<void>;
   setPrimaryWalletAddress: (value: string | null) => Promise<void>;
+  patchSnapshot: (patch: Partial<CoreAppSnapshot>) => void;
   setOnboardingTasks: (value: CoreOnboardingTasks | null) => Promise<void>;
   storeSessionToken: (token: string, user?: object) => Promise<void>;
   clearSession: () => Promise<void>;
@@ -424,6 +425,13 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     });
   }, [commitState, refresh]);
 
+  const patchSnapshot = useCallback(
+    (patch: Partial<CoreAppSnapshot>) => {
+      commitState(previous => ({ ...previous, snapshot: { ...previous.snapshot, ...patch } }));
+    },
+    [commitState]
+  );
+
   const value = useMemo<CoreStateContextValue>(
     () => ({
       ...state,
@@ -431,6 +439,7 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       refreshTeams,
       refreshTeamMembers,
       refreshTeamInvites,
+      patchSnapshot,
       setAnalyticsEnabled,
       setOnboardingCompletedFlag,
       setEncryptionKey: value => updateLocalState({ encryptionKey: value }),
@@ -445,6 +454,7 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       refreshTeamInvites,
       refreshTeamMembers,
       refreshTeams,
+      patchSnapshot,
       setAnalyticsEnabled,
       setOnboardingCompletedFlag,
       state,

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -64,6 +64,18 @@ interface CoreStateContextValue extends CoreState {
   setOnboardingCompletedFlag: (value: boolean) => Promise<void>;
   setEncryptionKey: (value: string | null) => Promise<void>;
   setPrimaryWalletAddress: (value: string | null) => Promise<void>;
+  /**
+   * Shallow-merge `patch` into `state.snapshot`. Top-level keys in `patch`
+   * REPLACE the existing value — they are not deep-merged.
+   *
+   * This means passing a nested object (e.g. `{ localState: { encryptionKey: 'x' } }`)
+   * will CLOBBER sibling fields on that object (`primaryWalletAddress`,
+   * `onboardingTasks`). Only flat top-level fields are safe to patch directly:
+   * `currentUser`, `onboardingCompleted`, `chatOnboardingCompleted`,
+   * `analyticsEnabled`, `sessionToken`. For nested-object updates, use the
+   * dedicated setter (`setEncryptionKey`, `setPrimaryWalletAddress`,
+   * `setOnboardingTasks`) which preserves siblings.
+   */
   patchSnapshot: (patch: Partial<CoreAppSnapshot>) => void;
   setOnboardingTasks: (value: CoreOnboardingTasks | null) => Promise<void>;
   storeSessionToken: (token: string, user?: object) => Promise<void>;

--- a/app/src/providers/README.md
+++ b/app/src/providers/README.md
@@ -1,0 +1,24 @@
+# App Providers
+
+This directory contains the React context providers that manage the global state and services of the application.
+
+## CoreStateProvider
+
+Manages the authoritative global state of the application, including user authentication, session tokens, and the application snapshot.
+
+### Turn-Boundary Refetch Contract
+
+To ensure that the UI stays in sync with the backend state (especially during onboarding and context gathering), the application follows a refetch-on-turn-end contract:
+
+- **Refetch Timing**: After every agent reply completes (the `chat_done` event in `ChatRuntimeProvider`), the application refetches the authoritative user state via `userApi.getMe()`.
+- **Debounce**: Multiple rapid turn-finalized events within 750ms are collapsed into a single refetch call to avoid unnecessary network traffic.
+- **Single Source of Truth**: The refetched state is merged into the global snapshot using `patchSnapshot`. Components should bind to this global snapshot to ensure they reflect the latest backend state without requiring a full remount.
+- **Fire-and-Forget**: The refetch operation is non-blocking and fires on a microtask after the chat UI has painted the final response.
+
+## ChatRuntimeProvider
+
+Manages the live chat state, including message streaming, tool execution timeline, and subagent orchestration. It subscribes to socket events and updates the Redux store.
+
+## SocketProvider
+
+Manages the Socket.IO connection to the Rust core, providing the underlying transport for real-time chat events.

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -31,8 +31,9 @@ vi.mock('../../services/api/threadApi', () => ({
 
 vi.mock('../../hooks/usageRefresh', () => ({ requestUsageRefresh: vi.fn() }));
 
+const mockRefetchSnapshot = vi.fn();
 vi.mock('../../hooks/useRefetchSnapshotOnTurnEnd', () => ({
-  useRefetchSnapshotOnTurnEnd: () => ({ refetch: vi.fn() }),
+  useRefetchSnapshotOnTurnEnd: () => ({ refetch: mockRefetchSnapshot }),
 }));
 
 function renderProvider(): chatService.ChatEventListeners {
@@ -101,7 +102,7 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       expect(timeline[0]?.status).toBe('running');
     });
 
-    it('drops duplicate chat_done events with the same thread/request', () => {
+    it('drops duplicate chat_done events with the same thread/request', async () => {
       const listeners = renderProvider();
 
       const doneEvent: chatService.ChatDoneEvent = {
@@ -111,6 +112,7 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
         rounds_used: 1,
         total_input_tokens: 5,
         total_output_tokens: 7,
+        segment_total: 1,
       };
 
       act(() => {
@@ -123,6 +125,9 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       expect(usage.inputTokens).toBe(5);
       expect(usage.outputTokens).toBe(7);
       expect(usage.turns).toBe(1);
+
+      // Snapshot refetch fired exactly once on the first chat_done — issue #924.
+      expect(mockRefetchSnapshot).toHaveBeenCalledTimes(1);
     });
 
     it('processes tool_call for different rounds as distinct events', () => {

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -31,6 +31,10 @@ vi.mock('../../services/api/threadApi', () => ({
 
 vi.mock('../../hooks/usageRefresh', () => ({ requestUsageRefresh: vi.fn() }));
 
+vi.mock('../../hooks/useRefetchSnapshotOnTurnEnd', () => ({
+  useRefetchSnapshotOnTurnEnd: () => ({ refetch: vi.fn() }),
+}));
+
 function renderProvider(): chatService.ChatEventListeners {
   let captured: chatService.ChatEventListeners = {};
   vi.mocked(chatService.subscribeChatEvents).mockImplementation(listeners => {


### PR DESCRIPTION
## Summary

- New `useRefetchSnapshotOnTurnEnd` hook (`app/src/hooks/`) — debounced 750ms `userApi.getMe()` that merges into the global snapshot via a new `patchSnapshot` helper on `CoreStateProvider`.
- Wired into `ChatRuntimeProvider` at both `chat_done` paths (proactive-handoff branch + ordinary branch).
- Frontend-only; no Rust core, no Tauri shell, no new runtime deps, no chat-render latency change.

## Problem

Anything bound to `snapshot.currentUser.*` (the App-level onboarding gate, settings panels, billing surfaces, etc.) was driven by a one-time load. After the agent flipped state server-side — for example `onboardingCompleted: true` once the welcome flow finished — the renderer kept showing the stale value until the user navigated away and back. Issue #924 surfaced this as "context progress bars stale after agent turns; refresh from server."

## Solution

- The hook is fire-and-forget on a microtask after the chat reply paints; failures are swallowed with `console.warn` so chat rendering is never blocked.
- The 750ms debounce collapses bursts of `chat_done` events down to one `getMe()` round trip.
- `patchSnapshot` on `CoreStateProvider` is a narrow `Partial<CoreAppSnapshot>` merge that goes through the existing `commitState` reducer — there is no parallel state container.
- All consumers reading `snapshot.currentUser` via `useCoreState` automatically pick up the freshness because the centralized snapshot is the single source of truth.

### Why we did NOT rebind `ContextGatheringStep.tsx`

The original specification asked to rebind that component to the snapshot, but an audit during implementation showed the per-stage `stageStatuses` it tracks (Gmail → Apify → saveProfile) is purely client-driven — the backend has no view of the per-stage state, and `auth_get_me` does not (and should not) carry an `onboardingStatus` payload. Rebinding it would have required inventing a phantom backend field. The correct outcome is that all snapshot-bound progress surfaces (`App.tsx` onboarding gate, settings, billing, etc.) get the freshness benefit automatically because they read from the same `useCoreState` snapshot that the hook patches; `ContextGatheringStep` keeps its local pipeline state, which is the right boundary.

## Submission Checklist

- [x] **Unit tests** — Three new Vitest cases on `useRefetchSnapshotOnTurnEnd`: post-debounce refetch + patch, three rapid finalize → one `getMe()`, two-payload sequence → second value lands in snapshot. `pnpm test:unit` reports 921 passed / 4 skipped / 1 todo.
- [x] **E2E / integration** — N/A. Frontend-only; no UI → Tauri → sidecar → JSON-RPC surface introduced. The hook calls the existing `userApi.getMe()` wrapper on `openhuman.auth_get_me`.
- [x] **Doc comments** — JSDoc on the new hook; `app/src/providers/README.md` documents the contract (single source of truth, debounce window, fire-and-forget, no-toast failure).
- [x] **Inline comments** — Added only where invariants are non-obvious (debounce timer ref, microtask boundary).

## Impact

- All UI bound to `snapshot.currentUser.*` re-syncs after every agent turn without a remount; in particular the welcome-agent → onboarded transition now reflects immediately.
- One 750ms-debounced HTTP round-trip per chat turn, fired after `chat_done` paints; no chat latency regression.
- New public method `patchSnapshot` on `CoreStateProvider` for narrow snapshot merges (consumed only by the new hook today).
- No platform / migration / security implications. No Rust, Tauri shell, or dependency changes.

## Related

- Closes #924
- Follow-up PR(s)/TODOs: none required.

---

Original implementation by `google-labs-jules[bot]`; restructured into 3 GPG-signed micro-commits with the phantom-field bind dropped, broken `ChatRuntimeProvider` and `ContextGatheringStep` tests fixed, and Prettier compliance restored.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profile refresh is now queued at the end of chat turns with a 750ms debounce to avoid duplicate requests and ensure the latest data is applied; pending refreshes are cancelled on unmount.

* **Documentation**
  * Added provider architecture docs describing context and state management behaviors.

* **Tests**
  * New tests cover debounce behavior, collapse of rapid refetches into one call, sequential refresh correctness, dedupe on duplicate events, and cleanup on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->