### PR TITLE
Update issue templates for GitHub issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,11 +1,13 @@
 ---
 name: Bug
 about: Used for bug reports
-title: "[Bug] "
-labels: bug, enhancement
+title: ""
+type: Bug
 assignees: ''
 
 ---
+
+Use a concise sentence-case title that describes the broken behavior. Do not add `Bug` or bracket prefixes to the title.
 
 ## Summary
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,11 +1,13 @@
 ---
 name: Feature
 about: Used for new features or suggestions
-title: "[Feature] "
-labels: enhancement
+title: ""
+type: Feature
 assignees: ''
 
 ---
+
+Use a concise sentence-case title that describes the requested outcome. Do not add `Feature` or bracket prefixes to the title.
 
 ## Summary
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,35 @@
+---
+name: Task
+about: Used for work items that are not primarily bugs or net-new features
+title: ""
+type: Task
+assignees: ''
+
+---
+
+Use a concise sentence-case title that describes the work item. Do not add `Task` or bracket prefixes to the title.
+
+## Summary
+
+What needs to be done and the intended outcome.
+
+## Problem / Context
+
+Why this work matters, what it unblocks, and any constraints or dependencies. Include links to related issues, PRs, docs, or design context where helpful.
+
+## Scope (optional)
+
+What is in scope, what is not, and any implementation notes or tradeoffs worth capturing up front.
+
+## Acceptance criteria
+
+- [ ] **Task 1** — TODO
+- [ ] **Task 2** — TODO
+- [ ] **Task 3** — TODO
+- [ ] **Diff coverage ≥ 80%** — the implementing PR meets the changed-lines coverage gate (Vitest + cargo-llvm-cov, enforced by [`.github/workflows/coverage.yml`](../../.github/workflows/coverage.yml)) when code changes are involved.
+
+- …
+
+## Related
+
+Links to issues, PRs, docs, or prior discussion.


### PR DESCRIPTION
## Summary

- Update `.github/ISSUE_TEMPLATE/bug.md` to use GitHub Issue Type `Bug` instead of a title prefix and redundant labels.
- Update `.github/ISSUE_TEMPLATE/feature.md` to use GitHub Issue Type `Feature` instead of a title prefix and redundant labels.
- Add a new `.github/ISSUE_TEMPLATE/task.md` template for non-bug, non-feature work items using GitHub Issue Type `Task`.
- Add explicit title guidance so reporters use concise sentence-case titles without bracket prefixes.

## Problem

- The repo has moved its top-level issue classification from labels into GitHub Issue Types.
- The existing bug and feature templates still pre-populated bracketed title prefixes and legacy labels, which conflicts with the current issue triage model.
- There was no dedicated task template even though the repo now uses `Task` as a first-class issue type.

## Solution

- Replace the old template front matter with `type: Bug` and `type: Feature`.
- Remove the default `[Bug]` / `[Feature]` title prefixes and redundant label assignments from those templates.
- Add a new task template with `type: Task` for chores, refactors, docs, testing, perf work, and similar non-feature/non-bug work.
- Add short inline guidance telling reporters not to add type prefixes to issue titles.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
  N/A: repository metadata/template change only; no runtime behavior changed.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
  N/A: no executable code changed.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
  N/A: issue template maintenance only.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
  N/A: no feature IDs apply.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
  N/A: no code or dependency changes.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
  N/A: GitHub template metadata only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section
  N/A: standalone repository hygiene change.

## Impact

- Repository issue-creation flow now aligns with the current GitHub Issue Type model.
- New issues created from templates will no longer add bracketed type prefixes or redundant bug/feature labels.
- Contributors now have an explicit task template for work that should be typed as `Task`.

## Related

- Closes: N/A (repository issue-template maintenance)
- Follow-up PR(s)/TODOs: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bug and Feature issue templates to remove automatic title prefixes, requiring concise, sentence-case titles from users.
  * Added a new Task issue template with structured sections for problem context, acceptance criteria, and related links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->