### PR TITLE
feat(redirect-links): stage util to append ?u= on openhm.xyz URLs (#1164)

### DIFF
--- a/src/openhuman/redirect_links/mod.rs
+++ b/src/openhuman/redirect_links/mod.rs
@@ -12,7 +12,10 @@ mod store;
 mod types;
 
 pub use ops as rpc;
-pub use ops::{expand_link, rewrite_inbound, rewrite_outbound, shorten_url};
+pub use ops::{
+    append_user_id_to_public_links, expand_link, rewrite_inbound, rewrite_outbound,
+    rewrite_outbound_for_user, shorten_url,
+};
 pub use schemas::{
     all_controller_schemas as all_redirect_links_controller_schemas,
     all_registered_controllers as all_redirect_links_registered_controllers,

--- a/src/openhuman/redirect_links/ops.rs
+++ b/src/openhuman/redirect_links/ops.rs
@@ -404,4 +404,29 @@ mod tests {
         let got = append_user_id_to_public_links(text, Some("nikhil"));
         assert_eq!(got, "Click https://openhm.xyz/abc?u=nikhil.");
     }
+
+    #[test]
+    fn rewrite_outbound_for_user_expands_placeholder_and_tags_public_url() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp);
+
+        // Shorten LONG into an openhuman:// placeholder, then craft outbound text
+        // that mixes the placeholder with a public openhm.xyz URL.
+        let inbound = rewrite_inbound(&cfg, LONG).unwrap();
+        let placeholder = &inbound.replacements[0].replacement;
+        let text = format!("see {placeholder} and https://openhm.xyz/abc");
+
+        let result = rewrite_outbound_for_user(&cfg, &text, Some("nikhil")).unwrap();
+        assert!(result.text.contains(LONG), "placeholder must expand back to LONG");
+        assert!(
+            result.text.contains("https://openhm.xyz/abc?u=nikhil"),
+            "openhm.xyz URL must carry ?u= tag"
+        );
+
+        // None user_id leaves openhm.xyz untouched but still expands placeholder.
+        let result_none = rewrite_outbound_for_user(&cfg, &text, None).unwrap();
+        assert!(result_none.text.contains(LONG));
+        assert!(result_none.text.contains("https://openhm.xyz/abc"));
+        assert!(!result_none.text.contains("?u="));
+    }
 }

--- a/src/openhuman/redirect_links/ops.rs
+++ b/src/openhuman/redirect_links/ops.rs
@@ -26,6 +26,15 @@ fn short_url_regex() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"openhuman://link/([0-9a-f]+)").unwrap())
 }
 
+fn public_url_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Anchor on `https?://` and match the `openhm.xyz` domain specifically to
+    // avoid lookalikes (evil-openhm.xyz) or mid-token matches.
+    RE.get_or_init(|| {
+        Regex::new(r#"https?://openhm\.xyz/[A-Za-z0-9_-]+(?:\?[\w\d./\?=%\-&#:+@~!,;]*)?"#).unwrap()
+    })
+}
+
 /// Strip trailing sentence punctuation (`.`, `,`, `;`, `:`, `!`) so that
 /// "see https://example.com/path." doesn't capture the period.
 fn trim_trailing_punct(s: &str) -> &str {
@@ -120,6 +129,53 @@ pub fn rewrite_outbound(config: &Config, text: &str) -> Result<RewriteResult> {
         text: out,
         replacements,
     })
+}
+
+/// Convenience wrapper that runs `rewrite_outbound` and then appends the
+/// `user_id` to any public `openhm.xyz` links in the result.
+pub fn rewrite_outbound_for_user(
+    config: &Config,
+    text: &str,
+    user_id: Option<&str>,
+) -> Result<RewriteResult> {
+    let mut result = rewrite_outbound(config, text)?;
+    result.text = append_user_id_to_public_links(&result.text, user_id);
+    Ok(result)
+}
+
+/// Append `?u=<user_id>` to every `openhm.xyz/<id>` URL in a string.
+/// If `user_id` is `None`, the text is returned unchanged.
+/// Idempotent: URLs already containing a `u=` query parameter are left alone.
+pub fn append_user_id_to_public_links(text: &str, user_id: Option<&str>) -> String {
+    let Some(user_id) = user_id else {
+        return text.to_string();
+    };
+
+    let re = public_url_regex();
+    let encoded_user_id = urlencoding::encode(user_id);
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+
+    for m in re.find_iter(text) {
+        out.push_str(&text[cursor..m.start()]);
+        let raw = m.as_str();
+        let url = trim_trailing_punct(raw);
+        let trailing = &raw[url.len()..];
+
+        if !url.contains("?u=") && !url.contains("&u=") {
+            let separator = if url.contains('?') { "&" } else { "?" };
+            out.push_str(url);
+            out.push_str(separator);
+            out.push_str("u=");
+            out.push_str(&encoded_user_id);
+        } else {
+            out.push_str(url);
+        }
+        out.push_str(trailing);
+        cursor = m.end();
+    }
+    out.push_str(&text[cursor..]);
+    out
 }
 
 // ── RPC handlers ────────────────────────────────────────────────────────
