### PR TITLE
fix(auth): stop stale chat threads after signup

### DIFF
--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -28,6 +28,7 @@ import {
 import { socketService } from '../services/socketService';
 import { store } from '../store';
 import { resetUserScopedState } from '../store/resetActions';
+import { clearAllThreads, loadThreads } from '../store/threadSlice';
 import { getActiveUserId, setActiveUserId } from '../store/userScopedStorage';
 import {
   openhumanUpdateAnalyticsSettings,
@@ -239,6 +240,19 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
         teamInvitesById: shouldClearScopedCaches ? {} : previous.teamInvitesById,
       };
     });
+
+    // When the authenticated identity changes without a full restart-driven
+    // flip (e.g. same-process session attach or web where `restartApp` is a
+    // no-op), the thread slice can still hold rows from the pre-login
+    // workspace. Clear and re-list from the core so new signups never render
+    // stale titles from another bucket (#1157). `handleIdentityFlip` already
+    // dispatches `resetUserScopedState`, so skip when `isFlip` is true.
+    if (!isFlip && shouldClearScopedCaches && nextIdentity && !isLogout) {
+      store.dispatch(clearAllThreads());
+      void store.dispatch(loadThreads()).catch(err => {
+        log('post-identity thread reload failed: %O', sanitizeError(err));
+      });
+    }
 
     if (isFlip && nextIdentity) {
       await handleIdentityFlip({ reason: 'identity-flip', nextUserId: nextIdentity }).catch(err => {

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -247,11 +247,26 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     // workspace. Clear and re-list from the core so new signups never render
     // stale titles from another bucket (#1157). `handleIdentityFlip` already
     // dispatches `resetUserScopedState`, so skip when `isFlip` is true.
-    if (!isFlip && shouldClearScopedCaches && nextIdentity && !isLogout) {
+    // Match `commitState`'s request-id guard so a superseded refresh cannot
+    // clear threads after a newer snapshot has already won (CodeRabbit).
+    if (
+      requestId === snapshotRequestIdRef.current &&
+      !isFlip &&
+      shouldClearScopedCaches &&
+      nextIdentity &&
+      !isLogout
+    ) {
+      const threadReloadRequestId = requestId;
       store.dispatch(clearAllThreads());
-      void store.dispatch(loadThreads()).catch(err => {
-        log('post-identity thread reload failed: %O', sanitizeError(err));
-      });
+      void store
+        .dispatch(loadThreads())
+        .unwrap()
+        .catch(err => {
+          if (threadReloadRequestId !== snapshotRequestIdRef.current) {
+            return;
+          }
+          log('post-identity thread reload failed: %O', sanitizeError(err));
+        });
     }
 
     if (isFlip && nextIdentity) {

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as coreStateApi from '../../services/coreStateApi';
+import * as threadSlice from '../../store/threadSlice';
 import * as userScopedStorage from '../../store/userScopedStorage';
 import * as tauriCommands from '../../utils/tauriCommands';
 import { setCoreStateSnapshot } from '../../lib/coreState/store';
@@ -150,6 +151,35 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     expect(setActiveSpy).not.toHaveBeenCalled();
 
     setActiveSpy.mockRestore();
+  });
+
+  it('seed matches next user (no restart) but identity hydrates null→B: clears threads and reloads (#1157)', async () => {
+    userScopedStorage.setActiveUserId('B');
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
+    const dispatchSpy = vi.spyOn(store, 'dispatch');
+    const loadThreadsSpy = vi.spyOn(threadSlice, 'loadThreads');
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    expect(restartApp).not.toHaveBeenCalled();
+    expect(
+      dispatchSpy.mock.calls.some(([action]) => {
+        if (!action || typeof action !== 'object' || !('type' in action)) return false;
+        return (action as { type: string }).type === threadSlice.clearAllThreads().type;
+      })
+    ).toBe(true);
+    expect(loadThreadsSpy).toHaveBeenCalled();
+
+    dispatchSpy.mockRestore();
+    loadThreadsSpy.mockRestore();
   });
 
   it('auth-to-auth flip (A→B without intermediate logout): restart, re-points to B', async () => {

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -14,8 +14,10 @@ use crate::rpc::RpcOutcome;
 
 use super::{AuthService, APP_SESSION_PROVIDER, DEFAULT_AUTH_PROFILE_NAME};
 use crate::openhuman::config::{
-    default_root_openhuman_dir, user_openhuman_dir, write_active_user_id,
+    default_root_openhuman_dir, pre_login_user_dir, read_active_user_id, user_openhuman_dir,
+    write_active_user_id,
 };
+use crate::openhuman::memory::conversations;
 
 /// Start all login-gated background services (local AI, voice, screen
 /// intelligence, autocomplete).  Called both from the initial boot path
@@ -158,6 +160,9 @@ pub async fn store_session(
 
     if let Some(ref uid) = resolved_user_id {
         if let Ok(root_dir) = default_root_openhuman_dir() {
+            // Snapshot before we overwrite `active_user.toml` so we can tell
+            // first activation from signed-out vs an in-place account switch.
+            let previous_active = read_active_user_id(&root_dir);
             let user_dir = user_openhuman_dir(&root_dir, uid);
             if let Err(e) = std::fs::create_dir_all(&user_dir) {
                 tracing::warn!(
@@ -178,6 +183,36 @@ pub async fn store_session(
                     user_dir = %user_dir.display(),
                     "User-scoped directory activated"
                 );
+                // Onboarding and other pre-auth flows write threads under the
+                // `users/local/workspace` tree. After the first successful login
+                // there was no previous `active_user.toml`, wipe that anonymous
+                // conversation store so a fresh account never inherits demo or
+                // scratch threads from the pre-login bucket (#1157).
+                if previous_active.is_none() {
+                    let pre_ws = pre_login_user_dir(&root_dir).join("workspace");
+                    let pre_ws_log = pre_ws.display().to_string();
+                    match conversations::purge_threads(pre_ws) {
+                        Ok(stats) => {
+                            tracing::info!(
+                                pre_login_workspace = %pre_ws_log,
+                                threads = stats.thread_count,
+                                messages = stats.message_count,
+                                "[credentials] purged pre-login conversation threads after first session activation"
+                            );
+                            logs.push(format!(
+                                "purged pre-login conversation history (threads={}, messages={})",
+                                stats.thread_count, stats.message_count
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                error = %e,
+                                pre_login_workspace = %pre_ws_log,
+                                "[credentials] pre-login conversation purge skipped (non-fatal)"
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -188,6 +188,10 @@ pub async fn store_session(
                 // there was no previous `active_user.toml`, wipe that anonymous
                 // conversation store so a fresh account never inherits demo or
                 // scratch threads from the pre-login bucket (#1157).
+                //
+                // This shares `memory::conversations`' process-wide mutex with
+                // `list_threads` / `purge_threads` on any workspace, so purge and
+                // concurrent thread RPC in this process cannot interleave.
                 if previous_active.is_none() {
                     let pre_ws = pre_login_user_dir(&root_dir).join("workspace");
                     let pre_ws_log = pre_ws.display().to_string();


### PR DESCRIPTION
## Summary
Fixes new signups showing conversation threads from the anonymous (`users/local`) workspace or stale Redux thread rows when auth hydrates without a full identity-flip restart.

## Changes
- **Core (`store_session`)**: After the first activation from signed-out (no prior `active_user.toml`), purge local conversation JSONL under the pre-login workspace so onboarding/demo threads are not retained in the shared bucket.
- **UI (`CoreStateProvider`)**: When scoped caches clear for an identity change but `handleIdentityFlip` does not run, dispatch `clearAllThreads()` and `loadThreads()` so the thread list re-syncs from the core.
- **Tests**: Vitest coverage for the seed-matches-next-user hydration path.

## Verification
- `cargo fmt --check`, `cargo check` (root crate)
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`
- `cargo test -p openhuman credentials::ops`

Closes #1157

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling to ensure thread caches are cleared and reloaded when an authenticated identity changes (excluding restart-driven flips or logouts).
  * Enhanced initial-login cleanup to purge conversation threads from pre-login workspaces, non-fatal failures logged.

* **Tests**
  * Added test coverage for identity transition scenarios to verify thread cache invalidation and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->