### PR TITLE
fix(channels): preserve overflow segments instead of dropping them (#1041)

### DIFF
--- a/src/openhuman/channels/providers/presentation.rs
+++ b/src/openhuman/channels/providers/presentation.rs
@@ -261,10 +261,23 @@ fn cap_segments(segments: Vec<String>, max: usize, joiner: &str) -> Vec<String> 
     if max == 0 || segments.len() <= max {
         return segments;
     }
+    let original_len = segments.len();
     let mut iter = segments.into_iter();
     let mut result: Vec<String> = (&mut iter).take(max - 1).collect();
     let tail: Vec<String> = iter.collect();
-    result.push(tail.join(joiner));
+    let tail_count = tail.len();
+    let merged = tail.join(joiner);
+    tracing::debug!(
+        target: "presentation",
+        max,
+        original_len,
+        tail_count,
+        tail_len = merged.len(),
+        joiner_len = joiner.len(),
+        "[presentation:segment] merging {} overflow segments into tail",
+        tail_count
+    );
+    result.push(merged);
     result
 }
 

--- a/src/openhuman/channels/providers/presentation.rs
+++ b/src/openhuman/channels/providers/presentation.rs
@@ -187,7 +187,7 @@ fn segment_for_delivery(text: &str) -> Vec<String> {
                 segments = merged.len(),
                 "[presentation:segment] split by paragraphs"
             );
-            return merged.into_iter().take(MAX_SEGMENTS).collect();
+            return cap_segments(merged, MAX_SEGMENTS, "\n\n");
         }
     }
 
@@ -200,7 +200,7 @@ fn segment_for_delivery(text: &str) -> Vec<String> {
                 segments = grouped.len(),
                 "[presentation:segment] split by sentences"
             );
-            return grouped.into_iter().take(MAX_SEGMENTS).collect();
+            return cap_segments(grouped, MAX_SEGMENTS, " ");
         }
     }
 
@@ -247,6 +247,25 @@ fn is_numbered_list_item(line: &str) -> bool {
     }
     // Must have consumed at least one digit, followed by ". ".
     i > 0 && i <= 3 && bytes.get(i) == Some(&b'.') && bytes.get(i + 1) == Some(&b' ')
+}
+
+/// Cap the number of delivered segments at `max` without losing content:
+/// the first `max - 1` segments are kept as-is, and any overflow is
+/// concatenated into a single trailing segment using `joiner`.
+///
+/// The earlier behavior (`.take(MAX_SEGMENTS)`) silently dropped every
+/// segment past the cap, which truncated long agent replies in the UI
+/// (issue #1041). Merging into the tail preserves all content while
+/// still bounding the inter-bubble delay budget.
+fn cap_segments(segments: Vec<String>, max: usize, joiner: &str) -> Vec<String> {
+    if max == 0 || segments.len() <= max {
+        return segments;
+    }
+    let mut iter = segments.into_iter();
+    let mut result: Vec<String> = (&mut iter).take(max - 1).collect();
+    let tail: Vec<String> = iter.collect();
+    result.push(tail.join(joiner));
+    result
 }
 
 /// Merge adjacent segments shorter than MIN_SEGMENT_CHARS.

