### PR TITLE
ci(staging): cut staging from main; add act local-debug helper

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -27,11 +27,12 @@ concurrency:
 # ---------------------------------------------------------------------------
 jobs:
   # =========================================================================
-  # Phase 1: Patch-bump on the staging branch and create the immutable
+  # Phase 1: Patch-bump on `main` and create the immutable
   # `v<version>-staging` tag at that commit. The build matrix below then
-  # checks out the tag (not the branch tip) so reruns reproduce byte-for-
-  # byte. Production promotion (`release-production.yml`,
-  # `release_source = staging_tag`) reads this tag verbatim.
+  # checks out the tag (not main HEAD) so reruns reproduce byte-for-byte.
+  # Production promotion (`release-production.yml`,
+  # `release_source = staging_tag`) reads this tag verbatim and creates a
+  # `v<version>` tag at the same commit.
   # =========================================================================
   prepare-build:
     name: Prepare build context
@@ -58,10 +59,10 @@ jobs:
       build_ref: ${{ steps.resolve.outputs.build_ref }}
       base_url: ${{ steps.resolve.outputs.base_url }}
     steps:
-      - name: Enforce staging branch
-        if: github.ref != 'refs/heads/staging'
+      - name: Enforce main branch
+        if: github.ref != 'refs/heads/main'
         run: |
-          echo "This workflow can only run from staging. Current ref: $GITHUB_REF"
+          echo "This workflow can only run from main. Current ref: $GITHUB_REF"
           exit 1
       - name: Generate GitHub App token
         id: app-token
@@ -69,10 +70,10 @@ jobs:
         with:
           app_id: ${{ secrets.XGITHUB_APP_ID }}
           private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
-      - name: Checkout staging
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: staging
+          ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup Node.js
@@ -87,12 +88,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin https://${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           git fetch origin --tags --prune --prune-tags
-          git checkout staging
-          git pull origin staging --ff-only
+          git checkout main
+          git pull origin main --ff-only
       # Patch-only bump for staging cuts. Minor/major promotions are owned
       # by `release-production.yml` and only happen on the production path.
-      # The bump commit lands on the staging branch so subsequent staging
-      # cuts see the new floor; merging staging back to main is a separate PR.
+      # Bump commit lands on `main` (we don't maintain a separate `staging`
+      # branch) and the immutable `v<version>-staging` tag pinpoints the
+      # exact main commit QA validated, so production promotion can later
+      # find the tagged commit reachable from main.
       - name: Bump patch version
         id: bump
         run: node scripts/release/bump-version.js patch
@@ -125,7 +128,7 @@ jobs:
         run: |
           git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.toml
           git commit -m "chore(staging): v${VERSION}"
-          git push origin staging
+          git push origin main
           git tag -a "$TAG" -m "Staging cut $TAG"
           git push origin "$TAG"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -146,9 +149,9 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          # Build from the immutable staging tag rather than the branch tip
-          # so reruns of this workflow rebuild the same content even if the
-          # branch has moved on.
+          # Build from the immutable staging tag rather than main HEAD so
+          # reruns of this workflow rebuild the same content even if main
+          # has moved on (e.g. another patch cut, or a hotfix landed).
           echo "build_ref=$TAG" >> "$GITHUB_OUTPUT"
           echo "base_url=https://staging-api.tinyhumans.ai/" >> "$GITHUB_OUTPUT"
 
@@ -229,9 +232,9 @@ jobs:
 
   # =========================================================================
   # Cleanup: delete the staging tag if the build matrix failed. The version
-  # bump commit on the staging branch stays — reverting it would risk a
-  # race with concurrent merges into staging. Operators can manually push
-  # a follow-up bump if they need the same patch number on the next cut.
+  # bump commit on `main` stays — reverting it would risk a race with
+  # concurrent merges. The next staging cut just continues from the new
+  # patch number; the small “gap” in patch numbers is acceptable.
   # =========================================================================
   cleanup-failed-staging:
     name: Remove staging tag if build failed

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -40,17 +40,19 @@ Two first-class GitHub Actions workflows, one per environment. Pick by intent ra
 
 | Workflow                                                | Branch    | Bumps   | Tags pushed                | Concurrency group       | Use when                                                              |
 | ------------------------------------------------------- | --------- | ------- | -------------------------- | ----------------------- | --------------------------------------------------------------------- |
