### PR TITLE
fix(ci): bump pinned sentry-cli to 3.4.1 (2.34.2 was never published)

### DIFF
--- a/scripts/upload_sentry_symbols.sh
+++ b/scripts/upload_sentry_symbols.sh
@@ -106,7 +106,13 @@ ensure_sentry_cli() {
             ;;
     esac
 
-    local version="2.34.2"
+    # `2.34.2` was never a real release of getsentry/sentry-cli (we presumably
+    # confused it with python-sentry-sdk versions — sentry-python ships those
+    # numbers, sentry-cli's 2.x series is gone from the releases page). Pin
+    # to 3.4.1, the latest stable that matches the `--log-level=warn` flag
+    # the upload step uses (2.x called it `--log-level=warning`). Override
+    # via SENTRY_CLI_VERSION if a future bump is needed.
+    local version="${SENTRY_CLI_VERSION:-3.4.1}"
     local download_url="https://github.com/getsentry/sentry-cli/releases/download/${version}/sentry-cli-${os_arch}"
 
     # Create temporary directory for installation. Cleanup runs as a


### PR DESCRIPTION
Follow-up to #1100. That PR fixed the asset-name casing (`linux-x86_64` → `Linux-x86_64`) and the cleanup-trap scope, but left the version pinned to `2.34.2`. The next staging run hit:

```
[INFO] Downloading sentry-cli 2.34.2 for Linux-x86_64...
curl: (22) The requested URL returned error: 404
[ERROR] Failed to download sentry-cli from https://github.com/getsentry/sentry-cli/releases/download/2.34.2/sentry-cli-Linux-x86_64
```

`2.34.2` was never a real release of [`getsentry/sentry-cli`](https://github.com/getsentry/sentry-cli/releases) — its 2.x series is no longer published, only 3.x stable + 3.x snapshots. The 2.34.2 number presumably came from `sentry-python` (which does ship that release), copy-pasted by mistake.

## Changes

- Pin to `3.4.1` (current latest stable). Matches the `--log-level=warn` flag the upload step already uses; 2.x called it `--log-level=warning` and 3.x renamed it.
- Allow override via `SENTRY_CLI_VERSION` env so the next bump can land without code change.

## Test plan

- [ ] Re-trigger **Release (Staging)** after merge and confirm `Upload Tauri shell debug symbols to Sentry` now downloads + installs `sentry-cli` 3.4.1 successfully on the linux runner.
- [ ] Confirm same for the macOS matrix entries (Darwin-universal asset).
- [ ] Spot-check that DIFs land in the `openhuman-tauri` Sentry project under `openhuman@<version>+<short_sha>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sentry CLI version configuration to support environment variable override, with a default version of 3.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->