### PR TITLE
feat(home): EarlyBirdyBanner + agent terminology + LinkedIn enrichment model pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.11"
+version = "0.53.12"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.4"
+version = "0.53.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.4"
+version = "0.53.11"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.11"
+version = "0.53.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.11"
+version = "0.53.12"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src/components/home/HomeBanners.tsx
+++ b/app/src/components/home/HomeBanners.tsx
@@ -87,6 +87,38 @@ export function PromotionalCreditsBanner({ promoCredits }: { promoCredits: numbe
   );
 }
 
+export function EarlyBirdyBanner() {
+  return (
+    <div className="mb-3 mt-3 rounded-2xl border border-orange-200 bg-gradient-to-r from-orange-50 via-amber-50 to-orange-50 px-4 py-4 text-left shadow-soft">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-orange-100 text-lg">
+          🐦
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-orange-700">
+            The first 1,000 users get 60% off.
+          </p>
+          <p className="mt-1 text-sm leading-relaxed text-orange-600">
+            Use discount code{' '}
+            <span className="rounded-md border border-orange-300 bg-white px-1.5 py-0.5 font-mono text-[12px] font-bold text-orange-700">
+              EARLYBIRDY
+            </span>{' '}
+            to on your{' '}
+            <button
+              type="button"
+              onClick={() => {
+                void openUrl(BILLING_DASHBOARD_URL);
+              }}
+              className="cursor-pointer border-b border-amber-700 border-dashed font-bold text-amber-700 hover:text-amber-800">
+              first subscription.
+            </button>{' '}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function DiscordBanner() {
   return (
     <button

--- a/app/src/components/home/HomeBanners.tsx
+++ b/app/src/components/home/HomeBanners.tsx
@@ -103,7 +103,7 @@ export function EarlyBirdyBanner() {
             <span className="rounded-md border border-orange-300 bg-white px-1.5 py-0.5 font-mono text-[12px] font-bold text-orange-700">
               EARLYBIRDY
             </span>{' '}
-            to on your{' '}
+            on your{' '}
             <button
               type="button"
               onClick={() => {

--- a/app/src/components/home/HomeBanners.tsx
+++ b/app/src/components/home/HomeBanners.tsx
@@ -87,9 +87,18 @@ export function PromotionalCreditsBanner({ promoCredits }: { promoCredits: numbe
   );
 }
 
-export function EarlyBirdyBanner() {
+export function EarlyBirdyBanner({ onDismiss }: { onDismiss?: () => void }) {
   return (
-    <div className="mb-3 mt-3 rounded-2xl border border-orange-200 bg-gradient-to-r from-orange-50 via-amber-50 to-orange-50 px-4 py-4 text-left shadow-soft">
+    <div className="relative mb-3 mt-3 rounded-2xl border border-orange-200 bg-gradient-to-r from-orange-50 via-amber-50 to-orange-50 px-4 py-4 text-left shadow-soft">
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss early bird banner"
+          className="absolute right-3 top-3 rounded-md p-1 text-orange-500 hover:bg-orange-100 hover:text-orange-700">
+          ✕
+        </button>
+      )}
       <div className="flex items-start gap-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-orange-100 text-lg">
           🐦

--- a/app/src/components/home/__tests__/HomeBanners.test.tsx
+++ b/app/src/components/home/__tests__/HomeBanners.test.tsx
@@ -1,9 +1,14 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DISCORD_INVITE_URL } from '../../../utils/links';
+import { BILLING_DASHBOARD_URL, DISCORD_INVITE_URL } from '../../../utils/links';
 import { openUrl } from '../../../utils/openUrl';
-import { DiscordBanner, PromotionalCreditsBanner, UsageLimitBanner } from '../HomeBanners';
+import {
+  DiscordBanner,
+  EarlyBirdyBanner,
+  PromotionalCreditsBanner,
+  UsageLimitBanner,
+} from '../HomeBanners';
 
 vi.mock('../../../utils/openUrl', () => ({ openUrl: vi.fn() }));
 
@@ -28,6 +33,21 @@ describe('HomeBanners', () => {
     expect(openUrl).toHaveBeenCalledWith('https://tinyhumans.ai/dashboard');
   });
 
+  it('renders danger tone styles for UsageLimitBanner', () => {
+    render(
+      <UsageLimitBanner
+        tone="danger"
+        icon="⚠️"
+        title="Out of Usage"
+        message="You are out of budget."
+        ctaLabel="Get a subscription"
+      />
+    );
+    expect(screen.getByText('Out of Usage')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Get a subscription' }));
+    expect(openUrl).toHaveBeenCalledWith(BILLING_DASHBOARD_URL);
+  });
+
   it('opens the billing dashboard through openUrl from the promotional credits banner', () => {
     render(<PromotionalCreditsBanner promoCredits={12} />);
 
@@ -42,5 +62,57 @@ describe('HomeBanners', () => {
     fireEvent.click(screen.getByRole('button', { name: /join our discord/i }));
 
     expect(openUrl).toHaveBeenCalledWith(DISCORD_INVITE_URL);
+  });
+
+  describe('EarlyBirdyBanner', () => {
+    it('renders the discount code and headline', () => {
+      render(<EarlyBirdyBanner />);
+
+      expect(screen.getByText('The first 1,000 users get 60% off.')).toBeInTheDocument();
+      expect(screen.getByText('EARLYBIRDY')).toBeInTheDocument();
+    });
+
+    it('opens the billing dashboard when the subscription link is clicked', () => {
+      render(<EarlyBirdyBanner />);
+
+      fireEvent.click(screen.getByRole('button', { name: /first subscription/i }));
+
+      expect(openUrl).toHaveBeenCalledWith(BILLING_DASHBOARD_URL);
+    });
+
+    it('does not render a dismiss button when onDismiss is not provided', () => {
+      render(<EarlyBirdyBanner />);
+
+      expect(
+        screen.queryByRole('button', { name: /dismiss early bird banner/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders an accessible dismiss button when onDismiss is provided', () => {
+      const onDismiss = vi.fn();
+      render(<EarlyBirdyBanner onDismiss={onDismiss} />);
+
+      expect(
+        screen.getByRole('button', { name: /dismiss early bird banner/i })
+      ).toBeInTheDocument();
+    });
+
+    it('calls onDismiss when the dismiss button is clicked', () => {
+      const onDismiss = vi.fn();
+      render(<EarlyBirdyBanner onDismiss={onDismiss} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /dismiss early bird banner/i }));
+
+      expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it('does not call openUrl when the dismiss button is clicked', () => {
+      const onDismiss = vi.fn();
+      render(<EarlyBirdyBanner onDismiss={onDismiss} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /dismiss early bird banner/i }));
+
+      expect(openUrl).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/src/components/skills/ScreenIntelligenceSetupModal.tsx
+++ b/app/src/components/skills/ScreenIntelligenceSetupModal.tsx
@@ -191,7 +191,7 @@ export default function ScreenIntelligenceSetupModal({ onClose, initialStep }: P
           {step === 'permissions' && (
             <div className="space-y-3">
               <p className="text-xs text-stone-500 leading-relaxed">
-                Screen Intelligence needs macOS permissions to capture your screen and provide context to your AI assistant.
+                Screen Intelligence needs macOS permissions to capture your screen and provide context to your agent.
               </p>
 
               <div className="space-y-2">
@@ -274,7 +274,7 @@ export default function ScreenIntelligenceSetupModal({ onClose, initialStep }: P
               </div>
 
               <p className="text-xs text-stone-500 leading-relaxed">
-                Enable Screen Intelligence to continuously capture what's on your screen and feed useful context into your AI assistant's memory.
+                Enable Screen Intelligence to continuously capture what's on your screen and feed useful context into your agent's memory.
               </p>
 
               <div className="space-y-2">
@@ -320,7 +320,7 @@ export default function ScreenIntelligenceSetupModal({ onClose, initialStep }: P
               <div>
                 <h3 className="text-sm font-semibold text-stone-900">Screen Intelligence is Enabled</h3>
                 <p className="mt-1 text-xs text-stone-500 leading-relaxed">
-                  Screen Intelligence is now enabled. Start a session from the settings panel to begin capturing screen context for your AI assistant.
+                  Screen Intelligence is now enabled. Start a session from the settings panel to begin capturing screen context for your agent.
                 </p>
               </div>
 

--- a/app/src/components/skills/VoiceSetupModal.tsx
+++ b/app/src/components/skills/VoiceSetupModal.tsx
@@ -195,8 +195,8 @@ export default function VoiceSetupModal({ onClose, skillStatus }: Props) {
 
               <div>
                 <h3 className="text-sm font-semibold text-stone-900">Voice Intelligence is Active</h3>
-                <p className="mt-1 text-xs text-stone-500 leading-relaxed">
-                  Press <span className="font-mono font-medium">{serverStatus?.hotkey ?? 'Fn'}</span> to start dictating. Your voice will be transcribed and sent to your AI assistant.
+                <p className="text-center mt-1 text-xs text-stone-500 leading-relaxed">
+                  Press <span className="font-mono font-medium">{serverStatus?.hotkey ?? 'Fn'}</span> to start dictating. Your voice will be transcribed and sent to your agent.
                 </p>
               </div>
 

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -319,7 +319,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
       setSendError(
         chatSendError(
           'safety_timeout',
-          'No response from the assistant after 10 minutes. Try again or check your connection.'
+          'No response from the agent after 10 minutes. Try again or check your connection.'
         )
       );
       dispatch(clearRuntimeForThread({ threadId }));

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import ConnectionIndicator from '../components/ConnectionIndicator';
 import {
   DiscordBanner,
+  EarlyBirdyBanner,
   PromotionalCreditsBanner,
   UsageLimitBanner,
 } from '../components/home/HomeBanners';
@@ -165,6 +166,8 @@ const Home = () => {
             Message OpenHuman
           </button>
         </div>
+
+        <EarlyBirdyBanner />
 
         <DiscordBanner />
 

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -62,7 +62,7 @@ const Home = () => {
   const socketStatus = useAppSelector(selectSocketStatus);
   const statusCopy = {
     connected:
-      'Your device is connected. Keep the app running to keep the connection alive. Message your assistant with the button below.',
+      'Your device is connected. Keep the app running to keep the connection alive. Message your agent with the button below.',
     connecting: 'Connecting. Hang tight, this usually takes a second.',
     disconnected:
       'Your device is offline right now. Check your network or restart the app to reconnect.',

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import {
   PromotionalCreditsBanner,
   UsageLimitBanner,
 } from '../components/home/HomeBanners';
+import { dismissBanner, shouldShowBanner } from '../components/upsell/upsellDismissState';
 import { useUsageState } from '../hooks/useUsageState';
 import { useUser } from '../hooks/useUser';
 import { useAppSelector } from '../store/hooks';
@@ -47,6 +48,16 @@ const Home = () => {
   const isFreeTier =
     user?.subscription?.plan === 'FREE' || !user?.subscription?.hasActiveSubscription;
   const showPromoBanner = isFreeTier && promoCredits > 0.01;
+
+  // Early birdy banner: once dismissed it stays gone (cooldown longer than any realistic session).
+  const [showEarlyBirdy, setShowEarlyBirdy] = useState(() =>
+    shouldShowBanner('home-earlybirdy', Number.MAX_SAFE_INTEGER)
+  );
+
+  const handleDismissEarlyBirdy = () => {
+    dismissBanner('home-earlybirdy');
+    setShowEarlyBirdy(false);
+  };
 
   const welcomeVariants = useMemo(
     () => [`Welcome, ${userName} 👋`, `Let's cook, ${userName} 🧑‍🍳.`, `Time to Zone In 🧘🏻`],
@@ -167,7 +178,7 @@ const Home = () => {
           </button>
         </div>
 
-        <EarlyBirdyBanner />
+        {showEarlyBirdy && <EarlyBirdyBanner onDismiss={handleDismissEarlyBirdy} />}
 
         <DiscordBanner />
 

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -794,8 +794,9 @@ export default function Skills() {
                         Channels
                       </h2>
                       <p className="mt-0.5 text-[11px] leading-relaxed text-stone-500">
-                        Connect messaging platforms so your assistant can chat where your community
-                        already lives.
+                        Connect messaging platforms so your agent can chat where you already are.
+                        Note that you will need to have OpenHuman running either on your desktop or
+                        in your own cloud.
                       </p>
                     </div>
                     <div
@@ -818,8 +819,8 @@ export default function Skills() {
                   <div className="px-1 pb-3 pt-1">
                     <h2 className="text-sm font-semibold text-stone-900">Integrations</h2>
                     <p className="mt-0.5 text-[11px] leading-relaxed text-stone-500">
-                      Connect external apps. Connected services are sorted first and highlighted in
-                      green.
+                      Connect external apps. Connected services give your agent access to the tools
+                      it needs to perform tasks.
                     </p>
                   </div>
                   <div className="space-y-3 px-1 pb-3">

--- a/app/src/pages/__tests__/Home.test.tsx
+++ b/app/src/pages/__tests__/Home.test.tsx
@@ -1,19 +1,39 @@
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { resolveHomeUserName } from '../Home';
-
-const mockUseUser = vi.fn(() => ({ user: { firstName: 'Shrey' } }));
 
 vi.mock('../../components/ConnectionIndicator', () => ({
   default: () => <div>Connection Indicator</div>,
 }));
 
-vi.mock('../../hooks/useUser', () => ({ useUser: () => mockUseUser() }));
+vi.mock('../../hooks/useUser', () => ({ useUser: () => ({ user: { firstName: 'Shrey' } }) }));
 
 vi.mock('../../utils/config', async importOriginal => {
   const actual = await importOriginal<typeof import('../../utils/config')>();
   return { ...actual, APP_VERSION: '0.0.0-test' };
 });
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+
+vi.mock('../../hooks/useUsageState', () => ({
+  useUsageState: () => ({ isRateLimited: false, shouldShowBudgetCompletedMessage: false }),
+}));
+
+vi.mock('../../store/hooks', () => ({ useAppSelector: () => 'connected' }));
+
+vi.mock('../../store/socketSelectors', () => ({ selectSocketStatus: vi.fn() }));
+
+vi.mock('../../utils/openUrl', () => ({ openUrl: vi.fn() }));
+
+const mockShouldShowBanner = vi.fn<() => boolean>(() => true);
+const mockDismissBanner = vi.fn<(id: string) => void>();
+
+vi.mock('../../components/upsell/upsellDismissState', () => ({
+  shouldShowBanner: (...args: Parameters<typeof mockShouldShowBanner>) =>
+    mockShouldShowBanner(...args),
+  dismissBanner: (...args: Parameters<typeof mockDismissBanner>) => mockDismissBanner(...args),
+}));
 
 describe('resolveHomeUserName', () => {
   it('uses camelCase name fields when present', () => {
@@ -30,5 +50,53 @@ describe('resolveHomeUserName', () => {
 
   it('falls back to the email local-part when no explicit name exists', () => {
     expect(resolveHomeUserName({ email: 'ada@example.com' })).toBe('ada');
+  });
+
+  it('returns User when given null', () => {
+    expect(resolveHomeUserName(null)).toBe('User');
+  });
+
+  it('returns User when given undefined', () => {
+    expect(resolveHomeUserName(undefined)).toBe('User');
+  });
+
+  it('returns User when given an empty object', () => {
+    expect(resolveHomeUserName({})).toBe('User');
+  });
+
+  it('prefixes @-less usernames with @', () => {
+    expect(resolveHomeUserName({ username: '@already' })).toBe('@already');
+  });
+
+  it('returns User when email local-part is empty', () => {
+    expect(resolveHomeUserName({ email: '@nodomain.com' })).toBe('User');
+  });
+});
+
+describe('Home page — EarlyBirdy banner integration', () => {
+  it('shows the EarlyBirdy banner when shouldShowBanner returns true', async () => {
+    mockShouldShowBanner.mockReturnValue(true);
+    const { default: Home } = await import('../Home');
+    render(<Home />);
+    expect(screen.getByText('The first 1,000 users get 60% off.')).toBeInTheDocument();
+  });
+
+  it('hides the EarlyBirdy banner when shouldShowBanner returns false', async () => {
+    mockShouldShowBanner.mockReturnValue(false);
+    const { default: Home } = await import('../Home');
+    render(<Home />);
+    expect(screen.queryByText('The first 1,000 users get 60% off.')).not.toBeInTheDocument();
+  });
+
+  it('dismisses the EarlyBirdy banner and calls dismissBanner when the X button is clicked', async () => {
+    mockShouldShowBanner.mockReturnValue(true);
+    const { default: Home } = await import('../Home');
+    render(<Home />);
+
+    const dismissBtn = screen.getByRole('button', { name: /dismiss early bird banner/i });
+    fireEvent.click(dismissBtn);
+
+    expect(mockDismissBanner).toHaveBeenCalledWith('home-earlybirdy');
+    expect(screen.queryByText('The first 1,000 users get 60% off.')).not.toBeInTheDocument();
   });
 });

--- a/app/src/utils/tauriCommands/config.ts
+++ b/app/src/utils/tauriCommands/config.ts
@@ -193,7 +193,7 @@ export async function aiGetConfig(): Promise<AIPreview> {
     soul: {
       raw: '',
       name: 'OpenHuman',
-      description: 'AI assistant',
+      description: 'Agent',
       personalityPreview: [],
       safetyRulesPreview: [],
       loadedAt: Date.now(),

--- a/src/openhuman/learning/linkedin_enrichment.rs
+++ b/src/openhuman/learning/linkedin_enrichment.rs
@@ -350,10 +350,7 @@ Rules:\n\
 - Keep the entire output under 400 words.\n\
 - Do not invent information — only use what is in the input.";
 
-    let model = config
-        .default_model
-        .as_deref()
-        .unwrap_or("neocortex-preview");
+    let model = "summarization-v1";
 
     tracing::debug!(
         model = model,


### PR DESCRIPTION
## Summary
- Adds `EarlyBirdyBanner` to the home view (with dismiss + tests) promoting the subscription discount, plus copy refinements.
- Renames user-facing terminology from \"assistant\" → \"agent\" across components for consistency.
- Pins the LinkedIn enrichment summarization to the dedicated `summarization-v1` model instead of falling back to `default_model`/`neocortex-preview`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test:unit`
- [ ] `cargo check --manifest-path Cargo.toml`
- [ ] Manual: home shows EarlyBirdyBanner and dismisses correctly
- [ ] Manual: LinkedIn enrichment summarization runs against `summarization-v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new dismissible banner on the home page with a call-to-action button linking to the billing dashboard.

* **Updates**
  * Updated application terminology from "AI assistant" to "agent" across user-facing screens, modals, and error messages.

* **Tests**
  * Expanded test coverage for banner functionality and home page interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->