### PR TITLE
fix(auth): hide email sign-in when email auth is unavailable

### DIFF
--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import OAuthProviderButton from '../components/oauth/OAuthProviderButton';
 import { oauthProviderConfigs } from '../components/oauth/providerConfigs';
 import RotatingTetrahedronCanvas from '../components/RotatingTetrahedronCanvas';
+import { isEmailAuthAvailable, sendEmailMagicLink } from '../services/api/authApi';
 import { clearCoreRpcUrlCache } from '../services/coreRpcClient';
 import { useDeepLinkAuthState } from '../store/deepLinkAuthState';
 import {
@@ -13,6 +14,7 @@ import {
   normalizeRpcUrl,
   storeRpcUrl,
 } from '../utils/configPersistence';
+import { isTauri } from '../utils/tauriCommands';
 
 const Welcome = () => {
   const { isProcessing, errorMessage } = useDeepLinkAuthState();
@@ -22,6 +24,35 @@ const Welcome = () => {
   const [rpcUrlError, setRpcUrlError] = useState<string | null>(null);
   const [isTestingConnection, setIsTestingConnection] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [emailAuthAvailable, setEmailAuthAvailable] = useState<boolean | null>(null);
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [emailSuccess, setEmailSuccess] = useState<string | null>(null);
+  const [isSendingEmail, setIsSendingEmail] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveEmailAuthAvailability = async () => {
+      try {
+        const available = await isEmailAuthAvailable();
+        if (!cancelled) {
+          setEmailAuthAvailable(available);
+        }
+      } catch (error) {
+        console.debug('[welcome][email-auth] failed to resolve availability', error);
+        if (!cancelled) {
+          setEmailAuthAvailable(false);
+        }
+      }
+    };
+
+    resolveEmailAuthAvailability();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleRpcUrlChange = (value: string) => {
     setRpcUrl(value);
@@ -83,6 +114,29 @@ const Welcome = () => {
       setRpcUrlError(`Connection failed: ${message}`);
     } finally {
       setIsTestingConnection(false);
+    }
+  };
+
+  const handleSendMagicLink = async () => {
+    const trimmed = email.trim();
+    if (!trimmed) {
+      setEmailError('Please enter your email address.');
+      setEmailSuccess(null);
+      return;
+    }
+
+    setIsSendingEmail(true);
+    setEmailError(null);
+    setEmailSuccess(null);
+
+    try {
+      const frontendRedirectUri = isTauri() ? 'openhuman://' : window.location.origin;
+      await sendEmailMagicLink(trimmed, frontendRedirectUri);
+      setEmailSuccess('Magic link sent. Check your inbox to continue.');
+    } catch (error) {
+      setEmailError(error instanceof Error ? error.message : 'Failed to send magic link.');
+    } finally {
+      setIsSendingEmail(false);
     }
   };
 
@@ -202,6 +256,73 @@ const Welcome = () => {
                     />
                   ))}
               </div>
+              {emailAuthAvailable === true ? (
+                <div className="mt-6">
+                  <div className="mb-3 flex items-center gap-3">
+                    <div className="h-px flex-1 bg-stone-200" />
+                    <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-stone-400">
+                      Or continue with email
+                    </p>
+                    <div className="h-px flex-1 bg-stone-200" />
+                  </div>
+
+                  <form
+                    onSubmit={event => {
+                      event.preventDefault();
+                      void handleSendMagicLink();
+                    }}
+                    className="space-y-2">
+                    <div className="rounded-xl border border-stone-200 bg-stone-50/70 p-3">
+                      <label htmlFor="email-login-input" className="sr-only">
+                        Email address
+                      </label>
+                      <div className="flex items-center gap-2 rounded-lg border border-stone-300 bg-white px-3 py-2 transition-colors focus-within:border-stone-500 focus-within:ring-1 focus-within:ring-stone-300">
+                        <svg
+                          aria-hidden="true"
+                          viewBox="0 0 24 24"
+                          className="h-4 w-4 text-stone-400"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.8">
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M4 6.75h16A1.25 1.25 0 0 1 21.25 8v8A1.25 1.25 0 0 1 20 17.25H4A1.25 1.25 0 0 1 2.75 16V8A1.25 1.25 0 0 1 4 6.75Z"
+                          />
+                          <path strokeLinecap="round" strokeLinejoin="round" d="m4 8 8 6 8-6" />
+                        </svg>
+                        <input
+                          id="email-login-input"
+                          type="email"
+                          autoComplete="email"
+                          value={email}
+                          onChange={e => {
+                            setEmail(e.target.value);
+                            setEmailError(null);
+                            setEmailSuccess(null);
+                          }}
+                          placeholder="you@example.com"
+                          className="w-full appearance-none border-0 bg-transparent p-0 text-sm text-stone-900 placeholder:text-stone-400 focus:!border-0 focus:!outline-none focus:!ring-0 focus:!shadow-none"
+                        />
+                      </div>
+
+                      <p className="mt-2 text-xs text-stone-500">
+                        We will send a secure magic link. No password required.
+                      </p>
+                    </div>
+
+                    <button
+                      type="submit"
+                      disabled={isSendingEmail}
+                      className="w-full rounded-lg bg-stone-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-stone-700 disabled:cursor-not-allowed disabled:opacity-60">
+                      {isSendingEmail ? 'Sending...' : 'Continue with email'}
+                    </button>
+                  </form>
+
+                  {emailError ? <p className="mt-2 text-xs text-red-600">{emailError}</p> : null}
+                  {emailSuccess ? <p className="mt-2 text-xs text-green-600">{emailSuccess}</p> : null}
+                </div>
+              ) : null}
             </>
           )}
         </div>

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -320,7 +320,9 @@ const Welcome = () => {
                   </form>
 
                   {emailError ? <p className="mt-2 text-xs text-red-600">{emailError}</p> : null}
-                  {emailSuccess ? <p className="mt-2 text-xs text-green-600">{emailSuccess}</p> : null}
+                  {emailSuccess ? (
+                    <p className="mt-2 text-xs text-green-600">{emailSuccess}</p>
+                  ) : null}
                 </div>
               ) : null}
             </>

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { isEmailAuthAvailable, sendEmailMagicLink } from '../../services/api/authApi';
 import { useDeepLinkAuthState } from '../../store/deepLinkAuthState';
 import Welcome from '../Welcome';
 