@@ -272,5 +328,80 @@ mod tests {
         let text = format!("{LONG} and also {LONG}?extra=1234567890abcdef");
         let result = rewrite_inbound(&cfg, &text).unwrap();
         assert_eq!(result.replacements.len(), 2);
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_bare() {
+        let text = "https://openhm.xyz/abc";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, "https://openhm.xyz/abc?u=nikhil");
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_query() {
+        let text = "https://openhm.xyz/abc?foo=bar";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, "https://openhm.xyz/abc?foo=bar&u=nikhil");
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_idempotent() {
+        // Already ?u=
+        let text = "https://openhm.xyz/abc?u=existing";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, text);
+
+        // Already &u=
+        let text = "https://openhm.xyz/abc?foo=bar&u=existing";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, text);
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_none() {
+        let text = "https://openhm.xyz/abc";
+        let got = append_user_id_to_public_links(text, None);
+        assert_eq!(got, text);
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_no_match() {
+        let text = "https://example.com/abc";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, text);
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_multiple() {
+        let text = "https://openhm.xyz/a and https://openhm.xyz/b?x=y";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(
+            got,
+            "https://openhm.xyz/a?u=nikhil and https://openhm.xyz/b?x=y&u=nikhil"
+        );
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_encoding() {
+        let text = "https://openhm.xyz/abc";
+        let got = append_user_id_to_public_links(text, Some("nikhil@example.com + space"));
+        assert_eq!(
+            got,
+            "https://openhm.xyz/abc?u=nikhil%40example.com%20%2B%20space"
+        );
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_lookalikes() {
+        let text = "https://evil-openhm.xyz/abc and openhm.xyz.evil.com/abc";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, text);
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_punctuation() {
+        let text = "Click https://openhm.xyz/abc.";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, "Click https://openhm.xyz/abc?u=nikhil.");
     }
 }

--- a/src/openhuman/redirect_links/ops.rs
+++ b/src/openhuman/redirect_links/ops.rs
@@ -417,7 +417,10 @@ mod tests {
         let text = format!("see {placeholder} and https://openhm.xyz/abc");
 
         let result = rewrite_outbound_for_user(&cfg, &text, Some("nikhil")).unwrap();
-        assert!(result.text.contains(LONG), "placeholder must expand back to LONG");
+        assert!(
+            result.text.contains(LONG),
+            "placeholder must expand back to LONG"
+        );
         assert!(
             result.text.contains("https://openhm.xyz/abc?u=nikhil"),
             "openhm.xyz URL must carry ?u= tag"

--- a/src/openhuman/redirect_links/ops.rs
+++ b/src/openhuman/redirect_links/ops.rs
@@ -29,9 +29,14 @@ fn short_url_regex() -> &'static Regex {
 fn public_url_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     // Anchor on `https?://` and match the `openhm.xyz` domain specifically to
-    // avoid lookalikes (evil-openhm.xyz) or mid-token matches.
+    // avoid lookalikes (evil-openhm.xyz) or mid-token matches. Capture optional
+    // query and fragment as separate tail parts so callers can safely insert
+    // `?u=` into the query without polluting the fragment.
     RE.get_or_init(|| {
-        Regex::new(r#"https?://openhm\.xyz/[A-Za-z0-9_-]+(?:\?[\w\d./\?=%\-&#:+@~!,;]*)?"#).unwrap()
+        Regex::new(
+            r#"https?://openhm\.xyz/[A-Za-z0-9_-]+(?:\?[\w\d./\?=%\-&:+@~!,;]*)?(?:#[\w\d./\?=%\-&:+@~!,;]*)?"#,
+        )
+        .unwrap()
     })
 }
 
@@ -162,14 +167,24 @@ pub fn append_user_id_to_public_links(text: &str, user_id: Option<&str>) -> Stri
         let url = trim_trailing_punct(raw);
         let trailing = &raw[url.len()..];
 
-        if !url.contains("?u=") && !url.contains("&u=") {
-            let separator = if url.contains('?') { "&" } else { "?" };
-            out.push_str(url);
+        // Split off any fragment (#…) so `?u=` lands in the query, not the fragment.
+        let (base, fragment) = match url.split_once('#') {
+            Some((b, f)) => (b, Some(f)),
+            None => (url, None),
+        };
+
+        if !base.contains("?u=") && !base.contains("&u=") {
+            let separator = if base.contains('?') { "&" } else { "?" };
+            out.push_str(base);
             out.push_str(separator);
             out.push_str("u=");
             out.push_str(&encoded_user_id);
         } else {
-            out.push_str(url);
+            out.push_str(base);
+        }
+        if let Some(frag) = fragment {
+            out.push('#');
+            out.push_str(frag);
         }
         out.push_str(trailing);
         cursor = m.end();
@@ -403,6 +418,20 @@ mod tests {
         let text = "Click https://openhm.xyz/abc.";
         let got = append_user_id_to_public_links(text, Some("nikhil"));
         assert_eq!(got, "Click https://openhm.xyz/abc?u=nikhil.");
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_query_with_fragment() {
+        let text = "https://openhm.xyz/abc?foo=bar#frag";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, "https://openhm.xyz/abc?foo=bar&u=nikhil#frag");
+    }
+
+    #[test]
+    fn append_user_id_to_public_links_bare_with_fragment() {
+        let text = "https://openhm.xyz/abc#frag";
+        let got = append_user_id_to_public_links(text, Some("nikhil"));
+        assert_eq!(got, "https://openhm.xyz/abc?u=nikhil#frag");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stage a rust util that appends `?u=<user_id>` to every `openhm.xyz/<id>` URL in a string. Util-only — no call sites yet; the wire-up belongs in a follow-up once `openhm.xyz` URL emission lands client-side (today the repo only emits internal `openhuman://link/<id>`).

## Problem

Per #1164, every public `openhm.xyz/<id>` short URL surfaced to the user must carry `?u=<user_id>` so the redirect service can attribute clicks and resolve user-scoped state. Today `grep -rn "openhm.xyz" src/` returns no hits — the public form is produced backend-side. This PR puts the rewrite logic in place so wiring it from a future caller is one line.

## Solution

- `append_user_id_to_public_links(text, Option<user_id>) -> String` in `src/openhuman/redirect_links/ops.rs` — regex-based, idempotent, URL-encodes `user_id`, preserves existing query strings, anchored on `https?://` so lookalike domains (`evil-openhm.xyz`, `openhm.xyz.evil.com`) do not match.
- `rewrite_outbound_for_user(config, text, Option<user_id>)` — convenience wrapper running the existing `rewrite_outbound` then injecting `?u=`.
- Re-exported from `redirect_links::mod`.
- 10 inline `#[cfg(test)]` cases cover bare URL, existing query, idempotent, `None` user, no-URL, multi-URL, special-char encoding, lookalike rejection, surrounding text/punctuation, and the wrapper roundtrip.

## Submission Checklist

- [x] Tests added — 10 inline cases in `ops.rs`
- [x] `cargo check`, `cargo fmt --check`, `cargo clippy` clean for `redirect_links`
- [x] `cargo test --lib redirect_links` green (27 pass)
- [x] Diff coverage ≥ 80%
- [N/A: util-only PR — no call sites today] — no behavior change for existing callers
- [N/A: rust-core only, no frontend touch] — no `pnpm` gates apply

## Impact

Zero runtime impact today (no caller). Stages the substitution layer so a future backend or follow-up PR can wrap outbound text in one call.

## Related

Closes #1164. Wire-up deferred to follow-up — confirm with @senamakel whether `?u=` injection should land render-time (here) or resolve-time (server-side at openhm.xyz).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically appends a URL-encoded user identifier to public openhm.xyz links where applicable, preserving surrounding punctuation, handling fragments and existing query parameters, and leaving links unchanged when no identifier is provided or already present.
* **Tests**
  * Expanded tests covering expansion and outbound rewriting, encoding, multiple matches, idempotency, query/fragment edge cases, lookalike avoidance, and punctuation preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->