### PR TITLE
fix(app): reload webview instead of restart_app in dev mode (#1068)

### DIFF
--- a/app/src/utils/tauriCommands/core.test.ts
+++ b/app/src/utils/tauriCommands/core.test.ts
@@ -1,5 +1,5 @@
 import { invoke, isTauri } from '@tauri-apps/api/core';
-import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(), isTauri: vi.fn() }));
 vi.mock('../../services/coreRpcClient', () => ({ callCoreRpc: vi.fn() }));
@@ -19,6 +19,30 @@ describe('tauriCommands/core', () => {
   });
 
   describe('restartApp', () => {
+    // window.location.reload is non-configurable on jsdom's default location;
+    // swap in a mocked location object for the dev-mode tests and restore after.
+    let originalLocation: Location;
+    let reloadSpy: Mock;
+
+    beforeEach(() => {
+      originalLocation = window.location;
+      reloadSpy = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { ...originalLocation, reload: reloadSpy },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        configurable: true,
+        writable: true,
+      });
+      vi.unstubAllEnvs();
+    });
+
     test('no-ops when not in Tauri', async () => {
       mockIsTauri.mockReturnValue(false);
       const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
@@ -26,15 +50,45 @@ describe('tauriCommands/core', () => {
       await restartApp();
 
       expect(mockInvoke).not.toHaveBeenCalled();
+      expect(reloadSpy).not.toHaveBeenCalled();
       expect(debug).toHaveBeenCalledWith(
         expect.stringContaining('restartApp: skipped — not running in Tauri')
       );
       debug.mockRestore();
     });
 
-    test('invokes restart_app when in Tauri', async () => {
+    test('reloads webview in dev mode (#1068 — avoid orphaning vite)', async () => {
+      // setup.ts seeds DEV=true globally; the binding imported above already
+      // captured that value, so we just need to invoke the dev-mode branch.
+      const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
       await restartApp();
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+      expect(mockInvoke).not.toHaveBeenCalled();
+      expect(debug).toHaveBeenCalledWith(
+        expect.stringContaining('restartApp: dev mode → window.location.reload()')
+      );
+      debug.mockRestore();
+    });
+
+    test('invokes restart_app in production mode (IS_DEV=false)', async () => {
+      // setup.ts globally mocks ../config with IS_DEV: true. Override with
+      // doMock + resetModules so a fresh import of ./core sees IS_DEV=false
+      // and runs the production branch (#1068 dev workaround should be inert).
+      vi.doMock('../config', () => ({
+        IS_DEV: false,
+        // Re-export anything else core.ts might end up using; today just IS_DEV.
+      }));
+      vi.resetModules();
+      const prodCore = await import('./core');
+
+      await prodCore.restartApp();
+
       expect(mockInvoke).toHaveBeenCalledWith('restart_app');
+      expect(reloadSpy).not.toHaveBeenCalled();
+
+      vi.doUnmock('../config');
     });
   });
 

--- a/app/src/utils/tauriCommands/core.ts
+++ b/app/src/utils/tauriCommands/core.ts
@@ -4,6 +4,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
 import { callCoreRpc } from '../../services/coreRpcClient';
+import { IS_DEV } from '../config';
 import { CommandResponse, isTauri } from './common';
 
 export interface CoreUpdateStatus {
@@ -61,10 +62,26 @@ export async function restartCoreProcess(): Promise<void> {
 
 /**
  * Restart the desktop shell so CEF relaunches with updated profile paths.
+ *
+ * In `pnpm dev:app` the launcher graph is:
+ *   `pnpm tauri dev` → `cargo run` → `tauri-cef` CLI → `vite` (child).
+ * Tauri's `app.restart()` exits the cargo parent, which orphans/kills the
+ * vite child and tears down the entire dev session (#1068). Use a webview
+ * reload in dev mode instead — module init re-runs, so localStorage seeds
+ * (e.g. `OPENHUMAN_ACTIVE_USER_ID`, set by `setActiveUserId` before the
+ * caller invokes us) are read fresh and redux-persist re-hydrates from
+ * the active user's namespace, all without touching the cargo / vite
+ * processes. Packaged builds keep the original `app.restart()` path —
+ * there is no vite child to orphan there.
  */
 export async function restartApp(): Promise<void> {
   if (!isTauri()) {
     console.debug('[app] restartApp: skipped — not running in Tauri');
+    return;
+  }
+  if (IS_DEV) {
+    console.debug('[app] restartApp: dev mode → window.location.reload()');
+    window.location.reload();
     return;
   }
   console.debug('[app] restartApp: invoking restart_app');


### PR DESCRIPTION
## Summary

- Replace Tauri `app.restart()` with `window.location.reload()` in `pnpm dev:app` so the dev session survives an identity flip / restart trigger.
- Packaged builds keep the original `app.restart()` path; no behaviour change there.
- Add Vitest coverage for the dev (reload) and prod (`invoke('restart_app')`) branches in `restartApp`.

## Problem

`pnpm dev:app` runs `pnpm tauri dev` -> `cargo run` -> `tauri-cef` CLI -> `vite` (child). When `restartApp()` invokes Tauri's `app.restart()`, the cargo parent exits and orphans the vite child, killing the entire dev session — the desktop window disappears and the user has to re-run `pnpm dev:app` by hand.

The dominant caller is the identity-flip path in `app/src/providers/CoreStateProvider.tsx`, which fires automatically when persisted `OPENHUMAN_ACTIVE_USER_ID` differs from the bootstrap snapshot's `auth.userId` (e.g. after switching profiles in the UI). This made dev-mode profile switching effectively unusable.

## Solution

Gate at the source — `restartApp()` in `app/src/utils/tauriCommands/core.ts`:

- In dev mode (`IS_DEV` from `app/src/utils/config.ts`), call `window.location.reload()`. Module init re-runs, so the freshly-set `OPENHUMAN_ACTIVE_USER_ID` localStorage seed (already updated by `setActiveUserId` upstream of `restartApp`) is read at boot, redux-persist re-hydrates from the new user's namespace, and singleton services come up clean — without touching the cargo / vite processes.
- In production mode, keep the original `app.restart()` invocation. There is no vite child to orphan, and the existing CEF profile-path machinery still needs the full process restart.

Gating at the source means every current and future caller benefits without per-call-site changes. `IS_DEV` is the canonical re-export from `app/src/utils/config.ts`, per the project's "no `import.meta.env` outside `config.ts`" rule.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: behaviour-only — no matrix rows touched. Coverage matrix not affected; existing `restartApp` row still describes the user-visible contract.
- [ ] N/A: behaviour-only — no new feature IDs. Listed under `## Related` below.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: dev-only path — release-cut surfaces unchanged; `app.restart()` continues to run in packaged builds, which is what `RELEASE-MANUAL-SMOKE.md` covers.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: Desktop dev (`pnpm dev:app`) only. Packaged macOS/Windows/Linux builds keep `app.restart()` unchanged.
- **Performance**: Dev reload is faster than the previous (broken) full process restart and avoids the manual re-launch cost.
- **Security**: None — same trust boundary; the reload still re-runs the bootstrap/auth chain.
- **Migration**: None.
- **Compatibility**: All current `restartApp()` callers (identity flip, CEF profile rotation, post-update relaunch in dev) get the new behaviour automatically. Production semantics are byte-identical.

## Related

- Closes #1068
- Surfaced while smoke-testing #1069 (the OAuth re-enable PR) in `pnpm dev:app`. Independent of #1069 — the bug exists on `main` regardless of OAuth state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app restart functionality with enhanced runtime environment detection for more reliable restart behavior across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->