### PR TITLE
fix(threads): preserve selectedThreadId on cold-boot identity hydration

### DIFF
--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -28,7 +28,7 @@ import {
 import { socketService } from '../services/socketService';
 import { store } from '../store';
 import { resetUserScopedState } from '../store/resetActions';
-import { clearAllThreads, loadThreads } from '../store/threadSlice';
+import { loadThreads, resetThreadCachesPreservingSelection } from '../store/threadSlice';
 import { getActiveUserId, setActiveUserId } from '../store/userScopedStorage';
 import {
   openhumanUpdateAnalyticsSettings,
@@ -257,7 +257,12 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
       !isLogout
     ) {
       const threadReloadRequestId = requestId;
-      store.dispatch(clearAllThreads());
+      // Reset the in-memory thread caches (rows from a pre-auth bucket — see
+      // #1157) but preserve the redux-persisted `selectedThreadId` so a
+      // reload of an already-authed user resumes the user's last-viewed
+      // thread (#1168). The Conversations mount effect falls back to "most
+      // recent" if the persisted id is no longer in the reloaded list.
+      store.dispatch(resetThreadCachesPreservingSelection());
       void store
         .dispatch(loadThreads())
         .unwrap()

--- a/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.identityFlip.test.tsx
@@ -153,9 +153,13 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     setActiveSpy.mockRestore();
   });
 
