### PR TITLE
fix(chat): make agent message bubbles fit content width

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1040,7 +1040,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                   <div
                     className={`group/msg flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
                     <div
-                      className={`relative ${msg.sender === 'user' ? 'w-fit max-w-[75%]' : 'w-full md:max-w-[75%]'}`}>
+                      className="relative w-fit max-w-[75%]">
                       {msg.sender === 'agent' ? (
                         <div className="space-y-1">
                           {splitAgentMessageIntoBubbles(msg.content).map(
@@ -1224,7 +1224,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                 (selectedStreamingAssistant.content.length > 0 ||
                   selectedStreamingAssistant.thinking.length > 0) && (
                   <div className="flex justify-start">
-                    <div className="relative w-full md:max-w-[75%]">
+                    <div className="relative w-fit max-w-[75%]">
                       {selectedStreamingAssistant.thinking.length > 0 && (
                         <details className="mb-1.5 bg-stone-100 rounded-lg px-3 py-1.5 text-xs text-stone-600 open:bg-stone-100">
                           <summary className="cursor-pointer select-none flex items-center gap-1.5">

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1039,8 +1039,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
                     )}
                   <div
                     className={`group/msg flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
-                    <div
-                      className="relative w-fit max-w-[75%]">
+                    <div className="relative w-fit max-w-[75%]">
                       {msg.sender === 'agent' ? (
                         <div className="space-y-1">
                           {splitAgentMessageIntoBubbles(msg.content).map(


### PR DESCRIPTION
## Summary
- Agent (left) chat bubbles had `w-full` which stretched them to 100% width regardless of content
- Changed to `w-fit max-w-[75%]` so they size to their content, matching user (right) bubble behavior
- Applied to both rendered messages and streaming preview

## Test plan
- [ ] Open a conversation with short agent messages — bubbles should shrink to fit content
- [ ] Send long messages — bubbles should cap at 75% width
- [ ] Verify streaming preview also sizes correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout consistency for agent and assistant messages in conversations by standardizing container widths and removing responsive breakpoint variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->