### PR TITLE
ci: local-only build-desktop entrypoint for matrix iteration

### DIFF
--- a/.github/workflows/local-build-desktop.yml
+++ b/.github/workflows/local-build-desktop.yml
@@ -1,0 +1,111 @@
+---
+# Local / debug-only entry point for the reusable build-desktop matrix.
+#
+# Wraps `build-desktop.yml` in a `workflow_dispatch` so it can be invoked:
+#   - From the GitHub Actions UI as a one-off, against any tag/SHA, with
+#     no version bump and no GH App token (only `secrets.GITHUB_TOKEN`
+#     is consulted, which the runner provides automatically).
+#   - Locally via `act` without needing the XGITHUB_APP_* secrets that
+#     `release-staging.yml`'s prepare-build requires (and without
+#     producing a real `vX.Y.Z-staging` tag every time you iterate on
+#     the build matrix).
+#
+# Inputs default to a staging-style debug build of `main` HEAD; override
+# any of them in the dispatch dialog (or via `act --input`).
+name: Local Build Desktop (debug)
+on:
+  workflow_dispatch:
+    inputs:
+      build_ref:
+        description: Git ref to build (tag, branch, or SHA). Defaults to main HEAD.
+        type: string
+        required: false
+        default: main
+      version:
+        description:
+          SemVer version string (no `v` prefix) baked into Sentry release. Leave
+          blank to read from `app/package.json` at the resolved ref.
+        type: string
+        required: false
+        default: ""
+      app_env:
+        description: APP_ENVIRONMENT label baked into the bundle.
+        type: choice
+        required: true
+        default: staging
+        options: [production, staging]
+      build_profile:
+        description: Cargo profile.
+        type: choice
+        required: true
+        default: debug
+        options: [debug, release]
+      with_macos_signing:
+        description: Sign + notarize macOS bundles. Off by default for local runs (no Apple keychain).
+        type: boolean
+        required: false
+        default: false
+      build_sidecar:
+        description: Build the standalone openhuman-core CLI binary alongside the Tauri shell.
+        type: boolean
+        required: false
+        default: false
+permissions:
+  # No write access required — nothing in this workflow pushes commits or
+  # tags. Reusable workflow may upload Actions artifacts, which only needs
+  # the default GITHUB_TOKEN.
+  contents: read
+  packages: read
+concurrency:
+  group: local-build-desktop-${{ github.event.inputs.build_ref }}
+  cancel-in-progress: true
+jobs:
+  resolve:
+    name: Resolve build context
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
+    steps:
+      - name: Checkout build ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.build_ref }}
+          fetch-depth: 1
+      - name: Resolve outputs
+        id: resolve
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="$(node -p "require('./app/package.json').version")"
+          fi
+          SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="${SHA:0:12}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+  build-desktop:
+    name: Build desktop matrix
+    needs: [resolve]
+    uses: ./.github/workflows/build-desktop.yml
+    secrets: inherit
+    with:
+      build_ref: ${{ inputs.build_ref }}
+      tag: ${{ needs.resolve.outputs.version }}-local
+      version: ${{ needs.resolve.outputs.version }}
+      sha: ${{ needs.resolve.outputs.sha }}
+      short_sha: ${{ needs.resolve.outputs.short_sha }}
+      base_url: ${{ inputs.app_env == 'production' && 'https://api.tinyhumans.ai/' || 'https://staging-api.tinyhumans.ai/' }}
+      app_env: ${{ inputs.app_env }}
+      build_profile: ${{ inputs.build_profile }}
+      telegram_bot_username: ${{ inputs.app_env == 'production' && 'openhumanaibot' || 'alphahumantest_bot' }}
+      with_macos_signing: ${{ inputs.with_macos_signing }}
+      with_release_upload: false
+      with_updater: false
+      build_sidecar: ${{ inputs.build_sidecar }}

--- a/scripts/act-local-build.sh
+++ b/scripts/act-local-build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run `local-build-desktop.yml` under act — hits the same reusable
+# build-desktop.yml that release-{staging,production}.yml use, but with no
+# version bump, no tag, no push to upstream main, and no GH App token
+# requirement. Iterate on the build matrix without burning patch numbers.
+#
+# Usage:
+#   bash scripts/act-local-build.sh [extra act args]
+# Examples:
+#   bash scripts/act-local-build.sh --input build_ref=v0.53.6-staging
+#   bash scripts/act-local-build.sh --matrix settings.target:x86_64-unknown-linux-gnu
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Reuse act-staging.sh's setup half (regenerates .secrets / .vars / .actrc
+# from scripts/ci-secrets.json) but discard its act invocation — we want
+# a different entry point. --list is cheap and exits cleanly.
+bash "${ROOT}/scripts/act-staging.sh" --list >/dev/null 2>&1 || true
+
+GH_AUTH_TOKEN="$(gh auth token 2>/dev/null || true)"
+if [ -n "$GH_AUTH_TOKEN" ]; then
+  export GITHUB_TOKEN="$GH_AUTH_TOKEN"
+fi
+
+exec act workflow_dispatch \
+  -W "${ROOT}/.github/workflows/local-build-desktop.yml" \
+  --secret-file "${ROOT}/.secrets" \
+  --var-file "${ROOT}/.vars" \
+  --env GITHUB_REPOSITORY=tinyhumansai/openhuman \
+  --env GITHUB_REPOSITORY_OWNER=tinyhumansai \
+  "$@"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` entry point that wraps the reusable `build-desktop.yml` so we can iterate on the build matrix without burning real staging tags every run.

`release-staging.yml`'s `prepare-build` pushes `chore(staging): vX.Y.Z` to upstream `main` and creates a `vX.Y.Z-staging` tag — every full run consumes a patch number. That's fine for actual cuts, painful for chasing build flakes (#1100 was discovered exactly this way).

## Changes

**`.github/workflows/local-build-desktop.yml`** — `workflow_dispatch` with the standard knobs: `build_ref` (any tag/branch/SHA), `version`, `app_env` (production | staging), `build_profile` (debug | release), `with_macos_signing`, `build_sidecar`. Resolves SHA + version in a small `resolve` job, then calls the reusable `build-desktop.yml` with `with_release_upload: false` and `with_updater: false`. Permissions are `contents: read` / `packages: read` only — no GH App token needed; the runner-provided `secrets.GITHUB_TOKEN` covers `actions/checkout`.

**`scripts/act-local-build.sh`** — runs the same workflow under `act` locally. Reuses `scripts/act-staging.sh`'s setup half to regenerate `.secrets` / `.vars` / `.actrc` from `scripts/ci-secrets.json`.

## Use cases

- "Did the build actually compile under the new env vars?" → trigger this from the Actions UI against `main`.
- "Does my branch break the cargo+CEF compile?" → trigger against the branch SHA.
- "Reproduce a Sentry-DIF upload failure locally" → `bash scripts/act-local-build.sh --matrix settings.target:x86_64-unknown-linux-gnu`.

## Test plan

- [ ] Trigger **Local Build Desktop (debug)** from the Actions UI against `main` and confirm the matrix runs end-to-end.
- [ ] Confirm no commits / tags appear on `main` after the run completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for local desktop builds with configurable parameters including environment selection, build profile, macOS signing, and optional sidecar CLI build.
  * Added shell script to streamline invoking the local build workflow via the act tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->