### PR TITLE
refactor(voice): move CLI adapter to controller registry

### DIFF
--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -20,6 +20,16 @@ pub type ControllerFuture = Pin<Box<dyn Future<Output = Result<Value, String>> +
 /// Handlers take a map of parameters and return a [`ControllerFuture`].
 pub type ControllerHandler = fn(Map<String, Value>) -> ControllerFuture;
 
+/// A function pointer type for domain-specific CLI handlers.
+pub type CliHandler = fn(&[String]) -> anyhow::Result<()>;
+
+/// A registered standalone CLI adapter for a domain.
+#[derive(Clone)]
+pub struct RegisteredCliAdapter {
+    pub namespace: &'static str,
+    pub handler: CliHandler,
+}
+
 /// A registered controller combining its schema and handler function.
 #[derive(Clone)]
 pub struct RegisteredController {
@@ -39,6 +49,9 @@ impl RegisteredController {
 /// The global static registry of all controllers, initialized once on first access.
 static REGISTRY: OnceLock<Vec<RegisteredController>> = OnceLock::new();
 
+/// The global static registry of standalone CLI adapters.
+static CLI_ADAPTERS: OnceLock<Vec<RegisteredCliAdapter>> = OnceLock::new();
+
 /// Returns a reference to the global controller registry.
 ///
 /// This function initializes the registry if it hasn't been already,
@@ -54,6 +67,16 @@ fn registry() -> &'static [RegisteredController] {
             registered
         })
         .as_slice()
+}
+
+/// Returns a reference to the global CLI adapter registry.
+fn cli_adapters() -> &'static [RegisteredCliAdapter] {
+    CLI_ADAPTERS.get_or_init(|| {
+        vec![RegisteredCliAdapter {
+            namespace: "voice",
+            handler: crate::openhuman::voice::cli::run_standalone_subcommand,
+        }]
+    })
 }
 
 /// Aggregates all controller implementations from across the codebase.
@@ -304,6 +327,14 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         ),
         _ => None,
     }
+}
+
+/// Returns the CLI handler for a given namespace, if one is registered.
+pub fn cli_handler_for_namespace(namespace: &str) -> Option<CliHandler> {
+    cli_adapters()
+        .iter()
+        .find(|a| a.namespace == namespace)
+        .map(|a| a.handler)
 }
 
 /// Looks up an RPC method name based on namespace and function.

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -63,7 +63,6 @@ pub fn run_from_cli_args(args: &[String]) -> Result<()> {
         "screen-intelligence" => {
             crate::openhuman::screen_intelligence::cli::run_screen_intelligence_command(&args[1..])
         }
-        "voice" | "dictate" => crate::openhuman::voice::cli::run_standalone_subcommand(&args[1..]),
         "text-input" => crate::openhuman::text_input::cli::run_text_input_command(&args[1..]),
         "tree-summarizer" => {
             crate::openhuman::tree_summarizer::cli::run_tree_summarizer_command(&args[1..])
@@ -361,6 +360,10 @@ fn run_namespace_command(
     }
 
     if args.is_empty() || is_help(&args[0]) {
+        // If there's a domain-specific CLI handler for this namespace, use it as the default.
+        if let Some(cli_handler) = all::cli_handler_for_namespace(namespace) {
+            return cli_handler(args);
+        }
         print_namespace_help(namespace, schemas);
         return Ok(());
     }


### PR DESCRIPTION
## Summary

- Removes the hardcoded `"voice" | "dictate"` branch from `src/core/cli.rs` dispatch
- Introduces `RegisteredCliAdapter` + `CLI_ADAPTERS` static registry in `src/core/all.rs`
- Adds `cli_handler_for_namespace()` lookup so the voice CLI is wired the same way as RPC controllers — via the registry, not ad-hoc branching
- `run_namespace_command` now falls through to the registry before printing help, making future CLI adapters zero-touch in `cli.rs`

## Test plan

- [ ] `cargo check` passes clean (pre-existing `private_interfaces` warning only, unrelated)
- [ ] `cargo fmt --check` passes
- [ ] `openhuman voice` / `openhuman dictate` subcommands still dispatch correctly
- [ ] Adding a new CLI adapter requires only a registry entry in `all.rs`, no change to `cli.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the CLI dispatch system to support namespace-based command handling, improving the flexibility and organization of command routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->