### PR TITLE
fix(memory_tree/embed): set num_ctx=8192 on Ollama embed requests

### DIFF
--- a/src/openhuman/memory/tree/score/embed/ollama.rs
+++ b/src/openhuman/memory/tree/score/embed/ollama.rs
@@ -98,10 +98,34 @@ impl OllamaEmbedder {
     }
 }
 
+/// Override for Ollama's per-model `num_ctx` default. We always request
+/// `num_ctx = 8192` so embedding models that natively support a larger
+/// context (e.g. `nomic-embed-text` v1.5, max 8192 tokens) actually use
+/// it.
+///
+/// **Why this matters**: Ollama's default `num_ctx` for `nomic-embed-text`
+/// is 2048, NOT the model's nominal max of 8192. Without this override,
+/// long chunks (~1500+ chunker-tokens) fail with `500 Internal Server
+/// Error: "the input length exceeds the context length"` — even though
+/// the chunker stays under its own 3000-token cap. The chunker's
+/// char-based heuristic underestimates BERT-WordPiece token counts by
+/// ~1.5–2x for HTML-derived markdown, so 1500 chunker-tokens can be 2500+
+/// real tokens, busting the 2048 default.
+///
+/// For embedding models that don't natively support 8192, Ollama clamps
+/// `num_ctx` to the model's actual maximum — overriding upward is safe.
+const EMBED_NUM_CTX: u32 = 8192;
+
 #[derive(Serialize)]
 struct EmbedRequest<'a> {
     model: &'a str,
     prompt: &'a str,
+    options: EmbedOptions,
+}
+
+#[derive(Serialize)]
+struct EmbedOptions {
+    num_ctx: u32,
 }
 
 #[derive(Deserialize)]
@@ -126,6 +150,9 @@ impl Embedder for OllamaEmbedder {
         let req = EmbedRequest {
             model: &self.model,
             prompt: text,
+            options: EmbedOptions {
+                num_ctx: EMBED_NUM_CTX,
+            },
         };
         let resp = self
             .client
@@ -224,6 +251,12 @@ mod tests {
                 async move {
                     assert_eq!(body["model"], "nomic-embed-text");
                     assert_eq!(body["prompt"], "hello world");
+                    // Regression: we must explicitly request the embedder's
+                    // full nominal context. Ollama's per-model default for
+                    // `nomic-embed-text` is num_ctx=2048, which causes long
+                    // chunks (~1500+ chunker-tokens) to fail. See doc on
+                    // `EMBED_NUM_CTX`.
+                    assert_eq!(body["options"]["num_ctx"], 8192);
                     Json(serde_json::json!({ "embedding": v }))
                 }
             }),


### PR DESCRIPTION
## Summary

- Set `options.num_ctx = 8192` on every `/api/embeddings` request body so embedding models that natively support a larger context (e.g. `nomic-embed-text` v1.5) actually use it instead of Ollama's per-model default.
- Unblocks long-chunk embedding failures: chunker stays under its own 3000-token cap but Ollama's default `num_ctx = 2048` for `nomic-embed-text` rejects ~half of real-world Gmail-derived chunks.
- For models that don't natively support 8192, Ollama clamps to the model's actual max — safe to override upward.

## Problem

Diagnostic data from a 96-message Gmail backfill on staging, all extract_chunk jobs against `gemma3:1b-it-qat` extractor + `nomic-embed-text` embedder:

| group | n | token range | avg |
|---|---|---|---|
| succeeded extract_chunk | 82 | 19 – 2813 | 360 |
| **failed** extract_chunk | **50** | **1640 – 2997** | **2731** |

Every failure was the same error from the embedder:

```
ollama embeddings failed status=500 Internal Server Error
body={\"error\":\"the input length exceeds the context length\"}
```

50 chunks burned all 5 retry attempts and ended in `mem_tree_jobs.status='failed'`. They sit in `pending_extraction` indefinitely; downstream summarisation/topic routing skips them.

