### PR TITLE
fix: filter out global namespace from citation chips

### DIFF
--- a/app/src/pages/conversations/components/CitationChips.tsx
+++ b/app/src/pages/conversations/components/CitationChips.tsx
@@ -12,10 +12,11 @@ export type MessageCitation = {
 };
 
 export function CitationChips({ citations }: { citations: MessageCitation[] }) {
-  if (citations.length === 0) return null;
+  const filteredCitations = citations.filter(c => c.namespace !== 'global');
+  if (filteredCitations.length === 0) return null;
   return (
     <div className="mt-1.5 flex flex-wrap gap-1">
-      {citations.map(citation => {
+      {filteredCitations.map(citation => {
         const scoreLabel =
           typeof citation.score === 'number' ? ` ${Math.round(citation.score * 100)}%` : '';
         const title = `${citation.key}${citation.namespace ? ` (${citation.namespace})` : ''}\n${citation.snippet}`;


### PR DESCRIPTION
This PR fixes issue #1121 where assistant messages showed an unintended "global 100%" citation chip.

### Changes
* Updated `app/src/pages/conversations/components/CitationChips.tsx` to explicitly filter out citations with the `global` namespace before they are mapped and rendered.
* Re-evaluates whether to return `null` if the remaining filtered list of citations is empty, preventing a blank citation container.

### Testing
* Confirmed that `npm run test` successfully passes the full test suite in `app/`.

---
*PR created automatically by Jules for task [11407212333738798334](https://jules.google.com/task/11407212333738798334) started by @senamakel-droid*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that filters a specific citation namespace before rendering; main risk is unintentionally hiding legitimate citations if upstream labeling changes.
> 
> **Overview**
> Filters assistant message citations to exclude those with the `global` namespace before rendering chips in `CitationChips`.
> 
> Updates the empty-state logic to return `null` when all citations are filtered out, preventing an empty citation container from showing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c167b32856d127dd55edbf26cfa8c5a8f8fed5a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined citation display to show only relevant citations, improving clarity in citation chips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->