### PR TITLE
docs(domains): add foundation domain READMEs (#966)

### DIFF
--- a/src/core/event_bus/README.md
+++ b/src/core/event_bus/README.md
@@ -6,7 +6,7 @@ In-process pub/sub plus typed request/response. Owns the global `EventBus` singl
 
 - `pub struct EventBus` — `bus.rs` — broadcast singleton over `tokio::sync::broadcast`.
 - `pub const DEFAULT_CAPACITY: usize = 256` — `bus.rs` — default channel capacity.
-- `pub fn init_global(capacity: usize) -> &'static EventBus` — `bus.rs` — initialize once at startup; panics if called more than once (uses `OnceLock::set`).
+- `pub fn init_global(capacity: usize) -> &'static EventBus` — `bus.rs` — initialize once at startup via `OnceLock::get_or_init`; subsequent calls return the already-initialized bus (capacity argument ignored).
 - `pub fn global() -> Option<&'static EventBus>` — `bus.rs` — accessor; returns `None` before `init_global`.
 - `pub fn publish_global(event: DomainEvent)` — `bus.rs` — fire-and-forget broadcast.
 - `pub fn subscribe_global(handler: Arc<dyn EventHandler>) -> Option<SubscriptionHandle>` — `bus.rs` — register a subscriber.

--- a/src/core/event_bus/README.md
+++ b/src/core/event_bus/README.md
@@ -6,7 +6,7 @@ In-process pub/sub plus typed request/response. Owns the global `EventBus` singl
 
 - `pub struct EventBus` — `bus.rs` — broadcast singleton over `tokio::sync::broadcast`.
 - `pub const DEFAULT_CAPACITY: usize = 256` — `bus.rs` — default channel capacity.
-- `pub fn init_global(capacity: usize) -> &'static EventBus` — `bus.rs` — initialize once at startup; safe to call repeatedly.
+- `pub fn init_global(capacity: usize) -> &'static EventBus` — `bus.rs` — initialize once at startup; panics if called more than once (uses `OnceLock::set`).
 - `pub fn global() -> Option<&'static EventBus>` — `bus.rs` — accessor; returns `None` before `init_global`.
 - `pub fn publish_global(event: DomainEvent)` — `bus.rs` — fire-and-forget broadcast.
 - `pub fn subscribe_global(handler: Arc<dyn EventHandler>) -> Option<SubscriptionHandle>` — `bus.rs` — register a subscriber.

--- a/src/core/event_bus/README.md
+++ b/src/core/event_bus/README.md
@@ -1,0 +1,44 @@
+# Event Bus
+
+In-process pub/sub plus typed request/response. Owns the global `EventBus` singleton (built on `tokio::sync::broadcast`), the `DomainEvent` enum that names every cross-module event, the `NativeRegistry` (one-to-one typed dispatch keyed by method string with zero serialization), the `EventHandler` trait + `SubscriptionHandle` RAII guard, and the bundled `TracingSubscriber` debug logger. ~33 internal call sites — every domain that emits or consumes cross-module events lives here.
+
+## Public surface
+
+- `pub struct EventBus` — `bus.rs` — broadcast singleton over `tokio::sync::broadcast`.
+- `pub const DEFAULT_CAPACITY: usize = 256` — `bus.rs` — default channel capacity.
+- `pub fn init_global(capacity: usize) -> &'static EventBus` — `bus.rs` — initialize once at startup; safe to call repeatedly.
+- `pub fn global() -> Option<&'static EventBus>` — `bus.rs` — accessor; returns `None` before `init_global`.
+- `pub fn publish_global(event: DomainEvent)` — `bus.rs` — fire-and-forget broadcast.
+- `pub fn subscribe_global(handler: Arc<dyn EventHandler>) -> Option<SubscriptionHandle>` — `bus.rs` — register a subscriber.
+- `pub enum DomainEvent` — `events.rs` — `#[non_exhaustive]` catalog of events; current variants cover Agent (`AgentTurnStarted/Completed`, `AgentError`), Memory (`MemoryStored`, `MemoryRecalled`), Channels (`ChannelInboundMessage`, `ChannelMessageReceived/Processed`, `ChannelReactionReceived/Sent`, `ChannelConnected/Disconnected`), Cron (`CronJobTriggered/Completed`, `CronDeliveryRequested`), Skills, Tools, Webhooks, and System.
+- `pub trait EventHandler` — `subscriber.rs:12-24` — `name()` + optional `domains()` filter + async `handle()`.
+- `pub struct SubscriptionHandle` — `subscriber.rs:29` — RAII; drop aborts the subscriber task.
+- `pub struct TracingSubscriber` — `tracing.rs` — built-in handler that logs every event at `debug` level.
+- `pub struct NativeRegistry` — `native_request.rs` — typed in-process request/response dispatcher keyed by method string.
+- `pub enum NativeRequestError` — `native_request.rs` — `MethodNotFound`, `TypeMismatch`, etc.
+- `pub fn init_native_registry() -> &'static NativeRegistry` / `pub fn native_registry() -> Option<&'static NativeRegistry>` / `pub fn register_native_global` / `pub fn request_native_global` — `native_request.rs`.
+- `pub mod testing` — `testing.rs` — helpers to build isolated bus / registry instances per test.
+
+## Calls into
+
+- `tokio::sync::broadcast` for the broadcast channel.
+- `async_trait` and `tokio::task::JoinHandle` for handler plumbing.
+- No openhuman-domain dependencies — this module sits below every domain.
+
+## Called by
+
+- ~33 sites across the workspace. Hot consumers:
+- `src/openhuman/agent/bus.rs`, `agent/triage/{events,evaluator,escalation}.rs`, `tools/impl/agent/{dispatch,spawn_subagent}.rs` — agent + sub-agent events.
+- `src/openhuman/memory/conversations/bus.rs` — conversation persistence subscriber.
+- `src/openhuman/channels/bus.rs` — `ChannelInboundSubscriber`.
+- `src/openhuman/cron/{bus,scheduler}.rs` — `CronDeliverySubscriber` + `CronJobTriggered` emission.
+- `src/openhuman/webhooks/bus.rs` — `WebhookRequestSubscriber`.
+- `src/openhuman/health/bus.rs` — health-event subscriber.
+- `src/openhuman/update/scheduler.rs` — update-cycle events.
+- `src/openhuman/tree_summarizer/{engine,bus}.rs` — async summarisation triggers.
+- `src/openhuman/composio/bus.rs`, `notifications/`, `learning/` — analytics fan-out.
+
+## Tests
+
+- Unit: `bus_tests.rs`, `events_tests.rs`, `native_request_tests.rs`.
+- Test infrastructure: `testing.rs` exposes helpers; many domain tests construct a fresh `NativeRegistry::new()` for isolation, or override an existing method by re-registering it.

--- a/src/openhuman/accessibility/README.md
+++ b/src/openhuman/accessibility/README.md
@@ -1,0 +1,35 @@
+# Accessibility
+
+Cross-platform accessibility middleware. Owns macOS AX / CGEvent / IOKit FFI, the unified Swift helper-process bridge, screen capture, focused-text + foreground app inspection, system-permission detection (Accessibility, Input Monitoring, Screen Recording, Microphone), the Globe-key listener, the floating overlay window, paste / backspace key synthesis, terminal heuristics, and AX-string normalization. Centralises platform-specific code so that `autocomplete`, `screen_intelligence`, and `voice` never touch FFI directly.
+
+## Public surface
+
+- `pub fn capture_screen_image_ref_for_context` / `pub enum CaptureMode` / `pub const MAX_SCREENSHOT_BYTES` — `capture.rs` — bounded screen capture.
+- `pub fn focused_text_context` / `focused_text_context_verbose` / `foreground_context` / `parse_foreground_output` / `validate_focused_target` — `focus.rs` — query the OS for the currently focused text field and frontmost app.
+- `pub fn globe_listener_start` / `globe_listener_stop` / `globe_listener_poll` / `pub struct GlobeHotkeyPollResult` / `pub enum GlobeHotkeyStatus` — `globe.rs` — macOS Globe-key (Fn) hotkey monitor.
+- `pub fn precompile_helper_background` — `helper.rs` — warm the Swift helper process at startup.
+- `pub fn any_modifier_down` / `is_escape_key_down` / `is_tab_key_down` — `keys.rs` — modifier polling for cancellation gestures.
+- `pub fn show_overlay` / `hide_overlay` / `quit_overlay` — `overlay.rs` — floating completion overlay control.
+- `pub fn apply_text_to_focused_field` / `pub fn send_backspace` — `paste.rs` — programmatic text insertion.
+- Permission detection: `detect_permissions`, `detect_microphone_permission`, `microphone_denied_message`, `permission_to_str`, `request_microphone_access` (cross-platform); macOS-only `detect_accessibility_permission`, `detect_input_monitoring_permission`, `detect_screen_recording_permission`, `open_macos_privacy_pane`, `request_accessibility_access`, `request_screen_recording_access` — `permissions.rs`.
+- `pub fn extract_terminal_input_context` / `is_terminal_app` / `is_text_role` / `looks_like_terminal_buffer` — `terminal.rs` — terminal-window heuristics.
+- `pub fn normalize_ax_value` / `parse_ax_number` / `truncate_tail` — `text_util.rs` — AX value normalization.
+- `pub struct AppContext` / `ElementBounds` / `FocusedTextContext` / `PermissionKind` / `PermissionState` / `PermissionStatus` — `types.rs`.
+
+## Calls into
+
+- macOS frameworks (`ApplicationServices`, `CoreGraphics`, `IOKit`, `AVFoundation`) via FFI.
+- Bundled Swift helper process for AX queries that require a separate process.
+- `src/openhuman/config/` — overlay sizing and helper paths (light dependency).
+
+## Called by
+
+- `src/openhuman/autocomplete/core/{terminal,text,overlay,types,focus}.rs` — focus-driven autocomplete needs every accessibility primitive.
+- `src/openhuman/screen_intelligence/{types,state,capture_worker,input,tests}.rs` — screen capture + focus context for vision pipelines.
+- `src/openhuman/voice/` — microphone permission + foreground app context (indirect, via re-exports).
+- `src/core/` — surfaces `AccessibilityStatus` snapshots for the shell.
+
+## Tests
+
+- This domain has no `*_tests.rs` siblings; coverage runs through the consumer modules' `tests.rs` (notably `screen_intelligence/tests.rs`) and integration tests in `tests/screen_intelligence_vision_e2e.rs`.
+- AX FFI surface is best validated end-to-end on a real macOS host — most CI runs are Linux and skip platform-gated paths.

--- a/src/openhuman/agent/README.md
+++ b/src/openhuman/agent/README.md
@@ -1,6 +1,6 @@
 # Agent
 
-Multi-agent orchestration domain. Owns the LLM tool-calling loop, sub-agent dispatch, conversation transcripts, and the trigger-triage pipeline that classifies incoming external events. Does NOT own provider HTTP transport (`providers/`), tool implementations (`tools/`), prompt section data (lives in `context/`), or memory storage (`memory/`).
+Multi-agent orchestration domain. Owns the LLM tool-calling loop, sub-agent dispatch, conversation transcripts, the trigger-triage pipeline that classifies incoming external events, and the bundled prompt assets in `agent/prompts/`. Does NOT own provider HTTP transport (`providers/`), tool implementations (`tools/`), prompt section assembly (lives in `context/` — which re-exports from `agent::prompts` via `context::prompt`), or memory storage (`memory/`).
 
 ## Public surface
 

--- a/src/openhuman/agent/README.md
+++ b/src/openhuman/agent/README.md
@@ -1,0 +1,44 @@
+# Agent
+
+Multi-agent orchestration domain. Owns the LLM tool-calling loop, sub-agent dispatch, conversation transcripts, and the trigger-triage pipeline that classifies incoming external events. Does NOT own provider HTTP transport (`providers/`), tool implementations (`tools/`), prompt section data (lives in `context/`), or memory storage (`memory/`).
+
+## Public surface
+
+- `pub struct Agent` / `pub struct AgentBuilder` — `harness/session/types.rs` — top-level conversation runtime; entry point for any chat turn.
+- `pub mod harness::session::{builder, runtime, turn}` — `harness/session/mod.rs:23-27` — turn lifecycle, fluent builder, `run_single` / `run_interactive`.
+- `pub fn run_subagent` / `pub struct SubagentRunOptions` / `pub enum SubagentRunError` — `harness/subagent_runner/` — execute a hierarchical sub-agent from a parent tool loop.
+- `pub struct AgentDefinition` / `pub struct AgentDefinitionRegistry` / `pub enum SandboxMode` / `pub enum ToolScope` — `harness/definition.rs` — sub-agent archetypes loaded from built-ins + workspace TOML.
+- `pub mod harness::fork_context` — `harness/fork_context.rs` — task-local parent context for KV-cache reuse.
+- `pub mod harness::interrupt` (`check_interrupt`, `InterruptFence`, `InterruptedError`) — `harness/interrupt.rs` — graceful cancellation primitives.
+- `pub trait ToolDispatcher` / `pub struct ParsedToolCall` / `pub struct ToolExecutionResult` — `dispatcher.rs:14-50` — pluggable tool-call format (XML / JSON / P-Format).
+- `pub mod triage` (`run_triage`, `apply_decision`, `TriggerEnvelope`, `TriageDecision`, `TriageAction`) — `triage/mod.rs:34-45` — classify external triggers, escalate to sub-agents.
+- `pub mod prompts::SystemPromptBuilder` — `prompts/` — system-prompt section composer.
+- `pub mod agents` — `agents/mod.rs` — built-in archetypes (orchestrator, planner, researcher, code_executor, summarizer, archivist, trigger_triage, trigger_reactor, etc.).
+- RPC `agent.chat`, `agent.chat_simple`, `agent.server_status`, `agent.list_definitions`, `agent.get_definition`, `agent.reload_definitions`, `agent.triage_evaluate` — `schemas.rs:17-158`.
+
+## Calls into
+
+- `src/openhuman/providers/` — `ChatMessage`, `ChatResponse` send/receive against LLMs.
+- `src/openhuman/tools/` — `Tool` / `ToolSpec` execution surface invoked from the tool loop.
+- `src/openhuman/memory/` — episodic indexing + memory-loader context injection.
+- `src/openhuman/context/` — prompt sections, tool-call format selection.
+- `src/openhuman/local_ai/` — `agent_chat` / `agent_chat_simple` execution backend.
+- `src/openhuman/config/` — runtime config load via `config::rpc::load_config_with_timeout`.
+- `src/core/event_bus/` — emits `DomainEvent::Agent(*)` and `Trigger*` events; subscribers in `agent/bus.rs`.
+
+## Called by
+
+- `src/openhuman/channels/runtime/dispatch.rs` and `channels/providers/web.rs` — drive chat turns from inbound channel messages.
+- `src/openhuman/cron/scheduler.rs` — fire scheduled triggers through `triage::run_triage` + `apply_decision`.
+- `src/openhuman/webhooks/ops.rs` — webhook ingestion routes through triage.
+- `src/openhuman/composio/bus.rs` — Composio trigger envelopes go through `agent::triage`.
+- `src/openhuman/notifications/rpc.rs` — surfaces agent runs to the UI.
+- `src/openhuman/learning/{reflection,tool_tracker,user_profile}.rs` — read transcripts + tool outcomes.
+- `src/openhuman/tools/impl/agent/{dispatch,spawn_subagent}.rs` — `spawn_subagent` tool delegates here.
+- `src/core/all.rs` — controller registry wires `all_agent_registered_controllers`.
+
+## Tests
+
+- Unit: `mod.rs` `#[cfg(test)] mod tests;`, `tests.rs`, `multimodal_tests.rs`, `dispatcher_tests.rs`, plus `*_tests.rs` files under `harness/`, `harness/session/`, `triage/`.
+- Integration: `tests/agent_builder_public.rs`, `tests/agent_harness_public.rs`, `tests/agent_memory_loader_public.rs`, `tests/agent_multimodal_public.rs`.
+- Schema regression: `schemas.rs:393-410` (`controller_schema_inventory_is_stable`).

--- a/src/openhuman/app_state/README.md
+++ b/src/openhuman/app_state/README.md
@@ -1,6 +1,6 @@
 # App State
 
-Aggregator the React shell polls every few seconds to render the OS-level chrome (auth user, autocomplete status, accessibility status, local-AI status, service health, onboarding tasks). Owns the on-disk `app-state.json`, an in-memory current-user cache, and the merge/patch surface for shell-managed local fields. Does NOT own any of the underlying domain state — it only assembles snapshots from peer domains and persists shell-side onboarding metadata.
+Aggregator that the React shell polls every few seconds to render the OS-level chrome (auth user, autocomplete status, accessibility status, local-AI status, service health, onboarding tasks). Owns the on-disk `app-state.json`, an in-memory current-user cache, and the merge/patch surface for shell-managed local fields. Does NOT own any of the underlying domain state — it only assembles snapshots from peer domains and persists shell-side onboarding metadata.
 
 ## Public surface
 

--- a/src/openhuman/app_state/README.md
+++ b/src/openhuman/app_state/README.md
@@ -1,0 +1,34 @@
+# App State
+
+Aggregator the React shell polls every few seconds to render the OS-level chrome (auth user, autocomplete status, accessibility status, local-AI status, service health, onboarding tasks). Owns the on-disk `app-state.json`, an in-memory current-user cache, and the merge/patch surface for shell-managed local fields. Does NOT own any of the underlying domain state — it only assembles snapshots from peer domains and persists shell-side onboarding metadata.
+
+## Public surface
+
+- `pub struct AppStateSnapshot` — `ops.rs` — composite payload returned to the shell (auth user, runtime status, autocomplete, local AI, accessibility, onboarding).
+- `pub struct RuntimeSnapshot` — `ops.rs` — runtime sub-section of the snapshot.
+- `pub struct StoredAppState` — `ops.rs` — disk schema persisted to `<workspace>/app-state.json`.
+- `pub struct StoredAppStatePatch` — `ops.rs` — partial-update payload used by `update_local_state`.
+- `pub struct StoredOnboardingTasks` — `ops.rs:42-50` — shell-tracked onboarding completion flags (accessibility permission, local model consent, etc.).
+- `pub async fn snapshot() -> Result<RpcOutcome<AppStateSnapshot>, String>` — `ops.rs` — collect the full snapshot.
+- `pub async fn update_local_state(...)` — `ops.rs` — apply a `StoredAppStatePatch`.
+- RPC `app_state.{snapshot, update_local_state}` — `schemas.rs:20-37` (re-exported via `all_app_state_controller_schemas` / `all_app_state_registered_controllers`).
+
+## Calls into
+
+- `src/openhuman/config/` — `config_rpc::*` for `Config` reads and the workspace dir resolver.
+- `src/openhuman/autocomplete/` — `AutocompleteStatus` snapshot.
+- `src/openhuman/local_ai/` — `LocalAiStatus` snapshot.
+- `src/openhuman/screen_intelligence/` — `AccessibilityStatus` snapshot.
+- `src/openhuman/service/` — `ServiceState` / `ServiceStatus` runtime info.
+- `src/openhuman/credentials/` — `session_support::build_session_state` for the auth slice.
+- `src/api/{config,jwt}` — backend base URL + bearer token used by the cached current-user fetch.
+
+## Called by
+
+- `src/openhuman/agent/harness/session/builder.rs` — agent builder reads cached app state when resolving identity.
+- `src/core/all.rs` — registers `all_app_state_*` controllers; the shell hits these via `core_rpc_relay`.
+- `app/src/` — Tauri shell consumes the snapshot in its polling loops (out of scope for this README).
+
+## Tests
+
+- This domain has no `*_tests.rs` siblings; coverage is exercised indirectly through controller-registry tests in `src/core/` and through the JSON-RPC harness `tests/json_rpc_e2e.rs`.

--- a/src/openhuman/channels/README.md
+++ b/src/openhuman/channels/README.md
@@ -1,0 +1,39 @@
+# Channels
+
+Multi-platform messaging integration. Owns the `Channel` trait, per-provider connectors (Slack, Discord, Telegram, WhatsApp, IRC, Matrix, Signal, iMessage, Email, Lark, Mattermost, DingTalk, QQ, Linq, Web, CLI), the runtime supervisor that brings channels online, inbound dispatch into the agent loop, and proactive outbound delivery. Does NOT own the channel system prompt copy (lives in `context/channels_prompt.rs`) or per-channel credential storage (delegated to `credentials/`).
+
+## Public surface
+
+- `pub trait Channel` / `pub struct SendMessage` / `pub struct ChannelMessage` — `traits.rs:5-60` — provider contract for inbound + outbound messages.
+- `pub struct ChannelDefinition` / `pub enum ChannelAuthMode` — `controllers/definitions.rs` (re-exported `mod.rs:59`) — declarative provider metadata.
+- `pub fn start_channels` — `runtime/startup.rs` (re-exported `mod.rs:65`) — boot all enabled channels under the supervisor.
+- `pub fn doctor_channels` — `commands.rs` — diagnose connectivity for the doctor CLI.
+- `pub fn build_system_prompt` — re-exported from `crate::openhuman::context::channels_prompt`.
+- Per-provider channel structs: `pub struct CliChannel`, `DingTalkChannel`, `DiscordChannel`, `EmailChannel`, `IMessageChannel`, `IrcChannel`, `LarkChannel`, `LinqChannel`, `MattermostChannel`, `QQChannel`, `SignalChannel`, `SlackChannel`, `TelegramChannel`, `WhatsAppChannel` — `providers/<name>.rs`. Cargo-feature-gated: `MatrixChannel` (`channel-matrix`), `WhatsAppWebChannel` (`whatsapp-web`).
+- Stable `pub use providers::<name>` paths for every provider — `mod.rs:18-36`.
+- RPC `channels.{list, describe, connect, disconnect, status, test, telegram_login_start, telegram_login_check, discord_link_start, discord_link_check, discord_list_guilds, discord_list_channels, discord_check_permissions, send_message, send_reaction, create_thread, update_thread, list_threads}` — `controllers/schemas.rs`.
+
+## Calls into
+
+- `src/openhuman/agent/` — inbound messages spawn or resume agent runs through `runtime/dispatch.rs`.
+- `src/openhuman/credentials/` — per-channel auth tokens, refresh flow.
+- `src/openhuman/config/schema/channels.rs` — runtime channel configuration.
+- `src/openhuman/threads/` — thread state for platforms with native threading (Slack `thread_ts`).
+- `src/openhuman/notifications/` — surface inbound deliveries to the UI.
+- `src/openhuman/encryption/` — at-rest secret protection.
+- `src/core/event_bus/` — emits `DomainEvent::Channel(*)`; `channels/bus.rs` registers `ChannelInboundSubscriber`.
+
+## Called by
+
+- `src/openhuman/threads/ops.rs` — thread lifecycle uses channel send paths.
+- `src/openhuman/memory/conversations/bus.rs` — persists incoming channel messages as conversation memories.
+- `src/openhuman/cron/bus.rs` — scheduled triggers can post via channels.
+- `src/openhuman/config/schema/channels.rs` — config layer references channel types for validation.
+- `src/core/all.rs` — controller registry wiring.
+
+## Tests
+
+- Unit: `bus_tests.rs`, `routes_tests.rs`, plus per-provider `*_tests.rs` (`email_channel_tests.rs`, `imessage_tests.rs`, `irc_tests.rs`, `lark_tests.rs`, `linq_tests.rs`, `matrix_tests.rs`, `mattermost_tests.rs`, `qq_tests.rs`, `signal_tests.rs`, `web_tests.rs`, `whatsapp_tests.rs`, `whatsapp_web_tests.rs`, `presentation_tests.rs`).
+- Cross-channel integration tests: `tests/discord_integration.rs`, `tests/telegram_integration.rs`, `tests/runtime_dispatch.rs`, `tests/common.rs`.
+- Telegram channel-level: `providers/telegram/channel_tests.rs`.
+- Controller tests: `controllers/{definitions_tests,ops_tests,schemas_tests}.rs`.

--- a/src/openhuman/config/README.md
+++ b/src/openhuman/config/README.md
@@ -1,0 +1,34 @@
+# Config
+
+Authoritative TOML-backed configuration layer. Owns the `Config` schema (every domain section: agent, channels, memory, autonomy, voice, scheduler, observability, etc.), env-variable overrides, the per-user openhuman directory layout, runtime proxy settings, the daemon descriptor, and the settings CLI. Roughly 177 internal consumers — almost every other domain reads `Config` here.
+
+## Public surface
+
+- `pub struct Config` — `schema/types.rs` (re-exported `mod.rs:28`) — top-level user settings.
+- Per-domain config structs (re-exported `mod.rs:28-39`): `AgentConfig`, `AuditConfig`, `AutocompleteConfig`, `AutonomyConfig`, `BrowserComputerUseConfig`, `BrowserConfig`, `ChannelsConfig`, `ComposioConfig`, `ContextConfig`, `CostConfig`, `CronConfig`, `CurlConfig`, `DelegateAgentConfig`, `DictationConfig`, `DiscordConfig`, `DockerRuntimeConfig`, `EmbeddingRouteConfig`, `GitbooksConfig`, `HeartbeatConfig`, `HttpRequestConfig`, `IMessageConfig`, `IntegrationsConfig`, `LarkConfig`, `LearningConfig`, `LocalAiConfig`, `MatrixConfig`, `MemoryConfig`, `ModelRouteConfig`, `MultimodalConfig`, `ObservabilityConfig`, `ProxyConfig`, `ReliabilityConfig`, `ResourceLimitsConfig`, `RuntimeConfig`, `SandboxConfig`, `SchedulerConfig`, `ScreenIntelligenceConfig`, `SecretsConfig`, `SecurityConfig`, `SlackConfig`, `StorageConfig`, `TelegramConfig`, `UpdateConfig`, `VoiceServerConfig`, `WebSearchConfig`, `WebhookConfig`.
+- Enums: `DictationActivationMode`, `IntegrationToggle`, `ProxyScope`, `ReflectionSource`, `SandboxBackend`, `StorageProviderConfig`, `StorageProviderSection`, `StreamMode`, `VoiceActivationMode`.
+- Model constants: `DEFAULT_MODEL`, `MODEL_AGENTIC_V1`, `MODEL_CODING_V1`, `MODEL_REASONING_V1`.
+- `pub struct DaemonConfig` — `daemon.rs` — sidecar lifecycle / port descriptor.
+- `pub fn apply_runtime_proxy_to_builder` / `pub fn build_runtime_proxy_client` / `pub fn build_runtime_proxy_client_with_timeouts` / `pub fn runtime_proxy_config` / `pub fn set_runtime_proxy_config` — `schema/proxy.rs`.
+- Workspace identity helpers: `pub fn clear_active_user`, `default_root_openhuman_dir`, `pre_login_user_dir`, `read_active_user_id`, `user_openhuman_dir`, `write_active_user_id`, `PRE_LOGIN_USER_ID` — `schema/identity_cost.rs`.
+- `pub mod ops` (re-exported as `rpc`) — `ops.rs` — RPC handlers and settings mutation.
+- `pub mod settings_cli` — `settings_cli.rs` — `openhuman settings ...` CLI surface.
+- RPC `config.{get_config, update_model_settings, update_memory_settings, update_screen_intelligence_settings, update_runtime_settings, update_browser_settings, resolve_api_url, get_runtime_flags, set_browser_allow_all, workspace_onboarding_flag_exists, workspace_onboarding_flag_set, update_analytics_settings, get_analytics_settings, agent_server_status, reset_local_data, get_onboarding_completed, get_dictation_settings, update_dictation_settings, get_voice_server_settings, update_voice_server_settings, set_onboarding_completed}` — `schemas.rs`.
+
+## Calls into
+
+- Std + serde TOML for serialization.
+- `src/openhuman/encryption/` indirectly when secrets sections need at-rest crypto (read direction only).
+- Filesystem under `~/.openhuman/<user-id>/` via `schema/identity_cost.rs`.
+
+## Called by
+
+- ~177 sites across the workspace — every domain pulls `Config` for its slice.
+- Hot consumers: `src/openhuman/agent/` (model + autonomy), `src/openhuman/channels/` (provider tokens), `src/openhuman/memory/` (storage paths), `src/openhuman/cron/` (scheduler poll), `src/openhuman/local_ai/` (Ollama / device routing), `src/openhuman/security/` (sandbox backend), `src/openhuman/voice/`, `src/openhuman/notifications/`, `src/openhuman/tools/`, `src/openhuman/encryption/`, `src/openhuman/tree_summarizer/`, `src/openhuman/referral/`.
+- `src/core/all.rs` — registers `all_config_*`.
+
+## Tests
+
+- Unit: `ops_tests.rs`, `schemas_tests.rs`, plus per-section `*_tests.rs` under `schema/` (`channels_tests.rs`, `load_tests.rs`, `proxy_tests.rs`).
+- Cross-test serialization: `schema/load.rs` round-trips against `schema/defaults.rs`.
+- `TEST_ENV_LOCK` (`mod.rs:55`) is shared with sibling test modules that mutate `OPENHUMAN_WORKSPACE`.

--- a/src/openhuman/cron/README.md
+++ b/src/openhuman/cron/README.md
@@ -1,0 +1,34 @@
+# Cron
+
+Scheduled-job runtime. Owns cron-expression and human-delay parsing, the persistent job + run store, the polling scheduler that fires due jobs (`shell` and `agent` types), and the delivery layer that publishes events into the agent / channel pipelines. Does NOT own the actual agent execution (`agent::triage`) or shell sandboxing (`security::SecurityPolicy`).
+
+## Public surface
+
+- `pub struct CronJob` / `pub struct CronJobPatch` / `pub struct CronRun` / `pub enum JobType` / `pub enum Schedule` / `pub enum SessionTarget` / `pub struct DeliveryConfig` — `types.rs:1-100` — durable job + run model.
+- `pub fn add_once` / `pub fn add_once_at` / `pub fn parse_human_delay` / `pub fn pause_job` / `pub fn resume_job` / `pub fn update_cron_job` — `ops.rs` (re-exported `mod.rs:12`).
+- `pub fn schedule_cron_expression` / `pub fn next_run_for_schedule` / `pub fn normalize_expression` / `pub fn validate_schedule` — `schedule.rs` (re-exported `mod.rs:14-16`).
+- `pub fn add_job` / `pub fn add_agent_job` / `pub fn add_agent_job_with_definition` / `pub fn add_shell_job` / `pub fn due_jobs` / `pub fn get_job` / `pub fn list_jobs` / `pub fn list_runs` / `pub fn record_last_run` / `pub fn record_run` / `pub fn remove_job` / `pub fn reschedule_after_run` / `pub fn update_job` — `store.rs` (re-exported `mod.rs:22-26`).
+- `pub mod scheduler` (`pub async fn run(config: Config)`) — `scheduler.rs:19` — main poll loop.
+- `pub mod seed` — `seed.rs` — install built-in jobs on first launch.
+- `pub mod bus` — `bus.rs` — `CronDeliverySubscriber` for the event bus.
+- RPC `cron.{add, list, update, remove, run, runs}` — `schemas.rs` (re-exported via `all_cron_controller_schemas` / `all_cron_registered_controllers`).
+
+## Calls into
+
+- `src/openhuman/agent/` — `agent` job type runs through `agent::triage::TriggerEnvelope::from_cron` + `apply_decision`.
+- `src/openhuman/security/` — `SecurityPolicy::from_config` sandboxes shell jobs.
+- `src/openhuman/config/` — `Config` provides poll interval, workspace dir, autonomy policy.
+- `src/openhuman/health/` — `health::bus::register_health_subscriber` on startup.
+- `src/openhuman/channels/` — `bus.rs` can fan delivery events into channels.
+- `src/core/event_bus/` — `init_global`, `publish_global(DomainEvent::Cron(*))`.
+
+## Called by
+
+- `src/openhuman/tools/impl/system/schedule.rs` — `schedule` tool exposes cron operations to agents.
+- `src/core/all.rs` — controller registry wires `all_cron_*`.
+- Channel and agent runtimes consume `Cron` events via the bus.
+
+## Tests
+
+- Unit: `ops_tests.rs`, `scheduler_tests.rs`, `store_tests.rs`.
+- Schema/parsing coverage lives inside `schedule.rs` and `schemas.rs` `#[cfg(test)] mod tests` blocks.

--- a/src/openhuman/encryption/README.md
+++ b/src/openhuman/encryption/README.md
@@ -1,0 +1,31 @@
+# Encryption
+
+AES-256-GCM at-rest crypto for AI memory storage and the encrypt/decrypt RPC surface. Owns the encrypted-payload format, Argon2id password-derived keys, and the data-directory resolver. The `encrypt_secret` / `decrypt_secret` RPCs are thin shims that delegate to the credentials domain — this module is intentionally small and composable, not a key-management service.
+
+## Public surface
+
+- `pub struct EncryptedPayload` — `core.rs:18-26` — `{ ciphertext, nonce, salt }` triple persisted to disk.
+- `pub struct EncryptionKey` — `core.rs:29-32` — `[u8; 32]` AES-256 key wrapper.
+- `impl EncryptionKey::derive(password: &str, salt: &[u8]) -> Result<Self, String>` — `core.rs:35` — Argon2id with parameters `m=65536, t=3, p=1`.
+- `pub fn get_data_dir() -> Result<PathBuf, String>` — `core.rs` — resolve the encrypted-data directory under the openhuman workspace.
+- `pub async fn encrypt_secret(config: &Config, plaintext: &str) -> Result<RpcOutcome<String>, String>` — `ops.rs:6` — RPC handler, delegates to `credentials::rpc::encrypt_secret`.
+- `pub async fn decrypt_secret(config: &Config, ciphertext: &str) -> Result<RpcOutcome<String>, String>` — `ops.rs:13` — RPC handler, delegates to `credentials::rpc::decrypt_secret`.
+- RPC `encryption.{encrypt_secret, decrypt_secret}` — `schemas.rs` (re-exported via `all_encryption_controller_schemas` / `all_encryption_registered_controllers`).
+- Constants: `SALT_LENGTH = 16`, `NONCE_LENGTH = 12`, `KEY_LENGTH = 32` (private but stable parameters).
+
+## Calls into
+
+- `argon2` crate for `Argon2id` password-derived keys.
+- `aes-gcm` crate for `Aes256Gcm` AEAD.
+- `src/openhuman/config/` — `Config` for workspace-relative data directory.
+- `src/openhuman/credentials/` — `credentials::rpc::{encrypt_secret, decrypt_secret}` carry the actual key-management responsibility.
+
+## Called by
+
+- `src/openhuman/credentials/` — uses the same `EncryptedPayload` / `EncryptionKey` primitives directly when storing per-channel secrets.
+- `src/core/all.rs` — registers `all_encryption_*` controllers so the shell + CLI can encrypt configuration secrets.
+- Indirect: `src/openhuman/memory/`, `src/openhuman/channels/`, and `src/openhuman/local_ai/` rely on the credentials domain (which in turn uses this layer) for secrets at rest.
+
+## Tests
+
+- This domain has no `*_tests.rs` siblings; the underlying crypto round-trips are exercised by `src/openhuman/security/secrets_tests.rs` and the credentials tests, which both cover encrypt/decrypt happy paths and tampered-ciphertext rejection.

--- a/src/openhuman/local_ai/README.md
+++ b/src/openhuman/local_ai/README.md
@@ -1,0 +1,40 @@
+# Local AI
+
+On-device inference stack. Owns the bundled Ollama runtime, whisper.cpp speech-to-text, Piper text-to-speech, sentiment scoring, vision-embedding routing, the model preset / device-profile chooser, asset download + install management, the GIF-decision heuristic, and the per-session `LocalAiService` singleton. Does NOT own remote-provider HTTP transport (`providers/`) or the agent tool loop (`agent/`).
+
+## Public surface
+
+- `pub struct LocalAiService` — `service/mod.rs` — singleton holding Ollama / whisper / Piper handles.
+- `pub fn global(config: &Config) -> Arc<LocalAiService>` — `core.rs` — singleton accessor.
+- `pub fn model_artifact_path(config: &Config) -> PathBuf` — `core.rs` — resolve on-disk model path.
+- `pub struct DeviceProfile` — `device.rs` — RAM / VRAM / CPU classification used for preset selection.
+- `pub struct ModelPreset` / `pub enum ModelTier` / `pub enum VisionMode` — `presets.rs` — bundled preset matrix.
+- `pub struct SentimentResult` — `sentiment.rs` — polarity + magnitude scoring.
+- `pub struct GifDecision` / `pub struct TenorGifResult` / `pub struct TenorSearchResult` — `gif_decision.rs`.
+- Status / progress / result types: `pub struct LocalAiStatus`, `LocalAiAssetStatus`, `LocalAiAssetsStatus`, `LocalAiDownloadProgressItem`, `LocalAiDownloadsProgress`, `LocalAiEmbeddingResult`, `LocalAiSpeechResult`, `LocalAiTtsResult` — `types.rs`.
+- `pub mod ops` (re-exported as `rpc`) — `ops.rs` — typed Rust wrappers around each capability (`agent_chat`, `agent_chat_simple`, `summarize`, `prompt`, `vision_prompt`, `embed`, `transcribe`, `tts`, `should_react`, `analyze_sentiment`, `should_send_gif`, `tenor_search`).
+- RPC `local_ai.{agent_chat, agent_chat_simple, local_ai_status, local_ai_download, local_ai_download_all_assets, local_ai_summarize, local_ai_prompt, local_ai_vision_prompt, local_ai_embed, local_ai_transcribe, local_ai_transcribe_bytes, local_ai_tts, local_ai_assets_status, local_ai_downloads_progress, local_ai_download_asset, local_ai_device_profile, local_ai_presets, local_ai_apply_preset, local_ai_diagnostics, local_ai_set_ollama_path, local_ai_chat, local_ai_should_react, local_ai_analyze_sentiment, local_ai_should_send_gif, local_ai_tenor_search}` — `schemas.rs`.
+
+## Calls into
+
+- `src/openhuman/config/` — model paths, Ollama URL override, device-profile inputs.
+- `src/openhuman/encryption/` — Tenor / asset keys at rest.
+- Bundled binaries: Ollama (HTTP `OLLAMA_BASE_URL`), whisper.cpp, Piper.
+- HTTP for Tenor GIF search.
+- Filesystem under `~/.openhuman/local-ai/` for downloaded model artifacts.
+
+## Called by
+
+- `src/openhuman/agent/` — `local_ai::rpc::agent_chat` / `agent_chat_simple` are the primary chat backends; triage uses `agent::triage::routing` to decide local vs remote.
+- `src/openhuman/voice/{streaming,postprocess,ops,types}.rs` — speech-to-text + text-to-speech.
+- `src/openhuman/screen_intelligence/processing_worker.rs` — vision embedding + summarisation.
+- `src/openhuman/autocomplete/core/engine.rs` — local-AI completions.
+- `src/openhuman/tree_summarizer/ops.rs` — summarisation backend.
+- `src/openhuman/app_state/ops.rs` — `LocalAiStatus` snapshot.
+- `src/core/all.rs` — registers `all_local_ai_*`.
+
+## Tests
+
+- Unit: `ops_tests.rs`, `schemas_tests.rs`, plus `service/ollama_admin_tests.rs`, `service/public_infer_tests.rs`.
+- Domain mutex: `LOCAL_AI_TEST_MUTEX` (`mod.rs:4`) serializes tests that mutate the singleton or env vars.
+- Routing: `agent/triage/routing_tests.rs` covers local-vs-remote escalation.

--- a/src/openhuman/memory/README.md
+++ b/src/openhuman/memory/README.md
@@ -1,0 +1,38 @@
+# Memory
+
+Persistent knowledge layer. Owns the unified store (SQLite + FTS5 + vector embeddings + graph relations), document ingestion pipelines, namespace + KV operations, conversation history, and retrieval scoring. Does NOT own raw provider embedding APIs (`local_ai/`), agent prompt assembly (`agent/memory_loader.rs`), or per-channel ingestion adapters beyond the bundled Slack importer.
+
+## Public surface
+
+- `pub trait Memory` / `pub struct MemoryEntry` / `pub enum MemoryCategory` / `pub struct RecallOpts` — `traits.rs:11-100` — backend contract for any memory store.
+- `pub struct UnifiedMemory` — `store/unified/` (re-exported `store/mod.rs:40`) — primary SQLite + FTS5 + vector implementation.
+- `pub struct MemoryClient` / `pub struct MemoryClientRef` / `pub enum MemoryState` — `store/client.rs` — async client handle used by RPC handlers.
+- `pub fn create_memory` / `pub fn create_memory_with_storage` / `pub fn create_memory_with_storage_and_routes` / `pub fn create_memory_for_migration` — `store/factories.rs` — bootstrap a memory instance.
+- `pub struct MemoryIngestionRequest` / `pub struct MemoryIngestionResult` / `pub struct MemoryIngestionConfig` / `pub enum ExtractionMode` / `pub struct ExtractedEntity` / `pub struct ExtractedRelation` / `const DEFAULT_MEMORY_EXTRACTION_MODEL` — `ingestion.rs` (re-exported `mod.rs:22`).
+- `pub struct IngestionQueue` / `pub struct IngestionJob` — `ingestion_queue.rs` — async background ingestion worker.
+- `pub struct NamespaceDocumentInput` / `pub struct NamespaceMemoryHit` / `pub struct NamespaceQueryResult` / `pub struct NamespaceRetrievalContext` / `pub struct RetrievalScoreBreakdown` / `pub enum MemoryItemKind` — `store/types.rs`.
+- RPC `memory.{init, list_documents, list_namespaces, delete_document, query_namespace, recall_context, recall_memories, list_files, read_file, write_file, namespace_list, doc_put, doc_ingest, doc_list, doc_delete, context_query, context_recall, kv_set, kv_get, kv_delete, kv_list_namespace, graph_upsert, graph_query, clear_namespace}` — `schemas.rs:29-55`.
+- RPC tree `memory.tree.*` and retrieval — `tree/` (re-exported via `all_memory_tree_*` / `all_retrieval_*`).
+- RPC slack ingestion — `slack_ingestion/` (re-exported via `all_slack_ingestion_*`).
+
+## Calls into
+
+- `src/openhuman/local_ai/` — embedding model, sentiment scoring, extraction LLM.
+- `src/openhuman/embeddings/` — vector backend selection.
+- `src/openhuman/config/` — memory backend choice + filesystem paths.
+- `src/openhuman/encryption/` — at-rest secrets for KV namespaces.
+- `src/core/event_bus/` — emits `DomainEvent::Memory(*)` on ingestion / mutation.
+
+## Called by
+
+- `src/openhuman/agent/` (`memory_loader.rs`, `harness/memory_context.rs`, `harness/archivist*.rs`, `harness/fork_context.rs`) — context injection and episodic indexing.
+- `src/openhuman/learning/{reflection,tool_tracker,user_profile,prompt_sections}.rs` — long-term insight storage.
+- `src/openhuman/screen_intelligence/{helpers,tests}.rs` — recall surfaces for visual context.
+- `src/openhuman/autocomplete/history.rs` — query-history recall.
+- `src/openhuman/tools/ops.rs` and `tools/impl/system/tool_stats.rs` — memory-backed tool stats.
+- `src/core/all.rs` — registers `all_memory_*` controllers.
+
+## Tests
+
+- Unit: `ops_tests.rs`, `schemas_tests.rs`, `rpc_models_tests.rs`, `ingestion_tests.rs`, plus `*_tests.rs` files inside `store/`, `tree/`, `conversations/`, `slack_ingestion/`.
+- Integration: `tests/autocomplete_memory_e2e.rs`, `tests/memory_graph_sync_e2e.rs`.

--- a/src/openhuman/security/README.md
+++ b/src/openhuman/security/README.md
@@ -1,0 +1,38 @@
+# Security
+
+Trust boundary for the autonomous core. Owns the autonomy / risk policy, sandbox backends (Docker, Bubblewrap, Firejail, Landlock, Noop), the audit log of agent actions, the encrypted secret store, the public-bind / pairing guard, and the `redact()` helper used for safe logging. Does NOT own the cross-domain `EncryptionEngine` (lives in `encryption/`) or per-channel credential storage (`credentials/`).
+
+## Public surface
+
+- `pub struct SecurityPolicy` — `policy.rs` — assemble runtime policy from `AutonomyConfig` + workspace dir.
+- `pub enum AutonomyLevel` — `policy.rs` — `Supervised` / `SemiAutonomous` / `Autonomous`.
+- `pub enum CommandRiskLevel` / `pub enum ToolOperation` / `pub struct ActionTracker` — `policy.rs` — risk classification and per-session tracking.
+- `pub trait Sandbox` / `pub struct NoopSandbox` — `traits.rs` — pluggable sandbox abstraction.
+- `pub fn create_sandbox(config: &SecurityConfig) -> Arc<dyn Sandbox>` — `detect.rs:1` — pick the best backend for the host.
+- Sandbox backends: `pub mod docker`, `pub mod bubblewrap`, `pub mod firejail`, `pub mod landlock` — domain-specific implementations of `Sandbox`.
+- `pub struct SecretStore` — `secrets.rs` — XOR / OS-keychain encrypted secret persistence with round-trip helpers.
+- `pub struct AuditLogger` / `pub enum AuditEventType` / `pub struct AuditEvent` / `pub struct Actor` / `pub struct Action` / `pub struct ExecutionResult` / `pub struct SecurityContext` / `pub struct CommandExecutionLog` — `audit.rs` — append-only audit trail.
+- `pub struct PairingGuard` / `pub fn constant_time_eq` / `pub fn is_public_bind` — `pairing.rs` — pairing-token check before binding the RPC server publicly.
+- `pub fn redact(value: &str) -> String` — `core.rs:3` — uniform 4-char-prefix redaction for logs.
+- `pub fn security_policy_info() -> RpcOutcome<serde_json::Value>` — `ops.rs` — RPC handler used by the doctor / settings UI.
+
+## Calls into
+
+- `src/openhuman/config/` — `SecurityConfig`, `AutonomyConfig` for policy + sandbox selection.
+- OS-level sandbox tools — `docker`, `bwrap`, `firejail`, `landlock` syscalls (per backend).
+- Filesystem under the workspace dir for the audit log + secrets store.
+
+## Called by
+
+- `src/openhuman/cron/scheduler.rs` — wraps shell jobs in `SecurityPolicy::from_config`.
+- `src/openhuman/tools/local_cli.rs`, `tools/ops.rs`, and most `tools/impl/{system,network,memory,agent}/*.rs` — every executable tool consults `SecurityPolicy`.
+- `src/openhuman/tools/impl/network/{curl,http_request,composio}.rs` — risk-classify outbound calls.
+- `src/openhuman/tools/impl/memory/{store,forget}.rs` — sensitive-write tracking.
+- `src/openhuman/tools/impl/agent/delegate.rs` — sub-agent dispatch goes through autonomy gate.
+- `src/openhuman/credentials/` — uses `SecretStore` and `redact`.
+
+## Tests
+
+- Unit: `pairing_tests.rs`, `policy_tests.rs`, `secrets_tests.rs`.
+- `core.rs` `#[cfg(test)] mod tests` — round-trips `SecretStore` encrypt/decrypt, `redact()` cases, `PairingGuard` defaults.
+- Sandbox-backend smoke: each backend file has its own `#[cfg(test)]` blocks where the binary is available.

--- a/src/openhuman/skills/README.md
+++ b/src/openhuman/skills/README.md
@@ -1,6 +1,6 @@
 # Skills
 
-Discovery, parsing, and per-turn injection of agentskills.io-style skills (a directory containing `SKILL.md` with YAML frontmatter and Markdown instructions). Owns scope resolution (User vs Project vs Legacy), trust-marker enforcement, resource reading, install / uninstall, and the matching heuristic that decides which `SKILL.md` body to splice into a chat turn. Does NOT own the QuickJS-based runtime (removed) or general tool execution (`tools/`).
+Discovery, parsing, and per-turn injection of agentskills.io-style skills (a directory containing `SKILL.md` with YAML frontmatter and Markdown instructions). Owns scope resolution (User vs Project vs Legacy), trust-marker enforcement, resource reading, install / uninstall, and the matching heuristic that decides which `SKILL.md` body to splice into a chat turn. Does NOT own runtime execution internals (the `rquickjs` engine that runs skill JS lives elsewhere) or general tool execution (`tools/`).
 
 ## Public surface
 

--- a/src/openhuman/skills/README.md
+++ b/src/openhuman/skills/README.md
@@ -1,0 +1,35 @@
+# Skills
+
+Discovery, parsing, and per-turn injection of agentskills.io-style skills (a directory containing `SKILL.md` with YAML frontmatter and Markdown instructions). Owns scope resolution (User vs Project vs Legacy), trust-marker enforcement, resource reading, install / uninstall, and the matching heuristic that decides which `SKILL.md` body to splice into a chat turn. Does NOT own the QuickJS-based runtime (removed) or general tool execution (`tools/`).
+
+## Public surface
+
+- `pub enum SkillScope` — `ops.rs:42-58` — discovery scope (`User` / `Project` / `Legacy`); decides precedence on name collision.
+- `pub const MAX_SKILL_RESOURCE_BYTES: u64 = 128 * 1024` — `ops.rs:39` — bound on per-resource RPC payload.
+- `pub use ops::*` — `mod.rs:9` — re-exports skill discovery, parsing, install, uninstall, resource reading, and frontmatter types.
+- `pub struct ToolResult` / `pub enum ToolContent` — `types.rs:7-60` — content blocks returned by skill / tool execution.
+- `pub mod inject` — `inject.rs` — per-turn `SKILL.md` body matching + injection into the user prompt (explicit `@name`, tag / description / name substring, with an 8 KiB injected-byte cap).
+- `pub mod bus` — `bus.rs` — emits skill events on the global event bus.
+- RPC `skills.{skills_list, skills_read_resource, skills_create, skills_install_from_url, skills_uninstall}` — `schemas.rs` (re-exported `all_skills_controller_schemas` / `all_skills_registered_controllers` via `mod.rs:10`).
+
+## Calls into
+
+- `src/openhuman/config/` — workspace path resolution and trust-marker location.
+- `src/openhuman/agent/` — injection consumers in `agent/prompts/` and `agent/harness/session/turn.rs`.
+- `src/openhuman/workspace/` — workspace-relative skill paths.
+- `src/core/event_bus/` — emits `DomainEvent::Skill(*)` on install / uninstall.
+
+## Called by
+
+- `src/openhuman/tools/traits.rs` — `ToolResult` / `ToolContent` shape shared with the tool registry.
+- `src/openhuman/workspace/ops.rs` — workspace bootstrap touches the skill directory layout.
+- `src/openhuman/agent/agents/integrations_agent/prompt.rs` — integrations agent reads the skill catalog.
+- `src/openhuman/agent/harness/fork_context.rs` — fork context propagates injected skills.
+- `src/openhuman/agent/harness/session/turn.rs` — per-turn injection point.
+- `src/openhuman/agent/prompts/{mod,types}.rs` — render `## Available Skills` catalog section.
+- `src/core/all.rs` — controller registry wiring.
+
+## Tests
+
+- Unit: tests live alongside `ops.rs`, `inject.rs`, `schemas.rs`, and `types.rs` as `#[cfg(test)] mod tests` blocks (no separate `*_tests.rs` files in this domain).
+- Cross-cutting agent + skill behavior is covered indirectly by `src/openhuman/agent/harness/session/{turn,runtime}_tests.rs`.


### PR DESCRIPTION
## Summary

- 12 NEW domain READMEs at strict 5-section template (Responsibility / Public surface / Calls into / Called by / Tests).
- Domains covered: agent, memory, channels, skills, cron, config, app_state, security, accessibility, local_ai, encryption, plus core/event_bus.
- 446 lines total across 12 files (31-44 lines each).

## Problem

Foundation domains under \`src/openhuman/<domain>/\` and \`src/core/event_bus/\` had no per-domain README. Engineers landing in a domain dir had to read \`mod.rs\` + \`schemas.rs\` + grep consumers themselves to build a mental model — every time. Sub-issue of #773 asked for one README per domain so this work happens once and stays current with the source.

## Solution

Each README follows a fixed template:
- One-paragraph responsibility statement.
- Public surface — bulleted list of \`pub\` items + RPC methods with \`file:line\` refs.
- Calls into — other domains this one depends on.
- Called by — code paths that import from this domain (consumer grep).
- Tests — pointer to unit / integration / Vitest coverage.

Content is grounded in actual source: \`pub fn\`, \`pub struct\`, \`pub trait\`, \`pub enum\`, \`pub use\` were enumerated from each domain's top-level \`*.rs\` files; consumer lists from \`use crate::openhuman::<domain>::\` greps.

## Submission Checklist

- [x] Tests added or updated — N/A: docs-only PR, no code changes.
- [x] Coverage matrix updated — N/A: no feature rows added/removed/renamed; READMEs are reference docs, not test layer changes.
- [ ] All affected feature IDs from the matrix are listed under \`## Related\` — N/A: no matrix rows touched.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface changes.
- [x] Linked issue closed via \`Closes #NNN\`.

## Impact

- **Runtime**: zero. Markdown only.
- **Build**: zero. No \`Cargo.toml\` / \`package.json\` touched.
- **Reviewer effort**: 12 short additive files, each independently reviewable.
- **Lychee**: once #965 lands, the new pr-quality.yml link-check job will validate the relative refs across all 12 READMEs.

## Related

- Closes #966
- Parent epic: #773
- Depends on (for CI gate): #965 (lychee glob includes \`src/**/README.md\`)
- Follow-up: encryption domain is a thin shim over credentials/ — candidate for refactor (separate PR, not blocking).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README docs for twelve core modules (event bus, accessibility, agent orchestration, app state, channels, config, cron, encryption, local AI, memory, security, skills), detailing each module’s responsibilities, public API/RPC surfaces, integration points, testing guidance, and examples for consumers (including event/request patterns and accessibility/agent behavior summaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->