### PR TITLE
fix(onboarding): personalize welcome agent greeting with user identity

### DIFF
--- a/src/openhuman/agent/agents/welcome/prompt.rs
+++ b/src/openhuman/agent/agents/welcome/prompt.rs
@@ -8,7 +8,8 @@
 //! skill-executor wording stays scoped to `integrations_agent/prompt.rs`).
 
 use crate::openhuman::context::prompt::{
-    render_tools, render_user_files, render_workspace, ConnectedIntegration, PromptContext,
+    render_tools, render_user_files, render_user_identity, render_workspace,
+    ConnectedIntegration, PromptContext,
 };
 use anyhow::Result;
 use std::fmt::Write;
@@ -19,6 +20,12 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
     let mut out = String::with_capacity(8192);
     out.push_str(ARCHETYPE.trim_end());
     out.push_str("\n\n");
+
+    let user_id = render_user_identity(ctx)?;
+    if !user_id.trim().is_empty() {
+        out.push_str(user_id.trim_end());
+        out.push_str("\n\n");
+    }
 
     let user_files = render_user_files(ctx)?;
     if !user_files.trim().is_empty() {
@@ -132,6 +139,27 @@ mod tests {
         let body = build(&ctx_with(&[])).unwrap();
         assert!(!body.is_empty());
         assert!(!body.contains("## Connected Integrations"));
+    }
+
+    #[test]
+    fn build_injects_user_identity_when_present() {
+        use crate::openhuman::context::prompt::UserIdentity;
+        let mut ctx = ctx_with(&[]);
+        ctx.user_identity = Some(UserIdentity {
+            name: Some("Alice".into()),
+            email: Some("alice@example.com".into()),
+            id: None,
+        });
+        let body = build(&ctx).unwrap();
+        assert!(body.contains("## User"), "should contain user identity heading");
+        assert!(body.contains("Alice"), "should contain the user's name");
+        assert!(body.contains("alice@example.com"), "should contain the user's email");
+    }
+
+    #[test]
+    fn build_omits_user_identity_when_absent() {
+        let body = build(&ctx_with(&[])).unwrap();
+        assert!(!body.contains("## User"), "should not contain user identity when None");
     }
 
     #[test]

--- a/src/openhuman/agent/agents/welcome/prompt.rs
+++ b/src/openhuman/agent/agents/welcome/prompt.rs
@@ -8,8 +8,8 @@
 //! skill-executor wording stays scoped to `integrations_agent/prompt.rs`).
 
 use crate::openhuman::context::prompt::{
-    render_tools, render_user_files, render_user_identity, render_workspace,
-    ConnectedIntegration, PromptContext,
+    render_tools, render_user_files, render_user_identity, render_workspace, ConnectedIntegration,
+    PromptContext,
 };
 use anyhow::Result;
 use std::fmt::Write;
@@ -151,15 +151,24 @@ mod tests {
             id: None,
         });
         let body = build(&ctx).unwrap();
-        assert!(body.contains("## User"), "should contain user identity heading");
+        assert!(
+            body.contains("## User"),
+            "should contain user identity heading"
+        );
         assert!(body.contains("Alice"), "should contain the user's name");
-        assert!(body.contains("alice@example.com"), "should contain the user's email");
+        assert!(
+            body.contains("alice@example.com"),
+            "should contain the user's email"
+        );
     }
 
     #[test]
     fn build_omits_user_identity_when_absent() {
         let body = build(&ctx_with(&[])).unwrap();
-        assert!(!body.contains("## User"), "should not contain user identity when None");
+        assert!(
+            !body.contains("## User"),
+            "should not contain user identity when None"
+        );
     }
 
     #[test]

--- a/src/openhuman/agent/prompts/mod.rs
+++ b/src/openhuman/agent/prompts/mod.rs
@@ -535,13 +535,13 @@ impl PromptSection for UserIdentitySection {
         // failure mode we're trying to suppress (#926).
         let mut fields = String::new();
         if let Some(name) = identity.name.as_deref().filter(|s| !s.trim().is_empty()) {
-            let _ = writeln!(fields, "- name: {name}");
+            let _ = writeln!(fields, "- name: {}", sanitize_identity_field(name));
         }
         if let Some(email) = identity.email.as_deref().filter(|s| !s.trim().is_empty()) {
-            let _ = writeln!(fields, "- email: {email}");
+            let _ = writeln!(fields, "- email: {}", sanitize_identity_field(email));
         }
         if let Some(id) = identity.id.as_deref().filter(|s| !s.trim().is_empty()) {
-            let _ = writeln!(fields, "- id: {id}");
+            let _ = writeln!(fields, "- id: {}", sanitize_identity_field(id));
         }
         if fields.trim().is_empty() {
             return Ok(String::new());
@@ -555,6 +555,20 @@ impl PromptSection for UserIdentitySection {
         out.push_str(&fields);
         Ok(out.trim_end().to_string())
     }
+}
+
+/// Collapse newlines and runs of whitespace in a user-identity field so
+/// it fits on a single markdown bullet without breaking the prompt
+/// structure. Values come from `auth_get_me` (server-controlled), but
+/// defence-in-depth: a name with embedded newlines could split the
+/// `- name:` bullet and reshape the `## User` block.
+fn sanitize_identity_field(s: &str) -> String {
+    s.chars()
+        .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Injects `render_user_identity` into the welcome agent's prompt builder so the LLM sees the user's name/email from `auth_get_me`
- Previously the welcome agent only had PROFILE.md for personalization, which doesn't exist yet for brand-new users during onboarding
- The first message was generic ("Welcome, glad you are all set up") instead of greeting the user by name

## Test plan

- [x] `GGML_NATIVE=OFF cargo check` passes
- [x] `cargo test -- welcome::prompt::tests` — 4/4 pass (including 2 new tests for identity injection)
- [x] Manual: reset onboarding, verify the opener uses the user's name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Welcome prompts now display personalized user information (name and email) when available for a more customized greeting.

* **Bug Fixes**
  * Identity fields are now sanitized to prevent embedded newlines or extra whitespace from breaking prompt formatting.

* **Tests**
  * Added unit tests verifying correct inclusion/omission of the user section and that identity content is rendered safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->