### PR TITLE
feat(composio): client-side trigger enable/disable toggles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.8"
+version = "0.53.10"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -19,23 +19,18 @@ import { createPortal } from 'react-dom';
 import {
   authorize,
   deleteConnection,
-  disableTrigger,
-  enableTrigger,
   getUserScopes,
-  listAvailableTriggers,
   listConnections,
-  listTriggers,
   setUserScopes,
 } from '../../lib/composio/composioApi';
 import {
-  type ComposioActiveTrigger,
-  type ComposioAvailableTrigger,
   type ComposioConnection,
   type ComposioUserScopePref,
   deriveComposioState,
 } from '../../lib/composio/types';
 import { openUrl } from '../../utils/openUrl';
 import type { ComposioToolkitMeta } from './toolkitMeta';
+import TriggerToggles from './TriggerToggles';
 
 type Phase = 'idle' | 'authorizing' | 'waiting' | 'connected' | 'disconnecting' | 'error';
 
@@ -543,214 +538,6 @@ function ScopeToggles({ scopes, savingScope, onToggle, error }: ScopeTogglesProp
         })}
       </ul>
       {error && <p className="text-[11px] text-coral-600">{error}</p>}
-    </div>
-  );
-}
-
-// ── Trigger toggles ─────────────────────────────────────────────────
-
-/**
- * Stable signature for matching an `AvailableTrigger` to an
- * `ActiveTrigger`. Static toolkits key by slug; GitHub per-repo
- * triggers key by `slug::owner/repo` to disambiguate the same slug
- * across repos.
- */
-function triggerSignature(
-  slug: string,
-  scope: 'static' | 'github_repo',
-  config?: { owner?: string; repo?: string }
-): string {
-  if (scope === 'github_repo' && config?.owner && config?.repo) {
-    return `${slug.toUpperCase()}::${config.owner.toLowerCase()}/${config.repo.toLowerCase()}`;
-  }
-  return slug.toUpperCase();
-}
-
-function activeTriggerSignature(t: ComposioActiveTrigger): string {
-  const cfg = t.triggerConfig ?? {};
-  const owner = typeof cfg.owner === 'string' ? cfg.owner : undefined;
-  const repo = typeof cfg.repo === 'string' ? cfg.repo : undefined;
-  if (owner && repo) {
-    return `${t.slug.toUpperCase()}::${owner.toLowerCase()}/${repo.toLowerCase()}`;
-  }
-  return t.slug.toUpperCase();
-}
-
-interface TriggerTogglesProps {
-  toolkitSlug: string;
-  toolkitName: string;
-  connectionId: string;
-}
-
-function TriggerToggles({ toolkitSlug, toolkitName, connectionId }: TriggerTogglesProps) {
-  const [available, setAvailable] = useState<ComposioAvailableTrigger[] | null>(null);
-  const [activeBySignature, setActiveBySignature] = useState<Map<string, ComposioActiveTrigger>>(
-    new Map()
-  );
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [pendingSignature, setPendingSignature] = useState<string | null>(null);
-  const [rowError, setRowError] = useState<string | null>(null);
-
-  // Load both lists in parallel on mount / when connection changes.
-  useEffect(() => {
-    let cancelled = false;
-    setAvailable(null);
-    setActiveBySignature(new Map());
-    setLoadError(null);
-    void (async () => {
-      try {
-        const [avail, active] = await Promise.all([
-          listAvailableTriggers(toolkitSlug, connectionId),
-          listTriggers(toolkitSlug),
-        ]);
-        if (cancelled) return;
-        setAvailable(avail.triggers);
-        const map = new Map<string, ComposioActiveTrigger>();
-        for (const t of active.triggers) {
-          if (t.connectionId && t.connectionId !== connectionId) continue;
-          map.set(activeTriggerSignature(t), t);
-        }
-        setActiveBySignature(map);
-      } catch (err) {
-        if (cancelled) return;
-        const msg = err instanceof Error ? err.message : String(err);
-        setLoadError(`Couldn't load triggers: ${msg}`);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [toolkitSlug, connectionId]);
-
-  const handleToggle = useCallback(
-    async (entry: ComposioAvailableTrigger) => {
-      const config = entry.scope === 'github_repo' ? entry.repo : undefined;
-      const sig = triggerSignature(entry.slug, entry.scope, config);
-      if (pendingSignature) return;
-      setPendingSignature(sig);
-      setRowError(null);
-
-      const existing = activeBySignature.get(sig);
-      try {
-        if (existing) {
-          await disableTrigger(existing.id);
-          setActiveBySignature(prev => {
-            const next = new Map(prev);
-            next.delete(sig);
-            return next;
-          });
-        } else {
-          const triggerConfig =
-            entry.scope === 'github_repo' && entry.repo
-              ? { owner: entry.repo.owner, repo: entry.repo.repo }
-              : entry.defaultConfig;
-          const created = await enableTrigger(connectionId, entry.slug, triggerConfig);
-          setActiveBySignature(prev => {
-            const next = new Map(prev);
-            next.set(sig, {
-              id: created.triggerId,
-              slug: created.slug,
-              toolkit: toolkitSlug,
-              connectionId: created.connectionId,
-              ...(triggerConfig ? { triggerConfig } : {}),
-            });
-            return next;
-          });
-        }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        setRowError(`${existing ? 'Disable' : 'Enable'} failed for ${entry.slug}: ${msg}`);
-      } finally {
-        setPendingSignature(null);
-      }
-    },
-    [activeBySignature, connectionId, pendingSignature, toolkitSlug]
-  );
-
-  if (loadError) {
-    return (
-      <div className="border-t border-stone-100 pt-3 mt-1">
-        <p className="text-[11px] text-coral-600">{loadError}</p>
-      </div>
-    );
-  }
-
-  if (available === null) {
-    return (
-      <div className="border-t border-stone-100 pt-3 mt-1">
-        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
-        <p className="mt-1 text-[11px] text-stone-400">Loading…</p>
-      </div>
-    );
-  }
-
-  if (available.length === 0) {
-    return (
-      <div className="border-t border-stone-100 pt-3 mt-1">
-        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
-        <p className="mt-1 text-[11px] text-stone-400">
-          No triggers are currently available for {toolkitName}.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="border-t border-stone-100 pt-3 mt-1 space-y-2">
-      <div className="flex items-baseline justify-between">
-        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
-        <p className="text-[10px] text-stone-400">Listen for events from {toolkitName}</p>
-      </div>
-      <ul className="space-y-1.5 max-h-56 overflow-y-auto pr-1">
-        {available.map(entry => {
-          const config = entry.scope === 'github_repo' ? entry.repo : undefined;
-          const sig = triggerSignature(entry.slug, entry.scope, config);
-          const enabled = activeBySignature.has(sig);
-          const requiresConfig =
-            (entry.requiredConfigKeys?.length ?? 0) > 0 && entry.scope === 'static';
-          const isPending = pendingSignature === sig;
-          const disabled = requiresConfig || pendingSignature !== null;
-
-          const label =
-            entry.scope === 'github_repo' && entry.repo
-              ? `${entry.repo.owner}/${entry.repo.repo}`
-              : entry.slug;
-          const sub =
-            entry.scope === 'github_repo'
-              ? entry.slug
-              : requiresConfig
-                ? 'Needs configuration'
-                : '';
-
-          return (
-            <li
-              key={sig}
-              className="flex items-start justify-between gap-3 rounded-lg px-2 py-1.5 hover:bg-stone-50">
-              <div className="min-w-0 flex-1">
-                <span className="text-sm font-medium text-stone-900 break-all">{label}</span>
-                {sub && <p className="text-[11px] text-stone-400 leading-snug">{sub}</p>}
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={enabled}
-                aria-label={`${enabled ? 'Disable' : 'Enable'} ${entry.slug}`}
-                disabled={disabled}
-                onClick={() => void handleToggle(entry)}
-                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${
-                  enabled ? 'bg-primary-500' : 'bg-stone-300'
-                }`}>
-                <span
-                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
-                    enabled ? 'translate-x-5' : 'translate-x-0.5'
-                  } ${isPending ? 'animate-pulse' : ''}`}
-                />
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-      {rowError && <p className="text-[11px] text-coral-600">{rowError}</p>}
     </div>
   );
 }

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -19,11 +19,17 @@ import { createPortal } from 'react-dom';
 import {
   authorize,
   deleteConnection,
+  disableTrigger,
+  enableTrigger,
   getUserScopes,
+  listAvailableTriggers,
   listConnections,
+  listTriggers,
   setUserScopes,
 } from '../../lib/composio/composioApi';
 import {
+  type ComposioActiveTrigger,
+  type ComposioAvailableTrigger,
   type ComposioConnection,
   type ComposioUserScopePref,
   deriveComposioState,
@@ -414,6 +420,13 @@ export default function ComposioConnectModal({
                 onToggle={handleToggleScope}
                 error={scopeError}
               />
+              {activeConnection && (
+                <TriggerToggles
+                  toolkitSlug={toolkit.slug}
+                  toolkitName={toolkit.name}
+                  connectionId={activeConnection.id}
+                />
+              )}
               <div className="grid grid-cols-2 gap-3">
                 <button
                   type="button"
@@ -530,6 +543,214 @@ function ScopeToggles({ scopes, savingScope, onToggle, error }: ScopeTogglesProp
         })}
       </ul>
       {error && <p className="text-[11px] text-coral-600">{error}</p>}
+    </div>
+  );
+}
+
+// ── Trigger toggles ─────────────────────────────────────────────────
+
+/**
+ * Stable signature for matching an `AvailableTrigger` to an
+ * `ActiveTrigger`. Static toolkits key by slug; GitHub per-repo
+ * triggers key by `slug::owner/repo` to disambiguate the same slug
+ * across repos.
+ */
+function triggerSignature(
+  slug: string,
+  scope: 'static' | 'github_repo',
+  config?: { owner?: string; repo?: string }
+): string {
+  if (scope === 'github_repo' && config?.owner && config?.repo) {
+    return `${slug.toUpperCase()}::${config.owner.toLowerCase()}/${config.repo.toLowerCase()}`;
+  }
+  return slug.toUpperCase();
+}
+
+function activeTriggerSignature(t: ComposioActiveTrigger): string {
+  const cfg = t.triggerConfig ?? {};
+  const owner = typeof cfg.owner === 'string' ? cfg.owner : undefined;
+  const repo = typeof cfg.repo === 'string' ? cfg.repo : undefined;
+  if (owner && repo) {
+    return `${t.slug.toUpperCase()}::${owner.toLowerCase()}/${repo.toLowerCase()}`;
+  }
+  return t.slug.toUpperCase();
+}
+
+interface TriggerTogglesProps {
+  toolkitSlug: string;
+  toolkitName: string;
+  connectionId: string;
+}
+
+function TriggerToggles({ toolkitSlug, toolkitName, connectionId }: TriggerTogglesProps) {
+  const [available, setAvailable] = useState<ComposioAvailableTrigger[] | null>(null);
+  const [activeBySignature, setActiveBySignature] = useState<Map<string, ComposioActiveTrigger>>(
+    new Map()
+  );
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [pendingSignature, setPendingSignature] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  // Load both lists in parallel on mount / when connection changes.
+  useEffect(() => {
+    let cancelled = false;
+    setAvailable(null);
+    setActiveBySignature(new Map());
+    setLoadError(null);
+    void (async () => {
+      try {
+        const [avail, active] = await Promise.all([
+          listAvailableTriggers(toolkitSlug, connectionId),
+          listTriggers(toolkitSlug),
+        ]);
+        if (cancelled) return;
+        setAvailable(avail.triggers);
+        const map = new Map<string, ComposioActiveTrigger>();
+        for (const t of active.triggers) {
+          if (t.connectionId && t.connectionId !== connectionId) continue;
+          map.set(activeTriggerSignature(t), t);
+        }
+        setActiveBySignature(map);
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setLoadError(`Couldn't load triggers: ${msg}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [toolkitSlug, connectionId]);
+
+  const handleToggle = useCallback(
+    async (entry: ComposioAvailableTrigger) => {
+      const config = entry.scope === 'github_repo' ? entry.repo : undefined;
+      const sig = triggerSignature(entry.slug, entry.scope, config);
+      if (pendingSignature) return;
+      setPendingSignature(sig);
+      setRowError(null);
+
+      const existing = activeBySignature.get(sig);
+      try {
+        if (existing) {
+          await disableTrigger(existing.id);
+          setActiveBySignature(prev => {
+            const next = new Map(prev);
+            next.delete(sig);
+            return next;
+          });
+        } else {
+          const triggerConfig =
+            entry.scope === 'github_repo' && entry.repo
+              ? { owner: entry.repo.owner, repo: entry.repo.repo }
+              : entry.defaultConfig;
+          const created = await enableTrigger(connectionId, entry.slug, triggerConfig);
+          setActiveBySignature(prev => {
+            const next = new Map(prev);
+            next.set(sig, {
+              id: created.triggerId,
+              slug: created.slug,
+              toolkit: toolkitSlug,
+              connectionId: created.connectionId,
+              ...(triggerConfig ? { triggerConfig } : {}),
+            });
+            return next;
+          });
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setRowError(`${existing ? 'Disable' : 'Enable'} failed for ${entry.slug}: ${msg}`);
+      } finally {
+        setPendingSignature(null);
+      }
+    },
+    [activeBySignature, connectionId, pendingSignature, toolkitSlug]
+  );
+
+  if (loadError) {
+    return (
+      <div className="border-t border-stone-100 pt-3 mt-1">
+        <p className="text-[11px] text-coral-600">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (available === null) {
+    return (
+      <div className="border-t border-stone-100 pt-3 mt-1">
+        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
+        <p className="mt-1 text-[11px] text-stone-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (available.length === 0) {
+    return (
+      <div className="border-t border-stone-100 pt-3 mt-1">
+        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
+        <p className="mt-1 text-[11px] text-stone-400">
+          No triggers are currently available for {toolkitName}.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-stone-100 pt-3 mt-1 space-y-2">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
+        <p className="text-[10px] text-stone-400">Listen for events from {toolkitName}</p>
+      </div>
+      <ul className="space-y-1.5 max-h-56 overflow-y-auto pr-1">
+        {available.map(entry => {
+          const config = entry.scope === 'github_repo' ? entry.repo : undefined;
+          const sig = triggerSignature(entry.slug, entry.scope, config);
+          const enabled = activeBySignature.has(sig);
+          const requiresConfig =
+            (entry.requiredConfigKeys?.length ?? 0) > 0 && entry.scope === 'static';
+          const isPending = pendingSignature === sig;
+          const disabled = requiresConfig || pendingSignature !== null;
+
+          const label =
+            entry.scope === 'github_repo' && entry.repo
+              ? `${entry.repo.owner}/${entry.repo.repo}`
+              : entry.slug;
+          const sub =
+            entry.scope === 'github_repo'
+              ? entry.slug
+              : requiresConfig
+                ? 'Needs configuration'
+                : '';
+
+          return (
+            <li
+              key={sig}
+              className="flex items-start justify-between gap-3 rounded-lg px-2 py-1.5 hover:bg-stone-50">
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium text-stone-900 break-all">{label}</span>
+                {sub && <p className="text-[11px] text-stone-400 leading-snug">{sub}</p>}
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                aria-label={`${enabled ? 'Disable' : 'Enable'} ${entry.slug}`}
+                disabled={disabled}
+                onClick={() => void handleToggle(entry)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  enabled ? 'bg-primary-500' : 'bg-stone-300'
+                }`}>
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                    enabled ? 'translate-x-5' : 'translate-x-0.5'
+                  } ${isPending ? 'animate-pulse' : ''}`}
+                />
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {rowError && <p className="text-[11px] text-coral-600">{rowError}</p>}
     </div>
   );
 }

--- a/app/src/components/composio/TriggerToggles.test.tsx
+++ b/app/src/components/composio/TriggerToggles.test.tsx
@@ -1,0 +1,246 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TriggerToggles, { activeTriggerSignature, triggerSignature } from './TriggerToggles';
+
+const mockListAvailable = vi.fn();
+const mockListTriggers = vi.fn();
+const mockEnable = vi.fn();
+const mockDisable = vi.fn();
+
+vi.mock('../../lib/composio/composioApi', () => ({
+  listAvailableTriggers: (toolkit: string, conn?: string) => mockListAvailable(toolkit, conn),
+  listTriggers: (toolkit?: string) => mockListTriggers(toolkit),
+  enableTrigger: (conn: string, slug: string, cfg?: Record<string, unknown>) =>
+    mockEnable(conn, slug, cfg),
+  disableTrigger: (id: string) => mockDisable(id),
+}));
+
+beforeEach(() => {
+  mockListAvailable.mockReset();
+  mockListTriggers.mockReset();
+  mockEnable.mockReset();
+  mockDisable.mockReset();
+});
+
+describe('triggerSignature / activeTriggerSignature', () => {
+  it('keys static triggers by uppercase slug', () => {
+    expect(triggerSignature('gmail_new', 'static')).toBe('GMAIL_NEW');
+  });
+
+  it('keys github triggers by slug + lowercase owner/repo', () => {
+    expect(
+      triggerSignature('GITHUB_PUSH_EVENT', 'github_repo', { owner: 'Acme', repo: 'API' })
+    ).toBe('GITHUB_PUSH_EVENT::acme/api');
+  });
+
+  it('falls back to slug when owner/repo are missing on a github_repo entry', () => {
+    expect(triggerSignature('GITHUB_PUSH_EVENT', 'github_repo')).toBe('GITHUB_PUSH_EVENT');
+  });
+
+  it('matches active trigger signature using triggerConfig.owner/repo', () => {
+    expect(
+      activeTriggerSignature({
+        id: 't1',
+        slug: 'github_push_event',
+        toolkit: 'github',
+        connectionId: 'c1',
+        triggerConfig: { owner: 'Acme', repo: 'API' },
+      })
+    ).toBe('GITHUB_PUSH_EVENT::acme/api');
+  });
+
+  it('falls back to slug when triggerConfig has no owner/repo', () => {
+    expect(
+      activeTriggerSignature({ id: 't2', slug: 'GMAIL_NEW', toolkit: 'gmail', connectionId: 'c1' })
+    ).toBe('GMAIL_NEW');
+  });
+});
+
+describe('<TriggerToggles>', () => {
+  it('renders Loading then a list of available triggers', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [{ slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' }],
+    });
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Enable GMAIL_NEW_GMAIL_MESSAGE/)).toBeInTheDocument()
+    );
+    expect(mockListAvailable).toHaveBeenCalledWith('gmail', 'c1');
+    expect(mockListTriggers).toHaveBeenCalledWith('gmail');
+  });
+
+  it('renders the empty state when no triggers are available', async () => {
+    mockListAvailable.mockResolvedValue({ triggers: [] });
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+
+    render(<TriggerToggles toolkitSlug="notion" toolkitName="Notion" connectionId="c1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No triggers are currently available for Notion.')
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('shows a load error when both lists fail', async () => {
+    mockListAvailable.mockRejectedValue(new Error('boom'));
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load triggers: boom/)).toBeInTheDocument()
+    );
+  });
+
+  it('marks a trigger as enabled when present in active list (matched by signature)', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [{ slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' }],
+    });
+    mockListTriggers.mockResolvedValue({
+      triggers: [
+        { id: 't1', slug: 'GMAIL_NEW_GMAIL_MESSAGE', toolkit: 'gmail', connectionId: 'c1' },
+      ],
+    });
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    const sw = await screen.findByLabelText(/Disable GMAIL_NEW_GMAIL_MESSAGE/);
+    expect(sw).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('ignores active triggers attached to a different connection', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [{ slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' }],
+    });
+    mockListTriggers.mockResolvedValue({
+      triggers: [
+        { id: 't1', slug: 'GMAIL_NEW_GMAIL_MESSAGE', toolkit: 'gmail', connectionId: 'OTHER' },
+      ],
+    });
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    const sw = await screen.findByLabelText(/Enable GMAIL_NEW_GMAIL_MESSAGE/);
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('disables and shows a hint for static triggers that require config', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [{ slug: 'SLACK_NEW_MESSAGE', scope: 'static', requiredConfigKeys: ['channel'] }],
+    });
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+
+    render(<TriggerToggles toolkitSlug="slack" toolkitName="Slack" connectionId="c1" />);
+
+    const sw = await screen.findByLabelText(/Enable SLACK_NEW_MESSAGE/);
+    expect(sw).toBeDisabled();
+    expect(screen.getByText('Needs configuration')).toBeInTheDocument();
+  });
+
+  it('enables a trigger via enableTrigger and flips the toggle on', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [
+        { slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static', defaultConfig: { labelIds: 'INBOX' } },
+      ],
+    });
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+    mockEnable.mockResolvedValue({
+      triggerId: 'ti_1',
+      slug: 'GMAIL_NEW_GMAIL_MESSAGE',
+      connectionId: 'c1',
+    });
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    const sw = await screen.findByLabelText(/Enable GMAIL_NEW_GMAIL_MESSAGE/);
+    fireEvent.click(sw);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Disable GMAIL_NEW_GMAIL_MESSAGE/)).toHaveAttribute(
+        'aria-checked',
+        'true'
+      )
+    );
+    expect(mockEnable).toHaveBeenCalledWith('c1', 'GMAIL_NEW_GMAIL_MESSAGE', { labelIds: 'INBOX' });
+  });
+
+  it('renders github_repo entries with owner/repo label and forwards repo as triggerConfig on enable', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [
+        {
+          slug: 'GITHUB_PUSH_EVENT',
+          scope: 'github_repo',
+          repo: { owner: 'acme', repo: 'api' },
+          defaultConfig: { owner: 'acme', repo: 'api' },
+        },
+      ],
+    });
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+    mockEnable.mockResolvedValue({
+      triggerId: 'ti_g',
+      slug: 'GITHUB_PUSH_EVENT',
+      connectionId: 'c1',
+    });
+
+    render(<TriggerToggles toolkitSlug="github" toolkitName="GitHub" connectionId="c1" />);
+
+    expect(await screen.findByText('acme/api')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Enable GITHUB_PUSH_EVENT/));
+
+    await waitFor(() => expect(mockEnable).toHaveBeenCalled());
+    expect(mockEnable).toHaveBeenCalledWith('c1', 'GITHUB_PUSH_EVENT', {
+      owner: 'acme',
+      repo: 'api',
+    });
+  });
+
+  it('disables a trigger via disableTrigger and flips the toggle off', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [{ slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' }],
+    });
+    mockListTriggers.mockResolvedValue({
+      triggers: [
+        { id: 't1', slug: 'GMAIL_NEW_GMAIL_MESSAGE', toolkit: 'gmail', connectionId: 'c1' },
+      ],
+    });
+    mockDisable.mockResolvedValue({ deleted: true });
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    const sw = await screen.findByLabelText(/Disable GMAIL_NEW_GMAIL_MESSAGE/);
+    fireEvent.click(sw);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Enable GMAIL_NEW_GMAIL_MESSAGE/)).toHaveAttribute(
+        'aria-checked',
+        'false'
+      )
+    );
+    expect(mockDisable).toHaveBeenCalledWith('t1');
+  });
+
+  it('surfaces an error message when enableTrigger fails', async () => {
+    mockListAvailable.mockResolvedValue({
+      triggers: [{ slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' }],
+    });
+    mockListTriggers.mockResolvedValue({ triggers: [] });
+    mockEnable.mockRejectedValue(new Error('upstream 500'));
+
+    render(<TriggerToggles toolkitSlug="gmail" toolkitName="Gmail" connectionId="c1" />);
+
+    fireEvent.click(await screen.findByLabelText(/Enable GMAIL_NEW_GMAIL_MESSAGE/));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Enable failed for GMAIL_NEW_GMAIL_MESSAGE: upstream 500/)
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/app/src/components/composio/TriggerToggles.tsx
+++ b/app/src/components/composio/TriggerToggles.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  disableTrigger,
+  enableTrigger,
+  listAvailableTriggers,
+  listTriggers,
+} from '../../lib/composio/composioApi';
+import type { ComposioActiveTrigger, ComposioAvailableTrigger } from '../../lib/composio/types';
+
+/**
+ * Stable signature for matching an `AvailableTrigger` to an
+ * `ActiveTrigger`. Static toolkits key by slug; GitHub per-repo
+ * triggers key by `slug::owner/repo` to disambiguate the same slug
+ * across repos.
+ */
+export function triggerSignature(
+  slug: string,
+  scope: 'static' | 'github_repo',
+  config?: { owner?: string; repo?: string }
+): string {
+  if (scope === 'github_repo' && config?.owner && config?.repo) {
+    return `${slug.toUpperCase()}::${config.owner.toLowerCase()}/${config.repo.toLowerCase()}`;
+  }
+  return slug.toUpperCase();
+}
+
+export function activeTriggerSignature(t: ComposioActiveTrigger): string {
+  const cfg = t.triggerConfig ?? {};
+  const owner = typeof cfg.owner === 'string' ? cfg.owner : undefined;
+  const repo = typeof cfg.repo === 'string' ? cfg.repo : undefined;
+  if (owner && repo) {
+    return `${t.slug.toUpperCase()}::${owner.toLowerCase()}/${repo.toLowerCase()}`;
+  }
+  return t.slug.toUpperCase();
+}
+
+export interface TriggerTogglesProps {
+  toolkitSlug: string;
+  toolkitName: string;
+  connectionId: string;
+}
+
+export default function TriggerToggles({
+  toolkitSlug,
+  toolkitName,
+  connectionId,
+}: TriggerTogglesProps) {
+  const [available, setAvailable] = useState<ComposioAvailableTrigger[] | null>(null);
+  const [activeBySignature, setActiveBySignature] = useState<Map<string, ComposioActiveTrigger>>(
+    new Map()
+  );
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [pendingSignature, setPendingSignature] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  // Load both lists in parallel on mount / when connection changes.
+  useEffect(() => {
+    let cancelled = false;
+    setAvailable(null);
+    setActiveBySignature(new Map());
+    setLoadError(null);
+    void (async () => {
+      try {
+        const [avail, active] = await Promise.all([
+          listAvailableTriggers(toolkitSlug, connectionId),
+          listTriggers(toolkitSlug),
+        ]);
+        if (cancelled) return;
+        setAvailable(avail.triggers);
+        const map = new Map<string, ComposioActiveTrigger>();
+        for (const t of active.triggers) {
+          if (t.connectionId && t.connectionId !== connectionId) continue;
+          map.set(activeTriggerSignature(t), t);
+        }
+        setActiveBySignature(map);
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setLoadError(`Couldn't load triggers: ${msg}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [toolkitSlug, connectionId]);
+
+  const handleToggle = useCallback(
+    async (entry: ComposioAvailableTrigger) => {
+      const config = entry.scope === 'github_repo' ? entry.repo : undefined;
+      const sig = triggerSignature(entry.slug, entry.scope, config);
+      if (pendingSignature) return;
+      setPendingSignature(sig);
+      setRowError(null);
+
+      const existing = activeBySignature.get(sig);
+      try {
+        if (existing) {
+          await disableTrigger(existing.id);
+          setActiveBySignature(prev => {
+            const next = new Map(prev);
+            next.delete(sig);
+            return next;
+          });
+        } else {
+          const triggerConfig =
+            entry.scope === 'github_repo' && entry.repo
+              ? { owner: entry.repo.owner, repo: entry.repo.repo }
+              : entry.defaultConfig;
+          const created = await enableTrigger(connectionId, entry.slug, triggerConfig);
+          setActiveBySignature(prev => {
+            const next = new Map(prev);
+            next.set(sig, {
+              id: created.triggerId,
+              slug: created.slug,
+              toolkit: toolkitSlug,
+              connectionId: created.connectionId,
+              ...(triggerConfig ? { triggerConfig } : {}),
+            });
+            return next;
+          });
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setRowError(`${existing ? 'Disable' : 'Enable'} failed for ${entry.slug}: ${msg}`);
+      } finally {
+        setPendingSignature(null);
+      }
+    },
+    [activeBySignature, connectionId, pendingSignature, toolkitSlug]
+  );
+
+  if (loadError) {
+    return (
+      <div className="border-t border-stone-100 pt-3 mt-1">
+        <p className="text-[11px] text-coral-600">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (available === null) {
+    return (
+      <div className="border-t border-stone-100 pt-3 mt-1">
+        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
+        <p className="mt-1 text-[11px] text-stone-400">Loading…</p>
+      </div>
+    );
+  }
+
+  if (available.length === 0) {
+    return (
+      <div className="border-t border-stone-100 pt-3 mt-1">
+        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
+        <p className="mt-1 text-[11px] text-stone-400">
+          No triggers are currently available for {toolkitName}.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-stone-100 pt-3 mt-1 space-y-2" data-testid="trigger-toggles">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-xs font-semibold text-stone-700 uppercase tracking-wide">Triggers</h3>
+        <p className="text-[10px] text-stone-400">Listen for events from {toolkitName}</p>
+      </div>
+      <ul className="space-y-1.5 max-h-56 overflow-y-auto pr-1">
+        {available.map(entry => {
+          const config = entry.scope === 'github_repo' ? entry.repo : undefined;
+          const sig = triggerSignature(entry.slug, entry.scope, config);
+          const enabled = activeBySignature.has(sig);
+          const requiresConfig =
+            (entry.requiredConfigKeys?.length ?? 0) > 0 && entry.scope === 'static';
+          const isPending = pendingSignature === sig;
+          const disabled = requiresConfig || pendingSignature !== null;
+
+          const label =
+            entry.scope === 'github_repo' && entry.repo
+              ? `${entry.repo.owner}/${entry.repo.repo}`
+              : entry.slug;
+          const sub =
+            entry.scope === 'github_repo'
+              ? entry.slug
+              : requiresConfig
+                ? 'Needs configuration'
+                : '';
+
+          return (
+            <li
+              key={sig}
+              data-testid={`trigger-row-${sig}`}
+              className="flex items-start justify-between gap-3 rounded-lg px-2 py-1.5 hover:bg-stone-50">
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium text-stone-900 break-all">{label}</span>
+                {sub && <p className="text-[11px] text-stone-400 leading-snug">{sub}</p>}
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                aria-label={`${enabled ? 'Disable' : 'Enable'} ${entry.slug}`}
+                disabled={disabled}
+                onClick={() => void handleToggle(entry)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${
+                  enabled ? 'bg-primary-500' : 'bg-stone-300'
+                }`}>
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                    enabled ? 'translate-x-5' : 'translate-x-0.5'
+                  } ${isPending ? 'animate-pulse' : ''}`}
+                />
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {rowError && <p className="text-[11px] text-coral-600">{rowError}</p>}
+    </div>
+  );
+}

--- a/app/src/lib/composio/composioApi.test.ts
+++ b/app/src/lib/composio/composioApi.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { disableTrigger, enableTrigger, listAvailableTriggers, listTriggers } from './composioApi';
+
+const mockCallCoreRpc = vi.fn();
+
+vi.mock('../../services/coreRpcClient', () => ({
+  callCoreRpc: (args: unknown) => mockCallCoreRpc(args),
+}));
+
+describe('composioApi trigger wrappers', () => {
+  beforeEach(() => {
+    mockCallCoreRpc.mockReset();
+  });
+
+  it('listAvailableTriggers passes toolkit + optional connection_id and unwraps the envelope', async () => {
+    mockCallCoreRpc.mockResolvedValue({
+      result: { triggers: [{ slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' }] },
+      logs: ['composio: 1 available trigger(s) for toolkit gmail'],
+    });
+
+    const out = await listAvailableTriggers('gmail', 'conn_1');
+
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_list_available_triggers',
+      params: { toolkit: 'gmail', connection_id: 'conn_1' },
+    });
+    expect(out.triggers).toHaveLength(1);
+    expect(out.triggers[0].scope).toBe('static');
+  });
+
+  it('listAvailableTriggers omits connection_id when not provided', async () => {
+    mockCallCoreRpc.mockResolvedValue({ triggers: [] });
+    await listAvailableTriggers('gmail');
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_list_available_triggers',
+      params: { toolkit: 'gmail' },
+    });
+  });
+
+  it('listTriggers omits filters when no toolkit is given', async () => {
+    mockCallCoreRpc.mockResolvedValue({ result: { triggers: [] }, logs: [] });
+    await listTriggers();
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_list_triggers',
+      params: {},
+    });
+  });
+
+  it('listTriggers forwards toolkit filter', async () => {
+    mockCallCoreRpc.mockResolvedValue({ triggers: [] });
+    await listTriggers('gmail');
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_list_triggers',
+      params: { toolkit: 'gmail' },
+    });
+  });
+
+  it('enableTrigger forwards trigger_config when provided', async () => {
+    mockCallCoreRpc.mockResolvedValue({
+      result: { triggerId: 'ti_1', slug: 'GMAIL_NEW_GMAIL_MESSAGE', connectionId: 'c1' },
+      logs: [],
+    });
+
+    const out = await enableTrigger('c1', 'GMAIL_NEW_GMAIL_MESSAGE', { labelIds: 'INBOX' });
+
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_enable_trigger',
+      params: {
+        connection_id: 'c1',
+        slug: 'GMAIL_NEW_GMAIL_MESSAGE',
+        trigger_config: { labelIds: 'INBOX' },
+      },
+    });
+    expect(out.triggerId).toBe('ti_1');
+  });
+
+  it('enableTrigger omits trigger_config when not provided', async () => {
+    mockCallCoreRpc.mockResolvedValue({ triggerId: 'ti_2', slug: 'X', connectionId: 'c1' });
+    await enableTrigger('c1', 'X');
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_enable_trigger',
+      params: { connection_id: 'c1', slug: 'X' },
+    });
+  });
+
+  it('disableTrigger forwards trigger_id', async () => {
+    mockCallCoreRpc.mockResolvedValue({ result: { deleted: true }, logs: [] });
+    const out = await disableTrigger('ti_1');
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.composio_disable_trigger',
+      params: { trigger_id: 'ti_1' },
+    });
+    expect(out.deleted).toBe(true);
+  });
+});

--- a/app/src/lib/composio/composioApi.ts
+++ b/app/src/lib/composio/composioApi.ts
@@ -12,9 +12,13 @@
  */
 import { callCoreRpc } from '../../services/coreRpcClient';
 import type {
+  ComposioActiveTriggersResponse,
   ComposioAuthorizeResponse,
+  ComposioAvailableTriggersResponse,
   ComposioConnectionsResponse,
   ComposioDeleteResponse,
+  ComposioDisableTriggerResponse,
+  ComposioEnableTriggerResponse,
   ComposioExecuteResponse,
   ComposioToolkitsResponse,
   ComposioToolsResponse,
@@ -151,4 +155,60 @@ export async function execute(
     params: { tool, arguments: args ?? {} },
   });
   return unwrapCliEnvelope<ComposioExecuteResponse>(raw);
+}
+
+// ── Trigger management ────────────────────────────────────────────
+
+/**
+ * List the catalog of triggers the user could enable for a toolkit.
+ * For GitHub, the backend fans out into per-repo entries — pass the
+ * GitHub `connectionId` (or the user's first GitHub connection is
+ * picked by the backend).
+ */
+export async function listAvailableTriggers(
+  toolkit: string,
+  connectionId?: string
+): Promise<ComposioAvailableTriggersResponse> {
+  const params: Record<string, unknown> = { toolkit };
+  if (connectionId) params.connection_id = connectionId;
+  const raw = await callCoreRpc<unknown>({
+    method: 'openhuman.composio_list_available_triggers',
+    params,
+  });
+  return unwrapCliEnvelope<ComposioAvailableTriggersResponse>(raw);
+}
+
+/**
+ * List the user's currently enabled Composio triggers.
+ */
+export async function listTriggers(toolkit?: string): Promise<ComposioActiveTriggersResponse> {
+  const params: Record<string, unknown> = {};
+  if (toolkit) params.toolkit = toolkit;
+  const raw = await callCoreRpc<unknown>({ method: 'openhuman.composio_list_triggers', params });
+  return unwrapCliEnvelope<ComposioActiveTriggersResponse>(raw);
+}
+
+/**
+ * Enable a single trigger on a connection the caller owns.
+ */
+export async function enableTrigger(
+  connectionId: string,
+  slug: string,
+  triggerConfig?: Record<string, unknown>
+): Promise<ComposioEnableTriggerResponse> {
+  const params: Record<string, unknown> = { connection_id: connectionId, slug };
+  if (triggerConfig !== undefined) params.trigger_config = triggerConfig;
+  const raw = await callCoreRpc<unknown>({ method: 'openhuman.composio_enable_trigger', params });
+  return unwrapCliEnvelope<ComposioEnableTriggerResponse>(raw);
+}
+
+/**
+ * Disable (delete) a trigger owned by the caller.
+ */
+export async function disableTrigger(triggerId: string): Promise<ComposioDisableTriggerResponse> {
+  const raw = await callCoreRpc<unknown>({
+    method: 'openhuman.composio_disable_trigger',
+    params: { trigger_id: triggerId },
+  });
+  return unwrapCliEnvelope<ComposioDisableTriggerResponse>(raw);
 }

--- a/app/src/lib/composio/types.ts
+++ b/app/src/lib/composio/types.ts
@@ -66,6 +66,45 @@ export interface ComposioUserScopePref {
   admin: boolean;
 }
 
+// ── Trigger management ─────────────────────────────────────────────
+
+export type ComposioAvailableTriggerScope = 'static' | 'github_repo';
+
+export interface ComposioAvailableTrigger {
+  slug: string;
+  scope: ComposioAvailableTriggerScope;
+  defaultConfig?: Record<string, unknown>;
+  requiredConfigKeys?: string[];
+  repo?: { owner: string; repo: string };
+}
+
+export interface ComposioAvailableTriggersResponse {
+  triggers: ComposioAvailableTrigger[];
+}
+
+export interface ComposioActiveTrigger {
+  id: string;
+  slug: string;
+  toolkit: string;
+  connectionId: string;
+  triggerConfig?: Record<string, unknown>;
+  state?: string;
+}
+
+export interface ComposioActiveTriggersResponse {
+  triggers: ComposioActiveTrigger[];
+}
+
+export interface ComposioEnableTriggerResponse {
+  triggerId: string;
+  slug: string;
+  connectionId: string;
+}
+
+export interface ComposioDisableTriggerResponse {
+  deleted: boolean;
+}
+
 // ── UI helpers ────────────────────────────────────────────────────
 
 /**

--- a/app/test/e2e/specs/composio-triggers-flow.spec.ts
+++ b/app/test/e2e/specs/composio-triggers-flow.spec.ts
@@ -1,0 +1,162 @@
+// @ts-nocheck
+/**
+ * End-to-end: client-side Composio trigger toggles (PR for backend #671).
+ *
+ * Drives the new `openhuman.composio_*` trigger RPC methods through the
+ * running core sidecar against the shared mock backend, then opens the
+ * Composio connection modal and asserts the Triggers section renders
+ * the expected toggle for an ACTIVE Gmail connection.
+ *
+ * The mock backend (`scripts/mock-api-core.mjs`) seeds:
+ *   - one ACTIVE Gmail connection (`c1`)
+ *   - one available trigger (`GMAIL_NEW_GMAIL_MESSAGE`)
+ *   - an empty active-trigger list that mutates as enable/disable run
+ *
+ * RPC behavior is deterministic across platforms; the UI assertion only
+ * runs when accessibility queries reach the WebView and tolerates
+ * regression-free skip on locked-down hosts.
+ */
+import { waitForApp, waitForAppReady } from '../helpers/app-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import { clearRequestLog, setMockBehavior, startMockServer, stopMockServer } from '../mock-server';
+
+const LOG = '[ComposioTriggersE2E]';
+
+function step(msg: string, ctx?: unknown) {
+  if (ctx === undefined) console.log(`${LOG} ${msg}`);
+  else console.log(`${LOG} ${msg}`, JSON.stringify(ctx, null, 2));
+}
+
+describe('Composio trigger toggles (UI + core RPC)', () => {
+  before(async () => {
+    await startMockServer();
+    setMockBehavior(
+      'composioConnections',
+      JSON.stringify([{ id: 'c1', toolkit: 'gmail', status: 'ACTIVE' }])
+    );
+    setMockBehavior(
+      'composioAvailableTriggers',
+      JSON.stringify([
+        { slug: 'GMAIL_NEW_GMAIL_MESSAGE', scope: 'static' },
+        { slug: 'SLACK_NEW_MESSAGE', scope: 'static', requiredConfigKeys: ['channel'] },
+      ])
+    );
+    setMockBehavior('composioActiveTriggers', JSON.stringify([]));
+    await waitForApp();
+    clearRequestLog();
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  it('signs in deterministically', async () => {
+    await triggerAuthDeepLinkBypass('e2e-composio-triggers-token');
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await waitForAppReady(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  it('list_available_triggers returns the seeded Gmail catalog', async () => {
+    const out = await callOpenhumanRpc('openhuman.composio_list_available_triggers', {
+      toolkit: 'gmail',
+      connection_id: 'c1',
+    });
+    expect(out.ok).toBe(true);
+    const result = out.value?.result ?? out.value;
+    const triggers = result?.triggers ?? [];
+    const slugs = triggers.map((t: any) => t.slug);
+    expect(slugs).toContain('GMAIL_NEW_GMAIL_MESSAGE');
+    expect(slugs).toContain('SLACK_NEW_MESSAGE');
+  });
+
+  it('list_triggers starts empty for the seeded user', async () => {
+    const out = await callOpenhumanRpc('openhuman.composio_list_triggers', {});
+    expect(out.ok).toBe(true);
+    const result = out.value?.result ?? out.value;
+    expect(result.triggers ?? []).toHaveLength(0);
+  });
+
+  it('enable_trigger creates a trigger that subsequent list calls observe', async () => {
+    const enable = await callOpenhumanRpc('openhuman.composio_enable_trigger', {
+      connection_id: 'c1',
+      slug: 'GMAIL_NEW_GMAIL_MESSAGE',
+    });
+    expect(enable.ok).toBe(true);
+    const created = enable.value?.result ?? enable.value;
+    expect(created.slug).toBe('GMAIL_NEW_GMAIL_MESSAGE');
+    expect(created.connectionId).toBe('c1');
+    expect(typeof created.triggerId).toBe('string');
+    expect(created.triggerId.length).toBeGreaterThan(0);
+
+    const list = await callOpenhumanRpc('openhuman.composio_list_triggers', { toolkit: 'gmail' });
+    const result = list.value?.result ?? list.value;
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].slug).toBe('GMAIL_NEW_GMAIL_MESSAGE');
+  });
+
+  it('disable_trigger removes the active trigger', async () => {
+    const list = await callOpenhumanRpc('openhuman.composio_list_triggers', {});
+    const beforeResult = list.value?.result ?? list.value;
+    const triggerId = beforeResult.triggers[0]?.id;
+    expect(typeof triggerId).toBe('string');
+
+    const disable = await callOpenhumanRpc('openhuman.composio_disable_trigger', {
+      trigger_id: triggerId,
+    });
+    expect(disable.ok).toBe(true);
+    const out = disable.value?.result ?? disable.value;
+    expect(out.deleted).toBe(true);
+
+    const after = await callOpenhumanRpc('openhuman.composio_list_triggers', {});
+    const afterResult = after.value?.result ?? after.value;
+    expect(afterResult.triggers ?? []).toHaveLength(0);
+  });
+
+  it('Triggers section renders in the Composio modal for an ACTIVE connection', async () => {
+    // Seed one active trigger so the modal shows both the enabled and
+    // available rows when it loads.
+    setMockBehavior(
+      'composioActiveTriggers',
+      JSON.stringify([
+        { id: 'ti-seeded', slug: 'GMAIL_NEW_GMAIL_MESSAGE', toolkit: 'gmail', connectionId: 'c1' },
+      ])
+    );
+
+    await navigateToSkills();
+
+    // The Skills page card for an ACTIVE Composio connection exposes a
+    // "Manage" affordance that opens the modal. We don't depend on a
+    // specific click target — accessibility text on either platform
+    // surfaces "Triggers" once the modal mounts.
+    const manageVisible = await waitForText('Manage', 10_000);
+    if (!manageVisible) {
+      step('Skills page did not surface a Manage affordance — skipping UI assertion');
+      return;
+    }
+
+    // Open whichever Manage button corresponds to Gmail. The modal then
+    // loads available + active triggers via the new RPCs.
+    try {
+      const el = await $('button=Manage');
+      if (el && (await el.isExisting())) {
+        await el.click();
+      }
+    } catch (err) {
+      step('Could not click Manage button', { err: String(err) });
+    }
+
+    const sectionVisible =
+      (await waitForText('Triggers', 10_000)) || (await textExists('GMAIL_NEW_GMAIL_MESSAGE'));
+    expect(sectionVisible).toBe(true);
+  });
+});

--- a/scripts/mock-api-core.mjs
+++ b/scripts/mock-api-core.mjs
@@ -1099,12 +1099,105 @@ async function handleRequest(req, res) {
     return;
   }
 
+  // ── Composio routes (used by trigger-toggles E2E spec) ────────────
+  //
+  // Behavior knobs (set via /__admin/behavior):
+  //   composioConnections        — JSON array, default `[{id:'c1',toolkit:'gmail',status:'ACTIVE'}]`
+  //   composioAvailableTriggers  — JSON array, default one Gmail trigger
+  //   composioActiveTriggers     — JSON array, default empty
+  //   composioEnableFails        — '1' to make POST /triggers return 500
+  //
+  // Enable/disable requests mutate `composioActiveTriggers` in place so the
+  // UI can poll subsequent reads and observe the change.
+  if (
+    method === "GET" &&
+    /^\/agent-integrations\/composio\/connections\/?(\?.*)?$/.test(url)
+  ) {
+    const connections = parseBehaviorJson(
+      "composioConnections",
+      [{ id: "c1", toolkit: "gmail", status: "ACTIVE" }],
+    );
+    json(res, 200, { success: true, data: { connections } });
+    return;
+  }
+
+  if (
+    method === "GET" &&
+    /^\/agent-integrations\/composio\/triggers\/available(\?.*)?$/.test(url)
+  ) {
+    const triggers = parseBehaviorJson("composioAvailableTriggers", [
+      { slug: "GMAIL_NEW_GMAIL_MESSAGE", scope: "static" },
+    ]);
+    json(res, 200, { success: true, data: { triggers } });
+    return;
+  }
+
+  if (
+    method === "GET" &&
+    /^\/agent-integrations\/composio\/triggers(\?.*)?$/.test(url)
+  ) {
+    const triggers = parseBehaviorJson("composioActiveTriggers", []);
+    json(res, 200, { success: true, data: { triggers } });
+    return;
+  }
+
+  if (
+    method === "POST" &&
+    /^\/agent-integrations\/composio\/triggers\/?$/.test(url)
+  ) {
+    if (mockBehavior.composioEnableFails === "1") {
+      json(res, 500, { success: false, error: "Mock enable trigger failure" });
+      return;
+    }
+    const slug = parsedBody?.slug ?? "UNKNOWN";
+    const connectionId = parsedBody?.connectionId ?? "";
+    const triggerId = `ti-${Date.now()}`;
+    const active = parseBehaviorJson("composioActiveTriggers", []);
+    active.push({
+      id: triggerId,
+      slug,
+      toolkit: slug.split("_")[0]?.toLowerCase() ?? "",
+      connectionId,
+      ...(parsedBody?.triggerConfig
+        ? { triggerConfig: parsedBody.triggerConfig }
+        : {}),
+    });
+    setMockBehavior("composioActiveTriggers", JSON.stringify(active));
+    json(res, 200, {
+      success: true,
+      data: { triggerId, slug, connectionId },
+    });
+    return;
+  }
+
+  if (
+    method === "DELETE" &&
+    /^\/agent-integrations\/composio\/triggers\/[^/]+\/?$/.test(url)
+  ) {
+    const id = url.split("/").filter(Boolean).pop().split("?")[0];
+    const active = parseBehaviorJson("composioActiveTriggers", []);
+    const next = active.filter((t) => t.id !== id);
+    setMockBehavior("composioActiveTriggers", JSON.stringify(next));
+    json(res, 200, { success: true, data: { deleted: true } });
+    return;
+  }
+
   // Catch-all: fail fast so tests notice missing mock endpoints.
   console.log(`[MockServer] UNHANDLED ${method} ${url}`);
   json(res, 404, {
     success: false,
     error: `Mock server: no handler for ${method} ${url}`,
   });
+}
+
+function parseBehaviorJson(key, fallback) {
+  const raw = mockBehavior[key];
+  if (!raw) return JSON.parse(JSON.stringify(fallback));
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return JSON.parse(JSON.stringify(fallback));
+  }
 }
 
 function handleSocketIOMessage(socket, text, sid) {

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -17,9 +17,10 @@ use serde_json::json;
 use crate::openhuman::integrations::IntegrationClient;
 
 use super::types::{
-    ComposioAuthorizeResponse, ComposioConnectionsResponse, ComposioCreateTriggerResponse,
-    ComposioDeleteResponse, ComposioExecuteResponse, ComposioGithubReposResponse,
-    ComposioToolkitsResponse, ComposioToolsResponse,
+    ComposioActiveTriggersResponse, ComposioAuthorizeResponse, ComposioAvailableTriggersResponse,
+    ComposioConnectionsResponse, ComposioCreateTriggerResponse, ComposioDeleteResponse,
+    ComposioDisableTriggerResponse, ComposioEnableTriggerResponse, ComposioExecuteResponse,
+    ComposioGithubReposResponse, ComposioToolkitsResponse, ComposioToolsResponse,
 };
 
 /// High-level client for all backend-proxied Composio operations.
@@ -175,6 +176,97 @@ impl ComposioClient {
         self.inner
             .post::<ComposioCreateTriggerResponse>("/agent-integrations/composio/triggers", &body)
             .await
+    }
+
+    // ── Trigger management (PR #671) ────────────────────────────────
+
+    /// `GET /agent-integrations/composio/triggers/available` — catalog of
+    /// triggers the user could enable for a toolkit. For GitHub the
+    /// backend fans out into per-repo entries scoped by `connection_id`.
+    pub async fn list_available_triggers(
+        &self,
+        toolkit: &str,
+        connection_id: Option<&str>,
+    ) -> Result<ComposioAvailableTriggersResponse> {
+        let toolkit = toolkit.trim();
+        if toolkit.is_empty() {
+            anyhow::bail!("composio.list_available_triggers: toolkit must not be empty");
+        }
+        let toolkit_q = urlencoding::encode(toolkit);
+        let path = match connection_id.map(str::trim).filter(|id| !id.is_empty()) {
+            Some(id) => format!(
+                "/agent-integrations/composio/triggers/available?toolkit={toolkit_q}&connectionId={}",
+                urlencoding::encode(id)
+            ),
+            None => format!(
+                "/agent-integrations/composio/triggers/available?toolkit={toolkit_q}"
+            ),
+        };
+        tracing::debug!(path = %path, "[composio] list_available_triggers");
+        self.inner
+            .get::<ComposioAvailableTriggersResponse>(&path)
+            .await
+    }
+
+    /// `GET /agent-integrations/composio/triggers` — currently enabled
+    /// triggers for the user, optionally filtered to a toolkit.
+    pub async fn list_active_triggers(
+        &self,
+        toolkit: Option<&str>,
+    ) -> Result<ComposioActiveTriggersResponse> {
+        let path = match toolkit.map(str::trim).filter(|t| !t.is_empty()) {
+            Some(t) => format!(
+                "/agent-integrations/composio/triggers?toolkit={}",
+                urlencoding::encode(t)
+            ),
+            None => "/agent-integrations/composio/triggers".to_string(),
+        };
+        tracing::debug!(path = %path, "[composio] list_active_triggers");
+        self.inner
+            .get::<ComposioActiveTriggersResponse>(&path)
+            .await
+    }
+
+    /// `POST /agent-integrations/composio/triggers` — enable a single
+    /// trigger on a connection the caller owns.
+    pub async fn enable_trigger(
+        &self,
+        connection_id: &str,
+        slug: &str,
+        trigger_config: Option<serde_json::Value>,
+    ) -> Result<ComposioEnableTriggerResponse> {
+        let connection_id = connection_id.trim();
+        let slug = slug.trim();
+        if connection_id.is_empty() {
+            anyhow::bail!("composio.enable_trigger: connectionId must not be empty");
+        }
+        if slug.is_empty() {
+            anyhow::bail!("composio.enable_trigger: slug must not be empty");
+        }
+        let mut body = json!({ "connectionId": connection_id, "slug": slug });
+        if let Some(config) = trigger_config {
+            body["triggerConfig"] = config;
+        }
+        tracing::debug!(slug = %slug, connection_id = %connection_id, "[composio] enable_trigger");
+        self.inner
+            .post::<ComposioEnableTriggerResponse>("/agent-integrations/composio/triggers", &body)
+            .await
+    }
+
+    /// `DELETE /agent-integrations/composio/triggers/:triggerId`.
+    pub async fn disable_trigger(
+        &self,
+        trigger_id: &str,
+    ) -> Result<ComposioDisableTriggerResponse> {
+        let trigger_id = trigger_id.trim();
+        if trigger_id.is_empty() {
+            anyhow::bail!("composio.disable_trigger: triggerId must not be empty");
+        }
+        tracing::debug!(trigger_id = %trigger_id, "[composio] disable_trigger");
+        self.raw_delete::<ComposioDisableTriggerResponse>(&format!(
+            "/agent-integrations/composio/triggers/{trigger_id}"
+        ))
+        .await
     }
 
     // ── Raw DELETE ──────────────────────────────────────────────────

--- a/src/openhuman/composio/client_tests.rs
+++ b/src/openhuman/composio/client_tests.rs
@@ -335,3 +335,152 @@ async fn delete_connection_happy_path_returns_deleted_true() {
     let resp = client.delete_connection("conn-42").await.unwrap();
     assert!(resp.deleted);
 }
+
+// ── Trigger management (PR #671) ────────────────────────────────────
+
+#[tokio::test]
+async fn list_available_triggers_rejects_empty_toolkit() {
+    let inner = Arc::new(crate::openhuman::integrations::IntegrationClient::new(
+        "http://127.0.0.1:0".into(),
+        "test".into(),
+    ));
+    let client = ComposioClient::new(inner);
+    let err = client
+        .list_available_triggers("   ", None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("toolkit must not be empty"),
+        "unexpected: {err}"
+    );
+}
+
+#[tokio::test]
+async fn list_available_triggers_forwards_query_params() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/available",
+        get(|Query(q): Query<HashMap<String, String>>| async move {
+            assert_eq!(q.get("toolkit").map(String::as_str), Some("github"));
+            assert_eq!(q.get("connectionId").map(String::as_str), Some("c1"));
+            Json(json!({
+                "success": true,
+                "data": {"triggers": [{"slug": "GITHUB_PUSH_EVENT", "scope": "github_repo"}]}
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client
+        .list_available_triggers("github", Some("c1"))
+        .await
+        .unwrap();
+    assert_eq!(resp.triggers.len(), 1);
+    assert_eq!(resp.triggers[0].scope, "github_repo");
+}
+
+#[tokio::test]
+async fn list_active_triggers_filters_by_toolkit() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers",
+        get(|Query(q): Query<HashMap<String, String>>| async move {
+            assert_eq!(q.get("toolkit").map(String::as_str), Some("gmail"));
+            Json(json!({
+                "success": true,
+                "data": {"triggers": []}
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client.list_active_triggers(Some("gmail")).await.unwrap();
+    assert!(resp.triggers.is_empty());
+}
+
+#[tokio::test]
+async fn enable_trigger_rejects_empty_inputs() {
+    let inner = Arc::new(crate::openhuman::integrations::IntegrationClient::new(
+        "http://127.0.0.1:0".into(),
+        "test".into(),
+    ));
+    let client = ComposioClient::new(inner);
+
+    let err = client.enable_trigger("", "X", None).await.unwrap_err();
+    assert!(err.to_string().contains("connectionId must not be empty"));
+
+    let err = client.enable_trigger("c1", "  ", None).await.unwrap_err();
+    assert!(err.to_string().contains("slug must not be empty"));
+}
+
+#[tokio::test]
+async fn enable_trigger_posts_body_and_parses_response() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers",
+        post(|Json(body): Json<Value>| async move {
+            assert_eq!(body["connectionId"], "c1");
+            assert_eq!(body["slug"], "GMAIL_NEW_GMAIL_MESSAGE");
+            assert_eq!(body["triggerConfig"]["labelIds"], "INBOX");
+            Json(json!({
+                "success": true,
+                "data": {
+                    "triggerId": "ti_1",
+                    "slug": "GMAIL_NEW_GMAIL_MESSAGE",
+                    "connectionId": "c1"
+                }
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client
+        .enable_trigger(
+            "c1",
+            "GMAIL_NEW_GMAIL_MESSAGE",
+            Some(json!({"labelIds": "INBOX"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.trigger_id, "ti_1");
+}
+
+#[tokio::test]
+async fn disable_trigger_rejects_empty_id() {
+    let inner = Arc::new(crate::openhuman::integrations::IntegrationClient::new(
+        "http://127.0.0.1:0".into(),
+        "test".into(),
+    ));
+    let client = ComposioClient::new(inner);
+    let err = client.disable_trigger("").await.unwrap_err();
+    assert!(err.to_string().contains("triggerId must not be empty"));
+}
+
+#[tokio::test]
+async fn disable_trigger_calls_delete_path() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/{id}",
+        axum::routing::delete(|Path(id): Path<String>| async move {
+            assert_eq!(id, "ti_1");
+            Json(json!({"success": true, "data": {"deleted": true}}))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client.disable_trigger("ti_1").await.unwrap();
+    assert!(resp.deleted);
+}
+
+#[tokio::test]
+async fn disable_trigger_surfaces_non_2xx_status() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/{id}",
+        axum::routing::delete(|Path(_id): Path<String>| async move {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"success": false, "error": "no"})),
+            )
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let err = client.disable_trigger("ti_x").await.unwrap_err();
+    assert!(err.to_string().contains("404"), "unexpected: {err}");
+}

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -26,9 +26,11 @@ use super::providers::{
     get_provider, ProviderContext, ProviderUserProfile, SyncOutcome, SyncReason,
 };
 use super::types::{
-    ComposioAuthorizeResponse, ComposioConnectionsResponse, ComposioCreateTriggerResponse,
-    ComposioDeleteResponse, ComposioExecuteResponse, ComposioGithubReposResponse,
-    ComposioToolkitsResponse, ComposioToolsResponse, ComposioTriggerHistoryResult,
+    ComposioActiveTriggersResponse, ComposioAuthorizeResponse, ComposioAvailableTriggersResponse,
+    ComposioConnectionsResponse, ComposioCreateTriggerResponse, ComposioDeleteResponse,
+    ComposioDisableTriggerResponse, ComposioEnableTriggerResponse, ComposioExecuteResponse,
+    ComposioGithubReposResponse, ComposioToolkitsResponse, ComposioToolsResponse,
+    ComposioTriggerHistoryResult,
 };
 
 /// Resolve a [`ComposioClient`] from the root config, or return an
@@ -291,6 +293,80 @@ pub async fn composio_create_trigger(
         vec![format!(
             "composio: trigger {trigger_id} created for slug {slug}"
         )],
+    ))
+}
+
+// ── Trigger management (catalog + enable/disable) ──────────────────
+
+pub async fn composio_list_available_triggers(
+    config: &Config,
+    toolkit: &str,
+    connection_id: Option<String>,
+) -> OpResult<RpcOutcome<ComposioAvailableTriggersResponse>> {
+    tracing::debug!(toolkit = %toolkit, ?connection_id, "[composio] rpc list_available_triggers");
+    let client = resolve_client(config)?;
+    let resp = client
+        .list_available_triggers(toolkit, connection_id.as_deref())
+        .await
+        .map_err(|e| format!("[composio] list_available_triggers failed: {e:#}"))?;
+    let count = resp.triggers.len();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!(
+            "composio: {count} available trigger(s) for toolkit {toolkit}"
+        )],
+    ))
+}
+
+pub async fn composio_list_triggers(
+    config: &Config,
+    toolkit: Option<String>,
+) -> OpResult<RpcOutcome<ComposioActiveTriggersResponse>> {
+    tracing::debug!(?toolkit, "[composio] rpc list_triggers");
+    let client = resolve_client(config)?;
+    let resp = client
+        .list_active_triggers(toolkit.as_deref())
+        .await
+        .map_err(|e| format!("[composio] list_triggers failed: {e:#}"))?;
+    let count = resp.triggers.len();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: {count} active trigger(s) listed")],
+    ))
+}
+
+pub async fn composio_enable_trigger(
+    config: &Config,
+    connection_id: &str,
+    slug: &str,
+    trigger_config: Option<serde_json::Value>,
+) -> OpResult<RpcOutcome<ComposioEnableTriggerResponse>> {
+    tracing::debug!(slug = %slug, connection_id = %connection_id, "[composio] rpc enable_trigger");
+    let client = resolve_client(config)?;
+    let resp = client
+        .enable_trigger(connection_id, slug, trigger_config)
+        .await
+        .map_err(|e| format!("[composio] enable_trigger failed: {e:#}"))?;
+    let trigger_id = resp.trigger_id.clone();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: enabled trigger {slug} → {trigger_id}")],
+    ))
+}
+
+pub async fn composio_disable_trigger(
+    config: &Config,
+    trigger_id: &str,
+) -> OpResult<RpcOutcome<ComposioDisableTriggerResponse>> {
+    tracing::debug!(trigger_id = %trigger_id, "[composio] rpc disable_trigger");
+    let client = resolve_client(config)?;
+    let resp = client
+        .disable_trigger(trigger_id)
+        .await
+        .map_err(|e| format!("[composio] disable_trigger failed: {e:#}"))?;
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: disabled trigger {trigger_id}")],
     ))
 }
 

--- a/src/openhuman/composio/ops_tests.rs
+++ b/src/openhuman/composio/ops_tests.rs
@@ -680,3 +680,178 @@ fn cache_entries_expire_after_ttl() {
         "entry aged past CACHE_TTL must not be treated as fresh"
     );
 }
+
+// ── Trigger management ops (PR #671) ────────────────────────────────
+
+#[tokio::test]
+async fn composio_list_available_triggers_via_mock() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/available",
+        get(|Query(q): Query<HashMap<String, String>>| async move {
+            // Echo back so the test can also assert what was forwarded.
+            Json(json!({
+                "success": true,
+                "data": {"triggers": [
+                    {
+                        "slug": "GMAIL_NEW_GMAIL_MESSAGE",
+                        "scope": "static",
+                        "defaultConfig": {"labelIds": "INBOX"},
+                        "_echoed_toolkit": q.get("toolkit"),
+                    }
+                ]}
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let outcome = composio_list_available_triggers(&config, "gmail", Some("c1".into()))
+        .await
+        .unwrap();
+    assert_eq!(outcome.value.triggers.len(), 1);
+    assert_eq!(outcome.value.triggers[0].slug, "GMAIL_NEW_GMAIL_MESSAGE");
+    assert_eq!(outcome.value.triggers[0].scope, "static");
+    assert!(outcome.logs.iter().any(|l| l.contains("available trigger")));
+}
+
+#[tokio::test]
+async fn composio_list_available_triggers_omits_connection_when_none() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/available",
+        get(|Query(q): Query<HashMap<String, String>>| async move {
+            assert!(
+                q.get("connectionId").is_none(),
+                "should not forward connectionId"
+            );
+            Json(json!({"success": true, "data": {"triggers": []}}))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let outcome = composio_list_available_triggers(&config, "gmail", None)
+        .await
+        .unwrap();
+    assert!(outcome.value.triggers.is_empty());
+}
+
+#[tokio::test]
+async fn composio_list_triggers_via_mock_with_filter() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers",
+        get(|Query(_q): Query<HashMap<String, String>>| async move {
+            Json(json!({
+                "success": true,
+                "data": {"triggers": [
+                    {
+                        "id": "ti_1",
+                        "slug": "GMAIL_NEW_GMAIL_MESSAGE",
+                        "toolkit": "gmail",
+                        "connectionId": "c1",
+                        "state": "active"
+                    }
+                ]}
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let outcome = composio_list_triggers(&config, Some("gmail".into()))
+        .await
+        .unwrap();
+    assert_eq!(outcome.value.triggers.len(), 1);
+    assert_eq!(outcome.value.triggers[0].id, "ti_1");
+    assert_eq!(outcome.value.triggers[0].connection_id, "c1");
+}
+
+#[tokio::test]
+async fn composio_list_triggers_without_filter() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers",
+        get(|| async { Json(json!({"success": true, "data": {"triggers": []}})) }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let outcome = composio_list_triggers(&config, None).await.unwrap();
+    assert!(outcome.value.triggers.is_empty());
+}
+
+#[tokio::test]
+async fn composio_enable_trigger_via_mock() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers",
+        post(|Json(body): Json<Value>| async move {
+            assert_eq!(body["slug"], "GMAIL_NEW_GMAIL_MESSAGE");
+            assert_eq!(body["connectionId"], "c1");
+            assert_eq!(body["triggerConfig"]["labelIds"], "INBOX");
+            Json(json!({
+                "success": true,
+                "data": {
+                    "triggerId": "ti_new",
+                    "slug": "GMAIL_NEW_GMAIL_MESSAGE",
+                    "connectionId": "c1"
+                }
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let outcome = composio_enable_trigger(
+        &config,
+        "c1",
+        "GMAIL_NEW_GMAIL_MESSAGE",
+        Some(json!({"labelIds": "INBOX"})),
+    )
+    .await
+    .unwrap();
+    assert_eq!(outcome.value.trigger_id, "ti_new");
+    assert_eq!(outcome.value.connection_id, "c1");
+    assert!(outcome.logs.iter().any(|l| l.contains("enabled trigger")));
+}
+
+#[tokio::test]
+async fn composio_disable_trigger_via_mock() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/{id}",
+        axum::routing::delete(|Path(id): Path<String>| async move {
+            assert_eq!(id, "ti_1");
+            Json(json!({"success": true, "data": {"deleted": true}}))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let outcome = composio_disable_trigger(&config, "ti_1").await.unwrap();
+    assert!(outcome.value.deleted);
+    assert!(outcome.logs.iter().any(|l| l.contains("disabled trigger")));
+}
+
+#[tokio::test]
+async fn composio_disable_trigger_propagates_backend_error() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers/{id}",
+        axum::routing::delete(|Path(_id): Path<String>| async move {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                Json(json!({"success": false, "error": "Trigger not found"})),
+            )
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let err = composio_disable_trigger(&config, "missing")
+        .await
+        .unwrap_err();
+    assert!(err.contains("disable_trigger failed"), "unexpected: {err}");
+}

--- a/src/openhuman/composio/schemas.rs
+++ b/src/openhuman/composio/schemas.rs
@@ -38,6 +38,24 @@ struct CreateTriggerParams {
     trigger_config: Option<Value>,
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct ListAvailableTriggersParams {
+    toolkit: String,
+    connection_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ListTriggersParams {
+    toolkit: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EnableTriggerParams {
+    connection_id: String,
+    slug: String,
+    trigger_config: Option<Value>,
+}
+
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
     vec![
         schemas("list_toolkits"),
@@ -53,6 +71,10 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("list_trigger_history"),
         schemas("get_user_scopes"),
         schemas("set_user_scopes"),
+        schemas("list_available_triggers"),
+        schemas("list_triggers"),
+        schemas("enable_trigger"),
+        schemas("disable_trigger"),
     ]
 }
 
@@ -109,6 +131,22 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("set_user_scopes"),
             handler: handle_set_user_scopes,
+        },
+        RegisteredController {
+            schema: schemas("list_available_triggers"),
+            handler: handle_list_available_triggers,
+        },
+        RegisteredController {
+            schema: schemas("list_triggers"),
+            handler: handle_list_triggers,
+        },
+        RegisteredController {
+            schema: schemas("enable_trigger"),
+            handler: handle_enable_trigger,
+        },
+        RegisteredController {
+            schema: schemas("disable_trigger"),
+            handler: handle_disable_trigger,
         },
     ]
 }
@@ -403,6 +441,102 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 required: true,
             }],
         },
+        "list_available_triggers" => ControllerSchema {
+            namespace: "composio",
+            function: "list_available_triggers",
+            description:
+                "List the catalog of triggers the caller can enable for a toolkit. \
+                 For GitHub, fans out into per-repo entries (requires connection_id).",
+            inputs: vec![
+                FieldSchema {
+                    name: "toolkit",
+                    ty: TypeSchema::String,
+                    comment: "Toolkit slug, e.g. 'gmail' or 'github'.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "connection_id",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+                    comment:
+                        "Optional connection id. Required to enumerate GitHub per-repo entries.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "triggers",
+                ty: TypeSchema::Json,
+                comment:
+                    "Array of {slug, scope, defaultConfig?, requiredConfigKeys?, repo?}.",
+                required: true,
+            }],
+        },
+        "list_triggers" => ControllerSchema {
+            namespace: "composio",
+            function: "list_triggers",
+            description: "List the user's currently enabled Composio triggers.",
+            inputs: vec![FieldSchema {
+                name: "toolkit",
+                ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+                comment: "Optional toolkit slug to filter by.",
+                required: false,
+            }],
+            outputs: vec![FieldSchema {
+                name: "triggers",
+                ty: TypeSchema::Json,
+                comment:
+                    "Array of {id, slug, toolkit, connectionId, triggerConfig?, state?}.",
+                required: true,
+            }],
+        },
+        "enable_trigger" => ControllerSchema {
+            namespace: "composio",
+            function: "enable_trigger",
+            description:
+                "Enable a single Composio trigger on a connection the caller owns.",
+            inputs: vec![
+                FieldSchema {
+                    name: "connection_id",
+                    ty: TypeSchema::String,
+                    comment: "Connection id to attach the trigger to.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "slug",
+                    ty: TypeSchema::String,
+                    comment: "Trigger slug, e.g. 'GMAIL_NEW_GMAIL_MESSAGE'.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "trigger_config",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Optional trigger config object.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Payload: {triggerId, slug, connectionId}.",
+                required: true,
+            }],
+        },
+        "disable_trigger" => ControllerSchema {
+            namespace: "composio",
+            function: "disable_trigger",
+            description: "Disable (delete) a Composio trigger owned by the caller.",
+            inputs: vec![FieldSchema {
+                name: "trigger_id",
+                ty: TypeSchema::String,
+                comment: "Identifier of the trigger to delete.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "deleted",
+                ty: TypeSchema::Bool,
+                comment: "True when the backend confirmed deletion.",
+                required: true,
+            }],
+        },
         _other => ControllerSchema {
             namespace: "composio",
             function: "unknown",
@@ -613,6 +747,64 @@ fn handle_set_user_scopes(params: Map<String, Value>) -> ControllerFuture {
             "[composio:scopes] handler exit"
         );
         to_json(crate::rpc::RpcOutcome::new(pref, vec![]))
+    })
+}
+
+fn handle_list_available_triggers(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let payload: ListAvailableTriggersParams = serde_json::from_value(Value::Object(params))
+            .map_err(|e| format!("invalid params: {e}"))?;
+        let toolkit = payload.toolkit.trim();
+        if toolkit.is_empty() {
+            return Err("invalid params: 'toolkit' must not be empty".to_string());
+        }
+        to_json(
+            super::ops::composio_list_available_triggers(&config, toolkit, payload.connection_id)
+                .await?,
+        )
+    })
+}
+
+fn handle_list_triggers(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let payload: ListTriggersParams = serde_json::from_value(Value::Object(params))
+            .map_err(|e| format!("invalid params: {e}"))?;
+        to_json(super::ops::composio_list_triggers(&config, payload.toolkit).await?)
+    })
+}
+
+fn handle_enable_trigger(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let payload: EnableTriggerParams = serde_json::from_value(Value::Object(params))
+            .map_err(|e| format!("invalid params: {e}"))?;
+        let connection_id = payload.connection_id.trim();
+        let slug = payload.slug.trim();
+        if connection_id.is_empty() {
+            return Err("invalid params: 'connection_id' must not be empty".to_string());
+        }
+        if slug.is_empty() {
+            return Err("invalid params: 'slug' must not be empty".to_string());
+        }
+        to_json(
+            super::ops::composio_enable_trigger(
+                &config,
+                connection_id,
+                slug,
+                payload.trigger_config,
+            )
+            .await?,
+        )
+    })
+}
+
+fn handle_disable_trigger(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let trigger_id = read_required_non_empty(&params, "trigger_id")?;
+        to_json(super::ops::composio_disable_trigger(&config, &trigger_id).await?)
     })
 }
 

--- a/src/openhuman/composio/schemas_tests.rs
+++ b/src/openhuman/composio/schemas_tests.rs
@@ -153,3 +153,77 @@ fn to_json_wraps_outcome() {
     let v = to_json(RpcOutcome::single_log(json!({"x": 1}), "note")).unwrap();
     assert!(v.get("logs").is_some() || v.get("result").is_some() || v.get("x").is_some());
 }
+
+// ── Trigger management schema coverage ──────────────────────────────
+
+#[test]
+fn trigger_management_schemas_resolve() {
+    for k in [
+        "list_available_triggers",
+        "list_triggers",
+        "enable_trigger",
+        "disable_trigger",
+    ] {
+        let s = schemas(k);
+        assert_eq!(s.namespace, "composio");
+        assert_ne!(s.function, "unknown", "key `{k}` fell through");
+        assert!(!s.description.is_empty());
+        assert!(!s.outputs.is_empty());
+    }
+}
+
+#[test]
+fn list_available_triggers_schema_input_shape() {
+    let s = schemas("list_available_triggers");
+    assert!(s.inputs.iter().any(|f| f.name == "toolkit" && f.required));
+    let conn = s.inputs.iter().find(|f| f.name == "connection_id").unwrap();
+    assert!(!conn.required);
+}
+
+#[test]
+fn list_triggers_schema_input_shape() {
+    let s = schemas("list_triggers");
+    let tk = s.inputs.iter().find(|f| f.name == "toolkit").unwrap();
+    assert!(!tk.required);
+}
+
+#[test]
+fn enable_trigger_schema_input_shape() {
+    let s = schemas("enable_trigger");
+    assert!(s
+        .inputs
+        .iter()
+        .any(|f| f.name == "connection_id" && f.required));
+    assert!(s.inputs.iter().any(|f| f.name == "slug" && f.required));
+    let cfg = s
+        .inputs
+        .iter()
+        .find(|f| f.name == "trigger_config")
+        .unwrap();
+    assert!(!cfg.required);
+}
+
+#[test]
+fn disable_trigger_schema_input_shape() {
+    let s = schemas("disable_trigger");
+    assert!(s
+        .inputs
+        .iter()
+        .any(|f| f.name == "trigger_id" && f.required));
+}
+
+#[test]
+fn trigger_management_controllers_are_all_registered() {
+    let registered = all_registered_controllers();
+    for k in [
+        "list_available_triggers",
+        "list_triggers",
+        "enable_trigger",
+        "disable_trigger",
+    ] {
+        assert!(
+            registered.iter().any(|c| c.schema.function == k),
+            "controller {k} not registered"
+        );
+    }
+}

--- a/src/openhuman/composio/types.rs
+++ b/src/openhuman/composio/types.rs
@@ -149,6 +149,84 @@ pub struct ComposioCreateTriggerResponse {
     pub status: Option<String>,
 }
 
+// ── Trigger management (catalog + active list + enable/disable) ─────
+
+/// Per-repo descriptor used by GitHub-scoped available triggers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioAvailableTriggerRepo {
+    pub owner: String,
+    pub repo: String,
+}
+
+/// One entry in `GET /agent-integrations/composio/triggers/available`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioAvailableTrigger {
+    pub slug: String,
+    /// `"static"` or `"github_repo"`.
+    pub scope: String,
+    #[serde(
+        rename = "defaultConfig",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_config: Option<serde_json::Value>,
+    #[serde(
+        rename = "requiredConfigKeys",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub required_config_keys: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<ComposioAvailableTriggerRepo>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioAvailableTriggersResponse {
+    #[serde(default)]
+    pub triggers: Vec<ComposioAvailableTrigger>,
+}
+
+/// One entry in `GET /agent-integrations/composio/triggers`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioActiveTrigger {
+    pub id: String,
+    pub slug: String,
+    pub toolkit: String,
+    #[serde(rename = "connectionId")]
+    pub connection_id: String,
+    #[serde(
+        rename = "triggerConfig",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub trigger_config: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioActiveTriggersResponse {
+    #[serde(default)]
+    pub triggers: Vec<ComposioActiveTrigger>,
+}
+
+/// Response body of `POST /agent-integrations/composio/triggers` (enable).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioEnableTriggerResponse {
+    #[serde(rename = "triggerId")]
+    pub trigger_id: String,
+    pub slug: String,
+    #[serde(rename = "connectionId")]
+    pub connection_id: String,
+}
+
+/// Response body of `DELETE /agent-integrations/composio/triggers/:id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioDisableTriggerResponse {
+    #[serde(default)]
+    pub deleted: bool,
+}
+
 // ── Triggers ────────────────────────────────────────────────────────
 
 /// Payload of the `composio:trigger` Socket.IO event emitted by the backend


### PR DESCRIPTION
## Summary

- Mirror backend [tinyhumansai/backend#671](https://github.com/tinyhumansai/backend/pull/671)'s new trigger management endpoints in the core RPC layer (`openhuman.composio_list_available_triggers`, `composio_list_triggers`, `composio_enable_trigger`, `composio_disable_trigger`).
- Surface them as per-trigger toggle rows inside the existing Composio connection modal, so triggers are now opt-in from the client instead of being fire-and-forget provisioned server-side on every authorize.
- Triggers with `requiredConfigKeys` (e.g. Slack `channel`) render as disabled rows with a "Needs configuration" hint; richer config UI is intentionally deferred.

## Why

The backend used to wire every default trigger automatically inside `composioAuthorizeController`, which burned tokens on triggers users didn't want. Backend PR #671 removed that and replaced it with explicit enable/disable endpoints. This PR ports the OpenHuman desktop app to that contract.

## Files

- `src/openhuman/composio/client.rs` — `list_available_triggers`, `list_active_triggers`, `enable_trigger`, `disable_trigger` HTTP wrappers.
- `src/openhuman/composio/ops.rs` — matching `RpcOutcome`-returning ops.
- `src/openhuman/composio/schemas.rs` — 4 new RPC controllers registered alongside the existing composio surface.
- `src/openhuman/composio/types.rs` — wire types matching the backend shapes (`AvailableTrigger`, `ActiveTrigger`, etc.).
- `app/src/lib/composio/composioApi.ts` + `types.ts` — TS wrappers + types.
- `app/src/components/composio/TriggerToggles.tsx` — new component used by the modal.
- `app/src/components/composio/ComposioConnectModal.tsx` — renders `<TriggerToggles>` when the connection is `ACTIVE`.

## Tests

- 7 Vitest cases in `composioApi.test.ts` covering envelope unwrap + RPC param shapes.
- 15 RTL tests in `TriggerToggles.test.tsx` covering loading / empty / error states, signature matching for static + GitHub triggers, the `requiredConfigKeys` "needs config" hint, optimistic flip on enable, optimistic removal on disable, and error surfacing.
- 7 Rust client tests (`client_tests.rs`) covering input validation + HTTP envelope round-trips against an in-process axum mock.
- 6 Rust ops tests (`ops_tests.rs`) covering each new op via the mock backend, plus a 404-surfacing case.
- Schema tests confirming all 4 controllers are registered and their input shapes are correct.
- WDIO spec `composio-triggers-flow.spec.ts` drives `list_available_triggers` → `list_triggers` → `enable_trigger` → `list_triggers` → `disable_trigger` against the running core sidecar + shared mock backend, then asserts the modal renders the Triggers section for an ACTIVE Gmail connection.
- Shared mock (`scripts/mock-api-core.mjs`) gained `/agent-integrations/composio/{connections, triggers, triggers/available}` routes that mutate `composioActiveTriggers` behavior in place so subsequent reads observe each enable/disable.

`diff-cover` ≥ 83% on changed lines locally (only the handler bodies in `schemas.rs` remain uncovered — those need a tokio runtime + full config which the current per-domain test scaffold doesn't provide; their delegated ops are at 100%).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors, 31 pre-existing warnings)
- [x] `pnpm format:check`
- [x] `pnpm --filter openhuman-app test src/components/composio src/lib/composio` — 27 pass
- [x] `cargo test -p openhuman --lib openhuman::composio::` — 286 pass
- [x] `cargo check --manifest-path Cargo.toml`
- [x] `diff-cover lcov-app.info lcov-core.info --compare-branch=main --fail-under=80` — 83%
- [ ] WDIO spec on macOS (`bash app/scripts/e2e-run-spec.sh test/e2e/specs/composio-triggers-flow.spec.ts composio-triggers`) — needs built `.app`; not run locally.

## Related

- Backend: [tinyhumansai/backend#671](https://github.com/tinyhumansai/backend/pull/671)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now manage triggers for Composio connections—view available triggers and enable/disable them directly within the connection modal
  * Support for multiple trigger types including static triggers and GitHub repository-based triggers with configurable settings

* **Tests**
  * Added comprehensive unit, integration, and end-to-end test coverage for trigger management functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->