### PR TITLE
feat(ci): split staging vs release workflows; release from staging tag

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -2,9 +2,12 @@
 name: Release (Staging)
 on:
   workflow_dispatch: {}
+# `contents: write` is required to push the immutable `staging/v*` tag
+# created by `prepare-build`. Permissions are kept narrower than the
+# production release workflow (no `packages` write) because staging
+# builds do not push container images or update releases.
 permissions:
-  contents: read
-  packages: read
+  contents: write
 concurrency:
   group: release-staging
   cancel-in-progress: false
@@ -38,28 +41,63 @@ jobs:
       # artifacts attach to the same release events report.
       short_sha: ${{ steps.resolve.outputs.short_sha }}
       build_ref: ${{ steps.resolve.outputs.build_ref }}
+      tag: ${{ steps.resolve.outputs.tag }}
       base_url: ${{ steps.resolve.outputs.base_url }}
     steps:
-      - name: Enforce staging branch
-        if: github.ref != 'refs/heads/staging'
+      - name: Enforce main branch
+        if: github.ref != 'refs/heads/main'
         run: |
-          echo "This workflow can only run from staging. Current ref: $GITHUB_REF"
+          echo "This workflow can only run from main. Current ref: $GITHUB_REF"
           exit 1
-      - name: Checkout staging
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: staging
-          fetch-depth: 1
+          ref: main
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-      - name: Resolve build outputs
-        id: resolve
+      - name: Configure Git
         shell: bash
         run: |
-          VERSION="$(node -p "require('./app/package.json').version")"
-          SHA="$(git rev-parse HEAD)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin --tags
+      # Compute the next `staging/vX.Y.Z-N` tag. The script reads the
+      # base version from `app/package.json` (kept untouched here — staging
+      # never bumps versioned files) and counts existing staging tags for
+      # that base to pick the next N.
+      - name: Compute next staging tag
+        id: bump
+        shell: bash
+        run: node scripts/release/next-staging-tag.js
+      - name: Ensure staging tag does not already exist on remote
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        shell: bash
+        run: |
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            echo "Tag already exists on origin: ${TAG}"
+            exit 1
+          fi
+      - name: Create and push staging tag
+        id: tag
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        shell: bash
+        run: |
+          git tag -a "$TAG" -m "Staging build $TAG"
+          git push origin "$TAG"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Resolve build outputs
+        id: resolve
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          SHA: ${{ steps.tag.outputs.sha }}
+        shell: bash
+        run: |
           # Match the 12-char truncation runtime code applies to
           # VITE_BUILD_SHA / OPENHUMAN_BUILD_SHA when constructing the
           # release tag at startup, so SENTRY_RELEASE assembled in CI
@@ -68,7 +106,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "build_ref=$SHA" >> "$GITHUB_OUTPUT"
+          echo "build_ref=$TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "base_url=https://staging-api.tinyhumans.ai/" >> "$GITHUB_OUTPUT"
 
   # =========================================================================
@@ -455,3 +494,43 @@ jobs:
           echo "==> Recording deploy marker: ${SENTRY_RELEASE} -> ${SENTRY_ENVIRONMENT}"
           sentry-cli releases deploys "${SENTRY_RELEASE}" new \
             -e "${SENTRY_ENVIRONMENT}"
