### PR TITLE
fix(composio): per-action tool consumes backend markdownFormatted

### DIFF
--- a/src/openhuman/composio/action_tool.rs
+++ b/src/openhuman/composio/action_tool.rs
@@ -134,9 +134,27 @@ impl Tool for ComposioActionTool {
                         elapsed_ms,
                     },
                 );
-                Ok(ToolResult::success(
-                    serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
-                ))
+                // Mirror `ComposioExecuteTool::execute` (composio/tools.rs):
+                // prefer the backend-rendered `markdownFormatted` for LLM
+                // consumption when present, fall back to the raw JSON
+                // envelope on absence or non-success. Keeps both routes
+                // (dispatcher + per-action) consistent so the model sees
+                // the same compact transcript regardless of which tool
+                // surface integrations_agent picked.
+                let body = if resp.successful {
+                    match resp
+                        .markdown_formatted
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                    {
+                        Some(md) => md.to_string(),
+                        None => serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
+                    }
+                } else {
+                    serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into())
+                };
+                Ok(ToolResult::success(body))
             }
             Err(e) => {
                 crate::core::event_bus::publish_global(


### PR DESCRIPTION
## Summary

- PR #1165 swapped the dispatcher path (`composio/tools.rs`) and the JSON-RPC op (`composio/ops.rs`) to prefer the backend's `markdownFormatted` for LLM-facing output, but missed the third LLM-facing surface: `ComposioActionTool::execute` (the per-action tool wrapper that `integrations_agent` registers when spawned with a toolkit).
- Toolkit-scoped sub-agents kept seeing raw `ComposioExecuteResponse` JSON in `<tool_result>` even though the backend was returning a compact markdown transcript — defeating the point of #1165 for that path.
- Mirror the success-branch logic from `composio/tools.rs:538-550`: prefer `markdown_formatted` when set + non-empty, fall back to the JSON envelope on absence or non-success.

## Problem

`ComposioActionTool` is one of three routes from the LLM to the Composio backend:

1. `ComposioExecuteTool::execute` (`composio/tools.rs`) — generic dispatcher used by orchestrator. Fixed in #1165.
2. `composio_execute` JSON-RPC op (`composio/ops.rs`) — Tauri/CLI consumer. Fixed in #1165.
3. **`ComposioActionTool::execute` (`composio/action_tool.rs`)** — per-action tool registered dynamically by `integrations_agent` when spawned with a `toolkit` argument (one tool per action, e.g. `GMAIL_FETCH_EMAILS` as a first-class tool, with the generic dispatcher deliberately excluded). **Missed by #1165.**

Reproduction: spawn `integrations_agent` with `toolkit=gmail`, have the model call `GMAIL_FETCH_EMAILS`. The `<tool_result>` body comes back as `{"data":{"messages":[…]}, "successful":true, …}` instead of the backend-rendered markdown transcript — same hot-path duplicated parsing waste #1165 was supposed to remove.

## Solution

In `ComposioActionTool::execute` success branch (`composio/action_tool.rs:127-154`), apply the same `markdown_formatted`-or-fallback swap as `composio/tools.rs:538-550`:

- On `resp.successful`, prefer `resp.markdown_formatted.as_deref().map(str::trim).filter(|s| !s.is_empty())` for the body; fall back to `serde_json::to_string(&resp)` when `None` / empty.
- On non-success, keep serializing the envelope (preserves `error`, `data`, `cost_usd` for the model to see what failed).

Both LLM-facing routes (dispatcher + per-action) now produce the same compact transcript regardless of which tool surface `integrations_agent` happens to use.

## Submission Checklist

- [ ] N/A: tests — passive consumption of an existing serde-renamed field; no new branch logic beyond a 1:1 mirror of the dispatcher path. The dispatcher's behaviour is exercised by the existing `composio` test suite (`cargo test composio`); the per-action tool's sandbox-gate tests in `action_tool.rs` already cover the surrounding execute() shape.
- [ ] N/A: diff coverage — change is a 13-line success-branch swap (markdown vs JSON serialization) inside an existing `match` arm. The new `Some(md) => md.to_string()` branch is the only added path; the JSON fallback was the prior behaviour.
- [ ] N/A: coverage matrix — no feature added/removed/renamed; the `composio_execute` slug, args, and success/error semantics are unchanged.
- [ ] N/A: no matrix-listed feature IDs touched.
- [x] No new external network dependencies introduced.
- [ ] N/A: does not touch release-cut surfaces (no UI, no installer, no migration).
- [ ] N/A: no linked issue — direct follow-up to #1165.

## Impact

- **Runtime**: removes the residual JSON-envelope serialization from the per-action LLM path; net win on prompt tokens for any toolkit-scoped `integrations_agent` spawn that calls Composio actions returning `markdownFormatted`.
- **Compatibility**: serde-additive — pre-#683 backends that don't return `markdownFormatted` simply hit the JSON-envelope fallback. No breaking change.
- **Security**: no new attack surface; we now consume *less* untrusted input than before on this path too (no client-side parse of the envelope when markdown is supplied).

## Related

- Follows-up: #1165 (consumed `markdownFormatted` on the dispatcher + JSON-RPC paths but missed the per-action wrapper)
- Backend PR: tinyhumansai/backend#683
- Closes:
- Follow-up PR(s)/TODOs: none — this closes the LLM-facing gap. Memory ingestion paths (`composio/providers/gmail/provider.rs::sync()`, `bin/gmail_backfill_3d.rs`) intentionally still call `post_process_action_result` — they need the structured slim envelope, not the markdown string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced action result output to display readable transcripts when available, with improved fallback to structured data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->