### PR TITLE
docs(release): add manual smoke checklist (#971)

### DIFF
--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -1,0 +1,73 @@
+# Release Manual Smoke Checklist
+
+Run this checklist on every release-cut. Sign-off lives in the release PR description (paste the checklist with checked items + the sign-off block at the bottom). Owns OS-level surfaces that drivers cannot assert — everything else is automated under WDIO, Vitest, or Rust integration tests (see [`TESTING-STRATEGY.md`](./TESTING-STRATEGY.md)).
+
+This is the **only** acceptable substitute for a `🚫` row in [`TEST-COVERAGE-MATRIX.md`](./TEST-COVERAGE-MATRIX.md). If a feature has neither automated coverage nor an entry on this checklist, treat it as untested and open a coverage gap.
+
+---
+
+## How to use
+
+1. Build the release artifact for each platform you ship.
+2. On a clean machine (or fresh user account), walk through `## Per-release smoke` then the section for the active release line.
+3. Tick each box only after you have verified the expected outcome with your own eyes.
+4. Paste the completed checklist + sign-off block into the release PR description.
+5. Any item that is genuinely not applicable for this release: mark `N/A` with a one-line reason; do not silently skip.
+
+---
+
+## Per-release smoke
+
+Applies to every release, all platforms.
+
+### macOS
+
+- [ ] **Gatekeeper accepts the signed `.app` on first launch** — Double-click the `.app` from a fresh download (Quarantine attribute set). Expected: app opens without `"OpenHuman" cannot be opened because the developer cannot be verified` dialog. If it appears, the build is unsigned or the notarization stapler is missing.
+- [ ] **`codesign --verify --deep --strict <path-to-OpenHuman.app>` exits 0** — Run from terminal. Expected: no output, exit 0. Any `code object is not signed at all` or `invalid signature` output blocks the release.
+- [ ] **DMG drag-to-Applications flow works** — Mount the `.dmg`, drag `OpenHuman.app` to the `Applications` alias. Expected: copy completes; eject succeeds; first launch from `/Applications` does not re-prompt Gatekeeper.
+- [ ] **Accessibility permission prompt fires on first agent run** — Trigger an agent action that uses Accessibility (e.g. window-control skill). Expected: macOS prompts `OpenHuman would like to control this computer using accessibility features`. Granting it allows the action; denying it surfaces a clear in-app fallback.
+- [ ] **Input Monitoring prompt fires on first hotkey use** — Press the registered global hotkey for the first time. Expected: `Input Monitoring` prompt; granting it makes the hotkey trigger; denying it does not crash the app.
+- [ ] **Screen Recording prompt fires on first screen-share** — Use the screen-share skill or `getDisplayMedia` shim. Expected: `Screen Recording` prompt; granted → picker shows windows + screens; denied → in-app message explaining the requirement.
+- [ ] **Microphone prompt fires on first voice capture** — Start a voice session. Expected: standard mic prompt; granted → capture begins; denied → fallback message, no panic.
+
+### Windows
+
+- [ ] **SmartScreen does not block install** — Run the installer from a fresh download. Expected: SmartScreen passes (signed binary). If `Windows protected your PC` appears, the EV signature is missing or the reputation has not built up — escalate before shipping.
+- [ ] **Installer creates Start Menu + Desktop shortcuts** — Defaults preserved. Expected: both shortcuts launch the app.
+- [ ] **App registers `openhuman://` URL scheme** — From a browser, click an `openhuman://oauth/success?...` link. Expected: OS prompts to open in OpenHuman; clicking through delivers the deep link.
+
+### Linux
+
+- [ ] **`.deb` and/or `.AppImage` install on a clean Ubuntu 22.04** — `sudo dpkg -i openhuman_*.deb` or `chmod +x openhuman-*.AppImage && ./openhuman-*.AppImage`. Expected: no missing-dependency errors; app launches.
+- [ ] **OS-native notification toasts fire** — Trigger a notification from inside the app (e.g. memory captured, agent finished). Expected: a libnotify-style toast appears outside the app window. (CI Linux only sees Xvfb — this surface only verifies on a real desktop.)
+
+### Cross-platform
+
+- [ ] **First launch flow completes for a brand-new user** — Fresh OS user account, no `~/.openhuman` directory. Walk through onboarding to first agent reply. Expected: no crashes, no permission deadlocks, no stale-config errors.
+- [ ] **Auto-update download + relaunch succeeds** — Install the previous release, point the updater feed at this release, trigger an update check. Expected: download completes, relaunch installs the new binary, version string in `Settings > About` matches the release tag.
+- [ ] **Logging out + logging back in preserves nothing private** — Sign out, sign in as a different user. Expected: no leaked memory, threads, or skill state from the previous session (regression watch — see #900).
+
+---
+
+## Active release line
+
+> If multiple stable release lines are in flight (security backports, LTS), add a sub-section per line and check the same boxes for each. As of writing, `0.52.x` is the only active line — older minor versions are end-of-life. Fold this section to suit when more release lines exist.
+
+### 0.52.x — current
+
+- [ ] **OAuth gate respects `VITE_MINIMUM_SUPPORTED_APP_VERSION`** (per [`RELEASE_POLICY.md`](./RELEASE_POLICY.md)) — Set the variable to a value above this build's version, build, attempt OAuth from the older binary. Expected: gate blocks the deep link; opens `VITE_LATEST_APP_DOWNLOAD_URL`.
+- [ ] **Gmail connect succeeds on a fresh install from `releases/latest`** — Per release-policy step 4. Expected: token exchange completes, inbox lists in-app.
+
+---
+
+## Sign-off
+
+```
+Release: vX.Y.Z
+Tester: @<github-handle>
+Date: YYYY-MM-DD
+Platforms tested: [macOS arm64] [macOS x64] [Windows] [Linux .deb] [Linux .AppImage]
+Notes:
+```
+
+Paste the filled block into the release PR description before tagging.

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -39,7 +39,7 @@ Applies to every release, all platforms.
 ### Linux
 
 - [ ] **`.deb` and/or `.AppImage` install on a clean Ubuntu 22.04** — `sudo dpkg -i openhuman_*.deb` or `chmod +x openhuman-*.AppImage && ./openhuman-*.AppImage`. Expected: no missing-dependency errors; app launches.
-- [ ] **OS-native notification toasts fire** — Trigger a notification from inside the app (e.g. memory captured, agent finished). Expected: a libnotify-style toast appears outside the app window. (CI Linux only sees Xvfb — this surface only verifies on a real desktop.)
+- [ ] **OS-native notification toasts fire** — Trigger a notification from inside the app (e.g. memory captured, agent finished). Expected: a libnotify-style toast appears outside the app window. (CI Linux sees only Xvfb; this surface verifies on a real desktop.)
 
 ### Cross-platform
 
@@ -62,7 +62,7 @@ Applies to every release, all platforms.
 
 ## Sign-off
 
-```
+```text
 Release: vX.Y.Z
 Tester: @<github-handle>
 Date: YYYY-MM-DD

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -32,3 +32,4 @@ Implementation: `app/src/utils/oauthAppVersionGate.ts`, `app/src/utils/desktopDe
 2. When dropping support for older installs, set **`VITE_MINIMUM_SUPPORTED_APP_VERSION`** to the new floor **before** or **with** that release (repo Actions variables + both workflow steps above).
 3. Remove, redirect, or retire older stable installers and stale **updater** entries from user-facing surfaces (GitHub Release assets, website, CDN, updater feed). Confirm deprecated artifacts are not reachable from default install/update flows.
 4. Smoke-test **Gmail connect** on a fresh install from **releases/latest**.
+5. Complete the [manual smoke checklist](./RELEASE-MANUAL-SMOKE.md) and paste the sign-off block into the release PR description before tagging.

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -32,4 +32,4 @@ Implementation: `app/src/utils/oauthAppVersionGate.ts`, `app/src/utils/desktopDe
 2. When dropping support for older installs, set **`VITE_MINIMUM_SUPPORTED_APP_VERSION`** to the new floor **before** or **with** that release (repo Actions variables + both workflow steps above).
 3. Remove, redirect, or retire older stable installers and stale **updater** entries from user-facing surfaces (GitHub Release assets, website, CDN, updater feed). Confirm deprecated artifacts are not reachable from default install/update flows.
 4. Smoke-test **Gmail connect** on a fresh install from **releases/latest**.
-5. Complete the [manual smoke checklist](./RELEASE-MANUAL-SMOKE.md) and paste the sign-off block into the release PR description before tagging.
+5. Complete the [manual smoke checklist](./RELEASE-MANUAL-SMOKE.md), then paste the completed sign-off block (verbatim, with every checked item left checked) into the release PR description before tagging.

--- a/docs/TESTING-STRATEGY.md
+++ b/docs/TESTING-STRATEGY.md
@@ -12,7 +12,7 @@ How OpenHuman tests its product. Source of truth for "where does my test go?". C
 | **Rust integration** | `tests/*.rs` at repo root                                                                                                                             | Full domain wiring with real Tokio runtime, mock external services, JSON-RPC end-to-end (`tests/json_rpc_e2e.rs`), domain × domain interactions | `pnpm test:rust` (which calls `bash scripts/test-rust-with-mock.sh`)                                                       |
 | **Vitest unit**      | Co-located as `*.test.ts(x)` next to source under `app/src/**`, or under `app/src/**/__tests__/`                                                      | React components, hooks, store slices, pure utilities, service-layer adapters                                                                   | `pnpm test:unit`                                                                                                           |
 | **WDIO E2E**         | `app/test/e2e/specs/*.spec.ts`                                                                                                                        | Full desktop flow: UI → Tauri → core sidecar → JSON-RPC; user-visible behaviour                                                                 | Linux CI: `tauri-driver` (port 4444). macOS local: Appium Mac2 (port 4723). See [`docs/E2E-TESTING.md`](./E2E-TESTING.md). |
-| **Manual smoke**     | `docs/RELEASE-MANUAL-SMOKE.md` (not yet created — tracked in [#971](https://github.com/tinyhumansai/openhuman/issues/971))                            | OS-level surfaces drivers cannot assert: TCC permission prompts, Gatekeeper, code signing, DMG install, OS-native toasts                        | Human at release-cut, signed off in release PR                                                                             |
+| **Manual smoke**     | [`docs/RELEASE-MANUAL-SMOKE.md`](./RELEASE-MANUAL-SMOKE.md)                                                                                           | OS-level surfaces drivers cannot assert: TCC permission prompts, Gatekeeper, code signing, DMG install, OS-native toasts                        | Human at release-cut, signed off in release PR                                                                             |
 
 ---
 
@@ -120,7 +120,7 @@ bash app/scripts/e2e-run-spec.sh test/e2e/specs/<your-spec>.spec.ts <id>
 
 ## Not driver-automatable — manual smoke required
 
-Some surfaces cannot be driven by WDIO / Appium because they cross OS-level trust boundaries or hardware paths. These ship with a documented manual smoke checklist (the `docs/RELEASE-MANUAL-SMOKE.md` artifact will land alongside [#971](https://github.com/tinyhumansai/openhuman/issues/971)) and a sign-off on the release PR:
+Some surfaces cannot be driven by WDIO / Appium because they cross OS-level trust boundaries or hardware paths. These ship with a documented manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](./RELEASE-MANUAL-SMOKE.md)) and a sign-off on the release PR:
 
 - macOS TCC permission prompts (Accessibility, Input Monitoring, Screen Recording, Microphone)
 - Gatekeeper signature validation on first launch

--- a/docs/TESTING-STRATEGY.md
+++ b/docs/TESTING-STRATEGY.md
@@ -120,14 +120,14 @@ bash app/scripts/e2e-run-spec.sh test/e2e/specs/<your-spec>.spec.ts <id>
 
 ## Not driver-automatable — manual smoke required
 
-Some surfaces cannot be driven by WDIO / Appium because they cross OS-level trust boundaries or hardware paths. These ship with a documented manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](./RELEASE-MANUAL-SMOKE.md)) and a sign-off on the release PR:
+Some surfaces cannot be driven by WDIO / Appium because they cross OS-level trust boundaries or hardware paths. The complete checklist + sign-off block lives in [`docs/RELEASE-MANUAL-SMOKE.md`](./RELEASE-MANUAL-SMOKE.md) — that file is the source of truth for what must be verified per release. Examples of what it covers:
 
 - macOS TCC permission prompts (Accessibility, Input Monitoring, Screen Recording, Microphone)
 - Gatekeeper signature validation on first launch
 - Code-sign integrity (`codesign --verify --deep --strict`)
 - DMG install / drag-to-Applications flow
 - Auto-update download + relaunch
-- OS-native notification toasts on Linux CI (no display server visible to the driver beyond Xvfb)
+- OS-native notification toasts on Linux (no display server visible to the driver beyond Xvfb)
 
 If a feature has no automated coverage AND is not on the manual smoke list, treat it as untested — open a coverage gap.
 


### PR DESCRIPTION
## Summary

- New \`docs/RELEASE-MANUAL-SMOKE.md\` (~120 lines) covering OS-level surfaces drivers cannot assert.
- Closes two \`(see #971)\` placeholders in \`docs/TESTING-STRATEGY.md\`.
- Cross-link added as step 5 in \`docs/RELEASE_POLICY.md\` Release checklist.

## Problem

\`TESTING-STRATEGY.md\` (landed in #773 / PR #980) named \`docs/RELEASE-MANUAL-SMOKE.md\` as the manual-smoke source-of-truth but the file did not yet exist — two \`(see #971)\` / \`not yet created — tracked in #971\` placeholders pointed at this issue. Without the file, OS-level surfaces (TCC prompts, Gatekeeper, codesign, DMG install, auto-update) had nowhere documented to land sign-offs.

## Solution

\`docs/RELEASE-MANUAL-SMOKE.md\` ships a fixed checklist with sections per platform:

- **macOS** — TCC prompts (Accessibility / Input Monitoring / Screen Recording / Microphone), Gatekeeper, \`codesign --verify --deep --strict\`, DMG drag-to-Applications.
- **Windows** — SmartScreen pass-through, Start Menu shortcuts, \`openhuman://\` URL scheme.
- **Linux** — \`.deb\` / \`.AppImage\` install on clean Ubuntu, libnotify toasts.
- **Cross-platform** — first-launch flow, auto-update download + relaunch, sign-out / sign-in privacy regression watch.
- **Active release line** — currently \`0.52.x\` (only stream in CHANGELOG); OAuth-gate + Gmail-connect smoke per \`RELEASE_POLICY.md\`.

Sign-off block at the end pastes into the release PR description.

\`TESTING-STRATEGY.md\` placeholders replaced with markdown links. \`RELEASE_POLICY.md\` Release checklist gets a step 5: "Complete the manual smoke checklist and paste the sign-off block into the release PR description before tagging."

## Submission Checklist

- [x] Tests added or updated — N/A: this PR adds a manual checklist; the failure-path requirement applies to automated layers.
- [x] Coverage matrix updated — N/A: no feature rows added/removed/renamed.
- [ ] All affected feature IDs from the matrix are listed — N/A.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — yes; this PR introduces it.
- [x] Linked issue closed via \`Closes #NNN\`.

## Impact

- **Runtime**: zero. Markdown only.
- **Release process**: every release PR must paste the sign-off block before tagging (per updated \`RELEASE_POLICY.md\` step 5).
- **Coverage matrix**: rows currently marked \`🚫 manual\` in \`docs/TEST-COVERAGE-MATRIX.md\` now have a concrete checklist target instead of a dangling reference.

## Related

- Closes #971
- Parent epic: #773
- Cross-references: \`docs/TESTING-STRATEGY.md\` (landed in PR #980), \`docs/RELEASE_POLICY.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive manual smoke testing checklist for release verification, covering OS-specific install/launch flows, permission prompts, update/download relaunch, onboarding, logout/login, and notification behavior.
  * Updated release policy to require completing and pasting the checklist sign-off into the release PR before tagging.
  * Updated testing strategy to reference the new per-release manual smoke checklist as the authoritative process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->