+
+  # =========================================================================
+  # Cleanup: if the build matrix fails or is cancelled, drop the staging
+  # tag we just pushed so it doesn't pollute the staging-tag history. A
+  # half-built staging tag has no use — production's `release_source`
+  # resolver picks the latest staging tag, and pointing it at a known-
+  # broken artifact would silently regress production. Tag deletion here
+  # is safe because nothing else has consumed it yet (this job runs in
+  # the same workflow run that created it).
+  # =========================================================================
+  cleanup-failed-staging:
+    name: Remove staging tag if build failed
+    runs-on: ubuntu-latest
+    needs: [prepare-build, build-desktop]
+    if: >-
+      always()
+      && needs.prepare-build.result == 'success'
+      && (needs.build-desktop.result == 'failure' || needs.build-desktop.result == 'cancelled')
+    steps:
+      - name: Delete remote staging tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = '${{ needs.prepare-build.outputs.tag }}';
+            if (!tag) {
+              core.info('No staging tag to delete');
+              return;
+            }
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+              core.info(`Deleted remote tag ${tag}`);
+            } catch (e) {
+              if (e.status === 404) {
+                core.info(`Tag ${tag} already absent on remote`);
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,36 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      build_target:
-        description: Build target environment
+      release_source:
+        description: "Source ref to build production from"
         required: true
         type: choice
-        default: production
-        options: [production, staging]
-      release_type:
-        description: Version increment type
+        default: staging_tag
+        # staging_tag : default. Build from the staging tag chosen below
+        #               (or the latest `staging/v*` tag when blank). This
+        #               is the QA-validated path — production tracks what
+        #               staging already exercised.
+        # main_head   : escape hatch for hotfixes when no staging tag is
+        #               appropriate. Builds from `origin/main` HEAD.
+        options: [staging_tag, main_head]
+      staging_tag:
+        description: "Specific staging tag (e.g. staging/v0.53.4-2). Empty = latest staging tag. Ignored when release_source=main_head."
         required: false
-        default: patch
+        default: ""
+        type: string
+      release_type:
+        description: "Version increment (production owns minor/major; patch is allowed for hotfixes)"
+        required: false
+        default: minor
         type: choice
         options: [patch, minor, major]
 permissions:
   contents: write
   packages: write
+# Distinct from `release-staging`'s concurrency group so a staging cut
+# never blocks a production release and vice versa.
 concurrency:
-  group: release-${{ github.event.inputs.build_target || 'production' }}-main
+  group: release-production-main
   cancel-in-progress: false
 # ---------------------------------------------------------------------------
 # Job dependency graph
@@ -64,6 +77,9 @@ jobs:
       build_ref: ${{ steps.resolve.outputs.build_ref }}
       release_enabled: ${{ steps.resolve.outputs.release_enabled }}
       base_url: ${{ steps.resolve.outputs.base_url }}
+      source: ${{ steps.source.outputs.source }}
+      source_ref: ${{ steps.source.outputs.ref }}
+      source_sha: ${{ steps.source.outputs.sha }}
     steps:
       - name: Enforce main branch
         if: github.ref != 'refs/heads/main'
@@ -71,31 +87,22 @@ jobs:
           echo "This workflow can only run from main. Current ref: $GITHUB_REF"
           exit 1
       - name: Generate GitHub App token
-        if: inputs.build_target == 'production'
         id: app-token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.XGITHUB_APP_ID }}
           private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
-      - name: Checkout main for production release
-        if: inputs.build_target == 'production'
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-      - name: Checkout main for staging build
-        if: inputs.build_target == 'staging'
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
       - name: Configure Git
-        if: inputs.build_target == 'production'
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -105,15 +112,26 @@ jobs:
           git fetch origin --tags
           git checkout main
           git pull origin main --ff-only
+      # Resolve the source ref BEFORE bumping the version. We want
+      # production releases to carry the **content** of the chosen source
+      # (the validated staging tag, by default) but the bump commit and
+      # release tag are created on `main` — the version-file mutations
+      # need to land somewhere everyone can pull. So: compute the source
+      # SHA here for traceability + pass it through to the matrix as
+      # `build_ref`, and bump versions on main as before.
+      - name: Resolve release source ref
+        id: source
+        shell: bash
+        env:
+          RELEASE_SOURCE: ${{ inputs.release_source }}
+          STAGING_TAG: ${{ inputs.staging_tag }}
+        run: bash scripts/release/resolve-release-source.sh
       - name: Compute next version and sync release files
-        if: inputs.build_target == 'production'
         id: bump
         run: node scripts/release/bump-version.js "${{ inputs.release_type }}"
       - name: Verify release version sync
-        if: inputs.build_target == 'production'
         run: node scripts/release/verify-version-sync.js "${{ steps.bump.outputs.version }}"
       - name: Ensure tag does not already exist
-        if: inputs.build_target == 'production'
         env:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
@@ -126,37 +144,31 @@ jobs:
             exit 1
           fi
       - name: Commit, push and tag
-        if: inputs.build_target == 'production'
         id: push
         env:
           VERSION: ${{ steps.bump.outputs.version }}
           TAG: ${{ steps.bump.outputs.tag }}
