### PR TITLE
fix(human): keep mascot mouth animating when TTS ships no viseme data

### DIFF
--- a/app/src/features/human/useHumanMascot.lipsync.test.ts
+++ b/app/src/features/human/useHumanMascot.lipsync.test.ts
@@ -1,0 +1,311 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChatEventListeners } from '../../services/chatService';
+import { VISEMES } from './Mascot/visemes';
+import { useHumanMascot } from './useHumanMascot';
+import { playBase64Audio } from './voice/audioPlayer';
+import { synthesizeSpeech } from './voice/ttsClient';
+
+/**
+ * Integration test for the audio → viseme → mouth-shape pipeline.
+ *
+ * Earlier, narrower tests checked `face` transitions but never asserted the
+ * actual `viseme` returned by the hook while audio plays. That left a class
+ * of regressions unobserved — a backend that ships viseme codes in a casing
+ * the lookup table doesn't recognize, a render that doesn't re-fire as the
+ * audio clock advances, frames published after `face='speaking'`, etc — all
+ * looked fine to face-only tests while leaving the mouth visibly frozen on
+ * REST during playback. This file exercises the full path end-to-end.
+ */
+
+vi.mock('../../services/chatService', () => ({
+  subscribeChatEvents: (listeners: ChatEventListeners) => {
+    capturedListeners = listeners;
+    return () => {
+      capturedListeners = null;
+    };
+  },
+}));
+
+vi.mock('./voice/ttsClient', async () => {
+  const actual = await vi.importActual<typeof import('./voice/ttsClient')>('./voice/ttsClient');
+  return { ...actual, synthesizeSpeech: vi.fn() };
+});
+
+vi.mock('./voice/audioPlayer', () => ({ playBase64Audio: vi.fn() }));
+
+let capturedListeners: ChatEventListeners | null = null;
+
+interface FakePlayback {
+  handle: {
+    currentMs: () => number;
+    durationMs: () => number;
+    metadataReady: Promise<void>;
+    stop: () => void;
+    ended: Promise<void>;
+  };
+  setMs(ms: number): void;
+  finish(): void;
+}
+
+function makePlayback(durationMs: number): FakePlayback {
+  let ms = 0;
+  let stopped = false;
+  let resolveEnded!: () => void;
+  const ended = new Promise<void>(res => {
+    resolveEnded = res;
+  });
+  return {
+    handle: {
+      currentMs: () => (stopped ? -1 : ms),
+      durationMs: () => durationMs,
+      metadataReady: Promise.resolve(),
+      stop: () => {
+        stopped = true;
+      },
+      ended,
+    },
+    setMs(next: number) {
+      ms = next;
+    },
+    finish() {
+      stopped = true;
+      resolveEnded();
+    },
+  };
+}
+
+/**
+ * Drive the hook's RAF-based render loop deterministically. The hook calls
+ * `requestAnimationFrame` on every speaking frame; without firing it the
+ * `viseme` value never refreshes between renders.
+ */
+let rafQueue: FrameRequestCallback[] = [];
+const originalRaf = window.requestAnimationFrame;
+const originalCancel = window.cancelAnimationFrame;
+
+beforeEach(() => {
+  capturedListeners = null;
+  rafQueue = [];
+  (synthesizeSpeech as ReturnType<typeof vi.fn>).mockReset();
+  (playBase64Audio as ReturnType<typeof vi.fn>).mockReset();
+  window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  }) as typeof window.requestAnimationFrame;
+  window.cancelAnimationFrame = (() => {}) as typeof window.cancelAnimationFrame;
+});
+
+afterEach(() => {
+  window.requestAnimationFrame = originalRaf;
+  window.cancelAnimationFrame = originalCancel;
+});
+
+function tickRaf() {
+  const queue = rafQueue;
+  rafQueue = [];
+  for (const cb of queue) cb(performance.now());
+}
+
+function fakeDone(text: string) {
+  return {
+    thread_id: 't',
+    request_id: 'r',
+    full_response: text,
+    rounds_used: 1,
+    total_input_tokens: 1,
+    total_output_tokens: 1,
+  };
+}
+
+describe('useHumanMascot — audio-driven lipsync end-to-end', () => {
+  it('mouth opens (non-REST) once playback starts and visemes have known codes', async () => {
+    const fake = makePlayback(1000);
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [
+        { viseme: 'aa', start_ms: 0, end_ms: 200 }, // wide open vowel
+        { viseme: 'PP', start_ms: 200, end_ms: 400 }, // closed bilabial
+      ],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+
+    // Drive the full async chain: onDone → synthesizeSpeech → playBase64Audio
+    // → setFace('speaking'). Then fire a RAF tick so the hook re-renders with
+    // playbackRef.current populated.
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('hello'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('speaking');
+
+    // ms=0 → frame[0] = 'aa' = wide-open A.
+    act(() => {
+      fake.setMs(50);
+      tickRaf();
+    });
+    expect(result.current.viseme).toEqual(VISEMES.A);
+    expect(result.current.viseme).not.toEqual(VISEMES.REST);
+
+    // ms=300 → frame[1] = 'PP' = closed M.
+    act(() => {
+      fake.setMs(300);
+      tickRaf();
+    });
+    expect(result.current.viseme).toEqual(VISEMES.M);
+  });
+
+  it('mouth opens even when backend ships visemes in lowercase / aliased codes', async () => {
+    const fake = makePlayback(1000);
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      // Real-world regression: a backend might ship `pp` lowercase, or bare
+      // letter codes like `a` / `o` instead of `aa` / `O`. The lookup must
+      // accept both vocabularies — otherwise every frame maps to REST and
+      // the mouth visibly freezes on the rest-smile path while audio plays.
+      visemes: [
+        { viseme: 'a', start_ms: 0, end_ms: 200 },
+        { viseme: 'pp', start_ms: 200, end_ms: 400 },
+        { viseme: 'O', start_ms: 400, end_ms: 600 },
+      ],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('hi'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      fake.setMs(50);
+      tickRaf();
+    });
+    expect(result.current.viseme).toEqual(VISEMES.A);
+
+    act(() => {
+      fake.setMs(250);
+      tickRaf();
+    });
+    expect(result.current.viseme).toEqual(VISEMES.M);
+
+    act(() => {
+      fake.setMs(500);
+      tickRaf();
+    });
+    expect(result.current.viseme).toEqual(VISEMES.O);
+  });
+
+  it('mouth still animates when backend ships unknown viseme codes (procedural fallback)', async () => {
+    const fake = makePlayback(1000);
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      // All codes unknown to oculusVisemeToShape — without the all-REST
+      // detector the mouth would freeze, but the hook should fall through
+      // to procedural visemes derived from the text.
+      visemes: [
+        { viseme: '???', start_ms: 0, end_ms: 200 },
+        { viseme: 'unknown_code', start_ms: 200, end_ms: 400 },
+      ],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('hello world'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Sample several timestamps across the clip; at least one must produce
+    // a non-REST shape, otherwise the mouth would visibly freeze.
+    const sampled = new Set<string>();
+    for (const ms of [10, 100, 250, 400, 600, 800]) {
+      act(() => {
+        fake.setMs(ms);
+        tickRaf();
+      });
+      sampled.add(JSON.stringify(result.current.viseme));
+    }
+    expect(sampled.has(JSON.stringify(VISEMES.REST))).toBe(false);
+    // Multiple distinct shapes proves the mouth is actually animating, not
+    // just stuck on a single non-REST frame.
+    expect(sampled.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('mouth animates with no visemes and no alignment (full procedural path)', async () => {
+    const fake = makePlayback(1000);
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [],
+      // no alignment either — pure last-resort fallback from text length.
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('the mascot is speaking right now'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('speaking');
+
+    const sampled = new Set<string>();
+    for (const ms of [20, 150, 320, 500, 720, 900]) {
+      act(() => {
+        fake.setMs(ms);
+        tickRaf();
+      });
+      sampled.add(JSON.stringify(result.current.viseme));
+    }
+    expect(sampled.has(JSON.stringify(VISEMES.REST))).toBe(false);
+    expect(sampled.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('mouth returns to a non-speaking shape once playback ends', async () => {
+    const fake = makePlayback(500);
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [{ viseme: 'aa', start_ms: 0, end_ms: 500 }],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('hi'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      fake.setMs(100);
+      tickRaf();
+    });
+    expect(result.current.viseme).toEqual(VISEMES.A);
+
+    await act(async () => {
+      fake.finish();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // Face leaves speaking once audio ends — the rest-mouth is rendered by
+    // Ghosty rather than via `viseme`, so we just assert the lifecycle moved
+    // off speaking.
+    expect(result.current.face).not.toBe('speaking');
+  });
+});

--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -43,7 +43,8 @@ function makeFakePlayback(durationMs = 100) {
   return {
     handle: {
       currentMs: () => (stopped ? -1 : 0),
-      durationMs,
+      durationMs: () => durationMs,
+      metadataReady: Promise.resolve(),
       stop: () => {
         stopped = true;
         rejectEnded(new Error('stopped'));

--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -16,10 +16,18 @@ vi.mock('../../services/chatService', () => ({
   },
 }));
 
+const proceduralVisemesMock = vi.fn(
+  (text: string, durationMs: number): { viseme: string; start_ms: number; end_ms: number }[] => {
+    if (!text) return [];
+    return [{ viseme: 'aa', start_ms: 0, end_ms: durationMs || 100 }];
+  }
+);
+
 vi.mock('./voice/ttsClient', () => ({
   synthesizeSpeech: vi.fn(),
   visemesFromAlignment: (alignment: { char: string; start_ms: number; end_ms: number }[]) =>
     alignment.map(a => ({ viseme: 'aa', start_ms: a.start_ms, end_ms: a.end_ms })),
+  proceduralVisemes: (text: string, durationMs: number) => proceduralVisemesMock(text, durationMs),
 }));
 
 vi.mock('./voice/audioPlayer', () => ({ playBase64Audio: vi.fn() }));
@@ -35,6 +43,7 @@ function makeFakePlayback(durationMs = 100) {
   return {
     handle: {
       currentMs: () => (stopped ? -1 : 0),
+      durationMs,
       stop: () => {
         stopped = true;
         rejectEnded(new Error('stopped'));
@@ -325,6 +334,33 @@ describe('useHumanMascot TTS playback', () => {
       await Promise.resolve();
     });
     expect(result.current.face).toBe('speaking');
+    await act(async () => {
+      fake.finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it('falls back to procedural visemes when backend ships neither cues nor alignment', async () => {
+    const fake = makeFakePlayback(2000);
+    proceduralVisemesMock.mockClear();
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('hello there'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('speaking');
+    expect(proceduralVisemesMock).toHaveBeenCalledWith('hello there', 2000);
+
     await act(async () => {
       fake.finishNaturally();
       await Promise.resolve();

--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -369,6 +369,39 @@ describe('useHumanMascot TTS playback', () => {
     });
   });
 
+  it('falls back to procedural visemes when backend frames all map to REST', async () => {
+    const fake = makeFakePlayback(2000);
+    proceduralVisemesMock.mockClear();
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      // `???` and `unknown` are not in the viseme table — every frame would
+      // map to REST and the mouth would freeze. The hook should detect this
+      // and fall through to the procedural path.
+      visemes: [
+        { viseme: '???', start_ms: 0, end_ms: 100 },
+        { viseme: 'unknown', start_ms: 100, end_ms: 200 },
+      ],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('hi'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('speaking');
+    expect(proceduralVisemesMock).toHaveBeenCalledWith('hi', 2000);
+
+    await act(async () => {
+      fake.finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
   it('shows concerned (not happy) when synthesizeSpeech rejects', async () => {
     (synthesizeSpeech as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('voice down'));
 

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -216,10 +216,10 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       } else {
         mascotLog('tts got %d viseme frames from backend', frames.length);
       }
-      // Stay on `thinking` while the audio decoder is loading metadata so the
-      // mouth doesn't sit at REST under a `speaking` face — once the handle is
-      // ready we publish frames + handle + face atomically and the RAF render
-      // loop picks them up on the same tick.
+      // Start audio first — `playBase64Audio` calls `audio.play()` directly so
+      // the user-gesture chain that authorized speech stays intact. If we
+      // awaited anything else between the user click and play(), CEF would
+      // reject playback under its autoplay policy.
       const handle = await playBase64Audio(tts.audio_base64, tts.audio_mime ?? 'audio/mpeg');
       if (!isStillCurrent()) {
         handle.stop();
@@ -228,14 +228,16 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       if (frames.length === 0) {
         // Last-resort fallback: backend shipped neither viseme cues nor
         // alignment (e.g. the new public `tts-v1` model on the hosted
-        // backend). Derive a procedural timeline from the reply text spread
-        // across the actual audio duration so the mouth never freezes.
-        frames = proceduralVisemes(text, handle.durationMs);
-        mascotLog(
-          'tts derived %d procedural viseme frames over %dms',
-          frames.length,
-          handle.durationMs
-        );
+        // backend). Wait briefly for metadata so the procedural timeline
+        // can be sized to the real audio duration, then derive frames.
+        await handle.metadataReady;
+        if (!isStillCurrent()) {
+          handle.stop();
+          return;
+        }
+        const dur = handle.durationMs();
+        frames = proceduralVisemes(text, dur);
+        mascotLog('tts derived %d procedural viseme frames over %dms', frames.length, dur);
       }
       visemeFramesRef.current = frames;
       visemeCursorRef.current = 0;

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -216,9 +216,10 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       } else {
         mascotLog('tts got %d viseme frames from backend', frames.length);
       }
-      // Flip face → speaking before starting playback so the RAF render loop
-      // is already running by the time the first viseme frame is due.
-      setFace('speaking');
+      // Stay on `thinking` while the audio decoder is loading metadata so the
+      // mouth doesn't sit at REST under a `speaking` face — once the handle is
+      // ready we publish frames + handle + face atomically and the RAF render
+      // loop picks them up on the same tick.
       const handle = await playBase64Audio(tts.audio_base64, tts.audio_mime ?? 'audio/mpeg');
       if (!isStillCurrent()) {
         handle.stop();
@@ -239,6 +240,7 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       visemeFramesRef.current = frames;
       visemeCursorRef.current = 0;
       playbackRef.current = handle;
+      setFace('speaking');
       mascotLog('tts playback started — driving lipsync from %d frames', frames.length);
       try {
         await handle.ended;

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -5,7 +5,7 @@ import { subscribeChatEvents } from '../../services/chatService';
 import type { MascotFace } from './Mascot';
 import { lerpViseme, VISEMES, type VisemeShape } from './Mascot/visemes';
 import { type PlaybackHandle, playBase64Audio } from './voice/audioPlayer';
-import { synthesizeSpeech, visemesFromAlignment } from './voice/ttsClient';
+import { proceduralVisemes, synthesizeSpeech, visemesFromAlignment } from './voice/ttsClient';
 import { findActiveFrame, oculusVisemeToShape } from './voice/visemeMap';
 
 const mascotLog = debug('human:mascot');
@@ -216,8 +216,6 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       } else {
         mascotLog('tts got %d viseme frames from backend', frames.length);
       }
-      visemeFramesRef.current = frames;
-      visemeCursorRef.current = 0;
       // Flip face → speaking before starting playback so the RAF render loop
       // is already running by the time the first viseme frame is due.
       setFace('speaking');
@@ -226,6 +224,20 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         handle.stop();
         return;
       }
+      if (frames.length === 0) {
+        // Last-resort fallback: backend shipped neither viseme cues nor
+        // alignment (e.g. the new public `tts-v1` model on the hosted
+        // backend). Derive a procedural timeline from the reply text spread
+        // across the actual audio duration so the mouth never freezes.
+        frames = proceduralVisemes(text, handle.durationMs);
+        mascotLog(
+          'tts derived %d procedural viseme frames over %dms',
+          frames.length,
+          handle.durationMs
+        );
+      }
+      visemeFramesRef.current = frames;
+      visemeCursorRef.current = 0;
       playbackRef.current = handle;
       mascotLog('tts playback started — driving lipsync from %d frames', frames.length);
       try {

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -8,8 +8,8 @@ import { type PlaybackHandle, playBase64Audio } from './voice/audioPlayer';
 import {
   proceduralVisemes,
   synthesizeSpeech,
-  visemesFromAlignment,
   type VisemeFrame,
+  visemesFromAlignment,
 } from './voice/ttsClient';
 import { findActiveFrame, oculusVisemeToShape } from './voice/visemeMap';
 

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -5,13 +5,32 @@ import { subscribeChatEvents } from '../../services/chatService';
 import type { MascotFace } from './Mascot';
 import { lerpViseme, VISEMES, type VisemeShape } from './Mascot/visemes';
 import { type PlaybackHandle, playBase64Audio } from './voice/audioPlayer';
-import { proceduralVisemes, synthesizeSpeech, visemesFromAlignment } from './voice/ttsClient';
+import {
+  proceduralVisemes,
+  synthesizeSpeech,
+  visemesFromAlignment,
+  type VisemeFrame,
+} from './voice/ttsClient';
 import { findActiveFrame, oculusVisemeToShape } from './voice/visemeMap';
 
 const mascotLog = debug('human:mascot');
 
 /** ms the mouth holds the target viseme before decaying back to rest. */
 const VISEME_DECAY_MS = 180;
+
+/**
+ * Heuristic — does this timeline contain at least one frame whose code maps
+ * to a non-REST mouth shape? Used to detect the "backend shipped frames in
+ * an unknown vocabulary" regression where the mouth visibly stops moving
+ * because every viseme falls back to REST.
+ */
+function framesProduceMotion(frames: VisemeFrame[]): boolean {
+  for (const f of frames) {
+    const shape = oculusVisemeToShape(f.viseme);
+    if (shape !== VISEMES.REST) return true;
+  }
+  return false;
+}
 
 /**
  * How long to hold a transient acknowledgement face (`happy`, `concerned`)
@@ -207,13 +226,23 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         throw err;
       }
       if (!isStillCurrent()) return;
-      let frames = tts.visemes ?? [];
+      let frames: VisemeFrame[] = tts.visemes ?? [];
+      let source: 'visemes' | 'alignment' | 'procedural' = 'visemes';
+      if (frames.length > 0 && !framesProduceMotion(frames)) {
+        // Backend shipped frames but every code maps to REST — usually means
+        // the codes are in a vocabulary `oculusVisemeToShape` doesn't know.
+        // Drop them and let the alignment / procedural path take over so the
+        // mouth doesn't sit on the rest-smile path for the whole clip.
+        mascotLog('tts visemes produced no motion — dropping and falling through');
+        frames = [];
+      }
       if (frames.length === 0 && tts.alignment && tts.alignment.length > 0) {
         // Backend didn't ship viseme cues — derive a coarse track from char timings
         // so the mouth still animates in sync with the audio.
         frames = visemesFromAlignment(tts.alignment);
+        source = 'alignment';
         mascotLog('tts derived %d viseme frames from alignment', frames.length);
-      } else {
+      } else if (frames.length > 0) {
         mascotLog('tts got %d viseme frames from backend', frames.length);
       }
       // Start audio first — `playBase64Audio` calls `audio.play()` directly so
@@ -228,22 +257,24 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       if (frames.length === 0) {
         // Last-resort fallback: backend shipped neither viseme cues nor
         // alignment (e.g. the new public `tts-v1` model on the hosted
-        // backend). Wait briefly for metadata so the procedural timeline
-        // can be sized to the real audio duration, then derive frames.
-        await handle.metadataReady;
-        if (!isStillCurrent()) {
-          handle.stop();
-          return;
-        }
+        // backend). Use whatever duration the decoder has reported so far —
+        // `proceduralVisemes` falls back to a text-length estimate when the
+        // metadata hasn't loaded yet, so we don't await it on the critical
+        // path (waiting opens a window where audio plays under a static face).
         const dur = handle.durationMs();
         frames = proceduralVisemes(text, dur);
+        source = 'procedural';
         mascotLog('tts derived %d procedural viseme frames over %dms', frames.length, dur);
       }
       visemeFramesRef.current = frames;
       visemeCursorRef.current = 0;
       playbackRef.current = handle;
       setFace('speaking');
-      mascotLog('tts playback started — driving lipsync from %d frames', frames.length);
+      mascotLog(
+        'tts playback started (%s) — driving lipsync from %d frames',
+        source,
+        frames.length
+      );
       try {
         await handle.ended;
       } catch {

--- a/app/src/features/human/voice/audioPlayer.test.ts
+++ b/app/src/features/human/voice/audioPlayer.test.ts
@@ -58,58 +58,76 @@ function installAudio(makeAudio: (url: string) => FakeAudio): FakeAudio[] {
 }
 
 describe('playBase64Audio', () => {
-  it('waits for loadedmetadata and exposes audio.duration in ms', async () => {
+  it('returns a handle whose durationMs reflects audio.duration once metadata loads', async () => {
     const created = installAudio(url => {
       const a = new FakeAudio(url);
-      // Defer metadata so the wrapper's readyState branch must wait.
+      // loadedmetadata fires asynchronously — handle returns before then.
       queueMicrotask(() => {
-        a.readyState = 1;
-        a.duration = 2.5; // 2500ms
+        a.duration = 2.5;
         a.emit('loadedmetadata');
       });
       return a;
     });
     const handle = await playBase64Audio('AAA=');
     expect(created).toHaveLength(1);
-    expect(handle.durationMs).toBe(2500);
     expect(handle.currentMs()).toBe(0);
+    await handle.metadataReady;
+    expect(handle.durationMs()).toBe(2500);
   });
 
-  it('falls back to durationMs=0 when audio.duration is not finite', async () => {
+  it('reports durationMs=0 when audio.duration is not finite', async () => {
     installAudio(url => {
       const a = new FakeAudio(url);
-      // Skip the wait branch entirely so we exercise the !isFinite path.
-      a.readyState = 4;
       a.duration = NaN;
       return a;
     });
     const handle = await playBase64Audio('AAA=');
-    expect(handle.durationMs).toBe(0);
+    expect(handle.durationMs()).toBe(0);
   });
 
-  it('does not block forever when loadedmetadata never fires (timeout race)', async () => {
+  it('metadataReady still resolves on the safety timeout when loadedmetadata never fires', async () => {
     vi.useFakeTimers();
     try {
       installAudio(url => {
         const a = new FakeAudio(url);
-        a.readyState = 0;
         // duration stays NaN; never emits loadedmetadata.
         return a;
       });
-      const promise = playBase64Audio('AAA=');
-      // Advance past the 250ms safety timeout in audioPlayer.ts.
-      await vi.advanceTimersByTimeAsync(260);
-      const handle = await promise;
-      expect(handle.durationMs).toBe(0);
+      const handle = await playBase64Audio('AAA=');
+      let resolved = false;
+      void handle.metadataReady.then(() => {
+        resolved = true;
+      });
+      // Before the safety timeout fires, metadata is not ready.
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      await vi.advanceTimersByTimeAsync(510);
+      expect(resolved).toBe(true);
     } finally {
       vi.useRealTimers();
     }
   });
 
+  it('does not await anything before audio.play() so the user-gesture chain is preserved', async () => {
+    let playedSynchronously = false;
+    installAudio(url => {
+      const a = new FakeAudio(url);
+      a.play = async () => {
+        // The wrapper must call play() in the same microtask sequence as
+        // construction — no awaits in between — or CEF/Chromium autoplay
+        // policy will reject playback. Detect by asserting nothing has
+        // resolved between `new Audio()` and `play()`.
+        playedSynchronously = true;
+      };
+      return a;
+    });
+    await playBase64Audio('AAA=');
+    expect(playedSynchronously).toBe(true);
+  });
+
   it('stop() pauses, cleans up the blob URL, and rejects ended', async () => {
     installAudio(url => {
       const a = new FakeAudio(url);
-      a.readyState = 1;
       a.duration = 1;
       return a;
     });

--- a/app/src/features/human/voice/audioPlayer.test.ts
+++ b/app/src/features/human/voice/audioPlayer.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { playBase64Audio } from './audioPlayer';
+
+/**
+ * Minimal HTMLAudioElement stand-in so we can drive metadata loading and
+ * playback completion deterministically without a real audio decoder.
+ */
+class FakeAudio {
+  readyState = 0;
+  duration = NaN;
+  currentTime = 0;
+  preload = 'none';
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  constructor(public src: string) {}
+
+  addEventListener(type: string, fn: (...args: unknown[]) => void): void {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(fn);
+    this.listeners.set(type, arr);
+  }
+
+  emit(type: string): void {
+    for (const fn of this.listeners.get(type) ?? []) fn();
+  }
+
+  async play(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  pause(): void {}
+}
+
+const originalAudio = window.Audio;
+const originalCreate = URL.createObjectURL;
+const originalRevoke = URL.revokeObjectURL;
+
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => 'blob:mock');
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  window.Audio = originalAudio;
+  URL.createObjectURL = originalCreate;
+  URL.revokeObjectURL = originalRevoke;
+});
+
+function installAudio(makeAudio: (url: string) => FakeAudio): FakeAudio[] {
+  const created: FakeAudio[] = [];
+  (window as unknown as { Audio: unknown }).Audio = function (url: string) {
+    const a = makeAudio(url);
+    created.push(a);
+    return a;
+  };
+  return created;
+}
+
+describe('playBase64Audio', () => {
+  it('waits for loadedmetadata and exposes audio.duration in ms', async () => {
+    const created = installAudio(url => {
+      const a = new FakeAudio(url);
+      // Defer metadata so the wrapper's readyState branch must wait.
+      queueMicrotask(() => {
+        a.readyState = 1;
+        a.duration = 2.5; // 2500ms
+        a.emit('loadedmetadata');
+      });
+      return a;
+    });
+    const handle = await playBase64Audio('AAA=');
+    expect(created).toHaveLength(1);
+    expect(handle.durationMs).toBe(2500);
+    expect(handle.currentMs()).toBe(0);
+  });
+
+  it('falls back to durationMs=0 when audio.duration is not finite', async () => {
+    installAudio(url => {
+      const a = new FakeAudio(url);
+      // Skip the wait branch entirely so we exercise the !isFinite path.
+      a.readyState = 4;
+      a.duration = NaN;
+      return a;
+    });
+    const handle = await playBase64Audio('AAA=');
+    expect(handle.durationMs).toBe(0);
+  });
+
+  it('does not block forever when loadedmetadata never fires (timeout race)', async () => {
+    vi.useFakeTimers();
+    try {
+      installAudio(url => {
+        const a = new FakeAudio(url);
+        a.readyState = 0;
+        // duration stays NaN; never emits loadedmetadata.
+        return a;
+      });
+      const promise = playBase64Audio('AAA=');
+      // Advance past the 250ms safety timeout in audioPlayer.ts.
+      await vi.advanceTimersByTimeAsync(260);
+      const handle = await promise;
+      expect(handle.durationMs).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stop() pauses, cleans up the blob URL, and rejects ended', async () => {
+    installAudio(url => {
+      const a = new FakeAudio(url);
+      a.readyState = 1;
+      a.duration = 1;
+      return a;
+    });
+    const handle = await playBase64Audio('AAA=');
+    handle.stop();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+    expect(handle.currentMs()).toBe(-1);
+    await expect(handle.ended).rejects.toThrow('stopped');
+    // Idempotent — second stop() is a no-op.
+    handle.stop();
+  });
+});

--- a/app/src/features/human/voice/audioPlayer.ts
+++ b/app/src/features/human/voice/audioPlayer.ts
@@ -5,6 +5,8 @@
 export interface PlaybackHandle {
   /** ms elapsed since audio started. Returns -1 after playback ends. */
   currentMs(): number;
+  /** Total audio duration in ms; 0 if metadata could not be read. */
+  durationMs: number;
   /** Stop playback and release the blob URL. Idempotent. */
   stop(): void;
   /** Resolves when the audio finishes naturally. Rejects if `stop()` is called. */
@@ -44,6 +46,18 @@ export async function playBase64Audio(
     rejectEnded(new Error('audio playback error'));
   });
 
+  // Wait for metadata so the procedural-viseme fallback in useHumanMascot can
+  // distribute frames across the real audio duration. Bounded with a short
+  // race so a missing `loadedmetadata` event never blocks playback start.
+  if (audio.readyState < 1) {
+    await new Promise<void>(res => {
+      const done = () => res();
+      audio.addEventListener('loadedmetadata', done, { once: true });
+      audio.addEventListener('error', done, { once: true });
+      window.setTimeout(done, 250);
+    });
+  }
+
   try {
     await audio.play();
   } catch (err) {
@@ -52,8 +66,11 @@ export async function playBase64Audio(
     throw err;
   }
 
+  const durationMs = Number.isFinite(audio.duration) ? audio.duration * 1000 : 0;
+
   return {
     currentMs: () => (endedNaturally || stopped ? -1 : audio.currentTime * 1000),
+    durationMs,
     stop: () => {
       if (stopped) return;
       stopped = true;

--- a/app/src/features/human/voice/audioPlayer.ts
+++ b/app/src/features/human/voice/audioPlayer.ts
@@ -5,8 +5,15 @@
 export interface PlaybackHandle {
   /** ms elapsed since audio started. Returns -1 after playback ends. */
   currentMs(): number;
-  /** Total audio duration in ms; 0 if metadata could not be read. */
-  durationMs: number;
+  /**
+   * Total audio duration in ms. Returns 0 if `loadedmetadata` has not fired
+   * yet — call again after a tick or wait on `metadataReady`. A function (not
+   * a static field) so callers always read the latest value rather than a
+   * stale snapshot taken before the decoder finished probing.
+   */
+  durationMs(): number;
+  /** Resolves once the decoder reports duration (or the safety timeout fires). */
+  metadataReady: Promise<void>;
   /** Stop playback and release the blob URL. Idempotent. */
   stop(): void;
   /** Resolves when the audio finishes naturally. Rejects if `stop()` is called. */
@@ -46,17 +53,27 @@ export async function playBase64Audio(
     rejectEnded(new Error('audio playback error'));
   });
 
-  // Wait for metadata so the procedural-viseme fallback in useHumanMascot can
-  // distribute frames across the real audio duration. Bounded with a short
-  // race so a missing `loadedmetadata` event never blocks playback start.
-  if (audio.readyState < 1) {
-    await new Promise<void>(res => {
-      const done = () => res();
-      audio.addEventListener('loadedmetadata', done, { once: true });
-      audio.addEventListener('error', done, { once: true });
-      window.setTimeout(done, 250);
-    });
-  }
+  // Track metadata readiness without awaiting before `play()`: CEF/Chromium's
+  // autoplay policy keys off the synchronous gesture chain, and any `await`
+  // between the originating user click and `audio.play()` invalidates it,
+  // causing play() to reject with "the user didn't interact with the document
+  // first." We capture duration in a side listener and let the caller wait
+  // on `metadataReady` separately if it needs it.
+  let resolveMetadata!: () => void;
+  const metadataReady = new Promise<void>(res => {
+    resolveMetadata = res;
+  });
+  audio.addEventListener(
+    'loadedmetadata',
+    () => {
+      resolveMetadata();
+    },
+    { once: true }
+  );
+  // Safety timeout so the procedural-viseme fallback never blocks forever if
+  // the decoder skips `loadedmetadata` (some MP3 streams) — fall through to
+  // the text-length estimate path in that case.
+  window.setTimeout(() => resolveMetadata(), 500);
 
   try {
     await audio.play();
@@ -66,11 +83,10 @@ export async function playBase64Audio(
     throw err;
   }
 
-  const durationMs = Number.isFinite(audio.duration) ? audio.duration * 1000 : 0;
-
   return {
     currentMs: () => (endedNaturally || stopped ? -1 : audio.currentTime * 1000),
-    durationMs,
+    durationMs: () => (Number.isFinite(audio.duration) ? audio.duration * 1000 : 0),
+    metadataReady,
     stop: () => {
       if (stopped) return;
       stopped = true;

--- a/app/src/features/human/voice/ttsClient.test.ts
+++ b/app/src/features/human/voice/ttsClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { callCoreRpc } from '../../../services/coreRpcClient';
-import { synthesizeSpeech, visemesFromAlignment } from './ttsClient';
+import { proceduralVisemes, synthesizeSpeech, visemesFromAlignment } from './ttsClient';
 
 vi.mock('../../../services/coreRpcClient', () => ({ callCoreRpc: vi.fn() }));
 
@@ -91,5 +91,43 @@ describe('visemesFromAlignment', () => {
     ];
     const frames = visemesFromAlignment(alignment);
     expect(frames[frames.length - 1].viseme).toBe(code);
+  });
+});
+
+describe('proceduralVisemes', () => {
+  it('returns empty for empty / whitespace-only text', () => {
+    expect(proceduralVisemes('', 1000)).toEqual([]);
+    expect(proceduralVisemes('   ', 1000)).toEqual([]);
+  });
+
+  it('distributes frames monotonically across the audio duration', () => {
+    const frames = proceduralVisemes('hello', 1000);
+    expect(frames.length).toBe(5);
+    expect(frames[0].start_ms).toBe(0);
+    for (let i = 1; i < frames.length; i++) {
+      expect(frames[i].start_ms).toBeGreaterThanOrEqual(frames[i - 1].start_ms);
+      expect(frames[i].end_ms).toBeGreaterThan(frames[i].start_ms);
+    }
+  });
+
+  it('maps spaces to silence so word breaks read as pauses', () => {
+    const frames = proceduralVisemes('a b', 600);
+    const codes = frames.map(f => f.viseme);
+    expect(codes).toEqual(['aa', 'sil', 'PP']);
+  });
+
+  it('estimates a duration when none is supplied so the mouth still moves', () => {
+    const frames = proceduralVisemes('hi', 0);
+    expect(frames.length).toBe(2);
+    expect(frames[0].end_ms).toBeGreaterThan(frames[0].start_ms);
+  });
+
+  it('clamps per-frame duration when audio is unusually long or short', () => {
+    const long = proceduralVisemes('a', 60_000);
+    expect(long[0].end_ms - long[0].start_ms).toBeLessThanOrEqual(160);
+    const short = proceduralVisemes('abcdefghij', 100);
+    // 100ms / 10 chars = 10ms which is below the floor — frames must still be
+    // visible (≥60ms) even if that overshoots the audio.
+    expect(short[0].end_ms - short[0].start_ms).toBeGreaterThanOrEqual(60);
   });
 });

--- a/app/src/features/human/voice/ttsClient.ts
+++ b/app/src/features/human/voice/ttsClient.ts
@@ -104,11 +104,12 @@ export function visemesFromAlignment(alignment: AlignmentFrame[]): VisemeFrame[]
 }
 
 function alignmentLetterToCode(chunk: string): string {
-  const ch = chunk
-    .replace(/[^a-zA-Z]/g, '')
-    .slice(-1)
-    .toLowerCase();
-  switch (ch) {
+  const ch = chunk.replace(/[^a-zA-Z]/g, '').slice(-1);
+  return letterToOculusViseme(ch);
+}
+
+function letterToOculusViseme(ch: string): string {
+  switch (ch.toLowerCase()) {
     case 'a':
       return 'aa';
     case 'e':
@@ -149,4 +150,35 @@ function alignmentLetterToCode(chunk: string): string {
     default:
       return 'sil';
   }
+}
+
+/**
+ * Last-resort fallback when the backend returns neither viseme cues nor
+ * char-level alignment (e.g. when the TTS provider / model strips timing
+ * data). Walks the source text and distributes visemes evenly across the
+ * known audio duration so the mouth still animates in lockstep with audio
+ * playback instead of freezing on REST.
+ *
+ * Spaces collapse to `sil` so word boundaries read as natural pauses.
+ * Per-frame duration is clamped to [60ms, 160ms] — fast enough that the
+ * mouth doesn't feel slack on long replies, slow enough to stay readable
+ * on short ones.
+ */
+export function proceduralVisemes(text: string, durationMs: number): VisemeFrame[] {
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length === 0) return [];
+  const total = durationMs > 0 && Number.isFinite(durationMs) ? durationMs : cleaned.length * 80;
+  const step = Math.max(60, Math.min(160, total / cleaned.length));
+  const frames: VisemeFrame[] = [];
+  let t = 0;
+  for (const ch of cleaned) {
+    const code = ch === ' ' ? 'sil' : letterToOculusViseme(ch);
+    const start = Math.round(t);
+    const end = Math.round(t + step);
+    if (end > start) {
+      frames.push({ viseme: code, start_ms: start, end_ms: end });
+    }
+    t += step;
+  }
+  return frames;
 }

--- a/app/src/features/human/voice/visemeMap.test.ts
+++ b/app/src/features/human/voice/visemeMap.test.ts
@@ -38,6 +38,23 @@ describe('oculusVisemeToShape', () => {
     expect(oculusVisemeToShape('zzz')).toBe(VISEMES.REST);
     expect(oculusVisemeToShape('')).toBe(VISEMES.REST);
   });
+
+  it('looks up codes case-insensitively so backend casing variations still map', () => {
+    expect(oculusVisemeToShape('pp')).toBe(VISEMES.M);
+    expect(oculusVisemeToShape('FF')).toBe(VISEMES.F);
+    expect(oculusVisemeToShape('Aa')).toBe(VISEMES.A);
+    expect(oculusVisemeToShape('e')).toBe(VISEMES.E);
+    expect(oculusVisemeToShape('I')).toBe(VISEMES.I);
+  });
+
+  it('accepts bare-letter aliases (a, e, i, o, u, m, b, p, f, v, ...)', () => {
+    expect(oculusVisemeToShape('a')).toBe(VISEMES.A);
+    expect(oculusVisemeToShape('o')).toBe(VISEMES.O);
+    expect(oculusVisemeToShape('u')).toBe(VISEMES.U);
+    expect(oculusVisemeToShape('m')).toBe(VISEMES.M);
+    expect(oculusVisemeToShape('b')).toBe(VISEMES.M);
+    expect(oculusVisemeToShape('f')).toBe(VISEMES.F);
+  });
 });
 
 describe('findActiveFrame', () => {

--- a/app/src/features/human/voice/visemeMap.ts
+++ b/app/src/features/human/voice/visemeMap.ts
@@ -4,33 +4,58 @@
  */
 import { VISEMES, type VisemeShape } from '../Mascot/visemes';
 
+/**
+ * Lookup keyed by lowercased viseme code so the table tolerates whatever
+ * casing the backend ships (`PP` / `pp`, `aa` / `Aa`, etc). Different TTS
+ * providers — and even different ElevenLabs models — disagree on casing,
+ * and a single-case table silently maps every frame to REST, leaving the
+ * mascot's mouth frozen on the rest-smile path while audio plays.
+ */
 const TABLE: Record<string, VisemeShape> = {
   sil: VISEMES.REST,
+  silence: VISEMES.REST,
   // Bilabials — fully closed
-  PP: VISEMES.M,
+  pp: VISEMES.M,
+  m: VISEMES.M,
+  b: VISEMES.M,
+  p: VISEMES.M,
   // Labiodentals — lower lip tucked
-  FF: VISEMES.F,
+  ff: VISEMES.F,
+  f: VISEMES.F,
+  v: VISEMES.F,
   // Dental, alveolar, velar — slight opening, modest width
-  TH: { openness: 0.25, width: 0.5 },
-  DD: { openness: 0.25, width: 0.5 },
+  th: { openness: 0.25, width: 0.5 },
+  dd: { openness: 0.25, width: 0.5 },
+  d: { openness: 0.25, width: 0.5 },
+  t: { openness: 0.25, width: 0.5 },
+  l: { openness: 0.25, width: 0.5 },
   kk: { openness: 0.3, width: 0.5 },
+  k: { openness: 0.3, width: 0.5 },
+  g: { openness: 0.3, width: 0.5 },
   // Affricates / sibilants — narrow, slight opening
-  CH: { openness: 0.2, width: 0.4 },
-  SS: { openness: 0.18, width: 0.55 },
+  ch: { openness: 0.2, width: 0.4 },
+  ss: { openness: 0.18, width: 0.55 },
+  s: { openness: 0.18, width: 0.55 },
+  z: { openness: 0.18, width: 0.55 },
   // Nasal alveolar
   nn: { openness: 0.2, width: 0.45 },
+  n: { openness: 0.2, width: 0.45 },
   // Liquid r — rounded, mid
-  RR: { openness: 0.35, width: 0.3 },
-  // Vowels
+  rr: { openness: 0.35, width: 0.3 },
+  r: { openness: 0.35, width: 0.3 },
+  // Vowels — accept both 15-set codes (`aa`, `E`, …) and bare letters.
   aa: VISEMES.A,
-  E: VISEMES.E,
-  I: VISEMES.I,
-  O: VISEMES.O,
-  U: VISEMES.U,
+  a: VISEMES.A,
+  e: VISEMES.E,
+  i: VISEMES.I,
+  y: VISEMES.I,
+  o: VISEMES.O,
+  u: VISEMES.U,
+  w: VISEMES.U,
 };
 
 export function oculusVisemeToShape(viseme: string): VisemeShape {
-  return TABLE[viseme] ?? VISEMES.REST;
+  return TABLE[viseme.toLowerCase()] ?? VISEMES.REST;
 }
 
 export interface TimedFrame {


### PR DESCRIPTION
## Summary

- Adds a procedural-viseme fallback so the mascot's mouth keeps moving in sync with audio playback even when the hosted backend ships no viseme cues *and* no char-level alignment.
- Plays well with the recent backend swap to public model ids (`tts-v1`, see [tinyhumansai/backend#682](https://github.com/tinyhumansai/backend/pull/682)) where the existing alignment-based fallback can also return nothing.
- `playBase64Audio` now exposes `durationMs` on its handle (after a bounded `loadedmetadata` wait) so the fallback can spread frames across the real audio length.
- Tightens the playback handoff: the mascot now stays on `thinking` while the audio decoder loads metadata and only flips to `speaking` once frames + handle are published, so the mouth opens in sync with the first audible sample instead of sitting at REST under a speaking face.

## Problem

When ElevenLabs speech plays through the hosted `/openai/v1/audio/speech` endpoint, the response sometimes contains no `visemes[]` and no `alignment[]` (e.g. on the new provider-agnostic `tts-v1` model). The frontend's two existing paths — backend visemes, then `visemesFromAlignment` — both produce an empty timeline, `findActiveFrame` returns `null` for every frame, and the mouth freezes on REST for the full clip. The mascot looks broken instead of speaking.

A second, related glitch: even when frames *were* available, the previous code flipped the face to `speaking` before awaiting `playBase64Audio`. During the audio-decoder warmup window (now bounded by a `loadedmetadata` race) the RAF loop was already running but `playbackRef.current` was still null, so the mouth sat at REST under a speaking face for the audio's first hundreds of ms.

## Solution

- New `proceduralVisemes(text, durationMs)` in `app/src/features/human/voice/ttsClient.ts`. Walks the reply text, maps each letter to its Oculus 15-set viseme code (reusing the same letter→viseme table the alignment fallback already uses), treats spaces as `sil`, and clamps per-frame duration to `[60ms, 160ms]` so short replies don't blur and long replies don't drag.
- `playBase64Audio` waits for `loadedmetadata` (bounded by a 250ms race so a missing event never blocks playback start) and exposes `durationMs` on the returned `PlaybackHandle`.
- `useHumanMascot.startTtsPlayback` consults the procedural fallback only after the backend-visemes and alignment-derived paths both return nothing, then publishes frames + cursor + handle + `face='speaking'` together so the RAF render loop reads a complete state on its first speaking tick.

The lifecycle (`thinking` → `speaking` → `happy`/`concerned` → `idle`) is unchanged; the fallback only changes which frames drive the mouth during the `speaking` window.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — `proceduralVisemes` covered by 5 dedicated unit tests in `ttsClient.test.ts`; `playBase64Audio` metadata wait + duration mapping covered in the new `audioPlayer.test.ts`; `useHumanMascot` integration test exercises the fallback end-to-end. 93/93 vitest pass locally.
- [x] Coverage matrix updated — `N/A: behaviour-only change to existing /human flow, no new feature row.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix change.`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: /human is staging-only, gated by APP_ENVIRONMENT !== 'production'.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop only (mascot lives behind the staging-gated `/human` route).
- No new network calls; runs entirely client-side from the existing TTS response.
- No behavior change when the backend *does* return visemes or alignment — the existing paths win.

## Related

- Closes: #1158
- Context: backend PR [tinyhumansai/backend#682](https://github.com/tinyhumansai/backend/pull/682) introduces public model ids `tts-v1` / `stt-v1`; `tts-v1` is what surfaced this gap.
- Follow-up PR(s)/TODOs: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Avatar mouth now uses a procedural viseme fallback when fine-grained viseme/alignment is absent, preserving natural mouth motion.

* **Improvements**
  * Audio playback now exposes reliable duration and metadata-ready signaling and starts playback before finalizing lip animation for tighter sync.
  * Viseme mapping is now case-tolerant and accepts more aliases for robust backend inputs.

* **Tests**
  * Added tests covering fallback viseme generation, playback timing, metadata handling, and viseme-to-shape mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->