### PR TITLE
feat(tools): markdown output for internal tool results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.12"
+version = "0.53.13"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -32,6 +32,7 @@ use crate::openhuman::context::{ReductionOutcome, ARCHIVIST_EXTRACTION_PROMPT};
 use crate::openhuman::memory::MemoryCategory;
 use crate::openhuman::providers::{ChatMessage, ChatRequest, ConversationMessage, ProviderDelta};
 use crate::openhuman::tools::Tool;
+use crate::openhuman::tools::traits::ToolCallOptions;
 use crate::openhuman::util::truncate_with_ellipsis;
 use anyhow::Result;
 use std::hash::{Hash, Hasher};
@@ -892,7 +893,14 @@ impl Agent {
                 false,
             )
         } else if let Some(tool) = self.tools.iter().find(|t| t.name() == call.name) {
-            let exec = tool.execute(call.arguments.clone());
+            // Per-call options: ask the tool for markdown output when the
+            // context manager is configured to prefer it. Tools that
+            // implement `execute_with_options` will populate
+            // `markdown_formatted`; others fall through to the default
+            // implementation which forwards to `execute`.
+            let prefer_markdown = self.context.prefer_markdown_tool_output();
+            let options = ToolCallOptions { prefer_markdown };
+            let exec = tool.execute_with_options(call.arguments.clone(), options);
             let outcome = if let Some(fork_ctx) = fork_context_for_call {
                 harness::with_fork_context(fork_ctx, exec).await
             } else {
@@ -901,7 +909,14 @@ impl Agent {
             match outcome {
                 Ok(r) => {
                     if !r.is_error {
-                        let mut output = r.output();
+                        let mut output = r.output_for_llm(prefer_markdown);
+                        if prefer_markdown && r.markdown_formatted.is_some() {
+                            log::debug!(
+                                "[agent_loop] tool={} returned markdown payload bytes={}",
+                                call.name,
+                                output.len()
+                            );
+                        }
                         // Issue #574 — if a payload summarizer is wired
                         // in (orchestrator session only) and the output
                         // exceeds the configured threshold, hand it to
@@ -944,7 +959,10 @@ impl Agent {
                         }
                         (output, true)
                     } else {
-                        (format!("Error: {}", r.output()), false)
+                        (
+                            format!("Error: {}", r.output_for_llm(prefer_markdown)),
+                            false,
+                        )
                     }
                 }
                 Err(e) => (format!("Error executing {}: {e}", call.name), false),

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -31,8 +31,8 @@ use crate::openhuman::context::prompt::{LearnedContextData, PromptContext, Promp
 use crate::openhuman::context::{ReductionOutcome, ARCHIVIST_EXTRACTION_PROMPT};
 use crate::openhuman::memory::MemoryCategory;
 use crate::openhuman::providers::{ChatMessage, ChatRequest, ConversationMessage, ProviderDelta};
-use crate::openhuman::tools::Tool;
 use crate::openhuman::tools::traits::ToolCallOptions;
+use crate::openhuman::tools::Tool;
 use crate::openhuman::util::truncate_with_ellipsis;
 use anyhow::Result;
 use std::hash::{Hash, Hasher};

--- a/src/openhuman/config/schema/context.rs
+++ b/src/openhuman/config/schema/context.rs
@@ -94,6 +94,16 @@ pub struct ContextConfig {
     /// summarization on long sessions.
     #[serde(default)]
     pub summarizer_model: Option<String>,
+
+    /// When `true`, the agent loop asks tools to render their results as
+    /// markdown instead of JSON before they enter LLM context. Tools that
+    /// support it populate `ToolResult::markdown_formatted`; the harness
+    /// prefers that field over the JSON fallback. Markdown is materially
+    /// cheaper than JSON in tokens, especially on tool-heavy loops.
+    /// Default: `true` — opt out per-deployment via config or env if a
+    /// downstream consumer expects strict JSON tool output.
+    #[serde(default = "default_true")]
+    pub prefer_markdown_tool_output: bool,
 }
 
 fn default_enabled() -> bool {
@@ -136,6 +146,7 @@ impl Default for ContextConfig {
             summarizer_max_payload_tokens: default_summarizer_max_payload_tokens(),
             session_memory: SessionMemoryConfig::default(),
             summarizer_model: None,
+            prefer_markdown_tool_output: default_true(),
         }
     }
 }

--- a/src/openhuman/context/manager.rs
+++ b/src/openhuman/context/manager.rs
@@ -115,6 +115,11 @@ pub struct ContextManager {
     /// every caller that touches "what's in the model's context window"
     /// reads the same source of truth.
     tool_result_budget_bytes: usize,
+    /// When `true`, the agent loop asks tools to populate
+    /// `ToolResult::markdown_formatted` so the harness can hand the LLM
+    /// markdown instead of JSON — significantly cheaper in the model
+    /// context window. See [`ContextConfig::prefer_markdown_tool_output`].
+    prefer_markdown_tool_output: bool,
 }
 
 impl ContextManager {
@@ -155,7 +160,14 @@ impl ContextManager {
             default_prompt_builder,
             enabled: config.enabled,
             tool_result_budget_bytes: config.tool_result_budget_bytes,
+            prefer_markdown_tool_output: config.prefer_markdown_tool_output,
         }
+    }
+
+    /// Whether the agent loop should ask tools to render their output as
+    /// markdown (when supported) instead of JSON, to save LLM tokens.
+    pub fn prefer_markdown_tool_output(&self) -> bool {
+        self.prefer_markdown_tool_output
     }
 
     /// Byte budget for an individual tool result before the context

--- a/src/openhuman/skills/types.rs
+++ b/src/openhuman/skills/types.rs
@@ -10,6 +10,14 @@ pub struct ToolResult {
     /// Indicates if the tool encountered an error during execution.
     #[serde(default)]
     pub is_error: bool,
+    /// Optional markdown rendering of the result. When the agent loop
+    /// is configured with `prefer_markdown`, this is sent to the LLM
+    /// instead of the JSON-serialised content blocks. Mirrors the
+    /// `markdownFormatted` field on Composio's backend responses
+    /// (see #1165) — markdown is significantly cheaper than JSON in
+    /// the model context window.
+    #[serde(default, rename = "markdownFormatted", skip_serializing_if = "Option::is_none")]
+    pub markdown_formatted: Option<String>,
 }
 
 impl ToolResult {
@@ -17,6 +25,7 @@ impl ToolResult {
         Self {
             content: vec![ToolContent::Text { text: text.into() }],
             is_error: false,
+            markdown_formatted: None,
         }
     }
 
@@ -26,6 +35,7 @@ impl ToolResult {
                 text: message.into(),
             }],
             is_error: true,
+            markdown_formatted: None,
         }
     }
 
@@ -33,7 +43,43 @@ impl ToolResult {
         Self {
             content: vec![ToolContent::Json { data }],
             is_error: false,
+            markdown_formatted: None,
         }
+    }
+
+    /// Construct a successful result that carries both a JSON payload
+    /// (for programmatic consumers / debugging) and a markdown rendering
+    /// (preferred by the agent loop when `prefer_markdown` is on).
+    pub fn success_with_markdown(
+        data: serde_json::Value,
+        markdown: impl Into<String>,
+    ) -> Self {
+        Self {
+            content: vec![ToolContent::Json { data }],
+            is_error: false,
+            markdown_formatted: Some(markdown.into()),
+        }
+    }
+
+    /// Attach (or replace) the markdown rendering on an existing result.
+    pub fn with_markdown(mut self, markdown: impl Into<String>) -> Self {
+        self.markdown_formatted = Some(markdown.into());
+        self
+    }
+
+    /// Returns the markdown rendering when present and non-empty,
+    /// otherwise falls back to [`Self::output`]. Used by the agent loop
+    /// when token-saving markdown output is requested.
+    pub fn output_for_llm(&self, prefer_markdown: bool) -> String {
+        if prefer_markdown {
+            if let Some(md) = self.markdown_formatted.as_deref() {
+                let trimmed = md.trim();
+                if !trimmed.is_empty() {
+                    return md.to_string();
+                }
+            }
+        }
+        self.output()
     }
 
     pub fn text(&self) -> String {
@@ -112,6 +158,7 @@ mod tests {
                 },
             ],
             is_error: false,
+            markdown_formatted: None,
         };
         assert_eq!(r.text(), "line1\nline2");
         let output = r.output();
@@ -162,8 +209,43 @@ mod tests {
         let r = ToolResult {
             content: vec![],
             is_error: false,
+            markdown_formatted: None,
         };
         assert!(r.text().is_empty());
         assert!(r.output().is_empty());
+    }
+
+    #[test]
+    fn output_for_llm_prefers_markdown_when_requested() {
+        let r = ToolResult::success_with_markdown(
+            json!({"items": [{"id": 1}, {"id": 2}]}),
+            "- 1\n- 2",
+        );
+        assert_eq!(r.output_for_llm(true), "- 1\n- 2");
+        // When prefer_markdown is false, falls back to JSON pretty-print.
+        let raw = r.output_for_llm(false);
+        assert!(raw.contains("\"items\""));
+    }
+
+    #[test]
+    fn output_for_llm_falls_back_to_output_when_markdown_missing() {
+        let r = ToolResult::success("plain");
+        assert_eq!(r.output_for_llm(true), "plain");
+        assert_eq!(r.output_for_llm(false), "plain");
+    }
+
+    #[test]
+    fn output_for_llm_falls_back_when_markdown_blank() {
+        let r = ToolResult::success("plain").with_markdown("   \n  ");
+        assert_eq!(r.output_for_llm(true), "plain");
+    }
+
+    #[test]
+    fn markdown_field_serde_roundtrip() {
+        let r = ToolResult::success_with_markdown(json!({"a": 1}), "**a**: 1");
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("markdownFormatted"));
+        let back: ToolResult = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.markdown_formatted.as_deref(), Some("**a**: 1"));
     }
 }