+          SOURCE: ${{ steps.source.outputs.source }}
+          SOURCE_REF: ${{ steps.source.outputs.ref }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
           git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.toml
-          git commit -m "chore(release): v${VERSION}"
+          git commit -m "chore(release): v${VERSION}" \
+            -m "source=${SOURCE} ref=${SOURCE_REF} sha=${SOURCE_SHA}"
           git push origin main
-          git tag -a "$TAG" -m "Release $TAG"
+          git tag -a "$TAG" -m "Release $TAG (source=${SOURCE} ref=${SOURCE_REF})"
           git push origin "$TAG"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Resolve build outputs
         id: resolve
         shell: bash
         run: |
-          if [ "${{ inputs.build_target }}" = "production" ]; then
-            VERSION="${{ steps.bump.outputs.version }}"
-            TAG="${{ steps.bump.outputs.tag }}"
-            SHA="${{ steps.push.outputs.sha }}"
-            BUILD_REF="$TAG"
-            RELEASE_ENABLED="true"
-            BASE_URL="https://api.tinyhumans.ai/"
-          else
-            VERSION="$(node -p "require('./app/package.json').version")"
-            TAG=""
-            SHA="$(git rev-parse HEAD)"
-            BUILD_REF="$SHA"
-            RELEASE_ENABLED="false"
-            BASE_URL="https://staging-api.tinyhumans.ai/"
-          fi
+          VERSION="${{ steps.bump.outputs.version }}"
+          TAG="${{ steps.bump.outputs.tag }}"
+          SHA="${{ steps.push.outputs.sha }}"
+          BUILD_REF="$TAG"
+          RELEASE_ENABLED="true"
+          BASE_URL="https://api.tinyhumans.ai/"
           # Match the 12-char truncation runtime code applies to
           # VITE_BUILD_SHA / OPENHUMAN_BUILD_SHA when constructing the release
           # tag at startup, so SENTRY_RELEASE assembled in CI agrees with
@@ -250,8 +262,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Keep in sync with DEFAULT_TELEGRAM_BOT_USERNAME_* in channels/controllers/ops.rs
-      OPENHUMAN_TELEGRAM_BOT_USERNAME: ${{ inputs.build_target == 'staging' && 'alphahumantest_bot' || 'openhumanaibot' }}
-      VITE_TELEGRAM_BOT_USERNAME: ${{ inputs.build_target == 'staging' && 'alphahumantest_bot' || 'openhumanaibot' }}
+      OPENHUMAN_TELEGRAM_BOT_USERNAME: openhumanaibot
+      VITE_TELEGRAM_BOT_USERNAME: openhumanaibot
     steps:
       - name: Checkout build ref
         uses: actions/checkout@v4
@@ -259,14 +271,6 @@ jobs:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
           submodules: recursive
-      - name: Configure staging app environment
-        if: inputs.build_target == 'staging'
-        shell: bash
-        run: |
-          echo "OPENHUMAN_APP_ENV=staging" >> "$GITHUB_ENV"
-          echo "VITE_OPENHUMAN_APP_ENV=staging" >> "$GITHUB_ENV"
-          echo "OPENHUMAN_TELEGRAM_BOT_USERNAME=alphahumantest_bot" >> "$GITHUB_ENV"
-          echo "VITE_TELEGRAM_BOT_USERNAME=alphahumantest_bot" >> "$GITHUB_ENV"
       - name: Set Xcode version
         if: matrix.settings.platform == 'macos-latest'
         uses: maxim-lobanov/setup-xcode@v1
@@ -301,8 +305,8 @@ jobs:
         run: |
           set +e
           for BIN in \
-            app/src-tauri/target/${{ matrix.settings.target }}/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/OpenHuman \
-            target/${{ matrix.settings.target }}/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/OpenHuman; do
+            app/src-tauri/target/${{ matrix.settings.target }}/release/OpenHuman \
+            target/${{ matrix.settings.target }}/release/OpenHuman; do
             if [ -x "$BIN" ]; then
               echo "ldd $BIN"
               ldd "$BIN" | grep 'not found' || echo "  all resolved"
@@ -457,8 +461,8 @@ jobs:
         working-directory: app
         env:
           BASE_URL: ${{ needs.prepare-build.outputs.base_url }}
-          OPENHUMAN_APP_ENV: ${{ inputs.build_target == 'staging' && 'staging' || 'production' }}
-          VITE_OPENHUMAN_APP_ENV: ${{ inputs.build_target == 'staging' && 'staging' || 'production' }}
+          OPENHUMAN_APP_ENV: production
+          VITE_OPENHUMAN_APP_ENV: production
           VITE_BACKEND_URL: ${{ needs.prepare-build.outputs.base_url }}
           # Re-declare Vite env so tauri.conf.json's `beforeBuildCommand`
           # (`vite build`) bakes Sentry + debug flags into the final bundle.
@@ -508,11 +512,7 @@ jobs:
           # Inline NODE_OPTIONS so it reaches the vite child spawned by
           # beforeBuildCommand. Step-level env was observed not to propagate
           # on macos-arm64 runners, causing OOM at node's ~2GB auto default.
-          if [ "${{ inputs.build_target }}" = "staging" ]; then
-            NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build --debug -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
-          else
-            NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
-          fi
+          NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
 
       # Upload Rust debug info to Sentry so all Rust stack traces (Tauri
       # shell + linked-in core) symbolicate in production. The frontend
@@ -571,7 +571,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare-build.outputs.tag }}
           MATRIX_TARGET: ${{ matrix.settings.target }}
