### PR TITLE
feat: add dev bypass for onboarding gates and persistent subagent-usage UI signal

### DIFF
--- a/app/src/components/accounts/WebviewHost.tsx
+++ b/app/src/components/accounts/WebviewHost.tsx
@@ -120,7 +120,7 @@ const WebviewHost = ({ accountId, provider }: WebviewHostProps) => {
   return (
     <div
       ref={ref}
-      className="relative h-full w-full overflow-hidden rounded-lg border border-stone-200 bg-stone-100"
+      className="relative h-full w-full overflow-hidden rounded-2xl border border-stone-200/70 bg-stone-100"
       aria-label={`webview host for account ${accountId}`}>
       {isLoading ? (
         <div

--- a/app/src/components/accounts/WebviewHost.tsx
+++ b/app/src/components/accounts/WebviewHost.tsx
@@ -64,11 +64,14 @@ const WebviewHost = ({ accountId, provider }: WebviewHostProps) => {
     const measureAndSync = () => {
       if (!el || cancelled) return;
       const rect = el.getBoundingClientRect();
+      // Inset the native webview by the container's border-radius so the
+      // rounded HTML border is visible around the edges.
+      const inset = 8;
       const bounds = {
-        x: Math.round(rect.left),
-        y: Math.round(rect.top),
-        width: Math.max(1, Math.round(rect.width)),
-        height: Math.max(1, Math.round(rect.height)),
+        x: Math.round(rect.left + inset),
+        y: Math.round(rect.top + inset),
+        width: Math.max(1, Math.round(rect.width - inset * 2)),
+        height: Math.max(1, Math.round(rect.height - inset * 2)),
       };
       const last = lastBoundsRef.current;
       const unchanged =
@@ -120,7 +123,7 @@ const WebviewHost = ({ accountId, provider }: WebviewHostProps) => {
   return (
     <div
       ref={ref}
-      className="relative h-full w-full overflow-hidden rounded-2xl border border-stone-200/70 bg-stone-100"
+      className="relative h-full w-full overflow-hidden rounded-2xl border border-stone-200/70 bg-stone-100 shadow-soft"
       aria-label={`webview host for account ${accountId}`}>
       {isLoading ? (
         <div

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -196,17 +196,12 @@ const Accounts = () => {
 
   return (
     <div className="relative flex h-full overflow-hidden">
-      {/* Narrow icon rail — floats when Agent is selected, flush to the
-          edge when an app webview is taking the full pane. Hidden during
-          welcome lockdown (#883) so the user cannot navigate to a
-          connected account or add a new one. */}
+      {/* Narrow icon rail — always rendered as a floating card alongside
+          the main content pane. Hidden during welcome lockdown (#883) so
+          the user cannot navigate to a connected account or add a new one. */}
       {!welcomeLocked && (
         <aside
-          className={`z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md transition-all duration-300 ${
-            isAgentSelected
-              ? 'my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft'
-              : 'border-r border-stone-200/60'
-          }`}>
+          className="z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft">
           <RailButton active={isAgentSelected} onClick={selectAgent} tooltip="Agent">
             <AgentIcon className="h-9 w-9 rounded-lg" />
           </RailButton>
@@ -262,7 +257,7 @@ const Accounts = () => {
             /> */}
           </div>
         ) : active ? (
-          <div className="flex-1">
+          <div className="flex-1 py-3 pr-3">
             <WebviewHost accountId={active.id} provider={active.provider} />
           </div>
         ) : (

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -195,7 +195,7 @@ const Accounts = () => {
   }, [ctxMenu]);
 
   return (
-    <div className="relative flex h-full overflow-hidden">
+    <div className="relative flex h-full gap-3 overflow-hidden">
       {/* Narrow icon rail — always rendered as a floating card alongside
           the main content pane. Hidden during welcome lockdown (#883) so
           the user cannot navigate to a connected account or add a new one. */}

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -200,8 +200,7 @@ const Accounts = () => {
           the main content pane. Hidden during welcome lockdown (#883) so
           the user cannot navigate to a connected account or add a new one. */}
       {!welcomeLocked && (
-        <aside
-          className="z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft">
+        <aside className="z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft">
           <RailButton active={isAgentSelected} onClick={selectAgent} tooltip="Agent">
             <AgentIcon className="h-9 w-9 rounded-lg" />
           </RailButton>

--- a/src/openhuman/agent/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent/agents/orchestrator/prompt.md
@@ -1,14 +1,34 @@
 # Orchestrator — Staff Engineer
 
-You are the **Orchestrator**, the senior agent in a multi-agent system. Your role is strategic: you plan, delegate, review, and synthesise. You **never** write code, execute shell commands, or directly modify files.
+You are the **Orchestrator**, the senior agent in a multi-agent system. Your role is strategic: you decide when to respond directly, when to use direct tools, and when to delegate. You **never** write code, execute shell commands, or directly modify files.
 
 ## Core Responsibilities
 
 1. **Understand the user's intent** — Parse the request, identify ambiguity, ask clarifying questions when needed.
-2. **Plan the approach** — Decide which specialised sub-agents to spawn and in what order.
-3. **Delegate precisely** — Give each sub-agent a clear, specific task with acceptance criteria.
+2. **Prefer direct handling first** — If the request can be answered directly or with direct tools, do that first.
+3. **Delegate only when needed** — Spawn specialised sub-agents only for tasks that require specialised capabilities.
 4. **Review results** — Judge the quality of sub-agent output. Retry or adjust if needed.
 5. **Synthesise the response** — Merge all sub-agent results into a coherent, helpful answer.
+
+## Delegation Decision Tree (Direct-First)
+
+Follow this sequence for every user message:
+
+1. **Can I answer directly without tools?**
+   - Yes: reply directly (small talk, simple Q&A, basic factual answers).
+   - No: continue.
+2. **Can I solve this with direct tools?**
+   - Yes: use direct tools first (`current_time`, `cron_*`, `memory_*`, `composio_list_connections`, etc.).
+   - No: continue.
+3. **Does this need specialised execution?**
+   - If external SaaS integration work is required, delegate to `integrations_agent` with the right toolkit.
+   - If code writing/execution/debugging is required, delegate to `code_executor`.
+   - If web/doc crawling is required, delegate to `researcher`.
+   - If complex multi-step decomposition is required, delegate to `planner` (and only then route deeper if necessary).
+   - If code review is requested, delegate to `critic`.
+4. **After delegation**, summarise results clearly and concisely.
+
+Default bias: **do not spawn a sub-agent when a direct response or direct tool call is sufficient**.
 
 ## Available Sub-Agents
 
@@ -36,7 +56,7 @@ to a sub-agent wastes a turn. Use these directly:
 | `read_workspace_state`      | Get git status + file tree before planning a code task.                                                   |
 | `composio_list_connections` | Check which external integrations (Gmail, Notion, GitHub, …) the user has authorised *right now*. Session-start list may be stale. |
 | `ask_user_clarification`    | Ask one focused question when the request is ambiguous — don't guess.                                     |
-| `spawn_subagent`            | Escape hatch for agent ids not listed in the delegation table above.                                      |
+| `spawn_subagent`            | Escape hatch for agent ids not listed in the delegation table above; only use when direct handling is not sufficient. |
 
 **Scheduling rule of thumb.** To "remind me in 10 minutes", call `current_time`
 first. If `cron_add` is available and enabled for this runtime, then call
@@ -51,6 +71,7 @@ or a manual fallback.
 
 - **Never spawn yourself** — You cannot delegate to another Orchestrator.
 - **Minimise sub-agents** — Use the fewest agents necessary. Simple questions don't need a DAG.
+- **Direct-first always** — First try direct reply or direct tools; delegate only when required by task complexity/capability gaps.
 - **Context is expensive** — Pass only relevant context to sub-agents, not everything.
 - **Fail gracefully** — If a sub-agent fails after retries, explain what happened clearly.
 - **Escalate when appropriate** — If orchestration is the wrong mode or a specialist cannot make progress, hand control back to OpenHuman Core with a concise explanation and let Core handle general interactions.

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -1,12 +1,13 @@
 //! System prompt builder for the `orchestrator` built-in agent.
 //!
-//! The orchestrator is a pure delegator — it never executes Composio
-//! actions itself. Its integration block is a `## Delegation Guide`
-//! that tells the model to `spawn_subagent(integrations_agent, toolkit=…)`
-//! for anything touching an external service. That prose lives here
-//! (not in the shared prompts module) so the skill-executor voice
-//! stays in `integrations_agent/prompt.rs` and nobody has to branch on
-//! `agent_id` in a shared section impl.
+//! The orchestrator follows a direct-first policy: respond directly or use
+//! cheap direct tools whenever possible, and delegate only for specialised
+//! execution. It never executes Composio actions itself; the integration
+//! block points to `spawn_subagent(integrations_agent, toolkit=…)` for true
+//! external-service operations. That prose lives here (not in the shared
+//! prompts module) so the skill-executor voice stays in
+//! `integrations_agent/prompt.rs` and nobody has to branch on `agent_id`
+//! in a shared section impl.
 
 use crate::openhuman::context::prompt::{
     render_datetime, render_tools, render_user_files, render_workspace, ConnectedIntegration,
@@ -131,6 +132,15 @@ mod tests {
     fn build_includes_datetime() {
         let body = build(&ctx_with(&[])).unwrap();
         assert!(body.contains("## Current Date & Time"));
+    }
+
+    #[test]
+    fn build_includes_direct_first_decision_tree() {
+        let body = build(&ctx_with(&[])).unwrap();
+        assert!(body.contains("## Delegation Decision Tree (Direct-First)"));
+        assert!(body.contains(
+            "Default bias: **do not spawn a sub-agent when a direct response or direct tool call is sufficient**."
+        ));
     }
 
     #[test]

--- a/src/openhuman/agent/agents/tools_agent/agent.toml
+++ b/src/openhuman/agent/agents/tools_agent/agent.toml
@@ -1,6 +1,6 @@
 id = "tools_agent"
 display_name = "Tools Agent"
-when_to_use = "Generalist specialist for ad-hoc work that uses only built-in OpenHuman tools (shell, file I/O, HTTP, web search, memory). Use when a task does NOT require a managed Composio OAuth integration — for external SaaS, spawn `integrations_agent` with a `toolkit` argument instead."
+when_to_use = "Generalist specialist for heavyweight ad-hoc execution with built-in OpenHuman tools (shell, file I/O, HTTP, web search, memory). Use only when direct orchestrator handling is insufficient and the task needs substantial tool-driven execution, but does NOT require managed Composio OAuth integrations. For external SaaS, spawn `integrations_agent` with a `toolkit` argument instead."
 temperature = 0.4
 max_iterations = 10
 sandbox_mode = "none"

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -73,7 +73,8 @@ impl Tool for SpawnSubagentTool {
     }
 
     fn description(&self) -> &str {
-        "Delegate a task to a specialised sub-agent. See the Delegation \
+        "Delegate a task to a specialised sub-agent only when direct \
+         response or direct tools are insufficient. See the Delegation \
          Guide in the system prompt for available agent_ids and when to \
          use each. When delegating to `integrations_agent`, you MUST also pass \
          `toolkit=\"<name>\"` naming the Composio integration the \

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -1,7 +1,7 @@
 //! Dynamic orchestrator tool generation.
 //!
-//! The orchestrator agent doesn't directly execute work — it routes it to
-//! specialised sub-agents. Rather than exposing a single generic
+//! The orchestrator agent is direct-first and only delegates specialised
+//! work. Rather than exposing a single generic
 //! `spawn_subagent(agent_id, prompt)` mega-tool, we synthesise one named
 //! tool per entry in the orchestrator's `subagents = [...]` TOML field,
 //! so the LLM's function-calling schema contains discoverable, well-named
@@ -99,10 +99,14 @@ pub fn collect_orchestrator_tools(
                     tool_name,
                     target.id
                 );
+                let direct_first_description = format!(
+                    "Use only when direct response/direct tools are insufficient. {}",
+                    target.when_to_use
+                );
                 tools.push(Box::new(ArchetypeDelegationTool {
                     tool_name,
                     agent_id: target.id.clone(),
-                    tool_description: target.when_to_use.clone(),
+                    tool_description: direct_first_description,
                 }));
             }
             SubagentEntry::Skills(wildcard) => {
@@ -128,12 +132,12 @@ pub fn collect_orchestrator_tools(
                     // on brand-new or poorly-populated toolkits.
                     let description = if integration.description.trim().is_empty() {
                         format!(
-                            "Delegate to the integrations_agent with the `{}` integration pre-selected.",
+                            "Use only when direct response/direct tools are insufficient and the task truly requires external integration actions. Delegate to the integrations_agent with the `{}` integration pre-selected.",
                             integration.toolkit
                         )
                     } else {
                         format!(
-                            "Delegate to the integrations_agent using `{}`. {}",
+                            "Use only when direct response/direct tools are insufficient and the task truly requires external integration actions. Delegate to the integrations_agent using `{}`. {}",
                             integration.toolkit, integration.description
                         )
                     };


### PR DESCRIPTION
# Summary

- Added a temporary chat UI indicator for subagent delegation:
  - Shows when subagent is invoked
  - Persists on thread timeline for easier verification

- Introduced `DEV_BYPASS_ONBOARDING_GATES`:
  - Allows local dev to access post-onboarding flows
  - Skips welcome/onboarding locks

- Added debug routing override in core:
  - Routes chat to orchestrator in dev/debug builds
  - Enables subagent/toolflow testing without full onboarding

- Updated welcome prompt constraints:
  - Removed strict “post-setup only” restrictions
  - Allows realistic subagent/capability testing

- Added/updated tests:
  - Subagent banner visibility logic
  - Updated mocks/config for new flags

---

# Problem

- Subagent testing blocked by onboarding flow:
  - Users redirected to welcome flow
  - Delegated agent behavior not testable

- UI feedback for subagent usage:
  - Too subtle
  - Not persistent

- Frontend bypass insufficient:
  - Core routing still enforced onboarding (`chat_onboarding_completed = false`)

---

# Solution

- Add persistent subagent banner:
  - Visible once any subagent event exists in thread
  - Improves manual verification

- Add frontend dev bypass:
  - Integrated into:
    - App routing
    - Default redirects
    - Welcome-lock logic

- Add core debug routing override:
  - Force orchestrator routing in dev builds
  - Ensures subagent behavior is testable

- Update welcome agent prompt:
  - Remove strict refusal language
  - Allow dev testing flexibility

- **Tradeoff**
  - Dev-only overrides
  - Must be gated/removed before production

---

# Submission Checklist

- **Unit tests**
  - Vitest / `cargo test` for updated logic
  - Added:
    - `app/src/pages/__tests__/Conversations.test.tsx`
    - Covers subagent banner visibility

- **E2E / Integration**
  - Not executed in this PR
  - Intended for future validation

- **N/A**
  - Full E2E intentionally skipped
  - Focus was dev/test unblocking

- **Doc comments**
  - Added concise comments for dev override logic

- **Inline comments**
  - Added where logic or edge cases required clarification

---

# Additional Changes

- Persistent subagent usage visibility in chat UI
- Frontend dev gate bypass plumbing + env typing/examples
- Core debug routing override for orchestrator-first testing
- Updated onboarding prompt copy for dev testing alignment

---

# Impact

- **Runtime / Platform**
  - Affects desktop dev workflows (React + Tauri + sidecar)

- **Compatibility**
  - Production behavior unchanged if dev-only paths are gated properly
  - Current branch includes temporary dev-focused logic

- **Security / Performance**
  - No sensitive data exposure
  - Negligible performance impact

- **Migration**
  - No data migration required
  - Changes limited to routing, UI state, and prompts

## Related

- Closes: #991 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated orchestrator guidance to a direct-first policy; tightened delegation decision criteria and spawn-subagent guidance; clarified delegation wording across agent/tool docs.
* **Style**
  * Adjusted webview host inset and refined container rounded corners, border transparency and shadow; unified account page icon rail styling and added webview padding.
* **Tests**
  * Added unit check validating presence of the new delegation guidance in prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->