### PR TITLE
feat(webview/gmeet): native cam/mic/screenshare + keep Meet routing in-app (#1022)

### DIFF
--- a/app/src-tauri/src/cdp/session.rs
+++ b/app/src-tauri/src/cdp/session.rs
@@ -85,6 +85,17 @@ fn origin_of(url: &str) -> Option<String> {
     }
 }
 
+/// Does `origin` (a `scheme://host[:port]` string from [`origin_of`]) match
+/// a specific host? Tolerates an explicit port suffix on `origin` so the
+/// callers can pass canonical hosts without hard-coding default ports.
+fn origin_host_is(origin: &str, host: &str) -> bool {
+    let Some(rest) = origin.strip_prefix("https://").or_else(|| origin.strip_prefix("http://")) else {
+        return false;
+    };
+    let host_part = rest.split(':').next().unwrap_or(rest);
+    host_part.eq_ignore_ascii_case(host)
+}
+
 fn target_matches_account_url(target_url: &str, account_id: &str) -> bool {
     let marker = placeholder_marker(account_id);
     let marker_fragment = format!("#{marker}");
@@ -271,27 +282,51 @@ async fn run_session_cycle<R: Runtime>(
     // `forward_native_notification` in `webview_accounts`. Without it,
     // the constructor silently no-ops and no toast ever fires (#1016).
     if let Some(origin) = origin_of(&real_url) {
+        // Default permission set every embedded provider needs. Origin-scoped
+        // so we don't leak grants across providers running in the same CEF
+        // browser process.
+        let mut perms: Vec<&str> = vec!["notifications"];
+
+        // Google Meet additionally needs:
+        //   - audioCapture / videoCapture: getUserMedia for cam/mic so the
+        //     pre-call greenroom auto-grants instead of falling back to
+        //     Meet's "Use microphone and camera" consent dialog
+        //   - displayCapture: getDisplayMedia for screen-share present
+        //   - clipboardReadWrite: copy meeting link / paste join code
+        // Without these, Meet sits on the consent dialog forever and cam/mic
+        // never enumerate (verified during #1022 smoke).
+        if origin_host_is(&origin, "meet.google.com") {
+            perms.extend_from_slice(&[
+                "audioCapture",
+                "videoCapture",
+                "displayCapture",
+                "clipboardReadWrite",
+            ]);
+        }
+
         if let Err(e) = cdp
             .call(
                 "Browser.grantPermissions",
                 json!({
                     "origin": origin,
-                    "permissions": ["notifications"],
+                    "permissions": perms,
                 }),
                 None,
             )
             .await
         {
             log::warn!(
-                "[cdp-session][{}] Browser.grantPermissions(notifications) for {} failed: {}",
+                "[cdp-session][{}] Browser.grantPermissions({:?}) for {} failed: {}",
                 account_id,
+                perms,
                 origin,
                 e
             );
         } else {
             log::info!(
-                "[cdp-session][{}] granted notifications for origin={}",
+                "[cdp-session][{}] granted {:?} for origin={}",
                 account_id,
+                perms,
                 origin
             );
         }
@@ -397,6 +432,24 @@ mod tests {
             origin_of("https://APP.SLACK.COM/client"),
             Some("https://app.slack.com".to_string())
         );
+    }
+
+    #[test]
+    fn origin_host_is_matches_canonical_origin() {
+        assert!(origin_host_is("https://meet.google.com", "meet.google.com"));
+        assert!(origin_host_is("http://meet.google.com:8080", "meet.google.com"));
+        assert!(origin_host_is("https://MEET.GOOGLE.COM", "meet.google.com"));
+    }
+
+    #[test]
+    fn origin_host_is_rejects_non_match() {
+        // Different host
+        assert!(!origin_host_is("https://workspace.google.com", "meet.google.com"));
+        // Subdomain mismatch
+        assert!(!origin_host_is("https://chat.meet.google.com", "meet.google.com"));
+        // Non-http scheme
+        assert!(!origin_host_is("about:blank", "meet.google.com"));
+        assert!(!origin_host_is("file:///etc/hosts", "meet.google.com"));
     }
 
     #[test]

--- a/app/src-tauri/src/cdp/session.rs
+++ b/app/src-tauri/src/cdp/session.rs
@@ -89,7 +89,10 @@ fn origin_of(url: &str) -> Option<String> {
 /// a specific host? Tolerates an explicit port suffix on `origin` so the
 /// callers can pass canonical hosts without hard-coding default ports.
 fn origin_host_is(origin: &str, host: &str) -> bool {
-    let Some(rest) = origin.strip_prefix("https://").or_else(|| origin.strip_prefix("http://")) else {
+    let Some(rest) = origin
+        .strip_prefix("https://")
+        .or_else(|| origin.strip_prefix("http://"))
+    else {
         return false;
     };
     let host_part = rest.split(':').next().unwrap_or(rest);
@@ -437,16 +440,25 @@ mod tests {
     #[test]
     fn origin_host_is_matches_canonical_origin() {
         assert!(origin_host_is("https://meet.google.com", "meet.google.com"));
-        assert!(origin_host_is("http://meet.google.com:8080", "meet.google.com"));
+        assert!(origin_host_is(
+            "http://meet.google.com:8080",
+            "meet.google.com"
+        ));
         assert!(origin_host_is("https://MEET.GOOGLE.COM", "meet.google.com"));
     }
 
     #[test]
     fn origin_host_is_rejects_non_match() {
         // Different host
-        assert!(!origin_host_is("https://workspace.google.com", "meet.google.com"));
+        assert!(!origin_host_is(
+            "https://workspace.google.com",
+            "meet.google.com"
+        ));
         // Subdomain mismatch
-        assert!(!origin_host_is("https://chat.meet.google.com", "meet.google.com"));
+        assert!(!origin_host_is(
+            "https://chat.meet.google.com",
+            "meet.google.com"
+        ));
         // Non-http scheme
         assert!(!origin_host_is("about:blank", "meet.google.com"));
         assert!(!origin_host_is("file:///etc/hosts", "meet.google.com"));

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -243,10 +243,23 @@ fn popup_should_navigate_parent(provider: &str, url: &Url) -> Option<Url> {
                 return None;
             }
             if is_google_auth_popup(url) {
-                Some(url.clone())
-            } else {
-                None
+                return Some(url.clone());
             }
+            // Gmeet: "Start an instant meeting" / "New meeting" / clicking
+            // a meeting code link calls `window.open(meet.google.com/<roomid>)`
+            // to launch the room. Default popup handling would route the
+            // URL to the user's system browser, leaking the Meet session
+            // out of OpenHuman entirely. Deny the popup and navigate the
+            // embedded parent into the room URL instead — matches the
+            // user's expectation that the meeting stays in-app.
+            if provider == "google-meet" {
+                if let Some(host) = url.host_str() {
+                    if host == "meet.google.com" {
+                        return Some(url.clone());
+                    }
+                }
+            }
+            None
         }
         _ => None,
     }
@@ -1438,6 +1451,40 @@ pub async fn webview_account_open<R: Runtime>(
                 "[webview-accounts] emit webview-account:navigate failed: {}",
                 err
             );
+        }
+        // Google Meet: when Google's edge SSR-redirects the post-account-
+        // picker URL to `workspace.google.com/products/meet/...` (the
+        // marketing landing page), `workspace.google.com` matches the
+        // bare `google.com` suffix in `provider_allowed_hosts` so
+        // `url_is_internal` would commit the navigation and the user
+        // would land on the Workspace marketing page instead of Meet.
+        // Catch this here and replace the parent URL with the canonical
+        // Meet entry point so the embedded view stays on the app.
+        if nav_provider == "google-meet" {
+            if let Some(host) = url.host_str() {
+                if host == "workspace.google.com" || host.ends_with(".workspace.google.com") {
+                    log::info!(
+                        "[webview-accounts] gmeet workspace marketing redirect intercepted ({}); rewriting parent to https://meet.google.com/",
+                        url
+                    );
+                    let app = nav_app.clone();
+                    let label = nav_label.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Some(wv) = app.get_webview(&label) {
+                            if let Ok(target) = Url::parse("https://meet.google.com/") {
+                                if let Err(e) = wv.navigate(target) {
+                                    log::warn!(
+                                        "[webview-accounts] gmeet workspace rewrite navigate failed label={} err={}",
+                                        label,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    });
+                    return false;
+                }
+            }
         }
         if let Some(rewritten) = rewrite_provider_deep_link(&nav_provider, url) {
             log::info!(
@@ -2703,6 +2750,58 @@ mod tests {
             &url("https://accounts.google.com/signin/v2/identifier"),
         )
         .is_some());
+    }
+
+    #[test]
+    fn gmeet_room_popup_navigates_parent() {
+        // "Start an instant meeting" / "New meeting" calls
+        // window.open(meet.google.com/<roomid>) to launch a room.
+        // Without intervention this would route to system Chrome and
+        // leak the meeting out of OpenHuman.
+        assert_eq!(
+            popup_should_navigate_parent(
+                "google-meet",
+                &url("https://meet.google.com/abc-defg-hij"),
+            )
+            .map(|u| u.to_string()),
+            Some("https://meet.google.com/abc-defg-hij".to_string())
+        );
+    }
+
+    #[test]
+    fn gmeet_landing_popup_navigates_parent() {
+        // Bare meet.google.com (no room code) should also be kept
+        // in-app — matches the "back to Meet home" UX after hangup.
+        assert!(popup_should_navigate_parent(
+            "google-meet",
+            &url("https://meet.google.com/"),
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn gmeet_workspace_popup_does_not_navigate_parent() {
+        // workspace.google.com is the marketing page; if it ever
+        // arrives via window.open() we let the default external-route
+        // logic handle it (covered in the on_navigation rewrite path
+        // separately).
+        assert!(popup_should_navigate_parent(
+            "google-meet",
+            &url("https://workspace.google.com/products/meet/"),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn gmeet_unrelated_popup_does_not_navigate_parent() {
+        // External link in the post-call review screen, for instance.
+        // Should NOT navigate the parent — should fall through to the
+        // system-browser path.
+        assert!(popup_should_navigate_parent(
+            "google-meet",
+            &url("https://example.com/blog"),
+        )
+        .is_none());
     }
 
     #[test]

--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -2772,11 +2772,10 @@ mod tests {
     fn gmeet_landing_popup_navigates_parent() {
         // Bare meet.google.com (no room code) should also be kept
         // in-app — matches the "back to Meet home" UX after hangup.
-        assert!(popup_should_navigate_parent(
-            "google-meet",
-            &url("https://meet.google.com/"),
-        )
-        .is_some());
+        assert!(
+            popup_should_navigate_parent("google-meet", &url("https://meet.google.com/"),)
+                .is_some()
+        );
     }
 
     #[test]
@@ -2797,11 +2796,10 @@ mod tests {
         // External link in the post-call review screen, for instance.
         // Should NOT navigate the parent — should fall through to the
         // system-browser path.
-        assert!(popup_should_navigate_parent(
-            "google-meet",
-            &url("https://example.com/blog"),
-        )
-        .is_none());
+        assert!(
+            popup_should_navigate_parent("google-meet", &url("https://example.com/blog"),)
+                .is_none()
+        );
     }
 
     #[test]

--- a/docs/qa/GMEET-PARITY.md
+++ b/docs/qa/GMEET-PARITY.md
@@ -1,0 +1,79 @@
+# Google Meet Webview Parity — QA Matrix
+
+> Issue: [#1022](https://github.com/tinyhumansai/openhuman/issues/1022)
+> Related: [#1035](https://github.com/tinyhumansai/openhuman/issues/1035) — Meet landing page + post-2FA auth refresh
+> Branch: `feat/1022-gmeet-parity-audit`
+> Tester: oxoxDev
+> Build: `upstream/main @ 680589d8` + `feat/1022-gmeet-parity-audit` HEAD
+> Date: 2026-04-30
+> Method: manual smoke against `pnpm dev:app` on macOS (per `feedback_validation_test_target.md`)
+
+## Verdict legend
+
+- ✅ **pass** — feature works as native app
+- ⚠️ **partial** — works but with limitation; needs follow-up
+- ❌ **fail** — broken; child issue filed
+- 🔍 **needs investigation** — non-deterministic behavior; revisit
+- ⏭️ **deferred** — out of scope for this PR; tracked elsewhere
+
+## Acceptance criteria audit
+
+| # | Criterion | Verdict | Evidence | Notes / child issue |
+|---|-----------|---------|----------|---------------------|
+| 1 | **Auth** — Google sign-in completes (email → password → 2FA); session persists across restarts | ❌ blocked on #1046 | After password entry the in-app webview was redirected to system Chrome (the post-password `SetSID` hop on `accounts.google.<cctld>` falls through `provider_allowed_hosts` for gmeet because the country-localized hosts aren't suffix-matched against bare `google.com`). Identical to the gmail bug fixed in #1020. | **Fix lives in PR #1046** (`is_google_sso_host` predicate at `webview_accounts/mod.rs`). Once #1046 merges and this branch rebases on main, in-app SSO completes natively and CEF lands the cookie in the right jar — no extra change needed in this PR. |
+| 2 | **Landing page** — `webview_account_open("google-meet")` lands on `meet.google.com`, not Google's marketing surface | ✅ pass (after fix) | Baseline behavior: post-account-pick redirect committed to `workspace.google.com/products/meet/...` because the bare `google.com` suffix in `provider_allowed_hosts` matched it as in-app. Fix: `on_navigation` intercepts gmeet `workspace.google.com` (and any subdomain) and rewrites the parent to `https://meet.google.com/`. | **Bug fixed in this PR**: `on_navigation` workspace marketing rewrite. |
+| 3 | **Start a new meeting** — "Start an instant meeting" / "New meeting" launches the room in-app | ✅ pass (after fix) | Baseline behavior: clicking "Start now" called `window.open(meet.google.com/<roomid>)`; default popup chain routed it to system Chrome and the user lost the in-app session entirely. Fix: `popup_should_navigate_parent` extended to match `meet.google.com` hosts for the `google-meet` provider so the popup is denied and the embedded parent is navigated into the room. Smoke result: "Start now" instantly drops the user into the meeting tab. | **Bug fixed in this PR**: gmeet popup parent-nav. |
+| 4 | **Join via meeting code** — entering a code in the input lands the user in the pre-call greenroom | ✅ pass | After perm-grant fix the join-by-code form correctly takes the user into the pre-call screen. | — |
+| 5 | **Pre-call cam/mic preview (greenroom)** — camera tile shows live video, mic level meter responds | ✅ pass (after fix) | Baseline behavior: greenroom showed Meet's "Use microphone and camera" consent dialog; clicking "Use microphone and camera" was a no-op (`getUserMedia` returned `NotAllowedError`). Fix: per-origin `Browser.grantPermissions` for `meet.google.com` now grants `audioCapture` + `videoCapture` so `getUserMedia` succeeds without the consent dialog. | **Bug fixed in this PR**: cam/mic perm grant. |
+| 6 | **In-call cam/mic** — toggling cam/mic during call works; tiles show live state | ✅ pass | Confirmed in active call. | — |
+| 7 | **Screenshare send** — "Present now" picks a window/screen and broadcasts | ✅ pass | `displayCapture` granted via `Browser.grantPermissions`; the macOS screen-recording prompt resolves once and the share starts. | — |
+| 8 | **Screenshare receive** — remote participant's share renders | ✅ pass | Verified live with a colleague's share. | — |
+| 9 | **Captions** — "Turn on captions" renders the live transcript over the call | ✅ pass | DOM-rendered captions appear inline on the call surface. | The captions are observable to recipe.js (the existing `meet_captions` event), but not yet ingested into OpenHuman memory — that gap is row 13. |
+| 10 | **In-call chat** — open chat panel; send + receive in-meeting messages | ✅ pass | DOM-driven chat works as in stock Chrome. | — |
+| 11 | **Reactions / raise hand** — emoji reactions and raise-hand toggles | ✅ pass | Confirmed live. | — |
+| 12 | **Session persistence** — close + reopen webview tab without sign-out; account stays active | ✅ pass | CEF profile persistence behaves identically to gmail/slack. | — |
+| 13 | **Captions ingestion → memory** — `meet_captions` rows + `meet_call_ended` lifecycle event flush a transcript document via `openhuman.memory_doc_ingest` | ⏭️ deferred to #1052 | Current handler at `webview_accounts/mod.rs:2219-2247` is log-only. Not a regression — recipe.js has been log-only since inception. Filed as **feature** at #1052 with module sketch (`google_meet/` mirroring `gmail/` shape, persistent `MeetingTranscriptStore`, opt-in toggle for the privacy-sensitive transcript). | Out of scope for this PR. |
+| 14 | **Hangup return UX** — leaving the call returns to a recognizable state (rejoin / 5-star review prompt) | ✅ pass | Behavior is identical to stock Chrome — rejoin button + 5-star review with 60s auto-dismiss. | — |
+| 15 | **Background effects** — virtual background / blur applies without breaking the camera | ❌ deferred to #1053 | Selecting a virtual background turns the camera off and Gmeet shows a "something went wrong" toast. Hypothesis: Chromium runtime gates absent in the vendored CEF build (insertable streams `MediaStreamTrackProcessor` / `MediaStreamTrackGenerator`, MediaPipe segmentation requiring SharedArrayBuffer + COOP/COEP cross-origin isolation, HW accel). | Filed as **bug** at #1053 with investigation sketch. Out of scope for this PR — needs CEF runtime-flag tuning, separate from the `webview_accounts` parity work. |
+
+## Smoke run procedure
+
+For each criterion:
+
+1. Reproduce in running app (`pnpm dev:app` from this worktree).
+2. Capture exact symptom + log line if relevant.
+3. Mark verdict in table.
+4. If ❌: file child issue against `tinyhumansai/openhuman` titled `[Bug] webview/gmeet: <symptom>` linking back to #1022.
+5. If ⚠️: note limitation + scope follow-up; decide whether to fix in this PR or defer.
+
+## Pre-audit code-level gaps confirmed during smoke
+
+These were diagnosed against `main` before this PR's fixes landed; the smoke run confirmed each manifests as a user-visible bug.
+
+1. **Cam/mic permission gap** — `Browser.grantPermissions` for the gmeet CDP session granted only `notifications` (added by #1028). `getUserMedia` and `getDisplayMedia` had no underlying CEF permission and Gmeet's web client fell back to its own consent dialog, which the embedded view couldn't satisfy. Fixed by per-origin grant of `audioCapture` / `videoCapture` / `displayCapture` / `clipboardReadWrite` for `meet.google.com`.
+2. **Workspace marketing redirect** — `provider_allowed_hosts("google-meet")` listed bare `google.com`; the SSR-redirect to `workspace.google.com/products/meet/...` matched as in-app and committed. Fixed by `on_navigation` intercept that rewrites the parent to `meet.google.com/`.
+3. **"Start now" popup leak** — `window.open(meet.google.com/<roomid>)` had no in-app handler for the gmeet provider in `popup_should_navigate_parent` / `popup_should_stay_in_app`. Fixed by extending `popup_should_navigate_parent` to match `meet.google.com` hosts for `google-meet`.
+4. **Auth post-2FA redirect** — same root cause as #1020 row #1 (Google SSO ccTLD coverage). Fix lives in PR #1046 (`is_google_sso_host`); this branch rebases on main once #1046 merges.
+
+## Hardcoded constants worth capturing
+
+| Constant | Value | File:line |
+|----------|-------|-----------|
+| Provider URL | `https://meet.google.com/` | `webview_accounts/mod.rs:58` |
+| Allow-list suffixes (gmeet) | `google.com`, `googleusercontent.com`, `gstatic.com`, `googleapis.com` | `webview_accounts/mod.rs:108-113` |
+| Recipe.js bundle (legacy) | `app/src-tauri/recipes/google-meet/recipe.js` | bundled via `include_str!` at `mod.rs:46` |
+| URL fragment account marker | `#openhuman-account-<id>` | `cdp/session.rs:46-48` |
+| Granted permissions (gmeet) | `notifications`, `audioCapture`, `videoCapture`, `displayCapture`, `clipboardReadWrite` | `cdp/session.rs` |
+
+## CDP-migration sketch (out of scope)
+
+The legacy `recipe.js` polls the call DOM for caption rows. A future epic should migrate this to a Rust-side `google_meet_scanner` module driven by `DOMSnapshot.captureSnapshot` / `Network.responseReceived`, mirroring the `slack_scanner` / `whatsapp_scanner` shape. Captions are DOM-rendered (not network-delivered), so the migration cannot use `Network.responseReceived` alone — needs a polling DOM snapshot. This work would also enable native dedup and let us drop the recipe.js bundle. **Filed under follow-up — not gated on this PR.**
+
+## Sign-off
+
+- Tester: oxoxDev
+- Result: 11 ✅ / 0 ⚠️ / 2 ❌ (one blocked on #1046, one deferred to #1053) / 1 ⏭️ deferred to #1052 / 1 ❌ blocked on #1046
+- Date: 2026-04-30
+- Action items:
+  - Land #1046 (gmail PR) → rebase this branch → row #1 Auth flips ✅
+  - Track #1052 (caption ingest feature) and #1053 (background effects CEF gap) as follow-up issues


### PR DESCRIPTION
## Summary

- Embedded Google Meet now matches stock Chrome for cam, mic, screenshare, captions, in-call chat, reactions, raise-hand, session persistence, and hangup-return UX.
- Per-origin `Browser.grantPermissions` for `meet.google.com` adds `audioCapture` / `videoCapture` / `displayCapture` / `clipboardReadWrite` so `getUserMedia` succeeds without Meet's "Use microphone and camera" consent dialog.
- Two routing leaks closed: (a) post-account-pick `workspace.google.com` marketing redirect → rewritten to `meet.google.com/`; (b) "Start now" / room-popup → kept in-app via parent navigation instead of leaking to system Chrome.
- 6 new unit tests (`origin_host_is` accept/reject + 4 popup-routing cases). Manual smoke logged in `docs/qa/GMEET-PARITY.md` (15-row matrix, 11 ✅).
- Two follow-ups filed before opening this PR: #1052 (caption transcript ingestion feature) and #1053 (background effects CEF runtime gap).

## Problem

Surfaced during the #1022 parity audit smoke against `pnpm dev:app`:

1. **Cam/mic gap** — Gmeet's pre-call greenroom showed its own "Use microphone and camera" consent dialog and clicking it was a no-op. Root cause: `Browser.grantPermissions` for the gmeet CDP session granted only `notifications` (added by #1028 for Slack), so `getUserMedia` returned `NotAllowedError` and Gmeet's web client fell back to its own consent UI which the embedded view couldn't satisfy.
2. **Workspace marketing leak** — after the user picked an account in the in-app sign-in flow, Google's edge SSR-redirected to `workspace.google.com/products/meet/...`. `provider_allowed_hosts("google-meet")` lists a bare `google.com` suffix (`webview_accounts/mod.rs:108-113`); `url_is_internal` matches `workspace.google.com` against `.google.com` so the navigation committed and the user landed on the Workspace marketing page instead of Meet.
3. **"Start now" leak** — clicking "Start an instant meeting" / "New meeting" calls `window.open(meet.google.com/<roomid>)`. The default `on_new_window` chain had no in-app handler for gmeet's own host (`popup_should_navigate_parent` only matched the Google auth popup; `popup_should_stay_in_app` is slack/zoom-only), so the URL fell through to `open_in_system_browser` and the meeting opened in Chrome — the user lost the in-app session entirely.

A fourth gap surfaced during smoke (auth post-2FA refresh, audit row 1) but is fixed by PR #1046's `is_google_sso_host` predicate. This PR documents the dependency in `docs/qa/GMEET-PARITY.md` and stays out of that surface.

## Solution

### Per-origin Meet permission grant — `cdp/session.rs`

Extends `Browser.grantPermissions` to dispatch a per-provider permission set. Default for every embedded provider is `["notifications"]`. For `meet.google.com` (matched via the new `origin_host_is(origin, host)` helper) it additionally grants `audioCapture`, `videoCapture`, `displayCapture`, `clipboardReadWrite`. Origin-scoped so Slack / WhatsApp / Telegram / Discord / Browserscan grants are unaffected.

### Workspace marketing rewrite — `webview_accounts/mod.rs::on_navigation`

Pre-intercept inside the existing `on_navigation` closure. For the `google-meet` provider, if the navigation host is `workspace.google.com` (or any subdomain), the original navigation is cancelled and the embedded parent is navigated to `https://meet.google.com/`. Logged for diagnostics.

### Room-popup parent navigation — `popup_should_navigate_parent`

Extends the existing gmeet branch (which already handled the Google auth popup) to also match `meet.google.com` hosts. The popup is denied and the embedded parent is navigated into the room URL, so "Start now" / room-link clicks stay in the same in-app tab the user clicked from.

### Audit dossier — `docs/qa/GMEET-PARITY.md`

Mirrors the `GMAIL-PARITY.md` shape: 15-row acceptance matrix pre-filled from the smoke run, hardcoded constants table, smoke procedure, CDP-migration sketch, sign-off block.

## Submission Checklist

- [x] Tests added or updated — 2 unit tests for `origin_host_is` (accept/reject) + 4 unit tests for `popup_should_navigate_parent` (gmeet room popup, gmeet landing popup, workspace not navigating parent, unrelated link not navigating parent).
- [ ] N/A: this PR delivers a webview-parity audit row already tracked in `docs/qa/GMEET-PARITY.md`, not a new `TEST-COVERAGE-MATRIX` feature row, so no matrix sync applies.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`.
- [x] No new external network dependencies introduced — same Meet origin as the existing webview; mock backend untouched.
- [ ] N/A: parity work for an already-shipping webview surface — covered by the #1022 audit dossier (`docs/qa/GMEET-PARITY.md`); no new release-cut surface added.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Desktop only** — CEF runtime + Tauri shell. No frontend / web / CLI changes.
- **Permission grants** — origin-scoped to `https://meet.google.com`. No other provider's permission set changes. Permissions are limited to the four Meet actually exercises during a call (audio capture, video capture, display capture for screenshare, clipboard for copy-meeting-link).
- **Routing changes** — gmeet-specific. The workspace rewrite only fires for `workspace.google.com` (and subdomains) when the active provider is `google-meet`. The room-popup parent-nav only fires for `meet.google.com` hosts when the active provider is `google-meet`.
- **Performance** — no new background tasks. One additional `Browser.grantPermissions` argument list at session attach.
- **Security** — no new origins, no new JS injection, no new credential surfaces. Permission grants are origin-scoped via CDP and tied to the per-account CEF profile.
- **Migration** — none.

## Related

- Closes #1022
- Fixes #1035
- Builds on #1028 (Slack notifications grant — same `Browser.grantPermissions` infra reused)
- Depends on #1046 for audit row 1 (Auth) — once #1046 merges and this branch rebases on main, the `is_google_sso_host` predicate keeps the post-password `SetSID` hop in-app and CEF lands cookies natively. No additional change needed in this PR.
- Follow-up TODOs:
  - #1052 — `[Feature] Gmeet caption transcript ingestion via memory_doc_ingest` (replaces current log-only handler at `webview_accounts/mod.rs:2219-2247`)
  - #1053 — `[Bug] Gmeet background effects fail in CEF — "something went wrong"` (Chromium runtime gates absent in CEF for MediaPipe segmentation pipeline)
  - CDP migration of recipe.js scraping (separate epic; sketched in `GMEET-PARITY.md` CDP-migration section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Meet popups and navigation now remain within the app instead than opening externally.
  * Automatic permission grants for audio capture, video capture, and screen sharing on Google Meet.

* **Bug Fixes**
  * Improved handling of Google Meet landing page redirects within the webview.

* **Documentation**
  * Added Google Meet webview compatibility testing matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->