### PR TITLE
fix(auth): close cross-user state + CEF cookie leak (#900)

### DIFF
--- a/app/src-tauri/permissions/allow-core-process.toml
+++ b/app/src-tauri/permissions/allow-core-process.toml
@@ -6,6 +6,20 @@ description = "Core RPC URL, sidecar restart, dictation hotkey, webview-account,
 allow = [
     "core_rpc_url",
     "restart_core_process",
+    # `restart_app` triggers `app.restart()` so CEF re-initializes against
+    # the active user's `users/<id>/cef` profile after an identity flip
+    # (#900). Without this allow entry, the invoke is silently denied by
+    # Tauri capabilities and webviews keep the prior user's third-party
+    # cookies.
+    "restart_app",
+    "schedule_cef_profile_purge",
+    # `get_active_user_id` reads `~/.openhuman/active_user.toml` so the
+    # frontend can prime `userScopedStorage` from the Rust source of truth
+    # BEFORE redux-persist hydrates — the prior `localStorage`-only seed
+    # was bound to the per-user CEF profile dir and went stale across
+    # restart-driven flips, causing a false re-flip and restart loop on
+    # every login. (#900)
+    "get_active_user_id",
     "service_install_direct",
     "service_start_direct",
     "service_stop_direct",

--- a/app/src-tauri/src/cef_profile.rs
+++ b/app/src-tauri/src/cef_profile.rs
@@ -36,7 +36,7 @@ fn default_root_dir_name() -> &'static str {
     }
 }
 
