### PR TITLE
fix(windows): align install.ps1 MSI with per-machine scope (#913)

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -23,13 +23,17 @@ jobs:
       - name: Run installer dry-run
         run: bash scripts/install.sh --dry-run --verbose
 
-  # smoke-windows:
-  #   name: Smoke install.ps1 (windows-latest)
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+  smoke-windows:
+    name: install.ps1 tests + dry-run (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  #     - name: Run installer dry-run
-  #       shell: pwsh
-  #       run: ./scripts/install.ps1 -DryRun
+      - name: Unit tests (MSI args / asset selection)
+        shell: pwsh
+        run: pwsh -NoProfile -File ./scripts/tests/OpenHumanWindowsInstall.Tests.ps1
+
+      - name: Run installer dry-run
+        shell: pwsh
+        run: ./scripts/install.ps1 -DryRun

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "review": "bash scripts/review/cli.sh",
     "work": "bash scripts/work/cli.sh",
     "debug": "bash scripts/debug/cli.sh",
+    "test:install-ps1": "pwsh -NoProfile -File scripts/tests/OpenHumanWindowsInstall.Tests.ps1",
     "rust:check": "pnpm --filter openhuman-app rust:check",
     "typecheck": "pnpm --filter openhuman-app compile"
   },

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -203,7 +203,11 @@ Examples:
     if ($assetName -like "*.msi") {
       $dryMsiArgs = Get-OpenHumanMsiexecInstallArgumentList -MsiPath $tmpFile
       Write-Output "DRY RUN: msiexec ArgumentList = $($dryMsiArgs | ConvertTo-Json -Compress)"
-      Write-Output "DRY RUN: (non-admin) Start-Process msiexec -Verb RunAs -Wait -ArgumentList <above>"
+      if (Test-OpenHumanWindowsProcessElevated) {
+        Write-Output "DRY RUN: (already elevated) Start-Process msiexec -Wait -ArgumentList <above>"
+      } else {
+        Write-Output "DRY RUN: (non-admin) Start-Process msiexec -Verb RunAs -Wait -ArgumentList <above>"
+      }
     } else {
       Write-Output "DRY RUN: Start-Process `"$tmpFile`" -Wait"
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,7 +9,68 @@
 
   Also works when saved and run directly:
   .\scripts\install.ps1 -DryRun
+
+  MSI installs use the Tauri WiX package (InstallScope perMachine). Per-user
+  public properties (MSIINSTALLPERUSER / ALLUSERS=2) conflict with that layout
+  and commonly fail with exit 1603 — see tinyhumansai/openhuman#913.
+
+  When the current session is not elevated, msiexec is started with -Verb RunAs
+  so Windows shows UAC once (machine install to Program Files).
 #>
+
+# --- Script-scoped helpers (unit-tested; safe to dot-source this file) ---
+
+function Get-OpenHumanMsiexecInstallArgumentList {
+  <#
+  .SYNOPSIS
+    Argument list for Start-Process msiexec.exe (no per-user MSI overrides).
+  #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$MsiPath
+  )
+  return @('/i', $MsiPath, '/qn', '/norestart')
+}
+
+function Test-OpenHumanWindowsProcessElevated {
+  <#
+  .SYNOPSIS
+    True when the current process is running with an administrator token (Windows only).
+  #>
+  if ($env:OS -ne 'Windows_NT') {
+    return $false
+  }
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+  return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Select-OpenHumanWindowsAssetFromRelease {
+  <#
+  .SYNOPSIS
+    Pick the Windows x64 MSI from a GitHub release object, else NSIS exe.
+  #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Release
+  )
+  $assets = @($Release.assets)
+  if (-not $assets -or $assets.Count -eq 0) {
+    return $null
+  }
+
+  $msi = $assets | Where-Object { $_.name -match 'OpenHuman_.*x64.*\.msi$' } | Select-Object -First 1
+  if ($msi) {
+    return $msi
+  }
+
+  $exe = $assets | Where-Object { $_.name -match 'OpenHuman_.*x64.*\.exe$' } | Select-Object -First 1
+  if ($exe) {
+    return $exe
+  }
+
+  return $null
+}
 
 # Wrap in a function so `param()` works when piped via `irm | iex`.
 # When piped, PowerShell cannot bind param() at the top-level scope.
@@ -23,7 +84,7 @@ function Install-OpenHuman {
 
   $ErrorActionPreference = "Stop"
 
-  $InstallerVersion = "1.0.0"
+  $InstallerVersion = "1.1.0"
   $Repo = "tinyhumansai/openhuman"
   $LatestReleaseApiUrl = "https://api.github.com/repos/$Repo/releases/latest"
 
@@ -90,25 +151,10 @@ Examples:
   $assetUrl = ""
   $assetDigest = ""
 
-  function Select-WindowsAssetFromRelease([object]$Rel) {
-    $assets = @($Rel.assets)
-    if (-not $assets -or $assets.Count -eq 0) {
-      return $null
-    }
-
-    $msi = $assets | Where-Object { $_.name -match 'OpenHuman_.*x64.*\.msi$' } | Select-Object -First 1
-    if ($msi) { return $msi }
-
-    $exe = $assets | Where-Object { $_.name -match 'OpenHuman_.*x64.*\.exe$' } | Select-Object -First 1
-    if ($exe) { return $exe }
-
-    return $null
-  }
-
   try {
     $release = Invoke-RestMethod -Uri $LatestReleaseApiUrl -UseBasicParsing
     $releaseTag = ($release.tag_name -replace '^v', '')
-    $selected = Select-WindowsAssetFromRelease -Rel $release
+    $selected = Select-OpenHumanWindowsAssetFromRelease -Release $release
     if ($selected) {
       $assetName = $selected.name
       $assetUrl = $selected.browser_download_url
@@ -155,7 +201,9 @@ Examples:
 
   if ($DryRun) {
     if ($assetName -like "*.msi") {
-      Write-Output "DRY RUN: msiexec /i `"$tmpFile`" MSIINSTALLPERUSER=1 ALLUSERS=2 /qn /norestart"
+      $dryMsiArgs = Get-OpenHumanMsiexecInstallArgumentList -MsiPath $tmpFile
+      Write-Output "DRY RUN: msiexec ArgumentList = $($dryMsiArgs | ConvertTo-Json -Compress)"
+      Write-Output "DRY RUN: (non-admin) Start-Process msiexec -Verb RunAs -Wait -ArgumentList <above>"
     } else {
       Write-Output "DRY RUN: Start-Process `"$tmpFile`" -Wait"
     }
@@ -164,10 +212,17 @@ Examples:
 
   Write-Info "Installing OpenHuman"
   if ($assetName -like "*.msi") {
-    $msiArgs = "/i `"$tmpFile`" MSIINSTALLPERUSER=1 ALLUSERS=2 /qn /norestart"
-    $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -PassThru
+    $msiArgs = Get-OpenHumanMsiexecInstallArgumentList -MsiPath $tmpFile
+    $elevated = Test-OpenHumanWindowsProcessElevated
+    if ($elevated) {
+      $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -PassThru
+    } else {
+      Write-Info "Requesting administrator approval for machine-wide install (UAC)…"
+      $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Verb RunAs -Wait -PassThru
+    }
     if ($proc.ExitCode -ne 0) {
       Write-Err "MSI install failed with exit code $($proc.ExitCode)."
+      Write-WarnMsg "If this persists, capture a log: msiexec /i `"$tmpFile`" /l*v `"$env:TEMP\OpenHuman-msi.log`""
       return
     }
   } elseif ($assetName -like "*.exe") {
@@ -199,5 +254,7 @@ Examples:
   }
 }
 