--- a/src/openhuman/channels/providers/presentation_tests.rs
+++ b/src/openhuman/channels/providers/presentation_tests.rs
@@ -72,10 +72,12 @@ fn max_segments_respected_without_dropping_content() {
     let result = segment_for_delivery(&text);
     assert!(result.len() <= MAX_SEGMENTS);
     let joined = result.join("\n\n");
-    for i in 0..10 {
+    // Assert the full paragraph body survives, not just the prefix —
+    // a mid-text truncation would slip past a substring-only check.
+    for (i, original) in paras.iter().enumerate() {
         assert!(
-            joined.contains(&format!("Paragraph number {} ", i)),
-            "paragraph {} missing from delivered segments",
+            joined.contains(original),
+            "paragraph {} truncated or missing from delivered segments",
             i
         );
     }

--- a/src/openhuman/channels/providers/presentation_tests.rs
+++ b/src/openhuman/channels/providers/presentation_tests.rs
@@ -56,7 +56,10 @@ fn numbered_list_detection() {
 }
 
 #[test]
-fn max_segments_respected() {
+fn max_segments_respected_without_dropping_content() {
+    // Regression: the prior `.take(MAX_SEGMENTS)` silently dropped every
+    // paragraph past the cap (issue #1041). Verify the cap holds AND no
+    // input paragraph disappears from the delivered output.
     let paras: Vec<String> = (0..10)
         .map(|i| {
             format!(
@@ -68,6 +71,94 @@ fn max_segments_respected() {
     let text = paras.join("\n\n");
     let result = segment_for_delivery(&text);
     assert!(result.len() <= MAX_SEGMENTS);
+    let joined = result.join("\n\n");
+    for i in 0..10 {
+        assert!(
+            joined.contains(&format!("Paragraph number {} ", i)),
+            "paragraph {} missing from delivered segments",
+            i
+        );
+    }
+}
+
+#[test]
+fn cap_segments_passthrough_when_under_cap() {
+    let segs = vec!["one".to_string(), "two".to_string(), "three".to_string()];
+    assert_eq!(cap_segments(segs.clone(), 5, "\n\n"), segs);
+    assert_eq!(cap_segments(segs.clone(), 3, "\n\n"), segs);
+}
+
+#[test]
+fn cap_segments_merges_overflow_into_tail() {
+    let segs = vec![
+        "one".to_string(),
+        "two".to_string(),
+        "three".to_string(),
+        "four".to_string(),
+        "five".to_string(),
+        "six".to_string(),
+    ];
+    let out = cap_segments(segs, 3, "\n\n");
+    assert_eq!(out.len(), 3);
+    assert_eq!(out[0], "one");
+    assert_eq!(out[1], "two");
+    assert_eq!(out[2], "three\n\nfour\n\nfive\n\nsix");
+}
+
+#[test]
+fn cap_segments_handles_zero_max() {
+    let segs = vec!["one".to_string(), "two".to_string()];
+    // max=0 is a no-op: returns input unchanged rather than panicking.
+    assert_eq!(cap_segments(segs.clone(), 0, " "), segs);
+}
+
+#[test]
+fn issue_1041_transcript_preserves_bullets_and_trailing_paragraphs() {
+    // The exact shape of the agent reply that triggered issue #1041:
+    // 11 paragraphs including a bullet list and 4 trailing paragraphs.
+    // Pre-fix `.take(MAX_SEGMENTS)` dropped paragraphs 6-11 entirely;
+    // post-fix they must survive (merged into the final segment).
+    let text = "here's the full message with a sharper CTA:\n\n\
+        ---\n\n\
+        hey [name], great meeting you at Startup Grind SF last week. really enjoyed our conversation about [insert 1 specific detail if you remember, otherwise remove this line].\n\n\
+        i'm reaching out to share what we're building at TinyHumans. we just launched OpenHuman, and the insight is simple: AI agents are incredibly powerful, but today they're locked behind developer workflows. setup, API keys, terminals. the 99% who can't code are completely left out.\n\n\
+        OpenHuman fixes that. it's AI agents that work out of the box. no setup, no API keys, no copy-paste. just plain English.\n\n\
+        we launched a week ago and the response has been strong:\n\n\
+        - 100+ paying users\n- 200+ GitHub stars, growing ~150% week over week\n- 50+ outside PRs merged\n\n\
+        attaching a screenshot of our growth curve since day one.\n\n\
+        we're second-time founders. previously scaled products to 100k DAUs, had a 1.5M exit, and built to 3M ARR. now we're going after the \"Apple moment\" for AI agents, making them actually usable for everyone.\n\n\
+        are you open to a 15-min demo next week? happy to work around your schedule.\n\n\
+        cheers,\n[your name]";
+
+    let result = segment_for_delivery(text);
+    assert!(
+        result.len() <= MAX_SEGMENTS,
+        "segment count {} exceeds cap",
+        result.len()
+    );
+
+    let joined = result.join("\n\n");
+    // Bullet list — the highest-priority symptom of #1041
+    assert!(joined.contains("100+ paying users"), "bullet 1 dropped");
+    assert!(joined.contains("200+ GitHub stars"), "bullet 2 dropped");
+    assert!(
+        joined.contains("50+ outside PRs merged"),
+        "bullet 3 dropped"
+    );
+    // Trailing paragraphs — also dropped pre-fix
+    assert!(
+        joined.contains("attaching a screenshot"),
+        "screenshot paragraph dropped"
+    );
+    assert!(
+        joined.contains("second-time founders"),
+        "founders paragraph dropped"
+    );
+    assert!(
+        joined.contains("15-min demo next week"),
+        "demo ask paragraph dropped"
+    );
+    assert!(joined.contains("[your name]"), "signature dropped");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fix issue #1041: long agent replies were missing roughly half their content in the UI (bullet lists + trailing paragraphs disappeared).
- Root cause was in **`segment_for_delivery`** (`src/openhuman/channels/providers/presentation.rs`): `.take(MAX_SEGMENTS)` silently dropped every paragraph past the 5th cap.
- New `cap_segments(segments, max, joiner)` helper preserves all content by merging overflow into the final segment instead of discarding it.
- Pre-existing `MAX_SEGMENTS = 5` cap retained — bubble count is still bounded; no inter-bubble delay regression.
- New regression test runs the exact agent reply text from the issue's transcript screenshot and asserts every bullet and every trailing paragraph survives.

## Problem

The web channel applies a "human-feeling" presentation layer that splits long replies into multiple chat bubbles. The split was implemented as `paragraphs.into_iter().take(MAX_SEGMENTS).collect()` (and the same pattern on the sentence-fallback path).

Once a reply produced more than `MAX_SEGMENTS = 5` natural paragraphs, every paragraph past the cap was silently dropped before the segments were ever published to the frontend. The final `chat_done` event still carried `full_response` with the complete text, but the frontend's `onDone` handler in `ChatRuntimeProvider` skips the full-response branch when `segment_total > 0` (it trusts segments already delivered everything) — so the truncation was unrecoverable on the client side.

The reporter's screenshots show this exactly: an 11-paragraph draft email rendered as the first 5 bubbles, then `2m ago` and end of message. Bullets and the entire sign-off were gone.

## Solution

Replace `.take(MAX_SEGMENTS)` with a `cap_segments` helper that:

- Returns the input unchanged when it already fits under the cap.
- Otherwise keeps the first `max - 1` segments as-is and concatenates the remaining tail into a single trailing segment with the appropriate joiner (`\n\n` for paragraph strategy, `" "` for sentence strategy).
- Treats `max == 0` as a no-op rather than panicking.

Applied at both call sites in `segment_for_delivery`. The `MAX_SEGMENTS` constant and the inter-bubble delay model (`segment_delay`) are unchanged — bubble count is still bounded, the user just no longer loses content past the cap.

The previously-passing test `max_segments_respected` was renamed to `max_segments_respected_without_dropping_content` and now also asserts that **every** input paragraph appears in the joined output — the assertion that would have caught this bug originally.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement) — 4 new tests + 1 enhanced existing test in `presentation_tests.rs`
- [x] N/A: behaviour-only change — coverage matrix unchanged (no new/renamed feature row)
- [x] N/A: behaviour-only change — no new feature IDs
- [x] N/A — no new external network dependencies introduced
- [x] N/A — no release-cut surface touched (purely internal segmentation logic; observable as "long replies render fully" but doesn't change UX surface)
- [x] Linked issue closed via `Closes #1041` below

## Impact

- **Runtime**: web-channel chat delivery only. No other channel paths or domains touched.
- **Performance**: identical to baseline — same bubble count published, same inter-bubble delay, just one of the bubbles is now potentially longer (the tail).
- **Compatibility**: backward-compatible. Existing replies that fit under the cap behave identically. Replies that previously hit the cap now deliver their full content instead of partial.
- **Migration**: none.

## Related

- Closes #1041
- Follow-up PR(s)/TODOs: none planned. The frontend `ChatRuntimeProvider.onDone` fallback (using `event.full_response` when `segment_total > 0` but fewer segments arrived than claimed) was considered as defense-in-depth but isn't needed once the backend is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented content loss when segment limits are exceeded by capping delivered segments and merging any overflow into the final segment so all original content is retained.

* **Tests**
  * Added unit and end-to-end regression tests to verify capped delivery preserves all input content and handles edge cases (including zero max).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->