### PR TITLE
fix(agent): drop redundant [Memory context] recall injection

### DIFF
--- a/src/openhuman/agent/memory_loader.rs
+++ b/src/openhuman/agent/memory_loader.rs
@@ -1,7 +1,6 @@
 use crate::openhuman::memory::Memory;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 use super::harness::memory_context::{WORKING_MEMORY_KEY_PREFIX, WORKING_MEMORY_LIMIT};
 
@@ -110,49 +109,22 @@ impl MemoryLoader for DefaultMemoryLoader {
         memory: &dyn Memory,
         user_message: &str,
     ) -> anyhow::Result<String> {
-        let entries = memory
-            .recall(
-                user_message,
-                self.limit,
-                crate::openhuman::memory::RecallOpts::default(),
-            )
-            .await?;
+        // Primary `[Memory context]` semantic recall used to be injected here,
+        // but it duplicated content the agent can already reach via the
+        // compressed memory tree (eager prefetch) and the on-demand memory
+        // search tool — and worse, the auto-saved `user_msg` entry would come
+        // back as the top "relevant" memory and echo the user's text back at
+        // them. Only the bounded `[User working memory]` block remains: it
+        // surfaces sync-derived profile facts (timezone, preferences) that the
+        // tree digest doesn't always carry, and it is keyed by a fixed
+        // `working.user.*` namespace so it can't catch arbitrary chat content.
         let mut context = String::new();
         let budget = if self.max_context_chars > 0 {
             self.max_context_chars
         } else {
             usize::MAX
         };
-        let mut seen_keys = HashSet::new();
 
-        let header = "[Memory context]\n";
-        for entry in entries {
-            if let Some(score) = entry.score {
-                if score < self.min_relevance_score {
-                    continue;
-                }
-            }
-            let line = format!("- {}: {}\n", entry.key, entry.content);
-            if context.is_empty() {
-                if header.len() >= budget {
-                    return Ok(String::new());
-                }
-                context.push_str(header);
-            }
-            if context.len() + line.len() > budget {
-                tracing::debug!(
-                    budget,
-                    current_len = context.len(),
-                    skipped_line_len = line.len(),
-                    "[memory_loader] context budget reached, skipping remaining entries"
-                );
-                break;
-            }
-            seen_keys.insert(entry.key);
-            context.push_str(&line);
-        }
-
-        // Explicit bounded recall for sync-derived user working memory.
         let working_query = format!("working.user {user_message}");
         let working_entries = memory
             .recall(
@@ -166,7 +138,6 @@ impl MemoryLoader for DefaultMemoryLoader {
         for entry in working_entries
             .into_iter()
             .filter(|entry| entry.key.starts_with(WORKING_MEMORY_KEY_PREFIX))
-            .filter(|entry| !seen_keys.contains(&entry.key))
             .filter(|entry| match entry.score {
                 Some(score) => score >= self.min_relevance_score,
                 None => true,
@@ -175,7 +146,7 @@ impl MemoryLoader for DefaultMemoryLoader {
         {
             if !appended_working_header {
                 let section = "[User working memory]\n";
-                if context.len() + section.len() > budget {
+                if section.len() > budget {
                     break;
                 }
                 context.push_str(section);

--- a/tests/agent_memory_loader_public.rs
+++ b/tests/agent_memory_loader_public.rs
@@ -85,7 +85,11 @@ fn entry(key: &str, content: &str, score: Option<f64>) -> MemoryEntry {
 }
 
 #[tokio::test]
-async fn loader_merges_primary_and_working_memory_with_filters() -> Result<()> {
+async fn loader_skips_primary_recall_and_filters_working_memory() -> Result<()> {
+    // The open-ended `[Memory context]` recall block was removed: it duplicated
+    // what the memory tree + memory search tool already cover, and would echo
+    // the just-saved `user_msg` entry back at the user. The loader now only
+    // emits the bounded `[User working memory]` block.
     let memory: Arc<dyn Memory> = Arc::new(ScriptedMemory {
         primary: vec![
             entry("high", "keep me", Some(0.9)),
@@ -93,7 +97,7 @@ async fn loader_merges_primary_and_working_memory_with_filters() -> Result<()> {
         ],
         working: vec![
             entry("working.user.pref", "concise", Some(0.95)),
-            entry("high", "duplicate", Some(0.95)),
+            entry("not.working.user", "ignored", Some(0.95)),
         ],
     });
 
@@ -102,12 +106,12 @@ async fn loader_merges_primary_and_working_memory_with_filters() -> Result<()> {
         .load_context(memory.as_ref(), "hello")
         .await?;
 
-    assert!(context.contains("[Memory context]"));
-    assert!(context.contains("- high: keep me"));
+    assert!(!context.contains("[Memory context]"));
+    assert!(!context.contains("keep me"));
     assert!(!context.contains("drop me"));
     assert!(context.contains("[User working memory]"));
     assert!(context.contains("working.user.pref"));
-    assert!(!context.contains("duplicate"));
+    assert!(!context.contains("not.working.user"));
     Ok(())
 }
 
@@ -130,23 +134,30 @@ async fn loader_can_return_only_working_memory_when_primary_is_empty() -> Result
 
 #[tokio::test]
 async fn loader_respects_tight_budgets() -> Result<()> {
+    // Primary `[Memory context]` recall is no longer injected, so any
+    // entries on the `primary` channel must be ignored regardless of budget.
+    // Tight budgets that can't fit the `[User working memory]` header should
+    // produce an empty context.
     let memory: Arc<dyn Memory> = Arc::new(ScriptedMemory {
         primary: vec![entry("main", "1234567890", Some(0.9))],
         working: vec![entry("working.user.tip", "include me", Some(0.9))],
     });
 
-    let header_len = "[Memory context]\n".len();
+    let header = "[User working memory]\n";
     let empty = DefaultMemoryLoader::new(1, 0.4)
-        .with_max_chars(header_len)
+        .with_max_chars(header.len() - 1)
         .load_context(memory.as_ref(), "hello")
         .await?;
     assert!(empty.is_empty());
 
+    let line = "- working.user.tip: include me\n";
     let bounded = DefaultMemoryLoader::new(1, 0.4)
-        .with_max_chars("[Memory context]\n- main: 1234567890\n".len() + 1)
+        .with_max_chars(header.len() + line.len() + 1)
         .load_context(memory.as_ref(), "hello")
         .await?;
-    assert!(bounded.contains("- main: 1234567890"));
-    assert!(!bounded.contains("working.user.tip"));
+    assert!(bounded.contains("[User working memory]"));
+    assert!(bounded.contains("- working.user.tip: include me"));
+    // Primary recall is gone — `main` must never appear.
+    assert!(!bounded.contains("- main: 1234567890"));
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Stops echoing the user's own message back to them as a `- user_msg: <same text>` line at the top of every agent turn.
- Removes the open-ended `recall(user_message)` block (`[Memory context]`) from `DefaultMemoryLoader::load_context`; keeps the bounded `[User working memory]` (`working.user.*`) injection.
- The compressed memory tree (eager prefetch) and the on-demand memory search tool already cover what the recall block was doing, so this is a redundancy removal.

## Problem

The agent harness auto-saves each user message under the fixed key `user_msg` (`session/turn.rs:131-142`), then `DefaultMemoryLoader::load_context` runs a wide semantic recall against the same text and prepends the top hits as `[Memory context]`. The just-saved entry comes back as the top-scoring "memory", so the next preamble looks like:

```
[Memory context]
- user_msg: nah.. search my emails for spiderman content

nah.. search my emails for spiderman content
```

That block was already redundant: the eager memory-tree prefetch (`tree_loader`) injects a compressed cross-source digest on the first turn and every refresh interval, and the agent has an explicit memory search tool for on-demand lookups.

## Solution

`DefaultMemoryLoader::load_context` no longer runs the open-ended recall. It now only emits `[User working memory]`, which is keyed on the `working.user.*` namespace (timezone, profile facts) — small, deterministic, and can't catch arbitrary chat content.

Untouched on purpose:
- `MemoryLoader` trait, builder wiring, and the `auto_save` of `user_msg` (still useful for the search tool — just no longer reflected back).
- `collect_recall_citations` (UI provenance for memory-informed answers).
- The memory-tree eager prefetch.
- `channels/context.rs` — different code path (inbound channel handlers), not part of this report.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: pure removal of recall + concat path; existing `collect_recall_citations_filters_and_truncates_entries` still passes, and session-level tests under `agent::harness::session` (60 tests) all pass with the simplified loader. No new behaviour to assert.
- [ ] N/A: behaviour-only change (preamble noise removal — no feature added/removed/renamed)
- [ ] N/A: no matrix-tracked feature IDs touched
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: not a release-cut surface
- [ ] N/A: no linked issue

## Impact

- Runtime: desktop agent only. Inbound channel context (`channels/context.rs`) is on a separate code path and unchanged.
- Cosmetic + token-saving — the per-turn user message is now smaller and no longer carries a self-reference back to the model.
- No migration / compat concerns. Memory storage format unchanged; `auto_save` of `user_msg` continues so the search tool can still find prior turns.

## Related

- Closes:
- Follow-up PR(s)/TODOs: consider also removing `auto_save` of `user_msg` if the search tool isn't actually exercising it; out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory loading now limits context to a bounded "User working memory" section only—primary/open-ended memory entries are no longer injected into the context.
  * Tight budget handling updated so headers/content are evaluated by their own size, preventing accidental inclusion when space is insufficient.
  * Tests updated to reflect and validate the new, tighter working-memory-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->