### PR TITLE
feat(gmail): native OS notifications via Atom-feed poll (#1020)

### DIFF
--- a/app/src-tauri/src/gmail/cdp_fetch.rs
+++ b/app/src-tauri/src/gmail/cdp_fetch.rs
@@ -29,12 +29,42 @@ use crate::cdp::CdpConn;
 /// without asking the browser to buffer the universe.
 const READ_CHUNK: usize = 256 * 1024;
 
+/// Per-fetch options that callers can flip without breaking the default
+/// shape. Today the only knob is HTTP cache bypass — the polling-based
+/// notification path needs `disable_cache: true` so each tick observes
+/// fresh atom-feed bytes (Gmail's atom URL otherwise returns a cached
+/// body across consecutive CDP fetches), while one-shot reads and the
+/// search/get paths keep the default `disable_cache: false` to take
+/// advantage of in-flight CEF caching.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FetchOptions {
+    pub disable_cache: bool,
+}
+
 /// Issue an authenticated GET through the attached CDP session.
+///
+/// Uses the default [`FetchOptions`] (cache enabled). Callers that need
+/// cache bypass should reach for [`fetch_with_options`] directly.
 pub async fn fetch(cdp: &mut CdpConn, session: &str, url: &str) -> Result<String, String> {
+    fetch_with_options(cdp, session, url, FetchOptions::default()).await
+}
+
+/// Issue an authenticated GET through the attached CDP session with
+/// explicit options. The polling notification path uses this to bypass
+/// the HTTP cache.
+pub async fn fetch_with_options(
+    cdp: &mut CdpConn,
+    session: &str,
+    url: &str,
+    options: FetchOptions,
+) -> Result<String, String> {
     // `Network.loadNetworkResource` needs a frameId to charge the
     // request against — we use the main frame of the target.
     let frame_id = main_frame_id(cdp, session).await?;
-    log::debug!("[gmail-cdp-fetch] session={session} frame={frame_id} url={url}");
+    log::debug!(
+        "[gmail-cdp-fetch] session={session} frame={frame_id} url={url} disable_cache={}",
+        options.disable_cache
+    );
 
     // Network must be enabled for loadNetworkResource to work on some
     // CDP builds. Enabling is idempotent — safe to call every fetch.
@@ -50,7 +80,7 @@ pub async fn fetch(cdp: &mut CdpConn, session: &str, url: &str) -> Result<String
                 "frameId": frame_id,
                 "url": url,
                 "options": {
-                    "disableCache": false,
+                    "disableCache": options.disable_cache,
                     "includeCredentials": true,
                 },
             }),

--- a/app/src-tauri/src/gmail/mod.rs
+++ b/app/src-tauri/src/gmail/mod.rs
@@ -45,6 +45,7 @@ pub mod types;
 
 mod atom;
 mod cdp_fetch;
+pub mod notify_poll;
 mod print_view;
 mod reads;
 mod session;