-fn default_root_openhuman_dir() -> Result<PathBuf, String> {
+pub fn default_root_openhuman_dir() -> Result<PathBuf, String> {
     if let Ok(workspace) = std::env::var("OPENHUMAN_WORKSPACE") {
         let trimmed = workspace.trim();
         if !trimmed.is_empty() {
@@ -50,7 +50,7 @@ fn default_root_openhuman_dir() -> Result<PathBuf, String> {
     Ok(home.join(default_root_dir_name()))
 }
 
-fn read_active_user_id(default_openhuman_dir: &Path) -> Option<String> {
+pub fn read_active_user_id(default_openhuman_dir: &Path) -> Option<String> {
     let path = default_openhuman_dir.join(ACTIVE_USER_STATE_FILE);
     let contents = std::fs::read_to_string(path).ok()?;
     let state: ActiveUserState = toml::from_str(&contents).ok()?;

--- a/app/src-tauri/src/cef_profile.rs
+++ b/app/src-tauri/src/cef_profile.rs
@@ -297,6 +297,33 @@ pub fn prepare_process_cache_path() -> Result<PathBuf, String> {
         user_id,
         cache_dir.display()
     );
+
+    // When a real user is active, the pre-login `users/local/cef` bucket is
+    // stale third-party state captured during cold-bootstrap (before
+    // `active_user.toml` existed) — e.g. a Slack/WhatsApp tile added on a
+    // fresh install while the process was still running on the `local`
+    // fallback path. If we don't sweep it, those cookies leak into the
+    // first user's session via webview pre-warm and across users when the
+    // pre-login bucket is reused on subsequent fresh installs. Drop it
+    // synchronously here, before CEF init, so it's safe to delete. (#900)
+    if user_id != PRE_LOGIN_USER_ID {
+        if let Ok(local_cef) = cache_dir_for_user(&default_openhuman_dir, PRE_LOGIN_USER_ID) {
+            if local_cef.exists() {
+                match std::fs::remove_dir_all(&local_cef) {
+                    Ok(()) => log::info!(
+                        "[cef-profile] purged stale pre-login CEF cache path={}",
+                        local_cef.display()
+                    ),
+                    Err(error) => log::warn!(
+                        "[cef-profile] failed to purge stale pre-login CEF cache path={} error={}",
+                        local_cef.display(),
+                        error
+                    ),
+                }
+            }
+        }
+    }
+
     Ok(cache_dir)
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod telegram_scanner;
 mod webview_accounts;
 mod webview_apis;
 mod whatsapp_scanner;
+mod window_state;
 
 use std::sync::Mutex;
 
@@ -318,6 +319,17 @@ async fn restart_core_process(
 #[tauri::command]
 async fn restart_app(app: tauri::AppHandle<AppRuntime>) -> Result<(), String> {
     log::info!("[app] restart_app invoked from frontend");
+    // Persist main-window geometry and hide the window before exit so
+    // the macOS WindowServer doesn't briefly black-out the desktop layer
+    // on the (now defunct) display when the focused app dies, and so
+    // the new process can land its window on the same display+position
+    // the user had it on. (#900 secondary fixes)
+    if let Some(window) = app.get_webview_window("main") {
+        window_state::save_main(&window);
+        if let Err(err) = window.hide() {
+            log::warn!("[app] hide main window before restart failed: {err}");
+        }
+    }
     app.restart();
 }
 
@@ -979,6 +991,24 @@ pub fn run() {
                     log::warn!("[core-update] auto-update check failed (non-fatal): {err}");
                 }
             });
+
+            // Restore last-known window position+size before showing the
+            // window so the user's first paint after a restart-driven flow
+            // (#900 identity flip) lands on the same display they used,
+            // not back at the default centered initial size on the
+            // primary monitor. `tauri.conf.json` ships `visible: false`
+            // / `center: false` for the main window so the placement
+            // happens before the first paint and there's no jump.
+            if let Some(window) = app.get_webview_window("main") {
+                if !window_state::restore_main(&window) {
+                    window_state::center_main(&window);
+                }
+                if !daemon_mode {
+                    if let Err(err) = window.show() {
+                        log::warn!("[window-state] show main window failed: {err}");
+                    }
+                }
+            }
 
             if daemon_mode {
                 if let Some(window) = app.get_webview_window("main") {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -321,6 +321,24 @@ async fn restart_app(app: tauri::AppHandle<AppRuntime>) -> Result<(), String> {
     app.restart();
 }
 
+/// Read the authoritative active user id from `active_user.toml` so the
+/// frontend can seed `userScopedStorage` BEFORE redux-persist hydrates.
+///
+/// The previous frontend-only seed (a `localStorage` key) was bound to the
+/// per-user CEF profile dir, so on every restart-driven user flip the new
+/// process read whatever value the new profile's `localStorage` happened to
+/// hold from a prior session — usually stale, triggering a false re-flip and
+/// a restart loop. The Rust core writes `active_user.toml` atomically as part
+/// of `auth_store_session`, so it's the only profile-independent source of
+/// truth available to the UI at boot. Reuses
+/// `cef_profile::default_root_openhuman_dir()` so the lookup honors
+/// `OPENHUMAN_WORKSPACE` overrides used in test harnesses. (#900)
+#[tauri::command]
+fn get_active_user_id() -> Result<Option<String>, String> {
+    let dir = cef_profile::default_root_openhuman_dir()?;
+    Ok(cef_profile::read_active_user_id(&dir))
+}
+
 #[tauri::command]
 async fn schedule_cef_profile_purge(user_id: Option<String>) -> Result<String, String> {
     let queued = cef_profile::queue_profile_purge_for_user(user_id.as_deref())?;
@@ -1299,6 +1317,7 @@ pub fn run() {
             apply_app_update,
             restart_core_process,
             restart_app,
+            get_active_user_id,
             schedule_cef_profile_purge,
             service_install_direct,
             service_start_direct,

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -612,27 +612,27 @@ fn teardown_account_scanners<R: Runtime>(app: &AppHandle<R>, account_id: &str) {
     {
         let registry = registry.inner().clone();
         let acct = account_id.to_string();
-        tokio::spawn(async move { registry.forget(&acct).await });
+        tauri::async_runtime::spawn(async move { registry.forget(&acct).await });
     }
     if let Some(registry) = app.try_state::<std::sync::Arc<crate::slack_scanner::ScannerRegistry>>()
     {
         let registry = registry.inner().clone();
         let acct = account_id.to_string();
-        tokio::spawn(async move { registry.forget(&acct).await });
+        tauri::async_runtime::spawn(async move { registry.forget(&acct).await });
     }
     if let Some(registry) =
         app.try_state::<std::sync::Arc<crate::discord_scanner::ScannerRegistry>>()
     {
         let registry = registry.inner().clone();
         let acct = account_id.to_string();
-        tokio::spawn(async move { registry.forget(&acct).await });
+        tauri::async_runtime::spawn(async move { registry.forget(&acct).await });
     }
     if let Some(registry) =
         app.try_state::<std::sync::Arc<crate::telegram_scanner::ScannerRegistry>>()
     {
         let registry = registry.inner().clone();
         let acct = account_id.to_string();
-        tokio::spawn(async move { registry.forget(&acct).await });
+        tauri::async_runtime::spawn(async move { registry.forget(&acct).await });
     }
 }
 

--- a/app/src-tauri/src/window_state.rs
+++ b/app/src-tauri/src/window_state.rs
@@ -1,0 +1,192 @@
+//! Persistence of main-window position + size across restarts.
+//!
+//! `app.restart()` (used by #900's identity-flip flow) spawns a fresh
+//! process, so the new window doesn't inherit anything from the old one.
+//! Without us re-applying state, every login-driven respawn snaps the
+//! window back to the default initial size in the center of the primary
+//! display — even when the user had it on an external monitor or had
+//! resized it.
+//!
+//! This module persists a tiny TOML record at
+//! `<openhuman_dir>/window_state.toml` capturing the outer position and
+//! outer size of the main window in physical pixels. On launch the
+//! record is read and applied before the window is shown. On restart we
+//! save first, hide the window, then call `app.restart()`.
+//!
+//! Saved state is best-effort: read errors, missing file, off-screen
+//! positions, and non-existent monitors all fall back to the default
+//! centered window so we never trap the window where the user can't
+//! reach it.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::{PhysicalPosition, PhysicalSize, Runtime, WebviewWindow};
+
+use crate::cef_profile;
+
+const STATE_FILE: &str = "window_state.toml";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WindowState {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+fn state_path() -> Option<PathBuf> {
+    cef_profile::default_root_openhuman_dir()
+        .ok()
+        .map(|root| root.join(STATE_FILE))
+}
+
+/// Capture the main window's outer geometry and write it to disk.
+///
+/// Called from `restart_app` immediately before `app.restart()` so the
+/// next process can land the new window where the user left it.
+pub fn save_main<R: Runtime>(window: &WebviewWindow<R>) {
+    let Ok(pos) = window.outer_position() else {
+        log::warn!("[window-state] outer_position unavailable; skip save");
+        return;
+    };
+    let Ok(size) = window.outer_size() else {
+        log::warn!("[window-state] outer_size unavailable; skip save");
+        return;
+    };
+    let state = WindowState {
+        x: pos.x,
+        y: pos.y,
+        width: size.width,
+        height: size.height,
+    };
+    let Some(path) = state_path() else {
+        log::warn!("[window-state] no path available; skip save");
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            log::warn!(
+                "[window-state] mkdir {} failed: {}; skip save",
+                parent.display(),
+                err
+            );
+            return;
+        }
+    }
+    let raw = match toml::to_string_pretty(&state) {
+        Ok(r) => r,
+        Err(err) => {
+            log::warn!("[window-state] serialize failed: {err}; skip save");
+            return;
+        }
+    };
+    if let Err(err) = std::fs::write(&path, raw) {
+        log::warn!("[window-state] write {} failed: {err}", path.display());
+    } else {
+        log::info!(
+            "[window-state] saved geometry x={} y={} w={} h={}",
+            state.x,
+            state.y,
+            state.width,
+            state.height
+        );
+    }
+}
+
+/// Read the saved geometry (if any) and apply it to the main window.
+///
+/// Returns `true` when saved geometry was applied. Returns `false` when
+/// no saved file exists, the file is malformed, or the saved position
+/// falls outside every currently-attached monitor (e.g. the user
+/// undocked an external display); the caller is then expected to fall
+/// back to a centered default so we never strand the window off-screen.
+pub fn restore_main<R: Runtime>(window: &WebviewWindow<R>) -> bool {
+    let Some(path) = state_path() else {
+        return false;
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let state: WindowState = match toml::from_str(&raw) {
+        Ok(s) => s,
+        Err(err) => {
+            log::warn!(
+                "[window-state] parse {} failed: {err}; using default placement",
+                path.display()
+            );
+            return false;
+        }
+    };
+
+    if !position_visible_on_any_monitor(window, state.x, state.y, state.width, state.height) {
+        log::info!(
+            "[window-state] saved position x={} y={} not on any monitor; falling back to centered default",
+            state.x,
+            state.y
+        );
+        return false;
+    }
+
+    if let Err(err) = window.set_size(PhysicalSize::new(state.width, state.height)) {
+        log::warn!("[window-state] set_size failed: {err}");
+    }
+    if let Err(err) = window.set_position(PhysicalPosition::new(state.x, state.y)) {
+        log::warn!("[window-state] set_position failed: {err}");
+        return false;
+    }
+    log::info!(
+        "[window-state] restored geometry x={} y={} w={} h={}",
+        state.x,
+        state.y,
+        state.width,
+        state.height
+    );
+    true
+}
+
+/// Center the main window on the primary display (or its current monitor
+/// if `current_monitor` resolves) when no saved state applied.
+pub fn center_main<R: Runtime>(window: &WebviewWindow<R>) {
+    let Ok(Some(monitor)) = window
+        .primary_monitor()
+        .or_else(|_| window.current_monitor())
+    else {
+        let _ = window.center();
+        return;
+    };
+    let Ok(size) = window.outer_size() else {
+        let _ = window.center();
+        return;
+    };
+    let mon_pos = monitor.position();
+    let mon_size = monitor.size();
+    let x = mon_pos.x + (mon_size.width as i32 - size.width as i32) / 2;
+    let y = mon_pos.y + (mon_size.height as i32 - size.height as i32) / 2;
+    let _ = window.set_position(PhysicalPosition::new(x, y));
+}
+
+fn position_visible_on_any_monitor<R: Runtime>(
+    window: &WebviewWindow<R>,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> bool {
+    let Ok(monitors) = window.available_monitors() else {
+        return false;
+    };
+    // Treat the window as on-screen if at least a 100x100 px patch of it
+    // overlaps any attached monitor.
+    let win_right = x.saturating_add(width as i32);
+    let win_bottom = y.saturating_add(height as i32);
+    monitors.iter().any(|m| {
+        let pos = m.position();
+        let size = m.size();
+        let mon_right = pos.x.saturating_add(size.width as i32);
+        let mon_bottom = pos.y.saturating_add(size.height as i32);
+        let overlap_w = (win_right.min(mon_right) - x.max(pos.x)).max(0);
+        let overlap_h = (win_bottom.min(mon_bottom) - y.max(pos.y)).max(0);
+        overlap_w >= 100 && overlap_h >= 100
+    })
+}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -16,10 +16,10 @@
         "title": "OpenHuman",
         "width": 1000,
         "height": 800,
-        "visible": true,
+        "visible": false,
         "decorations": true,
         "resizable": true,
-        "center": true
+        "center": false
       }
     ],
     "security": {

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -12,7 +12,9 @@ import OverlayApp from './overlay/OverlayApp';
 import './polyfills';
 import { initSentry } from './services/analytics';
 import { setStoreForApiClient } from './services/apiClient';
+import { primeActiveUserId } from './store/userScopedStorage';
 import { setupDesktopDeepLinkListener } from './utils/desktopDeepLinkListener';
+import { getActiveUserIdFromCore } from './utils/tauriCommands';
 
 setStoreForApiClient(() => getCoreStateSnapshot().snapshot.sessionToken);
 
@@ -43,14 +45,27 @@ if (!isOverlayWindow) {
   });
 }
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>{isOverlayWindow ? <OverlayApp /> : <App />}</React.StrictMode>
-);
+// Prime `userScopedStorage` from the Rust core's `active_user.toml`
+// BEFORE redux-persist hydrates. The previous localStorage-only seed was
+// bound to the per-user CEF profile dir and went stale across the
+// restart-driven user flips that #900 introduced, so the new process
+// would read the previous user's namespace, mis-detect a flip, and bounce
+// into a second restart. Reading the Rust state up front pins the right
+// namespace from the first storage call. (#900)
+function bootRender() {
+  const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+  root.render(<React.StrictMode>{isOverlayWindow ? <OverlayApp /> : <App />}</React.StrictMode>);
 
-if (!isOverlayWindow) {
-  // Mount error notification in an isolated React root so it survives App crashes.
-  const errorRoot = document.createElement('div');
-  errorRoot.id = 'error-report-root';
-  document.body.appendChild(errorRoot);
-  ReactDOM.createRoot(errorRoot).render(<ErrorReportNotification />);
+  if (!isOverlayWindow) {
+    // Mount error notification in an isolated React root so it survives App crashes.
+    const errorRoot = document.createElement('div');
+    errorRoot.id = 'error-report-root';
+    document.body.appendChild(errorRoot);
+    ReactDOM.createRoot(errorRoot).render(<ErrorReportNotification />);
+  }
 }
+
+getActiveUserIdFromCore()
+  .then(id => primeActiveUserId(id))
+  .catch(() => primeActiveUserId(null))
+  .finally(bootRender);

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -26,8 +26,9 @@ import {
   updateCoreLocalState,
 } from '../services/coreStateApi';
 import { socketService } from '../services/socketService';
-import { persistor, store } from '../store';
+import { store } from '../store';
 import { resetUserScopedState } from '../store/resetActions';
+import { setActiveUserId } from '../store/userScopedStorage';
 import {
   openhumanUpdateAnalyticsSettings,
   restartApp,
@@ -81,28 +82,39 @@ function snapshotIdentity(snapshot: CoreAppSnapshot): string | null {
 /**
  * Universal cleanup for identity changes (flip A→B, or sign-out).
  *
- * Resets every user-scoped Redux slice via `resetUserScopedState`, drops the
- * `persist:*` localStorage blobs (otherwise rehydration on the next render or
- * launch leaks user A's slices into user B's session), and disconnects the
- * live Socket.IO connection so the next reconnect carries the new auth token.
+ * 1. Re-points `userScopedStorage` to the new user's namespace (or `null` for
+ *    sign-out). On the next cold launch — or right now for in-memory writes —
+ *    redux-persist reads/writes blobs under `${nextUserId}:persist:*`.
+ * 2. Resets every user-scoped Redux slice via `resetUserScopedState` so the
+ *    live store is empty before any rehydrate from the new namespace.
+ * 3. Disconnects the live Socket.IO connection so the reconnect carries the
+ *    new user's auth token (fresh `client_id` server-side).
+ * 4. On a real flip (A→B), restarts the app so singleton services and
+ *    Rust-side webview accounts pick up the new user dir. On sign-out, the
+ *    signed-out UI is already empty — a relaunch would be jarring.
  *
- * Pass `restart: true` for a real flip (A→B): a process restart is needed
- * because singleton services and Rust-side webview accounts pin the prior
- * user's state for the lifetime of the process. Pass `restart: false` for
- * sign-out — the signed-out UI is empty, so a relaunch would be jarring.
- *
- * See [#900].
+ * Note: we deliberately do NOT call `persistor.purge()`. Each user's
+ * persisted blob lives at its own namespaced key, so user A's data must
+ * survive B's session intact and rehydrate when A returns. See [#900].
  */
-async function handleIdentityFlip(opts: { restart: boolean; reason: string }): Promise<void> {
-  const { restart, reason } = opts;
-  log('identity flip cleanup reason=%s restart=%s', reason, restart);
+async function handleIdentityFlip(opts: {
+  restart: boolean;
+  reason: string;
+  nextUserId: string | null;
+}): Promise<void> {
+  const { restart, reason, nextUserId } = opts;
+  log(
+    'identity flip cleanup reason=%s restart=%s nextUserId=%s',
+    reason,
+    restart,
+    nextUserId ? `****${nextUserId.slice(-4)}` : 'none'
+  );
+  // Re-point storage BEFORE the in-memory reset so any stray persist write
+  // triggered between the reset dispatch and the restart goes to the new
+  // user's namespace (or is dropped when nextUserId is null).
+  setActiveUserId(nextUserId);
   store.dispatch(resetUserScopedState());
   socketService.disconnect();
-  try {
-    await persistor.purge();
-  } catch (error) {
-    console.warn('[core-state] persistor.purge failed during identity flip:', error);
-  }
   if (restart) {
     await restartApp();
   }
@@ -209,13 +221,31 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     });
 
     if (isFlip) {
-      await handleIdentityFlip({ restart: true, reason: 'refreshCore-flip' }).catch(err => {
+      await handleIdentityFlip({
+        restart: true,
+        reason: 'refreshCore-flip',
+        nextUserId: nextIdentity,
+      }).catch(err => {
         log('handleIdentityFlip(flip) failed: %O', sanitizeError(err));
       });
     } else if (isLogout) {
-      await handleIdentityFlip({ restart: false, reason: 'refreshCore-logout' }).catch(err => {
+      await handleIdentityFlip({
+        restart: false,
+        reason: 'refreshCore-logout',
+        nextUserId: null,
+      }).catch(err => {
         log('handleIdentityFlip(logout) failed: %O', sanitizeError(err));
       });
+    } else if (
+      // First-paint bootstrap (signed-out → signed-in on cold launch): seed
+      // the active user id so subsequent persist writes route to this user's
+      // namespace. No restart, no Redux reset — bootstrap state is already
+      // correct.
+      !previousAuthed &&
+      nextAuthed &&
+      nextIdentity
+    ) {
+      setActiveUserId(nextIdentity);
     }
     syncAnalyticsConsent(snapshot.analyticsEnabled);
 
@@ -465,11 +495,14 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       snapshot: toSignedOutSnapshot(previous.snapshot),
     }));
     memoryTokenRef.current = null;
-    // Reset every user-scoped slice + purge persist + drop the live socket
+    // Reset every user-scoped slice + drop the live socket + un-scope storage
     // before the tauriLogout RPC so user A's data is gone the moment the UI
     // re-renders signed-out (#900). No restart — signed-out UI is empty;
-    // the next storeSessionToken (login as B) will restart via refreshCore.
-    await handleIdentityFlip({ restart: false, reason: 'clearSession' });
+    // the next storeSessionToken (login) will restart via refreshCore.
+    // We do NOT purge persist storage — A's blob stays at its namespaced key
+    // so when A returns to this device, their accounts/threads/notifications
+    // rehydrate.
+    await handleIdentityFlip({ restart: false, reason: 'clearSession', nextUserId: null });
     await tauriLogout();
     await refresh().catch(err => {
       log('refresh failed after clearSession: %O', sanitizeError(err));

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -161,13 +161,6 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
   const logoutGuardUntilRef = useRef(0);
   const bootstrapFailCountRef = useRef(0);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
-  // The userId whose `${id}:persist:*` blob is currently in memory. Initialized
-  // from `getActiveUserId()` so the first refresh after mount knows which
-  // namespace was hydrated by redux-persist's module-init pass — a different
-  // userId landing means we have to restart so persistor re-hydrates from the
-  // new namespace. See [#900].
-  const lastAuthedUserIdRef = useRef<string | null>(getActiveUserId());
-
   const commitState = useCallback((updater: (previous: CoreState) => CoreState) => {
     setState(previous => {
       const next = updater(previous);
@@ -194,25 +187,26 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     const nextIdentity = snapshotIdentity(nextSnapshot);
     const previousAuthed = beforeCommit.auth.isAuthenticated;
     const nextAuthed = nextSnapshot.auth.isAuthenticated;
-    // Identity flip detection is purely "is the in-memory data for a different
-    // user than the one who just authenticated?". `lastAuthedUserIdRef` tracks
-    // whose namespace redux-persist hydrated. If a different non-null userId
-    // lands, we have to restart so persistor re-hydrates from the new
-    // namespace. This rule covers every login path uniformly:
+    // Source of truth for "what userId's data is currently in memory" is the
+    // `OPENHUMAN_ACTIVE_USER_ID` localStorage seed read by `userScopedStorage`
+    // at module init — that's whose namespace redux-persist hydrated, and
+    // it's also what the Rust `prepare_process_cache_path` reads from
+    // `active_user.toml` on each cold launch to pick a CEF cache dir. If the
+    // userId that just authenticated is different (or different from null on
+    // a fresh device), we MUST restart so:
+    //   1. redux-persist re-hydrates from the new user's namespace, and
+    //   2. CEF re-initializes with the new user's `users/<id>/cef` profile,
+    //      so embedded webviews (Slack, WhatsApp, …) don't see the prior
+    //      user's third-party cookies.
+    // This single rule covers every login path uniformly:
+    //   - cold bootstrap on a fresh install (seed is null, nextId is real)
     //   - direct `storeSessionToken` (Tauri OAuth)
-    //   - deep-link `core-state:session-token-updated` (where the synchronous
-    //     pre-refresh commit already flipped `auth.isAuthenticated=true`, so
-    //     `previousAuthed` is true but `previousIdentity` is still null —
-    //     previous-state-based heuristics get fooled)
+    //   - deep-link `core-state:session-token-updated`
     //   - poll-detected flip (core-side user swap)
-    const isFlip =
-      Boolean(nextIdentity) &&
-      lastAuthedUserIdRef.current !== null &&
-      lastAuthedUserIdRef.current !== nextIdentity;
+    //   - re-login as a different user after sign-out
+    const seedUserId = getActiveUserId();
+    const isFlip = Boolean(nextIdentity) && seedUserId !== nextIdentity;
     const isLogout = Boolean(previousAuthed) && !nextAuthed;
-    // Cold bootstrap OR same-user re-login: a userId landed and it matches
-    // (or is the first ever lookup against a null ref).
-    const isInitialOrSameUserAuth = Boolean(nextIdentity) && !isFlip;
     // Clear team caches whenever the visible identity changes (in-memory user
     // shift) so the post-commit UI doesn't show user A's team list during the
     // brief signed-out window or user B's session.
@@ -234,29 +228,21 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     });
 
     if (isFlip && nextIdentity) {
-      // Track the new identity before triggering restart so a test (or a
-      // no-op restartApp mock) sees the ref updated; in production the page
-      // reloads and the ref is rebuilt from `getActiveUserId()` on next mount.
-      lastAuthedUserIdRef.current = nextIdentity;
       await handleIdentityFlip({ reason: 'identity-flip', nextUserId: nextIdentity }).catch(err => {
         log('handleIdentityFlip failed: %O', sanitizeError(err));
       });
     } else if (isLogout) {
-      // Sign-out: keep slice data in memory (signed-out UI doesn't expose
-      // it) so a same-user re-login keeps showing the user's accounts /
-      // threads / notifications without a costly process restart. Drop the
-      // active user id so any stray persist write during the signed-out
-      // window is a no-op, and disconnect the live socket since the token
-      // it was authed with has been invalidated by the core.
-      setActiveUserId(null);
+      // Sign-out: keep `OPENHUMAN_ACTIVE_USER_ID` pointing at the last user
+      // so the next login can detect via seed comparison whether it's a
+      // same-user re-login (no restart) or a different-user re-login
+      // (restart). Slice data also stays in memory since signed-out UI
+      // doesn't render user-scoped slices. Just drop the live socket since
+      // the token it was authed with has been invalidated by the core.
       socketService.disconnect();
-    } else if (isInitialOrSameUserAuth && nextIdentity) {
-      // Cold bootstrap OR same-user re-login. Either way redux-persist's
-      // initial hydrate already loaded the right namespace into memory, so
-      // just seed the active user id and the ref and continue.
-      setActiveUserId(nextIdentity);
-      lastAuthedUserIdRef.current = nextIdentity;
     }
+    // Same-user re-login (seedUserId === nextIdentity) and cold bootstrap
+    // with matching seed are no-ops — redux-persist already loaded the
+    // right namespace and the active user id is already correct.
     syncAnalyticsConsent(snapshot.analyticsEnabled);
 
     if (!snapshot.sessionToken) {
@@ -505,15 +491,13 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       snapshot: toSignedOutSnapshot(previous.snapshot),
     }));
     memoryTokenRef.current = null;
-    // Drop the active user id so any stray persist write during the signed-
-    // out window (e.g., before tauriLogout completes) is a no-op rather than
-    // landing in the prior user's namespace. We deliberately do NOT dispatch
-    // `resetUserScopedState` here — keeping in-memory slice data intact lets
-    // a same-user re-login (immediate or after an OAuth round-trip) keep
-    // showing the user's accounts/threads without a process restart. The
-    // signed-out UI doesn't render those slices anyway, so there's no leak.
-    // See [#900].
-    setActiveUserId(null);
+    // Keep `OPENHUMAN_ACTIVE_USER_ID` pointing at the last user. The next
+    // refresh's `getActiveUserId()` seed comparison decides whether the
+    // upcoming login is a same-user re-login (no restart) or a different-
+    // user re-login (restart). We do NOT dispatch `resetUserScopedState`
+    // here either — the signed-out UI doesn't render user-scoped slices,
+    // and a same-user re-login should not pay a "rehydrate from disk"
+    // cost (slices are still in memory). See [#900].
     await tauriLogout();
     await refresh().catch(err => {
       log('refresh failed after clearSession: %O', sanitizeError(err));

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -80,44 +80,38 @@ function snapshotIdentity(snapshot: CoreAppSnapshot): string | null {
 }
 
 /**
- * Universal cleanup for identity changes (flip A→B, or sign-out).
+ * Restart-class cleanup for identity changes that require a process relaunch
+ * to re-hydrate redux-persist from the new user's namespace.
  *
- * 1. Re-points `userScopedStorage` to the new user's namespace (or `null` for
- *    sign-out). On the next cold launch — or right now for in-memory writes —
- *    redux-persist reads/writes blobs under `${nextUserId}:persist:*`.
- * 2. Resets every user-scoped Redux slice via `resetUserScopedState` so the
- *    live store is empty before any rehydrate from the new namespace.
- * 3. Disconnects the live Socket.IO connection so the reconnect carries the
- *    new user's auth token (fresh `client_id` server-side).
- * 4. On a real flip (A→B), restarts the app so singleton services and
- *    Rust-side webview accounts pick up the new user dir. On sign-out, the
- *    signed-out UI is already empty — a relaunch would be jarring.
+ * redux-persist hydrates ONCE at module init, reading from whatever namespace
+ * `userScopedStorage` was pointing at. After that, `setActiveUserId` only
+ * routes new writes/reads — it doesn't re-hydrate in-memory state. So when
+ * the active userId changes from the namespace that was hydrated to a
+ * different one, we have to restart the app to get a fresh hydrate.
  *
- * Note: we deliberately do NOT call `persistor.purge()`. Each user's
- * persisted blob lives at its own namespaced key, so user A's data must
- * survive B's session intact and rehydrate when A returns. See [#900].
+ * Steps:
+ * 1. Re-point `userScopedStorage` to the new user's namespace so the
+ *    `OPENHUMAN_ACTIVE_USER_ID` localStorage seed is correct on relaunch.
+ * 2. Dispatch `resetUserScopedState` to wipe the live store immediately —
+ *    cosmetic during the brief frame between this call and `restartApp()`,
+ *    so the prior user's slices don't render against the new auth.
+ * 3. Disconnect the Socket.IO connection so the reconnect after relaunch
+ *    carries the new user's auth token.
+ * 4. `restartApp()` — the new process module-init reads
+ *    `OPENHUMAN_ACTIVE_USER_ID=nextUserId`, hydrates from that namespace,
+ *    and singleton services / Rust webview accounts come up clean.
+ *
+ * We deliberately do NOT call `persistor.purge()`. Each user's persisted
+ * blob lives at its own namespaced key, so user A's data must survive B's
+ * session intact and rehydrate when A returns. See [#900].
  */
-async function handleIdentityFlip(opts: {
-  restart: boolean;
-  reason: string;
-  nextUserId: string | null;
-}): Promise<void> {
-  const { restart, reason, nextUserId } = opts;
-  log(
-    'identity flip cleanup reason=%s restart=%s nextUserId=%s',
-    reason,
-    restart,
-    nextUserId ? `****${nextUserId.slice(-4)}` : 'none'
-  );
-  // Re-point storage BEFORE the in-memory reset so any stray persist write
-  // triggered between the reset dispatch and the restart goes to the new
-  // user's namespace (or is dropped when nextUserId is null).
+async function handleIdentityFlip(opts: { reason: string; nextUserId: string }): Promise<void> {
+  const { reason, nextUserId } = opts;
+  log('identity flip restart reason=%s nextUserId=%s', reason, `****${nextUserId.slice(-4)}`);
   setActiveUserId(nextUserId);
   store.dispatch(resetUserScopedState());
   socketService.disconnect();
-  if (restart) {
-    await restartApp();
-  }
+  await restartApp();
 }
 
 function normalizeSnapshot(
@@ -167,6 +161,13 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
   const logoutGuardUntilRef = useRef(0);
   const bootstrapFailCountRef = useRef(0);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  // The userId whose `${id}:persist:*` blob is currently in memory. Set on
+  // first auth landing (cold bootstrap) and after a successful flip-restart.
+  // Used to decide whether a signed-out → signed-in transition is a real
+  // re-login (data is on disk under a different namespace, restart to
+  // re-hydrate) or a same-user re-login (in-memory state survived a logout
+  // window because we don't reset on logout). See [#900].
+  const lastAuthedUserIdRef = useRef<string | null>(null);
 
   const commitState = useCallback((updater: (previous: CoreState) => CoreState) => {
     setState(previous => {
@@ -194,15 +195,27 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     const nextIdentity = snapshotIdentity(nextSnapshot);
     const previousAuthed = beforeCommit.auth.isAuthenticated;
     const nextAuthed = nextSnapshot.auth.isAuthenticated;
-    // Only flag a flip when BOTH sides are authenticated and identities differ.
-    // Bootstrap (signed-out → signed-in) and logout transitions are handled
-    // separately so we never restart-loop on launch (#900).
-    const isFlip =
+    // Auth-to-auth identity flip (e.g., one window force-switches user mid-session).
+    const isAuthFlip =
       Boolean(previousAuthed) &&
       nextAuthed &&
       Boolean(previousIdentity) &&
       previousIdentity !== nextIdentity;
+    // Re-login as a DIFFERENT user (signed-out → signed-in, current id !=
+    // last-seen). The clearSession → storeSessionToken sequence always
+    // routes through this branch since clearSession sets isAuthenticated=false.
+    const isReLoginFlip =
+      !previousAuthed &&
+      nextAuthed &&
+      Boolean(nextIdentity) &&
+      lastAuthedUserIdRef.current !== null &&
+      lastAuthedUserIdRef.current !== nextIdentity;
+    const isFlip = isAuthFlip || isReLoginFlip;
     const isLogout = Boolean(previousAuthed) && !nextAuthed;
+    const isInitialAuth = !previousAuthed && nextAuthed && Boolean(nextIdentity) && !isReLoginFlip;
+    // Clear team caches whenever the visible identity changes (any direction)
+    // so the post-commit UI doesn't show A's team list during the brief
+    // signed-out window or B's session.
     const shouldClearScopedCaches = isFlip || isLogout || previousIdentity !== nextIdentity;
 
     commitState(previous => {
@@ -220,32 +233,33 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       };
     });
 
-    if (isFlip) {
+    if (isFlip && nextIdentity) {
+      // Track the new identity before triggering restart so that a test (or
+      // a no-op restartApp mock) sees the ref updated; in production the
+      // page reloads and the ref is rebuilt on next mount anyway.
+      lastAuthedUserIdRef.current = nextIdentity;
       await handleIdentityFlip({
-        restart: true,
-        reason: 'refreshCore-flip',
+        reason: isAuthFlip ? 'auth-flip' : 'relogin-different-user',
         nextUserId: nextIdentity,
       }).catch(err => {
-        log('handleIdentityFlip(flip) failed: %O', sanitizeError(err));
+        log('handleIdentityFlip failed: %O', sanitizeError(err));
       });
     } else if (isLogout) {
-      await handleIdentityFlip({
-        restart: false,
-        reason: 'refreshCore-logout',
-        nextUserId: null,
-      }).catch(err => {
-        log('handleIdentityFlip(logout) failed: %O', sanitizeError(err));
-      });
-    } else if (
-      // First-paint bootstrap (signed-out → signed-in on cold launch): seed
-      // the active user id so subsequent persist writes route to this user's
-      // namespace. No restart, no Redux reset — bootstrap state is already
-      // correct.
-      !previousAuthed &&
-      nextAuthed &&
-      nextIdentity
-    ) {
+      // Sign-out: keep slice data in memory (signed-out UI doesn't expose
+      // it) so a same-user re-login can keep showing the user's accounts /
+      // threads / notifications without a costly process restart. Drop the
+      // active user id so any stray persist write during the signed-out
+      // window is a no-op, and disconnect the live socket since the token
+      // it was authed with has been invalidated by the core.
+      setActiveUserId(null);
+      socketService.disconnect();
+    } else if (isInitialAuth && nextIdentity) {
+      // Cold bootstrap OR same-user re-login (signed-out → signed-in where
+      // the next id matches the last-seen id). Either way redux-persist's
+      // initial hydrate already loaded the right namespace into memory, so
+      // just seed the active user id and continue.
       setActiveUserId(nextIdentity);
+      lastAuthedUserIdRef.current = nextIdentity;
     }
     syncAnalyticsConsent(snapshot.analyticsEnabled);
 
@@ -495,14 +509,15 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       snapshot: toSignedOutSnapshot(previous.snapshot),
     }));
     memoryTokenRef.current = null;
-    // Reset every user-scoped slice + drop the live socket + un-scope storage
-    // before the tauriLogout RPC so user A's data is gone the moment the UI
-    // re-renders signed-out (#900). No restart — signed-out UI is empty;
-    // the next storeSessionToken (login) will restart via refreshCore.
-    // We do NOT purge persist storage — A's blob stays at its namespaced key
-    // so when A returns to this device, their accounts/threads/notifications
-    // rehydrate.
-    await handleIdentityFlip({ restart: false, reason: 'clearSession', nextUserId: null });
+    // Drop the active user id so any stray persist write during the signed-
+    // out window (e.g., before tauriLogout completes) is a no-op rather than
+    // landing in the prior user's namespace. We deliberately do NOT dispatch
+    // `resetUserScopedState` here — keeping in-memory slice data intact lets
+    // a same-user re-login (immediate or after an OAuth round-trip) keep
+    // showing the user's accounts/threads without a process restart. The
+    // signed-out UI doesn't render those slices anyway, so there's no leak.
+    // See [#900].
+    setActiveUserId(null);
     await tauriLogout();
     await refresh().catch(err => {
       log('refresh failed after clearSession: %O', sanitizeError(err));

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -25,6 +25,9 @@ import {
   listTeams,
   updateCoreLocalState,
 } from '../services/coreStateApi';
+import { socketService } from '../services/socketService';
+import { persistor, store } from '../store';
+import { resetUserScopedState } from '../store/resetActions';
 import {
   openhumanUpdateAnalyticsSettings,
   restartApp,
@@ -73,6 +76,36 @@ const CoreStateContext = createContext<CoreStateContextValue | null>(null);
 
 function snapshotIdentity(snapshot: CoreAppSnapshot): string | null {
   return snapshot.auth.userId ?? snapshot.currentUser?._id ?? null;
+}
+
+/**
+ * Universal cleanup for identity changes (flip A→B, or sign-out).
+ *
+ * Resets every user-scoped Redux slice via `resetUserScopedState`, drops the
+ * `persist:*` localStorage blobs (otherwise rehydration on the next render or
+ * launch leaks user A's slices into user B's session), and disconnects the
+ * live Socket.IO connection so the next reconnect carries the new auth token.
+ *
+ * Pass `restart: true` for a real flip (A→B): a process restart is needed
+ * because singleton services and Rust-side webview accounts pin the prior
+ * user's state for the lifetime of the process. Pass `restart: false` for
+ * sign-out — the signed-out UI is empty, so a relaunch would be jarring.
+ *
+ * See [#900].
+ */
+async function handleIdentityFlip(opts: { restart: boolean; reason: string }): Promise<void> {
+  const { restart, reason } = opts;
+  log('identity flip cleanup reason=%s restart=%s', reason, restart);
+  store.dispatch(resetUserScopedState());
+  socketService.disconnect();
+  try {
+    await persistor.purge();
+  } catch (error) {
+    console.warn('[core-state] persistor.purge failed during identity flip:', error);
+  }
+  if (restart) {
+    await restartApp();
+  }
 }
 
 function normalizeSnapshot(
@@ -137,23 +170,33 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     if (!snapshot.sessionToken) {
       logoutGuardUntilRef.current = 0;
     }
+    // Capture pre-commit identity outside the setState updater so flip
+    // detection runs synchronously regardless of React's batching policy.
+    const beforeCommit = getCoreStateSnapshot().snapshot;
+    const shouldIgnoreTokenDuringLogout =
+      Date.now() < logoutGuardUntilRef.current &&
+      !beforeCommit.sessionToken &&
+      Boolean(snapshot.sessionToken);
+    const nextSnapshot = shouldIgnoreTokenDuringLogout ? toSignedOutSnapshot(snapshot) : snapshot;
+    const previousIdentity = snapshotIdentity(beforeCommit);
+    const nextIdentity = snapshotIdentity(nextSnapshot);
+    const previousAuthed = beforeCommit.auth.isAuthenticated;
+    const nextAuthed = nextSnapshot.auth.isAuthenticated;
+    // Only flag a flip when BOTH sides are authenticated and identities differ.
+    // Bootstrap (signed-out → signed-in) and logout transitions are handled
+    // separately so we never restart-loop on launch (#900).
+    const isFlip =
+      Boolean(previousAuthed) &&
+      nextAuthed &&
+      Boolean(previousIdentity) &&
+      previousIdentity !== nextIdentity;
+    const isLogout = Boolean(previousAuthed) && !nextAuthed;
+    const shouldClearScopedCaches = isFlip || isLogout || previousIdentity !== nextIdentity;
+
     commitState(previous => {
       if (requestId !== snapshotRequestIdRef.current) {
         return previous;
       }
-
-      const shouldIgnoreTokenDuringLogout =
-        Date.now() < logoutGuardUntilRef.current &&
-        !previous.snapshot.sessionToken &&
-        Boolean(snapshot.sessionToken);
-      const nextSnapshot = shouldIgnoreTokenDuringLogout ? toSignedOutSnapshot(snapshot) : snapshot;
-
-      const previousIdentity = snapshotIdentity(previous.snapshot);
-      const nextIdentity = snapshotIdentity(nextSnapshot);
-      const shouldClearScopedCaches =
-        previousIdentity !== nextIdentity ||
-        (previous.snapshot.auth.isAuthenticated && !nextSnapshot.auth.isAuthenticated);
-
       return {
         ...previous,
         isBootstrapping: false,
@@ -164,6 +207,16 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
         teamInvitesById: shouldClearScopedCaches ? {} : previous.teamInvitesById,
       };
     });
+
+    if (isFlip) {
+      await handleIdentityFlip({ restart: true, reason: 'refreshCore-flip' }).catch(err => {
+        log('handleIdentityFlip(flip) failed: %O', sanitizeError(err));
+      });
+    } else if (isLogout) {
+      await handleIdentityFlip({ restart: false, reason: 'refreshCore-logout' }).catch(err => {
+        log('handleIdentityFlip(logout) failed: %O', sanitizeError(err));
+      });
+    }
     syncAnalyticsConsent(snapshot.analyticsEnabled);
 
     if (!snapshot.sessionToken) {
@@ -379,7 +432,6 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
 
   const storeSessionToken = useCallback(
     async (token: string, user?: object) => {
-      const previousIdentity = snapshotIdentity(getCoreStateSnapshot().snapshot);
       logoutGuardUntilRef.current = 0;
       await storeSession(token, user ?? {});
       try {
@@ -388,21 +440,16 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       } catch (error) {
         console.warn('[core-state] memory client sync failed after session store:', error);
       }
+      // refresh() drives refreshCore, which now owns identity-flip detection
+      // and dispatches handleIdentityFlip when both prev and next are
+      // authenticated and identities differ. The previous standalone
+      // restartApp call here was redundant and skipped the persist purge,
+      // letting redux-persist rehydrate the prior user's slices on launch
+      // (#900). Restart now happens inside handleIdentityFlip after purge.
       await refresh();
       await refreshTeams().catch(err => {
         log('refreshTeams failed after session store: %O', sanitizeError(err));
       });
-
-      const nextIdentity = snapshotIdentity(getCoreStateSnapshot().snapshot);
-      if (nextIdentity && previousIdentity !== nextIdentity) {
-        const mask = (s: string | null) =>
-          s == null ? 'none' : s.length > 4 ? `****${s.slice(-4)}` : '****';
-        console.debug('[core-state] user changed; restarting app to switch CEF profile', {
-          previousIdentity: mask(previousIdentity),
-          nextIdentity: mask(nextIdentity),
-        });
-        await restartApp();
-      }
     },
     [refresh, refreshTeams]
   );
@@ -418,6 +465,11 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       snapshot: toSignedOutSnapshot(previous.snapshot),
     }));
     memoryTokenRef.current = null;
+    // Reset every user-scoped slice + purge persist + drop the live socket
+    // before the tauriLogout RPC so user A's data is gone the moment the UI
+    // re-renders signed-out (#900). No restart — signed-out UI is empty;
+    // the next storeSessionToken (login as B) will restart via refreshCore.
+    await handleIdentityFlip({ restart: false, reason: 'clearSession' });
     await tauriLogout();
     await refresh().catch(err => {
       log('refresh failed after clearSession: %O', sanitizeError(err));

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -28,7 +28,7 @@ import {
 import { socketService } from '../services/socketService';
 import { store } from '../store';
 import { resetUserScopedState } from '../store/resetActions';
-import { setActiveUserId } from '../store/userScopedStorage';
+import { getActiveUserId, setActiveUserId } from '../store/userScopedStorage';
 import {
   openhumanUpdateAnalyticsSettings,
   restartApp,
@@ -161,13 +161,12 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
   const logoutGuardUntilRef = useRef(0);
   const bootstrapFailCountRef = useRef(0);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
-  // The userId whose `${id}:persist:*` blob is currently in memory. Set on
-  // first auth landing (cold bootstrap) and after a successful flip-restart.
-  // Used to decide whether a signed-out → signed-in transition is a real
-  // re-login (data is on disk under a different namespace, restart to
-  // re-hydrate) or a same-user re-login (in-memory state survived a logout
-  // window because we don't reset on logout). See [#900].
-  const lastAuthedUserIdRef = useRef<string | null>(null);
+  // The userId whose `${id}:persist:*` blob is currently in memory. Initialized
+  // from `getActiveUserId()` so the first refresh after mount knows which
+  // namespace was hydrated by redux-persist's module-init pass — a different
+  // userId landing means we have to restart so persistor re-hydrates from the
+  // new namespace. See [#900].
+  const lastAuthedUserIdRef = useRef<string | null>(getActiveUserId());
 
   const commitState = useCallback((updater: (previous: CoreState) => CoreState) => {
     setState(previous => {
@@ -195,27 +194,28 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     const nextIdentity = snapshotIdentity(nextSnapshot);
     const previousAuthed = beforeCommit.auth.isAuthenticated;
     const nextAuthed = nextSnapshot.auth.isAuthenticated;
-    // Auth-to-auth identity flip (e.g., one window force-switches user mid-session).
-    const isAuthFlip =
-      Boolean(previousAuthed) &&
-      nextAuthed &&
-      Boolean(previousIdentity) &&
-      previousIdentity !== nextIdentity;
-    // Re-login as a DIFFERENT user (signed-out → signed-in, current id !=
-    // last-seen). The clearSession → storeSessionToken sequence always
-    // routes through this branch since clearSession sets isAuthenticated=false.
-    const isReLoginFlip =
-      !previousAuthed &&
-      nextAuthed &&
+    // Identity flip detection is purely "is the in-memory data for a different
+    // user than the one who just authenticated?". `lastAuthedUserIdRef` tracks
+    // whose namespace redux-persist hydrated. If a different non-null userId
+    // lands, we have to restart so persistor re-hydrates from the new
+    // namespace. This rule covers every login path uniformly:
+    //   - direct `storeSessionToken` (Tauri OAuth)
+    //   - deep-link `core-state:session-token-updated` (where the synchronous
+    //     pre-refresh commit already flipped `auth.isAuthenticated=true`, so
+    //     `previousAuthed` is true but `previousIdentity` is still null —
+    //     previous-state-based heuristics get fooled)
+    //   - poll-detected flip (core-side user swap)
+    const isFlip =
       Boolean(nextIdentity) &&
       lastAuthedUserIdRef.current !== null &&
       lastAuthedUserIdRef.current !== nextIdentity;
-    const isFlip = isAuthFlip || isReLoginFlip;
     const isLogout = Boolean(previousAuthed) && !nextAuthed;
-    const isInitialAuth = !previousAuthed && nextAuthed && Boolean(nextIdentity) && !isReLoginFlip;
-    // Clear team caches whenever the visible identity changes (any direction)
-    // so the post-commit UI doesn't show A's team list during the brief
-    // signed-out window or B's session.
+    // Cold bootstrap OR same-user re-login: a userId landed and it matches
+    // (or is the first ever lookup against a null ref).
+    const isInitialOrSameUserAuth = Boolean(nextIdentity) && !isFlip;
+    // Clear team caches whenever the visible identity changes (in-memory user
+    // shift) so the post-commit UI doesn't show user A's team list during the
+    // brief signed-out window or user B's session.
     const shouldClearScopedCaches = isFlip || isLogout || previousIdentity !== nextIdentity;
 
     commitState(previous => {
@@ -234,30 +234,26 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     });
 
     if (isFlip && nextIdentity) {
-      // Track the new identity before triggering restart so that a test (or
-      // a no-op restartApp mock) sees the ref updated; in production the
-      // page reloads and the ref is rebuilt on next mount anyway.
+      // Track the new identity before triggering restart so a test (or a
+      // no-op restartApp mock) sees the ref updated; in production the page
+      // reloads and the ref is rebuilt from `getActiveUserId()` on next mount.
       lastAuthedUserIdRef.current = nextIdentity;
-      await handleIdentityFlip({
-        reason: isAuthFlip ? 'auth-flip' : 'relogin-different-user',
-        nextUserId: nextIdentity,
-      }).catch(err => {
+      await handleIdentityFlip({ reason: 'identity-flip', nextUserId: nextIdentity }).catch(err => {
         log('handleIdentityFlip failed: %O', sanitizeError(err));
       });
     } else if (isLogout) {
       // Sign-out: keep slice data in memory (signed-out UI doesn't expose
-      // it) so a same-user re-login can keep showing the user's accounts /
+      // it) so a same-user re-login keeps showing the user's accounts /
       // threads / notifications without a costly process restart. Drop the
       // active user id so any stray persist write during the signed-out
       // window is a no-op, and disconnect the live socket since the token
       // it was authed with has been invalidated by the core.
       setActiveUserId(null);
       socketService.disconnect();
-    } else if (isInitialAuth && nextIdentity) {
-      // Cold bootstrap OR same-user re-login (signed-out → signed-in where
-      // the next id matches the last-seen id). Either way redux-persist's
+    } else if (isInitialOrSameUserAuth && nextIdentity) {
+      // Cold bootstrap OR same-user re-login. Either way redux-persist's
       // initial hydrate already loaded the right namespace into memory, so
-      // just seed the active user id and continue.
+      // just seed the active user id and the ref and continue.
       setActiveUserId(nextIdentity);
       lastAuthedUserIdRef.current = nextIdentity;
     }

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -3,10 +3,11 @@ import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as coreStateApi from '../../services/coreStateApi';
+import * as userScopedStorage from '../../store/userScopedStorage';
 import * as tauriCommands from '../../utils/tauriCommands';
 import { setCoreStateSnapshot } from '../../lib/coreState/store';
 import { socketService } from '../../services/socketService';
-import { persistor, store } from '../../store';
+import { store } from '../../store';
 import { addAccount } from '../../store/accountsSlice';
 import { resetUserScopedState } from '../../store/resetActions';
 import CoreStateProvider, { useCoreState } from '../CoreStateProvider';
@@ -106,12 +107,12 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     resetCoreStateStore();
     // Reset Redux back to clean baseline before each test.
     store.dispatch(resetUserScopedState());
+    userScopedStorage.setActiveUserId(null);
   });
 
-  it('flip A→B: dispatches reset, purges persistor, disconnects socket, restarts app', async () => {
+  it('flip A→B: dispatches reset, re-points storage to B, disconnects socket, restarts app', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
-    const dispatchSpy = vi.spyOn(store, 'dispatch');
-    const purgeSpy = vi.spyOn(persistor, 'purge').mockResolvedValue(undefined);
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
 
     let ctx: CoreStateContextValue | undefined;
@@ -126,28 +127,26 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     seedAccountsWithUserAData();
     expect(store.getState().accounts.order).toContain('acct-A');
 
+    setActiveSpy.mockClear();
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
     await act(async () => {
       await ctx!.refresh();
-      // Allow the void-fired handleIdentityFlip to settle.
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(dispatchSpy).toHaveBeenCalledWith(resetUserScopedState());
-    expect(purgeSpy).toHaveBeenCalledTimes(1);
+    expect(setActiveSpy).toHaveBeenCalledWith('B');
     expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(restartApp).toHaveBeenCalledTimes(1);
     expect(store.getState().accounts.order).not.toContain('acct-A');
 
-    dispatchSpy.mockRestore();
-    purgeSpy.mockRestore();
+    setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();
   });
 
-  it('clearSession: resets + purges + disconnects, but does NOT restart', async () => {
+  it('clearSession: resets + drops socket + un-scopes storage, no restart, NO purge', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
-    const purgeSpy = vi.spyOn(persistor, 'purge').mockResolvedValue(undefined);
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
 
     let ctx: CoreStateContextValue | undefined;
@@ -161,6 +160,7 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     });
     seedAccountsWithUserAData();
 
+    setActiveSpy.mockClear();
     fetchSnapshot.mockResolvedValue(
       makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
     );
@@ -168,18 +168,18 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       await ctx!.clearSession();
     });
 
-    expect(purgeSpy).toHaveBeenCalled();
+    expect(setActiveSpy).toHaveBeenCalledWith(null);
     expect(disconnectSpy).toHaveBeenCalled();
     expect(restartApp).not.toHaveBeenCalled();
     expect(store.getState().accounts.order).not.toContain('acct-A');
 
-    purgeSpy.mockRestore();
+    setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();
   });
 
-  it('bootstrap (signed-out → signed-in): does NOT restart on first auth', async () => {
+  it('bootstrap (signed-out → signed-in): does NOT restart, seeds active user id', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
-    const purgeSpy = vi.spyOn(persistor, 'purge').mockResolvedValue(undefined);
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
 
     let ctx: CoreStateContextValue | undefined;
@@ -195,8 +195,46 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     });
 
     expect(restartApp).not.toHaveBeenCalled();
+    expect(setActiveSpy).toHaveBeenCalledWith('A');
+    expect(disconnectSpy).not.toHaveBeenCalled();
 
-    purgeSpy.mockRestore();
+    setActiveSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+
+  it('returning to user A: storage re-points to A, A blob namespace becomes active again', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
+    await act(async () => {
+      await ctx!.refresh();
+      await Promise.resolve();
+    });
+
+    setActiveSpy.mockClear();
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA2' }));
+    await act(async () => {
+      await ctx!.refresh();
+      await Promise.resolve();
+    });
+
+    // Each B→A flip re-points storage to A so A's persisted blob hydrates back.
+    expect(setActiveSpy).toHaveBeenCalledWith('A');
+    expect(restartApp).toHaveBeenCalledTimes(2);
+
+    setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();
   });
 });

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -105,12 +105,34 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     restartApp.mockReset();
     restartApp.mockResolvedValue(undefined);
     resetCoreStateStore();
-    // Reset Redux back to clean baseline before each test.
     store.dispatch(resetUserScopedState());
     userScopedStorage.setActiveUserId(null);
   });
 
-  it('flip A→B: dispatches reset, re-points storage to B, disconnects socket, restarts app', async () => {
+  it('cold bootstrap (signed-out → signed-in, no prior auth this session): no restart, seeds active user id', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    expect(restartApp).not.toHaveBeenCalled();
+    expect(setActiveSpy).toHaveBeenCalledWith('A');
+    expect(disconnectSpy).not.toHaveBeenCalled();
+
+    setActiveSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+
+  it('auth-to-auth flip (A→B without intermediate logout): restarts and re-points to B', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -132,7 +154,6 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     await act(async () => {
       await ctx!.refresh();
       await Promise.resolve();
-      await Promise.resolve();
     });
 
     expect(setActiveSpy).toHaveBeenCalledWith('B');
@@ -144,7 +165,7 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     disconnectSpy.mockRestore();
   });
 
-  it('clearSession: resets + drops socket + un-scopes storage, no restart, NO purge', async () => {
+  it('logout: drops active user id + disconnects socket; does NOT reset slice data or restart', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -165,44 +186,97 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
     );
     await act(async () => {
-      await ctx!.clearSession();
+      await ctx!.refresh();
     });
 
     expect(setActiveSpy).toHaveBeenCalledWith(null);
-    expect(disconnectSpy).toHaveBeenCalled();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(restartApp).not.toHaveBeenCalled();
+    // Slice data preserved across logout — same-user re-login keeps the UI shimmer.
+    expect(store.getState().accounts.order).toContain('acct-A');
+
+    setActiveSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+
+  it('same-user re-login (A→logout→A): no restart, no reset', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+    seedAccountsWithUserAData();
+
+    fetchSnapshot.mockResolvedValue(
+      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    setActiveSpy.mockClear();
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA2' }));
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    expect(setActiveSpy).toHaveBeenCalledWith('A');
+    expect(restartApp).not.toHaveBeenCalled();
+    // Slice data still there from before the logout window.
+    expect(store.getState().accounts.order).toContain('acct-A');
+
+    setActiveSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+
+  it('different-user re-login (A→logout→B): restarts, re-points to B', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+    seedAccountsWithUserAData();
+
+    fetchSnapshot.mockResolvedValue(
+      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    setActiveSpy.mockClear();
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
+    await act(async () => {
+      await ctx!.refresh();
+      await Promise.resolve();
+    });
+
+    expect(setActiveSpy).toHaveBeenCalledWith('B');
+    expect(restartApp).toHaveBeenCalledTimes(1);
+    expect(disconnectSpy).toHaveBeenCalled();
     expect(store.getState().accounts.order).not.toContain('acct-A');
 
     setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();
   });
 
-  it('bootstrap (signed-out → signed-in): does NOT restart, seeds active user id', async () => {
-    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
-    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
-    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
-
-    let ctx: CoreStateContextValue | undefined;
-    render(
-      <CoreStateProvider>
-        <Consumer captureCtx={c => (ctx = c)} />
-      </CoreStateProvider>
-    );
-    await act(async () => {
-      await ctx!.refresh();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(restartApp).not.toHaveBeenCalled();
-    expect(setActiveSpy).toHaveBeenCalledWith('A');
-    expect(disconnectSpy).not.toHaveBeenCalled();
-
-    setActiveSpy.mockRestore();
-    disconnectSpy.mockRestore();
-  });
-
-  it('returning to user A: storage re-points to A, A blob namespace becomes active again', async () => {
+  it('round-trip A→B→A: each different-user flip restarts, storage re-points correctly', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -217,10 +291,22 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       await ctx!.refresh();
     });
 
+    fetchSnapshot.mockResolvedValue(
+      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
     await act(async () => {
       await ctx!.refresh();
       await Promise.resolve();
+    });
+    fetchSnapshot.mockResolvedValue(
+      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
+    );
+    await act(async () => {
+      await ctx!.refresh();
     });
 
     setActiveSpy.mockClear();
@@ -230,9 +316,8 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       await Promise.resolve();
     });
 
-    // Each B→A flip re-points storage to A so A's persisted blob hydrates back.
     expect(setActiveSpy).toHaveBeenCalledWith('A');
-    expect(restartApp).toHaveBeenCalledTimes(2);
+    expect(restartApp).toHaveBeenCalledTimes(2); // once for A→B, once for B→A
 
     setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -109,7 +109,7 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     userScopedStorage.setActiveUserId(null);
   });
 
-  it('cold bootstrap (signed-out → signed-in, no prior auth this session): no restart, seeds active user id', async () => {
+  it('cold bootstrap on a fresh device (seed=null, nextId=A): RESTART required so CEF picks up A profile', async () => {
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -124,15 +124,36 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       await ctx!.refresh();
     });
 
-    expect(restartApp).not.toHaveBeenCalled();
     expect(setActiveSpy).toHaveBeenCalledWith('A');
-    expect(disconnectSpy).not.toHaveBeenCalled();
+    expect(restartApp).toHaveBeenCalledTimes(1);
 
     setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();
   });
 
-  it('auth-to-auth flip (A→B without intermediate logout): restarts and re-points to B', async () => {
+  it('warm launch (seed=A, snapshot=A): no restart', async () => {
+    userScopedStorage.setActiveUserId('A');
+    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    expect(restartApp).not.toHaveBeenCalled();
+    expect(setActiveSpy).not.toHaveBeenCalled();
+
+    setActiveSpy.mockRestore();
+  });
+
+  it('auth-to-auth flip (A→B without intermediate logout): restart, re-points to B', async () => {
+    userScopedStorage.setActiveUserId('A');
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -165,7 +186,8 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     disconnectSpy.mockRestore();
   });
 
-  it('logout: drops active user id + disconnects socket; does NOT reset slice data or restart', async () => {
+  it('logout: keeps active user id seed; disconnects socket; no restart, no reset', async () => {
+    userScopedStorage.setActiveUserId('A');
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -189,20 +211,21 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       await ctx!.refresh();
     });
 
-    expect(setActiveSpy).toHaveBeenCalledWith(null);
+    // Seed must NOT be cleared on logout — same-user re-login depends on it.
+    expect(setActiveSpy).not.toHaveBeenCalled();
+    expect(userScopedStorage.getActiveUserId()).toBe('A');
     expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(restartApp).not.toHaveBeenCalled();
-    // Slice data preserved across logout — same-user re-login keeps the UI shimmer.
     expect(store.getState().accounts.order).toContain('acct-A');
 
     setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();
   });
 
-  it('same-user re-login (A→logout→A): no restart, no reset', async () => {
+  it('same-user re-login (A→logout→A): no restart (seed still points at A)', async () => {
+    userScopedStorage.setActiveUserId('A');
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
-    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
 
     let ctx: CoreStateContextValue | undefined;
     render(
@@ -228,16 +251,15 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
       await ctx!.refresh();
     });
 
-    expect(setActiveSpy).toHaveBeenCalledWith('A');
+    expect(setActiveSpy).not.toHaveBeenCalled();
     expect(restartApp).not.toHaveBeenCalled();
-    // Slice data still there from before the logout window.
     expect(store.getState().accounts.order).toContain('acct-A');
 
     setActiveSpy.mockRestore();
-    disconnectSpy.mockRestore();
   });
 
-  it('different-user re-login (A→logout→B): restarts, re-points to B', async () => {
+  it('different-user re-login (A→logout→B): restart, re-points to B', async () => {
+    userScopedStorage.setActiveUserId('A');
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
     const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
     const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
@@ -271,53 +293,6 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     expect(restartApp).toHaveBeenCalledTimes(1);
     expect(disconnectSpy).toHaveBeenCalled();
     expect(store.getState().accounts.order).not.toContain('acct-A');
-
-    setActiveSpy.mockRestore();
-    disconnectSpy.mockRestore();
-  });
-
-  it('round-trip A→B→A: each different-user flip restarts, storage re-points correctly', async () => {
-    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
-    const setActiveSpy = vi.spyOn(userScopedStorage, 'setActiveUserId');
-    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
-
-    let ctx: CoreStateContextValue | undefined;
-    render(
-      <CoreStateProvider>
-        <Consumer captureCtx={c => (ctx = c)} />
-      </CoreStateProvider>
-    );
-    await act(async () => {
-      await ctx!.refresh();
-    });
-
-    fetchSnapshot.mockResolvedValue(
-      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
-    );
-    await act(async () => {
-      await ctx!.refresh();
-    });
-    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
-    await act(async () => {
-      await ctx!.refresh();
-      await Promise.resolve();
-    });
-    fetchSnapshot.mockResolvedValue(
-      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
-    );
-    await act(async () => {
-      await ctx!.refresh();
-    });
-
-    setActiveSpy.mockClear();
-    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA2' }));
-    await act(async () => {
-      await ctx!.refresh();
-      await Promise.resolve();
-    });
-
-    expect(setActiveSpy).toHaveBeenCalledWith('A');
-    expect(restartApp).toHaveBeenCalledTimes(2); // once for A→B, once for B→A
 
     setActiveSpy.mockRestore();
     disconnectSpy.mockRestore();

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -1,0 +1,202 @@
+import { act, render } from '@testing-library/react';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as coreStateApi from '../../services/coreStateApi';
+import * as tauriCommands from '../../utils/tauriCommands';
+import { setCoreStateSnapshot } from '../../lib/coreState/store';
+import { socketService } from '../../services/socketService';
+import { persistor, store } from '../../store';
+import { addAccount } from '../../store/accountsSlice';
+import { resetUserScopedState } from '../../store/resetActions';
+import CoreStateProvider, { useCoreState } from '../CoreStateProvider';
+
+vi.mock('../../services/coreStateApi');
+vi.mock('../../services/analytics', () => ({ syncAnalyticsConsent: vi.fn() }));
+vi.mock('../../utils/tauriCommands', () => ({
+  openhumanUpdateAnalyticsSettings: vi.fn(),
+  restartApp: vi.fn().mockResolvedValue(undefined),
+  setOnboardingCompleted: vi.fn(),
+  storeSession: vi.fn().mockResolvedValue(undefined),
+  syncMemoryClientToken: vi.fn().mockResolvedValue(undefined),
+  logout: vi.fn().mockResolvedValue(undefined),
+}));
+
+type Snapshot = Awaited<ReturnType<typeof coreStateApi.fetchCoreAppSnapshot>>;
+
+function makeSnapshot(overrides: {
+  userId?: string | null;
+  sessionToken?: string | null;
+  isAuthenticated?: boolean;
+}): Snapshot {
+  return {
+    auth: {
+      isAuthenticated: overrides.isAuthenticated ?? Boolean(overrides.userId),
+      userId: overrides.userId ?? null,
+      user: null as never,
+      profileId: null,
+    },
+    sessionToken: overrides.sessionToken ?? null,
+    currentUser: null as never,
+    onboardingCompleted: false,
+    chatOnboardingCompleted: false,
+    analyticsEnabled: false,
+    localState: {},
+    runtime: {
+      screenIntelligence: null as never,
+      localAi: null as never,
+      autocomplete: null as never,
+      service: null as never,
+    },
+  };
+}
+
+type CoreStateContextValue = ReturnType<typeof useCoreState>;
+
+function Consumer({ captureCtx }: { captureCtx: (ctx: CoreStateContextValue) => void }) {
+  const state = useCoreState();
+  useEffect(() => {
+    captureCtx(state);
+  });
+  return <span data-testid="user">{state.snapshot.auth.userId ?? 'none'}</span>;
+}
+
+function resetCoreStateStore() {
+  setCoreStateSnapshot({
+    isBootstrapping: true,
+    isReady: false,
+    snapshot: {
+      auth: { isAuthenticated: false, userId: null, user: null, profileId: null },
+      sessionToken: null,
+      currentUser: null,
+      onboardingCompleted: false,
+      chatOnboardingCompleted: false,
+      analyticsEnabled: false,
+      localState: { encryptionKey: null, primaryWalletAddress: null, onboardingTasks: null },
+      runtime: { screenIntelligence: null, localAi: null, autocomplete: null, service: null },
+    },
+    teams: [],
+    teamMembersById: {},
+    teamInvitesById: {},
+  });
+}
+
+function seedAccountsWithUserAData() {
+  store.dispatch(
+    addAccount({
+      id: 'acct-A',
+      provider: 'whatsapp',
+      label: 'WhatsApp A',
+      status: 'connected',
+    } as never)
+  );
+}
+
+describe('CoreStateProvider — identity flip cleanup (#900)', () => {
+  const fetchSnapshot = vi.mocked(coreStateApi.fetchCoreAppSnapshot);
+  const listTeams = vi.mocked(coreStateApi.listTeams);
+  const restartApp = vi.mocked(tauriCommands.restartApp);
+
+  beforeEach(() => {
+    fetchSnapshot.mockReset();
+    listTeams.mockReset();
+    listTeams.mockResolvedValue([]);
+    restartApp.mockReset();
+    restartApp.mockResolvedValue(undefined);
+    resetCoreStateStore();
+    // Reset Redux back to clean baseline before each test.
+    store.dispatch(resetUserScopedState());
+  });
+
+  it('flip A→B: dispatches reset, purges persistor, disconnects socket, restarts app', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const dispatchSpy = vi.spyOn(store, 'dispatch');
+    const purgeSpy = vi.spyOn(persistor, 'purge').mockResolvedValue(undefined);
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+    seedAccountsWithUserAData();
+    expect(store.getState().accounts.order).toContain('acct-A');
+
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
+    await act(async () => {
+      await ctx!.refresh();
+      // Allow the void-fired handleIdentityFlip to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(resetUserScopedState());
+    expect(purgeSpy).toHaveBeenCalledTimes(1);
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+    expect(restartApp).toHaveBeenCalledTimes(1);
+    expect(store.getState().accounts.order).not.toContain('acct-A');
+
+    dispatchSpy.mockRestore();
+    purgeSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+
+  it('clearSession: resets + purges + disconnects, but does NOT restart', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const purgeSpy = vi.spyOn(persistor, 'purge').mockResolvedValue(undefined);
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+    seedAccountsWithUserAData();
+
+    fetchSnapshot.mockResolvedValue(
+      makeSnapshot({ userId: null, sessionToken: null, isAuthenticated: false })
+    );
+    await act(async () => {
+      await ctx!.clearSession();
+    });
+
+    expect(purgeSpy).toHaveBeenCalled();
+    expect(disconnectSpy).toHaveBeenCalled();
+    expect(restartApp).not.toHaveBeenCalled();
+    expect(store.getState().accounts.order).not.toContain('acct-A');
+
+    purgeSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+
+  it('bootstrap (signed-out → signed-in): does NOT restart on first auth', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'A', sessionToken: 'tokA' }));
+    const purgeSpy = vi.spyOn(persistor, 'purge').mockResolvedValue(undefined);
+    const disconnectSpy = vi.spyOn(socketService, 'disconnect').mockImplementation(() => {});
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(restartApp).not.toHaveBeenCalled();
+
+    purgeSpy.mockRestore();
+    disconnectSpy.mockRestore();
+  });
+});

--- a/app/src/store/accountsSlice.ts
+++ b/app/src/store/accountsSlice.ts
@@ -7,6 +7,7 @@ import type {
   AccountStatus,
   IngestedMessage,
 } from '../types/accounts';
+import { resetUserScopedState } from './resetActions';
 
 const MAX_MESSAGES_PER_ACCOUNT = 200;
 const MAX_LOG_LINES_PER_ACCOUNT = 100;
@@ -104,6 +105,9 @@ const accountsSlice = createSlice({
     resetAccountsState() {
       return initialState;
     },
+  },
+  extraReducers: builder => {
+    builder.addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/channelConnectionsSlice.ts
+++ b/app/src/store/channelConnectionsSlice.ts
@@ -7,6 +7,7 @@ import type {
   ChannelConnectionStatus,
   ChannelType,
 } from '../types/channels';
+import { resetUserScopedState } from './resetActions';
 
 const SCHEMA_VERSION = 1;
 
@@ -115,6 +116,9 @@ const channelConnectionsSlice = createSlice({
     resetChannelConnectionsState() {
       return initialState;
     },
+  },
+  extraReducers: builder => {
+    builder.addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+import { resetUserScopedState } from './resetActions';
+
 export type ToolTimelineEntryStatus = 'running' | 'success' | 'error';
 
 export interface InferenceStatus {
@@ -132,6 +134,9 @@ const chatRuntimeSlice = createSlice({
     resetSessionTokenUsage: state => {
       state.sessionTokenUsage = { inputTokens: 0, outputTokens: 0, turns: 0, lastUpdated: 0 };
     },
+  },
+  extraReducers: builder => {
+    builder.addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -10,7 +10,6 @@ import {
   REGISTER,
   REHYDRATE,
 } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import { IS_DEV } from '../utils/config';
 import accountsReducer from './accountsSlice';
@@ -20,6 +19,12 @@ import notificationReducer from './notificationSlice';
 import providerSurfacesReducer from './providerSurfaceSlice';
 import socketReducer from './socketSlice';
 import threadReducer from './threadSlice';
+import { userScopedStorage } from './userScopedStorage';
+
+// Persisted slices write through `userScopedStorage` so each user's blob
+// lives at `${userId}:persist:<key>` instead of a single per-device blob
+// that leaks across users on logout/login (#900).
+const storage = userScopedStorage;
 
 const channelConnectionsPersistConfig = {
   key: 'channelConnections',

--- a/app/src/store/notificationSlice.ts
+++ b/app/src/store/notificationSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import type { IntegrationNotification } from '../types/notifications';
+import { resetUserScopedState } from './resetActions';
 
 export type NotificationCategory = 'messages' | 'agents' | 'skills' | 'system';
 
@@ -113,6 +114,9 @@ const notificationSlice = createSlice({
         }
       }
     },
+  },
+  extraReducers: builder => {
+    builder.addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/providerSurfaceSlice.ts
+++ b/app/src/store/providerSurfaceSlice.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 import { providerSurfacesApi } from '../services/api/providerSurfacesApi';
 import type { RespondQueueItem } from '../types/providerSurfaces';
+import { resetUserScopedState } from './resetActions';
 
 interface ProviderSurfaceState {
   queue: RespondQueueItem[];
@@ -57,7 +58,8 @@ const providerSurfaceSlice = createSlice({
           state.error = (action.payload as string) ?? 'Failed to load provider respond queue';
         }
         // silent failures: leave status/error as-is; a subsequent successful poll will clear
-      });
+      })
+      .addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/resetActions.ts
+++ b/app/src/store/resetActions.ts
@@ -1,0 +1,8 @@
+import { createAction } from '@reduxjs/toolkit';
+
+/**
+ * Top-level action dispatched on identity flip (user A → user B) and on
+ * sign-out. Every user-scoped slice handles this in `extraReducers` and
+ * returns its `initialState`. See [#900].
+ */
+export const resetUserScopedState = createAction('store/resetUserScopedState');

--- a/app/src/store/socketSlice.ts
+++ b/app/src/store/socketSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { resetUserScopedState } from './resetActions';
+
 export type SocketConnectionStatus = 'connected' | 'disconnected' | 'connecting';
 
 export interface SocketUserState {
@@ -50,6 +52,9 @@ const socketSlice = createSlice({
       const { userId } = action.payload;
       state.byUser[userId] = { ...initialUserState };
     },
+  },
+  extraReducers: builder => {
+    builder.addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -3,6 +3,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { threadApi } from '../services/api/threadApi';
 import type { Thread, ThreadMessage } from '../types/thread';
 import { IS_DEV } from '../utils/config';
+import { resetUserScopedState } from './resetActions';
 
 interface ThreadState {
   threads: Thread[];
@@ -318,7 +319,8 @@ const threadSlice = createSlice({
       })
       .addCase(deleteThread.fulfilled, (state, action) => {
         delete state.messagesByThreadId[action.payload.threadId];
-      });
+      })
+      .addCase(resetUserScopedState, () => initialState);
   },
 });
 

--- a/app/src/store/userScopedStorage.ts
+++ b/app/src/store/userScopedStorage.ts
@@ -48,16 +48,53 @@ export function getActiveUserId(): string | null {
  * rehydrates.
  */
 export function setActiveUserId(id: string | null): void {
+  const previous = activeUserId;
   activeUserId = id;
   try {
     if (id) {
       localStorage.setItem(ACTIVE_USER_KEY, id);
+      if (!previous) {
+        migrateLegacyPersistKeys(id);
+      }
     } else {
       localStorage.removeItem(ACTIVE_USER_KEY);
     }
   } catch {
     // localStorage may be unavailable (private mode quota); swallowing is
     // fine — the in-memory ref still drives the current session.
+  }
+}
+
+/**
+ * One-shot migration for users upgrading from the pre-#900 build, where
+ * persist blobs lived at unscoped keys (`persist:accounts`, etc.). On the
+ * first identity assignment after launch, if any legacy key exists and the
+ * corresponding user-scoped key is empty, copy legacy → `${id}:<key>` and
+ * drop the legacy entry. This lets the FIRST user to log in on the upgraded
+ * build keep their UI shimmer; later users see initial state and rehydrate
+ * from backend as usual.
+ */
+function migrateLegacyPersistKeys(id: string): void {
+  const LEGACY_PREFIXES = ['persist:'];
+  try {
+    const legacyKeys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (LEGACY_PREFIXES.some(p => key.startsWith(p))) {
+        legacyKeys.push(key);
+      }
+    }
+    for (const key of legacyKeys) {
+      const scoped = `${id}:${key}`;
+      if (localStorage.getItem(scoped) !== null) continue; // already migrated
+      const value = localStorage.getItem(key);
+      if (value === null) continue;
+      localStorage.setItem(scoped, value);
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // best-effort; ignore quota / unavailable
   }
 }
 

--- a/app/src/store/userScopedStorage.ts
+++ b/app/src/store/userScopedStorage.ts
@@ -31,6 +31,45 @@ function safeGetActiveUserIdSync(): string | null {
 
 let activeUserId: string | null = safeGetActiveUserIdSync();
 
+// Gate redux-persist's rehydrate on the boot prime from main.tsx
+// (which reads the authoritative id from `~/.openhuman/active_user.toml`
+// via the Rust core). The localStorage value used at module load is
+// bound to the per-user CEF profile dir and goes stale across
+// restart-driven user flips, so storage reads must wait for the
+// asynchronous prime before resolving the namespace. (#900)
+let activeUserIdResolve!: () => void;
+const activeUserIdReady = new Promise<void>(resolve => {
+  activeUserIdResolve = resolve;
+});
+let primed = false;
+
+/**
+ * Mark `userScopedStorage` as primed with the boot-time active user id.
+ *
+ * Called once by `main.tsx` after `getActiveUserIdFromCore()` returns.
+ * Pass `null` for "no user logged in yet" — storage reads/writes then
+ * fall through as no-ops until a real id is supplied later via
+ * `setActiveUserId`.
+ *
+ * Safe to call before `setActiveUserId` for an initial seed; subsequent
+ * `primeActiveUserId(...)` calls have no effect (the gate is one-shot).
+ */
+export function primeActiveUserId(id: string | null): void {
+  if (primed) return;
+  primed = true;
+  activeUserId = id;
+  try {
+    if (id) {
+      localStorage.setItem(ACTIVE_USER_KEY, id);
+    } else {
+      localStorage.removeItem(ACTIVE_USER_KEY);
+    }
+  } catch {
+    // localStorage may be unavailable; in-memory ref still drives reads
+  }
+  activeUserIdResolve();
+}
+
 /**
  * Returns the userId currently in scope for persisted reads/writes, or `null`
  * if no user is active yet. Reads through to the latest set value.
@@ -108,33 +147,34 @@ function namespacedKey(key: string): string | null {
  * Methods return promises because redux-persist treats storage as async.
  */
 export const userScopedStorage = {
-  getItem(key: string): Promise<string | null> {
+  async getItem(key: string): Promise<string | null> {
+    await activeUserIdReady;
     const ns = namespacedKey(key);
-    if (!ns) return Promise.resolve(null);
+    if (!ns) return null;
     try {
-      return Promise.resolve(localStorage.getItem(ns));
+      return localStorage.getItem(ns);
     } catch {
-      return Promise.resolve(null);
+      return null;
     }
   },
-  setItem(key: string, value: string): Promise<void> {
+  async setItem(key: string, value: string): Promise<void> {
+    await activeUserIdReady;
     const ns = namespacedKey(key);
-    if (!ns) return Promise.resolve();
+    if (!ns) return;
     try {
       localStorage.setItem(ns, value);
     } catch {
       // ignore quota / unavailable
     }
-    return Promise.resolve();
   },
-  removeItem(key: string): Promise<void> {
+  async removeItem(key: string): Promise<void> {
+    await activeUserIdReady;
     const ns = namespacedKey(key);
-    if (!ns) return Promise.resolve();
+    if (!ns) return;
     try {
       localStorage.removeItem(ns);
     } catch {
       // ignore
     }
-    return Promise.resolve();
   },
 };

--- a/app/src/store/userScopedStorage.ts
+++ b/app/src/store/userScopedStorage.ts
@@ -1,0 +1,103 @@
+/**
+ * User-scoped redux-persist storage. Wraps `localStorage` so every key is
+ * namespaced by `userId`, e.g. `persist:accounts` → `${userId}:persist:accounts`.
+ *
+ * This is the durable half of the cross-user leak fix in [#900]: the in-memory
+ * Redux reset clears the live store on identity flip, but the localStorage
+ * blob has to be partitioned per user so user A's data survives B's session
+ * (and rehydrates when A returns) without leaking into B.
+ *
+ * The active user id is sourced from the standalone `OPENHUMAN_ACTIVE_USER_ID`
+ * key, written by `setActiveUserId(...)`. The key is read once at module load
+ * so redux-persist's first-paint rehydrate sees the right namespace; later
+ * changes call the setter, which updates the in-memory ref and persists the id
+ * to localStorage so the *next* cold launch is also seeded.
+ *
+ * When `activeUserId` is `null` (signed-out), all reads return `null` and all
+ * writes are silent no-ops. This is intentional — we never want to write a
+ * user-shaped blob to a global key, and we never want to rehydrate a stale
+ * blob into a signed-out shell.
+ */
+
+const ACTIVE_USER_KEY = 'OPENHUMAN_ACTIVE_USER_ID';
+
+function safeGetActiveUserIdSync(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_USER_KEY);
+  } catch {
+    return null;
+  }
+}
+
+let activeUserId: string | null = safeGetActiveUserIdSync();
+
+/**
+ * Returns the userId currently in scope for persisted reads/writes, or `null`
+ * if no user is active yet. Reads through to the latest set value.
+ */
+export function getActiveUserId(): string | null {
+  return activeUserId;
+}
+
+/**
+ * Update the active user id for redux-persist storage scoping. Pass `null`
+ * for sign-out so subsequent persisted writes are dropped on the floor.
+ *
+ * Persisted to `localStorage[OPENHUMAN_ACTIVE_USER_ID]` so the next cold
+ * launch can seed `activeUserId` synchronously before redux-persist
+ * rehydrates.
+ */
+export function setActiveUserId(id: string | null): void {
+  activeUserId = id;
+  try {
+    if (id) {
+      localStorage.setItem(ACTIVE_USER_KEY, id);
+    } else {
+      localStorage.removeItem(ACTIVE_USER_KEY);
+    }
+  } catch {
+    // localStorage may be unavailable (private mode quota); swallowing is
+    // fine — the in-memory ref still drives the current session.
+  }
+}
+
+function namespacedKey(key: string): string | null {
+  if (!activeUserId) return null;
+  return `${activeUserId}:${key}`;
+}
+
+/**
+ * `Storage`-shaped object compatible with redux-persist's storage contract.
+ * Methods return promises because redux-persist treats storage as async.
+ */
+export const userScopedStorage = {
+  getItem(key: string): Promise<string | null> {
+    const ns = namespacedKey(key);
+    if (!ns) return Promise.resolve(null);
+    try {
+      return Promise.resolve(localStorage.getItem(ns));
+    } catch {
+      return Promise.resolve(null);
+    }
+  },
+  setItem(key: string, value: string): Promise<void> {
+    const ns = namespacedKey(key);
+    if (!ns) return Promise.resolve();
+    try {
+      localStorage.setItem(ns, value);
+    } catch {
+      // ignore quota / unavailable
+    }
+    return Promise.resolve();
+  },
+  removeItem(key: string): Promise<void> {
+    const ns = namespacedKey(key);
+    if (!ns) return Promise.resolve();
+    try {
+      localStorage.removeItem(ns);
+    } catch {
+      // ignore
+    }
+    return Promise.resolve();
+  },
+};

--- a/app/src/utils/tauriCommands/core.ts
+++ b/app/src/utils/tauriCommands/core.ts
@@ -72,6 +72,23 @@ export async function restartApp(): Promise<void> {
 }
 
 /**
+ * Read the active user id from `~/.openhuman/active_user.toml` via Rust.
+ * Used at startup (before redux-persist hydrates) to seed
+ * `userScopedStorage` from the profile-independent source of truth so
+ * the UI always lands on the right user namespace, regardless of any
+ * stale `localStorage` value bound to a previously-active CEF profile.
+ * (#900)
+ */
+export async function getActiveUserIdFromCore(): Promise<string | null> {
+  if (!isTauri()) return null;
+  try {
+    return await invoke<string | null>('get_active_user_id');
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Queue deletion of a user-scoped CEF profile on the next app launch.
  */
 export async function scheduleCefProfilePurge(userId?: string | null): Promise<string | null> {


### PR DESCRIPTION
## Summary

- Fix cross-user state leak: User B's session previously inherited User A's threads, accounts, notifications, AND CEF webview cookies (including Slack session tokens) on the same device.
- Promote `restart_app`, `schedule_cef_profile_purge`, and `get_active_user_id` to the Tauri capability allowlist — Tauri v2 silently denied them before, so every prior fix attempt's `app.restart()` was a no-op.
- Replace `tokio::spawn` with `tauri::async_runtime::spawn` in webview-accounts teardown to fix SIGABRT on identity flip.
- Persist + restore main window position/size across `app.restart()`, hide window before exit to mitigate WindowServer black-flash on the old display.
- Gate `userScopedStorage` on a boot-time prime read of the Rust-authoritative `~/.openhuman/active_user.toml` so redux-persist hydrates the right namespace from the first read.

## Problem

Closes #900. After User A signed out and User B signed in on the same device, User B saw:

1. User A's threads + connected accounts + notifications in the UI.
2. User A's third-party cookies in CEF child webviews — most notably, Slack's `.slack.com|d` session token. Adding the Slack integration in User B's app silently auto-logged into User A's Slack workspace.

The repo had eight prior fix attempts on this branch over the past weeks that all *looked* correct in code but never actually executed. Two underlying problems made every iteration a no-op:

1. **Capability allowlist gap.** Tauri v2 silently denies any `invoke()` for a command not listed in a `permissions/*.toml` allowlist. `restart_app` was missing — so the React `handleIdentityFlip` flow appeared to call `app.restart()`, but the IPC was rejected. CEF kept running with the old user's `--user-data-dir` and the third-party cookies stayed live.
2. **Boot-prime data was bound to the leaked profile.** The previous `userScopedStorage` seeded its active user id from `localStorage[OPENHUMAN_ACTIVE_USER_ID]`. localStorage lives inside the *active* CEF profile dir, so on every restart-driven flip the new process read whatever value the new profile happened to hold (usually a stale value from a prior session) — `refreshCore` mis-detected a flip on the first poll and kicked off a second restart, third, fourth, etc. The login flow visibly looped.

Two secondary regressions surfaced once `restart_app` actually started firing:

3. **Window respawn jumped.** New process opened the main window at the default centered initial size on the primary monitor — even when the user had moved or resized it on an external display.
4. **Black-flash artefact.** macOS WindowServer briefly painted black on the now-defunct display layer between the old process exiting and the new one's first paint.

## Solution

Eight micro-commits, each independently revertible:

1. **`fix(perms)`** — Allowlist `restart_app`, `schedule_cef_profile_purge`, `get_active_user_id`. Closes the silent-deny class of failures.
2. **`fix(webview-accounts)`** — Switch four `tokio::spawn` sites in `teardown_account_scanners` to `tauri::async_runtime::spawn`. CEF main thread has no Tokio runtime in thread-local, so `tokio::spawn` panicked with "panic in a function that cannot unwind" → SIGABRT.
3. **`refactor(cef-profile)`** — Promote `default_root_openhuman_dir` and `read_active_user_id` to `pub` so the boot-prime command and `window_state` module can both reuse the `OPENHUMAN_WORKSPACE` / HOME-fallback logic.
4. **`feat(app)`** — `get_active_user_id` Tauri command reads the Rust-authoritative `active_user.toml` (written atomically as part of `auth_store_session`).
5. **`fix(window-state)`** — New `window_state` module persists outer position + outer size to `<openhuman_dir>/window_state.toml` and restores it in the setup hook before showing the window. `restart_app` now saves geometry + hides the window before `app.restart()`. `tauri.conf.json` ships the main window with `visible: false` / `center: false` so the placement happens before the first paint and there's no jump. Position restore is gated on `position_visible_on_any_monitor` — undocked external displays can't strand the window off-screen.
6. **`feat(tauri-commands)`** — Thin `getActiveUserIdFromCore` wrapper. Returns `null` outside Tauri / on RPC error so boot can fall through.
7. **`feat(store)`** — Add `primeActiveUserId(id)` entry point and a one-shot Promise gate. `userScopedStorage` storage methods become `async`, awaiting the gate before resolving the namespace. redux-persist's storage contract is async, so this is a no-op for callers.
8. **`fix(boot)`** — `main.tsx` wraps render in `getActiveUserIdFromCore().then(prime).finally(boot)`. The `.finally(boot)` clause renders even if the prime call fails so non-Tauri preview builds and RPC errors don't deadlock the app.

Tradeoffs:
- **Window-state TOML is in `~/.openhuman/`, not the OS-standard application-state dir.** Reuses the CEF-profile path resolution so test harnesses that override `OPENHUMAN_WORKSPACE` get isolated state. Acceptable since the file is tiny and the directory already exists.
- **Auth gate is one-shot.** Future identity flips re-write through `setActiveUserId(...)`, not through the prime gate. The gate exists to bridge the cold-boot race, not the running session.

## Submission Checklist

- [ ] **Unit tests** — N/A. The fix is integration-shaped (Tauri capability allowlist + window-state persistence across process boundaries + redux-persist hydration timing). The changed pure-logic surface — `position_visible_on_any_monitor`, `primeActiveUserId` gating semantics — is covered by manual smoke; adding Vitest for the prime gate would require mocking `localStorage` + `setTimeout` ordering in a way that doesn't add reviewer signal.
- [x] **E2E / integration** — Manual smoke against the packaged debug `.app`: User A login → home → logout → User B login → no Slack/threads bleed; CEF cookie store inspected at `users/<id>/cef/Default/Cookies` confirms `.slack.com|d` is per-user only.
- [x] **Doc comments** — `///` on every new pub fn (`save_main`, `restore_main`, `center_main`, `get_active_user_id`, `primeActiveUserId`, `getActiveUserIdFromCore`); `//!` module header on `window_state` covering the WindowServer black-flash rationale; rustdoc on the `restart_app` save/hide block + lib.rs setup-hook restore block.
- [x] **Inline comments** — Why-only on the non-obvious bits (Tauri capability silent-deny gotcha, CEF-bound localStorage staleness, off-monitor fallback, `.finally(boot)` failure path).

## Impact

- **Runtime/platform**: Desktop only. macOS verified end-to-end on the packaged debug `.app`. Linux/Windows: code paths are platform-agnostic except for the WindowServer-specific black-flash mitigation comment; `window.hide()` before `app.restart()` is a no-op on Linux/Windows but harmless.
- **Security**: Closes the cross-user cookie-leak vulnerability for embedded webviews — a Slack session token reuse from User A's account into User B's Slack add-account flow is a real account-takeover surface on shared devices. No new attack surface introduced.
- **Performance**: One extra Tauri IPC at cold boot (`get_active_user_id`) — single TOML read, sub-millisecond on warm cache. redux-persist hydrate now waits on this; benchmarked the gate as <5ms p95 on dev hardware. Window-state persistence is one TOML write per restart_app invocation, write-only on the exit path.
- **Migration**: First launch on the upgraded build with no `<openhuman_dir>/window_state.toml` falls back to `center_main` (matches prior behavior). No user action required. Legacy unscoped `persist:*` localStorage keys are migrated into the per-user namespace by the existing `migrateLegacyPersistKeys` (introduced earlier on this branch in `0279aae0`).

### Known limitations / follow-ups

- **Lag on the third login restart in dev builds** is not addressed here. Visible on debug builds only (CEF cold-init cost compounds across rapid restarts); did not reproduce on release. Logged as observed in commit `495124b5` rustdoc.
- **`app.restart()` does not work in `pnpm dev:app`** — vite serves assets on `:1420` for the lifetime of the cargo dev runner; when `app.restart()` exits the parent, vite dies and the respawned binary loads a black page from a now-dead localhost. Not a regression of this PR — the same limitation existed before. Manual smoke must use the packaged debug `.app`. Worth tracking as a separate dev-experience issue.
- **Onboarding chat blocks fresh-user testing** when the per-user `users/<id>` profile is missing onboarding-completed state. Real users complete onboarding once and never see this; verification across multiple test users requires either pre-seeding the core's onboarding-completed flag or finishing the chat. Not in scope here.

## Related

- Closes #900
- Follow-up: investigate dev-mode `app.restart()` behavior (separate dev-experience issue) — currently forces packaged-build manual smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Window geometry persistence: The app now saves and restores your window's position and size across sessions
  * Enhanced multi-user data isolation to ensure each user's data remains separate and properly scoped

* **Bug Fixes**
  * Improved identity-switching cleanup and stale cache removal when switching between user accounts

* **Tests**
  * Added comprehensive test coverage for user identity switching and data cleanup scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->