-# Run the installer, forwarding any arguments passed when invoked as a file.
-Install-OpenHuman @args
+# Run when executed as a script; skip when dot-sourced (e.g. unit tests).
+if ($MyInvocation.InvocationName -ne '.') {
+  Install-OpenHuman @args
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -29,6 +29,9 @@ function Get-OpenHumanMsiexecInstallArgumentList {
     [Parameter(Mandatory = $true)]
     [string]$MsiPath
   )
+  # Pass -ArgumentList as string[]: each entry is one argv token for msiexec, so spaces in
+  # $MsiPath do not split. Do not wrap $MsiPath in extra literal " characters here — that can
+  # double-escape when Start-Process builds the native command line (see PR #1187 review).
   return @('/i', $MsiPath, '/qn', '/norestart')
 }
 

--- a/scripts/tests/OpenHumanWindowsInstall.Tests.ps1
+++ b/scripts/tests/OpenHumanWindowsInstall.Tests.ps1
@@ -1,0 +1,96 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Unit tests for scripts/install.ps1 helpers (#913 MSI argument contract).
+
+.DESCRIPTION
+  Dot-sources install.ps1 (does not run Install-OpenHuman) and validates
+  Get-OpenHumanMsiexecInstallArgumentList, Select-OpenHumanWindowsAssetFromRelease,
+  and Test-OpenHumanWindowsProcessElevated.
+
+  Run from repo root:
+    pwsh -NoProfile -File scripts/tests/OpenHumanWindowsInstall.Tests.ps1
+#>
+$ErrorActionPreference = 'Stop'
+
+$installScript = (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') 'install.ps1')).Path
+. $installScript
+
+$testCount = 0
+$failCount = 0
+
+function Assert-Equal {
+  param(
+    [string]$Expected,
+    [string]$Actual,
+    [string]$Message
+  )
+  $script:testCount++
+  if ($Expected -ne $Actual) {
+    $script:failCount++
+    Write-Host "FAIL: $Message" -ForegroundColor Red
+    Write-Host "  expected: $Expected" -ForegroundColor Red
+    Write-Host "  actual:   $Actual" -ForegroundColor Red
+  } else {
+    Write-Host "ok $Message" -ForegroundColor Green
+  }
+}
+
+function Assert-True {
+  param([bool]$Condition, [string]$Message)
+  $script:testCount++
+  if (-not $Condition) {
+    $script:failCount++
+    Write-Host "FAIL: $Message" -ForegroundColor Red
+  } else {
+    Write-Host "ok $Message" -ForegroundColor Green
+  }
+}
+
+Write-Host "`n== Get-OpenHumanMsiexecInstallArgumentList (#913) ==" -ForegroundColor Cyan
+$p = 'C:\Temp\OpenHuman_0.0.0_x64_en-US.msi'
+$args = Get-OpenHumanMsiexecInstallArgumentList -MsiPath $p
+Assert-True ($args.Count -eq 4) 'returns exactly 4 argument tokens'
+Assert-Equal '/i' $args[0] 'first token is /i'
+Assert-Equal $p $args[1] 'second token is MSI path'
+Assert-Equal '/qn' $args[2] 'third token is /qn'
+Assert-Equal '/norestart' $args[3] 'fourth token is /norestart'
+Assert-True ($args -notcontains 'MSIINSTALLPERUSER') 'must not set MSIINSTALLPERUSER (perMachine MSI)'
+Assert-True ($args -notcontains 'ALLUSERS=2') 'must not set ALLUSERS=2'
+Assert-True ($args -notcontains 'ALLUSERS=1') 'must not set ALLUSERS=1 (use package default)'
+$joined = $args -join ' '
+Assert-True ($joined -notmatch 'MSIINSTALLPERUSER') 'joined args omit MSIINSTALLPERUSER'
+Assert-True ($joined -notmatch 'ALLUSERS') 'joined args omit ALLUSERS'
+
+Write-Host "`n== Select-OpenHumanWindowsAssetFromRelease ==" -ForegroundColor Cyan
+$release = [pscustomobject]@{
+  assets = @(
+    [pscustomobject]@{ name = 'OpenHuman_1.0.0_x64_en-US.msi'; browser_download_url = 'https://example/msi' }
+    [pscustomobject]@{ name = 'other.zip'; browser_download_url = 'https://example/z' }
+  )
+}
+$sel = Select-OpenHumanWindowsAssetFromRelease -Release $release
+Assert-Equal 'OpenHuman_1.0.0_x64_en-US.msi' $sel.name 'prefers MSI over other assets'
+
+$releaseExe = [pscustomobject]@{
+  assets = @(
+    [pscustomobject]@{ name = 'OpenHuman_1.0.0_x64-setup.exe'; browser_download_url = 'https://example/exe' }
+  )
+}
+$sel2 = Select-OpenHumanWindowsAssetFromRelease -Release $releaseExe
+Assert-True ($null -ne $sel2) 'selects exe when no msi'
+Assert-Equal 'OpenHuman_1.0.0_x64-setup.exe' $sel2.name 'exe name matches pattern'
+
+$releaseEmpty = [pscustomobject]@{ assets = @() }
+$sel3 = Select-OpenHumanWindowsAssetFromRelease -Release $releaseEmpty
+Assert-True ($null -eq $sel3) 'null when no assets'
+
+Write-Host "`n== Test-OpenHumanWindowsProcessElevated ==" -ForegroundColor Cyan
+$t = Test-OpenHumanWindowsProcessElevated
+Assert-True ($t -is [bool]) 'returns a boolean'
+
+Write-Host "`n== $($testCount) checks, $failCount failed ==" -ForegroundColor $(if ($failCount -eq 0) { 'Green' } else { 'Red' })
+if ($failCount -gt 0) {
+  exit 1
+}
+exit 0

--- a/scripts/tests/OpenHumanWindowsInstall.Tests.ps1
+++ b/scripts/tests/OpenHumanWindowsInstall.Tests.ps1
@@ -53,6 +53,9 @@ $args = Get-OpenHumanMsiexecInstallArgumentList -MsiPath $p
 Assert-True ($args.Count -eq 4) 'returns exactly 4 argument tokens'
 Assert-Equal '/i' $args[0] 'first token is /i'
 Assert-Equal $p $args[1] 'second token is MSI path'
+$pSpaces = 'C:\Temp\Test User\OpenHuman_0.0.0_x64_en-US.msi'
+$argsSpaces = Get-OpenHumanMsiexecInstallArgumentList -MsiPath $pSpaces
+Assert-Equal $pSpaces $argsSpaces[1] 'path with spaces remains one second argv token (no split)'
 Assert-Equal '/qn' $args[2] 'third token is /qn'
 Assert-Equal '/norestart' $args[3] 'fourth token is /norestart'
 Assert-True ($args -notcontains 'MSIINSTALLPERUSER') 'must not set MSIINSTALLPERUSER (perMachine MSI)'


### PR DESCRIPTION
## Summary

- Remove `MSIINSTALLPERUSER` / `ALLUSERS=2` from `msiexec` so silent install matches the Tauri WiX package (`InstallScope="perMachine"`), addressing MSI **1603** failures from `install.ps1` (see #913).
- Start elevated `msiexec` via `-Verb RunAs` when the shell is not already admin so UAC can approve a machine-wide install (still works with `irm … | iex`).
- Extract script-scoped helpers and a dot-source guard for unit tests.
- Add `scripts/tests/OpenHumanWindowsInstall.Tests.ps1`, `pnpm test:install-ps1`, and enable the Windows job in `installer-smoke.yml`.

## Problem

GitHub #913: `install.ps1` verified the MSI download and SHA256, then `msiexec` exited **1603**. The script passed per-user public properties while the shipped MSI is authored **per-machine** (Program Files, HKLM), which commonly produces a fatal install.

## Solution

- Use a fixed argument list: `/i <msi> /qn /norestart` with no conflicting ALLUSERS/MSIINSTALLPERUSER overrides.
- Request elevation only for the `msiexec` child process when needed.
- PowerShell tests assert the MSI argument contract and asset selection; CI runs them on `windows-latest`.

## Submission Checklist

- [x] Tests added or updated — PowerShell tests for MSI arg contract and release asset selection.
- [x] **Diff coverage ≥ 80%** — `N/A`: PowerShell + workflow only (no Vitest/Rust diff-cover surface).
- [x] Coverage matrix — `N/A`.
- [x] Feature IDs in matrix — `N/A`.
- [x] No new external network dependencies — same GitHub release API as before for real installs.
- [x] Manual smoke checklist — `N/A`.
- [x] Linked issue — see **Related**.

## Impact

- **Windows** users: one UAC prompt when installing the MSI without an elevated shell.
- **CI:** `installer-smoke` runs Windows tests + `install.ps1 -DryRun`.

## Related

Closes #913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now performs elevation-aware Windows installs and adapts how it launches the installer when admin rights are needed.

* **Tests**
  * Added a local Windows installer test suite validating asset selection and installer arguments.
  * Added automated Windows smoke tests in CI to run the installer tests and a dry-run.

* **Chores**
  * Installer version bumped to 1.1.0.
  * Added a convenience script entry to run the Windows installer tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->