@@ -64,6 +65,16 @@ pub async fn cdp_list_messages(
     label: Option<String>,
 ) -> Result<Vec<GmailMessage>, String> {
     reads::list_messages(account_id, limit, label).await
+}
+
+/// Cache-bypassing variant of `cdp_list_messages`. Used by the
+/// notification poll loop so each tick observes a fresh atom-feed body.
+pub async fn cdp_list_messages_uncached(
+    account_id: &str,
+    limit: u32,
+    label: Option<String>,
+) -> Result<Vec<GmailMessage>, String> {
+    reads::list_messages_uncached(account_id, limit, label).await
 }
 
 pub async fn cdp_search(

--- a/app/src-tauri/src/gmail/notify_poll.rs
+++ b/app/src-tauri/src/gmail/notify_poll.rs
@@ -1,0 +1,358 @@
+//! Gmail Atom-feed polling task that surfaces native OS notifications
+//! for newly-arriving unread mail.
+//!
+//! Why polling rather than relying on the page: Gmail's BrowserChannel
+//! real-time push (`mail.google.com/mail/u/0/channel/bind`) does not
+//! deliver to CEF webviews, and Web Push (FCM service worker) requires
+//! Chromium FCM glue absent in CEF builds. As a result the page's own
+//! `new Notification(...)` calls never fire, even with the
+//! `Browser.grantPermissions(["notifications"])` and JS shim that
+//! `cdp::session` installs. We bypass the page entirely by polling the
+//! stable Atom feed and dispatching synthetic toasts via
+//! `forward_synthetic_notification` for unread IDs we have not seen
+//! before.
+//!
+//! Lifecycle: one task per opened gmail webview account, started at
+//! `webview_account_open` and aborted at `webview_account_close` /
+//! `webview_account_purge`. The `JoinHandle` is kept in
+//! `WebviewAccountsState.gmail_notify_polls` keyed by account id.
+//!
+//! Persistence: the seen-id set is mirrored to
+//! `<workspace>/gmail/<account_id>/seen.json` so a relaunch does not
+//! replay the most-recent unread backlog as toasts. The set is capped
+//! at [`SEEN_SET_CAP`] entries with FIFO eviction; this is roughly six
+//! times the Gmail Atom-feed window of 20 messages so IDs that briefly
+//! rotate out and back in are not re-fired.
+//!
+//! All gating (DnD, mute, focused-account bypass, the global
+//! `NotificationSettings` toggle) is inherited via
+//! `forward_synthetic_notification` → `forward_native_notification`.
+
+use std::collections::{HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Runtime};
+use tokio::task::JoinHandle;
+use tokio::time::{interval, MissedTickBehavior};
+
+use crate::gmail;
+use crate::webview_accounts::forward_synthetic_notification;
+
+/// Time between successive Atom-feed polls.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Initial delay before the first poll. Gives the per-account CDP
+/// session time to attach and Gmail's first paint to settle so the
+/// authenticated `cdp_fetch` call does not race the navigation.
+pub const INITIAL_DELAY: Duration = Duration::from_secs(15);
+
+/// How many unread IDs to request from the Atom feed per poll. Gmail
+/// caps the feed at 20 most-recent unread regardless of larger limits,
+/// so this is the natural ceiling.
+pub const POLL_LIMIT: u32 = 20;
+
+/// Maximum number of IDs retained in the persistent seen-set. Older
+/// entries are evicted FIFO on overflow. Sized to ~6× the Atom-feed
+/// window so IDs that briefly leave and re-enter the window are not
+/// re-fired.
+pub const SEEN_SET_CAP: usize = 200;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct SeenStateOnDisk {
+    /// Insertion-ordered list of message IDs we have already toasted on
+    /// (or seeded from the first poll). Front is oldest, back is newest.
+    ids: Vec<String>,
+}
+
+/// In-memory mirror of the persistent seen-set. `set` is the lookup
+/// index, `order` preserves insertion order for FIFO eviction; both
+/// hold the same set of strings.
+#[derive(Debug, Default)]
+struct SeenState {
+    set: HashSet<String>,
+    order: VecDeque<String>,
+}
+
+impl SeenState {
+    fn from_disk(state: SeenStateOnDisk) -> Self {
+        let mut out = Self::default();
+        for id in state.ids {
+            out.insert(id);
+        }
+        out
+    }
+
+    fn to_disk(&self) -> SeenStateOnDisk {
+        SeenStateOnDisk {
+            ids: self.order.iter().cloned().collect(),
+        }
+    }
+
+    /// Insert `id` into the seen-set. Returns `true` when the id is
+    /// new, `false` when it was already present (callers use this to
+    /// decide whether to fire). Evicts the oldest entry when the set
+    /// would exceed [`SEEN_SET_CAP`].
+    fn insert(&mut self, id: String) -> bool {
+        if self.set.contains(&id) {
+            return false;
+        }
+        self.set.insert(id.clone());
+        self.order.push_back(id);
+        while self.order.len() > SEEN_SET_CAP {
+            if let Some(evicted) = self.order.pop_front() {
+                self.set.remove(&evicted);
+            }
+        }
+        true
+    }
+}
+
+/// Build the path to the seen-set JSON file for a given account under
+/// the OpenHuman workspace dir.
+fn seen_set_path(workspace_dir: &Path, account_id: &str) -> PathBuf {
+    workspace_dir
+        .join("gmail")
+        .join(account_id)
+        .join("seen.json")
+}
+
+fn load_seen(path: &Path) -> SeenState {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => match serde_json::from_str::<SeenStateOnDisk>(&raw) {
+            Ok(state) => SeenState::from_disk(state),
+            Err(e) => {
+                log::warn!(
+                    "[gmail-notify-poll] could not parse {}: {} — starting empty",
+                    path.display(),
+                    e
+                );
+                SeenState::default()
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => SeenState::default(),
+        Err(e) => {
+            log::warn!(
+                "[gmail-notify-poll] could not read {}: {} — starting empty",
+                path.display(),
+                e
+            );
+            SeenState::default()
+        }
+    }
+}
+
+fn save_seen(path: &Path, state: &SeenState) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            log::warn!(
+                "[gmail-notify-poll] mkdir {} failed: {}",
+                parent.display(),
+                e
+            );
+            return;
+        }
+    }
+    let body = match serde_json::to_string(&state.to_disk()) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("[gmail-notify-poll] serialize seen-set failed: {}", e);
+            return;
+        }
+    };
+    if let Err(e) = std::fs::write(path, body) {
+        log::warn!("[gmail-notify-poll] write {} failed: {}", path.display(), e);
+    }
+}
+
+/// Spawn the per-account Gmail notification poll task. The returned
+/// `JoinHandle` should be stored in `WebviewAccountsState.gmail_notify_polls`
+/// so `webview_account_close` and `webview_account_purge` can abort it.
+pub fn spawn<R: Runtime>(
+    app: AppHandle<R>,
+    account_id: String,
+    workspace_dir: PathBuf,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let path = seen_set_path(&workspace_dir, &account_id);
+        let mut seen = load_seen(&path);
+        let resumed = !seen.set.is_empty();
+        log::info!(
+            "[gmail-notify-poll][{}] starting (interval={}s, limit={}, seen_loaded={}, path={})",
+            account_id,
+            POLL_INTERVAL.as_secs(),
+            POLL_LIMIT,
+            seen.set.len(),
+            path.display()
+        );
+
+        // Wait for the CDP session to attach and Gmail to finish its
+        // initial load before the first fetch.
+        tokio::time::sleep(INITIAL_DELAY).await;
+
+        let mut tick = interval(POLL_INTERVAL);
+        tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        // Whether the first poll of this task instance has run yet. A
+        // brand-new task with no persisted state seeds silently on its
+        // first poll; a resumed task already has IDs on disk and treats
+        // every new ID as fireable from tick 1.
+        let mut seeded = resumed;
+
+        loop {
+            tick.tick().await;
+            let result = gmail::cdp_list_messages_uncached(&account_id, POLL_LIMIT, None).await;
+            match result {
+                Ok(msgs) => {
+                    log::info!(
+                        "[gmail-notify-poll][{}] fetched={} seeded={} seen_pre={}",
+                        account_id,
+                        msgs.len(),
+                        seeded,
+                        seen.set.len()
+                    );
+                    let mut wrote_any = false;
+                    for m in &msgs {
+                        if m.id.is_empty() {
+                            continue;
+                        }
+                        let is_new = seen.insert(m.id.clone());
+                        if is_new {
+                            wrote_any = true;
+                            if seeded {
+                                fire_toast(&app, &account_id, m);
+                            }
+                        }
+                    }
+                    if wrote_any {
+                        save_seen(&path, &seen);
+                    }
+                    seeded = true;
+                }
+                Err(e) => {
+                    log::warn!("[gmail-notify-poll][{}] fetch failed: {}", account_id, e);
+                }
+            }
+        }
+    })
+}
+
+fn fire_toast<R: Runtime>(app: &AppHandle<R>, account_id: &str, msg: &gmail::types::GmailMessage) {
+    let title = msg
+        .from
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "Gmail".to_string());
+    let body = match (msg.subject.as_deref(), msg.snippet.as_deref()) {
+        (Some(s), Some(sn)) if !s.is_empty() && !sn.is_empty() => format!("{s}\n{sn}"),
+        (Some(s), _) if !s.is_empty() => s.to_string(),
+        (_, Some(sn)) if !sn.is_empty() => sn.to_string(),
+        _ => "New message".to_string(),
+    };
+    log::info!(
+        "[gmail-notify-poll][{}] firing toast id={} subject={:?}",
+        account_id,
+        msg.id,
+        msg.subject
+    );
+    forward_synthetic_notification(app, account_id, "gmail", title, body);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_returns_true_for_new_id_and_false_for_dup() {
+        let mut s = SeenState::default();
+        assert!(s.insert("a".into()));
+        assert!(!s.insert("a".into()));
+        assert!(s.insert("b".into()));
+    }
+
+    #[test]
+    fn fifo_evicts_oldest_at_cap() {
+        let mut s = SeenState::default();
+        for i in 0..SEEN_SET_CAP {
+            assert!(s.insert(format!("id{i}")));
+        }
+        assert_eq!(s.set.len(), SEEN_SET_CAP);
+
+        // Insert one more — oldest ("id0") must be evicted.
+        assert!(s.insert("overflow".into()));
+        assert_eq!(s.set.len(), SEEN_SET_CAP);
+        assert!(!s.set.contains("id0"));
+        assert!(s.set.contains("overflow"));
+    }
+
+    #[test]
+    fn round_trip_through_disk_format_preserves_order() {
+        let mut s = SeenState::default();
+        s.insert("first".into());
+        s.insert("second".into());
+        s.insert("third".into());
+
+        let on_disk = s.to_disk();
+        let s2 = SeenState::from_disk(on_disk);
+
+        assert_eq!(
+            s2.order.iter().cloned().collect::<Vec<_>>(),
+            vec!["first", "second", "third"]
+        );
+        assert_eq!(s2.set.len(), 3);
+    }
+
+    #[test]
+    fn save_and_load_round_trip_via_tempfile() {
+        let dir = tempfile_dir();
+        let path = dir.join("gmail").join("acct-x").join("seen.json");
+
+        let mut s = SeenState::default();
+        s.insert("alpha".into());
+        s.insert("beta".into());
+        save_seen(&path, &s);
+
+        let reloaded = load_seen(&path);
+        assert_eq!(reloaded.order.len(), 2);
+        assert!(reloaded.set.contains("alpha"));
+        assert!(reloaded.set.contains("beta"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_returns_empty_when_path_missing() {
+        let dir = tempfile_dir();
+        let path = dir.join("does-not-exist.json");
+        let s = load_seen(&path);
+        assert_eq!(s.set.len(), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_returns_empty_on_corrupt_json() {
+        let dir = tempfile_dir();
+        let path = dir.join("corrupt.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not valid json {{{").unwrap();
+        let s = load_seen(&path);
+        assert_eq!(s.set.len(), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn tempfile_dir() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "openhuman-gmail-notify-test-{}",
+            std::process::id()
+        ));
+        p.push(format!(
+            "{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+}

--- a/app/src-tauri/src/gmail/notify_poll.rs
+++ b/app/src-tauri/src/gmail/notify_poll.rs
@@ -161,8 +161,22 @@ fn save_seen(path: &Path, state: &SeenState) {
             return;
         }
     };
-    if let Err(e) = std::fs::write(path, body) {
-        log::warn!("[gmail-notify-poll] write {} failed: {}", path.display(), e);
+    // Atomic write: write to a sibling temp file then rename. Without this,
+    // a crash mid-`fs::write` leaves a truncated `seen.json` and the next
+    // launch re-toasts the entire backlog.
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, body) {
+        log::warn!("[gmail-notify-poll] write {} failed: {}", tmp.display(), e);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        log::warn!(
+            "[gmail-notify-poll] rename {} -> {} failed: {}",
+            tmp.display(),
+            path.display(),
+            e
+        );
+        let _ = std::fs::remove_file(&tmp);
     }
 }
 
@@ -249,11 +263,12 @@ fn fire_toast<R: Runtime>(app: &AppHandle<R>, account_id: &str, msg: &gmail::typ
         (_, Some(sn)) if !sn.is_empty() => sn.to_string(),
         _ => "New message".to_string(),
     };
+    // Don't log msg.subject — that is user email content and would land in
+    // long-lived app logs. id is opaque and safe to retain for debugging.
     log::info!(
-        "[gmail-notify-poll][{}] firing toast id={} subject={:?}",
+        "[gmail-notify-poll][{}] firing toast id={}",
         account_id,
-        msg.id,
-        msg.subject
+        msg.id
     );
     forward_synthetic_notification(app, account_id, "gmail", title, body);
 }

--- a/app/src-tauri/src/gmail/reads.rs
+++ b/app/src-tauri/src/gmail/reads.rs
@@ -45,13 +45,43 @@ pub async fn list_messages(
     limit: u32,
     label: Option<String>,
 ) -> Result<Vec<GmailMessage>, String> {
+    list_messages_internal(account_id, limit, label, cdp_fetch::FetchOptions::default()).await
+}
+
+/// Cache-bypassing variant used by the notification poll loop. Each
+/// tick must observe a fresh atom body — without `disableCache: true`
+/// CEF returns the same response across consecutive polls and new mail
+/// is invisible to the diff.
+pub async fn list_messages_uncached(
+    account_id: &str,
+    limit: u32,
+    label: Option<String>,
+) -> Result<Vec<GmailMessage>, String> {
+    list_messages_internal(
+        account_id,
+        limit,
+        label,
+        cdp_fetch::FetchOptions {
+            disable_cache: true,
+        },
+    )
+    .await
+}
+
+async fn list_messages_internal(
+    account_id: &str,
+    limit: u32,
+    label: Option<String>,
+    options: cdp_fetch::FetchOptions,
+) -> Result<Vec<GmailMessage>, String> {
     log::debug!(
-        "[gmail][{account_id}] list_messages limit={limit} label={:?}",
-        label
+        "[gmail][{account_id}] list_messages limit={limit} label={:?} disable_cache={}",
+        label,
+        options.disable_cache
     );
     let url = atom_feed_url(label.as_deref());
     let (mut cdp, session_id) = session::attach(account_id).await?;
-    let body = match cdp_fetch::fetch(&mut cdp, &session_id, &url).await {
+    let body = match cdp_fetch::fetch_with_options(&mut cdp, &session_id, &url, options).await {
         Ok(b) => b,
         Err(e) => {
             session::detach(&mut cdp, &session_id).await;

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -97,6 +97,14 @@ fn provider_allowed_hosts(provider: &str) -> &'static [&'static str] {
             "googleusercontent.com",
             "gstatic.com",
             "googleapis.com",
+            // Google's SSO sign-in flow does a cross-domain `SetSID` step on
+            // accounts.youtube.com (`accounts.youtube.com/accounts/SetSID?…
+            // &continue=https://mail.google.com/…`) to propagate the
+            // `__Secure-1PSID` cookie across Google properties. Without
+            // youtube.com here the navigation falls out to the system
+            // browser, the auth cookies never land in the CEF profile, and
+            // post-2FA login hangs on a blank page indefinitely.
+            "youtube.com",
         ],
         "slack" => &["slack.com", "slack-edge.com", "slackb.com"],
         "discord" => &[
@@ -110,6 +118,9 @@ fn provider_allowed_hosts(provider: &str) -> &'static [&'static str] {
             "googleusercontent.com",
             "gstatic.com",
             "googleapis.com",
+            // Same Google SSO `SetSID` cross-domain hop as gmail — see the
+            // comment in the gmail arm.
+            "youtube.com",
         ],
         "zoom" => &["zoom.us", "zoom.com", "zoomgov.com", "zdassets.com"],
         "browserscan" => &["browserscan.net"],
@@ -171,6 +182,18 @@ fn url_is_internal(provider: &str, url: &Url) -> bool {
     let Some(host) = url.host_str() else {
         return true;
     };
+    // Google's SSO post-password flow routes through country-localized
+    // `accounts.google.<ccTLD>` (e.g. `accounts.google.co.in`,
+    // `accounts.google.co.uk`, `accounts.google.com.au`) for the `SetSID`
+    // cross-domain cookie handshake. Listing every ccTLD in
+    // `provider_allowed_hosts` would be unwieldy and brittle; instead
+    // short-circuit to true for any `accounts.google.*` host (and the
+    // adjacent `accounts.youtube.com` cookie hop) when the provider speaks
+    // Google's auth surface. Without this, the post-password redirect leaks
+    // to the system browser and login hangs in the embedded webview.
+    if matches!(provider, "gmail" | "google-meet") && is_google_sso_host(host) {
+        return true;
+    }
     let allowed = provider_allowed_hosts(provider);
     if allowed.is_empty() {
         return true;
@@ -178,6 +201,34 @@ fn url_is_internal(provider: &str, url: &Url) -> bool {
     allowed
         .iter()
         .any(|suffix| host == *suffix || host.ends_with(&format!(".{}", suffix)))
+}
+
+/// `true` for hosts that are part of Google's authentication surface.
+/// Matches `accounts.google.<anything>` (covers every ccTLD Google uses
+/// for sign-in: `.com`, `.co.in`, `.co.uk`, `.com.au`, `.fr`, `.de`, etc.)
+/// plus `accounts.youtube.com` (which sets a cross-property session cookie
+/// during the OAuth handshake). Constraints: leftmost label must be
+/// `accounts`, second label must be `google`, and the remaining 1-3 TLD
+/// labels must be ASCII alphanumeric. Trade-off: a hypothetical
+/// `accounts.google.<attacker-tld>` would also match — but Google brand /
+/// DNS controls make that a non-issue for any TLD a normal user routes
+/// through, and the alternative (200-entry hardcoded ccTLD list) rots.
+fn is_google_sso_host(host: &str) -> bool {
+    if host == "accounts.youtube.com" {
+        return true;
+    }
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() < 3 || labels.len() > 5 {
+        return false;
+    }
+    if labels[0] != "accounts" || labels[1] != "google" {
+        return false;
+    }
+    labels[2..].iter().all(|l| {
+        !l.is_empty()
+            && l.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    })
 }
 
 /// `true` if the provider needs `window.open(url)` to return a live
@@ -495,6 +546,11 @@ pub struct WebviewAccountsState {
     /// keeps the UA override resident (see `cdp::session`); aborted on
     /// close/purge so reopen cycles don't stack multiple live loops.
     cdp_sessions: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
+    /// account_id -> Gmail notification poll task. Spawned for
+    /// `provider == "gmail"` accounts and aborted on close/purge so the
+    /// 30 s atom-feed loop in `gmail::notify_poll` does not survive past
+    /// the webview that owns it.
+    gmail_notify_polls: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
     /// account_id -> 15s `webview-account:load{state:"timeout"}` watchdog.
     /// Aborted in close/purge so a watchdog spawned for a now-closed
     /// account can't fire a stale timeout against a freshly-reused id.
@@ -546,6 +602,19 @@ impl WebviewAccountsState {
             task.abort();
             log::debug!(
                 "[webview-accounts] shutdown abort watchdog account={}",
+                acct
+            );
+        }
+        let notify_polls: Vec<_> = self
+            .gmail_notify_polls
+            .lock()
+            .ok()
+            .map(|mut g| g.drain().collect())
+            .unwrap_or_default();
+        for (acct, task) in notify_polls {
+            task.abort();
+            log::debug!(
+                "[webview-accounts] shutdown abort gmail notify-poll account={}",
                 acct
             );
         }
@@ -873,11 +942,7 @@ fn forward_native_notification<R: Runtime>(
                 prev
             );
             std::thread::spawn(move || {
-                let _ = mac_notification_sys::set_application(if tauri::is_dev() {
-                    "com.apple.Terminal"
-                } else {
-                    &app_id
-                });
+                let _ = mac_notification_sys::set_application(&app_id);
                 use mac_notification_sys::Notification as MacNotif;
                 let mut n = MacNotif::new();
                 n.title(&title_c).message(&body_c);
@@ -895,11 +960,7 @@ fn forward_native_notification<R: Runtime>(
             }
             let _guard = Guard;
 
-            let _ = mac_notification_sys::set_application(if tauri::is_dev() {
-                "com.apple.Terminal"
-            } else {
-                &app_id
-            });
+            let _ = mac_notification_sys::set_application(&app_id);
             use mac_notification_sys::{Notification as MacNotif, NotificationResponse};
             let t = title_c;
             let b = body_c;
@@ -1723,6 +1784,36 @@ pub async fn webview_account_open<R: Runtime>(
         }
     }
 
+    // Gmail's BrowserChannel real-time push does not deliver in CEF
+    // (mail arrives server-side but the page never observes it without
+    // a manual reload), so we route around the web frontend by polling
+    // the Atom feed and firing synthetic toasts for newly-seen unread
+    // messages. See `gmail::notify_poll`. The handle goes into
+    // `gmail_notify_polls` so close/purge can abort it.
+    if args.provider == "gmail" {
+        match app.path().app_local_data_dir() {
+            Ok(base) => {
+                let handle =
+                    crate::gmail::notify_poll::spawn(app.clone(), args.account_id.clone(), base);
+                if let Some(old) = state
+                    .gmail_notify_polls
+                    .lock()
+                    .unwrap()
+                    .insert(args.account_id.clone(), handle)
+                {
+                    old.abort();
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "[gmail-notify-poll] could not resolve app_local_data_dir for {}: {} — skipping spawn",
+                    args.account_id,
+                    e
+                );
+            }
+        }
+    }
+
     // For providers we know how to scrape via CDP, kick off the IndexedDB
     // scanner. CDP requires the CEF runtime's remote-debugging port.
     {
@@ -1883,6 +1974,18 @@ pub async fn webview_account_close<R: Runtime>(
             browser_id
         );
     }
+    if let Some(task) = state
+        .gmail_notify_polls
+        .lock()
+        .unwrap()
+        .remove(&args.account_id)
+    {
+        task.abort();
+        log::debug!(
+            "[gmail-notify-poll] aborted poll task for account={}",
+            args.account_id
+        );
+    }
     if let Some(task) = state.cdp_sessions.lock().unwrap().remove(&args.account_id) {
         task.abort();
         log::debug!(
@@ -1948,6 +2051,18 @@ pub async fn webview_account_purge<R: Runtime>(
             browser_id
         );
     }
+    if let Some(task) = state
+        .gmail_notify_polls
+        .lock()
+        .unwrap()
+        .remove(&args.account_id)
+    {
+        task.abort();
+        log::debug!(
+            "[gmail-notify-poll] purge aborted poll task for account={}",
+            args.account_id
+        );
+    }
     if let Some(task) = state.cdp_sessions.lock().unwrap().remove(&args.account_id) {
         task.abort();
         log::debug!(
@@ -1990,6 +2105,28 @@ pub async fn webview_account_purge<R: Runtime>(
             );
         } else {
             log::info!("[webview-accounts] purged data dir {}", data_dir.display());
+        }
+    }
+
+    // Drop the Gmail notification seen-set so a re-login does not skip
+    // toasts for messages that arrived while the previous session was
+    // active. Lives outside `data_directory_for` because that path is
+    // CEF-owned; the seen-set is OpenHuman-owned state.
+    if let Ok(base) = app.path().app_local_data_dir() {
+        let notify_dir = base.join("gmail").join(&args.account_id);
+        if notify_dir.exists() {
+            if let Err(err) = std::fs::remove_dir_all(&notify_dir) {
+                log::warn!(
+                    "[gmail-notify-poll] purge remove_dir_all {} failed: {}",
+                    notify_dir.display(),
+                    err
+                );
+            } else {
+                log::info!(
+                    "[gmail-notify-poll] purged seen-set dir {}",
+                    notify_dir.display()
+                );
+            }
         }
     }
 
@@ -2339,6 +2476,51 @@ mod tests {
         Url::parse(s).expect("valid url")
     }
 
+    // ── Google SSO host matcher ─────────────────────────────
+
+    #[test]
+    fn is_google_sso_host_accepts_com() {
+        assert!(is_google_sso_host("accounts.google.com"));
+    }
+
+    #[test]
+    fn is_google_sso_host_accepts_country_cctlds() {
+        // The post-password SetSID hop observed in #1020 smoke; broader
+        // ccTLD set covers users routed through localized Google
+        // properties.
+        assert!(is_google_sso_host("accounts.google.co.in"));
+        assert!(is_google_sso_host("accounts.google.co.uk"));
+        assert!(is_google_sso_host("accounts.google.com.au"));
+        assert!(is_google_sso_host("accounts.google.fr"));
+        assert!(is_google_sso_host("accounts.google.de"));
+    }
+
+    #[test]
+    fn is_google_sso_host_accepts_youtube_cookie_hop() {
+        assert!(is_google_sso_host("accounts.youtube.com"));
+    }
+
+    #[test]
+    fn is_google_sso_host_rejects_non_google() {
+        assert!(!is_google_sso_host("accounts.example.com"));
+        assert!(!is_google_sso_host("accounts.googleblog.com"));
+        assert!(!is_google_sso_host("google.com"));
+        assert!(!is_google_sso_host("mail.google.com")); // not the accounts surface
+        assert!(!is_google_sso_host("evil.com"));
+        assert!(!is_google_sso_host(""));
+    }
+
+    #[test]
+    fn url_is_internal_keeps_google_sso_setsid_in_app_for_gmail_and_meet() {
+        // The exact URL pattern that leaked to the system browser pre-fix.
+        let setsid = url("https://accounts.google.co.in/accounts/SetSID?ssdc=1&continue=https://mail.google.com/mail/u/0/");
+        assert!(url_is_internal("gmail", &setsid));
+        assert!(url_is_internal("google-meet", &setsid));
+        // Other providers should still go through the normal allowed_hosts
+        // suffix-match (slack/whatsapp/etc don't speak Google SSO).
+        assert!(!url_is_internal("slack", &setsid));
+    }
+
     // ── shutdown teardown ──────────────────────────────────
 
     /// Smoke-test [`WebviewAccountsState::drain_for_shutdown`] in isolation
@@ -2364,6 +2546,9 @@ mod tests {
         let watchdog_task = tokio::spawn(async {
             tokio::time::sleep(Duration::from_secs(60)).await;
         });
+        let notify_poll_task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
 
         state
             .cdp_sessions
@@ -2375,6 +2560,11 @@ mod tests {
             .lock()
             .unwrap()
             .insert("acct-1".into(), watchdog_task);
+        state
+            .gmail_notify_polls
+            .lock()
+            .unwrap()
+            .insert("acct-1".into(), notify_poll_task);
         state
             .browser_ids
             .lock()
@@ -2409,6 +2599,7 @@ mod tests {
         );
         assert!(state.cdp_sessions.lock().unwrap().is_empty());
         assert!(state.load_watchdogs.lock().unwrap().is_empty());
+        assert!(state.gmail_notify_polls.lock().unwrap().is_empty());
         assert!(state.browser_ids.lock().unwrap().is_empty());
         assert!(state.inner.lock().unwrap().is_empty());
         assert!(state.loaded_accounts.lock().unwrap().is_empty());

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -303,8 +303,12 @@ fn is_google_auth_popup(url: &Url) -> bool {
     let Some(host) = url.host_str() else {
         return false;
     };
-    let is_google_auth_host =
-        host == "accounts.google.com" || host == "accounts.googleusercontent.com";
+    // Delegate the host check to `is_google_sso_host` so this matcher stays
+    // aligned with the navigation allowlist (`url_is_internal`). The shared
+    // helper covers `accounts.google.<ccTLD>` plus `accounts.youtube.com`;
+    // the popup flow additionally allows the `accounts.googleusercontent.com`
+    // host that some signed-out sign-in chooser variants land on.
+    let is_google_auth_host = is_google_sso_host(host) || host == "accounts.googleusercontent.com";
     if !is_google_auth_host {
         return false;
     }

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -97,14 +97,11 @@ fn provider_allowed_hosts(provider: &str) -> &'static [&'static str] {
             "googleusercontent.com",
             "gstatic.com",
             "googleapis.com",
-            // Google's SSO sign-in flow does a cross-domain `SetSID` step on
-            // accounts.youtube.com (`accounts.youtube.com/accounts/SetSID?…
-            // &continue=https://mail.google.com/…`) to propagate the
-            // `__Secure-1PSID` cookie across Google properties. Without
-            // youtube.com here the navigation falls out to the system
-            // browser, the auth cookies never land in the CEF profile, and
-            // post-2FA login hangs on a blank page indefinitely.
-            "youtube.com",
+            // The cross-domain `accounts.youtube.com/accounts/SetSID?…` cookie
+            // hop used by Google's SSO post-password flow is handled in
+            // `url_is_internal` via `is_google_sso_host`, so we do NOT list a
+            // broad `youtube.com` suffix here — that would also keep ordinary
+            // YouTube links trapped inside the embedded provider webview.
         ],
         "slack" => &["slack.com", "slack-edge.com", "slackb.com"],
         "discord" => &[
@@ -118,9 +115,8 @@ fn provider_allowed_hosts(provider: &str) -> &'static [&'static str] {
             "googleusercontent.com",
             "gstatic.com",
             "googleapis.com",
-            // Same Google SSO `SetSID` cross-domain hop as gmail — see the
-            // comment in the gmail arm.
-            "youtube.com",
+            // `accounts.youtube.com` SSO hop is handled in `url_is_internal`
+            // via `is_google_sso_host` — see the comment in the gmail arm.
         ],
         "zoom" => &["zoom.us", "zoom.com", "zoomgov.com", "zdassets.com"],
         "browserscan" => &["browserscan.net"],

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -2112,8 +2112,14 @@ pub async fn webview_account_purge<R: Runtime>(
     // toasts for messages that arrived while the previous session was
     // active. Lives outside `data_directory_for` because that path is
     // CEF-owned; the seen-set is OpenHuman-owned state.
+    //
+    // `args.account_id` arrives unsanitized from IPC. `data_directory_for`
+    // above already enforces `sanitize_account_id`, but we re-validate here
+    // explicitly so a future refactor that moves the data-dir cleanup can't
+    // silently turn this into a path-traversal foothold for `remove_dir_all`.
     if let Ok(base) = app.path().app_local_data_dir() {
-        let notify_dir = base.join("gmail").join(&args.account_id);
+        let notify_account_id = sanitize_account_id(&args.account_id)?;
+        let notify_dir = base.join("gmail").join(notify_account_id);
         if notify_dir.exists() {
             if let Err(err) = std::fs::remove_dir_all(&notify_dir) {
                 log::warn!(
@@ -2917,5 +2923,37 @@ mod tests {
             "https://accounts.google.com/o/oauth2/v2/auth?code=secret#frag",
         ));
         assert_eq!(redacted, "https://accounts.google.com/o/oauth2/v2/auth");
+    }
+
+    // ── account_id sanitizer (path-traversal guard) ──────────
+    //
+    // `sanitize_account_id` is the only barrier between IPC-supplied
+    // account ids and `create_dir_all` / `remove_dir_all` paths under
+    // `app_local_data_dir`. The Gmail seen-set purge in
+    // `webview_account_purge` reuses it explicitly so a future refactor
+    // that drops the surrounding `data_directory_for` call can't turn
+    // this site into a path-traversal sink.
+    #[test]
+    fn sanitize_account_id_accepts_alnum_dash_underscore() {
+        assert_eq!(sanitize_account_id("acct-1").unwrap(), "acct-1");
+        assert_eq!(sanitize_account_id("ACCT_2").unwrap(), "ACCT_2");
+        assert_eq!(sanitize_account_id("a1b2c3").unwrap(), "a1b2c3");
+    }
+
+    #[test]
+    fn sanitize_account_id_rejects_traversal() {
+        assert!(sanitize_account_id("..").is_err());
+        assert!(sanitize_account_id("../etc").is_err());
+        assert!(sanitize_account_id("a/b").is_err());
+        assert!(sanitize_account_id("a\\b").is_err());
+        assert!(sanitize_account_id("a..b").is_err());
+    }
+
+    #[test]
+    fn sanitize_account_id_rejects_empty_and_whitespace() {
+        assert!(sanitize_account_id("").is_err());
+        assert!(sanitize_account_id(" ").is_err());
+        assert!(sanitize_account_id("a b").is_err());
+        assert!(sanitize_account_id("\nabc").is_err());
     }
 }

--- a/docs/qa/GMAIL-PARITY.md
+++ b/docs/qa/GMAIL-PARITY.md
@@ -1,0 +1,95 @@
+# Gmail Webview Parity — QA Matrix
+
+> Issue: [#1020](https://github.com/tinyhumansai/openhuman/issues/1020)
+> Branch: `feat/1020-gmail-parity-audit`
+> Tester: oxoxDev
+> Build: main @ `b11b8f33` + `feat/1020-gmail-parity-audit` HEAD
+> Date: 2026-04-30
+> Method: manual smoke against `pnpm dev:app` on macOS (per `feedback_validation_test_target.md`)
+
+## Verdict legend
+
+- ✅ **pass** — feature works as native app
+- ⚠️ **partial** — works but with limitation; needs follow-up
+- ❌ **fail** — broken; child issue filed
+- 🔍 **needs investigation** — non-deterministic behavior; revisit
+- ⏭️ **skipped** — could not test (env / dependency missing)
+
+## Acceptance criteria audit
+
+| # | Criterion | Verdict | Evidence | Notes / child issue |
+|---|-----------|---------|----------|---------------------|
+| 1 | **Auth** — Google sign-in completes (email → password → 2FA); Google auth popup rewriting works (navigate parent instead of popup); session persists across restarts | ✅ pass (after fix) | First attempt got stuck after password — `accounts.google.co.in/SetSID` redirect leaked to system Chrome (the SetSID hop's host is country-localized; `provider_allowed_hosts` for gmail only suffix-matched `google.com`). Fix added `is_google_sso_host` predicate matching `accounts.google.<any-cctld>` + `accounts.youtube.com`. Post-fix login completed end-to-end into inbox in 2-3s. | **Bug fixed in this PR**: Google SSO ccTLD coverage. 5 new unit tests lock the predicate. Same fix benefits Google Meet (#1022). |
+| 2 | **Read email** — Inbox loads; email threads open; HTML rendering correct; inline images display | ✅ pass | Inbox loads (3,508 messages visible in screenshot); threads open and render natively. | Browser-native rendering. |
+| 3 | **Compose** — New email compose window opens; To/CC/BCC fields work; rich text formatting; send completes | ✅ pass | User composed and sent a test email successfully. | Web UI handles send directly — bypasses our `writes.rs::gmail_send` stub since the user is interacting with Gmail's own compose dialog, not our Tauri command. The OpenHuman API stub for `gmail_send` (line 160-170) is a separate surface for programmatic send (e.g. agent-driven) and remains stubbed — see #9. |
+| 4 | **Reply / Forward** — Reply, Reply All, Forward from thread view | ✅ pass | User confirmed reply + forward work in webview. | Gmail web UI handles directly. |
+| 5 | **Search** — Gmail search bar works; results render correctly | ✅ pass | User confirmed search returns results in fullscreen (screenshot shows search dropdown with prefix matches + filter chips). | At narrow window widths the search bar visually compacts — Gmail's own responsive layout, cosmetic, not a bug. |
+| 6 | **Labels** — `list_labels` returns sidebar labels; apply/remove labels from messages | ✅ pass | Sidebar labels visible (Inbox, Starred, Snoozed, Sent, Drafts, Categories, More, custom Labels section). | Read works via `reads.rs::list_labels`. Apply/remove from messages goes through Gmail web UI directly (not our `writes.rs::gmail_add_label` stub which is an OpenHuman API surface for programmatic labeling). |
+| 7 | **Attachments** — Download attachments; attach files to compose; inline preview | ✅ pass | User confirmed preview + download work. | Web UI handles directly. |
+| 8 | **API: list_messages** — Atom feed returns unread messages; extend to cover read messages and pagination | _TBD_ | _TBD_ | Pre-audit: partial. Atom feed only ~20 most-recent unread; no pagination by Gmail design. |
+| 9 | **API: send** — Implement (currently stubbed) | _TBD_ | _TBD_ | Pre-audit: stub. Requires CDP Input automation of compose dialog — fragile. |
+| 10 | **API: trash** — Implement (currently stubbed) | _TBD_ | _TBD_ | Pre-audit: stub at `writes.rs:20-25`. |
+| 11 | **API: add_label** — Implement (currently stubbed) | _TBD_ | _TBD_ | Pre-audit: stub at `writes.rs:27-35`. |
+| 12 | **Notifications** — Native OS notifications for new emails; `notification_settings` toggle honored | ✅ pass (after fix) | First test: zero `forward_native_notification` events fired even with #1028's `Browser.grantPermissions` in place — colleague mail arrived only after manual Gmail refresh. Diagnosed: Gmail's BrowserChannel real-time push (`mail.google.com/mail/u/0/channel/bind`) does NOT deliver to CEF webviews, and Web Push (FCM service-worker) requires Chromium glue absent in CEF builds, so the page never observes new mail and never calls `new Notification(...)`. Fix: new `gmail::notify_poll` task polls the Atom feed every 30 s, dispatches synthetic toasts for newly-seen unread IDs via `forward_synthetic_notification`. Verified end-to-end against staging: colleague test mail produced macOS banner under "OpenHuman" attribution within 30 s, click routed to Gmail account. | **Bugs fixed in this PR**: (a) Gmail real-time delivery bypass via Atom-feed poll (new `gmail/notify_poll.rs`); (b) per-fetch `disable_cache` option on `cdp_fetch` so polls observe fresh atom bytes; (c) toasts now attribute to `app_id` always (dropped the dev-mode `com.apple.Terminal` hack at `webview_accounts/mod.rs:929,947` so packaged-bundle and dev share the OpenHuman attribution that the user has notification permissions on). 6 unit tests cover seen-set FIFO + persistence; lifecycle wired through `webview_account_close` / `purge` and the `drain_for_shutdown` shutdown path. |
+| 13 | **Memory ingestion** — Recipe.js DOM scraper feeds ingest events; plan migration to CDP-based ingestion with `memory_doc_ingest` | _TBD_ | _TBD_ | Pre-audit: partial. `recipe.js` polls `tr.zA` rows every 2s, pushes `{messages, unread, snapshotKey}` to `api.ingest()` → `provider_surfaces_ingest_event`. No `memory_doc_ingest` call. |
+| 14 | **Page load reliability** — Triple-signal fallback (native + CDP + 15s watchdog) verified stable; no missed loads | _TBD_ | _TBD_ | Pre-audit: wired. Triple-signal fallback at `webview_accounts/mod.rs:1084-1085, 1583-1626`. Watchdog 15s at line 498. |
+| 15 | **Session persistence** — Tab switch preserves session; Google cookies retained | ✅ pass | User confirmed switching to OpenHuman home and back to Gmail keeps the session live. Earlier in session, Gmail tab loaded already-signed-in across full process kill + relaunch (CEF data_directory persistence working). | Same UX quirk surfaced as Slack #1016: in-app Gmail logout removes the OpenHuman sidebar tile but doesn't purge CEF profile cookies, so re-add lands already signed in. Track in the existing logout-UX follow-up. |
+| 16 | **Multi-account** — `/mail/u/0/`, `/mail/u/1/` paths handled correctly | _TBD_ | _TBD_ | Pre-audit: partial. Atom feed URL hardcoded `/mail/u/0/` at `reads.rs:78`. |
+
+## Smoke run procedure
+
+For each criterion:
+
+1. Reproduce in running app (`pnpm dev:app`).
+2. Capture exact symptom + console/CDP log line if relevant.
+3. Mark verdict in table.
+4. If ❌: file child issue against `tinyhumansai/openhuman` titled `[Bug] webview/gmail: <symptom>` linking back to #1020.
+5. If ⚠️: note limitation + scope follow-up; decide whether to fix in this PR or defer.
+
+## Known issues from issue body (verify status)
+
+- Write ops (`send`, `trash`, `add_label`) all stubs — require CDP Input-event automation that is fragile against Gmail UI churn.
+- `Page.loadEventFired` unreliable — triple-signal fallback mitigates but is not ideal.
+- Google auth popup rewriting intercepts `accounts.google.com` popups and redirects parent — may break on Google login flow changes.
+- Atom feed only returns ~20 most-recent unread per label (Gmail-imposed limit).
+- Recipe.js (legacy JS injection) still active — should be migrated to pure CDP.
+
+## Pre-audit code-level gaps (from research dossier)
+
+These were confirmed by static read of `main` before smoke. The smoke run will validate which manifest as user-visible bugs vs. intentional non-features.
+
+1. **Auth wiring** — popup rewriting only covers `accounts.google.com` parent-navigation case (`webview_accounts/mod.rs:2655-2712`); no explicit 2FA path verified end-to-end in code.
+2. **Read email** — feed-based listing + print-view fetch only; no thread-state, no read/unread flag toggles, no inline-image cache strategy beyond browser-native rendering.
+3. **Compose stub** — `writes.rs:12-18` returns "not implemented" string; no compose-dialog UI automation exists.
+4. **Reply / Forward** — no code path; would need DOM/CDP automation of thread-action buttons.
+5. **Search fragility** — `reads.rs:121-203` polls snapshot 15× at 0.4s after `Page.navigate` to `#search/<query>`; brittle to Gmail table redesign and slow on cold loads.
+6. **Labels read-only + English-only** — sidebar snapshot at `reads.rs:686-727`; system label names hardcoded English at `reads.rs:779-797`; `add_label` stubbed at `writes.rs:27-35`.
+7. **Attachments missing** — no download capture, no compose-attach automation, no inline-preview hook.
+8. **list_messages limit** — Atom feed returns ~20 most-recent unread by Gmail design; no pagination is possible from this surface.
+9. **trash + add_label stubs** — `writes.rs:20-25` and `writes.rs:27-35` return stub errors.
+10. **Recipe.js still active** — legacy JS injection at `recipe.js` polls `tr.zA` rows every 2s and emits via `api.ingest()`; runs counter to the "no new JS injection in CEF webviews" rule and should migrate to a CDP-driven scanner with `memory_doc_ingest` calls.
+11. **Multi-account hardcoded** — Atom feed URL pinned to `/mail/u/0/` at `reads.rs:78`; secondary accounts (`/mail/u/1/`, `/mail/u/2/`, …) not handled.
+
+## Hardcoded constants worth capturing
+
+| Constant | Value | File:line |
+|----------|-------|-----------|
+| Atom feed base URL | `https://mail.google.com/mail/u/0/feed/atom` | `reads.rs:78` |
+| Print-view URL template | `https://mail.google.com/mail/u/0/?ui=2&view=pt&search=all&th={escaped}` | `reads.rs:672-673` |
+| Search row selector | `tr.zA` | `reads.rs:256, 532` |
+| Watchdog timeout | 15s | `webview_accounts/mod.rs:498, 1628` |
+| URL fragment account marker | `#openhuman-account-<id>` | `session.rs:8, 28` |
+| Recipe.js poll interval | 2000 ms | `runtime.js:31` |
+| Search snapshot polling | 400 ms × 15 attempts | `reads.rs:181-182` |
+| System label names (English-only) | hardcoded | `reads.rs:779-797` |
+| Notification poll interval | 30 s | `notify_poll.rs:44` |
+| Notification poll initial delay | 15 s | `notify_poll.rs:49` |
+| Notification poll limit | 20 entries | `notify_poll.rs:54` |
+| Seen-set FIFO cap | 200 entries | `notify_poll.rs:60` |
+
+## Sign-off
+
+- Tester: oxoxDev
+- Result: _TBD_
+- Date: _TBD_
+- Action items: _TBD_


### PR DESCRIPTION
## Summary

- Gmail row #12 of [#1020](https://github.com/tinyhumansai/openhuman/issues/1020) audit ✅: native macOS toasts now fire for new mail within 30 s.
- Fixes the dev-mode toast bundle-id attribution for **all** providers (Slack / WhatsApp / Telegram / Discord / Browserscan / Gmail) — drop `com.apple.Terminal` fallback, always use `com.openhuman.app` so notifications surface under the bundle the user has notification permissions configured for.
- Gmail Auth row #1 also resolved — Google SSO ccTLD coverage (`accounts.google.<cctld>` + `accounts.youtube.com`) so the post-password `SetSID` redirect doesn't leak to system Chrome.
- 6 new unit tests; lifecycle wired through `webview_account_open` / `close` / `purge` / `drain_for_shutdown`.

## Problem

Even after #1028 landed `Browser.grantPermissions` + the JS `Notification.permission` shim, the Gmail webview produced **zero** native toasts during the audit. Diagnosed by colleague-test mail + `[notify-cef]` log inspection: Gmail's BrowserChannel real-time push (`mail.google.com/mail/u/0/channel/bind`) does **not** deliver to CEF webviews, and Web Push (FCM service-worker) requires Chromium glue absent in CEF builds. As a result the page never observes new mail server-side and never calls `new Notification(...)` — the entire notification grant + IPC plumbing is wired correctly but nothing ever traverses it. Manual reload of the Gmail UI was required to see new mail.

Secondary problem caught during smoke: in dev mode (`pnpm dev:app`) toasts attempted to attribute to `com.apple.Terminal`, but the user's System Settings → Notifications had only `OpenHuman` configured (Terminal absent). Even when the Slack/Gmail page **did** fire `new Notification`, the toast landed in Notification Center silently instead of banner-popping.

Tertiary problem from #1020 row #1: the in-app webview kicked the user out to system Chrome after entering Google password — the post-password `SetSID` redirect uses a country-localized host (`accounts.google.co.in`, etc.) that the existing `provider_allowed_hosts` only suffix-matched against the bare `google.com`, so the SetSID hop tripped `url_is_internal == false` and opened externally.

## Solution

### Gmail Atom-feed notification poll

Bypass the broken page-side delivery entirely: a per-account `tokio::spawn` task in `gmail::notify_poll` polls the standard Atom feed at `mail.google.com/mail/u/0/feed/atom` every 30 s, diffs against a persistent seen-set, and dispatches synthetic toasts via `forward_synthetic_notification` (which already inherits all DnD / mute / focused-account-bypass / `NotificationSettings` gating).

- Persistent seen-set at `<app_local_data_dir>/gmail/<account_id>/seen.json`, capped at 200 entries with FIFO eviction (~6× the Atom-feed window so IDs that briefly rotate out and back in don't re-fire). Atomic write via temp + rename so a crash never leaves a truncated file.
- Cold start with no persisted state seeds silently on the first poll; subsequent ticks fire for new IDs. Resumed task with persisted IDs treats every new ID as fireable from tick 1.
- New `cdp_fetch::FetchOptions { disable_cache }` — poll path bypasses HTTP cache; `list_messages` / `search` / `get_message` keep default caching behavior unchanged.
- Lifecycle: `JoinHandle` stored in `WebviewAccountsState.gmail_notify_polls`, aborted on close + purge + shutdown drain. `webview_account_purge` also drops the seen-set dir so a re-login starts fresh.

### Notification bundle-id fix

Drop the `if tauri::is_dev() { "com.apple.Terminal" } else { app_id }` branch at both `mac_notification_sys::set_application` call sites. Always pass `app.config().identifier` so dev and packaged builds share OpenHuman attribution. Verified end-to-end: dev-mode Gmail and Slack toasts now banner-pop under the OpenHuman bundle settings.

### Google SSO ccTLD predicate

New `is_google_sso_host` accepts `accounts.google.<cctld>` (`.com` / `.co.in` / `.co.uk` / `.com.au` / `.fr` / `.de`) and `accounts.youtube.com`. `url_is_internal` short-circuits to `true` for `gmail` and `google-meet` providers when the host matches. 5 unit tests cover the accept set + reject set. Same fix benefits Google Meet (#1022).

### Audit doc

`docs/qa/GMAIL-PARITY.md` walks all 16 rows. Confirmed ✅: Auth (1), Read (2), Compose (3), Reply/Forward (4), Search (5), Labels (6, read), Attachments (7), Notifications (12), Session persistence (15). Deferred to follow-ups: API send/trash/add_label stubs (rows 9-11), memory ingestion plan (13), multi-account `/u/N/` (16).

## Submission Checklist

- [x] Tests added or updated — 6 unit tests in `gmail::notify_poll` (FIFO eviction, dup detection, on-disk round-trip, missing-file fallback, corrupt-JSON recovery) + 5 unit tests for `is_google_sso_host` predicate + extension to `drain_for_shutdown` test for the new `gmail_notify_polls` map.
- [ ] N/A: this PR delivers a webview-parity audit row already tracked in `docs/qa/GMAIL-PARITY.md`, not a new `TEST-COVERAGE-MATRIX` feature row, so no matrix sync applies.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced — Atom feed is the same Gmail-served endpoint already used by `list_messages`; mock backend untouched.
- [ ] N/A: notifications are user-visible but covered by the existing `notification_settings` smoke and the #1020 audit dossier (`docs/qa/GMAIL-PARITY.md`); no release-cut surface added.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop only** — CEF runtime + Tauri shell. No frontend / web / CLI changes.
- **Performance** — adds one CDP-authenticated HTTP fetch every 30 s per opened Gmail account (~10 KB body, no cache). Negligible CPU; one debounced disk write per tick. Default INBOX label only.
- **Latency floor** — up to 30 s between a mail arriving and the toast firing. Acceptable for email parity.
- **Bundle-id change** — every webview-originated native toast in dev mode now attributes to `com.openhuman.app`, which is the same bundle id as packaged builds. Affects Gmail / Slack / WhatsApp / Telegram / Discord / Browserscan. Verified for Gmail and Slack.
- **Security** — no new origins, no new JS injection, no new credential surfaces. Atom feed rides the existing CEF cookie jar via `Network.loadNetworkResource`. Email subject is no longer logged at info level (PII-safety).
- **Migration** — none. Persistent seen-set lives at a new path under `app_local_data_dir`; no migration of pre-existing state needed (none exists).

## Related

- Closes #1020 (rows #1 Auth, #12 Notifications)
- Builds on #1028 (Slack notifications grant — same `Browser.grantPermissions` infra reached for free)
- Adjacent: #1022 Google Meet — benefits from the same `is_google_sso_host` predicate
- Follow-up TODOs (separate issues):
  - Gmail per-label / multi-inbox notification scoping
  - Promotions / Social / Forums category suppression
  - Configurable poll interval via env or settings UI
  - Generic `notify_poll` framework when a second polling provider arrives
  - Gmail `/mail/u/N/` multi-account support (atom feed URL hardcoded `/u/0/`)
  - API write stubs (`send`, `trash`, `add_label`) — separate issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail notification polling per account with persistent seen-state, deduplication, FIFO eviction, and toast delivery for new messages.

* **Improvements**
  * Added an option to perform uncached fetches so polling observes fresh feeds.
  * Improved embedded Google SSO/navigation handling and safer poll task lifecycle (start/stop/purge).
  * macOS notification selection streamlined.

* **Documentation**
  * Added Gmail parity acceptance criteria and smoke-test procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->