### PR TITLE
fix(ui): consistent sidebar layout across all views

### DIFF
--- a/app/src/components/accounts/WebviewHost.tsx
+++ b/app/src/components/accounts/WebviewHost.tsx
@@ -120,7 +120,7 @@ const WebviewHost = ({ accountId, provider }: WebviewHostProps) => {
   return (
     <div
       ref={ref}
-      className="relative h-full w-full overflow-hidden rounded-lg border border-stone-200 bg-stone-100"
+      className="relative h-full w-full overflow-hidden rounded-2xl border border-stone-200/70 bg-stone-100"
       aria-label={`webview host for account ${accountId}`}>
       {isLoading ? (
         <div

--- a/app/src/components/accounts/WebviewHost.tsx
+++ b/app/src/components/accounts/WebviewHost.tsx
@@ -64,11 +64,14 @@ const WebviewHost = ({ accountId, provider }: WebviewHostProps) => {
     const measureAndSync = () => {
       if (!el || cancelled) return;
       const rect = el.getBoundingClientRect();
+      // Inset the native webview by the container's border-radius so the
+      // rounded HTML border is visible around the edges.
+      const inset = 8;
       const bounds = {
-        x: Math.round(rect.left),
-        y: Math.round(rect.top),
-        width: Math.max(1, Math.round(rect.width)),
-        height: Math.max(1, Math.round(rect.height)),
+        x: Math.round(rect.left + inset),
+        y: Math.round(rect.top + inset),
+        width: Math.max(1, Math.round(rect.width - inset * 2)),
+        height: Math.max(1, Math.round(rect.height - inset * 2)),
       };
       const last = lastBoundsRef.current;
       const unchanged =
@@ -120,7 +123,7 @@ const WebviewHost = ({ accountId, provider }: WebviewHostProps) => {
   return (
     <div
       ref={ref}
-      className="relative h-full w-full overflow-hidden rounded-2xl border border-stone-200/70 bg-stone-100"
+      className="relative h-full w-full overflow-hidden rounded-2xl border border-stone-200/70 bg-stone-100 shadow-soft"
       aria-label={`webview host for account ${accountId}`}>
       {isLoading ? (
         <div

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -196,17 +196,12 @@ const Accounts = () => {
 
   return (
     <div className="relative flex h-full overflow-hidden">
-      {/* Narrow icon rail — floats when Agent is selected, flush to the
-          edge when an app webview is taking the full pane. Hidden during
-          welcome lockdown (#883) so the user cannot navigate to a
-          connected account or add a new one. */}
+      {/* Narrow icon rail — always rendered as a floating card alongside
+          the main content pane. Hidden during welcome lockdown (#883) so
+          the user cannot navigate to a connected account or add a new one. */}
       {!welcomeLocked && (
         <aside
-          className={`z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md transition-all duration-300 ${
-            isAgentSelected
-              ? 'my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft'
-              : 'border-r border-stone-200/60'
-          }`}>
+          className="z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft">
           <RailButton active={isAgentSelected} onClick={selectAgent} tooltip="Agent">
             <AgentIcon className="h-9 w-9 rounded-lg" />
           </RailButton>
@@ -262,7 +257,7 @@ const Accounts = () => {
             /> */}
           </div>
         ) : active ? (
-          <div className="flex-1">
+          <div className="flex-1 py-3 pr-3">
             <WebviewHost accountId={active.id} provider={active.provider} />
           </div>
         ) : (

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -195,7 +195,7 @@ const Accounts = () => {
   }, [ctxMenu]);
 
   return (
-    <div className="relative flex h-full overflow-hidden">
+    <div className="relative flex h-full gap-3 overflow-hidden">
       {/* Narrow icon rail — always rendered as a floating card alongside
           the main content pane. Hidden during welcome lockdown (#883) so
           the user cannot navigate to a connected account or add a new one. */}

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -200,8 +200,7 @@ const Accounts = () => {
           the main content pane. Hidden during welcome lockdown (#883) so
           the user cannot navigate to a connected account or add a new one. */}
       {!welcomeLocked && (
-        <aside
-          className="z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft">
+        <aside className="z-30 flex w-16 flex-none flex-col items-center gap-2 bg-white/60 py-3 backdrop-blur-md my-3 ml-3 rounded-2xl border border-stone-200/70 shadow-soft">
           <RailButton active={isAgentSelected} onClick={selectAgent} tooltip="Agent">
             <AgentIcon className="h-9 w-9 rounded-lg" />
           </RailButton>


### PR DESCRIPTION
## Summary
- Sidebar icon rail now always renders as a floating card (rounded corners, border, shadow) regardless of whether the Agent or a webview account is selected — removes the jarring layout shift on switch
- Adds `gap-3` between the sidebar and main content area for consistent spacing
- Insets native CEF webview bounds by 8px so the rounded HTML border and shadow are visible around the webview

## Test plan
- [x] Open the app, verify sidebar looks the same on Agent view and any webview account
- [x] Verify there is a visible gap between sidebar and webview content
- [x] Verify webview has visible rounded corners, border, and shadow
- [x] Switch between multiple accounts and Agent — no layout shift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed positioning issue to ensure content displays correctly within visual boundaries.

* **Style**
  * Enhanced visual styling with improved border effects and shadow depth.
  * Refined spacing and alignment for better visual consistency across interface components.
  * Updated component appearance for a more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->