-          BUILD_PROFILE: ${{ inputs.build_target == 'staging' && 'debug' || 'release' }}
+          BUILD_PROFILE: release
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -610,8 +610,8 @@ jobs:
           # depending on workspace config — search both
           APP_PATH=""
           for candidate in \
-            "app/src-tauri/target/${{ matrix.settings.target }}/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/bundle/macos/OpenHuman.app" \
-            "target/${{ matrix.settings.target }}/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/bundle/macos/OpenHuman.app"; do
+            "app/src-tauri/target/${{ matrix.settings.target }}/release/bundle/macos/OpenHuman.app" \
+            "target/${{ matrix.settings.target }}/release/bundle/macos/OpenHuman.app"; do
             if [ -d "$candidate" ]; then
               APP_PATH="$candidate"
               break
@@ -620,7 +620,7 @@ jobs:
 
           # Fallback: search for it
           if [ -z "$APP_PATH" ]; then
-            APP_PATH="$(find . -path "*/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/bundle/macos/OpenHuman.app" -type d 2>/dev/null | head -1)"
+            APP_PATH="$(find . -path "*/release/bundle/macos/OpenHuman.app" -type d 2>/dev/null | head -1)"
           fi
           if [ -z "$APP_PATH" ]; then
             echo "ERROR: Could not find OpenHuman.app bundle anywhere"
@@ -680,16 +680,6 @@ jobs:
           APP_PATH="${{ steps.locate-app.outputs.app_path }}"
           echo "Checking staple at: $APP_PATH"
           xcrun stapler validate "$APP_PATH" || echo "WARNING: Staple validation failed"
