### PR TITLE
fix(welcome): re-enable OAuth buttons with focus/timeout recovery (#1049)

### DIFF
--- a/app/src/components/oauth/OAuthProviderButton.tsx
+++ b/app/src/components/oauth/OAuthProviderButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { getBackendUrl } from '../../services/backendUrl';
 import type { OAuthProviderConfig } from '../../types/oauth';
@@ -13,6 +13,11 @@ interface OAuthProviderButtonProps {
   onClickOverride?: () => void;
 }
 
+// Reset the loading state if the OAuth round-trip never completes — covers
+// the case where the user cancels in the system browser, or the backend
+// redirect fails so the `openhuman://` deep link never fires.
+const OAUTH_LOADING_TIMEOUT_MS = 90_000;
+
 const OAuthProviderButton = ({
   provider,
   className = '',
@@ -20,6 +25,32 @@ const OAuthProviderButton = ({
   onClickOverride,
 }: OAuthProviderButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading) return;
+
+    const reset = () => setIsLoading(false);
+
+    // Window-focus reset is the fast path: when the user returns to OpenHuman
+    // after the system browser, the loading state lifts immediately so the
+    // button is clickable again.
+    const handleFocus = () => {
+      console.debug(`[oauth-button][${provider.id}] window focus → reset isLoading`);
+      reset();
+    };
+
+    const timer = window.setTimeout(() => {
+      console.debug(`[oauth-button][${provider.id}] timeout → reset isLoading`);
+      reset();
+    }, OAUTH_LOADING_TIMEOUT_MS);
+
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [isLoading, provider.id]);
 
   const handleOAuthLogin = async () => {
     if (onClickOverride) {

--- a/app/src/components/oauth/OAuthProviderButton.tsx
+++ b/app/src/components/oauth/OAuthProviderButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { getBackendUrl } from '../../services/backendUrl';
+import { getDeepLinkAuthState } from '../../store/deepLinkAuthState';
 import type { OAuthProviderConfig } from '../../types/oauth';
 import { IS_DEV } from '../../utils/config';
 import { openUrl } from '../../utils/openUrl';
@@ -31,11 +32,32 @@ const OAuthProviderButton = ({
 
     const reset = () => setIsLoading(false);
 
-    // Window-focus reset is the fast path: when the user returns to OpenHuman
-    // after the system browser, the loading state lifts immediately so the
-    // button is clickable again.
+    // Skip reset when a deep-link auth round-trip is already in flight — the
+    // OAuth callback flips `isProcessing=true` AFTER the OS focus event fires,
+    // and resetting first would briefly re-enable the button mid-redirect.
+    const skipDuringDeepLink = (label: string) => {
+      if (getDeepLinkAuthState().isProcessing) {
+        console.debug(`[oauth-button][${provider.id}] ${label} — skip (deep-link processing)`);
+        return true;
+      }
+      return false;
+    };
+
+    // Fast path: window focus fires when the user returns from the system
+    // browser. On most platforms this lifts the loading state immediately.
     const handleFocus = () => {
+      if (skipDuringDeepLink('focus')) return;
       console.debug(`[oauth-button][${provider.id}] window focus → reset isLoading`);
+      reset();
+    };
+
+    // Backup path: macOS Spaces / virtual desktops sometimes restore window
+    // focus without firing a `focus` event. `visibilitychange` is the more
+    // reliable signal there.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      if (skipDuringDeepLink('visibilitychange')) return;
+      console.debug(`[oauth-button][${provider.id}] visibilitychange visible → reset isLoading`);
       reset();
     };
 
@@ -45,10 +67,12 @@ const OAuthProviderButton = ({
     }, OAUTH_LOADING_TIMEOUT_MS);
 
     window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.clearTimeout(timer);
       window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [isLoading, provider.id]);
 
@@ -60,7 +84,7 @@ const OAuthProviderButton = ({
 
     if (externalDisabled || isLoading) return;
 
-    console.log(`Starting ${provider.name} OAuth login`, isTauri());
+    console.debug(`[oauth-button][${provider.id}] starting OAuth login (isTauri=${isTauri()})`);
 
     setIsLoading(true);
 

--- a/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
+++ b/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
@@ -1,0 +1,125 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getBackendUrl } from '../../../services/backendUrl';
+import { openUrl } from '../../../utils/openUrl';
+import { isTauri } from '../../../utils/tauriCommands';
+import OAuthProviderButton from '../OAuthProviderButton';
+
+vi.mock('../../../services/backendUrl', () => ({ getBackendUrl: vi.fn() }));
+
+vi.mock('../../../utils/openUrl', () => ({ openUrl: vi.fn() }));
+
+vi.mock('../../../utils/tauriCommands', () => ({ isTauri: vi.fn() }));
+
+vi.mock('../../../utils/config', () => ({ IS_DEV: false }));
+
+const stubProvider = {
+  id: 'google' as const,
+  name: 'Google',
+  icon: ({ className }: { className?: string }) => (
+    <span aria-hidden="true" className={className} />
+  ),
+  color: '',
+  hoverColor: '',
+  textColor: '',
+  showOnWelcome: true,
+};
+
+describe('OAuthProviderButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(getBackendUrl).mockResolvedValue('https://backend.test');
+    vi.mocked(openUrl).mockResolvedValue(undefined);
+    vi.mocked(isTauri).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('opens the backend OAuth URL on click and shows Connecting...', async () => {
+    render(<OAuthProviderButton provider={stubProvider} />);
+
+    const button = screen.getByRole('button', { name: 'Google' });
+    fireEvent.click(button);
+
+    // Drain the microtasks queued by the async click handler so openUrl resolves.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getBackendUrl).toHaveBeenCalledTimes(1);
+    expect(openUrl).toHaveBeenCalledWith('https://backend.test/auth/google/login');
+    expect(screen.getByRole('button', { name: /Connecting/ })).toBeDisabled();
+  });
+
+  it('resets isLoading when the window regains focus', async () => {
+    render(<OAuthProviderButton provider={stubProvider} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'));
+    });
+
+    expect(screen.queryByText('Connecting...')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Google' })).toBeEnabled();
+  });
+
+  it('resets isLoading after the 90s safety timeout', async () => {
+    render(<OAuthProviderButton provider={stubProvider} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(90_000);
+    });
+
+    expect(screen.queryByText('Connecting...')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Google' })).toBeEnabled();
+  });
+
+  it('honors onClickOverride and skips the OAuth flow', () => {
+    const override = vi.fn();
+
+    render(<OAuthProviderButton provider={stubProvider} onClickOverride={override} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
+
+    expect(override).toHaveBeenCalledTimes(1);
+    expect(getBackendUrl).not.toHaveBeenCalled();
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(screen.queryByText('Connecting...')).not.toBeInTheDocument();
+  });
+
+  it('ignores rapid double-clicks while a request is in flight', async () => {
+    render(<OAuthProviderButton provider={stubProvider} />);
+
+    const button = screen.getByRole('button', { name: 'Google' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getBackendUrl).toHaveBeenCalledTimes(1);
+    expect(openUrl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
+++ b/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getBackendUrl } from '../../../services/backendUrl';
+import { getDeepLinkAuthState } from '../../../store/deepLinkAuthState';
 import { openUrl } from '../../../utils/openUrl';
 import { isTauri } from '../../../utils/tauriCommands';
 import OAuthProviderButton from '../OAuthProviderButton';
@@ -12,7 +13,7 @@ vi.mock('../../../utils/openUrl', () => ({ openUrl: vi.fn() }));
 
 vi.mock('../../../utils/tauriCommands', () => ({ isTauri: vi.fn() }));
 
-vi.mock('../../../utils/config', () => ({ IS_DEV: false }));
+vi.mock('../../../store/deepLinkAuthState', () => ({ getDeepLinkAuthState: vi.fn() }));
 
 const stubProvider = {
   id: 'google' as const,
@@ -32,6 +33,7 @@ describe('OAuthProviderButton', () => {
     vi.mocked(getBackendUrl).mockResolvedValue('https://backend.test');
     vi.mocked(openUrl).mockResolvedValue(undefined);
     vi.mocked(isTauri).mockReturnValue(true);
+    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
   });
 
   afterEach(() => {
@@ -52,7 +54,9 @@ describe('OAuthProviderButton', () => {
     });
 
     expect(getBackendUrl).toHaveBeenCalledTimes(1);
-    expect(openUrl).toHaveBeenCalledWith('https://backend.test/auth/google/login');
+    expect(openUrl).toHaveBeenCalledWith(
+      expect.stringMatching(/^https:\/\/backend\.test\/auth\/google\/login(\?.*)?$/)
+    );
     expect(screen.getByRole('button', { name: /Connecting/ })).toBeDisabled();
   });
 
@@ -69,6 +73,50 @@ describe('OAuthProviderButton', () => {
 
     await act(async () => {
       window.dispatchEvent(new FocusEvent('focus'));
+    });
+
+    expect(screen.queryByText('Connecting...')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Google' })).toBeEnabled();
+  });
+
+  it('does NOT reset isLoading on focus when a deep-link auth round-trip is processing', async () => {
+    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null });
+
+    render(<OAuthProviderButton provider={stubProvider} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(new FocusEvent('focus'));
+    });
+
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Connecting/ })).toBeDisabled();
+  });
+
+  it('resets isLoading on visibilitychange to visible', async () => {
+    render(<OAuthProviderButton provider={stubProvider} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
     });
 
     expect(screen.queryByText('Connecting...')).not.toBeInTheDocument();

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -16,7 +16,6 @@ import {
 
 const Welcome = () => {
   const { isProcessing, errorMessage } = useDeepLinkAuthState();
-  const handleDisabledOAuthClick = () => undefined;
 
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [rpcUrl, setRpcUrl] = useState(getStoredRpcUrl());
@@ -191,7 +190,7 @@ const Welcome = () => {
             </div>
           ) : (
             <>
-              {/* OAuth buttons intentionally inert until auth flow is re-enabled. */}
+              {/* Real OAuth: click → system browser → backend → deep link back to app. */}
               <div className="flex items-center justify-center gap-3">
                 {oauthProviderConfigs
                   .filter(provider => provider.showOnWelcome)
@@ -199,7 +198,6 @@ const Welcome = () => {
                     <OAuthProviderButton
                       key={provider.id}
                       provider={provider}
-                      onClickOverride={handleDisabledOAuthClick}
                       className="!rounded-full !px-4 !py-2"
                     />
                   ))}

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -62,7 +62,7 @@ describe('Welcome auth entrypoint', () => {
     expect(screen.queryByRole('button', { name: 'discord' })).not.toBeInTheDocument();
   });
 
-  it('keeps OAuth buttons as blank clicks on the welcome screen', () => {
+  it('delegates OAuth clicks to OAuthProviderButton without an override', () => {
     render(<Welcome />);
 
     fireEvent.click(screen.getByRole('button', { name: 'google' }));
@@ -72,11 +72,7 @@ describe('Welcome auth entrypoint', () => {
     expect(oauthButtonSpy).toHaveBeenNthCalledWith(1, 'google');
     expect(oauthButtonSpy).toHaveBeenNthCalledWith(2, 'github');
     expect(oauthButtonSpy).toHaveBeenNthCalledWith(3, 'twitter');
-    expect(oauthOverrideSpy).toHaveBeenNthCalledWith(1, 'google');
-    expect(oauthOverrideSpy).toHaveBeenNthCalledWith(2, 'github');
-    expect(oauthOverrideSpy).toHaveBeenNthCalledWith(3, 'twitter');
-    expect(screen.queryByText('Connecting...')).not.toBeInTheDocument();
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(oauthOverrideSpy).not.toHaveBeenCalled();
   });
 
   it('shows the deep-link processing state when auth is already in progress', () => {


### PR DESCRIPTION
## Summary

- Re-enable the welcome screen OAuth buttons (Google / GitHub / Twitter) by dropping the inert `onClickOverride` no-op added in #1033.
- Add an `isLoading` recovery path in `OAuthProviderButton` so the "Connecting..." state can no longer get permanently stuck.
- Tests cover focus reset, 90s safety timeout, override short-circuit, double-click safety, and live-click delegation from `Welcome`.

## Problem

The welcome OAuth buttons were intentionally disabled in #1033 because clicking them got stuck in a permanent "Connecting..." state. The flow is:

1. Button click → `setIsLoading(true)` → `openUrl(loginUrl)` opens system browser.
2. Backend OAuth → `openhuman://auth?token=...` deep link returns to the app and `useDeepLinkAuthState.isProcessing` flips on.

If the deep link never returns (user cancels in the browser, GitHub/Twitter creds missing per #963, Google redirect URI broken per #964), the local `isLoading` state never resets — button frozen until manual refresh. #1033 chose to short-circuit clicks with a no-op handler as a stopgap.

The underlying backend issues live in `tinyhumansai/backend` (#963, #964) and are out of scope here, but the UI freeze is fixable in this repo.

## Solution

`OAuthProviderButton.tsx` — add a `useEffect` that runs while `isLoading=true`:

- 90s safety timeout that resets `isLoading=false`.
- `window.addEventListener('focus', ...)` listener that resets immediately when the user returns from the system browser.

Both signals clean up on unmount, on the `isLoading=false` transition, and when the next click queues a new pair.

`Welcome.tsx` — drop the `handleDisabledOAuthClick` no-op and the `onClickOverride={...}` prop so clicks go through the real handler again. The `onClickOverride` prop on `OAuthProviderButton` itself is preserved (other surfaces may want it).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: Coverage matrix updated — no welcome OAuth feature row in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md), behaviour-only change to existing surface
- [ ] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix rows touched
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — welcome OAuth not on the release smoke list
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: desktop only (Tauri webview). The recovery is wrapped in `useEffect` with proper cleanup; no global listener leaks.
- **Backend**: Google should work as long as #964 (redirect URI) is configured on the backend side. GitHub / Twitter still surface backend errors until #963 lands — but the UI now recovers within ~1-2s via the focus listener instead of staying frozen.
- **Performance**: one `setTimeout` + one `focus` listener per click, both removed on reset. Negligible.
- **Security**: no change. Same backend OAuth URL, same deep-link return path.

## Related

- Closes #1049
- Related: #963 (backend GitHub/Twitter creds), #964 (backend Google redirect URI), #1033 (PR that added the inert override), #1068 (dev:app `restartApp()` regression — surfaced during smoke; tracked separately)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Welcome screen now initiates the real OAuth flow (system browser → backend → return to app).

* **Bug Fixes**
  * OAuth button recovers from stalled auth: resets on app resume (focus/visibility) and after a 90s safety timeout; avoids premature reset during deep-link processing.

* **Tests**
  * Added coverage for OAuth button behavior, recovery logic, override suppression, and deduplicated click handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->