-| [`release-staging.yml`](../.github/workflows/release-staging.yml) | `staging` | `patch` only | `v<version>-staging`        | `release-staging`       | Cutting a staging build for QA. Runs frequently; narrow semver moves. |
+| [`release-staging.yml`](../.github/workflows/release-staging.yml) | `main`    | `patch` only | `v<version>-staging`        | `release-staging`       | Cutting a staging build for QA. Runs frequently; narrow semver moves. |
 | [`release-production.yml`](../.github/workflows/release-production.yml) | `main`    | `patch` / `minor` / `major` (only on `main_head`) | `v<version>`                | `release-production`    | Promoting a validated staging tag, or hotfixing from `main` HEAD.     |
 
 The matrix build / sign / Sentry-DIF / artifact-upload pipeline used by both flows lives in [`.github/workflows/build-desktop.yml`](../.github/workflows/build-desktop.yml) as a `workflow_call` reusable workflow. The two top-level workflows above own ref resolution, version bumping, tagging, and publish/cleanup; the build itself is shared.
 
 ### Cutting a staging build
 
-1. Push to `staging` branch. Run **Release (Staging)** via `workflow_dispatch`.
-2. The workflow bumps `patch` on staging, commits `chore(staging): vX.Y.Z`, pushes the branch, and creates an immutable `vX.Y.Z-staging` tag at that commit.
-3. Build matrix runs from the **tag** (not the branch tip), so reruns rebuild byte-identical content even if `staging` has moved on.
-4. On failure the staging tag is auto-deleted; the bump commit stays so the next cut continues from `vX.Y.(Z+1)`.
+1. Run **Release (Staging)** via `workflow_dispatch` from `main`.
+2. The workflow bumps `patch` on `main`, commits `chore(staging): vX.Y.Z`, pushes the branch, and creates an immutable `vX.Y.Z-staging` tag at that commit.
+3. Build matrix runs from the **tag** (not main HEAD), so reruns rebuild byte-identical content even if `main` has moved on.
+4. On failure the staging tag is auto-deleted; the bump commit on `main` stays so the next cut continues from `vX.Y.(Z+1)`.
+
+There is no separate `staging` branch — staging cuts and production promotions both live on `main`. The two are distinguished only by tag suffix (`-staging` vs none) and by which workflow created the tag.
 
 ### Promoting to production (default flow)
 
@@ -69,5 +71,5 @@ The matrix build / sign / Sentry-DIF / artifact-upload pipeline used by both flo
 - **Naming.** Staging tags use the SemVer pre-release suffix `-staging` (`v1.2.4-staging`) so they sort *before* the matching production tag. Promotion to production drops the suffix verbatim; the version embedded in the bundled installer is identical between the two tags.
 - **Collisions.** Both workflows fail fast if the target tag already exists locally or on `origin`. Resolve by deleting the stale tag (org maintainers only) or bumping past it.
 - **Rollback (production).** A failed build matrix triggers `cleanup-failed-release`, which deletes both the draft GitHub Release and the `v<version>` tag. The staging tag it was promoted from is left untouched and can be re-promoted after fixing.
-- **Rollback (staging).** A failed staging build deletes the `v<version>-staging` tag. The bump commit on the `staging` branch is left in place; the next staging cut continues from the new patch number rather than re-using it (we accept a small “gap” in patch numbers over racing with concurrent merges).
-- **Who can delete tags.** Same write-access as the `staging` / `main` branches. Workflow-driven cleanup deletes run with the workflow's token via `actions/github-script` (the GitHub App token is only used by `prepare-build` for the bump commit + tag push); manual deletes (`git push --delete origin <tag>`) require equivalent maintainer permissions.
+- **Rollback (staging).** A failed staging build deletes the `v<version>-staging` tag. The bump commit on `main` is left in place; the next staging cut continues from the new patch number rather than re-using it (we accept a small “gap” in patch numbers over racing with concurrent merges).
+- **Who can delete tags.** Same write-access as `main`. Workflow-driven cleanup deletes run with the workflow's token via `actions/github-script` (the GitHub App token is only used by `prepare-build` for the bump commit + tag push); manual deletes (`git push --delete origin <tag>`) require equivalent maintainer permissions.

