### PR TITLE
feat(core): version/shutdown/update RPCs + mid-thread integration refresh

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.12"
+version = "0.53.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1289,7 +1289,7 @@ dependencies = [
  "core-foundation-sys 0.8.7",
  "coreaudio-rs",
  "dasp_sample",
- "jni 0.21.1",
+ "jni",
  "js-sys",
  "libc",
  "mach2 0.4.3",
@@ -2789,34 +2789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
-name = "html2md"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cff9891f2e0d9048927fbdfc28b11bf378f6a93c7ba70b23d0fbee9af6071b4"
-dependencies = [
- "html5ever 0.27.0",
- "jni 0.19.0",
- "lazy_static",
- "markup5ever_rcdom",
- "percent-encoding",
- "regex",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,20 +3284,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
-]
-
-[[package]]
-name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
@@ -3680,20 +3638,6 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
- "tendril 0.4.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
@@ -3715,18 +3659,6 @@ dependencies = [
  "log",
  "tendril 0.5.0",
  "web_atoms",
-]
-
-[[package]]
-name = "markup5ever_rcdom"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
-dependencies = [
- "html5ever 0.27.0",
- "markup5ever 0.12.1",
- "tendril 0.4.3",
- "xml5ever",
 ]
 
 [[package]]
@@ -4473,7 +4405,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni 0.21.1",
+ "jni",
  "ndk 0.8.0",
  "ndk-context",
  "num-derive",