Same source, same model, same call path — the only correlate is chunk size. Root cause:

1. **Chunker token heuristic underestimates BERT-WordPiece tokens** by ~1.5–2x for HTML-converted markdown (URLs, dense punctuation, base64 fragments). A 1640-chunker-token chunk can be ~2500+ real tokens.
2. **Ollama's per-model `num_ctx` for `nomic-embed-text` is 2048**, not the model's nominal max of 8192. The 2500 real tokens busts 2048 but is well within 8192.

So chunks above ~1500-1800 chunker-tokens consistently fail at embed time even though the chunker stays under its own 3000-token cap.

## Solution

Add an `EmbedOptions` block to the request struct with `num_ctx: u32`, and pass `EMBED_NUM_CTX = 8192` for every `embed()` call.

```rust
#[derive(Serialize)]
struct EmbedRequest<'a> {
    model: &'a str,
    prompt: &'a str,
    options: EmbedOptions,
}

#[derive(Serialize)]
struct EmbedOptions {
    num_ctx: u32,
}

const EMBED_NUM_CTX: u32 = 8192;
```

Doc comment on `EMBED_NUM_CTX` explains the rationale + safety: Ollama clamps to model max for embedders that don't support 8192, so override is safe across all models.

**Alternative considered:** lower the chunker's `DEFAULT_CHUNK_MAX_TOKENS` from 3000 to ~1200 to live below 2048 real tokens. Rejected because (a) it changes chunk boundaries → invalidates content-hashed chunk IDs → forces re-ingest of all existing data, (b) it caps the embedder below its actual capability for no reason, (c) it doesn't address the underlying chunker token-counting heuristic which would still drift.

**Alternative considered:** pre-truncate text in `embed()` to a safe length. Rejected because silent truncation of chunk content before embedding would make the embedding represent only a prefix while the chunk is stored whole — bad for retrieval quality. Better to actually use the model's full context.

## Submission Checklist

- [x] Tests added or updated — happy_path_returns_embedding now asserts `body[\"options\"][\"num_ctx\"] == 8192`. Regression test against the wire body.
- [x] Coverage matrix updated — **N/A: behaviour-only fix**, no feature added/removed/renamed.
- [x] All affected feature IDs listed in `## Related` — **N/A: behaviour-only fix.**
- [x] No new external network dependencies — **N/A: same Ollama call, just an extra field in the existing request body.**
- [x] Manual smoke checklist updated if this touches release-cut surfaces — **N/A: no new release-cut surface.**
- [x] Linked issue closed via `Closes #NNN` — **N/A: no linked issue (small, self-contained fix surfaced by failed-extract-job telemetry).**

## Impact

- **Runtime:** every embed call now sends 1 extra integer field — negligible HTTP overhead.
- **Performance:** longer effective context per request, which costs more memory and compute *only* for chunks that actually need it. Smaller chunks unchanged. Will recover the 50 currently-failed chunks once `mem_tree_jobs.status` is reset to `ready` (separate manual step).
- **Security:** no change.
- **Migration:** non-destructive. No data shape changes; existing chunks simply become embeddable now.
- **Compatibility:** Ollama API has accepted `options.num_ctx` for years; safe across the supported version range.

## Related

- Closes: N/A — surfaced by failed-extract-job telemetry on a staging Gmail backfill.
- Follow-up TODOs:
  - Chunker token-counting accuracy: the heuristic underestimates real BERT-WordPiece tokens by ~1.5-2x for HTML-derived markdown. A separate PR could swap to a tokenizer-accurate count or add a safety margin to `DEFAULT_CHUNK_MAX_TOKENS`. Lower priority once this PR makes the embedder accept the worst case.
  - Add a one-shot RPC / CLI helper to reset `mem_tree_jobs.status='failed'` rows back to `ready` so existing-deployment workspaces can recover the 50-ish stuck chunks without a SQL surgery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Ollama embedder with explicit context window configuration across all models, ensuring consistent and predictable embedding generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->