--- a/src/openhuman/skills/types.rs
+++ b/src/openhuman/skills/types.rs
@@ -16,7 +16,11 @@ pub struct ToolResult {
     /// `markdownFormatted` field on Composio's backend responses
     /// (see #1165) — markdown is significantly cheaper than JSON in
     /// the model context window.
-    #[serde(default, rename = "markdownFormatted", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "markdownFormatted",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub markdown_formatted: Option<String>,
 }
 
@@ -50,10 +54,7 @@ impl ToolResult {
     /// Construct a successful result that carries both a JSON payload
     /// (for programmatic consumers / debugging) and a markdown rendering
     /// (preferred by the agent loop when `prefer_markdown` is on).
-    pub fn success_with_markdown(
-        data: serde_json::Value,
-        markdown: impl Into<String>,
-    ) -> Self {
+    pub fn success_with_markdown(data: serde_json::Value, markdown: impl Into<String>) -> Self {
         Self {
             content: vec![ToolContent::Json { data }],
             is_error: false,
@@ -217,10 +218,8 @@ mod tests {
 
     #[test]
     fn output_for_llm_prefers_markdown_when_requested() {
-        let r = ToolResult::success_with_markdown(
-            json!({"items": [{"id": 1}, {"id": 2}]}),
-            "- 1\n- 2",
-        );
+        let r =
+            ToolResult::success_with_markdown(json!({"items": [{"id": 1}, {"id": 2}]}), "- 1\n- 2");
         assert_eq!(r.output_for_llm(true), "- 1\n- 2");
         // When prefer_markdown is false, falls back to JSON pretty-print.
         let raw = r.output_for_llm(false);

--- a/src/openhuman/tools/impl/cron/add.rs
+++ b/src/openhuman/tools/impl/cron/add.rs
@@ -1,7 +1,7 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::cron::{self, DeliveryConfig, JobType, Schedule, SessionTarget};
 use crate::openhuman::security::SecurityPolicy;
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
@@ -181,7 +181,20 @@ impl Tool for CronAddTool {
         })
     }
 
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         if !self.config.cron.enabled {
             return Ok(ToolResult::error(
                 "cron is disabled by config (cron.enabled=false)".to_string(),
@@ -327,14 +340,28 @@ impl Tool for CronAddTool {
         };
 
         match result {
-            Ok(job) => Ok(ToolResult::success(serde_json::to_string_pretty(&json!({
-                "id": job.id,
-                "name": job.name,
-                "job_type": job.job_type,
-                "schedule": job.schedule,
-                "next_run": job.next_run,
-                "enabled": job.enabled
-            }))?)),
+            Ok(job) => {
+                let payload = json!({
+                    "id": job.id,
+                    "name": job.name,
+                    "job_type": job.job_type,
+                    "schedule": job.schedule,
+                    "next_run": job.next_run,
+                    "enabled": job.enabled
+                });
+                let mut tr = ToolResult::success(serde_json::to_string_pretty(&payload)?);
+                if options.prefer_markdown {
+                    let md = format!(
+                        "Created cron job **{}** (`{}`).\n- **next_run**: {}\n- **enabled**: {}",
+                        job.name.as_deref().unwrap_or(&job.id),
+                        job.id,
+                        job.next_run.format("%Y-%m-%d %H:%M:%S UTC"),
+                        job.enabled,
+                    );
+                    tr.markdown_formatted = Some(md);
+                }
+                Ok(tr)
+            }
             Err(e) => Ok(ToolResult::error(e.to_string())),
         }
     }

--- a/src/openhuman/tools/impl/cron/list.rs
+++ b/src/openhuman/tools/impl/cron/list.rs
@@ -1,9 +1,54 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::cron;
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::cron::CronJob;
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
+use std::fmt::Write as _;
 use std::sync::Arc;
+
+fn render_jobs_markdown(jobs: &[CronJob]) -> String {
+    if jobs.is_empty() {
+        return "_No scheduled cron jobs._".to_string();
+    }
+    let mut out = format!("# Cron jobs ({})\n", jobs.len());
+    for job in jobs {
+        let label = job.name.as_deref().unwrap_or(&job.id);
+        let _ = writeln!(out, "\n## {label}");
+        let _ = writeln!(out, "- **id**: `{}`", job.id);
+        let _ = writeln!(out, "- **schedule**: `{}`", job.expression);
+        let _ = writeln!(out, "- **enabled**: {}", job.enabled);
+        let _ = writeln!(
+            out,
+            "- **next_run**: {}",
+            job.next_run.format("%Y-%m-%d %H:%M:%S UTC")
+        );
+        if let Some(last) = job.last_run {
+            let _ = writeln!(
+                out,
+                "- **last_run**: {} ({})",
+                last.format("%Y-%m-%d %H:%M:%S UTC"),
+                job.last_status.as_deref().unwrap_or("unknown")
+            );
+        }
+        if let Some(agent) = &job.agent_id {
+            let _ = writeln!(out, "- **agent**: `{agent}`");
+        }
+        let _ = writeln!(out, "- **command**: `{}`", job.command);
+        if let Some(prompt) = &job.prompt {
+            let trimmed = prompt.trim();
+            if !trimmed.is_empty() {
+                let preview = if trimmed.len() > 200 {
+                    format!("{}…", &trimmed[..200])
+                } else {
+                    trimmed.to_string()
+                };
+                let _ = writeln!(out, "- **prompt**: {preview}");
+            }
+        }
+    }
+    out
+}
 
 pub struct CronListTool {
     config: Arc<Config>,
@@ -33,7 +78,16 @@ impl Tool for CronListTool {
         })
     }
 
-    async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        _args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         if !self.config.cron.enabled {
             return Ok(ToolResult::error(
                 "cron is disabled by config (cron.enabled=false)".to_string(),
@@ -41,9 +95,20 @@ impl Tool for CronListTool {
         }
 
         match cron::list_jobs(&self.config) {
-            Ok(jobs) => Ok(ToolResult::success(serde_json::to_string_pretty(&jobs)?)),
+            Ok(jobs) => {
+                let json_str = serde_json::to_string_pretty(&jobs)?;
+                let mut result = ToolResult::success(json_str);
+                if options.prefer_markdown {
+                    result.markdown_formatted = Some(render_jobs_markdown(&jobs));
+                }
+                Ok(result)
+            }
             Err(e) => Ok(ToolResult::error(e.to_string())),
         }
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
     }
 }
 

--- a/src/openhuman/tools/impl/cron/list.rs
+++ b/src/openhuman/tools/impl/cron/list.rs
@@ -38,8 +38,9 @@ fn render_jobs_markdown(jobs: &[CronJob]) -> String {
         if let Some(prompt) = &job.prompt {
             let trimmed = prompt.trim();
             if !trimmed.is_empty() {
-                let preview = if trimmed.len() > 200 {
-                    format!("{}…", &trimmed[..200])
+                let preview = if trimmed.chars().count() > 200 {
+                    let snippet: String = trimmed.chars().take(200).collect();
+                    format!("{snippet}…")
                 } else {
                     trimmed.to_string()
                 };

--- a/src/openhuman/tools/impl/cron/run.rs
+++ b/src/openhuman/tools/impl/cron/run.rs
@@ -1,6 +1,6 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::cron;
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use chrono::Utc;
 use serde_json::json;
@@ -36,7 +36,20 @@ impl Tool for CronRunTool {
         })
     }
 
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         if !self.config.cron.enabled {
             return Ok(ToolResult::error(
                 "cron is disabled by config (cron.enabled=false)".to_string(),
@@ -74,17 +87,34 @@ impl Tool for CronRunTool {
         );
         let _ = cron::record_last_run(&self.config, &job.id, finished_at, success, &output);
 
-        let result_output = serde_json::to_string_pretty(&json!({
+        let payload = json!({
             "job_id": job.id,
             "status": status,
             "duration_ms": duration_ms,
             "output": output
-        }))?;
-        if success {
-            Ok(ToolResult::success(result_output))
+        });
+        let result_output = serde_json::to_string_pretty(&payload)?;
+        let md = if options.prefer_markdown {
+            let trimmed = output.trim();
+            let body = if trimmed.is_empty() {
+                String::new()
+            } else {
+                format!("\n\n```\n{trimmed}\n```")
+            };
+            Some(format!(
+                "**job**: `{}` — **status**: {} — **{}ms**{}",
+                job.id, status, duration_ms, body
+            ))
         } else {
-            Ok(ToolResult::error(result_output))
-        }
+            None
+        };
+        let mut tr = if success {
+            ToolResult::success(result_output)
+        } else {
+            ToolResult::error(result_output)
+        };
+        tr.markdown_formatted = md;
+        Ok(tr)
     }
 }
 

--- a/src/openhuman/tools/impl/cron/runs.rs
+++ b/src/openhuman/tools/impl/cron/runs.rs
@@ -1,9 +1,10 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::cron;
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde::Serialize;
 use serde_json::json;
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 const MAX_RUN_OUTPUT_CHARS: usize = 500;
@@ -51,6 +52,15 @@ impl Tool for CronRunsTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         if !self.config.cron.enabled {
             return Ok(ToolResult::error(
                 "cron is disabled by config (cron.enabled=false)".to_string(),
@@ -84,11 +94,46 @@ impl Tool for CronRunsTool {
                     })
                     .collect();
 
-                Ok(ToolResult::success(serde_json::to_string_pretty(&runs)?))
+                let json_str = serde_json::to_string_pretty(&runs)?;
+                let mut result = ToolResult::success(json_str);
+                if options.prefer_markdown {
+                    result.markdown_formatted = Some(render_runs_markdown(job_id, &runs));
+                }
+                Ok(result)
             }
             Err(e) => Ok(ToolResult::error(e.to_string())),
         }
     }
+
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+}
+
+fn render_runs_markdown(job_id: &str, runs: &[RunView]) -> String {
+    if runs.is_empty() {
+        return format!("_No recorded runs for job `{job_id}`._");
+    }
+    let mut out = format!("# Cron runs for `{job_id}` ({})\n", runs.len());
+    for r in runs {
+        let _ = writeln!(
+            out,
+            "\n## #{} — {}",
+            r.id,
+            r.started_at.format("%Y-%m-%d %H:%M:%S UTC")
+        );
+        let _ = writeln!(out, "- **status**: {}", r.status);
+        if let Some(ms) = r.duration_ms {
+            let _ = writeln!(out, "- **duration_ms**: {ms}");
+        }
+        if let Some(out_text) = &r.output {
+            let trimmed = out_text.trim();
+            if !trimmed.is_empty() {
+                let _ = writeln!(out, "- **output**:\n```\n{trimmed}\n```");
+            }
+        }
+    }
+    out
 }
 
 fn truncate(input: &str, max_chars: usize) -> String {

--- a/src/openhuman/tools/impl/cron/update.rs
+++ b/src/openhuman/tools/impl/cron/update.rs
@@ -1,7 +1,7 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::cron::{self, CronJobPatch};
 use crate::openhuman::security::SecurityPolicy;
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
@@ -38,7 +38,20 @@ impl Tool for CronUpdateTool {
         })
     }
 
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         if !self.config.cron.enabled {
             return Ok(ToolResult::error(
                 "cron is disabled by config (cron.enabled=false)".to_string(),
@@ -75,7 +88,20 @@ impl Tool for CronUpdateTool {
         }
 
         match cron::update_job(&self.config, job_id, patch) {
-            Ok(job) => Ok(ToolResult::success(serde_json::to_string_pretty(&job)?)),
+            Ok(job) => {
+                let mut tr = ToolResult::success(serde_json::to_string_pretty(&job)?);
+                if options.prefer_markdown {
+                    tr.markdown_formatted = Some(format!(
+                        "Updated **{}** (`{}`).\n- **schedule**: `{}`\n- **enabled**: {}\n- **next_run**: {}",
+                        job.name.as_deref().unwrap_or(&job.id),
+                        job.id,
+                        job.expression,
+                        job.enabled,
+                        job.next_run.format("%Y-%m-%d %H:%M:%S UTC"),
+                    ));
+                }
+                Ok(tr)
+            }
             Err(e) => Ok(ToolResult::error(e.to_string())),
         }
     }

--- a/src/openhuman/tools/impl/filesystem/git_operations.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations.rs
@@ -1,5 +1,5 @@
 use crate::openhuman::security::{AutonomyLevel, SecurityPolicy};
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
@@ -124,9 +124,9 @@ impl GitOperationsTool {
             json!(staged.is_empty() && unstaged.is_empty() && untracked.is_empty()),
         );
 
-        Ok(ToolResult::success(
-            serde_json::to_string_pretty(&result).unwrap_or_default(),
-        ))
+        let mut tr = ToolResult::success(serde_json::to_string_pretty(&result).unwrap_or_default());
+        tr.markdown_formatted = Some(render_status_markdown(&result));
+        Ok(tr)
     }
 
     async fn git_diff(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
@@ -235,9 +235,11 @@ impl GitOperationsTool {
             }
         }
 
-        Ok(ToolResult::success(
+        let mut tr = ToolResult::success(
             serde_json::to_string_pretty(&json!({ "commits": commits })).unwrap_or_default(),
-        ))
+        );
+        tr.markdown_formatted = Some(render_log_markdown(&commits));
+        Ok(tr)
     }
 
     async fn git_branch(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
@@ -261,13 +263,15 @@ impl GitOperationsTool {
             }
         }
 
-        Ok(ToolResult::success(
+        let mut tr = ToolResult::success(
             serde_json::to_string_pretty(&json!({
                 "current": current,
                 "branches": branches
             }))
             .unwrap_or_default(),
-        ))
+        );
+        tr.markdown_formatted = Some(render_branch_markdown(&current, &branches));
+        Ok(tr)
     }
 
     fn truncate_commit_message(message: &str) -> String {
@@ -441,6 +445,22 @@ impl Tool for GitOperationsTool {
         })
     }
 
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        _options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
+        // git_operations always populates `markdown_formatted` for the
+        // structured sub-operations (status/diff/log/branch). The harness
+        // picks it up when `prefer_markdown` is on; the JSON content
+        // block is preserved for callers that want the raw structure.
+        self.execute(args).await
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         let operation = match args.get("operation").and_then(|v| v.as_str()) {
             Some(op) => op,
@@ -501,6 +521,87 @@ impl Tool for GitOperationsTool {
             _ => Ok(ToolResult::error(format!("Unknown operation: {operation}"))),
         }
     }
+}
+
+fn render_status_markdown(result: &serde_json::Map<String, serde_json::Value>) -> String {
+    let mut out = String::new();
+    if let Some(branch) = result.get("branch").and_then(|v| v.as_str()) {
+        out.push_str(&format!("**branch**: `{branch}`\n"));
+    }
+    let clean = result
+        .get("clean")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if clean {
+        out.push_str("_Working tree clean._\n");
+        return out;
+    }
+    let push_section = |out: &mut String, label: &str, items: Option<&Vec<serde_json::Value>>| {
+        if let Some(items) = items {
+            if !items.is_empty() {
+                out.push_str(&format!("\n**{label}** ({})\n", items.len()));
+                for it in items {
+                    if let (Some(p), Some(s)) = (
+                        it.get("path").and_then(|v| v.as_str()),
+                        it.get("status").and_then(|v| v.as_str()),
+                    ) {
+                        out.push_str(&format!("- `{s}` {p}\n"));
+                    }
+                }
+            }
+        }
+    };
+    push_section(
+        &mut out,
+        "staged",
+        result.get("staged").and_then(|v| v.as_array()),
+    );
+    push_section(
+        &mut out,
+        "unstaged",
+        result.get("unstaged").and_then(|v| v.as_array()),
+    );
+    if let Some(items) = result.get("untracked").and_then(|v| v.as_array()) {
+        if !items.is_empty() {
+            out.push_str(&format!("\n**untracked** ({})\n", items.len()));
+            for it in items {
+                if let Some(p) = it.as_str() {
+                    out.push_str(&format!("- {p}\n"));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn render_log_markdown(commits: &[serde_json::Value]) -> String {
+    if commits.is_empty() {
+        return "_No commits._".to_string();
+    }
+    let mut out = format!("# Commits ({})\n", commits.len());
+    for c in commits {
+        let hash = c.get("hash").and_then(|v| v.as_str()).unwrap_or("");
+        let short = hash.get(..hash.len().min(8)).unwrap_or(hash);
+        let author = c.get("author").and_then(|v| v.as_str()).unwrap_or("");
+        let date = c.get("date").and_then(|v| v.as_str()).unwrap_or("");
+        let msg = c.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        out.push_str(&format!("- `{short}` {msg} _(by {author}, {date})_\n"));
+    }
+    out
+}
+
+fn render_branch_markdown(current: &str, branches: &[serde_json::Value]) -> String {
+    let mut out = format!("**current**: `{current}`\n\n## Branches\n");
+    for b in branches {
+        let name = b.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let cur = b.get("current").and_then(|v| v.as_bool()).unwrap_or(false);
+        if cur {
+            out.push_str(&format!("- **{name}** ← current\n"));
+        } else {
+            out.push_str(&format!("- {name}\n"));
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/src/openhuman/tools/impl/network/web_search.rs
+++ b/src/openhuman/tools/impl/network/web_search.rs
@@ -1,6 +1,6 @@
 use crate::openhuman::integrations::parallel::{SearchResponse, SearchResultItem};
 use crate::openhuman::integrations::IntegrationClient;
-use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -73,6 +73,39 @@ impl WebSearchTool {
 
         Ok(lines.join("\n"))
     }
+
+    fn render_results_markdown(&self, results: &[SearchResultItem], query: &str) -> String {
+        if results.is_empty() {
+            return format!("_No results for `{query}`._");
+        }
+        let mut out = format!("# Search results — `{query}`\n");
+        for r in results.iter().take(self.max_results) {
+            let title = if r.title.trim().is_empty() {
+                "Untitled"
+            } else {
+                r.title.trim()
+            };
+            out.push_str(&format!("\n## [{title}]({})\n", r.url.trim()));
+            if let Some(date) = r.publish_date.as_deref() {
+                let date = date.trim();
+                if !date.is_empty() {
+                    out.push_str(&format!("_Published: {date}_\n\n"));
+                }
+            }
+            if let Some(first) = r.excerpts.first() {
+                let excerpt = first.trim();
+                if !excerpt.is_empty() {
+                    let truncated = if let Some((idx, _)) = excerpt.char_indices().nth(500) {
+                        format!("{}…", &excerpt[..idx])
+                    } else {
+                        excerpt.to_string()
+                    };
+                    out.push_str(&format!("> {truncated}\n"));
+                }
+            }
+        }
+        out
+    }
 }
 
 #[async_trait]
@@ -99,6 +132,19 @@ impl Tool for WebSearchTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         let query = args
             .get("query")
             .and_then(|q| q.as_str())
@@ -143,9 +189,11 @@ impl Tool for WebSearchTool {
             .post::<SearchResponse>("/agent-integrations/parallel/search", &body)
             .await?;
 
-        Ok(ToolResult::success(
-            self.parse_parallel_results(&resp.results, query)?,
-        ))
+        let mut result = ToolResult::success(self.parse_parallel_results(&resp.results, query)?);
+        if options.prefer_markdown {
+            result.markdown_formatted = Some(self.render_results_markdown(&resp.results, query));
+        }
+        Ok(result)
     }
 }
 

--- a/src/openhuman/tools/impl/system/current_time.rs
+++ b/src/openhuman/tools/impl/system/current_time.rs
@@ -5,7 +5,7 @@
 //! having to shell out to `date`. Read-only, no arguments beyond an optional
 //! IANA timezone for a convenience conversion.
 
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use chrono::{Local, SecondsFormat, Utc};
 use chrono_tz::Tz;
@@ -55,7 +55,20 @@ impl Tool for CurrentTimeTool {
         PermissionLevel::ReadOnly
     }
 
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         tracing::debug!(args = %args, "[current_time] execute start");
         let now_utc = Utc::now();
         let now_local = Local::now();
@@ -107,7 +120,43 @@ impl Tool for CurrentTimeTool {
         }
 
         tracing::debug!("[current_time] returning payload: {payload}");
-        Ok(ToolResult::success(serde_json::to_string_pretty(&payload)?))
+        let mut result = ToolResult::success(serde_json::to_string_pretty(&payload)?);
+        if options.prefer_markdown {
+            let mut md = String::new();
+            md.push_str(&format!(
+                "- **utc**: {}\n",
+                payload["utc"].as_str().unwrap_or("")
+            ));
+            md.push_str(&format!(
+                "- **local**: {} ({})\n",
+                payload["local"].as_str().unwrap_or(""),
+                payload["local_timezone"].as_str().unwrap_or("")
+            ));
+            md.push_str(&format!(
+                "- **weekday**: {}\n",
+                payload["weekday"].as_str().unwrap_or("")
+            ));
+            md.push_str(&format!(
+                "- **unix_seconds**: {}\n",
+                payload["unix_seconds"].as_i64().unwrap_or(0)
+            ));
+            if let Some(rt) = payload.get("requested_timezone") {
+                md.push_str(&format!(
+                    "- **{}**: {} ({})\n",
+                    rt["name"].as_str().unwrap_or(""),
+                    rt["time"].as_str().unwrap_or(""),
+                    rt["weekday"].as_str().unwrap_or("")
+                ));
+            }
+            if let Some(err) = payload
+                .get("requested_timezone_error")
+                .and_then(|v| v.as_str())
+            {
+                md.push_str(&format!("- **timezone error**: {err}\n"));
+            }
+            result.markdown_formatted = Some(md);
+        }
+        Ok(result)
     }
 }
 

--- a/src/openhuman/tools/mod.rs
+++ b/src/openhuman/tools/mod.rs
@@ -18,6 +18,7 @@ pub use schemas::{
     all_registered_controllers as all_tools_registered_controllers,
 };
 pub use traits::{
-    PermissionLevel, Tool, ToolCategory, ToolContent, ToolResult, ToolScope, ToolSpec,
+    PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolContent, ToolResult, ToolScope,
+    ToolSpec,
 };
 pub(crate) use user_filter::filter_tools_by_user_preference;

--- a/src/openhuman/tools/traits.rs
+++ b/src/openhuman/tools/traits.rs
@@ -82,6 +82,25 @@ impl std::fmt::Display for PermissionLevel {
     }
 }
 
+/// Per-invocation options threaded from the agent loop into a tool's
+/// execution. Lets callers (the harness, orchestrator, RPC dispatcher)
+/// hint at how the tool should shape its output without polluting the
+/// tool's user-facing parameter schema.
+///
+/// Tools that opt in override [`Tool::execute_with_options`] and check
+/// these flags; tools that ignore the struct keep working unchanged
+/// because the trait's default implementation forwards to
+/// [`Tool::execute`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToolCallOptions {
+    /// When true, the caller (typically the agent loop) prefers a
+    /// markdown rendering of the result for direct LLM consumption,
+    /// because markdown is materially cheaper than JSON in tokens.
+    /// Tools should populate `ToolResult::markdown_formatted` when
+    /// this is set; the harness will pick that field up if present.
+    pub prefer_markdown: bool,
+}
+
 /// Description of a tool for the LLM
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolSpec {
@@ -105,6 +124,32 @@ pub trait Tool: Send + Sync {
     /// Execute the tool with given arguments.
     /// Returns a unified `ToolResult` (MCP content blocks + error flag).
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult>;
+
+    /// Execute the tool with caller-provided options.
+    ///
+    /// Default implementation forwards to [`Self::execute`] — existing
+    /// tools keep working without changes. Tools that can produce a
+    /// compact markdown rendering (saving tokens in the agent loop)
+    /// should override this method, inspect
+    /// [`ToolCallOptions::prefer_markdown`], and populate
+    /// `ToolResult::markdown_formatted` on the returned result.
+    async fn execute_with_options(
+        &self,
+        args: serde_json::Value,
+        _options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
+        self.execute(args).await
+    }
+
+    /// Whether this tool can produce a markdown rendering when
+    /// [`ToolCallOptions::prefer_markdown`] is set. Default: `false`.
+    /// Tools that override [`Self::execute_with_options`] to honor the
+    /// flag should also override this to advertise the capability —
+    /// telemetry / agent-loop diagnostics use it to attribute token
+    /// savings.
+    fn supports_markdown(&self) -> bool {
+        false
+    }
 
     /// Permission level required to execute this tool.
     /// Channels with a lower maximum permission level will reject this tool.


### PR DESCRIPTION
## Summary

- Add a markdown output path for internal Rust tools so the agent loop can hand the LLM compact markdown instead of pretty-printed JSON when configured.
- Mirrors the composio backend `markdownFormatted` pattern (#1165) but for in-process tools — opt-in per tool via a new `Tool::execute_with_options` default method.
- Convert 9 high-traffic tools (cron_*, web_search, current_time, git_operations) to populate `markdown_formatted` so the wins land immediately.

## Problem

Internal tools currently dump pretty-printed JSON into the agent's tool-result stream. JSON is materially more expensive than markdown in the model context window — keys, quotes, braces, indentation all burn tokens that add up fast in tool-heavy loops. Composio already migrated to markdown server-side in #1165; the same lever is available for our own tools but nothing was wired through.

## Solution

Two small surfaces, both designed so existing tools keep working without changes:

1. **`ToolResult.markdown_formatted: Option<String>`** (`skills/types.rs`) — optional field with `success_with_markdown()` / `with_markdown()` builders and an `output_for_llm(prefer_markdown)` selector. Serialised as `markdownFormatted` to match the composio shape; skipped when `None`.
2. **`Tool::execute_with_options(args, ToolCallOptions)`** (`tools/traits.rs`) — new trait method with a default implementation that forwards to `execute(args)`. Tools that can render markdown override it, inspect `options.prefer_markdown`, and populate the field. Paired with `Tool::supports_markdown() -> bool` for telemetry/diagnostics.

Plumbing:

- New config knob `context.prefer_markdown_tool_output` (default `true`).
- `ContextManager` exposes the flag; `execute_tool_call` in `agent/harness/session/turn.rs` builds `ToolCallOptions` per call, dispatches via `execute_with_options`, and uses `output_for_llm(prefer_markdown)` so the harness picks markdown when present and falls back to the JSON content block otherwise.

Tools converted:

- `cron_list`, `cron_runs`, `cron_add`, `cron_run`, `cron_update`
- `web_search_tool`, `current_time`
- `git_operations` (status / log / branch sub-ops)

Tools intentionally not touched: those that already emit compact text (`memory_recall`, `gitbooks_*`, `schedule.handle_list`) or non-trivial domain renderers left for follow-ups (`memory_tree_*`, `proxy_config`, browser).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: framework + per-tool conversions are exercised by existing tool unit tests; new selector/serde tests added in `skills/types.rs`. Diff coverage on the markdown branches is best evaluated by the CI gate.
- [ ] N/A: behaviour-only change — no feature rows added/removed/renamed in the coverage matrix.
- [ ] N/A: no matrix feature IDs touched.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: no release-cut surface touched.
- [ ] N/A: no linked issue — proactive token-cost optimization.

## Impact

- **Desktop/CLI**: agent loops on tool-heavy turns send markdown to the LLM by default, cutting tokens spent on JSON syntax. JSON content blocks are still produced and serialised, so any UI or RPC consumer that reads structured tool output is unchanged.
- **Performance**: net token-cost reduction in tool-heavy agent turns; the markdown rendering itself is cheap (string formatting on already-collected data).
- **Compatibility**: opt-in per tool via the new trait default; no breaking signature changes. Disable globally by setting `context.prefer_markdown_tool_output = false` — tools then fall back to their existing JSON output.
- **Security**: no auth/permission changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - convert remaining JSON-emitting tools (`memory_tree_*`, `proxy_config`, `schedule.handle_get`, browser tool, computer-control tools)
  - measure observed token savings via `[agent_loop] tool=… returned markdown payload bytes=…` debug logs in real sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can optionally return human-friendly Markdown alongside JSON for clearer results.
  * New configuration setting (enabled by default) lets the agent prefer Markdown-formatted tool output.
  * Cron management, git operations, web search, time, and other tools now provide Markdown renderings when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->