@@ -43,16 +44,24 @@ vi.mock('../../components/oauth/providerConfigs', () => ({
 }));
 
 vi.mock('../../store/deepLinkAuthState', () => ({ useDeepLinkAuthState: vi.fn() }));
+vi.mock('../../services/api/authApi', () => ({
+  isEmailAuthAvailable: vi.fn(),
+  sendEmailMagicLink: vi.fn(),
+}));
 
 describe('Welcome auth entrypoint', () => {
   beforeEach(() => {
     oauthButtonSpy.mockReset();
     oauthOverrideSpy.mockReset();
     vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(isEmailAuthAvailable).mockResolvedValue(false);
+    vi.mocked(sendEmailMagicLink).mockResolvedValue();
   });
 
-  it('renders only the OAuth buttons when auth is idle', () => {
+  it('renders OAuth buttons and hides email option when email auth is unavailable', async () => {
     render(<Welcome />);
+
+    await screen.findByRole('button', { name: 'google' });
 
     expect(screen.queryByLabelText('Email address')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Continue with email' })).not.toBeInTheDocument();
@@ -60,6 +69,14 @@ describe('Welcome auth entrypoint', () => {
     expect(screen.getByRole('button', { name: 'github' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'twitter' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'discord' })).not.toBeInTheDocument();
+  });
+
+  it('shows email login controls when email auth is available', async () => {
+    vi.mocked(isEmailAuthAvailable).mockResolvedValue(true);
+    render(<Welcome />);
+
+    expect(await screen.findByLabelText('Email address')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue with email' })).toBeInTheDocument();
   });
 
   it('delegates OAuth clicks to OAuthProviderButton without an override', () => {
@@ -73,6 +90,18 @@ describe('Welcome auth entrypoint', () => {
     expect(oauthButtonSpy).toHaveBeenNthCalledWith(2, 'github');
     expect(oauthButtonSpy).toHaveBeenNthCalledWith(3, 'twitter');
     expect(oauthOverrideSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends magic link when email auth is available and user submits email', async () => {
+    vi.mocked(isEmailAuthAvailable).mockResolvedValue(true);
+    render(<Welcome />);
+
+    fireEvent.change(await screen.findByLabelText('Email address'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with email' }));
+
+    expect(sendEmailMagicLink).toHaveBeenCalledWith('user@example.com', window.location.origin);
   });
 
   it('shows the deep-link processing state when auth is already in progress', () => {

--- a/app/src/services/api/__tests__/authApi.test.ts
+++ b/app/src/services/api/__tests__/authApi.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { sendEmailMagicLink } from '../authApi';
+import { isEmailAuthAvailable, sendEmailMagicLink } from '../authApi';
 
 describe('sendEmailMagicLink', () => {
   afterEach(() => {
@@ -41,5 +41,43 @@ describe('sendEmailMagicLink', () => {
     await vi.advanceTimersByTimeAsync(100);
 
     await rejection;
+  });
+
+  it('masks email-infra details when backend reports email auth unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'SMTP credentials not configured' }), { status: 503 })
+    );
+
+    await expect(sendEmailMagicLink('user@example.com', 'openhuman://')).rejects.toThrow(
+      'Email sign-in is currently unavailable. Please use a social login option.'
+    );
+  });
+});
+
+describe('isEmailAuthAvailable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when backend reports enabled=true', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { enabled: true } }), { status: 200 })
+    );
+
+    await expect(isEmailAuthAvailable()).resolves.toBe(true);
+  });
+
+  it('returns false when backend reports enabled=false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { enabled: false } }), { status: 200 })
+    );
+
+    await expect(isEmailAuthAvailable()).resolves.toBe(false);
+  });
+
+  it('returns false when endpoint is unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 503 }));
+
+    await expect(isEmailAuthAvailable()).resolves.toBe(false);
   });
 });

--- a/app/src/services/api/authApi.ts
+++ b/app/src/services/api/authApi.ts
@@ -2,6 +2,42 @@ import { getBackendUrl } from '../backendUrl';
 import { callCoreRpc } from '../coreRpcClient';
 
 const EMAIL_MAGIC_LINK_TIMEOUT_MS = 15_000;
+const EMAIL_SIGN_IN_UNAVAILABLE_MESSAGE =
+  'Email sign-in is currently unavailable. Please use a social login option.';
+
+type EmailAuthStatusResponse = { success?: boolean; data?: { enabled?: boolean } };
+
+function normalizeEmailAuthError(status: number, backendError?: string): string {
+  const message = (backendError ?? '').trim();
+  const lower = message.toLowerCase();
+  const revealsEmailInfra =
+    lower.includes('smtp') ||
+    lower.includes('loops') ||
+    lower.includes('transactional') ||
+    lower.includes('mail server') ||
+    lower.includes('email config');
+
+  if (status === 503 || revealsEmailInfra) {
+    return EMAIL_SIGN_IN_UNAVAILABLE_MESSAGE;
+  }
+
+  return message || `Failed to send magic link (${status})`;
+}
+
+/**
+ * Check whether backend email sign-in is available.
+ * GET /auth/email/status
+ */
+export async function isEmailAuthAvailable(): Promise<boolean> {
+  const backendUrl = await getBackendUrl();
+  const response = await fetch(`${backendUrl}/auth/email/status`, { method: 'GET' });
+  if (!response.ok) {
+    return false;
+  }
+
+  const body = (await response.json().catch(() => ({}))) as EmailAuthStatusResponse;
+  return Boolean(body?.success && body?.data?.enabled);
+}
 
 /**
  * Send a magic-link email for email-based login.
@@ -28,7 +64,7 @@ export async function sendEmailMagicLink(
     });
     if (!response.ok) {
       const body = (await response.json().catch(() => ({}))) as { error?: string };
-      throw new Error(body.error ?? `Failed to send magic link (${response.status})`);
+      throw new Error(normalizeEmailAuthError(response.status, body.error));
     }
   } catch (error) {
     if (


### PR DESCRIPTION
## Summary

- Added backend capability detection for email auth via `GET /auth/email/status` before rendering email sign-in UI.
- Updated Welcome auth entrypoint to show the email magic-link form only when email auth is enabled.
- Added graceful fallback behavior: if status check fails, email sign-in remains hidden and OAuth options stay available.
- Normalized magic-link errors to avoid exposing SMTP/email infrastructure details to end users.
- Expanded unit tests for both `Welcome` and `authApi` to cover availability gating and sanitized failure messaging.

## Problem

- Users were shown an email sign-in path even when backend email auth infrastructure was disabled/unconfigured.
- Submitting email sign-in in that state produced backend-originated infra errors (for example SMTP config issues), creating a confusing and potentially sensitive UX.
- Reviewers needed a deterministic client-side behavior for unavailable email auth, plus safe error messaging.

## Solution

- Introduced `isEmailAuthAvailable()` in `authApi` to call `/auth/email/status` and return a strict boolean availability signal.
- In `Welcome.tsx`, added mount-time availability resolution and conditional rendering for the email login form.
- Kept OAuth providers as the always-available fallback path when email auth is unavailable or status probing fails.
- Added `normalizeEmailAuthError()` to map infra-related failures (503 or SMTP/mail-config style backend messages) to a safe user-facing message.
- Added/updated tests for:
  - hidden email controls when unavailable
  - visible email controls when available
  - magic-link submit invocation
  - API availability true/false/unavailable outcomes
  - sanitized infra-error response handling

## Related

- Feature IDs: `N/A` — this specific Welcome/email-auth-gating behavior is not currently enumerated as a standalone row in `docs/TEST-COVERAGE-MATRIX.md`.
- Closes #NNN

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform: frontend auth entrypoint behavior change in the desktop app (`app/`); no Rust core, JSON-RPC contract, or CLI changes.
- Security/UX: reduces leakage of backend email infrastructure details in user-visible error messages.
- Compatibility: no migration required; behavior is backward compatible with OAuth sign-in flows.
- Performance: minimal additional startup request on Welcome page (`/auth/email/status`).


## Related

- Closes: #1150 
- Follow-up PR : https://github.com/tinyhumansai/backend/pull/685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced email magic-link sign-in option on the login page alongside existing OAuth providers
  * Dynamic email authentication availability checking with graceful fallback when unavailable
  * Improved error handling and user-friendly messaging for email sign-in issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->