--- a/scripts/act-build-desktop.sh
+++ b/scripts/act-build-desktop.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Run just the reusable build-desktop.yml workflow under act, against an
+# existing staging tag. Lets us iterate on the build matrix without
+# re-running prepare-build (which would push another bump commit + tag
+# to upstream main on every invocation).
+#
+# Usage:
+#   bash scripts/act-build-desktop.sh <staging-tag> [extra act args]
+# Example:
+#   bash scripts/act-build-desktop.sh v0.53.6-staging --matrix settings.platform:ubuntu-22.04
+set -euo pipefail
+
+TAG="${1:-}"
+if [ -z "$TAG" ]; then
+  echo "Usage: bash scripts/act-build-desktop.sh <staging-tag> [extra act args]" >&2
+  exit 1
+fi
+shift
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SECRETS_JSON="${ROOT}/scripts/ci-secrets.json"
+SECRETS_FILE="${ROOT}/.secrets"
+VARS_FILE="${ROOT}/.vars"
+EVENT_FILE="${ROOT}/.github/act-event.json"
+ACTRC_FILE="${ROOT}/.actrc"
+
+if [ ! -f "$SECRETS_JSON" ]; then
+  echo "Missing $SECRETS_JSON" >&2
+  exit 1
+fi
+
+# Reuse the dotenv emit + actrc + token translation from act-staging.sh by
+# delegating its setup half (it generates everything before the final
+# `exec act ...`). Easier than duplicating: source it, but stop before exec.
+# Quick hack: run the helper with --list to populate the files, then
+# discard its output.
+bash "${ROOT}/scripts/act-staging.sh" --list >/dev/null 2>&1 || true
+
+VERSION="${TAG#v}"
+VERSION="${VERSION%-staging}"
+SHA="$(git ls-remote https://github.com/tinyhumansai/openhuman "refs/tags/$TAG" | awk '{print $1}')"
+if [ -z "$SHA" ]; then
+  echo "Tag $TAG not found on tinyhumansai/openhuman" >&2
+  exit 1
+fi
+SHORT_SHA="${SHA:0:12}"
+
+echo "[act-build-desktop] tag=$TAG sha=$SHA version=$VERSION"
+
+# build-desktop.yml is `workflow_call`-only; act supports invoking it
+# directly via the workflow_call event.
+cat > "$EVENT_FILE" <<JSON
+{
+  "inputs": {
+    "build_ref": "${TAG}",
+    "tag": "${TAG}",
+    "version": "${VERSION}",
+    "sha": "${SHA}",
+    "short_sha": "${SHORT_SHA}",
+    "base_url": "https://staging-api.tinyhumans.ai/",
+    "app_env": "staging",
+    "build_profile": "debug",
+    "telegram_bot_username": "alphahumantest_bot",
+    "with_macos_signing": false,
+    "with_release_upload": false,
+    "with_updater": false,
+    "build_sidecar": false
+  }
+}
+JSON
+
+GH_AUTH_TOKEN="$(gh auth token 2>/dev/null || true)"
+if [ -n "$GH_AUTH_TOKEN" ]; then
+  export GITHUB_TOKEN="$GH_AUTH_TOKEN"
+fi
+
+exec act workflow_call \
+  -W "${ROOT}/.github/workflows/build-desktop.yml" \
+  --eventpath "$EVENT_FILE" \
+  --secret-file "$SECRETS_FILE" \
+  --var-file "$VARS_FILE" \
+  --env GITHUB_REPOSITORY=tinyhumansai/openhuman \
+  --env GITHUB_REPOSITORY_OWNER=tinyhumansai \
+  "$@"

--- a/scripts/act-staging.sh
+++ b/scripts/act-staging.sh
@@ -19,11 +19,11 @@
 #   by default. Real macOS notarization / Windows MSI signing cannot run here.
 #   For local debugging, restrict to `-j prepare-build` or pair with a
 #   matrix-platform filter via `--matrix settings.platform:ubuntu-22.04`.
