### PR TITLE
feat(composio/gmail): sync into memory tree (Slack-parity)

### DIFF
--- a/src/openhuman/composio/providers/gmail/provider.rs
+++ b/src/openhuman/composio/providers/gmail/provider.rs
@@ -302,9 +302,14 @@ impl ComposioProvider for GmailProvider {
 
             // ── Step 5: filter against synced_ids for early-stop, advance
             //    cursor tracker, and collect new messages for batched
-            //    memory-tree ingest.
+            //    memory-tree ingest. We collect candidate IDs to mark
+            //    synced but defer the mark until the batch ingest returns
+            //    Ok — otherwise a total ingest failure would leave these
+            //    messages flagged as synced (gmail-side fetch dedup) but
+            //    NOT in the memory tree, with no way to retry.
             let mut all_already_synced = true;
             let mut new_messages: Vec<Value> = Vec::with_capacity(messages.len());
+            let mut pending_synced_ids: Vec<String> = Vec::with_capacity(messages.len());
             for msg in &messages {
                 // Track the newest date we've seen for cursor advancement,
                 // independent of dedup status — we want the cursor to move
@@ -323,7 +328,7 @@ impl ComposioProvider for GmailProvider {
                     if state.is_synced(id) {
                         continue;
                     }
-                    state.mark_synced(id);
+                    pending_synced_ids.push(id.clone());
                 }
                 all_already_synced = false;
                 new_messages.push(msg.clone());
@@ -333,11 +338,21 @@ impl ComposioProvider for GmailProvider {
             // content-hashed so re-ingest of the same message is an
             // idempotent UPSERT at the SQL layer; per-message dedup above
             // is purely an optimisation for the hot path.
+            //
+            // `synced_ids` here means "Gmail-side fetch dedup" (don't burn
+            // API quota re-fetching this message), not "fully durable in
+            // memory tree". We only commit those marks once the batch
+            // returns Ok; on Err, nothing is marked, so the next sync
+            // re-fetches and the chunk-id content hash handles dedup at
+            // the storage layer.
             if !new_messages.is_empty() {
                 let owner = format!("gmail-sync:{connection_id}");
                 match ingest_page_into_memory_tree(ctx.config.as_ref(), &owner, &new_messages).await
                 {
                     Ok(n) => {
+                        for id in &pending_synced_ids {
+                            state.mark_synced(id);
+                        }
                         // total_persisted tracks messages, not chunks, for
                         // metric stability with the previous per-message
                         // persist path. n is the chunk count which we log

--- a/src/openhuman/composio/providers/gmail/provider.rs
+++ b/src/openhuman/composio/providers/gmail/provider.rs
@@ -1,4 +1,4 @@
-//! Gmail provider — incremental sync with per-item persistence.
+//! Gmail provider — incremental sync into the memory tree.
 //!
 //! On each sync pass:
 //!
@@ -6,9 +6,14 @@
 //!   2. Check the daily request budget — bail early if exhausted.
 //!   3. Fetch a page of recent messages via `GMAIL_FETCH_EMAILS`, adding
 //!      a date filter when a cursor exists so only newer mail is returned.
-//!   4. Deduplicate against `synced_ids` in the state.
-//!   5. Persist each **new** message as its own memory document (not a
-//!      single giant snapshot) so agent recall can find individual emails.
+//!   4. Run [`ComposioProvider::post_process_action_result`] (HTML→md,
+//!      normalise, sanitise) on the page so the LLM-facing chunk content
+//!      is cleaned, not raw.
+//!   5. Filter against `synced_ids` for an early-stop optimisation,
+//!      then ingest the new messages into the memory tree via
+//!      [`super::ingest::ingest_page_into_memory_tree`] — same pipeline
+//!      the standalone `gmail-backfill-3d` binary uses, mirroring the
+//!      Slack provider's `ingest_chat` pattern.
 //!   6. Paginate (up to budget) until no more results or all items in the
 //!      page are already synced.
 //!   7. Advance the cursor and save state.
@@ -20,10 +25,9 @@
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
+use super::ingest::ingest_page_into_memory_tree;
 use super::sync;
-use crate::openhuman::composio::providers::sync_state::{
-    extract_item_id, persist_single_item, SyncState,
-};
+use crate::openhuman::composio::providers::sync_state::{extract_item_id, SyncState};
 use crate::openhuman::composio::providers::{
     pick_str, ComposioProvider, CuratedTool, ProviderContext, ProviderUserProfile, SyncOutcome,
     SyncReason,
@@ -258,9 +262,9 @@ impl ComposioProvider for GmailProvider {
                 args["page_token"] = json!(token);
             }
 
-            let resp = ctx
+            let mut resp = ctx
                 .client
-                .execute_tool(ACTION_FETCH_EMAILS, Some(args))
+                .execute_tool(ACTION_FETCH_EMAILS, Some(args.clone()))
                 .await
                 .map_err(|e| {
                     format!("[composio:gmail] {ACTION_FETCH_EMAILS} page {page_num}: {e:#}")
@@ -280,6 +284,11 @@ impl ComposioProvider for GmailProvider {
                 ));
             }
 
+            // ── Step 4: post-process the page (HTML→md, normalise, sanitise)
+            //    so chunk content is clean before ingest. Same pipeline the
+            //    standalone gmail-backfill-3d binary runs.
+            self.post_process_action_result(ACTION_FETCH_EMAILS, Some(&args), &mut resp.data);
+
             let messages = sync::extract_messages(&resp.data);
             total_fetched += messages.len();
 
@@ -291,15 +300,15 @@ impl ComposioProvider for GmailProvider {
                 break;
             }
 
-            // ── Step 4: deduplicate and persist per-item ────────────
+            // ── Step 5: filter against synced_ids for early-stop, advance
+            //    cursor tracker, and collect new messages for batched
+            //    memory-tree ingest.
             let mut all_already_synced = true;
+            let mut new_messages: Vec<Value> = Vec::with_capacity(messages.len());
             for msg in &messages {
-                let Some(msg_id) = extract_item_id(msg, MESSAGE_ID_PATHS) else {
-                    tracing::debug!("[composio:gmail] message missing ID, skipping");
-                    continue;
-                };
-
-                // Track the newest date we've seen for cursor advancement.
+                // Track the newest date we've seen for cursor advancement,
+                // independent of dedup status — we want the cursor to move
+                // even if we've already ingested this page's content.
                 if let Some(date_val) = extract_item_id(msg, MESSAGE_DATE_PATHS) {
                     if newest_date
                         .as_ref()
@@ -309,45 +318,44 @@ impl ComposioProvider for GmailProvider {
                     }
                 }
 
-                if state.is_synced(&msg_id) {
-                    continue;
+                let msg_id = extract_item_id(msg, MESSAGE_ID_PATHS);
+                if let Some(ref id) = msg_id {
+                    if state.is_synced(id) {
+                        continue;
+                    }
+                    state.mark_synced(id);
                 }
                 all_already_synced = false;
+                new_messages.push(msg.clone());
+            }
 
-                // Build a human-readable title for this email document.
-                let subject = pick_str(
-                    msg,
-                    &[
-                        "subject",
-                        "data.subject",
-                        "payload.headers.Subject",
-                        "snippet",
-                    ],
-                )
-                .unwrap_or_else(|| format!("Email {msg_id}"));
-                let doc_id = format!("composio-gmail-msg-{msg_id}");
-                let title = format!("Gmail: {subject}");
-
-                match persist_single_item(
-                    &memory,
-                    "gmail",
-                    &doc_id,
-                    &title,
-                    msg,
-                    "gmail",
-                    ctx.connection_id.as_deref(),
-                )
-                .await
+            // Single batched ingest into memory_tree. Chunk IDs are
+            // content-hashed so re-ingest of the same message is an
+            // idempotent UPSERT at the SQL layer; per-message dedup above
+            // is purely an optimisation for the hot path.
+            if !new_messages.is_empty() {
+                let owner = format!("gmail-sync:{connection_id}");
+                match ingest_page_into_memory_tree(ctx.config.as_ref(), &owner, &new_messages).await
                 {
-                    Ok(_) => {
-                        state.mark_synced(&msg_id);
-                        total_persisted += 1;
+                    Ok(n) => {
+                        // total_persisted tracks messages, not chunks, for
+                        // metric stability with the previous per-message
+                        // persist path. n is the chunk count which we log
+                        // for diagnostic purposes only.
+                        total_persisted += new_messages.len();
+                        tracing::debug!(
+                            page = page_num,
+                            new_messages = new_messages.len(),
+                            ingested_chunks = n,
+                            "[composio:gmail] page ingested into memory tree"
+                        );
                     }
                     Err(e) => {
                         tracing::warn!(
-                            msg_id = %msg_id,
-                            error = %e,
-                            "[composio:gmail] failed to persist message (continuing)"
+                            error = %format!("{e:#}"),
+                            page = page_num,
+                            new_messages = new_messages.len(),
+                            "[composio:gmail] ingest_page_into_memory_tree failed (continuing)"
                         );
                     }
                 }


### PR DESCRIPTION
## Summary

- `GmailProvider::sync` now writes incremental sync output into the **memory tree** (`mem_tree_chunks` + content `.md` files) via `ingest_page_into_memory_tree`, replacing the per-message `persist_single_item` path that wrote into the legacy `MemoryClient` store.
- Brings Gmail to parity with Slack — `SlackProvider::sync` already routes through `ingest_chat`. Gmail data was previously invisible to memory-tree retrieval (`query_source`, `query_topic`, `query_global`, `search_entities`, `fetch_leaves`).
- Inline `post_process_action_result` (HTML → md, normalise, sanitise) now runs inside `sync()` — same call the standalone `gmail-backfill-3d` binary makes — so chunk content is cleaned before extraction.
- Cursor + dedup state, daily request budget, and pagination semantics are unchanged.

## Problem

Memory tree (Phase 4 retrieval per #710) is the structured store where `query_*` RPCs and the per-source / topic / global trees live. The Gmail provider's incremental sync was writing to the **legacy unified `MemoryClient`** store via `store_skill_sync`, which the memory-tree retrieval surface does not read from. Result: every Gmail sync via `openhuman.composio_sync` left memory_tree empty for Gmail, even though the standalone `gmail-backfill-3d` binary correctly populated it.

The Slack provider (`composio/providers/slack/provider.rs`) already side-steps this by calling `ingest_chat` — the Gmail provider was the outlier.

## Solution

Replace the per-message `persist_single_item` loop in `GmailProvider::sync` with a single per-page batched call to `ingest_page_into_memory_tree`. Identical pipeline to the standalone binary:

```
GMAIL_FETCH_EMAILS  -> post_process_action_result (HTML->md, sanitise)
                    -> bucket_by_participants
                    -> ingest_email
                    -> mem_tree_chunks + content .md files
```

**Preserved:**
- `SyncState` cursor + per-message dedup via `synced_ids` (early-stop when `all_already_synced`)
- Daily request budget (`DEFAULT_DAILY_REQUEST_LIMIT`, 500/day)
- Pagination loop, `MAX_PAGES_PER_SYNC` cap

**Changed:**
- `total_persisted` continues to track unique new messages (not chunks) — chunks are logged at debug for diagnostics. Keeps the metric stable across the swap.
- Page-level `post_process_action_result` now runs inside `sync()` — was previously a no-op for the sidecar path (only the standalone binary called it).

**Trade-off:** Gmail data no longer appears in `MemoryClient.list_documents` / `recall_namespace` calls. Today's primary consumer of those is the subconscious's `situation_report.rs`, so subconscious awareness of Gmail content shifts from "always visible" to "visible once subconscious is migrated to memory-tree retrieval". Acceptable: the subconscious situation report is a separate refactor on the roadmap and Gmail-via-`composio_sync` was the outlier.

**Alternative considered:** dual-write (call both `persist_single_item` AND `ingest_page_into_memory_tree`). Rejected because it doubles write cost, perpetuates the path the memory architecture is moving away from, and Slack already chose replace.

## Submission Checklist

- [x] Tests added or updated — **N/A: behaviour-only refactor.** The new path delegates to `ingest_page_into_memory_tree`, which has existing coverage via the standalone `gmail-backfill-3d` binary path and ``tests/agent_retrieval_e2e.rs``. The legacy code path being removed had no unit tests of its own. Smoke-tested end-to-end via `openhuman.composio_sync` RPC against a running standalone sidecar.
- [x] Coverage matrix updated — **N/A: behaviour-only change.** Gmail sync still surfaces messages; just to a different storage layer.
- [x] All affected feature IDs listed in `## Related` — **N/A: behaviour-only change.**
- [x] No new external network dependencies — **N/A: no new deps; uses existing Composio Gmail tools (`GMAIL_FETCH_EMAILS`).**
- [x] Manual smoke checklist updated if this touches release-cut surfaces — **N/A: no new release-cut surface.** Existing Gmail-sync smoke step (if any) still applies and now exercises the memory_tree path.
- [x] Linked issue closed via `Closes #NNN` — **N/A: no linked issue; small parity fix consistent with Slack provider.**

## Impact

- **Runtime:** desktop sidecar — Gmail data now flows into memory_tree on every periodic sync (default cadence 15 min). Per-page batched ingest produces fewer SQLite write transactions than the old per-message loop.
- **Performance:** roughly equivalent. Same downstream extract/embed/seal jobs enqueued via the async worker pool. Slightly lower SQLite contention from batching.
- **Security:** no change. Same Composio toolkit, same OAuth scopes, same daily-budget guard.
- **Migration:** non-destructive. Existing `MemoryClient`-stored Gmail documents from prior syncs remain in the legacy store untouched; new syncs land in memory_tree only.
- **Compatibility:** no breaking changes to RPC surface (`openhuman.composio_sync` signature and `SyncOutcome` shape unchanged).

## Related

- Closes: N/A — no linked issue (small parity fix)
- Follow-up PR(s)/TODOs:
  - Subconscious `situation_report.rs` should be migrated to query memory_tree (`query_global`, `query_source`, `search_entities`) so Gmail (and other memory-tree-only) content remains visible there. Existing roadmap item, separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reworked Gmail sync to ingest pages of messages with content cleaning and normalization before storage.
  * Improved deduplication: skips already-synced items early, batches only unsynced candidates, and advances cursors by newest dates.
  * Sync marks are now committed only after successful batch ingest, preventing false positives on failures.
  * Metrics and logs updated to more accurately reflect message vs. chunk counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->