### PR TITLE
ci: pull pnpm into CI image, drop redundant setup steps

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -48,10 +48,11 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
     -c rustfmt -c clippy \
     -t x86_64-unknown-linux-gnu
 
-# Node.js 24.x + yarn
+# Node.js 24.x + pnpm (project's package manager — pinned in package.json)
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g yarn
+    && corepack enable \
+    && corepack prepare pnpm@10.10.0 --activate
 
 # Install ALSA, X11, input, and E2E automation dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -88,4 +89,4 @@ COPY e2e/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 # Verify installs
-RUN rustc --version && cargo --version && node --version && yarn --version && mold --version && sccache --version && which tauri-driver && cargo tauri --version
+RUN rustc --version && cargo --version && node --version && pnpm --version && mold --version && sccache --version && which tauri-driver && cargo tauri --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,23 +44,19 @@ jobs:
           restore-keys: |
             cef-ubuntu-22.04-
 
-      # Note: the vendored CEF-aware tauri-cli is pre-installed in the
-      # ghcr.io/tinyhumansai/openhuman_ci image (see .github/Dockerfile),
-      # so `cargo tauri build` below resolves to the fork without any
-      # per-run compile step.
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      # Note: the vendored CEF-aware tauri-cli, Node 24, and pnpm are all
+      # pre-installed in the ghcr.io/tinyhumansai/openhuman_ci image (see
+      # .github/Dockerfile), so `cargo tauri build` below resolves to the
+      # fork without any per-run compile step.
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          cache: true
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Install cmake (for whisper-rs)
-        run: apt-get update && apt-get install -y --no-install-recommends cmake &&
-          rm -rf /var/lib/apt/lists/*
       # Core is linked into the Tauri binary as a path dep — no separate
       # sidecar build / stage step needed.
       - name: Build Tauri app (CEF default)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,20 +15,21 @@ concurrency:
 jobs:
   frontend-coverage:
     name: Frontend Coverage (Vitest)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          cache: true
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Vitest with coverage
@@ -74,8 +75,6 @@ jobs:
           workspaces: . -> target
           cache-on-failure: true
           key: core-coverage
-      - name: Install system dependencies (cmake, ALSA, X11)
-        run: apt-get update && apt-get install -y --no-install-recommends cmake libasound2-dev libxdo-dev libxtst-dev libx11-dev libevdev-dev && rm -rf /var/lib/apt/lists/*
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run cargo llvm-cov for openhuman core
@@ -116,8 +115,6 @@ jobs:
           key: cef-ubuntu-22.04-${{ hashFiles('app/src-tauri/Cargo.toml') }}
           restore-keys: |
             cef-ubuntu-22.04-
-      - name: Install system dependencies (cmake, ALSA, X11)
-        run: apt-get update && apt-get install -y --no-install-recommends cmake libasound2-dev libxdo-dev libxtst-dev libx11-dev libevdev-dev && rm -rf /var/lib/apt/lists/*
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run cargo llvm-cov for Tauri shell

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -15,7 +15,9 @@ jobs:
   # blocking merges. Flip to hard-fail once the false-positive rate is stable.
   checklist-guard:
     name: PR Submission Checklist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     continue-on-error: true
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:
@@ -23,17 +25,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
       - name: Verify Submission Checklist
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-pr-checklist.mjs
   coverage-matrix:
     name: Coverage Matrix Sync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     continue-on-error: true
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:
@@ -41,10 +41,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
       - name: Verify Coverage Matrix
         run: node scripts/check-coverage-matrix.mjs
   markdown-link-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,20 +22,21 @@ concurrency:
 jobs:
   unit-tests:
     name: Frontend Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          cache: true
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run tests with coverage
@@ -77,9 +78,6 @@ jobs:
           workspaces: . -> target
           cache-on-failure: true
           key: core
-
-      - name: Install system dependencies (cmake, ALSA, X11)
-        run: apt-get update && apt-get install -y --no-install-recommends cmake libasound2-dev libxdo-dev libxtst-dev libx11-dev libevdev-dev && rm -rf /var/lib/apt/lists/*
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -124,9 +122,6 @@ jobs:
           key: cef-ubuntu-22.04-${{ hashFiles('app/src-tauri/Cargo.toml') }}
           restore-keys: |
             cef-ubuntu-22.04-
-      - name: Install system dependencies (cmake, ALSA, X11)
-        run: apt-get update && apt-get install -y --no-install-recommends cmake libasound2-dev
-          libxdo-dev libxtst-dev libx11-dev libevdev-dev && rm -rf /var/lib/apt/lists/*
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,20 +14,21 @@ concurrency:
 jobs:
   typecheck:
     name: Type Check TypeScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          cache: true
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Type check TypeScript files
@@ -58,9 +59,6 @@ jobs:
           workspaces: |
             . -> target
           cache-on-failure: true
-      - name: Install cmake (for whisper-rs)
-        run: apt-get update && apt-get install -y --no-install-recommends cmake &&
-          rm -rf /var/lib/apt/lists/*
       - name: Check formatting (cargo fmt)
         run: cargo fmt --all -- --check
       - name: Run clippy (core crate)

--- a/.github/workflows/weekly-code-review.yml
+++ b/.github/workflows/weekly-code-review.yml
@@ -50,7 +50,9 @@ jobs:
         id: cache-cargo-audit
         uses: actions/cache@v4
         with:
-          path: ~/.cargo/bin/cargo-audit
+          # Image sets CARGO_HOME=/usr/local/cargo, so cargo install drops the
+          # binary there — not in $HOME/.cargo/bin.
+          path: /usr/local/cargo/bin/cargo-audit
           key: cargo-audit-${{ runner.os }}-v1
 
       - name: Install cargo-audit

--- a/.github/workflows/weekly-code-review.yml
+++ b/.github/workflows/weekly-code-review.yml
@@ -25,7 +25,9 @@ concurrency:
 jobs:
   weekly-review:
     name: Aggregate weekly signals
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -33,20 +35,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Enable Corepack (for pnpm)
-        run: corepack enable
-
-      - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          node-version: 24.x
-          cache: "pnpm"
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
 
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.93.0
 
       - name: Cache cargo-audit binary
         id: cache-cargo-audit


### PR DESCRIPTION
## Summary

- Add `pnpm@10.10.0` (via corepack) to `.github/Dockerfile` and drop yarn — the project moved to pnpm and yarn was unused in the image.
- Migrate non-release workflows to run inside `ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0` so they stop re-installing Node, pnpm, cmake, and the ALSA/X11 dev libs whisper-rs / the Tauri shell already need from the image.
- Each containerized pnpm job caches `~/.local/share/pnpm/store` keyed on `pnpm-lock.yaml` to keep the install speedup we lose by dropping `setup-node`'s `cache: pnpm`.

### Migrated to the container

- `test.yml` — `unit-tests` containerized; `rust-core-tests` and `rust-tauri-tests` drop the redundant `cmake / libasound2-dev / libxdo-dev / libxtst-dev / libx11-dev / libevdev-dev` install step.
- `typecheck.yml` — `typecheck` containerized; `rust-quality` drops the cmake install.
- `coverage.yml` — `frontend-coverage` containerized; `rust-core-coverage` and `rust-tauri-coverage` drop redundant cmake/X11 install.
- `build.yml` — drops `pnpm/action-setup`, `actions/setup-node`, and the cmake install.
- `pr-quality.yml` — `checklist-guard` and `coverage-matrix` containerized.
- `weekly-code-review.yml` — containerized; drops corepack/setup-node/dtolnay rust-toolchain steps.

### Intentionally untouched

- `release-production.yml`, `release-staging.yml`, `release-packages.yml`, `build-desktop.yml`, `build-windows.yml` — release/build paths (per task scope).
- `installer-smoke.yml` — intentionally tests the installer on clean macOS / Ubuntu runners.
- `e2e-agent-review.yml` — disabled (CEF + tauri-driver mismatch).
- `pr-quality.yml`'s `markdown-link-check` — `lycheeverse/lychee-action` is safer outside a nested container.
- `coverage.yml`'s `coverage-gate` — needs Python 3.12 + `diff-cover`, which the CI image doesn't ship.

### Image deltas (`.github/Dockerfile`)

- Replace `npm install -g yarn` with `corepack enable && corepack prepare pnpm@10.10.0 --activate` (version pinned to match `package.json` `packageManager`).
- Verify line now runs `pnpm --version` instead of `yarn --version`.
- whisper-rs prerequisites (`cmake`, `clang`, `libclang-dev`, `build-essential`) were already in the image — no further additions needed.

## Roll-out note

The new image needs to be republished by `docker-ci-image.yml` before the workflow changes will resolve correctly. After merge, the `Build CI Docker Image` workflow will fire on the Dockerfile diff and refresh `ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0`. If any of the migrated jobs land in the queue before that image build finishes, re-running them once the new image is published will get them green.

## Test plan

- [ ] `Build CI Docker Image` workflow succeeds on `main` and republishes `ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0` with `pnpm` available.
- [ ] `Test` workflow: `Frontend Unit Tests`, `Rust Core Tests + Quality`, `Rust Tauri Shell Tests` all green inside the container.
- [ ] `Type Check` workflow: `Type Check TypeScript` and `Rust Quality (fmt + clippy)` green.
- [ ] `Coverage Gate` workflow: all three coverage producers green; `coverage-gate` (host runner) still consumes the artifacts.
- [ ] `Build` workflow: `Build Tauri App` produces a `.deb` bundle.
- [ ] `PR Quality (soft)` workflow: `PR Submission Checklist` and `Coverage Matrix Sync` jobs run inside the container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows and build environment moved to a fixed container image and updated to Node.js 24 with pnpm as the package manager.
  * Removed redundant host setup steps and added pnpm store caching to speed installs across jobs.
  * Simplified test/coverage/typecheck jobs by relying on the containerized toolchain.

*Note: No user-facing changes in this release.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->