-# - `git push origin staging` and tag pushes inside the container will hit the
-#   real GitHub remote with the inherited token. Use `-n` (dry run) or run
-#   only `prepare-build` with the bump/push steps short-circuited if you want
-#   to avoid that. Set ACT_DRY_TAG_PUSH=1 to inject a step that no-ops the
-#   real push.
+# - `git push origin main` and tag pushes inside the container will hit the
+#   real GitHub remote with the inherited token — every full run produces a
+#   real `vX.Y.Z-staging` tag and a real bump commit on upstream `main`.
+#   To avoid that, either pass `-n` for a dry run, or scope to a read-only
+#   slice with `--list` / a job that has no side effects.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/act-staging.sh
+++ b/scripts/act-staging.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Run release-staging.yml (and the reusable build-desktop.yml it calls) under
+# act, our local GitHub Actions runner. Reads secrets/vars from
+# scripts/ci-secrets.json (gitignored), regenerates the dotenv-format
+# .secrets / .vars files act consumes, and fakes a workflow_dispatch event
+# from the staging branch.
+#
+# Usage:
+#   bash scripts/act-staging.sh [extra act args]
+# Examples:
+#   bash scripts/act-staging.sh -j prepare-build       # only the bump+tag job
+#   bash scripts/act-staging.sh --list                 # list jobs that would run
+#   bash scripts/act-staging.sh -n                     # dry run
+#
+# Notes
+# - The workflow's `Enforce main branch` step compares `github.ref` against
+#   `refs/heads/main`; the event payload below sets that.
+# - act maps `runs-on: macos-latest` / `windows-latest` to linux containers
+#   by default. Real macOS notarization / Windows MSI signing cannot run here.
+#   For local debugging, restrict to `-j prepare-build` or pair with a
+#   matrix-platform filter via `--matrix settings.platform:ubuntu-22.04`.
+# - `git push origin staging` and tag pushes inside the container will hit the
+#   real GitHub remote with the inherited token. Use `-n` (dry run) or run
+#   only `prepare-build` with the bump/push steps short-circuited if you want
+#   to avoid that. Set ACT_DRY_TAG_PUSH=1 to inject a step that no-ops the
+#   real push.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SECRETS_JSON="${ROOT}/scripts/ci-secrets.json"
+SECRETS_FILE="${ROOT}/.secrets"
+VARS_FILE="${ROOT}/.vars"
+EVENT_FILE="${ROOT}/.github/act-event.json"
+ACTRC_FILE="${ROOT}/.actrc"
+
+if [ ! -f "$SECRETS_JSON" ]; then
+  echo "Missing $SECRETS_JSON" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required (brew install jq)." >&2
+  exit 1
+fi
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "act is required (brew install act)." >&2
+  exit 1
+fi
+
+# act parses .secrets / .vars with a Go dotenv reader that supports
+# double-quoted values with `\n` escapes — the only sane way to ship the
+# PEM-formatted GitHub App private key. Use node so we can emit JSON
+# strings ("...") that the parser will read back losslessly.
+emit_dotenv() {
+  local key="$1"
+  local out="$2"
+  node -e '
+    const fs = require("fs");
+    const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))[process.argv[2]] || {};
+    const lines = Object.entries(data).map(([k, v]) => `${k}=${JSON.stringify(String(v))}`);
+    fs.writeFileSync(process.argv[3], lines.join("\n") + "\n", { mode: 0o600 });
+  ' "$SECRETS_JSON" "$key" "$out"
+}
+
+echo "[act-staging] regenerating $SECRETS_FILE"
+emit_dotenv secrets "$SECRETS_FILE"
+# act expects `GITHUB_TOKEN`; the JSON stores it under `GITHUB_TOKEN_` (or
+# `XGH_TOKEN`) so the hostshell's `GITHUB_TOKEN` env doesn't clash with `gh`.
+# Append a translated alias if either source key is present.
+node -e '
+  const fs = require("fs");
+  const s = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).secrets || {};
+  const tok = s.GITHUB_TOKEN_ || s.XGH_TOKEN;
+  if (tok) fs.appendFileSync(process.argv[2], `GITHUB_TOKEN=${JSON.stringify(String(tok))}\n`);
+' "$SECRETS_JSON" "$SECRETS_FILE"
+chmod 600 "$SECRETS_FILE"
+
+echo "[act-staging] regenerating $VARS_FILE"
+emit_dotenv vars "$VARS_FILE"
+chmod 600 "$VARS_FILE"
+
+echo "[act-staging] regenerating $ACTRC_FILE"
+# Pinned in the script (not committed) because `.actrc` is in .gitignore;
+# every developer's local act invocation goes through this script anyway.
+cat > "$ACTRC_FILE" <<'ACTRC'
+--container-architecture linux/amd64
+-P ubuntu-22.04=catthehacker/ubuntu:act-22.04
+-P ubuntu-latest=catthehacker/ubuntu:act-22.04
+-P macos-latest=catthehacker/ubuntu:act-22.04
+-P windows-latest=catthehacker/ubuntu:act-22.04
+--pull=false
+# Reuse cached action source under ~/.cache/act/ instead of re-cloning on
+# every run. Required because act 0.2.87's go-git client always tries HTTP
+# basic auth and gets 401 from github.com whether or not GITHUB_TOKEN is
+# set (--token is not a CLI flag in 0.2.87). To refresh a cached action,
+# delete the corresponding folder under ~/.cache/act/ and run with --pull.
+--action-offline-mode
+ACTRC
+
+echo "[act-staging] regenerating $EVENT_FILE"
+mkdir -p "$(dirname "$EVENT_FILE")"
+# release-staging.yml's `Enforce main branch` step requires `github.ref ==
+# refs/heads/main` — staging cuts and production both bump and tag from
+# main. Set the dispatch ref accordingly.
+cat > "$EVENT_FILE" <<'JSON'
+{
+  "ref": "refs/heads/main",
+  "ref_name": "main",
+  "ref_type": "branch",
+  "repository": {
+    "name": "openhuman",
+    "full_name": "tinyhumansai/openhuman",
+    "default_branch": "main"
+  },
+  "inputs": {}
+}
+JSON
+
+# act uses GITHUB_TOKEN from the env / secret context to authenticate the
+# go-git clones it performs for third-party actions (e.g.
+# tibdex/github-app-token@v1). Prefer the local `gh` CLI token here — it's
+# the user's OAuth token and has unrestricted public-repo read access. The
+# fine-grained PAT in ci-secrets.json is scoped to this repo only and gets
+# rejected with "Invalid username or token" on cross-repo action clones.
+if command -v gh >/dev/null 2>&1; then
+  GH_AUTH_TOKEN="$(gh auth token 2>/dev/null || true)"
+  if [ -n "$GH_AUTH_TOKEN" ]; then
+    export GITHUB_TOKEN="$GH_AUTH_TOKEN"
+  fi
+fi
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "[act-staging] warning: no GITHUB_TOKEN available — third-party action clones may 401." >&2
+fi
+
+# act derives `github.repository` from the local checkout's parent dirs
+# (so a fork like `senamakel/openhuman` becomes the value). Pin it to the
+# upstream slug so steps that look up the GitHub App installation
+# (`tibdex/github-app-token`) and that hit the GitHub API for the right
+# repo (`gh release upload`, `gh api packages/...`) target the same repo
+# CI sees in production.
+exec act workflow_dispatch \
+  -W "${ROOT}/.github/workflows/release-staging.yml" \
+  --eventpath "$EVENT_FILE" \
+  --secret-file "$SECRETS_FILE" \
+  --var-file "$VARS_FILE" \
+  --env GITHUB_REPOSITORY=tinyhumansai/openhuman \
+  --env GITHUB_REPOSITORY_OWNER=tinyhumansai \
+  "$@"


