### PR TITLE
chore(sentry): rename OPENHUMAN_SENTRY_DSN → OPENHUMAN_CORE_SENTRY_DSN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,8 +149,12 @@ OPENHUMAN_SKILLS_WORKING_MEMORY_ENABLED=true
 # ---------------------------------------------------------------------------
 # Error Reporting (Sentry)
 # ---------------------------------------------------------------------------
-# [optional] Sentry DSN for Rust core error reporting (no PII is sent)
-OPENHUMAN_SENTRY_DSN=
+# [optional] Sentry DSN for Rust core error reporting (no PII is sent).
+# Reports to the `openhuman-core` Sentry project. The Tauri shell uses a
+# separate `OPENHUMAN_TAURI_SENTRY_DSN`; the React frontend uses
+# `VITE_SENTRY_DSN`. The legacy unprefixed name `OPENHUMAN_SENTRY_DSN` is
+# still accepted as a fallback during the transition.
+OPENHUMAN_CORE_SENTRY_DSN=
 # [optional] Short git SHA baked into the Sentry release tag
 # (`openhuman@<version>+<sha>`) via `option_env!("OPENHUMAN_BUILD_SHA")`.
 # CI sets this automatically; leave blank locally (release tag falls back

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -341,11 +341,12 @@ jobs:
           # disabled and the symbols uploaded below have nothing to attach
           # to. Same DSN as `release-packages.yml` uses for the Linux arm64
           # tarball — there is one openhuman-core Sentry project that all
-          # standalone-CLI surfaces report to.
-          OPENHUMAN_SENTRY_DSN: ${{ vars.OPENHUMAN_SENTRY_DSN }}
+          # standalone-CLI surfaces report to. Prefer the namespaced GH
+          # var, fall back to the legacy unprefixed one during transition.
+          OPENHUMAN_CORE_SENTRY_DSN: ${{ vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN }}
         run: |
-          if [ -z "${OPENHUMAN_SENTRY_DSN}" ]; then
-            echo "::warning::vars.OPENHUMAN_SENTRY_DSN is empty — the standalone CLI artifact will ship without crash reporting."
+          if [ -z "${OPENHUMAN_CORE_SENTRY_DSN}" ]; then
+            echo "::warning::vars.OPENHUMAN_CORE_SENTRY_DSN (or legacy vars.OPENHUMAN_SENTRY_DSN) is empty — the standalone CLI artifact will ship without crash reporting."
           fi
           cargo build \
             --manifest-path "$CORE_MANIFEST" \

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -53,21 +53,24 @@ jobs:
       - name: Verify Sentry DSN is present
         shell: bash
         env:
-          OPENHUMAN_SENTRY_DSN: ${{ vars.OPENHUMAN_SENTRY_DSN }}
+          # Prefer the namespaced GH var; fall back to the legacy unprefixed
+          # one so the workflow keeps working until the org-level variable
+          # is renamed.
+          OPENHUMAN_CORE_SENTRY_DSN: ${{ vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN }}
         run: |
           # Sentry DSN is baked into the binary at compile time via
           # `option_env!`. Missing DSN here means the arm64 CLI silently
           # ships without error reporting — fail the job instead.
-          if [ -z "${OPENHUMAN_SENTRY_DSN}" ]; then
-            echo "::error::vars.OPENHUMAN_SENTRY_DSN is empty — the Linux arm64 CLI would ship without error reporting."
+          if [ -z "${OPENHUMAN_CORE_SENTRY_DSN}" ]; then
+            echo "::error::vars.OPENHUMAN_CORE_SENTRY_DSN (or legacy vars.OPENHUMAN_SENTRY_DSN) is empty — the Linux arm64 CLI would ship without error reporting."
             echo "Configure the repository / environment variable before re-running the release."
             exit 1
           fi
