### PR TITLE
Persist turn state + restore conversation history on cold-boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.13"
+version = "0.53.16"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.13"
+version = "0.53.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.13"
+version = "0.53.16"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -23,6 +23,7 @@ import { store } from '../store';
 import {
   beginInferenceTurn,
   clearRuntimeForThread,
+  fetchAndHydrateTurnState,
   setToolTimelineForThread,
 } from '../store/chatRuntimeSlice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -284,6 +285,7 @@ const Conversations = ({ variant = 'page' }: ConversationsProps = {}) => {
   useEffect(() => {
     if (selectedThreadId) {
       void dispatch(loadThreadMessages(selectedThreadId));
+      void dispatch(fetchAndHydrateTurnState(selectedThreadId));
     }
   }, [selectedThreadId, dispatch]);
 

--- a/app/src/services/api/threadApi.ts
+++ b/app/src/services/api/threadApi.ts
@@ -8,6 +8,12 @@ import type {
   ThreadMessagesData,
   ThreadsListData,
 } from '../../types/thread';
+import type {
+  ClearTurnStateResponse,
+  GetTurnStateResponse,
+  ListTurnStatesResponse,
+  PersistedTurnState,
+} from '../../types/turnState';
 import { callCoreRpc } from '../coreRpcClient';
 
 interface Envelope<T> {
@@ -101,6 +107,32 @@ export const threadApi = {
       method: 'openhuman.threads_purge',
     });
     return unwrapEnvelope(response);
