### PR TITLE
chore(memory_tree): drop body-read timeouts on Ollama HTTP calls

### DIFF
--- a/src/openhuman/memory/tree/score/embed/ollama.rs
+++ b/src/openhuman/memory/tree/score/embed/ollama.rs
@@ -63,16 +63,19 @@ impl OllamaEmbedder {
             timeout_ms
         };
         let timeout = Duration::from_millis(timeout_ms);
+        // No body-read timeout. Ollama is local — slow responses mean
+        // the model is genuinely processing, not that the network
+        // broke. A body-read timeout here would cancel mid-stream and
+        // force retries against the same slow model. `timeout` is
+        // repurposed as the TCP connect timeout (fast-fail when
+        // Ollama is actually down).
         let client = reqwest::Client::builder()
-            .timeout(timeout)
+            .connect_timeout(timeout)
             .build()
-            // Falling back to the default client keeps `new` infallible;
-            // timeouts will apply per-request via explicit `.timeout()`
-            // calls below.
             .unwrap_or_else(|e| {
                 log::warn!(
                     "[memory_tree::embed::ollama] failed to build client \
-                     with timeout — using default: {e}"
+                     with connect_timeout — using default: {e}"
                 );
                 reqwest::Client::new()
             });
@@ -130,9 +133,11 @@ impl Embedder for OllamaEmbedder {
         };
         let resp = self
             .client
+            // No per-request body-read timeout — see `OllamaEmbedder::new`
+            // for rationale. The Client's `connect_timeout` still applies
+            // and fails fast if Ollama isn't reachable.
             .post(self.embed_url())
             .json(&req)
-            .timeout(self.timeout)
             .send()
             .await
             .with_context(|| {

--- a/src/openhuman/memory/tree/score/extract/llm.rs
+++ b/src/openhuman/memory/tree/score/extract/llm.rs
@@ -49,8 +49,13 @@ pub struct LlmExtractorConfig {
     pub endpoint: String,
     /// Model identifier as known to the endpoint (e.g. `qwen2.5:0.5b`).
     pub model: String,
-    /// Per-request timeout. The default is generous because the first
-    /// request after a model swap may need to load weights.
+    /// TCP connect timeout. Used only to fail fast when Ollama is
+    /// down; no body-read timeout is applied (see `Self::new` for
+    /// rationale — local Ollama on slow CPU inference can take
+    /// minutes per call, and cancelling mid-stream triggered
+    /// cancellation-path retry storms). The default is generous
+    /// because the first request after a model swap may need to load
+    /// weights.
     pub timeout: Duration,
     /// Which entity kinds the LLM is allowed to emit. Anything outside this
     /// set is mapped to [`EntityKind::Misc`] or dropped depending on
@@ -105,8 +110,18 @@ impl LlmEntityExtractor {
     /// Build the extractor and its inner HTTP client. Fails only when
     /// `reqwest` rejects the timeout configuration.
     pub fn new(cfg: LlmExtractorConfig) -> anyhow::Result<Self> {
+        // No body-read timeout. Ollama is a local process — slow
+        // responses mean the model is genuinely processing under CPU
+        // load (e.g. gemma3:1b on CPU-only inference can take minutes
+        // per call), not that the network broke. A body-read timeout
+        // here would cancel mid-flight generation and force the
+        // existing 3× retry-with-backoff to re-run the same prompt
+        // against the same slow model, which empirically caused retry
+        // storms during high-load ingest. `cfg.timeout` is now the
+        // TCP connect timeout — short enough to fail fast when
+        // Ollama is actually unreachable.
         let http = Client::builder()
-            .timeout(cfg.timeout)
+            .connect_timeout(cfg.timeout)
             .build()
             .map_err(anyhow::Error::from)?;
         Ok(Self { cfg, http })

--- a/src/openhuman/memory/tree/tree_source/summariser/llm.rs
+++ b/src/openhuman/memory/tree/tree_source/summariser/llm.rs
@@ -115,8 +115,14 @@ impl LlmSummariser {
     /// Build a summariser around `cfg`. Returns an error only if the HTTP
     /// client fails to construct (timeout / TLS init).
     pub fn new(cfg: LlmSummariserConfig) -> Result<Self> {
+        // No body-read timeout. Ollama is local — slow responses mean
+        // the model is genuinely processing, not that the network
+        // broke. A body-read timeout here would cancel mid-stream and
+        // force retries against the same slow model. `cfg.timeout` is
+        // repurposed as the TCP connect timeout (fast-fail when
+        // Ollama is actually down).
         let http = Client::builder()
-            .timeout(cfg.timeout)
+            .connect_timeout(cfg.timeout)
             .build()
             .map_err(anyhow::Error::from)?;
         Ok(Self {


### PR DESCRIPTION
## Summary

The three Ollama-call-site `reqwest::Client` builders (extract LLM, embed, summariser) previously applied a body-read timeout via `Client::builder().timeout(cfg.timeout)`. For a **local** Ollama process this is the wrong shape — there is no network in between, so a slow response means the model is genuinely processing under CPU load (gemma3:1b on CPU-only inference takes minutes per call), not that the network is broken.

Cancellation under timeout was empirically the trigger for retry storms during high-load ingest: each cancelled request restarted a 3× retry loop against the same slow model, multiplying the in-flight load and pinning workers in the LLM semaphore for many minutes.

## Changes

- Replace `Client::builder().timeout(...)` with `Client::builder().connect_timeout(...)` in all three call sites:
  - `score::extract::llm::LlmEntityExtractor::new`
  - `score::embed::ollama::OllamaEmbedder::new`
  - `tree_source::summariser::llm::LlmSummariser::new`
- Drop the per-request `.timeout(self.timeout)` chain on the embedder send-path; the connect timeout on the shared client is now the only deadline.
- The `cfg.timeout` / `LlmExtractorConfig::timeout` field is semantically repurposed (TCP connect timeout, fail-fast when Ollama is unreachable). Default values unchanged so external configs don't need updating.

## Behavior

| Ollama state | Before | After |
|---|---|---|
| Healthy | Calls complete normally | Same — no observable change |
| Slow CPU inference | Cancel at 15s/10s/120s → retry storm | Calls wait; worker semaphore holds slot for full call (serializes LLM-bound work as designed) |
| Down | Connect refused after `cfg.timeout` → retry loop runs | Same — fast-fail behaviour preserved |

## Test plan

- [x] `cargo check --bin openhuman-core` clean
- [x] 45 unit tests pass across the three modules (`memory::tree::score::extract::llm`, `memory::tree::score::embed::ollama`, `memory::tree::tree_source::summariser::llm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP timeout handling to prevent long-running inference operations from being cancelled mid-request while maintaining fast failure detection when services are unreachable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->