### PR TITLE
refactor(composio): hide raw connection ID, derive friendly label (#1153)

### DIFF
--- a/app/src/components/composio/ComposioConnectModal.test.tsx
+++ b/app/src/components/composio/ComposioConnectModal.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type ComposioConnection } from '../../lib/composio/types';
+import ComposioConnectModal from './ComposioConnectModal';
+import { composioToolkitMeta } from './toolkitMeta';
+
+vi.mock('../../lib/composio/composioApi', () => ({
+  authorize: vi.fn(),
+  deleteConnection: vi.fn(),
+  getUserScopes: vi.fn(() => Promise.resolve({ read: true, write: true, admin: false })),
+  listConnections: vi.fn(),
+  setUserScopes: vi.fn(),
+}));
+
+vi.mock('../../utils/openUrl', () => ({ openUrl: vi.fn() }));
+
+// Mock TriggerToggles because it does its own API calls
+vi.mock('./TriggerToggles', () => ({ default: () => <div data-testid="trigger-toggles" /> }));
+
+const mockToolkit = composioToolkitMeta('gmail');
+
+describe('<ComposioConnectModal>', () => {
+  it('hides raw connection ID and "id:" label in connected phase', () => {
+    const connection: ComposioConnection = { id: 'ca_xyz', toolkit: 'gmail', status: 'ACTIVE' };
+
+    render(
+      <ComposioConnectModal toolkit={mockToolkit} connection={connection} onClose={() => {}} />
+    );
+
+    // Should be in 'connected' phase because connection.status is 'ACTIVE'
+    expect(screen.getByText(/Gmail is connected/)).toBeInTheDocument();
+    expect(screen.queryByText(/ca_xyz/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/id:/)).not.toBeInTheDocument();
+  });
+
+  it('renders accountEmail when provided', () => {
+    const connection: ComposioConnection = {
+      id: 'ca_xyz',
+      toolkit: 'gmail',
+      status: 'ACTIVE',
+      accountEmail: 'foo@bar.com',
+    };
+
+    render(
+      <ComposioConnectModal toolkit={mockToolkit} connection={connection} onClose={() => {}} />
+    );
+
+    expect(screen.getByText('(foo@bar.com)')).toBeInTheDocument();
+  });
+
+  it('renders workspace when accountEmail is missing', () => {
+    const connection: ComposioConnection = {
+      id: 'ca_xyz',
+      toolkit: 'gmail',
+      status: 'ACTIVE',
+      workspace: 'Acme',
+    };
+
+    render(
+      <ComposioConnectModal toolkit={mockToolkit} connection={connection} onClose={() => {}} />
+    );
+
+    expect(screen.getByText('(Acme)')).toBeInTheDocument();
+  });
+
+  it('renders username when email and workspace are missing', () => {
+    const connection: ComposioConnection = {
+      id: 'ca_xyz',
+      toolkit: 'gmail',
+      status: 'ACTIVE',
+      username: 'oxox',
+    };
+
+    render(
+      <ComposioConnectModal toolkit={mockToolkit} connection={connection} onClose={() => {}} />
+    );
+
+    expect(screen.getByText('(oxox)')).toBeInTheDocument();
+  });
+
+  it('prioritizes accountEmail over workspace and username', () => {
+    const connection: ComposioConnection = {
+      id: 'ca_xyz',
+      toolkit: 'gmail',
+      status: 'ACTIVE',
+      accountEmail: 'foo@bar.com',
+      workspace: 'Acme',
+      username: 'oxox',
+    };
+
+    render(
+      <ComposioConnectModal toolkit={mockToolkit} connection={connection} onClose={() => {}} />
+    );
+
+    expect(screen.getByText('(foo@bar.com)')).toBeInTheDocument();
+    expect(screen.queryByText('(Acme)')).not.toBeInTheDocument();
+    expect(screen.queryByText('(oxox)')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -32,6 +32,10 @@ import { openUrl } from '../../utils/openUrl';
 import type { ComposioToolkitMeta } from './toolkitMeta';
 import TriggerToggles from './TriggerToggles';
 
+function deriveConnectionLabel(c: ComposioConnection): string | null {
+  return c.accountEmail ?? c.workspace ?? c.username ?? null;
+}
+
 type Phase = 'idle' | 'authorizing' | 'waiting' | 'connected' | 'disconnecting' | 'error';
 
 interface ComposioConnectModalProps {
@@ -392,9 +396,9 @@ export default function ComposioConnectModal({
                 <div className="w-2 h-2 rounded-full bg-sage-500" />
                 <div>
                   {toolkit.name} is connected. &nbsp;
-                  {activeConnection && (
+                  {activeConnection && deriveConnectionLabel(activeConnection) && (
                     <span className="text-[11px] text-stone-400 font-mono">
-                      (id: {activeConnection.id})
+                      ({deriveConnectionLabel(activeConnection)})
                     </span>
                   )}
                 </div>

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -33,7 +33,11 @@ import type { ComposioToolkitMeta } from './toolkitMeta';
 import TriggerToggles from './TriggerToggles';
 
 function deriveConnectionLabel(c: ComposioConnection): string | null {
-  return c.accountEmail ?? c.workspace ?? c.username ?? null;
+  for (const value of [c.accountEmail, c.workspace, c.username]) {
+    const normalized = value?.trim();
+    if (normalized) return normalized;
+  }
+  return null;
 }
 
 type Phase = 'idle' | 'authorizing' | 'waiting' | 'connected' | 'disconnecting' | 'error';

--- a/app/src/lib/composio/types.ts
+++ b/app/src/lib/composio/types.ts
@@ -16,6 +16,11 @@ export interface ComposioConnection {
   status: string;
   /** ISO timestamp (backend passthrough). */
   createdAt?: string;
+
+  /** Optional friendly identity fields populated by later backend versions. */
+  accountEmail?: string;
+  workspace?: string;
+  username?: string;
 }
 
 export interface ComposioConnectionsResponse {


### PR DESCRIPTION
## Summary

Stop leaking raw `ca_…` Composio connection IDs in the Manage modal. Replace with a friendly identity string (`accountEmail`/`workspace`/`username`) when one is available; collapse the line cleanly otherwise.

## Problem

Per #1153, the Composio Manage modal renders `(id: ca_…)` to users in the connected-state footer (`ComposioConnectModal.tsx:391-401`). Internal IDs are not useful for users and look unfinished.

## Solution

- New helper `deriveConnectionLabel(c)` in `ComposioConnectModal.tsx` returning `c.accountEmail ?? c.workspace ?? c.username ?? null`.
- JSX swap: `(id: {activeConnection.id})` → `({deriveConnectionLabel(activeConnection)})`. When the helper returns `null`, the entire span is skipped — modal cleanly shows `Gmail is connected.` with no leak.
- `ComposioConnection` interface (`app/src/lib/composio/types.ts`) extended with optional `accountEmail`, `workspace`, `username` fields. Non-breaking — all existing usages still typecheck. A future backend version can populate these without further frontend changes.
- New Vitest at `ComposioConnectModal.test.tsx` (5 cases): asserts no `ca_` substring in DOM, asserts each identity field renders when present, asserts priority order (email > workspace > username).

## Submission Checklist

- [x] Tests added — 5 render assertions in new `ComposioConnectModal.test.tsx`
- [x] Lint, typecheck, format clean — `pnpm typecheck && pnpm lint && pnpm format:check`
- [x] Existing tests pass — `pnpm test:unit` 1279 pass
- [x] Diff coverage = 100%
- [N/A: no Rust touch] — no `cargo check` impact
- [N/A: no schema/RPC change] — no migration

## Impact

Modal post-OAuth shows toolkit name (e.g. `Gmail is connected.`) with no `ca_` ID. Backend follow-up can populate the new optional fields to surface email/workspace/username — no further frontend work needed.

## Related

Closes #1153.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Composio connection modal to show a friendly identifier (account email, workspace, or username) instead of raw connection IDs; uses that priority order and omits the label when no identifier exists.

* **Tests**
  * Added tests covering connection status and various identity scenarios to ensure correct modal display and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->