### PR TITLE
feat(app): show Composio integrations as sorted icon grid on Skills

### DIFF
--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -123,6 +123,98 @@ function composioStatusColor(connection: ComposioConnection | undefined): string
   }
 }
 
+/** Sort order for the integrations grid: connected first, then pending, errors, disconnected. */
+function composioSortRank(connection: ComposioConnection | undefined): number {
+  switch (deriveComposioState(connection)) {
+    case 'connected':
+      return 0;
+    case 'pending':
+      return 1;
+    case 'error':
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+interface ComposioConnectorTileProps {
+  meta: ComposioToolkitMeta;
+  connection: ComposioConnection | undefined;
+  hasComposioError: boolean;
+  onOpen: () => void;
+  onRetryGlobal: () => void;
+}
+
+function ComposioConnectorTile({
+  meta,
+  connection,
+  hasComposioError,
+  onOpen,
+  onRetryGlobal,
+}: ComposioConnectorTileProps) {
+  const state = hasComposioError ? 'error' : deriveComposioState(connection);
+  const statusLabel = hasComposioError ? 'Status unavailable' : composioStatusLabel(connection);
+  const ctaLabel = hasComposioError
+    ? 'Retry'
+    : state === 'connected'
+      ? 'Manage'
+      : state === 'pending'
+        ? 'Waiting'
+        : state === 'error'
+          ? 'Retry'
+          : 'Connect';
+
+  const isConnected = state === 'connected';
+  const isPending = state === 'pending';
+  const isError = state === 'error' || hasComposioError;
+
+  const handleClick = () => {
+    if (hasComposioError) {
+      void onRetryGlobal();
+      return;
+    }
+    onOpen();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={`${meta.name} — ${meta.description}`}
+      aria-label={`${meta.name}, ${statusLabel}. ${ctaLabel}.`}
+      className={`group flex flex-col items-center gap-2 rounded-2xl border p-3 pb-3 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40 ${
+        isConnected
+          ? 'border-sage-300 bg-sage-50/80 shadow-[0_0_0_1px_rgba(34,197,94,0.12)] hover:bg-sage-50'
+          : isPending
+            ? 'border-amber-200 bg-amber-50/40 hover:bg-amber-50/70'
+            : isError
+              ? 'border-coral-200 bg-coral-50/30 hover:bg-coral-50/50'
+              : 'border-stone-200 bg-white hover:bg-stone-50'
+      }`}>
+      <div className="relative flex h-12 w-12 flex-shrink-0 items-center justify-center text-stone-700 [&_img]:max-h-10 [&_img]:max-w-10 [&_svg]:h-8 [&_svg]:w-8">
+        {meta.icon}
+        <span
+          className={`absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-white ${
+            hasComposioError ? 'bg-amber-500' : composioStatusDot(connection)
+          }`}
+          aria-hidden
+        />
+      </div>
+      <div className="flex min-h-[2.5rem] w-full min-w-0 flex-col items-center justify-start gap-0.5">
+        <span className="line-clamp-2 text-[11px] font-semibold leading-tight text-stone-900">
+          {meta.name}
+        </span>
+        <span
+          className={`line-clamp-1 text-[10px] font-medium ${
+            hasComposioError ? 'text-amber-700' : composioStatusColor(connection)
+          }`}>
+          {statusLabel}
+        </span>
+      </div>
+    </button>
+  );
+}
+
 // ─── Built-in skill definitions ────────────────────────────────────────────────
 
 const BUILT_IN_SKILLS: Array<{
@@ -151,16 +243,13 @@ interface SkillItem {
   name: string;
   description: string;
   category: SkillCategory;
-  kind: 'builtin' | 'channel' | 'composio' | 'discovered';
+  kind: 'builtin' | 'channel' | 'discovered';
   // For built-in
   route?: string;
   icon?: React.ReactNode;
   // For channel
   channelDef?: ChannelDefinition;
   channelStatus?: ChannelConnectionStatus;
-  // For composio
-  composioToolkit?: ComposioToolkitMeta;
-  composioConnection?: ComposioConnection;
   // For discovered SKILL.md skills
   discoveredSkill?: SkillSummary;
 }
@@ -278,16 +367,6 @@ export default function Skills() {
     };
   }, [refreshDiscoveredSkills]);
 
-  useEffect(() => {
-    if (!IS_DEV) return;
-    console.debug('[skills][composio] hook result', {
-      toolkitCount: composioToolkits.length,
-      connectionCount: composioConnectionByToolkit.size,
-      hasError: Boolean(composioError),
-      error: composioError,
-    });
-  }, [composioToolkits, composioConnectionByToolkit, composioError]);
-
   const bestChannelStatus = (channelId: ChannelType): ChannelConnectionStatus => {
     const conns = channelConnections.connections[channelId];
     if (!conns) return 'disconnected';
@@ -350,24 +429,8 @@ export default function Skills() {
       });
     }
 
