### PR TITLE
fix(nav): hide Memory tab from bottom navigation bar

### DIFF
--- a/app/src/components/BottomTabBar.tsx
+++ b/app/src/components/BottomTabBar.tsx
@@ -53,21 +53,22 @@ const tabs = [
       </svg>
     ),
   },
-  {
-    id: 'intelligence',
-    label: 'Memory',
-    path: '/intelligence',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.8}
-          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-        />
-      </svg>
-    ),
-  },
+  // Memory tab hidden until Intelligence feature is ready (#976)
+  // {
+  //   id: 'intelligence',
+  //   label: 'Memory',
+  //   path: '/intelligence',
+  //   icon: (
+  //     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //         strokeWidth={1.8}
+  //         d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+  //       />
+  //     </svg>
+  //   ),
+  // },
   {
     id: 'notifications',
     label: 'Alerts',


### PR DESCRIPTION
## Summary

- Hides the **Memory** tab from the bottom navigation bar until the Intelligence feature is ready for release
- The `/intelligence` route and page remain intact — only the nav entry is commented out

## Test plan

- [ ] Verify the Memory tab no longer appears in the bottom navigation bar
- [ ] Verify all other tabs (Home, Chat, Connections, Alerts, Rewards, Settings) still render and navigate correctly
- [ ] Verify `/intelligence` route still works if accessed directly via URL

Closes #976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Memory tab from the bottom navigation menu to address reported issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->