-          echo "OPENHUMAN_SENTRY_DSN is set (length=${#OPENHUMAN_SENTRY_DSN})"
+          echo "OPENHUMAN_CORE_SENTRY_DSN is set (length=${#OPENHUMAN_CORE_SENTRY_DSN})"
       - name: Build CLI binary and package tarball
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENHUMAN_SENTRY_DSN: ${{ vars.OPENHUMAN_SENTRY_DSN }}
+          OPENHUMAN_CORE_SENTRY_DSN: ${{ vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN }}
           # Sentry release tracking (#405): keep the arm64 CLI tag in sync
           # with the desktop build (`openhuman@<version>+<short_sha>`).
           OPENHUMAN_BUILD_SHA: ${{ github.sha }}

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -88,8 +88,9 @@ pub fn run_from_cli_args(args: &[String]) -> Result<()> {
 /// and prints the event UUID to stdout. Optional `--panic` flag additionally
 /// triggers a panic so the panic integration is exercised too.
 ///
-/// Requires a DSN resolvable at runtime — either via the `OPENHUMAN_SENTRY_DSN`
-/// env var or baked into the binary at build time via `option_env!`. Absent a
+/// Requires a DSN resolvable at runtime — either via the
+/// `OPENHUMAN_CORE_SENTRY_DSN` env var (or the legacy `OPENHUMAN_SENTRY_DSN`
+/// alias) or baked into the binary at build time via `option_env!`. Absent a
 /// DSN, the command exits non-zero with a diagnostic instead of silently
 /// producing no telemetry.
 fn run_sentry_test_command(args: &[String]) -> Result<()> {
@@ -119,10 +120,11 @@ fn run_sentry_test_command(args: &[String]) -> Result<()> {
                 println!("  --panic           After capturing the event, trigger a panic so the");
                 println!("                    panic integration reports it as a separate event.");
                 println!();
-                println!("Requires OPENHUMAN_SENTRY_DSN at runtime, or baked into the binary at");
                 println!(
-                    "build time via option_env!. On success, prints the event UUID to stdout."
+                    "Requires OPENHUMAN_CORE_SENTRY_DSN (or the legacy OPENHUMAN_SENTRY_DSN alias)"
                 );
+                println!("at runtime, or baked into the binary at build time via option_env!. On");
+                println!("success, prints the event UUID to stdout.");
                 return Ok(());
             }
             other => return Err(anyhow::anyhow!("unknown sentry-test arg: {other}")),
@@ -140,8 +142,8 @@ fn run_sentry_test_command(args: &[String]) -> Result<()> {
         None => {
             return Err(anyhow::anyhow!(
                 "Sentry is not initialized in this binary — no DSN is resolvable. \
-                 Set OPENHUMAN_SENTRY_DSN in the environment (or rebuild with it defined \
-                 at compile time) and try again."
+                 Set OPENHUMAN_CORE_SENTRY_DSN (or the legacy OPENHUMAN_SENTRY_DSN alias) \
+                 in the environment (or rebuild with it defined at compile time) and try again."
             ));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,20 @@ fn main() {
     let _ = dotenvy::dotenv();
 
     // Initialize Sentry as the very first operation so the guard outlives everything.
-    // If OPENHUMAN_SENTRY_DSN is unset or empty, sentry::init returns a no-op guard.
+    // Resolves the core Sentry DSN by checking, in order:
+    //   1. `OPENHUMAN_CORE_SENTRY_DSN` at runtime (preferred, namespaced name)
+    //   2. `OPENHUMAN_SENTRY_DSN` at runtime (legacy unprefixed name — kept
+    //      so existing CI vars and contributor `.env` files keep working until
+    //      the GH org-level variable can be renamed)
+    //   3. Each of the same names baked at compile time via `option_env!`
+    // If none resolve to a non-empty value, `sentry::init` returns a no-op guard.
     let _sentry_guard = sentry::init(sentry::ClientOptions {
-        dsn: std::env::var("OPENHUMAN_SENTRY_DSN")
+        dsn: std::env::var("OPENHUMAN_CORE_SENTRY_DSN")
             .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| std::env::var("OPENHUMAN_SENTRY_DSN").ok())
+            .filter(|s| !s.is_empty())
+            .or_else(|| option_env!("OPENHUMAN_CORE_SENTRY_DSN").map(|s| s.to_string()))
             .filter(|s| !s.is_empty())
             .or_else(|| option_env!("OPENHUMAN_SENTRY_DSN").map(|s| s.to_string()))
             .filter(|s| !s.is_empty())

--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -821,8 +821,14 @@ impl Config {
             }
         }
 
+        // Prefer the namespaced name. `OPENHUMAN_SENTRY_DSN` is the legacy
+        // unprefixed name kept as a fallback so existing CI vars and local
+        // `.env` files keep working until the GH org-level variable can be
+        // renamed in lock-step.
         let dsn_value = env
-            .get("OPENHUMAN_SENTRY_DSN")
+            .get("OPENHUMAN_CORE_SENTRY_DSN")
+            .or_else(|| env.get("OPENHUMAN_SENTRY_DSN"))
+            .or_else(|| option_env!("OPENHUMAN_CORE_SENTRY_DSN").map(|s| s.to_string()))
             .or_else(|| option_env!("OPENHUMAN_SENTRY_DSN").map(|s| s.to_string()));
         if let Some(dsn) = dsn_value {
             let dsn = dsn.trim();

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -247,7 +247,7 @@ fn apply_env_overrides_web_search_max_results_and_timeout_clamped() {
 #[test]
 fn apply_env_overrides_picks_up_sentry_dsn() {
     let _g = ENV_LOCK.lock().unwrap();
-    clear_env(&["OPENHUMAN_SENTRY_DSN"]);
+    clear_env(&["OPENHUMAN_CORE_SENTRY_DSN", "OPENHUMAN_SENTRY_DSN"]);
     let mut cfg = Config::default();
     unsafe {
         std::env::set_var("OPENHUMAN_SENTRY_DSN", "https://token@sentry.io/1");
@@ -257,7 +257,41 @@ fn apply_env_overrides_picks_up_sentry_dsn() {
         cfg.observability.sentry_dsn.as_deref(),
         Some("https://token@sentry.io/1")
     );
-    clear_env(&["OPENHUMAN_SENTRY_DSN"]);
+    clear_env(&["OPENHUMAN_CORE_SENTRY_DSN", "OPENHUMAN_SENTRY_DSN"]);
+}
+
+#[test]
+fn apply_env_overrides_prefers_core_sentry_dsn_when_both_set() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear_env(&["OPENHUMAN_CORE_SENTRY_DSN", "OPENHUMAN_SENTRY_DSN"]);
+    let mut cfg = Config::default();
+    unsafe {
+        std::env::set_var("OPENHUMAN_SENTRY_DSN", "https://legacy@sentry.io/1");
+        std::env::set_var("OPENHUMAN_CORE_SENTRY_DSN", "https://new@sentry.io/2");
+    }
+    cfg.apply_env_overrides();
+    assert_eq!(
+        cfg.observability.sentry_dsn.as_deref(),
+        Some("https://new@sentry.io/2"),
+        "namespaced var must win over the legacy unprefixed one"
+    );
+    clear_env(&["OPENHUMAN_CORE_SENTRY_DSN", "OPENHUMAN_SENTRY_DSN"]);
+}
+
+#[test]
+fn apply_env_overrides_picks_up_core_sentry_dsn_alone() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear_env(&["OPENHUMAN_CORE_SENTRY_DSN", "OPENHUMAN_SENTRY_DSN"]);
+    let mut cfg = Config::default();
+    unsafe {
+        std::env::set_var("OPENHUMAN_CORE_SENTRY_DSN", "https://token@sentry.io/3");
+    }
+    cfg.apply_env_overrides();
+    assert_eq!(
+        cfg.observability.sentry_dsn.as_deref(),
+        Some("https://token@sentry.io/3")
+    );
+    clear_env(&["OPENHUMAN_CORE_SENTRY_DSN", "OPENHUMAN_SENTRY_DSN"]);
 }
 
 // ── EnvLookup seam for resolve_runtime_config_dirs ─────────────
@@ -592,6 +626,37 @@ fn env_overlay_sentry_dsn_trims_and_ignores_blank() {
     assert_eq!(
         cfg.observability.sentry_dsn.as_deref(),
         Some("https://t@sentry.io/42")
+    );
+}
+
+#[test]
+fn env_overlay_prefers_namespaced_core_sentry_dsn() {
+    let mut cfg = Config::default();
+    cfg.observability.sentry_dsn = None;
+
+    cfg.apply_env_overlay_with(
+        &HashMapEnv::new()
+            .with("OPENHUMAN_SENTRY_DSN", "https://legacy@sentry.io/1")
+            .with("OPENHUMAN_CORE_SENTRY_DSN", "https://new@sentry.io/2"),
+    );
+    assert_eq!(
+        cfg.observability.sentry_dsn.as_deref(),
+        Some("https://new@sentry.io/2"),
+        "OPENHUMAN_CORE_SENTRY_DSN must win over OPENHUMAN_SENTRY_DSN"
+    );
+}
+
+#[test]
+fn env_overlay_namespaced_core_sentry_dsn_works_alone() {
+    let mut cfg = Config::default();
+    cfg.observability.sentry_dsn = None;
+
+    cfg.apply_env_overlay_with(
+        &HashMapEnv::new().with("OPENHUMAN_CORE_SENTRY_DSN", "https://token@sentry.io/3"),
+    );
+    assert_eq!(
+        cfg.observability.sentry_dsn.as_deref(),
+        Some("https://token@sentry.io/3")
     );
 }
 

--- a/src/openhuman/config/schema/observability.rs
+++ b/src/openhuman/config/schema/observability.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ObservabilityConfig {
-    /// Sentry DSN for error reporting. Overridden by `OPENHUMAN_SENTRY_DSN` env var.
+    /// Sentry DSN for error reporting. Overridden by the
+    /// `OPENHUMAN_CORE_SENTRY_DSN` env var (or its legacy alias
+    /// `OPENHUMAN_SENTRY_DSN`).
     #[serde(default)]
     pub sentry_dsn: Option<String>,
 


### PR DESCRIPTION
## Summary

- Renames the Rust core's Sentry DSN env var from `OPENHUMAN_SENTRY_DSN` → `OPENHUMAN_CORE_SENTRY_DSN` so all three surfaces follow the same `OPENHUMAN_<SURFACE>_SENTRY_DSN` convention (`OPENHUMAN_TAURI_SENTRY_DSN`, `VITE_SENTRY_DSN`).
- Every read site checks the namespaced name first, then falls back to the legacy unprefixed name — nothing breaks while the GH Actions org-level variable is renamed in lock-step.
- Adds three Vitest-equivalent Rust tests covering: namespaced-only, legacy-only, and precedence (namespaced wins when both are set).
- CI workflows (`build-desktop.yml`, `release-packages.yml`) now read `vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN` so the build picks up whichever org var exists today.

## Problem

Cleanup pointed out while landing #1183: the core surface uses an unprefixed env var (`OPENHUMAN_SENTRY_DSN`) while the Tauri shell uses `OPENHUMAN_TAURI_SENTRY_DSN`. The inconsistency is a historical artifact — when the original Sentry integration (#131) shipped, the core was the only Rust surface and didn't need namespacing. PR #1032 ("split errors into per-surface projects") added the React + shell projects with cleanly-namespaced names but left the pre-existing core var as-is.

## Solution

**Transitional dual-read.** Every site that resolves the core DSN now checks:

1. `OPENHUMAN_CORE_SENTRY_DSN` at runtime (preferred)
2. `OPENHUMAN_SENTRY_DSN` at runtime (legacy)
3. Each of the same names baked at compile time via `option_env!`

This keeps existing GH Actions vars, local `.env` files, and shipped binaries working unchanged. Once a maintainer renames the org-level GH Actions variable from `OPENHUMAN_SENTRY_DSN` → `OPENHUMAN_CORE_SENTRY_DSN`, a follow-up PR can drop the legacy branch.

**Files touched:**
- `src/main.rs` — `sentry::init` resolves new name first, legacy fallback (runtime + compile-time).
- `src/openhuman/config/schema/load.rs` — same precedence in `apply_env_overlay_with`.
- `src/openhuman/config/schema/observability.rs` — doc comment on `ObservabilityConfig::sentry_dsn`.
- `src/core/cli.rs` — `sentry-test --help` text and the "DSN missing" diagnostic now reference both names.
- `src/openhuman/config/schema/load_tests.rs` — three new tests + extended `clear_env` lists in the existing test.
- `.env.example` — documents the new name + legacy fallback.
- `.github/workflows/{build-desktop,release-packages}.yml` — exports the new env name from `vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN` so workflows fire whichever GH var exists at the time of the run.

**Local verification:** rebuilt `target/debug/openhuman-core` and ran `sentry-test` twice from a clean shell:
- `OPENHUMAN_CORE_SENTRY_DSN=…` only → event `9a22a674-2e65-4b38-8f41-26960a3f4252` accepted by Sentry.
- `OPENHUMAN_SENTRY_DSN=…` only (legacy) → event `ab0671bb-04d4-42d5-bcf1-5715ee12a411` accepted by Sentry.

Both events appear in the `openhuman-core` project with environment `staging`.

## Submission Checklist

- [x] Tests added or updated — three new Rust tests cover namespaced-only, legacy-only, and precedence-when-both-set; existing test extended to clear both var names.
- [x] **Diff coverage ≥ 80%** — both branches of every changed `or_else` chain are exercised by the new tests; CI yaml lines are configuration not coverage-tracked.
- [ ] N/A — Coverage matrix update: env-var rename, no new feature row.
- [x] All affected feature IDs from the matrix are listed under `## Related` — see Related (no matrix row, see N/A above).
- [x] No new external network dependencies introduced.
- [ ] N/A — Manual smoke checklist update: not on the release-cut surface; observability env-var only.
- [x] Linked issue closed via `Closes #NNN` — no linked issue (cleanup follow-up surfaced during #1183 review).

## Impact

- **Backwards compatible.** Existing CI vars (`vars.OPENHUMAN_SENTRY_DSN`), local `.env` files, and previously-built binaries (which baked `OPENHUMAN_SENTRY_DSN` via `option_env!` at compile time) all continue to work because every read site falls back to the legacy name.
- **No protocol or schema change.** The DSN string itself is unchanged; only the env var name resolving to it changes.
- **Follow-up required:** rename the GitHub Actions org-level variable from `OPENHUMAN_SENTRY_DSN` → `OPENHUMAN_CORE_SENTRY_DSN` (or set the new name pointing at the same DSN value). Once both are present in CI, future PRs can drop the legacy branch from the source.

## Related

Follow-up cleanup from #1183 (Sentry test button).

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo build --bin openhuman-core` succeeds.
- [x] `cargo test --lib sentry_dsn` — all 6 tests pass (3 new, 3 existing extended).
- [x] Manual smoke: `sentry-test` with namespaced var only — event accepted.
- [x] Manual smoke: `sentry-test` with legacy var only — event accepted.
- [ ] N/A pre-merge — CI staging build (after merge) emits a deploy marker against `openhuman-core` as before. (Verification deferred to post-merge staging build cut.)