### PR TITLE
Fix CEF zombie processes on full app close and restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.11"
+version = "0.53.12"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -261,7 +261,14 @@ async fn restart_app(app: tauri::AppHandle<AppRuntime>) -> Result<(), String> {
             log::warn!("[app] hide main window before restart failed: {err}");
         }
     }
+
+    log::info!("[app] restart_app — starting early teardown before restart");
+    perform_early_teardown_async(&app).await;
+    log::info!("[app] restart_app — early teardown complete, restarting");
+
     app.restart();
+    // restart() does not return, but we must satisfy the signature
+    Ok(())
 }
 
 /// Read the authoritative active user id from `active_user.toml` so the
@@ -429,6 +436,10 @@ async fn apply_app_update(
 
     log::info!("[app-update] install complete — relaunching");
     let _ = app.emit("app-update:status", "restarting");
+
+    log::info!("[app-update] starting early teardown before restart");
+    perform_early_teardown_async(&app).await;
+
     // Note: app.restart() never returns. Anything after this is unreachable.
     app.restart();
 }
@@ -606,6 +617,10 @@ async fn install_app_update(
 
     log::info!("[app-update] install complete — relaunching");
     let _ = app.emit("app-update:status", "restarting");
+
+    log::info!("[app-update] starting early teardown before restart");
+    perform_early_teardown_async(&app).await;
+
     // Note: app.restart() never returns. Anything after this is unreachable.
     app.restart();
 }
@@ -916,7 +931,7 @@ fn setup_tray(app: &AppHandle<AppRuntime>) -> tauri::Result<()> {
             }
             "tray_quit" => {
                 log::info!("[tray] action=quit source=menu");
-                app.exit(0);
+                shutdown_app_sync(app, 0);
             }
             _ => {}
         })
@@ -980,6 +995,69 @@ fn teardown_cef_prewarm<R: tauri::Runtime>(app: &AppHandle<R>) -> Result<(), Str
     wv.close().map_err(|e| e.to_string())?;
     log::info!("[cef-prewarm] teardown ok");
     Ok(())
+}
+
+/// Shared early teardown logic before CEF's shutdown to prevent races and zombie processes.
+/// Synchronous version to be called from the main thread (e.g. `RunEvent::ExitRequested` or tray menu events).
+fn perform_early_teardown_sync(app_handle: &AppHandle<AppRuntime>) {
+    log::info!("[app] perform_early_teardown_sync — early teardown");
+
+    let _ = teardown_cef_prewarm(app_handle);
+
+    if let Some(state) = app_handle.try_state::<webview_accounts::WebviewAccountsState>() {
+        state.shutdown_all(app_handle);
+    }
+
+    webview_apis::server::stop();
+
+    if let Some(core) = app_handle.try_state::<core_process::CoreProcessHandle>() {
+        let core = core.inner().clone();
+        // Aborts the embedded server task. Synchronous and safe on
+        // the UI thread — `JoinHandle::abort` returns immediately.
+        tauri::async_runtime::block_on(async move {
+            core.send_terminate_signal().await;
+        });
+    }
+
+    // Give CEF's UI message loop a brief window to process the
+    // queued browser close messages before the runtime calls `cef::shutdown()`.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    log::info!("[app] perform_early_teardown_sync — early teardown complete");
+}
+
+/// Shared early teardown logic before CEF's shutdown to prevent races and zombie processes.
+/// Asynchronous version to be called from async Tauri commands (e.g. `restart_app`, updates).
+async fn perform_early_teardown_async(app_handle: &AppHandle<AppRuntime>) {
+    log::info!("[app] perform_early_teardown_async — early teardown");
+
+    let _ = teardown_cef_prewarm(app_handle);
+
+    if let Some(state) = app_handle.try_state::<webview_accounts::WebviewAccountsState>() {
+        state.shutdown_all(app_handle);
+    }
+
+    webview_apis::server::stop();
+
+    if let Some(core) = app_handle.try_state::<core_process::CoreProcessHandle>() {
+        let core = core.inner().clone();
+        core.send_terminate_signal().await;
+    }
+
+    // Give CEF's UI message loop a brief window to process the
+    // queued browser close messages before the runtime calls `cef::shutdown()`.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    log::info!("[app] perform_early_teardown_async — early teardown complete");
+}
+
+/// Explicitly winds down CEF and Tauri before an app.exit(0)
+#[allow(dead_code)]
+fn shutdown_app_sync(app_handle: &AppHandle<AppRuntime>, exit_code: i32) {
+    log::info!("[app] shutdown_app_sync — starting early teardown");
+    perform_early_teardown_sync(app_handle);
+    log::info!("[app] shutdown_app_sync — early teardown complete, exiting");
+    app_handle.exit(exit_code);
 }
 
 pub fn run() {
@@ -1675,35 +1753,7 @@ pub fn run() {
                 //      do not wait — that would block the main thread
                 //      and starve CEF's UI loop. The kernel reaps the
                 //      child after Tauri exits.
-                log::info!("[app] RunEvent::ExitRequested — early teardown");
-
-                let _ = teardown_cef_prewarm(app_handle);
-
-                if let Some(state) =
-                    app_handle.try_state::<webview_accounts::WebviewAccountsState>()
-                {
-                    state.shutdown_all(app_handle);
-                }
-
-                webview_apis::server::stop();
-
-                if let Some(core) = app_handle.try_state::<core_process::CoreProcessHandle>() {
-                    let core = core.inner().clone();
-                    // Aborts the embedded server task. Synchronous and safe on
-                    // the UI thread — `JoinHandle::abort` returns immediately.
-                    tauri::async_runtime::block_on(async move {
-                        core.send_terminate_signal().await;
-                    });
-                }
-
-                // Give CEF's UI message loop a brief window to process the
-                // queued browser close messages before the runtime calls
-                // `cef::shutdown()`. Without this, a webview that was mid-load
-                // when the user quit can race the shutdown and leave its
-                // renderer helper orphaned (re-parented to launchd on macOS).
-                std::thread::sleep(std::time::Duration::from_millis(50));
-
-                log::info!("[app] RunEvent::ExitRequested — early teardown complete");
+                perform_early_teardown_sync(app_handle);
             }
             RunEvent::Exit => {
                 log::info!("[app] RunEvent::Exit — cef::shutdown follows");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1052,7 +1052,6 @@ async fn perform_early_teardown_async(app_handle: &AppHandle<AppRuntime>) {
 }
 
 /// Explicitly winds down CEF and Tauri before an app.exit(0)
-#[allow(dead_code)]
 fn shutdown_app_sync(app_handle: &AppHandle<AppRuntime>, exit_code: i32) {
     log::info!("[app] shutdown_app_sync — starting early teardown");
     perform_early_teardown_sync(app_handle);


### PR DESCRIPTION
Extracts the early teardown logic into `perform_early_teardown_sync` and `perform_early_teardown_async` helpers, which ensure that child webviews, CDP tasks, and WebSockets are terminated before `cef::shutdown()` runs. Previously, this only executed on `RunEvent::ExitRequested`. Now, it also runs on tray quit (`shutdown_app_sync`), `restart_app`, and app update restarts, preventing orphaned helper processes.

## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [ ] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes:
- Follow-up PR(s)/TODOs:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown and restart reliability through enhanced system resource cleanup and graceful termination procedures.
  * Optimized the quit menu action for more reliable and consistent application exit behavior.

* **Refactor**
  * Streamlined internal exit event handling for improved consistency and reliability across application lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->