### PR TITLE
fix(ui): hide unsupported permission UI on non-macOS for Screen Intelligence

### DIFF
--- a/app/src/components/intelligence/ScreenIntelligenceDebugPanel.tsx
+++ b/app/src/components/intelligence/ScreenIntelligenceDebugPanel.tsx
@@ -68,11 +68,15 @@ const ScreenIntelligenceDebugPanelContent = ({
         <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-stone-400">
           Permissions
         </h4>
-        <div className="grid grid-cols-3 gap-2 text-xs">
-          <PermissionDot label="Screen" value={permissions?.screen_recording} />
-          <PermissionDot label="Accessibility" value={permissions?.accessibility} />
-          <PermissionDot label="Input" value={permissions?.input_monitoring} />
-        </div>
+        {status?.platform_supported === false ? (
+          <p className="text-xs text-stone-500">Platform not supported</p>
+        ) : (
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <PermissionDot label="Screen" value={permissions?.screen_recording} />
+            <PermissionDot label="Accessibility" value={permissions?.accessibility} />
+            <PermissionDot label="Input" value={permissions?.input_monitoring} />
+          </div>
+        )}
       </div>
 
       {/* Session Status */}

--- a/app/src/components/intelligence/__tests__/ScreenIntelligenceDebugPanel.test.tsx
+++ b/app/src/components/intelligence/__tests__/ScreenIntelligenceDebugPanel.test.tsx
@@ -117,6 +117,20 @@ describe('ScreenIntelligenceDebugPanel', () => {
     );
   });
 
+  it('shows "Platform not supported" and hides permission dots when platform_supported is false', () => {
+    const state: ScreenIntelligenceState = {
+      ...baseState,
+      status: { ...baseState.status!, platform_supported: false },
+    };
+
+    render(<ScreenIntelligenceDebugPanel state={state} />);
+
+    expect(screen.getByText('Platform not supported')).toBeInTheDocument();
+    expect(screen.queryByText('Screen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Accessibility')).not.toBeInTheDocument();
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+  });
+
   it('renders capture failures without breaking the diagnostics panel', async () => {
     const state: ScreenIntelligenceState = {
       ...baseState,

--- a/app/src/components/skills/ScreenIntelligenceSetupModal.tsx
+++ b/app/src/components/skills/ScreenIntelligenceSetupModal.tsx
@@ -170,6 +170,7 @@ export default function ScreenIntelligenceSetupModal({ onClose, initialStep }: P
             </div>
             <button
               type="button"
+              aria-label="Close"
               onClick={onClose}
               className="w-7 h-7 rounded-lg flex items-center justify-center text-stone-400 hover:text-stone-600 hover:bg-stone-100 transition-colors">
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/src/components/skills/ScreenIntelligenceSetupModal.tsx
+++ b/app/src/components/skills/ScreenIntelligenceSetupModal.tsx
@@ -147,6 +147,53 @@ export default function ScreenIntelligenceSetupModal({ onClose, initialStep }: P
     navigate('/settings/screen-intelligence');
   };
 
+  if (status?.platform_supported === false) {
+    return createPortal(
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+        onClick={e => {
+          if (e.target === e.currentTarget) onClose();
+        }}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="si-setup-title"
+          className="w-full max-w-md mx-4 rounded-2xl bg-white shadow-xl overflow-hidden animate-fade-up">
+          <div className="flex items-center justify-between border-b border-stone-100 px-5 py-4">
+            <div className="flex items-center gap-3">
+              <div className="w-9 h-9 rounded-xl bg-primary-50 flex items-center justify-center text-primary-600">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M3 5h18v12H3zM8 21h8m-4-4v4" />
+                </svg>
+              </div>
+              <h2 id="si-setup-title" className="text-sm font-semibold text-stone-900">Screen Intelligence</h2>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-7 h-7 rounded-lg flex items-center justify-center text-stone-400 hover:text-stone-600 hover:bg-stone-100 transition-colors">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <div className="px-5 py-6 space-y-4">
+            <p className="text-sm text-stone-600 leading-relaxed">
+              Screen Intelligence is currently available on macOS only.
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-full rounded-xl border border-stone-200 bg-stone-50 px-4 py-2.5 text-sm font-medium text-stone-600 hover:bg-stone-100 transition-colors">
+              Close
+            </button>
+          </div>
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
   return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"

--- a/app/src/components/skills/__tests__/ScreenIntelligenceSetupModal.test.tsx
+++ b/app/src/components/skills/__tests__/ScreenIntelligenceSetupModal.test.tsx
@@ -104,7 +104,7 @@ describe('ScreenIntelligenceSetupModal', () => {
     render(<ScreenIntelligenceSetupModal onClose={vi.fn()} />);
 
     expect(screen.getByText(/macOS only/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+    expect(screen.getByText('Close', { selector: 'button' })).toBeInTheDocument();
     expect(screen.queryByText('Grant permissions')).not.toBeInTheDocument();
     expect(screen.queryByText('Screen Recording')).not.toBeInTheDocument();
   });
@@ -118,7 +118,7 @@ describe('ScreenIntelligenceSetupModal', () => {
 
     render(<ScreenIntelligenceSetupModal onClose={onClose} />);
 
-    screen.getByRole('button', { name: /close/i }).click();
+    screen.getByText('Close', { selector: 'button' }).click();
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/app/src/components/skills/__tests__/ScreenIntelligenceSetupModal.test.tsx
+++ b/app/src/components/skills/__tests__/ScreenIntelligenceSetupModal.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type ScreenIntelligenceState,
+  useScreenIntelligenceState,
+} from '../../../features/screen-intelligence/useScreenIntelligenceState';
+import ScreenIntelligenceSetupModal from '../ScreenIntelligenceSetupModal';
+
+vi.mock('../../../features/screen-intelligence/useScreenIntelligenceState', () => ({
+  useScreenIntelligenceState: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('react-router-dom');
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) };
+});
+
+vi.mock('../../../utils/tauriCommands', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../../utils/tauriCommands');
+  return {
+    ...actual,
+    openhumanUpdateScreenIntelligenceSettings: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const baseState: ScreenIntelligenceState = {
+  status: {
+    platform_supported: true,
+    permissions: {
+      screen_recording: 'unknown',
+      accessibility: 'unknown',
+      input_monitoring: 'unknown',
+    },
+    features: { screen_monitoring: false },
+    session: {
+      active: false,
+      started_at_ms: null,
+      expires_at_ms: null,
+      remaining_ms: null,
+      ttl_secs: 300,
+      panic_hotkey: 'Cmd+Shift+.',
+      stop_reason: null,
+      frames_in_memory: 0,
+      last_capture_at_ms: null,
+      last_context: null,
+      vision_enabled: true,
+      vision_state: 'idle',
+      vision_queue_depth: 0,
+      last_vision_at_ms: null,
+      last_vision_summary: null,
+    },
+    config: {
+      enabled: false,
+      capture_policy: 'hybrid',
+      policy_mode: 'all_except_blacklist',
+      baseline_fps: 1,
+      vision_enabled: true,
+      session_ttl_secs: 300,
+      panic_stop_hotkey: 'Cmd+Shift+.',
+      autocomplete_enabled: true,
+      use_vision_model: true,
+      keep_screenshots: false,
+      allowlist: [],
+      denylist: [],
+    },
+    denylist: [],
+    is_context_blocked: false,
+  },
+  lastRestartSummary: null,
+  recentVisionSummaries: [],
+  captureTestResult: null,
+  isCaptureTestRunning: false,
+  isLoading: false,
+  isRequestingPermissions: false,
+  isRestartingCore: false,
+  isStartingSession: false,
+  isStoppingSession: false,
+  isLoadingVision: false,
+  isFlushingVision: false,
+  lastError: null,
+  refreshStatus: vi.fn().mockResolvedValue(null),
+  requestPermission: vi.fn().mockResolvedValue(null),
+  refreshPermissionsWithRestart: vi.fn().mockResolvedValue(null),
+  startSession: vi.fn().mockResolvedValue(null),
+  stopSession: vi.fn().mockResolvedValue(null),
+  refreshVision: vi.fn().mockResolvedValue([]),
+  flushVision: vi.fn().mockResolvedValue(undefined),
+  runCaptureTest: vi.fn().mockResolvedValue(undefined),
+  clearError: vi.fn(),
+};
+
+describe('ScreenIntelligenceSetupModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows macOS-only message and a Close button when platform_supported is false', () => {
+    vi.mocked(useScreenIntelligenceState).mockReturnValue({
+      ...baseState,
+      status: { ...baseState.status!, platform_supported: false },
+    });
+
+    render(<ScreenIntelligenceSetupModal onClose={vi.fn()} />);
+
+    expect(screen.getByText(/macOS only/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+    expect(screen.queryByText('Grant permissions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Screen Recording')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the Close button is clicked on the unsupported-platform screen', () => {
+    const onClose = vi.fn();
+    vi.mocked(useScreenIntelligenceState).mockReturnValue({
+      ...baseState,
+      status: { ...baseState.status!, platform_supported: false },
+    });
+
+    render(<ScreenIntelligenceSetupModal onClose={onClose} />);
+
+    screen.getByRole('button', { name: /close/i }).click();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the permissions setup flow when platform_supported is true', () => {
+    vi.mocked(useScreenIntelligenceState).mockReturnValue(baseState);
+
+    render(<ScreenIntelligenceSetupModal onClose={vi.fn()} />);
+
+    expect(screen.getByText('Grant permissions')).toBeInTheDocument();
+    expect(screen.getByText('Screen Recording')).toBeInTheDocument();
+    expect(screen.getByText('Accessibility')).toBeInTheDocument();
+    expect(screen.getByText('Input Monitoring')).toBeInTheDocument();
+    expect(screen.queryByText(/macOS only/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -28,6 +28,7 @@ import {
 import { socketService } from '../services/socketService';
 import { store } from '../store';
 import { resetUserScopedState } from '../store/resetActions';
+import { clearAllThreads, loadThreads } from '../store/threadSlice';
 import { getActiveUserId, setActiveUserId } from '../store/userScopedStorage';
 import {
   openhumanUpdateAnalyticsSettings,
@@ -239,6 +240,19 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
         teamInvitesById: shouldClearScopedCaches ? {} : previous.teamInvitesById,
       };
     });
+
+    // When the authenticated identity changes without a full restart-driven
+    // flip (e.g. same-process session attach or web where `restartApp` is a
+    // no-op), the thread slice can still hold rows from the pre-login
+    // workspace. Clear and re-list from the core so new signups never render
+    // stale titles from another bucket (#1157). `handleIdentityFlip` already
+    // dispatches `resetUserScopedState`, so skip when `isFlip` is true.
+    if (!isFlip && shouldClearScopedCaches && nextIdentity && !isLogout) {
+      store.dispatch(clearAllThreads());
+      void store.dispatch(loadThreads()).catch(err => {
+        log('post-identity thread reload failed: %O', sanitizeError(err));
+      });
+    }
 
     if (isFlip && nextIdentity) {
       await handleIdentityFlip({ reason: 'identity-flip', nextUserId: nextIdentity }).catch(err => {

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -247,11 +247,26 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     // workspace. Clear and re-list from the core so new signups never render
     // stale titles from another bucket (#1157). `handleIdentityFlip` already
     // dispatches `resetUserScopedState`, so skip when `isFlip` is true.
-    if (!isFlip && shouldClearScopedCaches && nextIdentity && !isLogout) {
+    // Match `commitState`'s request-id guard so a superseded refresh cannot
+    // clear threads after a newer snapshot has already won (CodeRabbit).
+    if (
+      requestId === snapshotRequestIdRef.current &&
+      !isFlip &&
+      shouldClearScopedCaches &&
+      nextIdentity &&
+      !isLogout
+    ) {
+      const threadReloadRequestId = requestId;
       store.dispatch(clearAllThreads());
-      void store.dispatch(loadThreads()).catch(err => {
-        log('post-identity thread reload failed: %O', sanitizeError(err));
-      });
+      void store
+        .dispatch(loadThreads())
+        .unwrap()
+        .catch(err => {
+          if (threadReloadRequestId !== snapshotRequestIdRef.current) {
+            return;
+          }
+          log('post-identity thread reload failed: %O', sanitizeError(err));
+        });
     }
 
     if (isFlip && nextIdentity) {

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as coreStateApi from '../../services/coreStateApi';
+import * as threadSlice from '../../store/threadSlice';
 import * as userScopedStorage from '../../store/userScopedStorage';
 import * as tauriCommands from '../../utils/tauriCommands';
 import { setCoreStateSnapshot } from '../../lib/coreState/store';
@@ -150,6 +151,35 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     expect(setActiveSpy).not.toHaveBeenCalled();
 
     setActiveSpy.mockRestore();
+  });
+
+  it('seed matches next user (no restart) but identity hydrates null→B: clears threads and reloads (#1157)', async () => {
+    userScopedStorage.setActiveUserId('B');
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
+    const dispatchSpy = vi.spyOn(store, 'dispatch');
+    const loadThreadsSpy = vi.spyOn(threadSlice, 'loadThreads');
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer captureCtx={c => (ctx = c)} />
+      </CoreStateProvider>
+    );
+    await act(async () => {
+      await ctx!.refresh();
+    });
+
+    expect(restartApp).not.toHaveBeenCalled();
+    expect(
+      dispatchSpy.mock.calls.some(([action]) => {
+        if (!action || typeof action !== 'object' || !('type' in action)) return false;
+        return (action as { type: string }).type === threadSlice.clearAllThreads().type;
+      })
+    ).toBe(true);
+    expect(loadThreadsSpy).toHaveBeenCalled();
+
+    dispatchSpy.mockRestore();
+    loadThreadsSpy.mockRestore();
   });
 
   it('auth-to-auth flip (A→B without intermediate logout): restart, re-points to B', async () => {

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -14,8 +14,10 @@ use crate::rpc::RpcOutcome;
 
 use super::{AuthService, APP_SESSION_PROVIDER, DEFAULT_AUTH_PROFILE_NAME};
 use crate::openhuman::config::{
-    default_root_openhuman_dir, user_openhuman_dir, write_active_user_id,
+    default_root_openhuman_dir, pre_login_user_dir, read_active_user_id, user_openhuman_dir,
+    write_active_user_id,
 };
+use crate::openhuman::memory::conversations;
 
 /// Start all login-gated background services (local AI, voice, screen
 /// intelligence, autocomplete).  Called both from the initial boot path
@@ -158,6 +160,9 @@ pub async fn store_session(
 
     if let Some(ref uid) = resolved_user_id {
         if let Ok(root_dir) = default_root_openhuman_dir() {
+            // Snapshot before we overwrite `active_user.toml` so we can tell
+            // first activation from signed-out vs an in-place account switch.
+            let previous_active = read_active_user_id(&root_dir);
             let user_dir = user_openhuman_dir(&root_dir, uid);
             if let Err(e) = std::fs::create_dir_all(&user_dir) {
                 tracing::warn!(
@@ -178,6 +183,36 @@ pub async fn store_session(
                     user_dir = %user_dir.display(),
                     "User-scoped directory activated"
                 );
+                // Onboarding and other pre-auth flows write threads under the
+                // `users/local/workspace` tree. After the first successful login
+                // there was no previous `active_user.toml`, wipe that anonymous
+                // conversation store so a fresh account never inherits demo or
+                // scratch threads from the pre-login bucket (#1157).
+                if previous_active.is_none() {
+                    let pre_ws = pre_login_user_dir(&root_dir).join("workspace");
+                    let pre_ws_log = pre_ws.display().to_string();
+                    match conversations::purge_threads(pre_ws) {
+                        Ok(stats) => {
+                            tracing::info!(
+                                pre_login_workspace = %pre_ws_log,
+                                threads = stats.thread_count,
+                                messages = stats.message_count,
+                                "[credentials] purged pre-login conversation threads after first session activation"
+                            );
+                            logs.push(format!(
+                                "purged pre-login conversation history (threads={}, messages={})",
+                                stats.thread_count, stats.message_count
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                error = %e,
+                                pre_login_workspace = %pre_ws_log,
+                                "[credentials] pre-login conversation purge skipped (non-fatal)"
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -188,6 +188,10 @@ pub async fn store_session(
                 // there was no previous `active_user.toml`, wipe that anonymous
                 // conversation store so a fresh account never inherits demo or
                 // scratch threads from the pre-login bucket (#1157).
+                //
+                // This shares `memory::conversations`' process-wide mutex with
+                // `list_threads` / `purge_threads` on any workspace, so purge and
+                // concurrent thread RPC in this process cannot interleave.
                 if previous_active.is_none() {
                     let pre_ws = pre_login_user_dir(&root_dir).join("workspace");
                     let pre_ws_log = pre_ws.display().to_string();


### PR DESCRIPTION
## Summary

- **ScreenIntelligenceSetupModal**: when `platform_supported` is `false`, show a "Screen Intelligence is currently available on macOS only" message with a Close button instead of rendering the permissions setup flow (Screen Recording / Accessibility / Input Monitoring grant rows)
- **ScreenIntelligenceDebugPanel**: replace the three permission dots with a "Platform not supported" indicator when the platform is unsupported
- Add tests for both changed components covering the unsupported-platform path

`ScreenIntelligencePanel.tsx` (settings panel) was already correctly guarded — `PermissionsSection` is hidden and a "macOS only" banner is shown when `platform_supported` is `false`. No Rust changes needed; the core already returns `PermissionState::Unsupported` and `platform_supported: false` on Windows/Linux.

Closes #903

## Test plan

- [x] Verify `ScreenIntelligenceSetupModal.test.tsx` (new): 3 tests pass — macOS-only message shown, Close button calls onClose, normal permissions flow renders when supported
- [x] Verify `ScreenIntelligenceDebugPanel.test.tsx`: existing tests pass + new "Platform not supported" case passes
- [x] On macOS: Screen Intelligence setup modal and debug panel show permissions as before — no regression (guard only fires when `platform_supported === false`; macOS returns `true`)
- [x] On Windows/Linux (or with `platform_supported: false` mocked): setup modal shows "macOS only" message; debug panel shows "Platform not supported" instead of the three Unsupported dots (covered by unit tests with mocked state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Screen Intelligence shows a macOS-only/platform-not-supported message and skips the permission/setup flow on unsupported systems.

* **Bug Fixes**
  * Clear and reload conversation threads on identity change to avoid stale thread state.
  * Purge pre-auth conversation threads when activating a new user to prevent leftover data.

* **Tests**
  * Added tests covering platform-compatibility UI flows and thread identity-change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->