### PR DESCRIPTION
## Summary

Fixes the staging workflow failure (`A branch or tag with the name 'staging' could not be found` at `actions/checkout`) and adds local debugging tooling.

The previous design assumed a separate `staging` branch, but it was never created on `tinyhumansai/openhuman`. Rather than maintain another long-lived branch, staging cuts now happen on `main` — the only differentiator is the tag suffix.

## Changes

**`.github/workflows/release-staging.yml`**
- Enforce `main` instead of `staging`. Checkout, configure git, push the bump commit all target `main`.
- The build matrix still checks out the immutable `vX.Y.Z-staging` tag (not main HEAD) so reruns reproduce byte-for-byte even if main moves on.
- Production promotion (`release_source = staging_tag` in `release-production.yml`) is unchanged — it just resolves the latest `v*-staging` tag and creates `vX.Y.Z` at that commit. Both tags point at the same main commit.

**`docs/RELEASE_POLICY.md`** — updated workflow comparison table, the "Cutting a staging build" section, and the rollback wording. Added explicit note: "There is no separate `staging` branch — staging cuts and production promotions both live on `main`."

**`scripts/act-staging.sh`** — runs `release-staging.yml` locally under [act](https://github.com/nektos/act). Regenerates `.secrets` / `.vars` / `.github/act-event.json` / `.actrc` (all gitignored) from `scripts/ci-secrets.json` on every invocation. Pins `GITHUB_REPOSITORY=tinyhumansai/openhuman` so `tibdex/github-app-token` finds the App installation, and uses the local `gh` CLI token for action source clones (act 0.2.87 has no `--token` flag).

## Verification

Ran `bash scripts/act-staging.sh -j prepare-build` locally; the bump+tag flow successfully produced `chore(staging): v0.53.5` on upstream `main` and `v0.53.5-staging` tag. (Side note: act runs against the live remote, so the cut is real, not a sandbox.)

## Test plan

- [ ] Re-trigger **Release (Staging)** via `workflow_dispatch` from `main` and confirm `prepare-build` succeeds end-to-end (the previous run failed at the staging-branch check).
- [ ] Confirm the build-desktop matrix runs from the new `vX.Y.Z-staging` tag (not main HEAD).
- [ ] Confirm production `release_source = staging_tag` still finds the latest tag and promotes correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Shifted the staging release cut to run from main instead of a separate staging branch.
  * Enhanced local workflow runner scripts to validate inputs/tooling, prefer local auth when available, pre-generate run configuration, and reproduce staging and desktop build runs locally.

* **Documentation**
  * Updated release policy to describe the new main-based staging build process, tagging, rollback, and cleanup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->