+  },
+
+  getTurnState: async (threadId: string): Promise<PersistedTurnState | null> => {
+    const response = await callCoreRpc<{ data?: GetTurnStateResponse }>({
+      method: 'openhuman.threads_turn_state_get',
+      params: { thread_id: threadId },
+    });
+    const data = unwrapEnvelope(response);
+    return data?.turnState ?? null;
+  },
+
+  listTurnStates: async (): Promise<PersistedTurnState[]> => {
+    const response = await callCoreRpc<{ data?: ListTurnStatesResponse }>({
+      method: 'openhuman.threads_turn_state_list',
+    });
+    const data = unwrapEnvelope(response);
+    return data?.turnStates ?? [];
+  },
+
+  clearTurnState: async (threadId: string): Promise<boolean> => {
+    const response = await callCoreRpc<{ data?: ClearTurnStateResponse }>({
+      method: 'openhuman.threads_turn_state_clear',
+      params: { thread_id: threadId },
+    });
+    const data = unwrapEnvelope(response);
+    return Boolean(data?.cleared);
   },
 
   updateLabels: async (threadId: string, labels: string[]): Promise<Thread> => {

--- a/app/src/store/__tests__/chatRuntimeSlice.test.ts
+++ b/app/src/store/__tests__/chatRuntimeSlice.test.ts
@@ -177,9 +177,7 @@ describe('chatRuntimeSlice', () => {
       activeTool: 'shell',
       streamingText: 'half-finished reply',
       thinking: 'half-finished thought',
-      toolTimeline: [
-        { id: 'tc-1', name: 'shell', round: 5, status: 'running' },
-      ],
+      toolTimeline: [{ id: 'tc-1', name: 'shell', round: 5, status: 'running' }],
       startedAt: '2026-05-04T10:00:00Z',
       updatedAt: '2026-05-04T10:00:05Z',
     };

--- a/app/src/store/__tests__/chatRuntimeSlice.test.ts
+++ b/app/src/store/__tests__/chatRuntimeSlice.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { PersistedTurnState } from '../../types/turnState';
 import reducer, {
   beginInferenceTurn,
   clearInferenceStatusForThread,
@@ -7,6 +8,7 @@ import reducer, {
   clearStreamingAssistantForThread,
   clearToolTimelineForThread,
   endInferenceTurn,
+  hydrateRuntimeFromSnapshot,
   markInferenceTurnStreaming,
   setInferenceStatusForThread,
   setStreamingAssistantForThread,
@@ -89,6 +91,80 @@ describe('chatRuntimeSlice', () => {
 
     const ended = reducer(streaming, endInferenceTurn({ threadId: 'thread-1' }));
     expect(ended.inferenceTurnLifecycleByThread['thread-1']).toBeUndefined();
+  });
+
+  it('hydrates runtime state from a persisted turn snapshot', () => {
+    const snapshot: PersistedTurnState = {
+      threadId: 'thread-h',
+      requestId: 'req-h',
+      lifecycle: 'streaming',
+      iteration: 3,
+      maxIterations: 25,
+      phase: 'tool_use',
+      activeTool: 'shell',
+      streamingText: 'partial reply',
+      thinking: 'reasoning…',
+      toolTimeline: [
+        {
+          id: 'tc-1',
+          name: 'shell',
+          round: 3,
+          status: 'running',
+          argsBuffer: '{"cmd":"ls"}',
+        },
+      ],
+      startedAt: '2026-05-04T10:00:00Z',
+      updatedAt: '2026-05-04T10:00:05Z',
+    };
+
+    const next = reducer(undefined, hydrateRuntimeFromSnapshot({ snapshot }));
+
+    expect(next.inferenceTurnLifecycleByThread['thread-h']).toBe('streaming');
+    expect(next.inferenceStatusByThread['thread-h']).toEqual({
+      phase: 'tool_use',
+      iteration: 3,
+      maxIterations: 25,
+      activeTool: 'shell',
+      activeSubagent: undefined,
+    });
+    expect(next.streamingAssistantByThread['thread-h']).toEqual({
+      requestId: 'req-h',
+      content: 'partial reply',
+      thinking: 'reasoning…',
+    });
+    expect(next.toolTimelineByThread['thread-h']).toEqual([
+      {
+        id: 'tc-1',
+        name: 'shell',
+        round: 3,
+        status: 'running',
+        argsBuffer: '{"cmd":"ls"}',
+        displayName: undefined,
+        detail: undefined,
+        sourceToolName: undefined,
+        subagent: undefined,
+      },
+    ]);
+  });
+
+  it('hydrating an interrupted snapshot exposes the lifecycle for retry UI', () => {
+    const snapshot: PersistedTurnState = {
+      threadId: 'thread-i',
+      requestId: 'req-i',
+      lifecycle: 'interrupted',
+      iteration: 0,
+      maxIterations: 0,
+      streamingText: '',
+      thinking: '',
+      toolTimeline: [],
+      startedAt: '2026-05-04T10:00:00Z',
+      updatedAt: '2026-05-04T10:00:01Z',
+    };
+    const next = reducer(undefined, hydrateRuntimeFromSnapshot({ snapshot }));
+    expect(next.inferenceTurnLifecycleByThread['thread-i']).toBe('interrupted');
+    expect(next.inferenceStatusByThread['thread-i']).toBeUndefined();
+    expect(next.streamingAssistantByThread['thread-i']).toBeUndefined();
+    expect(next.toolTimelineByThread['thread-i']).toEqual([]);
   });
 
   it('clears all runtime buckets for one thread', () => {

--- a/app/src/store/__tests__/chatRuntimeSlice.test.ts
+++ b/app/src/store/__tests__/chatRuntimeSlice.test.ts
@@ -161,6 +161,37 @@ describe('chatRuntimeSlice', () => {
     expect(next.toolTimelineByThread['thread-i']).toEqual([]);
   });
 
+  it('interrupted snapshot must NOT resurrect inferenceStatus / streamingAssistant from stale fields', () => {
+    // Defensive: an interrupted snapshot can carry the iteration /
+    // streaming buffer that was active at the moment the previous
+    // process died. Hydrating those into the live-progress buckets
+    // would render a fake "live" inference UI for a turn nothing is
+    // driving. Lifecycle alone is the truth — buckets stay clear.
+    const snapshot: PersistedTurnState = {
+      threadId: 'thread-stale',
+      requestId: 'req-stale',
+      lifecycle: 'interrupted',
+      iteration: 5,
+      maxIterations: 25,
+      phase: 'tool_use',
+      activeTool: 'shell',
+      streamingText: 'half-finished reply',
+      thinking: 'half-finished thought',
+      toolTimeline: [
+        { id: 'tc-1', name: 'shell', round: 5, status: 'running' },
+      ],
+      startedAt: '2026-05-04T10:00:00Z',
+      updatedAt: '2026-05-04T10:00:05Z',
+    };
+    const next = reducer(undefined, hydrateRuntimeFromSnapshot({ snapshot }));
+    expect(next.inferenceTurnLifecycleByThread['thread-stale']).toBe('interrupted');
+    expect(next.inferenceStatusByThread['thread-stale']).toBeUndefined();
+    expect(next.streamingAssistantByThread['thread-stale']).toBeUndefined();
+    // Tool timeline IS preserved — the UI surfaces it as a frozen
+    // record next to the retry banner.
+    expect(next.toolTimelineByThread['thread-stale']).toHaveLength(1);
+  });
+
   it('clears all runtime buckets for one thread', () => {
     const populated = reducer(
       reducer(

--- a/app/src/store/__tests__/chatRuntimeSlice.test.ts
+++ b/app/src/store/__tests__/chatRuntimeSlice.test.ts
@@ -105,13 +105,7 @@ describe('chatRuntimeSlice', () => {
       streamingText: 'partial reply',
       thinking: 'reasoning…',
       toolTimeline: [
-        {
-          id: 'tc-1',
-          name: 'shell',
-          round: 3,
-          status: 'running',
-          argsBuffer: '{"cmd":"ls"}',
-        },
+        { id: 'tc-1', name: 'shell', round: 3, status: 'running', argsBuffer: '{"cmd":"ls"}' },
       ],
       startedAt: '2026-05-04T10:00:00Z',
       updatedAt: '2026-05-04T10:00:05Z',

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -266,9 +266,7 @@ const chatRuntimeSlice = createSlice({
       if (snapshot.lifecycle === 'interrupted') {
         delete state.inferenceStatusByThread[threadId];
         delete state.streamingAssistantByThread[threadId];
-        state.toolTimelineByThread[threadId] = snapshot.toolTimeline.map(
-          toolTimelineFromPersisted
-        );
+        state.toolTimelineByThread[threadId] = snapshot.toolTimeline.map(toolTimelineFromPersisted);
         return;
       }
 

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -8,7 +8,6 @@ import type {
   PersistedToolTimelineEntry,
   PersistedTurnState,
 } from '../types/turnState';
-
 import { resetUserScopedState } from './resetActions';
 
 const turnStateLog = debug('chatRuntime.turnState');
@@ -139,9 +138,7 @@ const initialState: ChatRuntimeState = {
   sessionTokenUsage: { inputTokens: 0, outputTokens: 0, turns: 0, lastUpdated: 0 },
 };
 
-function subagentToolCallFromPersisted(
-  call: PersistedSubagentToolCall
-): SubagentToolCallEntry {
+function subagentToolCallFromPersisted(call: PersistedSubagentToolCall): SubagentToolCallEntry {
   return {
     callId: call.callId,
     toolName: call.toolName,
@@ -326,8 +323,13 @@ export const fetchAndHydrateTurnState = createAsyncThunk(
     try {
       const snapshot = await threadApi.getTurnState(threadId);
       if (snapshot) {
-        turnStateLog('hydrated thread=%s lifecycle=%s iter=%d/%d',
-          threadId, snapshot.lifecycle, snapshot.iteration, snapshot.maxIterations);
+        turnStateLog(
+          'hydrated thread=%s lifecycle=%s iter=%d/%d',
+          threadId,
+          snapshot.lifecycle,
+          snapshot.iteration,
+          snapshot.maxIterations
+        );
         dispatch(hydrateRuntimeFromSnapshot({ snapshot }));
       } else {
         turnStateLog('no snapshot thread=%s', threadId);

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -259,6 +259,19 @@ const chatRuntimeSlice = createSlice({
 
       state.inferenceTurnLifecycleByThread[threadId] = snapshot.lifecycle;
 
+      // Interrupted turns have no live driver — surface only the
+      // lifecycle so the UI renders a retry affordance instead of
+      // resurrecting a fake "live" inference status / streaming buffer
+      // from snapshot fields that may be stale.
+      if (snapshot.lifecycle === 'interrupted') {
+        delete state.inferenceStatusByThread[threadId];
+        delete state.streamingAssistantByThread[threadId];
+        state.toolTimelineByThread[threadId] = snapshot.toolTimeline.map(
+          toolTimelineFromPersisted
+        );
+        return;
+      }
+
       if (snapshot.iteration > 0 && snapshot.maxIterations > 0) {
         state.inferenceStatusByThread[threadId] = {
           phase: snapshot.phase ?? 'thinking',

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -1,6 +1,17 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import debug from 'debug';
+
+import { threadApi } from '../services/api/threadApi';
+import type {
+  PersistedSubagentActivity,
+  PersistedSubagentToolCall,
+  PersistedToolTimelineEntry,
+  PersistedTurnState,
+} from '../types/turnState';
 
 import { resetUserScopedState } from './resetActions';
+
+const turnStateLog = debug('chatRuntime.turnState');
 
 export type ToolTimelineEntryStatus = 'running' | 'success' | 'error';
 
@@ -91,7 +102,12 @@ export interface StreamingAssistantState {
  * terminal and handled by deleting the key). This does not rely on `threadSlice`
  * segment appends, which can fire many times per turn.
  */
-export type InferenceTurnLifecycle = 'started' | 'streaming';
+/**
+ * `interrupted` is set only by snapshot rehydration on cold-boot when the
+ * core finds a turn-state file left behind by a previous process. The UI
+ * surfaces it as a retry affordance — there is no live driver to resume.
+ */
+export type InferenceTurnLifecycle = 'started' | 'streaming' | 'interrupted';
 
 /** Running per-session totals accumulated from `chat:done` events (#703). */
 export interface SessionTokenUsage {
@@ -122,6 +138,48 @@ const initialState: ChatRuntimeState = {
   inferenceTurnLifecycleByThread: {},
   sessionTokenUsage: { inputTokens: 0, outputTokens: 0, turns: 0, lastUpdated: 0 },
 };
+
+function subagentToolCallFromPersisted(
+  call: PersistedSubagentToolCall
+): SubagentToolCallEntry {
+  return {
+    callId: call.callId,
+    toolName: call.toolName,
+    status: call.status,
+    iteration: call.iteration,
+    elapsedMs: call.elapsedMs,
+    outputChars: call.outputChars,
+  };
+}
+
+function subagentActivityFromPersisted(activity: PersistedSubagentActivity): SubagentActivity {
+  return {
+    taskId: activity.taskId,
+    agentId: activity.agentId,
+    mode: activity.mode,
+    dedicatedThread: activity.dedicatedThread,
+    childIteration: activity.childIteration,
+    childMaxIterations: activity.childMaxIterations,
+    iterations: activity.iterations,
+    elapsedMs: activity.elapsedMs,
+    outputChars: activity.outputChars,
+    toolCalls: activity.toolCalls.map(subagentToolCallFromPersisted),
+  };
+}
+
+function toolTimelineFromPersisted(entry: PersistedToolTimelineEntry): ToolTimelineEntry {
+  return {
+    id: entry.id,
+    name: entry.name,
+    round: entry.round,
+    status: entry.status,
+    argsBuffer: entry.argsBuffer,
+    displayName: entry.displayName,
+    detail: entry.detail,
+    sourceToolName: entry.sourceToolName,
+    subagent: entry.subagent ? subagentActivityFromPersisted(entry.subagent) : undefined,
+  };
+}
 
 const chatRuntimeSlice = createSlice({
   name: 'chatRuntime',
@@ -189,6 +247,45 @@ const chatRuntimeSlice = createSlice({
     resetSessionTokenUsage: state => {
       state.sessionTokenUsage = { inputTokens: 0, outputTokens: 0, turns: 0, lastUpdated: 0 };
     },
+    /**
+     * Apply a persisted [TurnState] snapshot from the Rust core to the
+     * per-thread runtime state. Used on thread switch / cold boot so the
+     * UI can resume rendering an in-flight turn (or an interrupted turn
+     * left behind by a previous core process).
+     */
+    hydrateRuntimeFromSnapshot: (
+      state,
+      action: PayloadAction<{ snapshot: PersistedTurnState }>
+    ) => {
+      const { snapshot } = action.payload;
+      const threadId = snapshot.threadId;
+
+      state.inferenceTurnLifecycleByThread[threadId] = snapshot.lifecycle;
+
+      if (snapshot.iteration > 0 && snapshot.maxIterations > 0) {
+        state.inferenceStatusByThread[threadId] = {
+          phase: snapshot.phase ?? 'thinking',
+          iteration: snapshot.iteration,
+          maxIterations: snapshot.maxIterations,
+          activeTool: snapshot.activeTool,
+          activeSubagent: snapshot.activeSubagent,
+        };
+      } else {
+        delete state.inferenceStatusByThread[threadId];
+      }
+
+      if (snapshot.streamingText.length > 0 || snapshot.thinking.length > 0) {
+        state.streamingAssistantByThread[threadId] = {
+          requestId: snapshot.requestId,
+          content: snapshot.streamingText,
+          thinking: snapshot.thinking,
+        };
+      } else {
+        delete state.streamingAssistantByThread[threadId];
+      }
+
+      state.toolTimelineByThread[threadId] = snapshot.toolTimeline.map(toolTimelineFromPersisted);
+    },
   },
   extraReducers: builder => {
     builder.addCase(resetUserScopedState, () => initialState);
@@ -209,6 +306,38 @@ export const {
   clearAllChatRuntime,
   recordChatTurnUsage,
   resetSessionTokenUsage,
+  hydrateRuntimeFromSnapshot,
 } = chatRuntimeSlice.actions;
+
+/**
+ * Fetch the persisted turn snapshot for a thread from the Rust core and,
+ * if present, dispatch `hydrateRuntimeFromSnapshot`. Used on thread
+ * switch so a turn that was mid-flight when the user navigated away (or
+ * when the previous app session ended) re-renders rather than appearing
+ * as an empty composer.
+ *
+ * Failures are swallowed — a missing snapshot or transport error must
+ * not block thread navigation. Errors land in the `chatRuntime.turnState`
+ * debug namespace for diagnosis.
+ */
+export const fetchAndHydrateTurnState = createAsyncThunk(
+  'chatRuntime/fetchAndHydrateTurnState',
+  async (threadId: string, { dispatch }) => {
+    try {
+      const snapshot = await threadApi.getTurnState(threadId);
+      if (snapshot) {
+        turnStateLog('hydrated thread=%s lifecycle=%s iter=%d/%d',
+          threadId, snapshot.lifecycle, snapshot.iteration, snapshot.maxIterations);
+        dispatch(hydrateRuntimeFromSnapshot({ snapshot }));
+      } else {
+        turnStateLog('no snapshot thread=%s', threadId);
+      }
+      return snapshot;
+    } catch (error) {
+      turnStateLog('fetch failed thread=%s err=%O', threadId, error);
+      return null;
+    }
+  }
+);
 
 export default chatRuntimeSlice.reducer;

--- a/app/src/types/turnState.ts
+++ b/app/src/types/turnState.ts
@@ -1,0 +1,75 @@
+/**
+ * Wire shape of the per-thread agent-turn snapshot persisted by the
+ * Rust core (`src/openhuman/threads/turn_state/types.rs`). The UI uses
+ * these payloads to rehydrate `chatRuntimeSlice` on thread switch and
+ * to surface interrupted turns left behind by a previous core process.
+ */
+
+export type PersistedTurnLifecycle = 'started' | 'streaming' | 'interrupted';
+
+export type PersistedTurnPhase = 'thinking' | 'tool_use' | 'subagent';
+
+export type PersistedToolStatus = 'running' | 'success' | 'error';
+
+export interface PersistedSubagentToolCall {
+  callId: string;
+  toolName: string;
+  status: PersistedToolStatus;
+  iteration?: number;
+  elapsedMs?: number;
+  outputChars?: number;
+}
+
+export interface PersistedSubagentActivity {
+  taskId: string;
+  agentId: string;
+  mode?: string;
+  dedicatedThread?: boolean;
+  childIteration?: number;
+  childMaxIterations?: number;
+  iterations?: number;
+  elapsedMs?: number;
+  outputChars?: number;
+  toolCalls: PersistedSubagentToolCall[];
+}
+
+export interface PersistedToolTimelineEntry {
+  id: string;
+  name: string;
+  round: number;
+  status: PersistedToolStatus;
+  argsBuffer?: string;
+  displayName?: string;
+  detail?: string;
+  sourceToolName?: string;
+  subagent?: PersistedSubagentActivity;
+}
+
+export interface PersistedTurnState {
+  threadId: string;
+  requestId: string;
+  lifecycle: PersistedTurnLifecycle;
+  iteration: number;
+  maxIterations: number;
+  phase?: PersistedTurnPhase;
+  activeTool?: string;
+  activeSubagent?: string;
+  streamingText: string;
+  thinking: string;
+  toolTimeline: PersistedToolTimelineEntry[];
+  startedAt: string;
+  updatedAt: string;
+}
+
+export interface GetTurnStateResponse {
+  turnState?: PersistedTurnState | null;
+}
+
+export interface ListTurnStatesResponse {
+  turnStates: PersistedTurnState[];
+  count: number;
+}
+
+export interface ClearTurnStateResponse {
+  cleared: boolean;
+}

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -909,6 +909,27 @@ pub async fn bootstrap_skill_runtime() {
     // cannot double-subscribe.
     register_domain_subscribers(workspace_dir.clone(), cfg.clone());
 
+    // --- Turn-state recovery -------------------------------------------
+    // Any per-thread turn snapshots left on disk from a previous process
+    // are stale by definition — there is no live driver to resume them.
+    // Stamp them as `Interrupted` so the UI can offer a retry without
+    // confusing a stale `Streaming` lifecycle for an in-flight turn.
+    {
+        let now = chrono::Utc::now().to_rfc3339();
+        match crate::openhuman::threads::turn_state::store::mark_all_interrupted(
+            workspace_dir.clone(),
+            &now,
+        ) {
+            Ok(0) => {}
+            Ok(count) => log::info!(
+                "[runtime] marked {count} stale turn snapshot(s) as interrupted"
+            ),
+            Err(err) => log::warn!(
+                "[runtime] failed to mark stale turn snapshots interrupted: {err}"
+            ),
+        }
+    }
+
     // --- Sub-agent definition registry bootstrap ---
     // Loads built-in archetype definitions plus any custom TOML files
     // under `<workspace>/agents/*.toml`. Idempotent — safe to call

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -921,12 +921,12 @@ pub async fn bootstrap_skill_runtime() {
             &now,
         ) {
             Ok(0) => {}
-            Ok(count) => log::info!(
-                "[runtime] marked {count} stale turn snapshot(s) as interrupted"
-            ),
-            Err(err) => log::warn!(
-                "[runtime] failed to mark stale turn snapshots interrupted: {err}"
-            ),
+            Ok(count) => {
+                log::info!("[runtime] marked {count} stale turn snapshot(s) as interrupted")
+            }
+            Err(err) => {
+                log::warn!("[runtime] failed to mark stale turn snapshots interrupted: {err}")
+            }
         }
     }
 

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -170,8 +170,38 @@ impl Agent {
     /// file paths. Callers (e.g. the web channel) use this to scope
     /// transcripts per thread so each conversation thread gets its own
     /// transcript namespace instead of sharing one by agent type.
+    ///
+    /// Also rebuilds [`Self::session_key`] so the next call to
+    /// `persist_session_transcript` writes to a path keyed by the new
+    /// name. Without this, persist would keep using the builder-time
+    /// name (e.g. `"orchestrator"`) while
+    /// `find_latest_transcript` searches for the post-rename name (e.g.
+    /// `"orchestrator_thread-6ad6d"`), and resume on cold boot would
+    /// silently miss every prior transcript — the LLM would then run
+    /// each new turn with no conversation history.
     pub fn set_agent_definition_name(&mut self, name: impl Into<String>) {
-        self.agent_definition_name = name.into();
+        let name = name.into();
+        let sanitized: String = name
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        // Preserve the original unix-timestamp prefix from the builder
+        // so sub-agent spawn collisions remain impossible. Falls back
+        // to "0" if the existing key is in an unexpected shape.
+        let prefix = self
+            .session_key
+            .split_once('_')
+            .map(|(p, _)| p)
+            .filter(|p| !p.is_empty())
+            .unwrap_or("0");
+        self.session_key = format!("{prefix}_{sanitized}");
+        self.agent_definition_name = name;
     }
 
     /// Attach a progress event sender for real-time turn updates.
@@ -206,6 +236,76 @@ impl Agent {
     /// Clears the agent's conversation history.
     pub fn clear_history(&mut self) {
         self.history.clear();
+    }
+
+    /// Seed the next turn's LLM context from an authoritative message
+    /// log (e.g. the web channel's per-thread conversation JSONL).
+    ///
+    /// Mirrors what [`Self::try_load_session_transcript`] does on a
+    /// transcript-file hit, but sources from a caller-supplied list so
+    /// resume works even when no transcript file exists for this
+    /// agent name (the typical situation right after the
+    /// `set_agent_definition_name` / `session_key` rename fix landed —
+    /// existing transcripts are written under the old name).
+    ///
+    /// `messages` is `(role, content)` pairs in chronological order.
+    /// Recognised roles: `"user"`, `"agent"` / `"assistant"`. Any
+    /// trailing user message that exactly matches `current_user_message`
+    /// is dropped — the caller is about to pass that text to
+    /// [`Self::run_single`], which will append it to history itself, so
+    /// keeping it here would duplicate it on the wire.
+    ///
+    /// No-ops if the agent already has a history or a cached transcript
+    /// (i.e. the per-process session cache is warm). Intended only for
+    /// cold-boot priming.
+    pub fn seed_resume_from_messages(
+        &mut self,
+        messages: Vec<(String, String)>,
+        current_user_message: &str,
+    ) -> Result<()> {
+        if !self.history.is_empty() || self.cached_transcript_messages.is_some() {
+            return Ok(());
+        }
+        let mut prior = messages;
+        if let Some(last) = prior.last() {
+            if last.0 == "user" && last.1.trim() == current_user_message.trim() {
+                prior.pop();
+            }
+        }
+        if prior.is_empty() {
+            return Ok(());
+        }
+
+        // Build the system prompt fresh — there's no persisted prefix
+        // to preserve here, and learned-context decoration is skipped
+        // intentionally so this fallback path stays synchronous and
+        // doesn't fan out to the memory store on every cold-boot turn.
+        let learned = crate::openhuman::agent::prompts::LearnedContextData::default();
+        let system_prompt = self.build_system_prompt(learned)?;
+
+        let mut cached: Vec<crate::openhuman::providers::ChatMessage> =
+            Vec::with_capacity(prior.len() + 1);
+        cached.push(crate::openhuman::providers::ChatMessage::system(system_prompt));
+        for (role, content) in prior {
+            let chat = match role.as_str() {
+                "user" => crate::openhuman::providers::ChatMessage::user(content),
+                "agent" | "assistant" => {
+                    crate::openhuman::providers::ChatMessage::assistant(content)
+                }
+                // Fall back to user role for unknown senders rather than
+                // dropping the message — losing context is worse than
+                // mislabelling a system/tool message.
+                _ => crate::openhuman::providers::ChatMessage::user(content),
+            };
+            cached.push(chat);
+        }
+
+        log::info!(
+            "[agent] seed_resume_from_messages — primed cached transcript with {} prior messages",
+            cached.len() - 1
+        );
+        self.cached_transcript_messages = Some(cached);
+        Ok(())
     }
 
     /// Drain and return memory citations collected for the latest completed turn.

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -285,7 +285,9 @@ impl Agent {
 
         let mut cached: Vec<crate::openhuman::providers::ChatMessage> =
             Vec::with_capacity(prior.len() + 1);
-        cached.push(crate::openhuman::providers::ChatMessage::system(system_prompt));
+        cached.push(crate::openhuman::providers::ChatMessage::system(
+            system_prompt,
+        ));
         for (role, content) in prior {
             let chat = match role.as_str() {
                 "user" => crate::openhuman::providers::ChatMessage::user(content),

--- a/src/openhuman/agent/harness/session/tests.rs
+++ b/src/openhuman/agent/harness/session/tests.rs
@@ -761,10 +761,7 @@ fn seed_resume_from_messages_primes_cached_transcript() {
         ("agent".to_string(), "$80,000".to_string()),
         // Trailing user message that the caller is about to pass to
         // run_single — must be deduped from the cached prefix.
-        (
-            "user".to_string(),
-            "what did i just ask".to_string(),
-        ),
+        ("user".to_string(), "what did i just ask".to_string()),
     ];
     agent
         .seed_resume_from_messages(prior, "what did i just ask")
@@ -795,10 +792,7 @@ fn seed_resume_from_messages_is_noop_on_warm_agent() {
         crate::openhuman::providers::ChatMessage::user("hi"),
     ]);
     agent
-        .seed_resume_from_messages(
-            vec![("user".into(), "different".into())],
-            "different",
-        )
+        .seed_resume_from_messages(vec![("user".into(), "different".into())], "different")
         .expect("seed");
     let cached = agent
         .cached_transcript_messages

--- a/src/openhuman/agent/harness/session/tests.rs
+++ b/src/openhuman/agent/harness/session/tests.rs
@@ -684,3 +684,154 @@ async fn system_prompt_and_model_are_byte_stable_across_turns() {
         );
     }
 }
+
+/// Regression test for the per-thread transcript resume bug.
+///
+/// `set_agent_definition_name` is called by the web channel after
+/// `Agent::from_config_for_agent("orchestrator")` returns, to scope
+/// transcripts per thread (e.g. `"orchestrator_thread-6ad6d"`). Prior
+/// to the fix this only updated `agent_definition_name` and left
+/// `session_key` pointing at the builder-time name. Persist would
+/// then write `session_raw/<ts>_orchestrator.jsonl` while resume
+/// searched for `session_raw/<ts>_orchestrator_thread-6ad6d.jsonl`,
+/// so every cold-boot turn ran against an empty transcript and the
+/// LLM had no conversation history.
+///
+/// This test pins the contract: after `set_agent_definition_name`,
+/// `session_key`'s suffix matches the new (sanitised) name so the
+/// next persist+resume pair land on the same file.
+#[test]
+fn set_agent_definition_name_rewrites_session_key_suffix() {
+    let agent_first = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    let original_key = agent_first.session_key().to_string();
+    assert!(
+        original_key.ends_with("_orchestrator"),
+        "builder should seed session_key suffix from agent_definition_name; got {original_key}"
+    );
+
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    let prefix = agent
+        .session_key()
+        .split_once('_')
+        .map(|(p, _)| p.to_string())
+        .expect("session_key must have a `<ts>_<suffix>` shape");
+
+    agent.set_agent_definition_name("orchestrator_thread-6ad6d");
+
+    assert_eq!(agent.agent_definition_name(), "orchestrator_thread-6ad6d");
+    assert_eq!(
+        agent.session_key(),
+        format!("{prefix}_orchestrator_thread-6ad6d"),
+        "session_key suffix must track agent_definition_name so transcript persist + \
+         resume agree on the file path"
+    );
+}
+
+/// `set_agent_definition_name` must sanitise non-allowed characters in
+/// the new name (matching the builder's policy) so `session_key`
+/// never contains anything that would escape the `session_raw/`
+/// directory or break filename parsing on disk.
+#[test]
+fn set_agent_definition_name_sanitises_unsafe_characters() {
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    agent.set_agent_definition_name("orch/../../etc/passwd thread-6ad6d");
+    assert!(
+        !agent.session_key().contains('/'),
+        "session_key must never contain path separators; got {}",
+        agent.session_key()
+    );
+    assert!(
+        !agent.session_key().contains(' '),
+        "session_key must never contain whitespace; got {}",
+        agent.session_key()
+    );
+}
+
+/// Cold-boot resume from the conversation JSONL works even when no
+/// matching transcript file exists. The web channel calls
+/// `seed_resume_from_messages` on the cache-miss path so the agent
+/// sees prior conversation context immediately, instead of having to
+/// wait for a transcript to be persisted under the new
+/// thread-scoped name.
+#[test]
+fn seed_resume_from_messages_primes_cached_transcript() {
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    let prior = vec![
+        ("user".to_string(), "what is btc price".to_string()),
+        ("agent".to_string(), "$80,000".to_string()),
+        // Trailing user message that the caller is about to pass to
+        // run_single — must be deduped from the cached prefix.
+        (
+            "user".to_string(),
+            "what did i just ask".to_string(),
+        ),
+    ];
+    agent
+        .seed_resume_from_messages(prior, "what did i just ask")
+        .expect("seed");
+
+    let cached = agent
+        .cached_transcript_messages
+        .as_ref()
+        .expect("cache populated");
+    // [system, user(btc), agent(80k)] — trailing user was deduped.
+    assert_eq!(cached.len(), 3);
+    assert_eq!(cached[0].role, "system");
+    assert_eq!(cached[1].role, "user");
+    assert_eq!(cached[1].content, "what is btc price");
+    assert_eq!(cached[2].role, "assistant");
+    assert_eq!(cached[2].content, "$80,000");
+}
+
+/// `seed_resume_from_messages` must not stomp the existing context if
+/// the agent has already been warmed (in-process session cache hit).
+/// Otherwise the cache-miss branch in the web channel would erase
+/// real progress whenever the caller defensively invoked seeding.
+#[test]
+fn seed_resume_from_messages_is_noop_on_warm_agent() {
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    agent.cached_transcript_messages = Some(vec![
+        crate::openhuman::providers::ChatMessage::system("warm prefix"),
+        crate::openhuman::providers::ChatMessage::user("hi"),
+    ]);
+    agent
+        .seed_resume_from_messages(
+            vec![("user".into(), "different".into())],
+            "different",
+        )
+        .expect("seed");
+    let cached = agent
+        .cached_transcript_messages
+        .as_ref()
+        .expect("still populated");
+    assert_eq!(cached.len(), 2);
+    assert_eq!(cached[0].content, "warm prefix");
+}
+
+/// Trailing user message that does NOT match the current incoming
+/// message must be preserved — the dedup heuristic only fires on
+/// exact match because the conversation JSONL is the source of truth
+/// and may legitimately contain back-to-back user messages (e.g. the
+/// thread-7242c case where an interrupted turn left the prior user
+/// message un-replied).
+#[test]
+fn seed_resume_from_messages_preserves_unmatched_trailing_user() {
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    let prior = vec![
+        ("user".to_string(), "earlier question".to_string()),
+        ("agent".to_string(), "earlier answer".to_string()),
+        ("user".to_string(), "stranded follow-up".to_string()),
+    ];
+    agent
+        .seed_resume_from_messages(prior, "completely different new turn")
+        .expect("seed");
+    let cached = agent
+        .cached_transcript_messages
+        .as_ref()
+        .expect("cache populated");
+    // [system, user, agent, user] — trailing kept because it doesn't
+    // match the current turn's user input.
+    assert_eq!(cached.len(), 4);
+    assert_eq!(cached[3].role, "user");
+    assert_eq!(cached[3].content, "stranded follow-up");
+}

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -409,7 +409,7 @@ async fn run_chat_task(
         sessions.remove(&map_key)
     };
 
-    let mut agent = match prior {
+    let (mut agent, was_built_fresh) = match prior {
         Some(entry)
             if entry.model_override == model_override
                 && entry.temperature == temperature
@@ -421,7 +421,7 @@ async fn run_chat_task(
                 client_id,
                 thread_id
             );
-            entry.agent
+            (entry.agent, false)
         }
         Some(prior_entry) => {
             log::info!(
@@ -431,22 +431,74 @@ async fn run_chat_task(
                 client_id,
                 thread_id
             );
+            (
+                build_session_agent(
+                    &config,
+                    client_id,
+                    thread_id,
+                    model_override.clone(),
+                    temperature,
+                )?,
+                true,
+            )
+        }
+        None => (
             build_session_agent(
                 &config,
                 client_id,
                 thread_id,
                 model_override.clone(),
                 temperature,
-            )?
-        }
-        None => build_session_agent(
-            &config,
-            client_id,
-            thread_id,
-            model_override.clone(),
-            temperature,
-        )?,
+            )?,
+            true,
+        ),
     };
+
+    // Cold-boot resume from the conversation JSONL.
+    //
+    // The agent's `try_load_session_transcript` mechanism only fires
+    // when a transcript file matches `agent_definition_name` — it
+    // misses on cold boot if the previous process wrote transcripts
+    // under a different name (the `set_agent_definition_name` /
+    // `session_key` rename bug fixed in this PR). The conversation
+    // JSONL store is the authoritative per-thread message log either
+    // way, so seed from it whenever we just built a fresh agent. The
+    // method is a no-op if the agent already has a cached transcript
+    // or non-empty history, so this is cheap on the warm path too.
+    if was_built_fresh {
+        match crate::openhuman::memory::conversations::get_messages(
+            config.workspace_dir.clone(),
+            thread_id,
+        ) {
+            Ok(prior_messages) if !prior_messages.is_empty() => {
+                let pairs: Vec<(String, String)> = prior_messages
+                    .into_iter()
+                    .map(|m| (m.sender, m.content))
+                    .collect();
+                if let Err(err) = agent.seed_resume_from_messages(pairs, message) {
+                    log::warn!(
+                        "[web-channel] failed to seed agent resume from conversation log \
+                         thread={} err={}",
+                        thread_id,
+                        err
+                    );
+                }
+            }
+            Ok(_) => {
+                log::debug!(
+                    "[web-channel] no prior messages to seed for thread={} — first turn",
+                    thread_id
+                );
+            }
+            Err(err) => {
+                log::warn!(
+                    "[web-channel] failed to read conversation log for resume thread={} err={}",
+                    thread_id,
+                    err
+                );
+            }
+        }
+    }
 
     // Wire up a real-time progress channel so tool calls, iterations,
     // and sub-agent events are emitted to the web channel as they happen

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -15,6 +15,7 @@ use crate::openhuman::config::Config;
 use crate::openhuman::prompt_injection::{
     enforce_prompt_input, PromptEnforcementAction, PromptEnforcementContext,
 };
+use crate::openhuman::threads::turn_state::{TurnStateMirror, TurnStateStore};
 use crate::rpc::RpcOutcome;
 
 use super::presentation;
@@ -452,11 +453,13 @@ async fn run_chat_task(
     // (instead of retroactively after the loop finishes).
     let (progress_tx, progress_rx) = tokio::sync::mpsc::channel(64);
     agent.set_on_progress(Some(progress_tx));
+    let turn_state_store = TurnStateStore::new(config.workspace_dir.clone());
     spawn_progress_bridge(
         progress_rx,
         client_id.to_string(),
         thread_id.to_string(),
         request_id.to_string(),
+        turn_state_store,
     );
 
     // Make `thread_id` ambient for any outbound provider call inside
@@ -524,6 +527,7 @@ fn spawn_progress_bridge(
     client_id: String,
     thread_id: String,
     request_id: String,
+    turn_state_store: TurnStateStore,
 ) {
     use crate::openhuman::agent::progress::AgentProgress;
 
@@ -536,8 +540,11 @@ fn spawn_progress_bridge(
         );
         let mut round: u32 = 0;
         let mut events_seen: u64 = 0;
+        let mut turn_state =
+            TurnStateMirror::new(turn_state_store, thread_id.clone(), request_id.clone());
         while let Some(event) = rx.recv().await {
             events_seen += 1;
+            turn_state.observe(&event);
             // Per-variant trace so branch decisions are visible in
             // terminal output when correlating progress over Socket.IO.
             // Kept at trace-level for high-volume deltas and debug for
@@ -935,6 +942,7 @@ fn spawn_progress_bridge(
                 }
             }
         }
+        turn_state.finish();
         log::debug!(
             "[web_channel][bridge] exit client_id={} thread_id={} request_id={} round={} events_seen={}",
             client_id,

--- a/src/openhuman/threads/mod.rs
+++ b/src/openhuman/threads/mod.rs
@@ -7,6 +7,7 @@
 pub mod ops;
 pub mod schemas;
 pub mod title;
+pub mod turn_state;
 
 pub use schemas::{
     all_controller_schemas as all_threads_controller_schemas,

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -434,6 +434,12 @@ pub async fn thread_delete(
     let dir = workspace_dir().await?;
     let deleted = conversations::ConversationStore::new(dir.clone())
         .delete_thread(&request.thread_id, &request.deleted_at)?;
+    // Invalidate the in-process web-channel session BEFORE the
+    // turn-state cleanup. The snapshot deletion is fallible and
+    // returns early on error; if invalidation ran after, an active
+    // session for the now-deleted thread could linger and try to
+    // append to a thread index row that no longer exists.
+    web_channel::invalidate_thread_sessions(&request.thread_id).await;
     // Drop any persisted in-flight turn snapshot for this thread —
     // otherwise `threads_turn_state_list` keeps surfacing it (as
     // `Interrupted` on next restart) for a thread that no longer
@@ -448,7 +454,6 @@ pub async fn thread_delete(
             request.thread_id
         )
     })?;
-    web_channel::invalidate_thread_sessions(&request.thread_id).await;
     Ok(envelope(
         DeleteConversationThreadResponse { deleted },
         None,

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -464,9 +464,7 @@ pub async fn threads_purge(
     match turn_state::store::list(dir.clone()) {
         Ok(snapshots) => {
             for snapshot in snapshots {
-                if let Err(err) =
-                    turn_state::store::delete(dir.clone(), &snapshot.thread_id)
-                {
+                if let Err(err) = turn_state::store::delete(dir.clone(), &snapshot.thread_id) {
                     log::warn!(
                         "[threads:ops] failed to clear orphan turn snapshot for {}: {err}",
                         snapshot.thread_id
@@ -474,9 +472,9 @@ pub async fn threads_purge(
                 }
             }
         }
-        Err(err) => log::warn!(
-            "[threads:ops] failed to enumerate turn snapshots during purge: {err}"
-        ),
+        Err(err) => {
+            log::warn!("[threads:ops] failed to enumerate turn snapshots during purge: {err}")
+        }
     }
     Ok(envelope(
         PurgeConversationThreadsResponse {

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -437,13 +437,17 @@ pub async fn thread_delete(
     // Drop any persisted in-flight turn snapshot for this thread —
     // otherwise `threads_turn_state_list` keeps surfacing it (as
     // `Interrupted` on next restart) for a thread that no longer
-    // exists. Best-effort: a missing snapshot is the common case.
-    if let Err(err) = turn_state::store::delete(dir, &request.thread_id) {
-        log::warn!(
-            "[threads:ops] failed to clear turn snapshot for deleted thread {}: {err}",
+    // exists. Failure here is surfaced as an RPC error so callers
+    // can't observe a thread "deleted" while its snapshot (which
+    // mirrors conversation-derived state) remains on disk; the
+    // thread row itself is already gone at this point so the caller
+    // sees a partial failure they can act on instead of silent drift.
+    turn_state::store::delete(dir, &request.thread_id).map_err(|err| {
+        format!(
+            "thread {} deleted but turn-snapshot cleanup failed: {err}",
             request.thread_id
-        );
-    }
+        )
+    })?;
     web_channel::invalidate_thread_sessions(&request.thread_id).await;
     Ok(envelope(
         DeleteConversationThreadResponse { deleted },
@@ -460,21 +464,19 @@ pub async fn threads_purge(
     let stats = conversations::purge_threads(dir.clone())?;
     // Threads are gone, so any orphan turn snapshots can never be
     // reattached to a live thread. Wipe them in the same call so
-    // `turn_state_list` returns an empty set after a purge.
-    match turn_state::store::list(dir.clone()) {
-        Ok(snapshots) => {
-            for snapshot in snapshots {
-                if let Err(err) = turn_state::store::delete(dir.clone(), &snapshot.thread_id) {
-                    log::warn!(
-                        "[threads:ops] failed to clear orphan turn snapshot for {}: {err}",
-                        snapshot.thread_id
-                    );
-                }
-            }
-        }
-        Err(err) => {
-            log::warn!("[threads:ops] failed to enumerate turn snapshots during purge: {err}")
-        }
+    // `turn_state_list` returns an empty set after a purge. Failures
+    // are surfaced as RPC errors — this is a destructive cleanup
+    // path, callers should not see "purged" while snapshots remain.
+    let snapshots = turn_state::store::list(dir.clone()).map_err(|err| {
+        format!("threads purged but turn-snapshot enumeration failed: {err}")
+    })?;
+    for snapshot in snapshots {
+        turn_state::store::delete(dir.clone(), &snapshot.thread_id).map_err(|err| {
+            format!(
+                "threads purged but turn-snapshot cleanup failed for {}: {err}",
+                snapshot.thread_id
+            )
+        })?;
     }
     Ok(envelope(
         PurgeConversationThreadsResponse {

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -16,6 +16,10 @@ use crate::openhuman::memory::{
     UpsertConversationThreadRequest,
 };
 use crate::openhuman::providers::{self, ProviderRuntimeOptions};
+use crate::openhuman::threads::turn_state::{
+    self, ClearTurnStateRequest, ClearTurnStateResponse, GetTurnStateRequest, GetTurnStateResponse,
+    ListTurnStatesResponse,
+};
 use crate::openhuman::threads::title::{
     build_title_prompt, collapse_whitespace, is_auto_generated_thread_title,
     sanitize_generated_title, title_log_fingerprint, THREAD_TITLE_LOG_PREFIX,
@@ -453,6 +457,45 @@ pub async fn threads_purge(
         None,
         None,
     ))
+}
+
+/// Returns the persisted in-flight turn snapshot for a thread, if any.
+pub async fn turn_state_get(
+    request: GetTurnStateRequest,
+) -> Result<RpcOutcome<ApiEnvelope<GetTurnStateResponse>>, String> {
+    let dir = workspace_dir().await?;
+    let turn_state = turn_state::store::get(dir, &request.thread_id)?;
+    let present = turn_state.is_some();
+    Ok(envelope(
+        GetTurnStateResponse { turn_state },
+        Some(counts([("present", usize::from(present))])),
+        None,
+    ))
+}
+
+/// Lists every persisted turn snapshot — used by the UI on cold boot to
+/// surface interrupted turns from a previous process.
+pub async fn turn_state_list(
+    _request: EmptyRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ListTurnStatesResponse>>, String> {
+    let dir = workspace_dir().await?;
+    let turn_states = turn_state::store::list(dir)?;
+    let count = turn_states.len();
+    Ok(envelope(
+        ListTurnStatesResponse { turn_states, count },
+        Some(counts([("num_turn_states", count)])),
+        None,
+    ))
+}
+
+/// Clears the persisted turn snapshot for a thread (e.g. after the user
+/// dismisses an "interrupted" banner).
+pub async fn turn_state_clear(
+    request: ClearTurnStateRequest,
+) -> Result<RpcOutcome<ApiEnvelope<ClearTurnStateResponse>>, String> {
+    let dir = workspace_dir().await?;
+    let cleared = turn_state::store::delete(dir, &request.thread_id)?;
+    Ok(envelope(ClearTurnStateResponse { cleared }, None, None))
 }
 
 #[cfg(test)]

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -469,19 +469,13 @@ pub async fn threads_purge(
     let stats = conversations::purge_threads(dir.clone())?;
     // Threads are gone, so any orphan turn snapshots can never be
     // reattached to a live thread. Wipe them in the same call so
-    // `turn_state_list` returns an empty set after a purge. Failures
-    // are surfaced as RPC errors — this is a destructive cleanup
-    // path, callers should not see "purged" while snapshots remain.
-    let snapshots = turn_state::store::list(dir.clone())
-        .map_err(|err| format!("threads purged but turn-snapshot enumeration failed: {err}"))?;
-    for snapshot in snapshots {
-        turn_state::store::delete(dir.clone(), &snapshot.thread_id).map_err(|err| {
-            format!(
-                "threads purged but turn-snapshot cleanup failed for {}: {err}",
-                snapshot.thread_id
-            )
-        })?;
-    }
+    // `turn_state_list` returns an empty set after a purge. Use the
+    // parse-independent `clear_all` so corrupted / half-written
+    // snapshot files (which `list()` would warn-and-skip) are also
+    // removed — a destructive cleanup must not leave behind anything
+    // it failed to deserialize. Failures surface as RPC errors.
+    turn_state::store::clear_all(dir.clone())
+        .map_err(|err| format!("threads purged but turn-snapshot cleanup failed: {err}"))?;
     Ok(envelope(
         PurgeConversationThreadsResponse {
             messages_deleted: stats.message_count,

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -467,9 +467,8 @@ pub async fn threads_purge(
     // `turn_state_list` returns an empty set after a purge. Failures
     // are surfaced as RPC errors — this is a destructive cleanup
     // path, callers should not see "purged" while snapshots remain.
-    let snapshots = turn_state::store::list(dir.clone()).map_err(|err| {
-        format!("threads purged but turn-snapshot enumeration failed: {err}")
-    })?;
+    let snapshots = turn_state::store::list(dir.clone())
+        .map_err(|err| format!("threads purged but turn-snapshot enumeration failed: {err}"))?;
     for snapshot in snapshots {
         turn_state::store::delete(dir.clone(), &snapshot.thread_id).map_err(|err| {
             format!(

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -432,8 +432,18 @@ pub async fn thread_delete(
     request: DeleteConversationThreadRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<DeleteConversationThreadResponse>>, String> {
     let dir = workspace_dir().await?;
-    let deleted = conversations::ConversationStore::new(dir)
+    let deleted = conversations::ConversationStore::new(dir.clone())
         .delete_thread(&request.thread_id, &request.deleted_at)?;
+    // Drop any persisted in-flight turn snapshot for this thread —
+    // otherwise `threads_turn_state_list` keeps surfacing it (as
+    // `Interrupted` on next restart) for a thread that no longer
+    // exists. Best-effort: a missing snapshot is the common case.
+    if let Err(err) = turn_state::store::delete(dir, &request.thread_id) {
+        log::warn!(
+            "[threads:ops] failed to clear turn snapshot for deleted thread {}: {err}",
+            request.thread_id
+        );
+    }
     web_channel::invalidate_thread_sessions(&request.thread_id).await;
     Ok(envelope(
         DeleteConversationThreadResponse { deleted },
@@ -447,7 +457,27 @@ pub async fn threads_purge(
     _request: EmptyRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<PurgeConversationThreadsResponse>>, String> {
     let dir = workspace_dir().await?;
-    let stats = conversations::purge_threads(dir)?;
+    let stats = conversations::purge_threads(dir.clone())?;
+    // Threads are gone, so any orphan turn snapshots can never be
+    // reattached to a live thread. Wipe them in the same call so
+    // `turn_state_list` returns an empty set after a purge.
+    match turn_state::store::list(dir.clone()) {
+        Ok(snapshots) => {
+            for snapshot in snapshots {
+                if let Err(err) =
+                    turn_state::store::delete(dir.clone(), &snapshot.thread_id)
+                {
+                    log::warn!(
+                        "[threads:ops] failed to clear orphan turn snapshot for {}: {err}",
+                        snapshot.thread_id
+                    );
+                }
+            }
+        }
+        Err(err) => log::warn!(
+            "[threads:ops] failed to enumerate turn snapshots during purge: {err}"
+        ),
+    }
     Ok(envelope(
         PurgeConversationThreadsResponse {
             messages_deleted: stats.message_count,

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -16,14 +16,14 @@ use crate::openhuman::memory::{
     UpsertConversationThreadRequest,
 };
 use crate::openhuman::providers::{self, ProviderRuntimeOptions};
-use crate::openhuman::threads::turn_state::{
-    self, ClearTurnStateRequest, ClearTurnStateResponse, GetTurnStateRequest, GetTurnStateResponse,
-    ListTurnStatesResponse,
-};
 use crate::openhuman::threads::title::{
     build_title_prompt, collapse_whitespace, is_auto_generated_thread_title,
     sanitize_generated_title, title_log_fingerprint, THREAD_TITLE_LOG_PREFIX,
     THREAD_TITLE_MODEL_HINT, THREAD_TITLE_SYSTEM_PROMPT,
+};
+use crate::openhuman::threads::turn_state::{
+    self, ClearTurnStateRequest, ClearTurnStateResponse, GetTurnStateRequest, GetTurnStateResponse,
+    ListTurnStatesResponse,
 };
 use crate::rpc::RpcOutcome;
 use serde::Serialize;

--- a/src/openhuman/threads/schemas.rs
+++ b/src/openhuman/threads/schemas.rs
@@ -11,6 +11,7 @@ use crate::openhuman::memory::{
     UpdateConversationMessageRequest, UpdateConversationThreadLabelsRequest,
     UpsertConversationThreadRequest,
 };
+use crate::openhuman::threads::turn_state::{ClearTurnStateRequest, GetTurnStateRequest};
 
 use super::ops;
 
@@ -26,6 +27,9 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("message_update"),
         schemas("delete"),
         schemas("purge"),
+        schemas("turn_state_get"),
+        schemas("turn_state_list"),
+        schemas("turn_state_clear"),
     ]
 }
 
@@ -70,6 +74,18 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("purge"),
             handler: handle_purge,
+        },
+        RegisteredController {
+            schema: schemas("turn_state_get"),
+            handler: handle_turn_state_get,
+        },
+        RegisteredController {
+            schema: schemas("turn_state_list"),
+            handler: handle_turn_state_list,
+        },
+        RegisteredController {
+            schema: schemas("turn_state_clear"),
+            handler: handle_turn_state_clear,
         },
     ]
 }
@@ -304,6 +320,53 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 required: true,
             }],
         },
+        "turn_state_get" => ControllerSchema {
+            namespace: "threads",
+            function: "turn_state_get",
+            description: "Fetch the persisted in-flight turn snapshot for a thread, if any.",
+            inputs: vec![FieldSchema {
+                name: "thread_id",
+                ty: TypeSchema::String,
+                comment: "Thread identifier.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope wrapping the turn state (may be null).",
+                required: true,
+            }],
+        },
+        "turn_state_list" => ControllerSchema {
+            namespace: "threads",
+            function: "turn_state_list",
+            description:
+                "List every persisted turn snapshot — used to surface interrupted turns on cold boot.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope with the list of turn snapshots and a count.",
+                required: true,
+            }],
+        },
+        "turn_state_clear" => ControllerSchema {
+            namespace: "threads",
+            function: "turn_state_clear",
+            description: "Delete the persisted turn snapshot for a thread.",
+            inputs: vec![FieldSchema {
+                name: "thread_id",
+                ty: TypeSchema::String,
+                comment: "Thread identifier.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Envelope reporting whether a snapshot was removed.",
+                required: true,
+            }],
+        },
         _other => ControllerSchema {
             namespace: "threads",
             function: "unknown",
@@ -383,6 +446,24 @@ fn handle_delete(params: Map<String, Value>) -> ControllerFuture {
 
 fn handle_purge(_params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move { to_json(ops::threads_purge(EmptyRequest {}).await?) })
+}
+
+fn handle_turn_state_get(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let p = parse::<GetTurnStateRequest>(params)?;
+        to_json(ops::turn_state_get(p).await?)
+    })
+}
+
+fn handle_turn_state_list(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { to_json(ops::turn_state_list(EmptyRequest {}).await?) })
+}
+
+fn handle_turn_state_clear(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let p = parse::<ClearTurnStateRequest>(params)?;
+        to_json(ops::turn_state_clear(p).await?)
+    })
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/openhuman/threads/schemas_tests.rs
+++ b/src/openhuman/threads/schemas_tests.rs
@@ -12,6 +12,9 @@ const ALL_FUNCTIONS: &[&str] = &[
     "message_update",
     "delete",
     "purge",
+    "turn_state_get",
+    "turn_state_list",
+    "turn_state_clear",
 ];
 
 #[test]

--- a/src/openhuman/threads/turn_state/mirror.rs
+++ b/src/openhuman/threads/turn_state/mirror.rs
@@ -85,17 +85,34 @@ impl TurnStateMirror {
                 self.state.lifecycle = TurnLifecycle::Streaming;
                 self.state.phase = Some(TurnPhase::ToolUse);
                 self.state.active_tool = Some(tool_name.clone());
-                self.state.tool_timeline.push(ToolTimelineEntry {
-                    id: call_id.clone(),
-                    name: tool_name.clone(),
-                    round: *iteration,
-                    status: ToolTimelineStatus::Running,
-                    args_buffer: None,
-                    display_name: None,
-                    detail: None,
-                    source_tool_name: None,
-                    subagent: None,
-                });
+                // `ToolCallArgsDelta` may have already created a
+                // synthetic placeholder for this `call_id` before the
+                // start event arrived. Reuse it (filling in `name` /
+                // `round`) so the timeline doesn't end up with two
+                // rows for one tool call.
+                if let Some(existing) = self
+                    .state
+                    .tool_timeline
+                    .iter_mut()
+                    .rev()
+                    .find(|e| e.id == *call_id)
+                {
+                    existing.name = tool_name.clone();
+                    existing.round = *iteration;
+                    existing.status = ToolTimelineStatus::Running;
+                } else {
+                    self.state.tool_timeline.push(ToolTimelineEntry {
+                        id: call_id.clone(),
+                        name: tool_name.clone(),
+                        round: *iteration,
+                        status: ToolTimelineStatus::Running,
+                        args_buffer: None,
+                        display_name: None,
+                        detail: None,
+                        source_tool_name: None,
+                        subagent: None,
+                    });
+                }
                 self.flush();
                 true
             }

--- a/src/openhuman/threads/turn_state/mirror.rs
+++ b/src/openhuman/threads/turn_state/mirror.rs
@@ -1,0 +1,347 @@
+//! Translate [`AgentProgress`] events into [`TurnState`] mutations and
+//! flush snapshots to disk at iteration / tool boundaries.
+//!
+//! Used by the web-channel progress bridge to keep an authoritative,
+//! restart-survivable record of the in-flight turn alongside the live
+//! socket emissions. High-frequency deltas (text, thinking, tool args)
+//! mutate the in-memory snapshot but do not trigger a disk flush —
+//! anything more granular than an iteration / tool boundary would
+//! thrash the filesystem under streaming load.
+//!
+//! On terminal completion the snapshot file is deleted. If the bridge
+//! exits without ever observing [`AgentProgress::TurnCompleted`] (for
+//! example because the agent loop returned an error), the snapshot is
+//! flagged [`TurnLifecycle::Interrupted`] and persisted so the UI can
+//! surface a retry affordance.
+
+use crate::openhuman::agent::progress::AgentProgress;
+
+use super::store::TurnStateStore;
+use super::types::{
+    SubagentActivity, SubagentToolCall, ToolTimelineEntry, ToolTimelineStatus, TurnLifecycle,
+    TurnPhase, TurnState,
+};
+
+const MIRROR_LOG_PREFIX: &str = "[threads:turn_state:mirror]";
+
+/// In-process cursor that keeps the authoritative [`TurnState`] in sync
+/// with the agent loop and writes it through to a [`TurnStateStore`].
+pub struct TurnStateMirror {
+    store: TurnStateStore,
+    state: TurnState,
+    /// Set to `true` once we observe `TurnCompleted` so `finish` knows
+    /// to delete the snapshot rather than mark it interrupted.
+    turn_completed: bool,
+}
+
+impl TurnStateMirror {
+    /// Build a mirror primed with a `Started` snapshot and immediately
+    /// flush so a crash before the first agent event still leaves a
+    /// recoverable record.
+    pub fn new(
+        store: TurnStateStore,
+        thread_id: impl Into<String>,
+        request_id: impl Into<String>,
+    ) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        let state = TurnState::started(thread_id, request_id, 0, now);
+        let mut mirror = Self {
+            store,
+            state,
+            turn_completed: false,
+        };
+        mirror.flush();
+        mirror
+    }
+
+    /// Apply one progress event to the in-memory snapshot. Returns `true`
+    /// if the event triggered a disk flush.
+    pub fn observe(&mut self, event: &AgentProgress) -> bool {
+        self.state.updated_at = chrono::Utc::now().to_rfc3339();
+        match event {
+            AgentProgress::TurnStarted => {
+                self.state.lifecycle = TurnLifecycle::Started;
+                self.flush();
+                true
+            }
+            AgentProgress::IterationStarted {
+                iteration,
+                max_iterations,
+            } => {
+                self.state.iteration = *iteration;
+                self.state.max_iterations = *max_iterations;
+                self.state.phase = Some(TurnPhase::Thinking);
+                self.state.lifecycle = TurnLifecycle::Streaming;
+                self.state.active_tool = None;
+                self.flush();
+                true
+            }
+            AgentProgress::ToolCallStarted {
+                call_id,
+                tool_name,
+                iteration,
+                ..
+            } => {
+                self.state.lifecycle = TurnLifecycle::Streaming;
+                self.state.phase = Some(TurnPhase::ToolUse);
+                self.state.active_tool = Some(tool_name.clone());
+                self.state.tool_timeline.push(ToolTimelineEntry {
+                    id: call_id.clone(),
+                    name: tool_name.clone(),
+                    round: *iteration,
+                    status: ToolTimelineStatus::Running,
+                    args_buffer: None,
+                    display_name: None,
+                    detail: None,
+                    source_tool_name: None,
+                    subagent: None,
+                });
+                self.flush();
+                true
+            }
+            AgentProgress::ToolCallCompleted {
+                call_id,
+                success,
+                ..
+            } => {
+                if let Some(entry) = self
+                    .state
+                    .tool_timeline
+                    .iter_mut()
+                    .rev()
+                    .find(|e| e.id == *call_id)
+                {
+                    entry.status = if *success {
+                        ToolTimelineStatus::Success
+                    } else {
+                        ToolTimelineStatus::Error
+                    };
+                }
+                if self.state.active_tool.is_some() {
+                    self.state.active_tool = None;
+                }
+                self.state.phase = Some(TurnPhase::Thinking);
+                self.flush();
+                true
+            }
+            AgentProgress::SubagentSpawned {
+                agent_id,
+                task_id,
+                mode,
+                dedicated_thread,
+                ..
+            } => {
+                self.state.phase = Some(TurnPhase::Subagent);
+                self.state.active_subagent = Some(agent_id.clone());
+                self.state.tool_timeline.push(ToolTimelineEntry {
+                    id: format!("subagent:{task_id}"),
+                    name: format!("subagent:{agent_id}"),
+                    round: self.state.iteration,
+                    status: ToolTimelineStatus::Running,
+                    args_buffer: None,
+                    display_name: Some(agent_id.clone()),
+                    detail: None,
+                    source_tool_name: Some("spawn_subagent".to_string()),
+                    subagent: Some(SubagentActivity {
+                        task_id: task_id.clone(),
+                        agent_id: agent_id.clone(),
+                        mode: Some(mode.clone()),
+                        dedicated_thread: Some(*dedicated_thread),
+                        child_iteration: None,
+                        child_max_iterations: None,
+                        iterations: None,
+                        elapsed_ms: None,
+                        output_chars: None,
+                        tool_calls: Vec::new(),
+                    }),
+                });
+                self.flush();
+                true
+            }
+            AgentProgress::SubagentCompleted {
+                task_id,
+                elapsed_ms,
+                iterations,
+                output_chars,
+                ..
+            } => {
+                if let Some(entry) = self.find_subagent_entry_mut(task_id) {
+                    entry.status = ToolTimelineStatus::Success;
+                    if let Some(activity) = entry.subagent.as_mut() {
+                        activity.elapsed_ms = Some(*elapsed_ms);
+                        activity.iterations = Some(*iterations);
+                        activity.output_chars = Some(*output_chars);
+                    }
+                }
+                self.state.active_subagent = None;
+                self.state.phase = Some(TurnPhase::Thinking);
+                self.flush();
+                true
+            }
+            AgentProgress::SubagentFailed { task_id, .. } => {
+                if let Some(entry) = self.find_subagent_entry_mut(task_id) {
+                    entry.status = ToolTimelineStatus::Error;
+                }
+                self.state.active_subagent = None;
+                self.state.phase = Some(TurnPhase::Thinking);
+                self.flush();
+                true
+            }
+            AgentProgress::SubagentIterationStarted {
+                task_id,
+                iteration,
+                max_iterations,
+                ..
+            } => {
+                if let Some(entry) = self.find_subagent_entry_mut(task_id) {
+                    if let Some(activity) = entry.subagent.as_mut() {
+                        activity.child_iteration = Some(*iteration);
+                        activity.child_max_iterations = Some(*max_iterations);
+                    }
+                }
+                false
+            }
+            AgentProgress::SubagentToolCallStarted {
+                task_id,
+                call_id,
+                tool_name,
+                iteration,
+                ..
+            } => {
+                if let Some(entry) = self.find_subagent_entry_mut(task_id) {
+                    if let Some(activity) = entry.subagent.as_mut() {
+                        activity.tool_calls.push(SubagentToolCall {
+                            call_id: call_id.clone(),
+                            tool_name: tool_name.clone(),
+                            status: ToolTimelineStatus::Running,
+                            iteration: Some(*iteration),
+                            elapsed_ms: None,
+                            output_chars: None,
+                        });
+                    }
+                }
+                false
+            }
+            AgentProgress::SubagentToolCallCompleted {
+                task_id,
+                call_id,
+                success,
+                output_chars,
+                elapsed_ms,
+                ..
+            } => {
+                if let Some(entry) = self.find_subagent_entry_mut(task_id) {
+                    if let Some(activity) = entry.subagent.as_mut() {
+                        if let Some(call) = activity
+                            .tool_calls
+                            .iter_mut()
+                            .rev()
+                            .find(|c| c.call_id == *call_id)
+                        {
+                            call.status = if *success {
+                                ToolTimelineStatus::Success
+                            } else {
+                                ToolTimelineStatus::Error
+                            };
+                            call.elapsed_ms = Some(*elapsed_ms);
+                            call.output_chars = Some(*output_chars);
+                        }
+                    }
+                }
+                false
+            }
+            AgentProgress::TextDelta { delta, .. } => {
+                self.state.streaming_text.push_str(delta);
+                false
+            }
+            AgentProgress::ThinkingDelta { delta, .. } => {
+                self.state.thinking.push_str(delta);
+                false
+            }
+            AgentProgress::ToolCallArgsDelta {
+                call_id,
+                tool_name,
+                delta,
+                ..
+            } => {
+                if let Some(entry) = self
+                    .state
+                    .tool_timeline
+                    .iter_mut()
+                    .rev()
+                    .find(|e| e.id == *call_id)
+                {
+                    let buffer = entry.args_buffer.get_or_insert_with(String::new);
+                    buffer.push_str(delta);
+                } else {
+                    // No matching entry yet — `ToolCallArgsDelta` may
+                    // arrive before `ToolCallStarted` so synthesise a
+                    // placeholder we can update once the start event lands.
+                    self.state.tool_timeline.push(ToolTimelineEntry {
+                        id: call_id.clone(),
+                        name: tool_name.clone(),
+                        round: self.state.iteration,
+                        status: ToolTimelineStatus::Running,
+                        args_buffer: Some(delta.clone()),
+                        display_name: None,
+                        detail: None,
+                        source_tool_name: None,
+                        subagent: None,
+                    });
+                }
+                false
+            }
+            AgentProgress::TurnCompleted { .. } => {
+                self.turn_completed = true;
+                if let Err(err) = self.store.delete(&self.state.thread_id) {
+                    log::warn!(
+                        "{MIRROR_LOG_PREFIX} failed to delete snapshot for thread={}: {err}",
+                        self.state.thread_id
+                    );
+                }
+                true
+            }
+        }
+    }
+
+    /// Mark the turn as `Interrupted` on the in-memory snapshot and
+    /// flush. Called when the bridge exits without a `TurnCompleted`
+    /// event (i.e. the agent loop errored out).
+    pub fn finish(mut self) {
+        if self.turn_completed {
+            return;
+        }
+        self.state.lifecycle = TurnLifecycle::Interrupted;
+        self.state.active_tool = None;
+        self.state.active_subagent = None;
+        self.state.updated_at = chrono::Utc::now().to_rfc3339();
+        self.flush();
+    }
+
+    fn flush(&mut self) {
+        if let Err(err) = self.store.put(&self.state) {
+            log::warn!(
+                "{MIRROR_LOG_PREFIX} failed to persist snapshot for thread={}: {err}",
+                self.state.thread_id
+            );
+        }
+    }
+
+    fn find_subagent_entry_mut(&mut self, task_id: &str) -> Option<&mut ToolTimelineEntry> {
+        let needle = format!("subagent:{task_id}");
+        self.state
+            .tool_timeline
+            .iter_mut()
+            .rev()
+            .find(|entry| entry.id == needle)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> &TurnState {
+        &self.state
+    }
+}
+
+#[cfg(test)]
+#[path = "mirror_tests.rs"]
+mod tests;

--- a/src/openhuman/threads/turn_state/mirror.rs
+++ b/src/openhuman/threads/turn_state/mirror.rs
@@ -100,9 +100,7 @@ impl TurnStateMirror {
                 true
             }
             AgentProgress::ToolCallCompleted {
-                call_id,
-                success,
-                ..
+                call_id, success, ..
             } => {
                 if let Some(entry) = self
                     .state

--- a/src/openhuman/threads/turn_state/mirror_tests.rs
+++ b/src/openhuman/threads/turn_state/mirror_tests.rs
@@ -83,6 +83,48 @@ fn args_delta_arriving_before_start_creates_placeholder() {
 }
 
 #[test]
+fn tool_call_started_reuses_args_delta_placeholder_for_same_call_id() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::IterationStarted {
+        iteration: 1,
+        max_iterations: 25,
+    });
+    // Args delta arrives first, before ToolCallStarted.
+    m.observe(&AgentProgress::ToolCallArgsDelta {
+        call_id: "tc-7".into(),
+        tool_name: String::new(),
+        delta: "{\"q\":1".into(),
+        iteration: 1,
+    });
+    assert_eq!(m.snapshot().tool_timeline.len(), 1);
+
+    // Start lands — must mutate the placeholder, not append a duplicate.
+    m.observe(&AgentProgress::ToolCallStarted {
+        call_id: "tc-7".into(),
+        tool_name: "shell".into(),
+        arguments: serde_json::json!({}),
+        iteration: 1,
+    });
+    let timeline = &m.snapshot().tool_timeline;
+    assert_eq!(timeline.len(), 1, "placeholder must be reused, not duplicated");
+    assert_eq!(timeline[0].id, "tc-7");
+    assert_eq!(timeline[0].name, "shell");
+    assert_eq!(timeline[0].args_buffer.as_deref(), Some("{\"q\":1"));
+
+    // Completion still resolves the same row.
+    m.observe(&AgentProgress::ToolCallCompleted {
+        call_id: "tc-7".into(),
+        tool_name: "shell".into(),
+        success: true,
+        output_chars: 1,
+        elapsed_ms: 5,
+        iteration: 1,
+    });
+    assert_eq!(m.snapshot().tool_timeline.len(), 1);
+    assert_eq!(m.snapshot().tool_timeline[0].status, ToolTimelineStatus::Success);
+}
+
+#[test]
 fn text_delta_appends_streaming_text_without_flushing() {
     let (_d, mut m) = fresh("t");
     assert!(!m.observe(&AgentProgress::TextDelta {

--- a/src/openhuman/threads/turn_state/mirror_tests.rs
+++ b/src/openhuman/threads/turn_state/mirror_tests.rs
@@ -1,0 +1,170 @@
+//! Unit tests for [`super::TurnStateMirror`].
+
+use super::*;
+use crate::openhuman::agent::progress::AgentProgress;
+use tempfile::tempdir;
+
+fn fresh(thread_id: &str) -> (tempfile::TempDir, TurnStateMirror) {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let mirror = TurnStateMirror::new(store, thread_id, "req-1");
+    (dir, mirror)
+}
+
+#[test]
+fn iteration_start_promotes_lifecycle_and_records_round() {
+    let (_d, mut m) = fresh("t");
+    let flushed = m.observe(&AgentProgress::IterationStarted {
+        iteration: 2,
+        max_iterations: 25,
+    });
+    assert!(flushed);
+    let s = m.snapshot();
+    assert_eq!(s.lifecycle, TurnLifecycle::Streaming);
+    assert_eq!(s.iteration, 2);
+    assert_eq!(s.max_iterations, 25);
+    assert_eq!(s.phase, Some(TurnPhase::Thinking));
+}
+
+#[test]
+fn tool_call_start_and_complete_track_timeline() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::IterationStarted {
+        iteration: 1,
+        max_iterations: 25,
+    });
+    m.observe(&AgentProgress::ToolCallStarted {
+        call_id: "tc-1".into(),
+        tool_name: "shell".into(),
+        arguments: serde_json::json!({}),
+        iteration: 1,
+    });
+    let s = m.snapshot();
+    assert_eq!(s.tool_timeline.len(), 1);
+    assert_eq!(s.tool_timeline[0].id, "tc-1");
+    assert_eq!(s.tool_timeline[0].status, ToolTimelineStatus::Running);
+    assert_eq!(s.active_tool.as_deref(), Some("shell"));
+
+    m.observe(&AgentProgress::ToolCallCompleted {
+        call_id: "tc-1".into(),
+        tool_name: "shell".into(),
+        success: true,
+        output_chars: 12,
+        elapsed_ms: 50,
+        iteration: 1,
+    });
+    let s = m.snapshot();
+    assert_eq!(s.tool_timeline[0].status, ToolTimelineStatus::Success);
+    assert!(s.active_tool.is_none());
+}
+
+#[test]
+fn args_delta_arriving_before_start_creates_placeholder() {
+    let (_d, mut m) = fresh("t");
+    let flushed = m.observe(&AgentProgress::ToolCallArgsDelta {
+        call_id: "tc-9".into(),
+        tool_name: "shell".into(),
+        delta: "{".into(),
+        iteration: 1,
+    });
+    assert!(!flushed);
+    let s = m.snapshot();
+    assert_eq!(s.tool_timeline.len(), 1);
+    assert_eq!(s.tool_timeline[0].args_buffer.as_deref(), Some("{"));
+
+    m.observe(&AgentProgress::ToolCallArgsDelta {
+        call_id: "tc-9".into(),
+        tool_name: "shell".into(),
+        delta: "\"k\":1}".into(),
+        iteration: 1,
+    });
+    let s = m.snapshot();
+    assert_eq!(s.tool_timeline[0].args_buffer.as_deref(), Some("{\"k\":1}"));
+}
+
+#[test]
+fn text_delta_appends_streaming_text_without_flushing() {
+    let (_d, mut m) = fresh("t");
+    assert!(!m.observe(&AgentProgress::TextDelta {
+        delta: "hello ".into(),
+        iteration: 1,
+    }));
+    assert!(!m.observe(&AgentProgress::TextDelta {
+        delta: "world".into(),
+        iteration: 1,
+    }));
+    assert_eq!(m.snapshot().streaming_text, "hello world");
+}
+
+#[test]
+fn turn_completed_deletes_snapshot_and_finish_is_noop() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let mut mirror = TurnStateMirror::new(store.clone(), "t", "req-1");
+    mirror.observe(&AgentProgress::TurnCompleted { iterations: 3 });
+    assert!(store.get("t").expect("get").is_none());
+
+    // finish() must not resurrect the snapshot.
+    mirror.finish();
+    assert!(store.get("t").expect("get").is_none());
+}
+
+#[test]
+fn finish_without_turn_completed_marks_interrupted() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let mut mirror = TurnStateMirror::new(store.clone(), "t", "req-1");
+    mirror.observe(&AgentProgress::IterationStarted {
+        iteration: 1,
+        max_iterations: 25,
+    });
+    mirror.finish();
+
+    let loaded = store.get("t").expect("get").expect("present");
+    assert_eq!(loaded.lifecycle, TurnLifecycle::Interrupted);
+    assert!(loaded.active_tool.is_none());
+}
+
+#[test]
+fn subagent_lifecycle_records_and_clears_active() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::IterationStarted {
+        iteration: 1,
+        max_iterations: 25,
+    });
+    m.observe(&AgentProgress::SubagentSpawned {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        mode: "typed".into(),
+        dedicated_thread: false,
+        prompt_chars: 42,
+    });
+    let s = m.snapshot();
+    assert_eq!(s.active_subagent.as_deref(), Some("researcher"));
+    assert_eq!(s.tool_timeline.len(), 1);
+    assert_eq!(s.tool_timeline[0].id, "subagent:sub-1");
+
+    m.observe(&AgentProgress::SubagentToolCallStarted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "ctc-1".into(),
+        tool_name: "search".into(),
+        iteration: 1,
+    });
+    let activity = m.snapshot().tool_timeline[0]
+        .subagent
+        .as_ref()
+        .expect("activity");
+    assert_eq!(activity.tool_calls.len(), 1);
+
+    m.observe(&AgentProgress::SubagentCompleted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        elapsed_ms: 1234,
+        iterations: 2,
+        output_chars: 80,
+    });
+    let s = m.snapshot();
+    assert_eq!(s.tool_timeline[0].status, ToolTimelineStatus::Success);
+    assert!(s.active_subagent.is_none());
+}

--- a/src/openhuman/threads/turn_state/mirror_tests.rs
+++ b/src/openhuman/threads/turn_state/mirror_tests.rs
@@ -106,7 +106,11 @@ fn tool_call_started_reuses_args_delta_placeholder_for_same_call_id() {
         iteration: 1,
     });
     let timeline = &m.snapshot().tool_timeline;
-    assert_eq!(timeline.len(), 1, "placeholder must be reused, not duplicated");
+    assert_eq!(
+        timeline.len(),
+        1,
+        "placeholder must be reused, not duplicated"
+    );
     assert_eq!(timeline[0].id, "tc-7");
     assert_eq!(timeline[0].name, "shell");
     assert_eq!(timeline[0].args_buffer.as_deref(), Some("{\"q\":1"));
@@ -121,7 +125,10 @@ fn tool_call_started_reuses_args_delta_placeholder_for_same_call_id() {
         iteration: 1,
     });
     assert_eq!(m.snapshot().tool_timeline.len(), 1);
-    assert_eq!(m.snapshot().tool_timeline[0].status, ToolTimelineStatus::Success);
+    assert_eq!(
+        m.snapshot().tool_timeline[0].status,
+        ToolTimelineStatus::Success
+    );
 }
 
 #[test]

--- a/src/openhuman/threads/turn_state/mod.rs
+++ b/src/openhuman/threads/turn_state/mod.rs
@@ -1,0 +1,20 @@
+//! Persistent per-thread snapshots of in-flight agent turns.
+//!
+//! See the rustdoc on [`types::TurnState`] for the snapshot shape and
+//! [`store::TurnStateStore`] for the on-disk layout. The web-channel
+//! progress consumer writes to this store at iteration / tool
+//! boundaries; the [`crate::openhuman::threads`] RPC surface lets the
+//! UI rehydrate its `chatRuntimeSlice` after a navigation or restart.
+
+pub mod mirror;
+pub mod store;
+pub mod types;
+
+pub use mirror::TurnStateMirror;
+
+pub use store::TurnStateStore;
+pub use types::{
+    ClearTurnStateRequest, ClearTurnStateResponse, GetTurnStateRequest, GetTurnStateResponse,
+    ListTurnStatesResponse, SubagentActivity, SubagentToolCall, ToolTimelineEntry,
+    ToolTimelineStatus, TurnLifecycle, TurnPhase, TurnState,
+};

--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -59,10 +59,7 @@ impl TurnStateStore {
         // a directory for sync is not supported (Windows). The fsync
         // failure is logged but not fatal.
         if let Err(err) = sync_dir(&dir) {
-            log::warn!(
-                "{LOG_PREFIX} failed to fsync {}: {err}",
-                dir.display()
-            );
+            log::warn!("{LOG_PREFIX} failed to fsync {}: {err}", dir.display());
         }
         debug!(
             "{LOG_PREFIX} wrote snapshot thread={} lifecycle={:?} iter={}/{} timeline={}",

--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -43,8 +43,8 @@ impl TurnStateStore {
         let path = self.snapshot_path(&state.thread_id);
         let mut tmp = NamedTempFile::new_in(&dir)
             .map_err(|e| format!("create turn-state tempfile in {}: {e}", dir.display()))?;
-        let bytes = serde_json::to_vec_pretty(state)
-            .map_err(|e| format!("serialize turn state: {e}"))?;
+        let bytes =
+            serde_json::to_vec_pretty(state).map_err(|e| format!("serialize turn state: {e}"))?;
         tmp.write_all(&bytes)
             .map_err(|e| format!("write turn-state tempfile: {e}"))?;
         tmp.as_file()
@@ -96,11 +96,10 @@ impl TurnStateStore {
             return Ok(Vec::new());
         }
         let mut snapshots = Vec::new();
-        for entry in fs::read_dir(&dir)
-            .map_err(|e| format!("read turn-state dir {}: {e}", dir.display()))?
+        for entry in
+            fs::read_dir(&dir).map_err(|e| format!("read turn-state dir {}: {e}", dir.display()))?
         {
-            let entry =
-                entry.map_err(|e| format!("read turn-state entry: {e}"))?;
+            let entry = entry.map_err(|e| format!("read turn-state entry: {e}"))?;
             let path = entry.path();
             if path.extension().and_then(|s| s.to_str()) != Some(SNAPSHOT_EXTENSION) {
                 continue;
@@ -135,9 +134,7 @@ impl TurnStateStore {
             count += 1;
         }
         if count > 0 {
-            debug!(
-                "{LOG_PREFIX} marked {count} snapshots as interrupted on startup"
-            );
+            debug!("{LOG_PREFIX} marked {count} snapshots as interrupted on startup");
         }
         Ok(count)
     }
@@ -171,8 +168,7 @@ fn read_snapshot(path: &Path) -> Result<TurnState, String> {
     let mut buf = String::new();
     file.read_to_string(&mut buf)
         .map_err(|e| format!("read turn-state {}: {e}", path.display()))?;
-    serde_json::from_str(&buf)
-        .map_err(|e| format!("parse turn-state {}: {e}", path.display()))
+    serde_json::from_str(&buf).map_err(|e| format!("parse turn-state {}: {e}", path.display()))
 }
 
 // Free-function wrappers mirroring `memory::conversations::store` so callers
@@ -194,10 +190,7 @@ pub fn list(workspace_dir: PathBuf) -> Result<Vec<TurnState>, String> {
     TurnStateStore::new(workspace_dir).list()
 }
 
-pub fn mark_all_interrupted(
-    workspace_dir: PathBuf,
-    now_rfc3339: &str,
-) -> Result<usize, String> {
+pub fn mark_all_interrupted(workspace_dir: PathBuf, now_rfc3339: &str) -> Result<usize, String> {
     TurnStateStore::new(workspace_dir).mark_all_interrupted(now_rfc3339)
 }
 

--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -155,7 +155,10 @@ impl TurnStateStore {
             removed += 1;
         }
         if removed > 0 {
-            debug!("{LOG_PREFIX} cleared {removed} snapshots from {}", dir.display());
+            debug!(
+                "{LOG_PREFIX} cleared {removed} snapshots from {}",
+                dir.display()
+            );
         }
         Ok(removed)
     }

--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -52,6 +52,18 @@ impl TurnStateStore {
             .map_err(|e| format!("fsync turn-state tempfile: {e}"))?;
         tmp.persist(&path)
             .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))?;
+        // Sync the directory entry created by the rename — without
+        // this a crash or power loss between persist() and the next
+        // fs flush can drop the snapshot, defeating the cold-boot
+        // recovery guarantee. Best-effort on platforms where opening
+        // a directory for sync is not supported (Windows). The fsync
+        // failure is logged but not fatal.
+        if let Err(err) = sync_dir(&dir) {
+            log::warn!(
+                "{LOG_PREFIX} failed to fsync {}: {err}",
+                dir.display()
+            );
+        }
         debug!(
             "{LOG_PREFIX} wrote snapshot thread={} lifecycle={:?} iter={}/{} timeline={}",
             state.thread_id,
@@ -160,6 +172,20 @@ impl TurnStateStore {
             SNAPSHOT_EXTENSION
         ))
     }
+}
+
+/// Best-effort `fsync` of a directory entry. On Unix, opens the
+/// directory for read and calls `sync_all` on the file handle. On
+/// Windows this is a no-op — directory fsync is not exposed by the
+/// platform and the rename's durability is provided by NTFS journaling.
+#[cfg(unix)]
+fn sync_dir(dir: &Path) -> std::io::Result<()> {
+    File::open(dir)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_dir(_dir: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 fn read_snapshot(path: &Path) -> Result<TurnState, String> {

--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -124,6 +124,42 @@ impl TurnStateStore {
         Ok(snapshots)
     }
 
+    /// Remove every snapshot file in the turn-state directory,
+    /// regardless of whether the contents are readable. Used by
+    /// `threads_purge` to guarantee no stale or corrupted snapshot
+    /// survives a destructive cleanup — `list()` only returns parseable
+    /// snapshots, so iterating list+delete would silently leave
+    /// half-written or schema-skewed files behind.
+    ///
+    /// Returns the count of files removed. Failures on individual
+    /// entries propagate as the first error encountered (the rest of
+    /// the directory is not touched once an error occurs, so a retry
+    /// can pick up where this left off).
+    pub fn clear_all(&self) -> Result<usize, String> {
+        let _guard = TURN_STATE_LOCK.lock();
+        let dir = self.dir();
+        if !dir.exists() {
+            return Ok(0);
+        }
+        let mut removed = 0usize;
+        for entry in
+            fs::read_dir(&dir).map_err(|e| format!("read turn-state dir {}: {e}", dir.display()))?
+        {
+            let entry = entry.map_err(|e| format!("read turn-state entry: {e}"))?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some(SNAPSHOT_EXTENSION) {
+                continue;
+            }
+            fs::remove_file(&path)
+                .map_err(|e| format!("remove turn-state file {}: {e}", path.display()))?;
+            removed += 1;
+        }
+        if removed > 0 {
+            debug!("{LOG_PREFIX} cleared {removed} snapshots from {}", dir.display());
+        }
+        Ok(removed)
+    }
+
     /// Mark every persisted snapshot as `Interrupted`. Intended to be
     /// invoked from the web-channel provider on startup so the UI can
     /// distinguish stale turns left behind by a previous process from
@@ -211,6 +247,10 @@ pub fn delete(workspace_dir: PathBuf, thread_id: &str) -> Result<bool, String> {
 
 pub fn list(workspace_dir: PathBuf) -> Result<Vec<TurnState>, String> {
     TurnStateStore::new(workspace_dir).list()
+}
+
+pub fn clear_all(workspace_dir: PathBuf) -> Result<usize, String> {
+    TurnStateStore::new(workspace_dir).clear_all()
 }
 
 pub fn mark_all_interrupted(workspace_dir: PathBuf, now_rfc3339: &str) -> Result<usize, String> {

--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -1,0 +1,206 @@
+//! Filesystem-backed snapshot store for [`super::types::TurnState`].
+//!
+//! One JSON file per thread under
+//! `<workspace>/memory/conversations/turn_states/<hex(thread_id)>.json`.
+//! Whole-file overwrite (latest snapshot wins). The presence of a file
+//! means the turn was non-terminal at last write.
+//!
+//! Mutations are serialised through a single process-wide mutex so the
+//! progress consumer cannot interleave a flush against an RPC handler
+//! reading the same file.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use log::{debug, warn};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use tempfile::NamedTempFile;
+
+use super::types::{TurnLifecycle, TurnState};
+
+const LOG_PREFIX: &str = "[threads:turn_state]";
+const TURN_STATE_DIR: &str = "turn_states";
+const SNAPSHOT_EXTENSION: &str = "json";
+static TURN_STATE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+/// Workspace-rooted handle that reads and writes per-thread turn snapshots.
+#[derive(Debug, Clone)]
+pub struct TurnStateStore {
+    workspace_dir: PathBuf,
+}
+
+impl TurnStateStore {
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        Self { workspace_dir }
+    }
+
+    /// Atomically overwrite the snapshot for `state.thread_id`.
+    pub fn put(&self, state: &TurnState) -> Result<(), String> {
+        let _guard = TURN_STATE_LOCK.lock();
+        let dir = self.ensure_dir()?;
+        let path = self.snapshot_path(&state.thread_id);
+        let mut tmp = NamedTempFile::new_in(&dir)
+            .map_err(|e| format!("create turn-state tempfile in {}: {e}", dir.display()))?;
+        let bytes = serde_json::to_vec_pretty(state)
+            .map_err(|e| format!("serialize turn state: {e}"))?;
+        tmp.write_all(&bytes)
+            .map_err(|e| format!("write turn-state tempfile: {e}"))?;
+        tmp.as_file()
+            .sync_all()
+            .map_err(|e| format!("fsync turn-state tempfile: {e}"))?;
+        tmp.persist(&path)
+            .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))?;
+        debug!(
+            "{LOG_PREFIX} wrote snapshot thread={} lifecycle={:?} iter={}/{} timeline={}",
+            state.thread_id,
+            state.lifecycle,
+            state.iteration,
+            state.max_iterations,
+            state.tool_timeline.len()
+        );
+        Ok(())
+    }
+
+    /// Return the snapshot for `thread_id`, or `None` if no file exists.
+    pub fn get(&self, thread_id: &str) -> Result<Option<TurnState>, String> {
+        let _guard = TURN_STATE_LOCK.lock();
+        let path = self.snapshot_path(thread_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        read_snapshot(&path).map(Some)
+    }
+
+    /// Delete the snapshot for `thread_id`. Returns `true` if a file was
+    /// removed, `false` if none existed.
+    pub fn delete(&self, thread_id: &str) -> Result<bool, String> {
+        let _guard = TURN_STATE_LOCK.lock();
+        let path = self.snapshot_path(thread_id);
+        if !path.exists() {
+            return Ok(false);
+        }
+        fs::remove_file(&path)
+            .map_err(|e| format!("remove turn-state file {}: {e}", path.display()))?;
+        debug!("{LOG_PREFIX} deleted snapshot thread={}", thread_id);
+        Ok(true)
+    }
+
+    /// List every persisted snapshot. Used by the UI to surface
+    /// interrupted turns on cold boot.
+    pub fn list(&self) -> Result<Vec<TurnState>, String> {
+        let _guard = TURN_STATE_LOCK.lock();
+        let dir = self.dir();
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut snapshots = Vec::new();
+        for entry in fs::read_dir(&dir)
+            .map_err(|e| format!("read turn-state dir {}: {e}", dir.display()))?
+        {
+            let entry =
+                entry.map_err(|e| format!("read turn-state entry: {e}"))?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some(SNAPSHOT_EXTENSION) {
+                continue;
+            }
+            match read_snapshot(&path) {
+                Ok(snapshot) => snapshots.push(snapshot),
+                Err(err) => warn!(
+                    "{LOG_PREFIX} skip unreadable snapshot {}: {err}",
+                    path.display()
+                ),
+            }
+        }
+        Ok(snapshots)
+    }
+
+    /// Mark every persisted snapshot as `Interrupted`. Intended to be
+    /// invoked from the web-channel provider on startup so the UI can
+    /// distinguish stale turns left behind by a previous process from
+    /// turns that are currently being driven in this session.
+    pub fn mark_all_interrupted(&self, now_rfc3339: &str) -> Result<usize, String> {
+        let snapshots = self.list()?;
+        let mut count = 0usize;
+        for mut snapshot in snapshots {
+            if matches!(snapshot.lifecycle, TurnLifecycle::Interrupted) {
+                continue;
+            }
+            snapshot.lifecycle = TurnLifecycle::Interrupted;
+            snapshot.updated_at = now_rfc3339.to_string();
+            snapshot.active_tool = None;
+            snapshot.active_subagent = None;
+            self.put(&snapshot)?;
+            count += 1;
+        }
+        if count > 0 {
+            debug!(
+                "{LOG_PREFIX} marked {count} snapshots as interrupted on startup"
+            );
+        }
+        Ok(count)
+    }
+
+    fn ensure_dir(&self) -> Result<PathBuf, String> {
+        let dir = self.dir();
+        fs::create_dir_all(&dir)
+            .map_err(|e| format!("create turn-state dir {}: {e}", dir.display()))?;
+        Ok(dir)
+    }
+
+    fn dir(&self) -> PathBuf {
+        self.workspace_dir
+            .join("memory")
+            .join("conversations")
+            .join(TURN_STATE_DIR)
+    }
+
+    fn snapshot_path(&self, thread_id: &str) -> PathBuf {
+        self.dir().join(format!(
+            "{}.{}",
+            hex::encode(thread_id.as_bytes()),
+            SNAPSHOT_EXTENSION
+        ))
+    }
+}
+
+fn read_snapshot(path: &Path) -> Result<TurnState, String> {
+    let mut file =
+        File::open(path).map_err(|e| format!("open turn-state {}: {e}", path.display()))?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf)
+        .map_err(|e| format!("read turn-state {}: {e}", path.display()))?;
+    serde_json::from_str(&buf)
+        .map_err(|e| format!("parse turn-state {}: {e}", path.display()))
+}
+
+// Free-function wrappers mirroring `memory::conversations::store` so callers
+// at the RPC layer don't have to instantiate `TurnStateStore` themselves.
+
+pub fn put(workspace_dir: PathBuf, state: &TurnState) -> Result<(), String> {
+    TurnStateStore::new(workspace_dir).put(state)
+}
+
+pub fn get(workspace_dir: PathBuf, thread_id: &str) -> Result<Option<TurnState>, String> {
+    TurnStateStore::new(workspace_dir).get(thread_id)
+}
+
+pub fn delete(workspace_dir: PathBuf, thread_id: &str) -> Result<bool, String> {
+    TurnStateStore::new(workspace_dir).delete(thread_id)
+}
+
+pub fn list(workspace_dir: PathBuf) -> Result<Vec<TurnState>, String> {
+    TurnStateStore::new(workspace_dir).list()
+}
+
+pub fn mark_all_interrupted(
+    workspace_dir: PathBuf,
+    now_rfc3339: &str,
+) -> Result<usize, String> {
+    TurnStateStore::new(workspace_dir).mark_all_interrupted(now_rfc3339)
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src/openhuman/threads/turn_state/store_tests.rs
+++ b/src/openhuman/threads/turn_state/store_tests.rs
@@ -105,6 +105,40 @@ fn mark_all_interrupted_promotes_lifecycle_and_clears_active_fields() {
 }
 
 #[test]
+fn clear_all_removes_corrupted_snapshots_too() {
+    use std::io::Write as _;
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    store.put(&sample_state("a")).expect("put a");
+    store.put(&sample_state("b")).expect("put b");
+
+    // Drop a corrupted JSON file alongside — `list()` would skip it,
+    // but a destructive purge must still remove it.
+    let corrupt_path = dir
+        .path()
+        .join("memory")
+        .join("conversations")
+        .join("turn_states")
+        .join("deadbeef.json");
+    let mut f = std::fs::File::create(&corrupt_path).expect("create corrupt");
+    f.write_all(b"{ not valid json").expect("write corrupt");
+    drop(f);
+    assert!(corrupt_path.exists());
+
+    let removed = store.clear_all().expect("clear_all");
+    assert_eq!(removed, 3, "all three snapshots must be removed");
+    assert!(!corrupt_path.exists(), "corrupted snapshot must be cleared");
+    assert!(store.list().expect("list").is_empty());
+}
+
+#[test]
+fn clear_all_on_missing_dir_returns_zero() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    assert_eq!(store.clear_all().expect("clear"), 0);
+}
+
+#[test]
 fn put_overwrites_previous_snapshot() {
     let dir = tempdir().expect("tempdir");
     let store = TurnStateStore::new(dir.path().to_path_buf());

--- a/src/openhuman/threads/turn_state/store_tests.rs
+++ b/src/openhuman/threads/turn_state/store_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::openhuman::threads::turn_state::types::{
-    TurnLifecycle, TurnState, ToolTimelineEntry, ToolTimelineStatus,
+    ToolTimelineEntry, ToolTimelineStatus, TurnLifecycle, TurnState,
 };
 use tempfile::tempdir;
 

--- a/src/openhuman/threads/turn_state/store_tests.rs
+++ b/src/openhuman/threads/turn_state/store_tests.rs
@@ -1,0 +1,121 @@
+//! Unit tests for [`super::TurnStateStore`].
+
+use super::*;
+use crate::openhuman::threads::turn_state::types::{
+    TurnLifecycle, TurnState, ToolTimelineEntry, ToolTimelineStatus,
+};
+use tempfile::tempdir;
+
+fn sample_state(thread_id: &str) -> TurnState {
+    TurnState::started(thread_id.to_string(), "req-1", 25, "2026-05-04T10:00:00Z")
+}
+
+#[test]
+fn put_then_get_roundtrips_state() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let mut state = sample_state("thread-abc");
+    state.lifecycle = TurnLifecycle::Streaming;
+    state.iteration = 3;
+    state.streaming_text = "hello".into();
+    state.tool_timeline.push(ToolTimelineEntry {
+        id: "tc-1".into(),
+        name: "shell".into(),
+        round: 1,
+        status: ToolTimelineStatus::Running,
+        args_buffer: Some("{".into()),
+        display_name: None,
+        detail: None,
+        source_tool_name: None,
+        subagent: None,
+    });
+
+    store.put(&state).expect("put");
+    let loaded = store.get("thread-abc").expect("get").expect("present");
+    assert_eq!(loaded, state);
+}
+
+#[test]
+fn get_returns_none_when_absent() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    assert!(store.get("missing").expect("get").is_none());
+}
+
+#[test]
+fn delete_removes_snapshot_and_reports_presence() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let state = sample_state("thread-x");
+    store.put(&state).expect("put");
+    assert!(store.delete("thread-x").expect("delete"));
+    assert!(!store.delete("thread-x").expect("delete-again"));
+    assert!(store.get("thread-x").expect("get").is_none());
+}
+
+#[test]
+fn list_returns_every_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    store.put(&sample_state("a")).expect("put a");
+    store.put(&sample_state("b")).expect("put b");
+    let mut ids: Vec<String> = store
+        .list()
+        .expect("list")
+        .into_iter()
+        .map(|s| s.thread_id)
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+}
+
+#[test]
+fn list_on_missing_dir_is_empty() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    assert!(store.list().expect("list").is_empty());
+}
+
+#[test]
+fn mark_all_interrupted_promotes_lifecycle_and_clears_active_fields() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let mut state = sample_state("t");
+    state.lifecycle = TurnLifecycle::Streaming;
+    state.active_tool = Some("shell".into());
+    state.active_subagent = Some("researcher".into());
+    store.put(&state).expect("put");
+
+    let count = store
+        .mark_all_interrupted("2026-05-04T10:01:00Z")
+        .expect("mark");
+    assert_eq!(count, 1);
+
+    let loaded = store.get("t").expect("get").expect("present");
+    assert_eq!(loaded.lifecycle, TurnLifecycle::Interrupted);
+    assert_eq!(loaded.updated_at, "2026-05-04T10:01:00Z");
+    assert!(loaded.active_tool.is_none());
+    assert!(loaded.active_subagent.is_none());
+
+    // Re-running is a no-op for already-interrupted snapshots.
+    let count = store
+        .mark_all_interrupted("2026-05-04T10:02:00Z")
+        .expect("mark again");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn put_overwrites_previous_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let store = TurnStateStore::new(dir.path().to_path_buf());
+    let mut state = sample_state("t");
+    state.iteration = 1;
+    store.put(&state).expect("put 1");
+    state.iteration = 7;
+    state.updated_at = "2026-05-04T10:05:00Z".into();
+    store.put(&state).expect("put 2");
+
+    let loaded = store.get("t").expect("get").expect("present");
+    assert_eq!(loaded.iteration, 7);
+    assert_eq!(loaded.updated_at, "2026-05-04T10:05:00Z");
+}

--- a/src/openhuman/threads/turn_state/types.rs
+++ b/src/openhuman/threads/turn_state/types.rs
@@ -1,0 +1,200 @@
+//! Wire/storage types for per-thread agent-turn snapshots.
+//!
+//! A [`TurnState`] mirrors the live state held by the web-channel
+//! progress consumer so the UI can rehydrate after a cold boot or
+//! after the user navigates away mid-turn. The shape intentionally
+//! parallels `app/src/store/chatRuntimeSlice.ts` so a snapshot can
+//! be applied directly to that slice.
+
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle of an in-flight (or formerly in-flight) turn.
+///
+/// `Started` is set when the user sends and the agent loop is about
+/// to enter the iteration loop. `Streaming` is set after the first
+/// progress signal arrives. `Interrupted` is stamped at startup on
+/// any snapshot that survived a process restart — there is no live
+/// driver to resume it, so the UI should surface a retry affordance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnLifecycle {
+    Started,
+    Streaming,
+    Interrupted,
+}
+
+/// High-level phase the agent is in within an iteration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnPhase {
+    Thinking,
+    ToolUse,
+    Subagent,
+}
+
+/// Per-tool entry shown in the live timeline UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolTimelineStatus {
+    Running,
+    Success,
+    Error,
+}
+
+/// One row in the per-turn tool timeline.
+///
+/// Field names use camelCase on the wire so a snapshot can be applied
+/// directly to `chatRuntimeSlice.toolTimelineByThread` without a
+/// translation layer in the UI.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolTimelineEntry {
+    pub id: String,
+    pub name: String,
+    pub round: u32,
+    pub status: ToolTimelineStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args_buffer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subagent: Option<SubagentActivity>,
+}
+
+/// Live sub-agent activity nested under a `subagent:*` timeline row.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubagentActivity {
+    pub task_id: String,
+    pub agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedicated_thread: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_iteration: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_max_iterations: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iterations: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_chars: Option<usize>,
+    #[serde(default)]
+    pub tool_calls: Vec<SubagentToolCall>,
+}
+
+/// One child tool call performed by a running sub-agent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubagentToolCall {
+    pub call_id: String,
+    pub tool_name: String,
+    pub status: ToolTimelineStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iteration: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_chars: Option<usize>,
+}
+
+/// Persisted snapshot of an in-flight agent turn for one thread.
+///
+/// Written to disk by the web-channel progress consumer at iteration
+/// boundaries, tool start/complete, and on terminal events. Deleted
+/// on successful turn completion. A surviving snapshot at startup
+/// indicates an interrupted turn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnState {
+    pub thread_id: String,
+    pub request_id: String,
+    pub lifecycle: TurnLifecycle,
+    pub iteration: u32,
+    pub max_iterations: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<TurnPhase>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_subagent: Option<String>,
+    #[serde(default)]
+    pub streaming_text: String,
+    #[serde(default)]
+    pub thinking: String,
+    #[serde(default)]
+    pub tool_timeline: Vec<ToolTimelineEntry>,
+    pub started_at: String,
+    pub updated_at: String,
+}
+
+/// Request payload for `openhuman.threads_turn_state_get`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetTurnStateRequest {
+    pub thread_id: String,
+}
+
+/// Response payload for `openhuman.threads_turn_state_get`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetTurnStateResponse {
+    /// `None` when no snapshot exists for the thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_state: Option<TurnState>,
+}
+
+/// Response payload for `openhuman.threads_turn_state_list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTurnStatesResponse {
+    pub turn_states: Vec<TurnState>,
+    pub count: usize,
+}
+
+/// Request payload for `openhuman.threads_turn_state_clear`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClearTurnStateRequest {
+    pub thread_id: String,
+}
+
+/// Response payload for `openhuman.threads_turn_state_clear`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearTurnStateResponse {
+    pub cleared: bool,
+}
+
+impl TurnState {
+    /// Build a fresh `Started` snapshot for a new turn.
+    pub fn started(
+        thread_id: impl Into<String>,
+        request_id: impl Into<String>,
+        max_iterations: u32,
+        now_rfc3339: impl Into<String>,
+    ) -> Self {
+        let now = now_rfc3339.into();
+        Self {
+            thread_id: thread_id.into(),
+            request_id: request_id.into(),
+            lifecycle: TurnLifecycle::Started,
+            iteration: 0,
+            max_iterations,
+            phase: None,
+            active_tool: None,
+            active_subagent: None,
+            streaming_text: String::new(),
+            thinking: String::new(),
+            tool_timeline: Vec::new(),
+            started_at: now.clone(),
+            updated_at: now,
+        }
+    }
+}

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -1070,8 +1070,7 @@ async fn json_rpc_thread_turn_state_lifecycle() {
         25,
         chrono::Utc::now().to_rfc3339(),
     );
-    state.lifecycle =
-        openhuman_core::openhuman::threads::turn_state::TurnLifecycle::Streaming;
+    state.lifecycle = openhuman_core::openhuman::threads::turn_state::TurnLifecycle::Streaming;
     state.iteration = 2;
     state.streaming_text = "partial".into();
     openhuman_core::openhuman::threads::turn_state::store::put(workspace_dir.clone(), &state)

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -1020,6 +1020,143 @@ async fn json_rpc_thread_labels_create_and_update() {
 }
 
 #[tokio::test]
+async fn json_rpc_thread_turn_state_lifecycle() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_url_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+    let _api_url_guard = EnvVarGuard::unset("OPENHUMAN_API_URL");
+
+    let (api_addr, api_join) = serve_on_ephemeral(mock_upstream_router()).await;
+    let api_origin = format!("http://{api_addr}");
+    write_min_config(openhuman_home.as_path(), &api_origin);
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{rpc_addr}");
+
+    // Empty workspace → no snapshots.
+    let empty_list = post_json_rpc(
+        &rpc_base,
+        9101,
+        "openhuman.threads_turn_state_list",
+        json!({}),
+    )
+    .await;
+    let outer = assert_no_jsonrpc_error(&empty_list, "turn_state_list (empty)");
+    assert_eq!(
+        outer
+            .get("data")
+            .and_then(|d| d.get("count"))
+            .and_then(serde_json::Value::as_u64),
+        Some(0)
+    );
+
+    // Drop a snapshot directly through the store — this is exactly what
+    // the web-channel progress mirror does mid-turn.
+    let workspace_dir = {
+        let cfg = openhuman_core::openhuman::config::Config::load_or_init()
+            .await
+            .expect("load config");
+        cfg.workspace_dir
+    };
+    let mut state = openhuman_core::openhuman::threads::turn_state::TurnState::started(
+        "thread-turn-1",
+        "req-turn-1",
+        25,
+        chrono::Utc::now().to_rfc3339(),
+    );
+    state.lifecycle =
+        openhuman_core::openhuman::threads::turn_state::TurnLifecycle::Streaming;
+    state.iteration = 2;
+    state.streaming_text = "partial".into();
+    openhuman_core::openhuman::threads::turn_state::store::put(workspace_dir.clone(), &state)
+        .expect("seed snapshot");
+
+    // get → present
+    let got = post_json_rpc(
+        &rpc_base,
+        9102,
+        "openhuman.threads_turn_state_get",
+        json!({ "thread_id": "thread-turn-1" }),
+    )
+    .await;
+    let got_outer = assert_no_jsonrpc_error(&got, "turn_state_get (present)");
+    let payload = got_outer
+        .get("data")
+        .and_then(|d| d.get("turnState"))
+        .expect("turnState present");
+    assert_eq!(
+        payload.get("threadId").and_then(serde_json::Value::as_str),
+        Some("thread-turn-1")
+    );
+    assert_eq!(
+        payload.get("lifecycle").and_then(serde_json::Value::as_str),
+        Some("streaming")
+    );
+    assert_eq!(
+        payload.get("iteration").and_then(serde_json::Value::as_u64),
+        Some(2)
+    );
+
+    // list → contains the seeded snapshot
+    let list = post_json_rpc(
+        &rpc_base,
+        9103,
+        "openhuman.threads_turn_state_list",
+        json!({}),
+    )
+    .await;
+    let list_outer = assert_no_jsonrpc_error(&list, "turn_state_list (one)");
+    assert_eq!(
+        list_outer
+            .get("data")
+            .and_then(|d| d.get("count"))
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
+
+    // clear → cleared:true
+    let cleared = post_json_rpc(
+        &rpc_base,
+        9104,
+        "openhuman.threads_turn_state_clear",
+        json!({ "thread_id": "thread-turn-1" }),
+    )
+    .await;
+    let cleared_outer = assert_no_jsonrpc_error(&cleared, "turn_state_clear");
+    assert_eq!(
+        cleared_outer
+            .get("data")
+            .and_then(|d| d.get("cleared"))
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+
+    // subsequent get returns null
+    let got_again = post_json_rpc(
+        &rpc_base,
+        9105,
+        "openhuman.threads_turn_state_get",
+        json!({ "thread_id": "thread-turn-1" }),
+    )
+    .await;
+    let again_outer = assert_no_jsonrpc_error(&got_again, "turn_state_get (after clear)");
+    assert!(again_outer
+        .get("data")
+        .and_then(|d| d.get("turnState"))
+        .map(|v| v.is_null())
+        .unwrap_or(true));
+
+    api_join.abort();
+    rpc_join.abort();
+}
+
+#[tokio::test]
 async fn json_rpc_memory_sync_and_learn() {
     let _env_lock = json_rpc_e2e_env_lock();
     let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- Persist each thread's in-flight agent turn to disk so the UI can rehydrate (or surface "interrupted") after a restart.
- Fix `set_agent_definition_name` to also rebuild `session_key` — previously, persist wrote `session_raw/<ts>_orchestrator.jsonl` while resume searched for `<ts>_orchestrator_thread-XXX.jsonl`, so transcript-resume always missed and the LLM ran every cold-boot turn with empty history.
- Add a JSONL fallback: when the web channel builds a fresh agent, seed it from the authoritative conversation log via `Agent::seed_resume_from_messages` so existing on-disk threads (with the misnamed transcripts) recover immediately, not just future ones.
- New JSON-RPC surface (`threads_turn_state_get` / `_list` / `_clear`) and Redux hydration plumbing for the snapshot.

## Problem

Cold-booting the desktop app and continuing a conversation behaved as if the thread had no history — the agent reflected the literal current message back instead of answering against the prior turns. Two layered bugs:

1. The web channel scopes transcripts per thread by calling `set_agent_definition_name("orchestrator_thread-XXX")` after build. The setter only updated `agent_definition_name`; `session_key` (used by `persist_session_transcript` for the filename) stayed at the builder-time `<ts>_orchestrator`. `find_latest_transcript` searches by `agent_definition_name`, so it could never match the on-disk file. Every cold boot ran with an empty transcript.
2. Even after fixing the rename, every existing transcript on disk still has the wrong filename, so the next cold boot would still come up empty for an entire release window.

In parallel, no per-thread runtime state (in-flight tool timeline, streaming buffer, lifecycle) survived a process restart, so a navigation away mid-turn always lost UI state.

## Solution

**Turn-state persistence**
- New `openhuman::threads::turn_state` module: `TurnState` types, atomic JSON `TurnStateStore` at `<workspace>/memory/conversations/turn_states/<hex(thread_id)>.json`, and a `TurnStateMirror` that translates `AgentProgress` → snapshot mutations. High-frequency text/thinking/args deltas mutate memory only; flushes happen on iteration / tool / subagent boundaries to avoid filesystem thrash. Terminal `TurnCompleted` deletes the file; bridge exit without completion stamps `Interrupted`.
- Web-channel progress bridge wires the mirror alongside its existing socket emissions.
- `bootstrap_skill_runtime` calls `mark_all_interrupted` once per process so stale snapshots from a previous process surface consistently.
- Three new RPC methods on the threads namespace: `threads_turn_state_get`, `_list`, `_clear`.
- App: `chatRuntimeSlice` gains a `hydrateRuntimeFromSnapshot` reducer + `fetchAndHydrateTurnState` thunk. `InferenceTurnLifecycle` extended with `'interrupted'`. `Conversations.tsx` dispatches the thunk on every thread switch.

**Cold-boot history restoration**
- `set_agent_definition_name` now rebuilds `session_key`'s suffix from the new sanitised name (preserving the unix-timestamp prefix). Future persists land at the same path resume searches.
- `Agent::seed_resume_from_messages(messages, current_user_message)` builds a system prompt and primes `cached_transcript_messages` with the prior conversation. `web::run_chat_request` calls it on every cache-miss build using `conversations::get_messages` as the authoritative source. Trailing user message that matches the incoming `message` is deduped to avoid double-sending.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — Rust unit tests for the store (7), mirror (7), and session_key/seed_resume regressions (5); JSON-RPC E2E lifecycle test (`json_rpc_thread_turn_state_lifecycle`); Vitest reducer tests for streaming + interrupted hydration. Full Vitest suite (1347) and `cargo test` for the affected modules pass locally.
- [ ] N/A: behaviour-only change — no new feature rows to add to [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md); the touched threads / agent surfaces are already represented.
- [ ] N/A: no matrix-row additions, so no feature IDs to list under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: not a release-cut surface — turn-state snapshot file + transcript path scoping are internal to the threads domain, no [`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md) entries.
- [x] Linked issue tracked via `Related` — see #1201 (this PR is the workaround that issue retires).

## Impact

- **Runtime**: desktop only. New writes under `<workspace>/memory/conversations/turn_states/`. Snapshot writes are atomic (`tempfile::persist`) and bounded to iteration / tool boundaries; no per-delta thrash.
- **Migration**: existing thread message JSONLs are left untouched. Existing misnamed transcripts under `session_raw/` are simply ignored — the JSONL fallback recovers history from `memory/conversations/threads/`.
- **Performance**: one extra disk read on cache-miss (conversation JSONL parse + system-prompt build), bounded by typical thread length. Hot path (cache-hit) is untouched.
- **Security**: snapshot files live alongside existing conversation logs and inherit the same workspace permissions; no new attack surface.

## Related

- Closes:
- Follow-up PR(s)/TODOs: #1201 — consolidate the two thread-message stores onto a single `session_raw`-backed transcript so the JSONL fallback added here can be retired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted per-thread turn snapshots with get/list/clear controls
  * UI fetches and hydrates per-thread runtime when opening a conversation
  * Fresh sessions can be seeded from conversation logs for improved resume

* **Behavior**
  * Startup marks stale snapshots as interrupted to enable retry paths
  * Session renaming is sanitized to avoid resume/persistence mismatches
  * Thread delete/purge now removes associated persisted turn snapshots

* **Tests**
  * Added unit and end-to-end tests for persistence, mirroring, recovery, and hydration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->