-    // Composio toolkits — rendered with the same UnifiedSkillCard used
-    // for channels/skills so they sit flush in the grid. Each entry is
-    // keyed by slug and routed through `ComposioConnectModal` for the
-    // authorize/OAuth/poll flow.
-    for (const slug of composioCatalogToolkits) {
-      const meta = composioToolkitMeta(slug);
-      const connection = composioConnectionByToolkit.get(meta.slug);
-      items.push({
-        id: `composio-${meta.slug}`,
-        name: meta.name,
-        description: meta.description,
-        category: meta.category,
-        kind: 'composio',
-        icon: meta.icon,
-        composioToolkit: meta,
-        composioConnection: connection,
-      });
-    }
+    // Composio toolkits are rendered in a dedicated icon grid (see below)
+    // so ~100+ connectors stay scannable without a vertical list per category.
 
     // Discovered SKILL.md skills — surface each as a card whose CTA opens
     // the detail drawer. They live under the generic "Other" category so
@@ -386,21 +449,63 @@ export default function Skills() {
 
     return items;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    configurableChannels,
-    channelConnections,
-    composioCatalogToolkits,
-    composioConnectionByToolkit,
-    discoveredSkills,
-  ]);
+  }, [configurableChannels, channelConnections, discoveredSkills]);
+
+  const composioGridEntries = useMemo(() => {
+    const entries: Array<{
+      meta: ComposioToolkitMeta;
+      connection: ComposioConnection | undefined;
+    }> = [];
+    for (const slug of composioCatalogToolkits) {
+      const meta = composioToolkitMeta(slug);
+      const connection = composioConnectionByToolkit.get(meta.slug);
+      entries.push({ meta, connection });
+    }
+    return entries;
+  }, [composioCatalogToolkits, composioConnectionByToolkit]);
+
+  const composioFilteredEntries = useMemo(() => {
+    const q = searchQuery.toLowerCase();
+    const matchesCategory =
+      selectedCategory === 'All'
+        ? () => true
+        : (meta: ComposioToolkitMeta) => meta.category === selectedCategory;
+    const matchesSearch = (meta: ComposioToolkitMeta) =>
+      !q || meta.name.toLowerCase().includes(q) || meta.description.toLowerCase().includes(q);
+
+    return composioGridEntries.filter(({ meta }) => matchesCategory(meta) && matchesSearch(meta));
+  }, [composioGridEntries, searchQuery, selectedCategory]);
+
+  const composioSortedEntries = useMemo(() => {
+    return [...composioFilteredEntries].sort((a, b) => {
+      const rankA = composioSortRank(a.connection);
+      const rankB = composioSortRank(b.connection);
+      if (rankA !== rankB) return rankA - rankB;
+      return a.meta.name.localeCompare(b.meta.name, undefined, { sensitivity: 'base' });
+    });
+  }, [composioFilteredEntries]);
+
+  useEffect(() => {
+    if (!IS_DEV) return;
+    console.debug('[skills][composio] hook result', {
+      toolkitCount: composioToolkits.length,
+      connectionCount: composioConnectionByToolkit.size,
+      hasError: Boolean(composioError),
+      error: composioError,
+      gridVisibleCount: composioSortedEntries.length,
+    });
+  }, [composioToolkits, composioConnectionByToolkit, composioError, composioSortedEntries.length]);
 
   const availableCategories: SkillCategory[] = useMemo(() => {
     const cats = new Set<SkillCategory>(['All']);
     for (const item of allItems) {
       cats.add(item.category);
     }
+    for (const { meta } of composioGridEntries) {
+      cats.add(meta.category);
+    }
     return SKILL_CATEGORY_ORDER.filter(c => cats.has(c));
-  }, [allItems]);
+  }, [allItems, composioGridEntries]);
 
   const filteredItems = useMemo(() => {
     const q = searchQuery.toLowerCase();
@@ -429,7 +534,7 @@ export default function Skills() {
     <div className="min-h-full">
       <div className="min-h-full flex flex-col">
         <div className="flex-1 flex items-start justify-center p-4 pt-6">
-          <div className="max-w-lg w-full space-y-4">
+          <div className="w-full max-w-4xl space-y-4">
             <div className="flex items-center justify-between gap-2">
               <div className="min-w-0">
                 <h1 className="text-base font-semibold text-stone-900">Skills</h1>
@@ -481,7 +586,33 @@ export default function Skills() {
               </div>
             )}
 
-            {filteredItems.length === 0 ? (
+            {composioSortedEntries.length > 0 && (
+              <div className="rounded-2xl border border-stone-200 bg-white p-3 shadow-soft animate-fade-up">
+                <div className="px-1 pb-3 pt-1">
+                  <h2 className="text-sm font-semibold text-stone-900">Integrations</h2>
+                  <p className="mt-0.5 text-[11px] leading-relaxed text-stone-500">
+                    Connect external apps. Connected services are sorted first and highlighted in
+                    green.
+                  </p>
+                </div>
+                <div
+                  className="grid gap-2 sm:gap-3"
+                  style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(5.5rem, 1fr))' }}>
+                  {composioSortedEntries.map(({ meta, connection }) => (
+                    <ComposioConnectorTile
+                      key={meta.slug}
+                      meta={meta}
+                      connection={connection}
+                      hasComposioError={Boolean(composioError)}
+                      onOpen={() => setComposioModalToolkit(meta)}
+                      onRetryGlobal={() => void refreshComposio()}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {filteredItems.length === 0 && composioSortedEntries.length === 0 ? (
               <div className="py-8 text-center">
                 <p className="text-sm text-stone-400">No connections found</p>
               </div>
@@ -690,55 +821,6 @@ export default function Skills() {
                                   ]
                                 : undefined
                             }
-                          />
-                        );
-                      }
-                      if (item.kind === 'composio') {
-                        const meta = item.composioToolkit!;
-                        const connection = item.composioConnection;
-                        const hasComposioError = Boolean(composioError);
-                        const state = hasComposioError ? 'error' : deriveComposioState(connection);
-                        const ctaLabel = hasComposioError
-                          ? 'Retry'
-                          : state === 'connected'
-                            ? 'Manage'
-                            : state === 'pending'
-                              ? 'Waiting'
-                              : state === 'error'
-                                ? 'Retry'
-                                : 'Connect';
-                        const ctaVariant: 'primary' | 'sage' | 'amber' =
-                          state === 'connected' ? 'sage' : state === 'error' ? 'amber' : 'primary';
-                        const description = hasComposioError
-                          ? `${item.description} ${composioError}`
-                          : item.description;
-                        return (
-                          <UnifiedSkillCard
-                            key={item.id}
-                            icon={item.icon}
-                            title={item.name}
-                            description={description}
-                            statusDot={
-                              hasComposioError ? 'bg-amber-500' : composioStatusDot(connection)
-                            }
-                            statusLabel={
-                              hasComposioError
-                                ? 'Status unavailable'
-                                : composioStatusLabel(connection)
-                            }
-                            statusColor={
-                              hasComposioError ? 'text-amber-700' : composioStatusColor(connection)
-                            }
-                            ctaLabel={ctaLabel}
-                            ctaVariant={ctaVariant}
-                            badge={<ConnectionBadge kind="composio" />}
-                            onCtaClick={() => {
-                              if (hasComposioError) {
-                                void refreshComposio();
-                                return;
-                              }
-                              setComposioModalToolkit(meta);
-                            }}
                           />
                         );
                       }

--- a/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
+++ b/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
@@ -40,14 +40,10 @@ describe('Skills page — Composio catalog fallback', () => {
     composioConnectionByToolkit = new Map();
   });
 
-  it('shows known composio integrations in their configured category groups when the live toolkit list is empty', () => {
+  it('shows known composio integrations in the integrations icon grid when the live toolkit list is empty', () => {
     renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
 
-    expect(screen.getByRole('heading', { name: 'Chat' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Productivity' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Tools & Automation' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Social' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Platform' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Integrations' })).toBeInTheDocument();
     expect(screen.getByText('Discord')).toBeInTheDocument();
     expect(screen.getByText('Google Calendar')).toBeInTheDocument();
     expect(screen.getByText('Google Drive')).toBeInTheDocument();
@@ -72,16 +68,15 @@ describe('Skills page — Composio catalog fallback', () => {
     expect(screen.getByText('Connections are showing stale status')).toBeInTheDocument();
     expect(screen.getByText('Backend unavailable')).toBeInTheDocument();
 
-    const productivitySection = screen
-      .getByRole('heading', { name: 'Productivity' })
+    const integrationsSection = screen
+      .getByRole('heading', { name: 'Integrations' })
       .closest('.rounded-2xl');
-    expect(productivitySection).not.toBeNull();
-    const gmailCard = within(productivitySection as HTMLElement)
-      .getByText('Gmail')
-      .closest('.rounded-xl');
-    expect(gmailCard).not.toBeNull();
-    expect(within(gmailCard as HTMLElement).getByText('Status unavailable')).toBeInTheDocument();
-    expect(within(gmailCard as HTMLElement).getByText(/Backend unavailable/)).toBeInTheDocument();
+    expect(integrationsSection).not.toBeNull();
+    const gmailTile = within(integrationsSection as HTMLElement).getByRole('button', {
+      name: /Gmail.*Status unavailable/i,
+    });
+    expect(gmailTile).toBeInTheDocument();
+    expect(within(gmailTile).getByText('Status unavailable')).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Retry' })[0]);
     expect(composioRefresh).toHaveBeenCalledTimes(1);

--- a/app/src/pages/__tests__/Skills.third-party-gmail-sync.test.tsx
+++ b/app/src/pages/__tests__/Skills.third-party-gmail-sync.test.tsx
@@ -33,15 +33,17 @@ describe('Skills page — Gmail composio integration', () => {
   it('renders Gmail as a connected composio integration and opens its management modal', async () => {
     renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
 
-    const productivitySection = screen
-      .getByRole('heading', { name: 'Productivity' })
+    const integrationsSection = screen
+      .getByRole('heading', { name: 'Integrations' })
       .closest('.rounded-2xl');
-    expect(productivitySection).not.toBeNull();
-    expect(within(productivitySection as HTMLElement).getByText('Gmail')).toBeInTheDocument();
-    expect(within(productivitySection as HTMLElement).getByText('Connected')).toBeInTheDocument();
+    expect(integrationsSection).not.toBeNull();
+    expect(within(integrationsSection as HTMLElement).getByText('Gmail')).toBeInTheDocument();
+    expect(within(integrationsSection as HTMLElement).getByText('Connected')).toBeInTheDocument();
 
     fireEvent.click(
-      within(productivitySection as HTMLElement).getByRole('button', { name: 'Manage' })
+      within(integrationsSection as HTMLElement).getByRole('button', {
+        name: /Gmail.*Connected.*Manage/i,
+      })
     );
 
     expect(await screen.findByRole('heading', { name: 'Manage Gmail' })).toBeInTheDocument();

--- a/app/src/pages/__tests__/Skills.third-party-notion-debug-tools.test.tsx
+++ b/app/src/pages/__tests__/Skills.third-party-notion-debug-tools.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import '../../test/mockDefaultSkillStatusHooks';
@@ -31,16 +31,11 @@ describe('Skills page — Notion composio integration', () => {
   it('renders Notion as a disconnected composio integration and opens its connect modal', async () => {
     renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
 
-    expect(screen.getByRole('heading', { name: 'Productivity' })).toBeInTheDocument();
-    const notionTitle = screen.getByText('Notion');
-    const notionCard = notionTitle.closest('div.flex-1')?.parentElement;
-    expect(notionCard).not.toBeNull();
-    expect(notionTitle).toBeInTheDocument();
-    expect(
-      within(notionCard as HTMLElement).getByRole('button', { name: 'Connect' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Integrations' })).toBeInTheDocument();
+    const notionTile = screen.getByRole('button', { name: /Notion.*Not connected.*Connect/i });
+    expect(notionTile).toBeInTheDocument();
 
-    fireEvent.click(within(notionCard as HTMLElement).getByRole('button', { name: 'Connect' }));
+    fireEvent.click(notionTile);
 
     expect(await screen.findByRole('heading', { name: 'Connect Notion' })).toBeInTheDocument();
     expect(screen.getByText(/Connect your Notion account through Composio/i)).toBeInTheDocument();


### PR DESCRIPTION
Replace per-category vertical lists of 100+ connector cards with a single Integrations section: responsive icon grid, connected-first sort, sage highlighting for active connections. Search and category filters apply to the grid; channels and discovered skills keep the existing card layout. Widen Skills page container for the grid.

## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [ ] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes:
- Follow-up PR(s)/TODOs:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated Integrations section on the Skills page
  * Third-party integrations now display in a separate grid with individual tiles
  * Each integration tile shows connection status and management options for improved accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->