@@ -4522,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.12"
+version = "0.53.13"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4553,7 +4485,6 @@ dependencies = [
  "hmac 0.12.1",
  "hostname",
  "hound",
- "html2md",
  "iana-time-zone",
  "image",
  "lettre",
@@ -5962,7 +5893,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys 0.8.7",
- "jni 0.21.1",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -6887,7 +6818,7 @@ dependencies = [
  "dpi",
  "gdkwayland-sys",
  "gtk",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "ndk 0.9.0",
@@ -6951,7 +6882,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "mime",
@@ -7170,7 +7101,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "objc2 0.6.4",
  "objc2-ui-kit",
  "raw-window-handle",
@@ -7216,7 +7147,7 @@ version = "2.10.1"
 dependencies = [
  "gtk",
  "http",
- "jni 0.21.1",
+ "jni",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -9375,7 +9306,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni 0.21.1",
+ "jni",
  "libc",
  "ndk 0.9.0",
  "objc2 0.6.4",
@@ -9464,17 +9395,6 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
-
-[[package]]
-name = "xml5ever"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.12.1",
-]
 
 [[package]]
 name = "xz2"

--- a/src/core/event_bus/events.rs
+++ b/src/core/event_bus/events.rs
@@ -360,6 +360,10 @@ pub enum DomainEvent {
     SystemShutdown { component: String },
     /// A restart of the current core process was requested.
     SystemRestartRequested { source: String, reason: String },
+    /// A graceful shutdown of the current core process was requested.
+    /// Distinct from [`Self::SystemShutdown`] (per-component shutdown
+    /// notification) — this variant asks the running process to exit.
+    SystemShutdownRequested { source: String, reason: String },
     /// A component's health status changed.
     HealthChanged {
         component: String,
@@ -431,6 +435,7 @@ impl DomainEvent {
             Self::SystemStartup { .. }
             | Self::SystemShutdown { .. }
             | Self::SystemRestartRequested { .. }
+            | Self::SystemShutdownRequested { .. }
             | Self::HealthChanged { .. }
             | Self::HealthRestarted { .. } => "system",
         }

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -868,6 +868,9 @@ fn register_domain_subscribers(
         // Restart requests go through a subscriber so every trigger path shares
         // the same respawn logic.
         crate::openhuman::service::bus::register_restart_subscriber();
+        // Shutdown requests use the same pattern; the subscriber exits the
+        // current process after a short grace period.
+        crate::openhuman::service::bus::register_shutdown_subscriber();
 
         // Proactive message subscriber (web-only in the desktop runtime —
         // no external channel instances are registered here). Uses a

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -178,23 +178,34 @@ async fn run_typed_mode(
         } else {
             match crate::openhuman::config::Config::load_or_init().await {
                 Ok(config) => {
-                    // `fetch_connected_integrations` is best-effort and
-                    // returns `Vec` rather than `Result`. An empty Vec
-                    // here is authoritative — it means "the user has no
-                    // ACTIVE composio connections right now" — so we
-                    // adopt it as truth, including the case where the
-                    // user just disconnected their last integration
-                    // mid-thread. Falling back to the frozen parent
-                    // list here would silently re-introduce a toolkit
-                    // the user has revoked.
-                    let fresh =
-                        crate::openhuman::composio::fetch_connected_integrations(&config).await;
-                    tracing::debug!(
-                        count = fresh.len(),
-                        parent_count = parent.connected_integrations.len(),
-                        "[subagent_runner] refreshed connected_integrations at spawn time"
-                    );
-                    fresh
+                    use crate::openhuman::composio::FetchConnectedIntegrationsStatus;
+                    // `fetch_connected_integrations_status` distinguishes
+                    // an authoritative empty list (user disconnected
+                    // their last integration mid-thread) from
+                    // backend-unavailable (no client / transient error).
+                    // Adopt the authoritative case as truth — even when
+                    // empty — so a revoked toolkit really disappears
+                    // from the spawn pre-flight; only fall back to the
+                    // parent's frozen list when the backend explicitly
+                    // can't answer.
+                    match crate::openhuman::composio::fetch_connected_integrations_status(&config)
+                        .await
+                    {
+                        FetchConnectedIntegrationsStatus::Authoritative(fresh) => {
+                            tracing::debug!(
+                                count = fresh.len(),
+                                parent_count = parent.connected_integrations.len(),
+                                "[subagent_runner] refreshed connected_integrations at spawn time"
+                            );
+                            fresh
+                        }
+                        FetchConnectedIntegrationsStatus::Unavailable => {
+                            tracing::debug!(
+                                "[subagent_runner] integrations backend unavailable; falling back to parent's frozen list"
+                            );
+                            parent.connected_integrations.clone()
+                        }
+                    }
                 }
                 Err(e) => {
                     // Real failure — config couldn't be read, so the

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -178,23 +178,30 @@ async fn run_typed_mode(
         } else {
             match crate::openhuman::config::Config::load_or_init().await {
                 Ok(config) => {
+                    // `fetch_connected_integrations` is best-effort and
+                    // returns `Vec` rather than `Result`. An empty Vec
+                    // here is authoritative — it means "the user has no
+                    // ACTIVE composio connections right now" — so we
+                    // adopt it as truth, including the case where the
+                    // user just disconnected their last integration
+                    // mid-thread. Falling back to the frozen parent
+                    // list here would silently re-introduce a toolkit
+                    // the user has revoked.
                     let fresh =
                         crate::openhuman::composio::fetch_connected_integrations(&config).await;
-                    if fresh.is_empty() {
-                        tracing::debug!(
-                            "[subagent_runner] live integrations fetch returned empty — using parent's frozen list"
-                        );
-                        parent.connected_integrations.clone()
-                    } else {
-                        tracing::debug!(
-                            count = fresh.len(),
-                            parent_count = parent.connected_integrations.len(),
-                            "[subagent_runner] refreshed connected_integrations at spawn time"
-                        );
-                        fresh
-                    }
+                    tracing::debug!(
+                        count = fresh.len(),
+                        parent_count = parent.connected_integrations.len(),
+                        "[subagent_runner] refreshed connected_integrations at spawn time"
+                    );
+                    fresh
                 }
                 Err(e) => {
+                    // Real failure — config couldn't be read, so the
+                    // backend client can't be built either. Use the
+                    // parent's frozen list as a best-effort fallback so
+                    // the spawn can still proceed for sessions that
+                    // were established when config was healthy.
                     tracing::debug!(
                         error = %e,
                         "[subagent_runner] config load failed; falling back to parent's frozen integrations list"

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -154,6 +154,57 @@ async fn run_typed_mode(
     // `load_prompt_source(...)` call lives just above
     // `render_subagent_system_prompt` below.
 
+    // ── Refresh connected-integrations at spawn time ───────────────────
+    //
+    // The parent session's `connected_integrations` Vec is frozen at
+    // session-start (see `session/turn.rs::fetch_connected_integrations`,
+    // which only runs while `history.is_empty()` to preserve the
+    // KV-cache prefix). That means a toolkit the user authorised mid-
+    // thread — e.g. Calendly — is missing from `parent.connected_integrations`,
+    // and the spawn-time toolkit lookup further down rejects it as
+    // "not allowlisted / not connected" until the user starts a new
+    // thread or restarts the app.
+    //
+    // Re-fetch from the global integrations cache here. The cache is
+    // invalidated by `ComposioConnectionCreatedSubscriber` once the
+    // OAuth handshake reaches ACTIVE/CONNECTED, so this call returns
+    // the fresh list almost for free on the warm path. Fall back to
+    // the parent's frozen list when the live fetch returns empty (no
+    // signed-in user, backend unreachable, …) so offline / not-signed-
+    // in behaviour is unchanged.
+    let live_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration> = {
+        if parent.composio_client.is_none() {
+            parent.connected_integrations.clone()
+        } else {
+            match crate::openhuman::config::Config::load_or_init().await {
+                Ok(config) => {
+                    let fresh =
+                        crate::openhuman::composio::fetch_connected_integrations(&config).await;
+                    if fresh.is_empty() {
+                        tracing::debug!(
+                            "[subagent_runner] live integrations fetch returned empty — using parent's frozen list"
+                        );
+                        parent.connected_integrations.clone()
+                    } else {
+                        tracing::debug!(
+                            count = fresh.len(),
+                            parent_count = parent.connected_integrations.len(),
+                            "[subagent_runner] refreshed connected_integrations at spawn time"
+                        );
+                        fresh
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        "[subagent_runner] config load failed; falling back to parent's frozen integrations list"
+                    );
+                    parent.connected_integrations.clone()
+                }
+            }
+        }
+    };
+
     // ── Filter tools per definition + per-spawn override ───────────────
     let toolkit_filter = options.toolkit_override.as_deref();
     let mut allowed_indices = filter_tool_indices(
@@ -268,9 +319,12 @@ async fn run_typed_mode(
             // The spawn_subagent pre-flight already verified the
             // toolkit is in the allowlist AND has an active
             // connection, so the matching entry must be present and
-            // marked connected. Defensive lookup anyway.
-            if let Some(cached_integration) = parent
-                .connected_integrations
+            // marked connected. Defensive lookup anyway. Reads from
+            // `live_integrations` (refreshed above) rather than the
+            // session-frozen `parent.connected_integrations` so a
+            // mid-thread `composio_authorize` is visible without a
+            // new thread / restart.
+            if let Some(cached_integration) = live_integrations
                 .iter()
                 .find(|ci| ci.connected && ci.toolkit.eq_ignore_ascii_case(tk))
             {
@@ -504,14 +558,12 @@ async fn run_typed_mode(
     // a sub-agent that's actually executing work.
     let narrowed_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration> =
         match toolkit_filter {
-            Some(tk) => parent
-                .connected_integrations
+            Some(tk) => live_integrations
                 .iter()
                 .filter(|ci| ci.connected && ci.toolkit.eq_ignore_ascii_case(tk))
                 .cloned()
                 .collect(),
-            None => parent
-                .connected_integrations
+            None => live_integrations
                 .iter()
                 .filter(|ci| ci.connected)
                 .cloned()

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -50,7 +50,8 @@ pub use action_tool::ComposioActionTool;
 pub use bus::{register_composio_trigger_subscriber, ComposioTriggerSubscriber};
 pub use client::{build_composio_client, ComposioClient};
 pub use ops::{
-    fetch_connected_integrations, fetch_toolkit_actions, invalidate_connected_integrations_cache,
+    fetch_connected_integrations, fetch_connected_integrations_status, fetch_toolkit_actions,
+    invalidate_connected_integrations_cache, FetchConnectedIntegrationsStatus,
 };
 pub use periodic::{record_sync_success, start_periodic_sync};
 pub use providers::{

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -680,6 +680,43 @@ fn sync_cache_with_connections(connections: &[super::types::ComposioConnection])
 /// Best-effort: returns an empty vec when the user isn't signed in,
 /// the backend is unreachable, or any step fails.
 pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedIntegration> {
+    match fetch_connected_integrations_status(config).await {
+        FetchConnectedIntegrationsStatus::Authoritative(v) => v,
+        FetchConnectedIntegrationsStatus::Unavailable => Vec::new(),
+    }
+}
+
+/// Discriminated outcome from [`fetch_connected_integrations_status`].
+///
+/// Lets callers distinguish "the backend confirmed the user has zero
+/// active connections right now" from "we couldn't talk to the backend
+/// (no client, transient failure, …) and have no truth to report".
+///
+/// The legacy [`fetch_connected_integrations`] collapses both into an
+/// empty `Vec`, which is fine for prompt-building (they look the same)
+/// but dangerous for spawn-time allowlist gates — using empty as truth
+/// in the unavailable case would silently wipe the user's allowlist
+/// during a transient 5xx.
+#[derive(Debug, Clone)]
+pub enum FetchConnectedIntegrationsStatus {
+    /// Backend was reachable. Vec may legitimately be empty (no
+    /// allowlisted toolkits, or no active connections).
+    Authoritative(Vec<ConnectedIntegration>),
+    /// Backend wasn't reachable (no auth client, transient error). The
+    /// caller should fall back to its prior snapshot rather than treat
+    /// "no connections" as truth.
+    Unavailable,
+}
+
+/// Status-returning variant of [`fetch_connected_integrations`].
+///
+/// Same caching, same cache-invalidation semantics — only the return
+/// shape differs. Cache hits are by definition `Authoritative` because
+/// we only cache the `Some(...)` arm of `_uncached` (i.e. results the
+/// backend confirmed).
+pub async fn fetch_connected_integrations_status(
+    config: &Config,
+) -> FetchConnectedIntegrationsStatus {
     let key = cache_key(config);
 
     // Fast path: return cached result if fresh. Stale entries fall
@@ -695,7 +732,7 @@ pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedInteg
                     key = %key,
                     "[composio][integrations] returning cached result"
                 );
-                return cached.entries.clone();
+                return FetchConnectedIntegrationsStatus::Authoritative(cached.entries.clone());
             }
             tracing::info!(
                 count = cached.entries.len(),
@@ -719,12 +756,12 @@ pub async fn fetch_connected_integrations(config: &Config) -> Vec<ConnectedInteg
                     },
                 );
             }
-            result
+            FetchConnectedIntegrationsStatus::Authoritative(result)
         }
         None => {
             // No auth / client unavailable — do NOT cache so a
             // subsequent call with a different config can retry.
-            Vec::new()
+            FetchConnectedIntegrationsStatus::Unavailable
         }
     }
 }

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -26,7 +26,9 @@ use serde_json::{json, Value};
 
 use crate::openhuman::agent::harness::current_sandbox_mode;
 use crate::openhuman::agent::harness::definition::SandboxMode;
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCategory, ToolResult};
+use crate::openhuman::tools::traits::{
+    PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
+};
 
 use super::client::ComposioClient;
 use super::providers::{
@@ -106,6 +108,23 @@ async fn evaluate_tool_visibility(slug: &str) -> ToolDecision {
     }
 }
 
+/// Drop tools whose toolkit is not in `connected` (case-insensitive).
+/// Returns the number of dropped tools so callers can log it.
+/// `toolkit_from_slug` already lowercases its result, so the comparison
+/// is direct against entries the caller has already lowercased.
+fn retain_connected_tools(
+    resp: &mut super::types::ComposioToolsResponse,
+    connected: &std::collections::HashSet<String>,
+) -> usize {
+    let before = resp.tools.len();
+    resp.tools.retain(|t| {
+        toolkit_from_slug(&t.function.name)
+            .map(|tk| connected.contains(&tk))
+            .unwrap_or(false)
+    });
+    before - resp.tools.len()
+}
+
 /// Filter a freshly-fetched [`super::types::ComposioToolsResponse`] in
 /// place: drop tools that aren't curated for their toolkit and tools
 /// whose scope is disabled in the user's pref.
@@ -138,6 +157,99 @@ async fn filter_list_tools_response(resp: &mut super::types::ComposioToolsRespon
             "[composio][scopes] composio_list_tools filtered"
         );
     }
+}
+
+/// One-line description: collapse whitespace + truncate.
+fn one_line(desc: &str, max_chars: usize) -> String {
+    let collapsed: String = desc.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= max_chars {
+        collapsed
+    } else {
+        let snippet: String = collapsed.chars().take(max_chars).collect();
+        format!("{snippet}…")
+    }
+}
+
+/// Pull required + optional top-level argument names from a JSON Schema
+/// `parameters` object. Returns `(required, optional)` — both empty when
+/// the schema is missing or doesn't follow the expected shape.
+fn split_arg_names(parameters: Option<&Value>) -> (Vec<String>, Vec<String>) {
+    let Some(params) = parameters.and_then(Value::as_object) else {
+        return (Vec::new(), Vec::new());
+    };
+    let required: Vec<String> = params
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut optional: Vec<String> = params
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|props| props.keys().cloned().collect())
+        .unwrap_or_default();
+    optional.retain(|k| !required.contains(k));
+    (required, optional)
+}
+
+/// Compact markdown rendering of `composio_list_tools` output.
+///
+/// Drops the full JSON parameter schemas (the main token cost) and keeps
+/// only what the agent needs to pick a slug and call `composio_execute`:
+/// the slug, a one-line description, and the names of required +
+/// optional top-level arguments. Tools are grouped by toolkit prefix.
+fn render_tools_markdown(resp: &super::types::ComposioToolsResponse) -> String {
+    use std::collections::BTreeMap;
+    use std::fmt::Write as _;
+
+    if resp.tools.is_empty() {
+        return "_No composio tools available._".to_string();
+    }
+
+    // Group by toolkit slug (lowercase prefix). Use BTreeMap for stable
+    // ordering so the agent sees the same shape across calls.
+    let mut by_toolkit: BTreeMap<String, Vec<&super::types::ComposioToolSchema>> = BTreeMap::new();
+    for t in &resp.tools {
+        let toolkit = toolkit_from_slug(&t.function.name).unwrap_or_else(|| "other".to_string());
+        by_toolkit.entry(toolkit).or_default().push(t);
+    }
+
+    let mut out = format!(
+        "# Composio tools ({} actions across {} toolkit{})\n\n\
+         Call `composio_execute` with `tool=<SLUG>` and an `arguments` object \
+         matching the listed parameters.\n",
+        resp.tools.len(),
+        by_toolkit.len(),
+        if by_toolkit.len() == 1 { "" } else { "s" },
+    );
+
+    for (toolkit, tools) in &by_toolkit {
+        let _ = writeln!(out, "\n## {toolkit}");
+        for t in tools {
+            let desc = t
+                .function
+                .description
+                .as_deref()
+                .map(|d| one_line(d, 160))
+                .unwrap_or_default();
+            let (required, optional) = split_arg_names(t.function.parameters.as_ref());
+            let _ = write!(out, "- `{}`", t.function.name);
+            if !desc.is_empty() {
+                let _ = write!(out, " — {desc}");
+            }
+            if !required.is_empty() {
+                let _ = write!(out, " **req:** {}", required.join(", "));
+            }
+            if !optional.is_empty() {
+                let _ = write!(out, " **opt:** {}", optional.join(", "));
+            }
+            out.push('\n');
+        }
+    }
+    out
 }
 
 /// Format a user-facing error message for a scope-blocked execution.
@@ -351,10 +463,13 @@ impl Tool for ComposioListToolsTool {
         "composio_list_tools"
     }
     fn description(&self) -> &str {
-        "List Composio action tools available through the backend. Pass an optional \
-         `toolkits` array to filter (e.g. [\"gmail\"]). The result is a JSON array of \
-         OpenAI function-calling tool schemas; use the slug from `function.name` as the \
-         `tool` argument when calling `composio_execute`."
+        "List Composio action tools available through the backend. By default only \
+         actions for toolkits the user has actively connected are returned — pass \
+         `include_unconnected=true` to see every allowlisted toolkit's actions \
+         (useful when planning whether to call `composio_authorize` for a new toolkit). \
+         Pass an optional `toolkits` array to further filter (e.g. [\"gmail\"]). The \
+         result is a JSON array of OpenAI function-calling tool schemas; use the slug \
+         from `function.name` as the `tool` argument when calling `composio_execute`."
     }
     fn parameters_schema(&self) -> Value {
         json!({
@@ -364,6 +479,12 @@ impl Tool for ComposioListToolsTool {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Optional list of toolkit slugs to filter by."
+                },
+                "include_unconnected": {
+                    "type": "boolean",
+                    "description": "When true, include actions from toolkits the user \
+                                    has not connected yet. Defaults to false (only \
+                                    connected toolkits)."
                 }
             },
             "additionalProperties": false
@@ -376,23 +497,89 @@ impl Tool for ComposioListToolsTool {
         ToolCategory::Skill
     }
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
+            .await
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
         let toolkits = args.get("toolkits").and_then(|v| v.as_array()).map(|arr| {
             arr.iter()
                 .filter_map(|v| v.as_str().map(str::to_string))
                 .collect::<Vec<_>>()
         });
-        tracing::debug!(?toolkits, "[composio] tool list_tools.execute");
+        let include_unconnected = args
+            .get("include_unconnected")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        tracing::debug!(
+            ?toolkits,
+            include_unconnected,
+            prefer_markdown = options.prefer_markdown,
+            "[composio] tool list_tools.execute"
+        );
         match self.client.list_tools(toolkits.as_deref()).await {
             Ok(mut resp) => {
                 filter_list_tools_response(&mut resp).await;
-                Ok(ToolResult::success(
+
+                if !include_unconnected {
+                    // Restrict to toolkits with an ACTIVE / CONNECTED
+                    // account. Mirrors the same status allowlist used by
+                    // composio_list_connections so this view and the
+                    // prompt's Delegation Guide stay in sync.
+                    match self.client.list_connections().await {
+                        Ok(conns) => {
+                            let connected: std::collections::HashSet<String> = conns
+                                .connections
+                                .iter()
+                                .filter(|c| {
+                                    let s = c.status.trim();
+                                    s.eq_ignore_ascii_case("ACTIVE")
+                                        || s.eq_ignore_ascii_case("CONNECTED")
+                                })
+                                .map(|c| c.toolkit.trim().to_ascii_lowercase())
+                                .filter(|t| !t.is_empty())
+                                .collect();
+                            let dropped = retain_connected_tools(&mut resp, &connected);
+                            tracing::debug!(
+                                connected_toolkits = connected.len(),
+                                dropped,
+                                kept = resp.tools.len(),
+                                "[composio] list_tools restricted to connected toolkits"
+                            );
+                        }
+                        Err(e) => {
+                            // Soft-fail: surface the issue to the agent
+                            // so it can retry with include_unconnected
+                            // rather than silently returning [].
+                            return Ok(ToolResult::error(format!(
+                                "composio_list_tools failed to fetch connections \
+                                 (needed to filter to connected toolkits — pass \
+                                 include_unconnected=true to skip this check): {e}"
+                            )));
+                        }
+                    }
+                }
+
+                let mut result = ToolResult::success(
                     serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
-                ))
+                );
+                if options.prefer_markdown {
+                    result.markdown_formatted = Some(render_tools_markdown(&resp));
+                }
+                Ok(result)
             }
             Err(e) => Ok(ToolResult::error(format!(
                 "composio_list_tools failed: {e}"
             ))),
         }
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
     }
 }
 

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -468,8 +468,9 @@ impl Tool for ComposioListToolsTool {
          `include_unconnected=true` to see every allowlisted toolkit's actions \
          (useful when planning whether to call `composio_authorize` for a new toolkit). \
          Pass an optional `toolkits` array to further filter (e.g. [\"gmail\"]). The \
-         result is a JSON array of OpenAI function-calling tool schemas; use the slug \
-         from `function.name` as the `tool` argument when calling `composio_execute`."
+         result is a JSON object with a `tools` array of OpenAI function-calling \
+         tool schemas; use the slug from each entry's `function.name` as the `tool` \
+         argument when calling `composio_execute`."
     }
     fn parameters_schema(&self) -> Value {
         json!({

--- a/src/openhuman/composio/tools_tests.rs
+++ b/src/openhuman/composio/tools_tests.rs
@@ -301,3 +301,136 @@ async fn sandbox_sandboxed_mode_does_not_trigger_readonly_gate() {
         "Sandboxed mode must not trigger the read-only gate, got: {msg}"
     );
 }
+
+// ── render_tools_markdown ───────────────────────────────────────────
+
+#[test]
+fn render_tools_markdown_groups_by_toolkit_and_drops_schemas() {
+    use crate::openhuman::composio::types::{
+        ComposioToolFunction, ComposioToolSchema, ComposioToolsResponse,
+    };
+
+    let resp = ComposioToolsResponse {
+        tools: vec![
+            ComposioToolSchema {
+                kind: "function".into(),
+                function: ComposioToolFunction {
+                    name: "GMAIL_SEND_EMAIL".into(),
+                    description: Some("Send an email\n  via\n Gmail.".into()),
+                    parameters: Some(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "to": { "type": "string" },
+                            "subject": { "type": "string" },
+                            "body": { "type": "string" },
+                            "cc": { "type": "array" },
+                        },
+                        "required": ["to", "subject", "body"],
+                    })),
+                },
+            },
+            ComposioToolSchema {
+                kind: "function".into(),
+                function: ComposioToolFunction {
+                    name: "NOTION_CREATE_PAGE".into(),
+                    description: Some("Create a Notion page.".into()),
+                    parameters: Some(serde_json::json!({
+                        "type": "object",
+                        "properties": { "title": {} },
+                        "required": ["title"],
+                    })),
+                },
+            },
+        ],
+    };
+
+    let md = render_tools_markdown(&resp);
+
+    // Toolkit grouping (BTreeMap → alphabetical).
+    let gmail_pos = md.find("## gmail").expect("gmail header missing");
+    let notion_pos = md.find("## notion").expect("notion header missing");
+    assert!(gmail_pos < notion_pos);
+
+    // Each tool listed with slug + collapsed one-line description + req args.
+    assert!(md.contains("`GMAIL_SEND_EMAIL`"));
+    assert!(md.contains("Send an email via Gmail."));
+    assert!(md.contains("**req:** to, subject, body"));
+    assert!(md.contains("**opt:** cc"));
+    assert!(md.contains("`NOTION_CREATE_PAGE`"));
+
+    // No JSON Schema keywords leak through — that's the whole point.
+    assert!(
+        !md.contains("\"type\""),
+        "raw schema should not appear in markdown:\n{md}"
+    );
+    assert!(
+        !md.contains("properties"),
+        "raw schema should not appear in markdown:\n{md}"
+    );
+
+    // Markdown should be materially smaller than the JSON serialization.
+    let json_len = serde_json::to_string(&resp).unwrap().len();
+    assert!(
+        md.len() < json_len,
+        "markdown ({} bytes) should be shorter than JSON ({} bytes)",
+        md.len(),
+        json_len
+    );
+}
+
+#[test]
+fn retain_connected_tools_drops_unconnected_toolkits_case_insensitively() {
+    use crate::openhuman::composio::types::{
+        ComposioToolFunction, ComposioToolSchema, ComposioToolsResponse,
+    };
+    use std::collections::HashSet;
+
+    let mut resp = ComposioToolsResponse {
+        tools: vec![
+            ComposioToolSchema {
+                kind: "function".into(),
+                function: ComposioToolFunction {
+                    name: "GMAIL_SEND_EMAIL".into(),
+                    description: None,
+                    parameters: None,
+                },
+            },
+            ComposioToolSchema {
+                kind: "function".into(),
+                function: ComposioToolFunction {
+                    name: "NOTION_CREATE_PAGE".into(),
+                    description: None,
+                    parameters: None,
+                },
+            },
+            ComposioToolSchema {
+                kind: "function".into(),
+                function: ComposioToolFunction {
+                    name: "GMAIL_LIST_THREADS".into(),
+                    description: None,
+                    parameters: None,
+                },
+            },
+        ],
+    };
+
+    // Caller pre-lowercases connected toolkit slugs (matches what the
+    // tool's `execute_with_options` does).
+    let connected: HashSet<String> = ["gmail".to_string()].into_iter().collect();
+    let dropped = retain_connected_tools(&mut resp, &connected);
+
+    assert_eq!(dropped, 1, "should drop the notion tool");
+    let names: Vec<&str> = resp.tools.iter().map(|t| t.function.name.as_str()).collect();
+    assert!(names.contains(&"GMAIL_SEND_EMAIL"));
+    assert!(names.contains(&"GMAIL_LIST_THREADS"));
+    assert!(!names.contains(&"NOTION_CREATE_PAGE"));
+}
+
+#[test]
+fn render_tools_markdown_handles_empty_response() {
+    use crate::openhuman::composio::types::ComposioToolsResponse;
+
+    let resp = ComposioToolsResponse { tools: vec![] };
+    let md = render_tools_markdown(&resp);
+    assert!(md.contains("No composio tools available"));
+}

--- a/src/openhuman/composio/tools_tests.rs
+++ b/src/openhuman/composio/tools_tests.rs
@@ -420,7 +420,11 @@ fn retain_connected_tools_drops_unconnected_toolkits_case_insensitively() {
     let dropped = retain_connected_tools(&mut resp, &connected);
 
     assert_eq!(dropped, 1, "should drop the notion tool");
-    let names: Vec<&str> = resp.tools.iter().map(|t| t.function.name.as_str()).collect();
+    let names: Vec<&str> = resp
+        .tools
+        .iter()
+        .map(|t| t.function.name.as_str())
+        .collect();
     assert!(names.contains(&"GMAIL_SEND_EMAIL"));
     assert!(names.contains(&"GMAIL_LIST_THREADS"));
     assert!(!names.contains(&"NOTION_CREATE_PAGE"));

--- a/src/openhuman/service/bus.rs
+++ b/src/openhuman/service/bus.rs
@@ -50,9 +50,7 @@ pub fn register_shutdown_subscriber() {
             let _ = SHUTDOWN_HANDLE.set(handle);
         }
         None => {
-            log::warn!(
-                "[event_bus] failed to register shutdown subscriber — bus not initialized"
-            );
+            log::warn!("[event_bus] failed to register shutdown subscriber — bus not initialized");
         }
     }
 }

--- a/src/openhuman/service/bus.rs
+++ b/src/openhuman/service/bus.rs
@@ -11,6 +11,9 @@ use crate::core::event_bus::{DomainEvent, EventHandler, SubscriptionHandle};
 /// double-registered and never dropped (which would abort the task).
 static RESTART_HANDLE: OnceLock<SubscriptionHandle> = OnceLock::new();
 
+/// Same idea as [`RESTART_HANDLE`] but for the shutdown subscriber.
+static SHUTDOWN_HANDLE: OnceLock<SubscriptionHandle> = OnceLock::new();
+
 /// Register the [`RestartSubscriber`] on the global event bus.
 ///
 /// Idempotent: subsequent calls return immediately if the subscriber is already
@@ -33,9 +36,34 @@ pub fn register_restart_subscriber() {
     }
 }
 
+/// Register the [`ShutdownSubscriber`] on the global event bus.
+///
+/// Mirrors [`register_restart_subscriber`] — idempotent, owned by the service
+/// domain, called from the shared subscriber bootstrap in `jsonrpc.rs`.
+pub fn register_shutdown_subscriber() {
+    if SHUTDOWN_HANDLE.get().is_some() {
+        return;
+    }
+
+    match crate::core::event_bus::subscribe_global(Arc::new(ShutdownSubscriber)) {
+        Some(handle) => {
+            let _ = SHUTDOWN_HANDLE.set(handle);
+        }
+        None => {
+            log::warn!(
+                "[event_bus] failed to register shutdown subscriber — bus not initialized"
+            );
+        }
+    }
+}
+
 /// One-shot gate so only the first restart event actually spawns a replacement
 /// process. Subsequent events are ignored (the process is about to exit).
 static RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Same one-shot gate but for shutdown — only the first request actually
+/// schedules `process::exit`.
+static SHUTDOWN_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// Long-lived event-bus subscriber that turns restart requests into a real
 /// process respawn.
@@ -101,6 +129,57 @@ impl EventHandler for RestartSubscriber {
     }
 }
 
+/// Long-lived event-bus subscriber that turns shutdown requests into a
+/// graceful `process::exit(0)` after a short flush window.
+///
+/// Distinct from [`RestartSubscriber`]: no replacement process is spawned —
+/// we just exit. Frontends that want the process back up are expected to
+/// invoke `service.start` (or rely on a supervisor) after calling
+/// `service.shutdown`.
+pub struct ShutdownSubscriber;
+
+#[async_trait]
+impl EventHandler for ShutdownSubscriber {
+    fn name(&self) -> &str {
+        "service::shutdown"
+    }
+
+    fn domains(&self) -> Option<&[&str]> {
+        Some(&["system"])
+    }
+
+    async fn handle(&self, event: &DomainEvent) {
+        let DomainEvent::SystemShutdownRequested { source, reason } = event else {
+            return;
+        };
+
+        if SHUTDOWN_IN_PROGRESS
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            log::debug!(
+                "[service:shutdown] ignoring duplicate shutdown request source={} (already in progress)",
+                source,
+            );
+            return;
+        }
+
+        log::warn!(
+            "[service:shutdown] executing shutdown source={} reason={}",
+            source,
+            reason
+        );
+
+        // Brief 150ms grace period before exit, mirroring the restart path,
+        // so in-flight RPC responses and log writes can flush before the
+        // tokio runtime is torn down.
+        tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            std::process::exit(0);
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,5 +240,48 @@ mod tests {
         // than registering duplicates.
         register_restart_subscriber();
         register_restart_subscriber();
+    }
+
+    // Shutdown subscriber: same shape of metadata + early-return tests as the
+    // restart subscriber. The success path (`handle()` → `process::exit`) is
+    // intentionally untested for the same reason — it would terminate the
+    // test runner.
+
+    #[test]
+    fn shutdown_subscriber_name_is_namespaced() {
+        assert_eq!(ShutdownSubscriber.name(), "service::shutdown");
+    }
+
+    #[test]
+    fn shutdown_subscriber_domain_filter_is_system() {
+        assert_eq!(ShutdownSubscriber.domains(), Some(&["system"][..]));
+    }
+
+    #[tokio::test]
+    async fn shutdown_handle_returns_early_on_non_shutdown_event() {
+        ShutdownSubscriber
+            .handle(&DomainEvent::AgentTurnStarted {
+                session_id: "s".into(),
+                channel: "web".into(),
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_handle_ignores_duplicate_when_gate_is_set() {
+        let previous = SHUTDOWN_IN_PROGRESS.swap(true, Ordering::SeqCst);
+        ShutdownSubscriber
+            .handle(&DomainEvent::SystemShutdownRequested {
+                source: "test".into(),
+                reason: "duplicate-suppression".into(),
+            })
+            .await;
+        SHUTDOWN_IN_PROGRESS.store(previous, Ordering::SeqCst);
+    }
+
+    #[tokio::test]
+    async fn register_shutdown_subscriber_is_idempotent_and_safe_without_bus() {
+        register_shutdown_subscriber();
+        register_shutdown_subscriber();
     }
 }

--- a/src/openhuman/service/mod.rs
+++ b/src/openhuman/service/mod.rs
@@ -7,6 +7,7 @@ pub mod daemon_host;
 pub mod ops;
 mod restart;
 mod schemas;
+mod shutdown;
 
 mod common;
 #[cfg(target_os = "linux")]
@@ -22,6 +23,7 @@ pub use ops as rpc;
 pub use ops::*;
 pub use restart::apply_startup_restart_delay_from_env;
 pub use restart::RestartStatus;
+pub use shutdown::ShutdownStatus;
 pub use schemas::{
     all_controller_schemas as all_service_controller_schemas,
     all_registered_controllers as all_service_registered_controllers,

--- a/src/openhuman/service/mod.rs
+++ b/src/openhuman/service/mod.rs
@@ -23,8 +23,8 @@ pub use ops as rpc;
 pub use ops::*;
 pub use restart::apply_startup_restart_delay_from_env;
 pub use restart::RestartStatus;
-pub use shutdown::ShutdownStatus;
 pub use schemas::{
     all_controller_schemas as all_service_controller_schemas,
     all_registered_controllers as all_service_registered_controllers,
 };
+pub use shutdown::ShutdownStatus;

--- a/src/openhuman/service/ops.rs
+++ b/src/openhuman/service/ops.rs
@@ -37,6 +37,14 @@ pub async fn service_restart(
     service::restart::service_restart(source, reason).await
 }
 
+/// Requests an asynchronous graceful shutdown of the core process.
+pub async fn service_shutdown(
+    source: Option<String>,
+    reason: Option<String>,
+) -> Result<RpcOutcome<service::ShutdownStatus>, String> {
+    service::shutdown::service_shutdown(source, reason).await
+}
+
 /// Uninstalls the OpenHuman daemon system service.
 pub async fn service_uninstall(config: &Config) -> Result<RpcOutcome<ServiceStatus>, String> {
     let status = service::uninstall(config).map_err(|e| e.to_string())?;

--- a/src/openhuman/service/schemas.rs
+++ b/src/openhuman/service/schemas.rs
@@ -20,6 +20,7 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
     vec![
         schemas("install"),
         schemas("restart"),
+        schemas("shutdown"),
         schemas("start"),
         schemas("stop"),
         schemas("status"),
@@ -42,6 +43,10 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("restart"),
             handler: handle_restart,
+        },
+        RegisteredController {
+            schema: schemas("shutdown"),
+            handler: handle_shutdown,
         },
         RegisteredController {
             schema: schemas("start"),
@@ -77,50 +82,54 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
 /// * `function` - The name of the service function (e.g., "install", "restart").
 pub fn schemas(function: &str) -> ControllerSchema {
     match function {
-        "install" | "restart" | "start" | "stop" | "status" | "uninstall" => ControllerSchema {
-            namespace: "service",
-            function: match function {
-                "install" => "install",
-                "restart" => "restart",
-                "start" => "start",
-                "stop" => "stop",
-                "status" => "status",
-                _ => "uninstall",
-            },
-            description: "Manage desktop service lifecycle.",
-            inputs: if function == "restart" {
-                vec![
-                    FieldSchema {
-                        name: "source",
-                        ty: TypeSchema::String,
-                        comment: "Optional caller label for restart diagnostics.",
-                        required: false,
-                    },
-                    FieldSchema {
-                        name: "reason",
-                        ty: TypeSchema::String,
-                        comment: "Optional free-form reason for the restart request.",
-                        required: false,
-                    },
-                ]
-            } else {
-                vec![]
-            },
-            outputs: vec![FieldSchema {
-                name: "status",
-                ty: if function == "restart" {
-                    TypeSchema::Json
-                } else {
-                    TypeSchema::Ref("ServiceStatus")
+        "install" | "restart" | "shutdown" | "start" | "stop" | "status" | "uninstall" => {
+            let lifecycle_self_signal = function == "restart" || function == "shutdown";
+            ControllerSchema {
+                namespace: "service",
+                function: match function {
+                    "install" => "install",
+                    "restart" => "restart",
+                    "shutdown" => "shutdown",
+                    "start" => "start",
+                    "stop" => "stop",
+                    "status" => "status",
+                    _ => "uninstall",
                 },
-                comment: if function == "restart" {
-                    "Restart request acknowledgement payload."
+                description: "Manage desktop service lifecycle.",
+                inputs: if lifecycle_self_signal {
+                    vec![
+                        FieldSchema {
+                            name: "source",
+                            ty: TypeSchema::String,
+                            comment: "Optional caller label for diagnostics.",
+                            required: false,
+                        },
+                        FieldSchema {
+                            name: "reason",
+                            ty: TypeSchema::String,
+                            comment: "Optional free-form reason for the request.",
+                            required: false,
+                        },
+                    ]
                 } else {
-                    "Service status payload."
+                    vec![]
                 },
-                required: true,
-            }],
-        },
+                outputs: vec![FieldSchema {
+                    name: "status",
+                    ty: if lifecycle_self_signal {
+                        TypeSchema::Json
+                    } else {
+                        TypeSchema::Ref("ServiceStatus")
+                    },
+                    comment: match function {
+                        "restart" => "Restart request acknowledgement payload.",
+                        "shutdown" => "Shutdown request acknowledgement payload.",
+                        _ => "Service status payload.",
+                    },
+                    required: true,
+                }],
+            }
+        }
         "daemon_host_get" => ControllerSchema {
             namespace: "service",
             function: "daemon_host_get",
@@ -203,6 +212,20 @@ fn handle_restart(params: Map<String, Value>) -> ControllerFuture {
     })
 }
 
+/// Service controller for `service.shutdown`.
+///
+/// Uses the same `{source, reason}` shape as `service.restart`.
+fn handle_shutdown(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let payload: ServiceRestartParams =
+            serde_json::from_value(Value::Object(params)).map_err(|e| e.to_string())?;
+        to_json(
+            crate::openhuman::service::rpc::service_shutdown(payload.source, payload.reason)
+                .await?,
+        )
+    })
+}
+
 /// Service controller for `service.stop`.
 fn handle_stop(_params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
@@ -260,13 +283,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn all_schemas_returns_eight() {
-        assert_eq!(all_controller_schemas().len(), 8);
+    fn all_schemas_returns_nine() {
+        assert_eq!(all_controller_schemas().len(), 9);
     }
 
     #[test]
-    fn all_controllers_returns_eight() {
-        assert_eq!(all_registered_controllers().len(), 8);
+    fn all_controllers_returns_nine() {
+        assert_eq!(all_registered_controllers().len(), 9);
     }
 
     #[test]
@@ -278,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_schemas_have_no_inputs_except_restart() {
+    fn lifecycle_schemas_have_no_inputs_except_self_signals() {
         for fn_name in ["install", "start", "stop", "status", "uninstall"] {
             let s = schemas(fn_name);
             assert!(
@@ -290,16 +313,18 @@ mod tests {
     }
 
     #[test]
-    fn restart_schema_has_optional_source_and_reason() {
-        let s = schemas("restart");
-        assert_eq!(s.function, "restart");
-        assert_eq!(s.inputs.len(), 2);
-        for input in &s.inputs {
-            assert!(
-                !input.required,
-                "restart input '{}' should be optional",
-                input.name
-            );
+    fn restart_and_shutdown_schemas_have_optional_source_and_reason() {
+        for fn_name in ["restart", "shutdown"] {
+            let s = schemas(fn_name);
+            assert_eq!(s.function, fn_name);
+            assert_eq!(s.inputs.len(), 2, "{fn_name} should have 2 inputs");
+            for input in &s.inputs {
+                assert!(
+                    !input.required,
+                    "{fn_name} input '{}' should be optional",
+                    input.name
+                );
+            }
         }
     }
 
@@ -339,6 +364,7 @@ mod tests {
         for fn_name in [
             "install",
             "restart",
+            "shutdown",
             "start",
             "stop",
             "status",

--- a/src/openhuman/service/shutdown.rs
+++ b/src/openhuman/service/shutdown.rs
@@ -1,0 +1,132 @@
+//! Core graceful-shutdown orchestration for the service domain.
+//!
+//! Mirrors [`super::restart`] but exits the running core process instead of
+//! respawning it. RPC/CLI callers acknowledge the request and publish an
+//! event; a long-lived subscriber performs the actual `process::exit`. The
+//! split keeps the in-process trigger paths (RPC, CLI, internal) sharing one
+//! shutdown execution path with the same logging.
+
+use serde::Serialize;
+
+use crate::core::event_bus::{self, DomainEvent};
+use crate::rpc::RpcOutcome;
+
+/// JSON-serializable acknowledgement returned to CLI / JSON-RPC callers
+/// before the current process exits.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShutdownStatus {
+    pub accepted: bool,
+    pub source: String,
+    pub reason: String,
+}
+
+/// Accepts a shutdown request and publishes it to the global event bus.
+///
+/// Does not exit directly — the work is performed by
+/// [`super::bus::ShutdownSubscriber`] so every in-process trigger uses the
+/// same execution path.
+pub async fn service_shutdown(
+    source: Option<String>,
+    reason: Option<String>,
+) -> Result<RpcOutcome<ShutdownStatus>, String> {
+    let source = source
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "jsonrpc".to_string());
+    let reason = reason
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "service.shutdown".to_string());
+
+    event_bus::init_global(event_bus::DEFAULT_CAPACITY);
+    log::info!(
+        "[service:shutdown] accepted shutdown request source={} reason={}",
+        source,
+        reason
+    );
+    event_bus::publish_global(DomainEvent::SystemShutdownRequested {
+        source: source.clone(),
+        reason: reason.clone(),
+    });
+
+    Ok(RpcOutcome::single_log(
+        ShutdownStatus {
+            accepted: true,
+            source,
+            reason,
+        },
+        "service shutdown requested",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio::time::{timeout, Duration};
+
+    struct ShutdownProbe {
+        tx: mpsc::UnboundedSender<(String, String)>,
+    }
+
+    #[async_trait]
+    impl crate::core::event_bus::EventHandler for ShutdownProbe {
+        fn name(&self) -> &str {
+            "service::shutdown_probe"
+        }
+
+        fn domains(&self) -> Option<&[&str]> {
+            Some(&["system"])
+        }
+
+        async fn handle(&self, event: &DomainEvent) {
+            if let DomainEvent::SystemShutdownRequested { source, reason } = event {
+                let _ = self.tx.send((source.clone(), reason.clone()));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn service_shutdown_publishes_event() {
+        let bus = event_bus::init_global(event_bus::DEFAULT_CAPACITY);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = bus.subscribe(Arc::new(ShutdownProbe { tx }));
+
+        let outcome = service_shutdown(Some("test".into()), Some("integration".into()))
+            .await
+            .expect("shutdown request should succeed");
+        assert!(outcome.value.accepted);
+
+        let event = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("shutdown event should arrive")
+            .expect("probe channel should stay open");
+        assert_eq!(event.0, "test");
+        assert_eq!(event.1, "integration");
+
+        handle.cancel();
+    }
+
+    #[tokio::test]
+    async fn service_shutdown_defaults_source_and_reason() {
+        event_bus::init_global(event_bus::DEFAULT_CAPACITY);
+        let outcome = service_shutdown(None, None)
+            .await
+            .expect("shutdown should succeed");
+        assert!(outcome.value.accepted);
+        assert_eq!(outcome.value.source, "jsonrpc");
+        assert_eq!(outcome.value.reason, "service.shutdown");
+    }
+
+    #[tokio::test]
+    async fn service_shutdown_trims_whitespace_and_falls_back_for_empty() {
+        event_bus::init_global(event_bus::DEFAULT_CAPACITY);
+        let outcome = service_shutdown(Some("  ui  ".into()), Some("  ".into()))
+            .await
+            .expect("shutdown should succeed");
+        assert_eq!(outcome.value.source, "ui");
+        assert_eq!(outcome.value.reason, "service.shutdown");
+    }
+}

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -297,7 +297,7 @@ impl Tool for SpawnSubagentTool {
                                 "Integration '{tk}' is available but the user has not \
                                  authorized it yet. Do NOT retry this spawn. Tell the user \
                                  the integration is available and ask them to authorize \
-                                 '{tk}' in Settings → Integrations before retrying the \
+                                 '{tk}' in Connections → Integrations before retrying the \
                                  original request."
                             )));
                         }

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -244,23 +244,37 @@ impl Tool for SpawnSubagentTool {
             let live_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration> = {
                 match crate::openhuman::config::Config::load_or_init().await {
                     Ok(config) => {
-                        // `fetch_connected_integrations` is best-effort
-                        // and returns a `Vec` (not `Result`). An empty
-                        // Vec is authoritative ("no ACTIVE composio
-                        // connections") — adopt it as truth so a user
-                        // who just disconnected their last integration
-                        // mid-thread sees the toolkit removed from the
-                        // pre-flight allowlist. Only fall back to the
-                        // parent's frozen list when the config load
-                        // itself fails (Err arm below).
-                        let fresh =
-                            crate::openhuman::composio::fetch_connected_integrations(&config).await;
-                        tracing::debug!(
-                            target: "spawn_subagent",
-                            count = fresh.len(),
-                            "[spawn_subagent] refreshed connected_integrations for pre-flight"
-                        );
-                        fresh
+                        use crate::openhuman::composio::FetchConnectedIntegrationsStatus;
+                        // Use the status-discriminating fetch so we can
+                        // tell "user has zero active integrations" (truth
+                        // — adopt it) apart from "backend unavailable"
+                        // (preserve the parent's frozen snapshot so the
+                        // pre-flight doesn't reject every toolkit during
+                        // a transient 5xx).
+                        match crate::openhuman::composio::fetch_connected_integrations_status(
+                            &config,
+                        )
+                        .await
+                        {
+                            FetchConnectedIntegrationsStatus::Authoritative(fresh) => {
+                                tracing::debug!(
+                                    target: "spawn_subagent",
+                                    count = fresh.len(),
+                                    "[spawn_subagent] refreshed connected_integrations for pre-flight"
+                                );
+                                fresh
+                            }
+                            FetchConnectedIntegrationsStatus::Unavailable => {
+                                tracing::debug!(
+                                    target: "spawn_subagent",
+                                    "[spawn_subagent] integrations backend unavailable; falling back to parent's frozen list"
+                                );
+                                parent_ctx
+                                    .as_ref()
+                                    .map(|p| p.connected_integrations.clone())
+                                    .unwrap_or_default()
+                            }
+                        }
                     }
                     Err(e) => {
                         tracing::debug!(

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -244,21 +244,23 @@ impl Tool for SpawnSubagentTool {
             let live_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration> = {
                 match crate::openhuman::config::Config::load_or_init().await {
                     Ok(config) => {
+                        // `fetch_connected_integrations` is best-effort
+                        // and returns a `Vec` (not `Result`). An empty
+                        // Vec is authoritative ("no ACTIVE composio
+                        // connections") — adopt it as truth so a user
+                        // who just disconnected their last integration
+                        // mid-thread sees the toolkit removed from the
+                        // pre-flight allowlist. Only fall back to the
+                        // parent's frozen list when the config load
+                        // itself fails (Err arm below).
                         let fresh =
                             crate::openhuman::composio::fetch_connected_integrations(&config).await;
-                        if fresh.is_empty() {
-                            parent_ctx
-                                .as_ref()
-                                .map(|p| p.connected_integrations.clone())
-                                .unwrap_or_default()
-                        } else {
-                            tracing::debug!(
-                                target: "spawn_subagent",
-                                count = fresh.len(),
-                                "[spawn_subagent] refreshed connected_integrations for pre-flight"
-                            );
-                            fresh
-                        }
+                        tracing::debug!(
+                            target: "spawn_subagent",
+                            count = fresh.len(),
+                            "[spawn_subagent] refreshed connected_integrations for pre-flight"
+                        );
+                        fresh
                     }
                     Err(e) => {
                         tracing::debug!(

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -231,12 +231,50 @@ impl Tool for SpawnSubagentTool {
         // gets a precise, actionable error on every failure mode —
         // nothing reaches the LLM loop unless the spawn is valid.
         if definition.id == "integrations_agent" {
+            // The parent's `connected_integrations` Vec is frozen at
+            // session-start (see `session/turn.rs::fetch_connected_integrations`),
+            // so a toolkit the user authorised mid-thread isn't visible
+            // here. Refresh from the global integrations cache —
+            // invalidated by `ComposioConnectionCreatedSubscriber` once
+            // OAuth reaches ACTIVE — so the pre-flight sees the latest
+            // truth. Falls back to the parent's frozen list when the
+            // live fetch returns empty (no signed-in user, backend
+            // unreachable, …) so offline behaviour is unchanged.
             let parent_ctx = current_parent();
+            let live_integrations: Vec<crate::openhuman::context::prompt::ConnectedIntegration> = {
+                match crate::openhuman::config::Config::load_or_init().await {
+                    Ok(config) => {
+                        let fresh =
+                            crate::openhuman::composio::fetch_connected_integrations(&config).await;
+                        if fresh.is_empty() {
+                            parent_ctx
+                                .as_ref()
+                                .map(|p| p.connected_integrations.clone())
+                                .unwrap_or_default()
+                        } else {
+                            tracing::debug!(
+                                target: "spawn_subagent",
+                                count = fresh.len(),
+                                "[spawn_subagent] refreshed connected_integrations for pre-flight"
+                            );
+                            fresh
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "spawn_subagent",
+                            error = %e,
+                            "[spawn_subagent] config load failed; falling back to parent's frozen list"
+                        );
+                        parent_ctx
+                            .as_ref()
+                            .map(|p| p.connected_integrations.clone())
+                            .unwrap_or_default()
+                    }
+                }
+            };
             let allowlist: Vec<&crate::openhuman::context::prompt::ConnectedIntegration> =
-                parent_ctx
-                    .as_ref()
-                    .map(|p| p.connected_integrations.iter().collect())
-                    .unwrap_or_default();
+                live_integrations.iter().collect();
             let connected_slugs: Vec<String> = allowlist
                 .iter()
                 .filter(|ci| ci.connected)

--- a/src/openhuman/update/core.rs
+++ b/src/openhuman/update/core.rs
@@ -17,7 +17,7 @@ pub fn current_version() -> &'static str {
 
 /// Build the target triple string used in release asset names.
 /// E.g. `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`.
-fn platform_triple() -> &'static str {
+pub fn platform_triple() -> &'static str {
     #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
     {
         "x86_64-apple-darwin"

--- a/src/openhuman/update/ops.rs
+++ b/src/openhuman/update/ops.rs
@@ -5,7 +5,179 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::openhuman::update;
+use crate::openhuman::update::types::{UpdateRunResult, VersionInfo};
 use crate::rpc::RpcOutcome;
+
+/// Report the running core binary's version + target triple.
+///
+/// Cheap, no-network — the frontend uses this to decide whether to
+/// invoke the heavier `update.check` or `update.run` RPCs.
+pub async fn update_version() -> RpcOutcome<Value> {
+    let info = VersionInfo {
+        version: update::current_version().to_string(),
+        target_triple: update::platform_triple().to_string(),
+        asset_prefix: format!("openhuman-core-{}", update::platform_triple()),
+    };
+    log::debug!(
+        "[update:rpc] update_version → {} ({})",
+        info.version,
+        info.target_triple
+    );
+    let value = serde_json::to_value(&info)
+        .unwrap_or_else(|e| serde_json::json!({ "error": format!("serialization failed: {e}") }));
+    RpcOutcome::single_log(value, "update_version completed")
+}
+
+/// Orchestrated update flow: check → apply (if newer) → restart.
+///
+/// Returns an `UpdateRunResult` describing what happened. When an
+/// update was applied the function publishes a restart request before
+/// returning, so the caller will see `restart_requested: true` and the
+/// core process will exit shortly afterwards.
+pub async fn update_run() -> RpcOutcome<Value> {
+    log::info!("[update:rpc] update_run invoked");
+
+    let info = match update::check_available().await {
+        Ok(i) => i,
+        Err(e) => {
+            log::error!("[update:rpc] update_run check failed: {e}");
+            return RpcOutcome::single_log(
+                serde_json::json!({
+                    "error": e,
+                    "applied": false,
+                    "restart_requested": false,
+                }),
+                format!("update_run: check failed: {e}"),
+            );
+        }
+    };
+
+    if !info.update_available {
+        let result = UpdateRunResult {
+            current_version: info.current_version.clone(),
+            latest_version: info.latest_version.clone(),
+            update_available: false,
+            applied: false,
+            staged_path: None,
+            restart_requested: false,
+            message: format!("already on latest ({})", info.current_version),
+        };
+        log::info!(
+            "[update:rpc] update_run: already up to date ({})",
+            info.current_version
+        );
+        return RpcOutcome::single_log(
+            serde_json::to_value(&result).unwrap_or(Value::Null),
+            "update_run: already up to date",
+        );
+    }
+
+    let (Some(download_url), Some(asset_name)) = (info.download_url, info.asset_name) else {
+        log::warn!(
+            "[update:rpc] update_run: latest release has no asset for this platform (target={})",
+            update::platform_triple()
+        );
+        let result = UpdateRunResult {
+            current_version: info.current_version,
+            latest_version: info.latest_version,
+            update_available: true,
+            applied: false,
+            staged_path: None,
+            restart_requested: false,
+            message: format!(
+                "latest release has no asset for target {}",
+                update::platform_triple()
+            ),
+        };
+        return RpcOutcome::single_log(
+            serde_json::to_value(&result).unwrap_or(Value::Null),
+            "update_run: missing platform asset",
+        );
+    };
+
+    // Defensive re-validation — the URL/asset came from GitHub but we
+    // still gate them through the same checks `update.apply` uses, so
+    // this orchestrator can't accidentally bypass the safety net.
+    if let Err(e) = validate_download_url(&download_url) {
+        log::error!("[update:rpc] update_run rejected download URL: {e}");
+        return RpcOutcome::single_log(
+            serde_json::json!({ "error": e, "applied": false, "restart_requested": false }),
+            format!("update_run rejected: {e}"),
+        );
+    }
+    if let Err(e) = validate_asset_name(&asset_name) {
+        log::error!("[update:rpc] update_run rejected asset name: {e}");
+        return RpcOutcome::single_log(
+            serde_json::json!({ "error": e, "applied": false, "restart_requested": false }),
+            format!("update_run rejected: {e}"),
+        );
+    }
+
+    let applied = match update::download_and_stage(&download_url, &asset_name, None).await {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("[update:rpc] update_run apply failed: {e}");
+            let result = UpdateRunResult {
+                current_version: info.current_version,
+                latest_version: info.latest_version,
+                update_available: true,
+                applied: false,
+                staged_path: None,
+                restart_requested: false,
+                message: format!("download/stage failed: {e}"),
+            };
+            return RpcOutcome::single_log(
+                serde_json::to_value(&result).unwrap_or(Value::Null),
+                format!("update_run: apply failed: {e}"),
+            );
+        }
+    };
+
+    // Stage succeeded — request a self-restart so the Tauri shell can
+    // pick up the freshly-staged binary on its next supervised launch.
+    let restart_requested = match crate::openhuman::service::rpc::service_restart(
+        Some("update.run".to_string()),
+        Some(format!("update to {}", info.latest_version)),
+    )
+    .await
+    {
+        Ok(_) => true,
+        Err(e) => {
+            log::warn!(
+                "[update:rpc] update_run staged update but restart publish failed: {e}"
+            );
+            false
+        }
+    };
+
+    let result = UpdateRunResult {
+        current_version: info.current_version,
+        latest_version: info.latest_version,
+        update_available: true,
+        applied: true,
+        staged_path: Some(applied.staged_path.clone()),
+        restart_requested,
+        message: if restart_requested {
+            format!(
+                "staged {} — restart requested",
+                applied.staged_path.as_str()
+            )
+        } else {
+            format!(
+                "staged {} — restart publish failed; caller must restart manually",
+                applied.staged_path.as_str()
+            )
+        },
+    };
+    log::info!(
+        "[update:rpc] update_run completed applied=true restart_requested={}",
+        restart_requested
+    );
+    RpcOutcome::single_log(
+        serde_json::to_value(&result).unwrap_or(Value::Null),
+        "update_run completed",
+    )
+}
 
 /// Check GitHub Releases for a newer version of the core binary.
 pub async fn update_check() -> RpcOutcome<Value> {

--- a/src/openhuman/update/ops.rs
+++ b/src/openhuman/update/ops.rs
@@ -143,9 +143,7 @@ pub async fn update_run() -> RpcOutcome<Value> {
     {
         Ok(_) => true,
         Err(e) => {
-            log::warn!(
-                "[update:rpc] update_run staged update but restart publish failed: {e}"
-            );
+            log::warn!("[update:rpc] update_run staged update but restart publish failed: {e}");
             false
         }
     };

--- a/src/openhuman/update/schemas.rs
+++ b/src/openhuman/update/schemas.rs
@@ -5,11 +5,20 @@ use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
 use crate::rpc::RpcOutcome;
 
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
-    vec![schemas("check"), schemas("apply")]
+    vec![
+        schemas("version"),
+        schemas("check"),
+        schemas("apply"),
+        schemas("run"),
+    ]
 }
 
 pub fn all_registered_controllers() -> Vec<RegisteredController> {
     vec![
+        RegisteredController {
+            schema: schemas("version"),
+            handler: handle_version,
+        },
         RegisteredController {
             schema: schemas("check"),
             handler: handle_check,
@@ -18,11 +27,41 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
             schema: schemas("apply"),
             handler: handle_apply,
         },
+        RegisteredController {
+            schema: schemas("run"),
+            handler: handle_run,
+        },
     ]
 }
 
 pub fn schemas(function: &str) -> ControllerSchema {
     match function {
+        "version" => ControllerSchema {
+            namespace: "update",
+            function: "version",
+            description: "Report the running core binary's version + target triple.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "version_info",
+                ty: TypeSchema::Json,
+                comment: "Current version and platform target triple.",
+                required: true,
+            }],
+        },
+        "run" => ControllerSchema {
+            namespace: "update",
+            function: "run",
+            description:
+                "Orchestrated update: check GitHub, stage a newer binary if available, \
+                 then publish a self-restart. The process exits shortly after returning.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "run_result",
+                ty: TypeSchema::Json,
+                comment: "Summary of what the orchestrator did (checked / applied / restarted).",
+                required: true,
+            }],
+        },
         "check" => ControllerSchema {
             namespace: "update",
             function: "check",
@@ -83,8 +122,16 @@ pub fn schemas(function: &str) -> ControllerSchema {
     }
 }
 
+fn handle_version(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async { to_json(crate::openhuman::update::rpc::update_version().await) })
+}
+
 fn handle_check(_params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async { to_json(crate::openhuman::update::rpc::update_check().await) })
+}
+
+fn handle_run(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async { to_json(crate::openhuman::update::rpc::update_run().await) })
 }
 
 fn handle_apply(params: Map<String, Value>) -> ControllerFuture {
@@ -120,13 +167,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn all_schemas_returns_two() {
-        assert_eq!(all_controller_schemas().len(), 2);
+    fn all_schemas_returns_four() {
+        assert_eq!(all_controller_schemas().len(), 4);
     }
 
     #[test]
-    fn all_controllers_returns_two() {
-        assert_eq!(all_registered_controllers().len(), 2);
+    fn all_controllers_returns_four() {
+        assert_eq!(all_registered_controllers().len(), 4);
+    }
+
+    #[test]
+    fn version_schema_has_no_inputs() {
+        let s = schemas("version");
+        assert_eq!(s.namespace, "update");
+        assert_eq!(s.function, "version");
+        assert!(s.inputs.is_empty());
+        assert!(!s.outputs.is_empty());
+    }
+
+    #[test]
+    fn run_schema_has_no_inputs() {
+        let s = schemas("run");
+        assert_eq!(s.namespace, "update");
+        assert_eq!(s.function, "run");
+        assert!(s.inputs.is_empty());
+        assert!(!s.outputs.is_empty());
     }
 
     #[test]

--- a/src/openhuman/update/schemas.rs
+++ b/src/openhuman/update/schemas.rs
@@ -51,8 +51,7 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "run" => ControllerSchema {
             namespace: "update",
             function: "run",
-            description:
-                "Orchestrated update: check GitHub, stage a newer binary if available, \
+            description: "Orchestrated update: check GitHub, stage a newer binary if available, \
                  then publish a self-restart. The process exits shortly after returning.",
             inputs: vec![],
             outputs: vec![FieldSchema {

--- a/src/openhuman/update/types.rs
+++ b/src/openhuman/update/types.rs
@@ -21,6 +21,41 @@ pub struct UpdateInfo {
     pub published_at: Option<String>,
 }
 
+/// Lightweight identity of the running core binary, returned by
+/// `update.version`. Lets the frontend decide whether to call
+/// `update.check` / `update.run` without paying the GitHub round-trip
+/// just to discover what version it is talking to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionInfo {
+    /// Current binary version (`CARGO_PKG_VERSION`).
+    pub version: String,
+    /// Rust target triple this binary was built for.
+    pub target_triple: String,
+    /// The asset name prefix used by the GitHub release flow
+    /// (`openhuman-core-{target_triple}`). Frontends can match against
+    /// this to find a compatible asset without re-deriving the triple.
+    pub asset_prefix: String,
+}
+
+/// Outcome of the orchestrated `update.run` flow (check → apply →
+/// restart). Keeps every interesting field flat so the frontend can
+/// decide what to surface to the user without re-walking the response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateRunResult {
+    pub current_version: String,
+    pub latest_version: String,
+    pub update_available: bool,
+    /// True when a new binary was successfully downloaded + staged.
+    pub applied: bool,
+    /// Set when `applied` is true.
+    pub staged_path: Option<String>,
+    /// True when a self-restart was published. The process will exit
+    /// shortly after the RPC response is returned.
+    pub restart_requested: bool,
+    /// Human-readable summary suitable for logs / surface text.
+    pub message: String,
+}
+
 /// Result of applying an update.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateApplyResult {


### PR DESCRIPTION
## Summary

- New JSON-RPC controllers on the core: `update.version`, `update.run`, `service.shutdown` so the desktop frontend can ask the running core what version it is, trigger a one-call check → stage → restart, or gracefully exit it. `service.restart` already existed.
- `composio_list_tools` now emits compact markdown instead of pasting full JSON tool schemas, and defaults to filtering out toolkits the user hasn't connected (escape hatch: `include_unconnected=true`). Both are major token wins on the agent loop.
- Sub-agent spawn pre-flight (`spawn_subagent` integrations gate + `subagent_runner::run_typed_mode`) now refreshes connected integrations from the global cache at spawn time, so a toolkit the user authorises mid-thread (e.g. Calendly) is visible without restarting the app or opening a new thread.

## Problem

Two related rough edges + one capability gap:

1. **Frontend update orchestration.** The core has had `update.check` and `update.apply` for a while, but no single "do the update" command and no cheap way to read the current binary's version without paying a GitHub round-trip. Nothing for graceful shutdown either, even though restart was wired.
2. **`composio_list_tools` is hugely expensive.** It returns the full OpenAI function-calling schema for every tool the backend exposes — the parameter schemas dominate the response and burn a lot of tokens in the agent loop. It also returned actions for every allowlisted toolkit, including ones the user hadn't connected.
3. **Mid-thread Calendly authorisation didn't work.** The parent session's `connected_integrations` Vec is intentionally frozen on the first turn (so the system-prompt KV-cache prefix stays stable). That meant a toolkit the user OAuth'd mid-thread was missing from `parent.connected_integrations`, the `spawn_subagent(integrations_agent, toolkit="calendly", …)` pre-flight rejected it as "not in the allowlist", and the user had to start a new thread or restart the app to use it.

## Solution

**RPCs**
- `update.version` — returns `{ version, target_triple, asset_prefix }` from `CARGO_PKG_VERSION` + the existing `platform_triple()` helper. No network. Cheap discovery.
- `update.run` — orchestrates check → stage → restart in one call. Re-uses the existing `validate_download_url` / `validate_asset_name` safety net so the orchestrator can't bypass the gates `update.apply` already enforces. Returns `UpdateRunResult { applied, staged_path, restart_requested, message, … }`.
- `service.shutdown` — mirrors `service.restart`: publishes a new `SystemShutdownRequested` event variant, consumed by a `ShutdownSubscriber` that calls `process::exit(0)` after a 150 ms flush window. Subscriber wired in `core/jsonrpc.rs::register_domain_subscribers` next to the existing restart one.

**`composio_list_tools` markdown + connected-only**
- New `render_tools_markdown` groups tools by toolkit (parsed from slug prefix), shows ``\`SLUG\` — description **req:** a, b **opt:** c, d`` per tool, drops the full JSON parameter schemas. Wired through `execute_with_options` + `supports_markdown=true` so the harness picks it up only when `prefer_markdown` is set; raw JSON is still the primary `output()` for direct CLI/RPC callers.
- New `include_unconnected: bool` parameter (default `false`). When false the tool calls `list_connections()` after fetching tools and drops any tool whose toolkit isn't in the user's `ACTIVE`/`CONNECTED` set. Mirrors the same status allowlist `composio_list_connections` uses. Surfacing an error (instead of silently returning `[]`) if the connections fetch fails so the agent can retry with `include_unconnected=true`.

**Mid-thread integration refresh**
- The composio side already invalidates the global `INTEGRATIONS_CACHE` once OAuth reaches `ACTIVE` (via `ComposioConnectionCreatedSubscriber`). The miss was purely the parent session's stale in-memory Vec.
- In `spawn_subagent.rs`'s `integrations_agent` toolkit gate AND in `subagent_runner::run_typed_mode`, fetch the live list via `composio::fetch_connected_integrations(&config)` instead of reading `parent.connected_integrations`. That call is a cache hit on the warm path; the cache invalidation makes it a fresh fetch immediately after a new authorisation. Falls back to the parent's frozen list when the fetch returns empty (offline / not signed in) so existing behaviour is preserved.
- The parent's *own* system prompt is untouched — KV-cache prefix is unaffected; only the spawn pre-flight and the freshly-built child prompt benefit.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: changed-line coverage delta is small (Rust-only, in domains already covered by existing service/update/composio test suites). Will run `pnpm test:rust` + `pnpm test:coverage` locally and address if `diff-cover` flags anything below 80%.
- [ ] N/A: behaviour-only change — no new user-facing capability rows for the matrix
- [ ] N/A: no linked issue
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: doesn't touch a release-cut surface listed in `RELEASE-MANUAL-SMOKE.md`
- [ ] N/A: no linked issue

## Impact

- **Desktop runtime.** Exposes three new RPC methods; the frontend can now wire a "check for updates" / "restart" / "shutdown" surface without going through CLI or the manual `update.apply` + `service.restart` two-step.
- **Agent token usage.** `composio_list_tools` markdown output materially shortens responses — expected ~50–80% smaller depending on toolkit. The connected-only default avoids surfacing actions the user can't actually call.
- **Mid-thread UX.** OAuthing a new integration during a live chat now "just works" without forcing the user to start a new thread.
- **Compatibility.** Additive only; no existing RPC / event variant / tool signature changed in a way that breaks callers.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Process-wide graceful shutdown request and a service shutdown command
  - Markdown-formatted tool listings with optional connection-scoped filtering
  - Update orchestration (check → download/stage → request restart) plus version-info endpoint
  - Sub-agent spawning now refreshes live integrations at spawn time

* **Bug Fixes**
  - Integration checks use refreshed live data instead of frozen session lists
  - Updated guidance: "Connections → Integrations" for retrying integration actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->