-  it('seed matches next user (no restart) but identity hydrates null→B: clears threads and reloads (#1157)', async () => {
+  it('seed matches next user (no restart) but identity hydrates null→B: resets thread caches (preserving selection) and reloads (#1157, #1168)', async () => {
     userScopedStorage.setActiveUserId('B');
     fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'B', sessionToken: 'tokB' }));
+    // Seed a persisted selection that should survive the boot-time reset so
+    // the user resumes their last-viewed thread instead of falling through
+    // to "most recent".
+    store.dispatch(threadSlice.setSelectedThread('thr-persisted'));
     const dispatchSpy = vi.spyOn(store, 'dispatch');
     const loadThreadsSpy = vi.spyOn(threadSlice, 'loadThreads');
 
@@ -173,10 +177,22 @@ describe('CoreStateProvider — identity flip cleanup (#900)', () => {
     expect(
       dispatchSpy.mock.calls.some(([action]) => {
         if (!action || typeof action !== 'object' || !('type' in action)) return false;
-        return (action as { type: string }).type === threadSlice.clearAllThreads().type;
+        return (
+          (action as { type: string }).type ===
+          threadSlice.resetThreadCachesPreservingSelection().type
+        );
       })
     ).toBe(true);
+    // The legacy `clearAllThreads` (which nulls selectedThreadId) must NOT
+    // be dispatched on this boot path — that was the #1168 regression.
+    expect(
+      dispatchSpy.mock.calls.some(([action]) => {
+        if (!action || typeof action !== 'object' || !('type' in action)) return false;
+        return (action as { type: string }).type === threadSlice.clearAllThreads().type;
+      })
+    ).toBe(false);
     expect(loadThreadsSpy).toHaveBeenCalled();
+    expect(store.getState().thread.selectedThreadId).toBe('thr-persisted');
 
     dispatchSpy.mockRestore();
     loadThreadsSpy.mockRestore();

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -279,6 +279,19 @@ const threadSlice = createSlice({
       state.activeThreadId = null;
       state.welcomeThreadId = null;
     },
+    // Like `clearAllThreads` but keeps `selectedThreadId`. Used on the
+    // post-bootstrap identity-observation path (#1168 + #1157): we need to
+    // drop pre-auth in-memory thread rows but the persisted last-viewed
+    // thread id is still valid for the reloaded user, so preserving it lets
+    // the Conversations effect resume that thread instead of falling
+    // through to "most recent".
+    resetThreadCachesPreservingSelection: state => {
+      state.threads = [];
+      state.messagesByThreadId = {};
+      state.messages = [];
+      state.activeThreadId = null;
+      state.welcomeThreadId = null;
+    },
     // [#1123] True no-op — welcome-agent onboarding replaced by Joyride walkthrough.
     // Kept to avoid breaking existing imports; state.welcomeThreadId is never
     // mutated because the welcome-agent flow no longer runs.
@@ -350,6 +363,7 @@ export const {
   clearSelectedThread,
   setActiveThread,
   clearAllThreads,
+  resetThreadCachesPreservingSelection,
   setWelcomeThreadId,
 } = threadSlice.actions;
 


### PR DESCRIPTION
## Summary

- Fix regression where reloading the app always dropped the user back into a freshly-selected "most recent" thread instead of the one they were viewing.
- Replace the boot-time `clearAllThreads()` dispatch in `CoreStateProvider` with a new `resetThreadCachesPreservingSelection` reducer that wipes pre-auth in-memory rows but keeps `selectedThreadId`.
- Update the existing #1157 boot-cleanup test to lock in both invariants (caches reset, persisted selection survives).

## Problem

After #1168 we persist `selectedThreadId` via redux-persist so reloads resume the user's last-viewed thread. In practice that never worked: every reload still snapped back to "most recent."

Root cause is in `CoreStateProvider.tsx`. When the bootstrap snapshot fetch resolves, the in-memory snapshot identity transitions from `null` (signed-out scaffold) to the real userId. That trips `shouldClearScopedCaches`, and the post-#1157 cleanup dispatches `clearAllThreads()` — which nulls `selectedThreadId`, throwing away the value redux-persist had just rehydrated. The `Conversations` mount effect then sees `selectedThreadId === null` and falls through to "most recent."

The #1157 scrub itself is still required: pre-auth flows (e.g. signup ceremony) can populate the in-memory `threads` list with rows from the wrong bucket before identity arrives, and those need to be dropped.

## Solution

Split the wipe from the selection reset.

- New reducer `resetThreadCachesPreservingSelection` in `app/src/store/threadSlice.ts:274` clears `threads`, `messagesByThreadId`, `messages`, `activeThreadId`, and `welcomeThreadId` but leaves `selectedThreadId` untouched.
- `app/src/providers/CoreStateProvider.tsx:259` dispatches the new reducer instead of `clearAllThreads()` on the post-bootstrap identity-observation path. The follow-up `loadThreads()` call still re-pulls a fresh list from core, and the `Conversations` mount effect already falls back to "most recent" when the persisted id is missing from the reloaded list — so deleted/foreign thread ids are handled the same as before.
- `clearAllThreads` is left intact for callers that genuinely need the full reset (e.g. logout flows downstream of `resetUserScopedState`).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: pure refactor of an existing reducer + provider branch; behaviour change is covered by the updated `CoreStateProvider.identityFlip.test.tsx` case (which now also asserts the absence of the buggy `clearAllThreads` dispatch and the survival of a seeded selection). Touched lines are inside the existing diff-cover surface and exercised by that test.
- [ ] N/A: behaviour-only fix — no feature added/removed/renamed, so the coverage matrix is unchanged.
- [ ] N/A: no matrix feature IDs apply.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: not a release-cut surface — fix is internal to in-memory thread cache lifecycle on reload.
- [ ] N/A: no linked issue (regression caught from in-app reproduction; if a tracking issue is desired I can file one).

## Impact

- **Desktop**: reloads now resume the previously viewed thread (the persisted `selectedThreadId` survives the bootstrap identity transition). No change for signup / identity-flip flows — the in-memory pre-auth thread rows are still scrubbed, the only difference is that the user's selection isn't collateral damage.
- No migration, no protocol change, no perf impact (one reducer is replaced by another with the same shape minus one line).
- Pre-push hook: required `pnpm install` before pushing because the local `node_modules` was missing `react-joyride` (added in #1180); after install the hook ran clean. No `--no-verify` bypass used.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread selection is now preserved when switching user identities, preventing loss of your active thread context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->