-      - name: Upload staging desktop bundles
-        if: needs.prepare-build.outputs.release_enabled != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name:
-            desktop-bundles-${{ matrix.settings.platform }}-${{ matrix.settings.artifact_suffix
-            }}
-          path: |
-            app/src-tauri/target/${{ matrix.settings.target }}/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/bundle/**
-            target/${{ matrix.settings.target }}/${{ inputs.build_target == 'staging' && 'debug' || 'release' }}/bundle/**
 
   # =========================================================================
   # Phase 5: Record a single Sentry deploy marker once the release has
@@ -730,7 +720,7 @@ jobs:
           SENTRY_RELEASE:
             openhuman@${{ needs.prepare-build.outputs.version }}+${{
             needs.prepare-build.outputs.short_sha }}
-          SENTRY_ENVIRONMENT: ${{ inputs.build_target == 'staging' && 'staging' || 'production' }}
+          SENTRY_ENVIRONMENT: production
         run: |
           set -euo pipefail
           echo "==> Recording deploy marker: ${SENTRY_RELEASE} -> ${SENTRY_ENVIRONMENT}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@ Narrative architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). Frontend
 
 ## Repository layout
 
-| Path | Role |
-| --- | --- |
-| **`app/`** | Yarn workspace `openhuman-app`: Vite + React (`app/src/`), Tauri desktop host (`app/src-tauri/`), Vitest tests |
-| **`src/`** (root) | Rust lib `openhuman_core` + `openhuman` CLI binary — `core_server`, `openhuman::*` domains, MCP routing |
-| **`Cargo.toml`** (root) | Core crate; `cargo build --bin openhuman` produces the sidecar staged by `app`'s `core:stage` |
-| **`docs/`** | Architecture and module guides |
+| Path                    | Role                                                                                                           |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **`app/`**              | Yarn workspace `openhuman-app`: Vite + React (`app/src/`), Tauri desktop host (`app/src-tauri/`), Vitest tests |
+| **`src/`** (root)       | Rust lib `openhuman_core` + `openhuman` CLI binary — `core_server`, `openhuman::*` domains, MCP routing        |
+| **`Cargo.toml`** (root) | Core crate; `cargo build --bin openhuman` produces the sidecar staged by `app`'s `core:stage`                  |
+| **`docs/`**             | Architecture and module guides                                                                                 |
 
 Commands assume the **repo root**; `pnpm dev` delegates to the `app` workspace. (Repo migrated from yarn to pnpm — `package.json` enforces pnpm via the `packageManager` field.)
 
@@ -26,6 +26,7 @@ Commands assume the **repo root**; `pnpm dev` delegates to the `app` workspace. 
 - **Core binary** (`openhuman`): spawned as a **sidecar**; the UI talks to it over HTTP (`core_rpc_relay` + `core_rpc` client), not by duplicating domain logic.
 
 **Where logic lives**
+
 - **Rust core**: business logic, execution, domains, RPC, persistence, CLI. Authoritative.
 - **Tauri + React (`app/`)**: UX, screens, navigation, bridging to the core. Presents and orchestrates only.
 
@@ -79,6 +80,7 @@ cargo check --manifest-path app/src-tauri/Cargo.toml
 ### Shared mock backend
 
 Used by both unit and Rust tests.
+
 - Core: `scripts/mock-api-core.mjs` · server: `scripts/mock-api-server.mjs` · E2E wrapper: `app/test/e2e/mock-server.ts`.
 - Admin: `GET /__admin/health`, `POST /__admin/reset`, `POST /__admin/behavior`, `GET /__admin/requests`.
 - Run manually: `pnpm mock:api`.
@@ -86,6 +88,7 @@ Used by both unit and Rust tests.
 ### E2E (WDIO — dual platform)
 
 Full guide: [`docs/E2E-TESTING.md`](docs/E2E-TESTING.md).
+
 - **Linux (CI)**: `tauri-driver` (WebDriver :4444).
 - **macOS (local)**: Appium Mac2 (XCUITest :4723) on the `.app` bundle.
 - Specs: `app/test/e2e/specs/*.spec.ts`. Helpers in `app/test/e2e/helpers/`. Config: `app/test/wdio.conf.ts`.
@@ -176,14 +179,14 @@ Typed pub/sub + in-process typed request/response. Both singletons — use modul
 
 Core types (all in `src/core/event_bus/`):
 
-| Type | File | Purpose |
-| --- | --- | --- |
-| `DomainEvent` | `events.rs` | `#[non_exhaustive]` enum of all cross-module events |
-| `EventBus` | `bus.rs` | Singleton over `tokio::sync::broadcast`; ctor is `pub(crate)` |
-| `NativeRegistry` / `NativeRequestError` | `native_request.rs` | Typed request/response registry by method name |
-| `EventHandler` | `subscriber.rs` | Async trait with optional `domains()` filter |
-| `SubscriptionHandle` | `subscriber.rs` | RAII — drops cancel the subscriber |
-| `TracingSubscriber` | `tracing.rs` | Built-in debug logger |
+| Type                                    | File                | Purpose                                                       |
+| --------------------------------------- | ------------------- | ------------------------------------------------------------- |
+| `DomainEvent`                           | `events.rs`         | `#[non_exhaustive]` enum of all cross-module events           |
+| `EventBus`                              | `bus.rs`            | Singleton over `tokio::sync::broadcast`; ctor is `pub(crate)` |
+| `NativeRegistry` / `NativeRequestError` | `native_request.rs` | Typed request/response registry by method name                |
+| `EventHandler`                          | `subscriber.rs`     | Async trait with optional `domains()` filter                  |
+| `SubscriptionHandle`                    | `subscriber.rs`     | RAII — drops cancel the subscriber                            |
+| `TracingSubscriber`                     | `tracing.rs`        | Built-in debug logger                                         |
 
 Singleton API: `init_global(capacity)`, `publish_global(event)`, `subscribe_global(handler)`, `register_native_global(method, handler)`, `request_native_global(method, req)`, `global()` / `native_registry()`.
 
@@ -211,6 +214,7 @@ Tauri/Rust in the shell is a **delivery vehicle** (windowing, process lifecycle,
 
 - Issues and PRs on upstream **[tinyhumansai/openhuman](https://github.com/tinyhumansai/openhuman)** — not a fork — unless explicitly told otherwise.
 - Issue templates: [`.github/ISSUE_TEMPLATE/feature.md`](.github/ISSUE_TEMPLATE/feature.md), [`.github/ISSUE_TEMPLATE/bug.md`](.github/ISSUE_TEMPLATE/bug.md). PR template: [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). AI-authored text should follow them verbatim.
+- **Releases**: staging and production are **separate workflows** — see [`docs/RELEASE.md`](docs/RELEASE.md). Staging cuts immutable `staging/vX.Y.Z-N` tags (no version-file bumps); production builds from the latest staging tag by default and bumps `minor`/`major`/`patch`.
 - PRs target **`main`**.
 
 ---
@@ -255,7 +259,7 @@ Specify → prove in Rust → prove over RPC → surface in the UI → test.
 
 - **File size**: prefer ≤ ~500 lines; split growing modules.
 - **Pre-merge** (code changes): Prettier, ESLint, `tsc --noEmit` in `app/`; `cargo fmt` + `cargo check` for changed Rust.
-- **No dynamic imports** in production `app/src` code — static `import` / `import type` only. No `import()`, `React.lazy(() => import(...))`, `await import(...)`. For heavy optional paths, use a static import and guard the call site with `try/catch` or a runtime check. *Exceptions*: Vitest harness patterns in `*.test.ts` / `__tests__` / `test/setup.ts`; ambient `typeof import('…')` in `.d.ts`; config files (e.g. `tailwind.config.js` JSDoc).
+- **No dynamic imports** in production `app/src` code — static `import` / `import type` only. No `import()`, `React.lazy(() => import(...))`, `await import(...)`. For heavy optional paths, use a static import and guard the call site with `try/catch` or a runtime check. _Exceptions_: Vitest harness patterns in `*.test.ts` / `__tests__` / `test/setup.ts`; ambient `typeof import('…')` in `.d.ts`; config files (e.g. `tailwind.config.js` JSDoc).
 - **Dual socket sync**: when changing the realtime protocol, keep `socketService` / MCP transport aligned with core socket behavior (see `docs/ARCHITECTURE.md` dual-socket section).
 
 ---

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,84 @@
+# Releases
+
+OpenHuman ships through two distinct GitHub Actions workflows. Staging
+proves a build; production promotes it.
+
+| Workflow                 | File                                                                                | Trigger                         | Tags it creates                                                | Cadence                            |
+| ------------------------ | ----------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------------------- | ---------------------------------- |
+| **Release (Staging)**    | [`.github/workflows/release-staging.yml`](../.github/workflows/release-staging.yml) | `workflow_dispatch` from `main` | `staging/vX.Y.Z-N` (immutable, monotonic `N` per base `X.Y.Z`) | Frequent (per-merge / per-feature) |
+| **Release** (production) | [`.github/workflows/release.yml`](../.github/workflows/release.yml)                 | `workflow_dispatch` from `main` | `vX.Y.Z` (semver)                                              | On promotion                       |
+
+The two workflows have **separate concurrency groups** (`release-staging`
+vs `release-production-main`), so a staging cut never blocks a production
+release and vice versa.
+
+---
+
+## Cutting a staging build
+
+1. Run **Release (Staging)** via the Actions tab.
+2. The workflow:
+   - reads the current base version from `app/package.json` (it does **not**
+     mutate any version files),
+   - counts existing `staging/v<base>-*` tags and picks the next `N`,
+   - pushes the immutable tag `staging/vX.Y.Z-N`,
+   - builds the desktop matrix in **debug profile**, uploads installers as
+     workflow artifacts (no GitHub Release object is created), and
+   - records a Sentry deploy marker with `environment=staging`.
+3. If any matrix leg fails, the `cleanup-failed-staging` job removes the
+   freshly-pushed staging tag so production can never resolve to a
+   half-built artifact.
+
+**Why patch-only / counter-only:** keeping staging cadence noise-free.
+No version-file commits land on `main` from staging — the tag itself is
+the stable version identity. Production decides its own semver bump
+separately when promoting.
+
+## Promoting to production
+
+1. Run **Release** via the Actions tab.
+2. Pick `release_source`:
+   - `staging_tag` (default) — build from the **last QA-validated staging
+     cut**. Leave `staging_tag` empty to auto-resolve the latest
+     `staging/v*` tag (`git tag --sort=-creatordate`), or pin a specific
+     one (e.g. `staging/v0.53.4-2`).
+   - `main_head` — escape hatch for hotfixes when no staging tag fits.
+     Builds from `origin/main` HEAD.
+3. Pick `release_type` (`patch` | `minor` | `major`). Production owns
+   `minor` and `major` semver promotion; `patch` is allowed for
+   hotfixes.
+4. The workflow:
+   - resolves the source ref (logged via
+     [`scripts/release/resolve-release-source.sh`](../scripts/release/resolve-release-source.sh)
+     for traceability — the bump commit message records `source`, `ref`,
+     and `sha`),
+   - bumps versions in `app/package.json`, `app/src-tauri/tauri.conf.json`,
+     `app/src-tauri/Cargo.toml`, and root `Cargo.toml`,
+   - commits, pushes, and tags `vX.Y.Z` on `main`,
+   - builds the matrix in **release profile**, signs and notarizes the
+     macOS bundles, builds the GHCR Docker image, publishes
+     `latest.json` for the Tauri auto-updater, and publishes the GitHub
+     Release.
+5. If any later phase fails, `cleanup-failed-release` deletes the draft
+   release, the remote tag, and the staging Docker image.
+
+## Tag conventions and rollback
+
+- **Production tags:** `vX.Y.Z` (e.g. `v0.53.4`). Never delete a
+  published production tag — the auto-updater clients pin to it.
+- **Staging tags:** `staging/vX.Y.Z-N` (e.g. `staging/v0.53.4-2`).
+  - Auto-deleted by `cleanup-failed-staging` when their build fails.
+  - May be deleted manually by a maintainer with `contents: write` if a
+    staging cut is later invalidated. Production's resolver uses
+    `--sort=-creatordate`, so dropping a tag promotes the next-latest.
+  - Tag collisions abort the staging workflow before the build matrix
+    starts (see `Ensure staging tag does not already exist on remote`).
+
+## Helper scripts
+
+| Script                                                                                      | Role                                                                           |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [`scripts/release/next-staging-tag.js`](../scripts/release/next-staging-tag.js)             | Compute next `staging/vX.Y.Z-N` tag from `app/package.json` + existing tags    |
+| [`scripts/release/resolve-release-source.sh`](../scripts/release/resolve-release-source.sh) | Resolve `release_source` + optional `staging_tag` to a concrete (`ref`, `sha`) |
+| [`scripts/release/bump-version.js`](../scripts/release/bump-version.js)                     | Bump semver across all four authoritative version files                        |
+| [`scripts/release/verify-version-sync.js`](../scripts/release/verify-version-sync.js)       | Assert version sync after a bump                                               |

--- a/scripts/release/next-staging-tag.js
+++ b/scripts/release/next-staging-tag.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Compute the next staging git tag without mutating any version files.
+//
+// Convention: `staging/vX.Y.Z-N`
+//   X.Y.Z = current `app/package.json` version (kept untouched)
+//   N     = monotonic counter of staging cuts already produced for that
+//           base version, +1
+//
+// This keeps staging cadence noise-free (no version-bump commits) while
+// still giving every staging artifact a stable, named ref. Production
+// releases resolve the latest such tag and decide their own semver bump
+// from there.
+//
+// Usage:
+//   node scripts/release/next-staging-tag.js
+//
+// Inputs:
+//   - `app/package.json` (version)
+//   - existing tags discovered via `git tag --list 'staging/v<base>-*'`
+//
+// Outputs (stdout, one per line; also appended to GITHUB_OUTPUT when set):
+//   version=X.Y.Z
+//   tag=staging/vX.Y.Z-N
+//   counter=N
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..", "..");
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(root, "app/package.json"), "utf8"),
+);
+const version = String(pkg.version || "");
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error(
+    `[next-staging-tag] app/package.json version must be SemVer X.Y.Z, found: ${version}`,
+  );
+  process.exit(1);
+}
+
+function listMatchingTags(pattern) {
+  const out = execFileSync("git", ["tag", "--list", pattern], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return out
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const pattern = `staging/v${version}-*`;
+const existing = listMatchingTags(pattern);
+let maxN = 0;
+const suffixRe = new RegExp(
+  `^staging/v${version.replace(/\./g, "\\.")}-(\\d+)$`,
+);
+for (const tag of existing) {
+  const m = tag.match(suffixRe);
+  if (m) {
+    const n = Number(m[1]);
+    if (Number.isInteger(n) && n > maxN) maxN = n;
+  }
+}
+const counter = maxN + 1;
+const tag = `staging/v${version}-${counter}`;
+
+const lines = `version=${version}\ntag=${tag}\ncounter=${counter}\n`;
+process.stdout.write(lines);
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, lines);
+}
+
+console.error(
+  `[next-staging-tag] base=${version} existing=${existing.length} -> ${tag}`,
+);

--- a/scripts/release/resolve-release-source.sh
+++ b/scripts/release/resolve-release-source.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Resolve the git ref a production release should build from.
+#
+# Inputs (env):
+#   RELEASE_SOURCE   `staging_tag` (default) | `main_head`
+#   STAGING_TAG      optional: a specific `staging/v*` tag to pin to.
+#                    Ignored when RELEASE_SOURCE=main_head.
+#                    When RELEASE_SOURCE=staging_tag and empty, the latest
+#                    `staging/v*` tag is selected by `git tag --sort=-creatordate`.
+#
+# Outputs (appended to GITHUB_OUTPUT, also echoed):
+#   ref     the resolved tag name or branch (e.g. `staging/v0.53.4-2` or `main`)
+#   sha     the resolved full commit SHA
+#   source  echoes RELEASE_SOURCE for downstream visibility
+#
+# Fails loudly when:
+#   - RELEASE_SOURCE is unrecognized
+#   - staging_tag is requested but no staging tag exists / the named one is missing
+
+set -euo pipefail
+
+RELEASE_SOURCE="${RELEASE_SOURCE:-staging_tag}"
+STAGING_TAG="${STAGING_TAG:-}"
+
+case "$RELEASE_SOURCE" in
+  staging_tag|main_head) ;;
+  *)
+    echo "[resolve-release-source] unknown RELEASE_SOURCE='$RELEASE_SOURCE' (expected staging_tag|main_head)" >&2
+    exit 1
+    ;;
+esac
+
+git fetch --tags --quiet origin
+
+if [ "$RELEASE_SOURCE" = "main_head" ]; then
+  REF="main"
+  SHA="$(git rev-parse origin/main)"
+else
+  if [ -z "$STAGING_TAG" ]; then
+    STAGING_TAG="$(git tag --list 'staging/v*' --sort=-creatordate | head -n 1)"
+  fi
+  if [ -z "$STAGING_TAG" ]; then
+    echo "[resolve-release-source] no staging tags found matching 'staging/v*' — push a staging cut first or rerun with release_source=main_head" >&2
+    exit 1
+  fi
+  if ! git rev-parse --verify --quiet "refs/tags/${STAGING_TAG}" >/dev/null; then
+    echo "[resolve-release-source] staging tag '${STAGING_TAG}' does not exist on this remote" >&2
+    exit 1
+  fi
+  REF="$STAGING_TAG"
+  SHA="$(git rev-parse "refs/tags/${STAGING_TAG}^{commit}")"
+fi
+
+echo "[resolve-release-source] source=$RELEASE_SOURCE ref=$REF sha=$SHA" >&2
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "ref=$REF"
+    echo "sha=$SHA"
+    echo "source=$RELEASE_SOURCE"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+echo "ref=$REF"
+echo "sha=$SHA"
+echo "source=$RELEASE_SOURCE"


### PR DESCRIPTION
## Summary

Closes #1089. Splits the unified `release.yml` (which routed both production and staging through one `build_target` switch) into two first-class workflows with separate concurrency, permissions, and artifacts.

- **Staging** (`release-staging.yml`): each successful cut now pushes an immutable `staging/vX.Y.Z-N` tag. Base `X.Y.Z` reads from `app/package.json` without mutation; `N` is a monotonic counter computed from existing staging tags (tag-only metadata, no version-bump commits land on `main`). A `cleanup-failed-staging` job drops the tag if the matrix fails so production never resolves to a half-built artifact.
- **Production** (`release.yml`): now production-only. Replaces `build_target` with `release_source` (`staging_tag` default | `main_head`) plus an optional `staging_tag` pin. Empty pin = latest `staging/v*` by `creatordate`. The bump commit and release tag record `source`/`ref`/`sha` provenance. Production keeps `patch`/`minor`/`major`; default is `minor`.
- **Concurrency**: `release-staging` and `release-production-main` are now distinct groups so neither blocks the other.
- **Helpers**: new `scripts/release/next-staging-tag.js` and `scripts/release/resolve-release-source.sh`.
- **Docs**: `docs/RELEASE.md` runbook covers both flows, tag conventions, rollback, and helper scripts. `CLAUDE.md` points at it.

## Test plan

- [ ] Trigger **Release (Staging)** from `main`; confirm a `staging/v0.53.4-1` tag is pushed and matrix succeeds
- [ ] Trigger **Release (Staging)** again; confirm counter increments to `-2` and prior tag stays put
- [ ] Trigger **Release** with `release_source=staging_tag`, `staging_tag=""`, `release_type=minor`; confirm latest staging tag resolves, version bumps on `main`, `vX.(Y+1).0` tag is pushed, and release ships
- [ ] Trigger **Release** with `release_source=main_head`, `release_type=patch`; confirm the hotfix path works
- [ ] Force-fail a staging matrix leg; confirm `cleanup-failed-staging` drops the tag
- [ ] Verify `scripts/release/resolve-release-source.sh` errors clearly when no staging tags exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release process documentation covering staging and production workflows, tag conventions, and rollback procedures.
  * Updated repository documentation with migration notes and refreshed layout information.

* **Chores**
  * Improved release workflow automation with separate staging and production pipelines, including immutable tag creation and enhanced cleanup on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->