### PR TITLE
feat(mascot): floating desktop mascot via native NSPanel + WKWebView (macOS)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.24.0",
  "toml 0.8.2",
+ "url",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-user-notifications",
+ "objc2-web-kit",
  "openhuman",
  "parking_lot",
  "rand 0.9.2",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -124,7 +124,10 @@ mac-notification-sys = "0.6"
 rusqlite = { version = "0.37", features = ["bundled"] }
 objc2-user-notifications = "0.3.2"
 block2 = "0.6.2"
-objc2-foundation = "0.3.2"
+objc2-foundation = { version = "0.3.2", features = ["NSTimer", "block2"] }
+# Native WKWebView host for the floating mascot window — bypasses CEF
+# (which can't render transparent windowed-mode browsers).
+objc2-web-kit = { version = "0.3.2", features = ["block2"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 notify-rust = { version = "4", default-features = false, features = ["dbus"] }

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "time
 #   JSON-RPC frames from the core sidecar so core-side handlers can
 #   reach the live-webview connectors via CDP.
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake"] }
+url = "2"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ mod core_rpc;
 mod discord_scanner;
 mod gmessages_scanner;
 mod imessage_scanner;
+#[cfg(target_os = "macos")]
+mod mascot_native_window;
 mod notification_settings;
 mod screen_capture;
 mod slack_scanner;
@@ -753,6 +755,52 @@ fn activate_main_window(app: AppHandle<AppRuntime>) -> Result<(), String> {
     show_main_window(&app)
 }
 
+const MASCOT_WINDOW_LABEL: &str = "mascot";
+
+/// Show the floating mascot. macOS: native NSPanel + WKWebView (so the
+/// window is actually transparent — vendored tauri-cef can't render
+/// transparent windowed-mode browsers). Other OSes: not yet wired up.
+#[tauri::command]
+fn mascot_window_show(app: AppHandle<AppRuntime>) -> Result<(), String> {
+    log::info!("[mascot-window] show requested");
+    #[cfg(target_os = "macos")]
+    {
+        return mascot_native_window::show(&app);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Err("floating mascot window is macOS-only for now".into())
+    }
+}
+
+/// Hide the floating mascot.
+#[tauri::command]
+fn mascot_window_hide(app: AppHandle<AppRuntime>) -> Result<(), String> {
+    log::info!("[mascot-window] hide requested");
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app;
+        mascot_native_window::hide();
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn mascot_native_window_is_open() -> bool {
+    mascot_native_window::is_open()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn mascot_native_window_is_open() -> bool {
+    false
+}
+
 /// Tauri command: fire a native OS notification from the frontend. Used by
 /// the in-app notification center to banner events (agent completions,
 /// connection drops, etc.) when the window is not focused.
@@ -910,8 +958,15 @@ fn setup_tray(app: &AppHandle<AppRuntime>) -> tauri::Result<()> {
         true,
         None::<&str>,
     )?;
+    let mascot_item = MenuItem::with_id(
+        app,
+        "tray_toggle_mascot",
+        "Toggle floating mascot",
+        true,
+        None::<&str>,
+    )?;
     let quit_item = MenuItem::with_id(app, "tray_quit", "Quit", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
+    let menu = Menu::with_items(app, &[&show_item, &mascot_item, &quit_item])?;
 
     let icon = app
         .default_window_icon()
@@ -926,6 +981,16 @@ fn setup_tray(app: &AppHandle<AppRuntime>) -> tauri::Result<()> {
                 log::info!("[tray] action=show_window source=menu");
                 if let Err(err) = show_main_window(app) {
                     log::error!("[tray] failed to show main window from menu: {err}");
+                }
+            }
+            "tray_toggle_mascot" => {
+                log::info!("[tray] action=toggle_mascot source=menu");
+                if mascot_native_window_is_open() {
+                    if let Err(err) = mascot_window_hide(app.clone()) {
+                        log::error!("[tray] failed to hide mascot window: {err}");
+                    }
+                } else if let Err(err) = mascot_window_show(app.clone()) {
+                    log::error!("[tray] failed to show mascot window: {err}");
                 }
             }
             "tray_quit" => {
@@ -1702,7 +1767,9 @@ pub fn run() {
             notification_permission_state,
             notification_permission_request,
             activate_main_window,
-            show_native_notification
+            show_native_notification,
+            mascot_window_show,
+            mascot_window_hide
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -755,11 +755,11 @@ fn activate_main_window(app: AppHandle<AppRuntime>) -> Result<(), String> {
     show_main_window(&app)
 }
 
-const MASCOT_WINDOW_LABEL: &str = "mascot";
-
 /// Show the floating mascot. macOS: native NSPanel + WKWebView (so the
 /// window is actually transparent — vendored tauri-cef can't render
-/// transparent windowed-mode browsers). Other OSes: not yet wired up.
+/// transparent windowed-mode browsers). Loads the Vite dev URL in
+/// development and the bundled `index.html` in production. Other OSes:
+/// not yet wired up.
 #[tauri::command]
 fn mascot_window_show(app: AppHandle<AppRuntime>) -> Result<(), String> {
     log::info!("[mascot-window] show requested");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -958,15 +958,24 @@ fn setup_tray(app: &AppHandle<AppRuntime>) -> tauri::Result<()> {
         true,
         None::<&str>,
     )?;
-    let mascot_item = MenuItem::with_id(
-        app,
-        "tray_toggle_mascot",
-        "Toggle floating mascot",
-        true,
-        None::<&str>,
-    )?;
     let quit_item = MenuItem::with_id(app, "tray_quit", "Quit", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&show_item, &mascot_item, &quit_item])?;
+    // The floating mascot has a native NSPanel + WKWebView host, so the
+    // tray entry only does anything on macOS. Don't surface a menu item
+    // on Windows that's guaranteed to error — gate it to the platform
+    // where `mascot_window_show` actually works.
+    #[cfg(target_os = "macos")]
+    let menu = {
+        let mascot_item = MenuItem::with_id(
+            app,
+            "tray_toggle_mascot",
+            "Toggle floating mascot",
+            true,
+            None::<&str>,
+        )?;
+        Menu::with_items(app, &[&show_item, &mascot_item, &quit_item])?
+    };
+    #[cfg(not(target_os = "macos"))]
+    let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
 
     let icon = app
         .default_window_icon()

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -31,9 +31,7 @@ use objc2_app_kit::{
     NSBackingStoreType, NSColor, NSEvent, NSPanel, NSScreen, NSWindowCollectionBehavior,
     NSWindowStyleMask,
 };
-use objc2_foundation::{
-    NSNumber, NSPoint, NSRect, NSSize, NSString, NSTimer, NSURL, NSURLRequest,
-};
+use objc2_foundation::{NSNumber, NSPoint, NSRect, NSSize, NSString, NSTimer, NSURLRequest, NSURL};
 use objc2_web_kit::{WKWebView, WKWebViewConfiguration};
 use tauri::AppHandle;
 
@@ -143,7 +141,10 @@ fn resolve_page_url(app: &AppHandle<AppRuntime>) -> Result<String, String> {
     // Append `?window=mascot` so main.tsx can branch on URL params (the
     // panel is not part of Tauri's runtime, so `getCurrentWindow().label`
     // doesn't apply here).
-    let query = url.query().map(|q| format!("{q}&window=mascot")).unwrap_or_else(|| "window=mascot".into());
+    let query = url
+        .query()
+        .map(|q| format!("{q}&window=mascot"))
+        .unwrap_or_else(|| "window=mascot".into());
     url.set_query(Some(&query));
     Ok(url.to_string())
 }
@@ -226,15 +227,6 @@ enum Slot {
     HopUp,
 }
 
-impl Slot {
-    fn other(self) -> Slot {
-        match self {
-            Slot::Home => Slot::HopUp,
-            Slot::HopUp => Slot::Home,
-        }
-    }
-}
-
 fn slot_frame(mtm: MainThreadMarker, slot: Slot) -> NSRect {
     let screen = NSScreen::mainScreen(mtm)
         .map(|s| s.frame())
@@ -305,20 +297,13 @@ unsafe fn spawn_hover_timer(
     }
 }
 
-unsafe fn build_webview(
-    mtm: MainThreadMarker,
-    panel: &NSPanel,
-    url: &str,
-) -> Retained<WKWebView> {
+unsafe fn build_webview(mtm: MainThreadMarker, panel: &NSPanel, url: &str) -> Retained<WKWebView> {
     let config: Retained<WKWebViewConfiguration> = unsafe {
         let alloc = WKWebViewConfiguration::alloc(mtm);
         msg_send![alloc, init]
     };
 
-    let frame = NSRect::new(
-        NSPoint::new(0.0, 0.0),
-        NSSize::new(PANEL_SIZE, PANEL_SIZE),
-    );
+    let frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(PANEL_SIZE, PANEL_SIZE));
     let webview: Retained<WKWebView> =
         unsafe { WKWebView::initWithFrame_configuration(WKWebView::alloc(mtm), frame, &config) };
 
@@ -355,4 +340,3 @@ unsafe fn build_webview(
 
     webview
 }
-

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -185,6 +185,21 @@ fn resolve_page_source(app: &AppHandle<AppRuntime>) -> Result<PageSource, String
     ))
 }
 
+/// Frame of the primary screen — the one hosting the menu bar at index
+/// 0 of `NSScreen.screens`. Note that `NSScreen.mainScreen` would be
+/// wrong here: it returns whichever screen has the active key window, so
+/// it changes when the user moves focus between displays and would
+/// reposition the panel under the cursor instead of pinning it to the
+/// menu-bar host.
+fn primary_screen_frame(mtm: MainThreadMarker) -> NSRect {
+    let screens = NSScreen::screens(mtm);
+    if let Some(primary) = screens.firstObject() {
+        return primary.frame();
+    }
+    log::warn!("[mascot-native] NSScreen::screens returned empty — falling back to 1440x900");
+    NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0))
+}
+
 /// Anchor the panel to the bottom-right of the primary screen using
 /// AppKit's bottom-left origin convention.
 fn bottom_right_frame(mtm: MainThreadMarker) -> NSRect {
@@ -192,9 +207,7 @@ fn bottom_right_frame(mtm: MainThreadMarker) -> NSRect {
     // bottom-right(0,0) lands at the absolute pixel corner — that's what
     // "extreme bottom right" wants. `visibleFrame()` would inset by Dock
     // height which leaves a gap.
-    let frame = NSScreen::mainScreen(mtm)
-        .map(|s| s.frame())
-        .unwrap_or_else(|| NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0)));
+    let frame = primary_screen_frame(mtm);
     let x = frame.origin.x + frame.size.width - PANEL_SIZE - PANEL_MARGIN;
     let y = frame.origin.y + PANEL_MARGIN;
     NSRect::new(NSPoint::new(x, y), NSSize::new(PANEL_SIZE, PANEL_SIZE))
@@ -264,9 +277,7 @@ enum Slot {
 }
 
 fn slot_frame(mtm: MainThreadMarker, slot: Slot) -> NSRect {
-    let screen = NSScreen::mainScreen(mtm)
-        .map(|s| s.frame())
-        .unwrap_or_else(|| NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0)));
+    let screen = primary_screen_frame(mtm);
     let x = screen.origin.x + screen.size.width - PANEL_SIZE - PANEL_MARGIN;
     // AppKit origin is bottom-left. `Home` sits at the bottom; `HopUp`
     // is one full panel-height above it so the mascot completely clears

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -14,13 +14,13 @@
 //! - No Tauri IPC bridge. The mascot window uses `WKScriptMessageHandler`
 //!   for the few host calls it needs (close, future: drag/clickthrough).
 //!   For now we keep the page passive — toggle via the tray menu.
-//! - Production bundle support is **not yet implemented**: we resolve the
-//!   page URL from `app.config().build.dev_url`, so this only works when
-//!   the Vite dev server is running. A bundle path would need to serve the
-//!   built HTML over a localhost HTTP server (or load via `file://` and
-//!   accept the ESM/CORS friction).
+//! - Page source is dev-server in development, bundled `file://` in
+//!   production. The bundled path uses `loadFileURL:allowingReadAccessToURL:`
+//!   with the resource directory as the read-access root so ESM imports
+//!   from the Vite build resolve correctly.
 
 use std::cell::{Cell, RefCell};
+use std::path::PathBuf;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
@@ -33,7 +33,7 @@ use objc2_app_kit::{
 };
 use objc2_foundation::{NSNumber, NSPoint, NSRect, NSSize, NSString, NSTimer, NSURLRequest, NSURL};
 use objc2_web_kit::{WKWebView, WKWebViewConfiguration};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use crate::AppRuntime;
 
@@ -99,8 +99,8 @@ pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     let mtm = MainThreadMarker::new()
         .ok_or_else(|| "mascot show called off the main thread".to_string())?;
 
-    let url = resolve_page_url(app)?;
-    log::info!("[mascot-native] loading url={url}");
+    let source = resolve_page_source(app)?;
+    log::info!("[mascot-native] loading source={source:?}");
 
     let frame = bottom_right_frame(mtm);
     log::debug!(
@@ -112,7 +112,7 @@ pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     );
 
     let panel = unsafe { build_panel(mtm, frame) };
-    let webview = unsafe { build_webview(mtm, &panel, &url) };
+    let webview = unsafe { build_webview(mtm, &panel, &source) };
 
     panel.makeKeyAndOrderFront(None);
     panel.orderFrontRegardless();
@@ -130,23 +130,59 @@ pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     Ok(())
 }
 
-fn resolve_page_url(app: &AppHandle<AppRuntime>) -> Result<String, String> {
-    let dev_url = app.config().build.dev_url.as_ref().cloned();
-    let Some(mut url) = dev_url else {
-        return Err(
-            "mascot native window requires a dev URL — production bundle path not implemented yet"
-                .into(),
-        );
-    };
-    // Append `?window=mascot` so main.tsx can branch on URL params (the
-    // panel is not part of Tauri's runtime, so `getCurrentWindow().label`
-    // doesn't apply here).
-    let query = url
-        .query()
-        .map(|q| format!("{q}&window=mascot"))
-        .unwrap_or_else(|| "window=mascot".into());
-    url.set_query(Some(&query));
-    Ok(url.to_string())
+/// Where the mascot's HTML lives. In dev we point WKWebView at the Vite
+/// dev server; in production we point it at the bundled `index.html` on
+/// disk and grant read access to its resource directory so ESM imports
+/// from the Vite output resolve correctly.
+#[derive(Debug)]
+enum PageSource {
+    Dev { url: String },
+    Bundled { index_html: PathBuf, root: PathBuf },
+}
+
+fn resolve_page_source(app: &AppHandle<AppRuntime>) -> Result<PageSource, String> {
+    if let Some(mut url) = app.config().build.dev_url.as_ref().cloned() {
+        // Append `?window=mascot` so main.tsx can branch on URL params
+        // (the panel is not part of Tauri's runtime, so
+        // `getCurrentWindow().label` doesn't apply here).
+        let query = url
+            .query()
+            .map(|q| format!("{q}&window=mascot"))
+            .unwrap_or_else(|| "window=mascot".into());
+        url.set_query(Some(&query));
+        return Ok(PageSource::Dev {
+            url: url.to_string(),
+        });
+    }
+
+    // Production: walk up from `resource_dir()` looking for `index.html`.
+    // The packaged layout typically puts the Vite output directly under
+    // the resource dir, but tauri-bundler can nest it (e.g. under a
+    // `dist/` subfolder), so we search a couple of likely spots before
+    // giving up.
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("resolve resource_dir: {e}"))?;
+    for candidate in [
+        resource_dir.join("index.html"),
+        resource_dir.join("dist").join("index.html"),
+    ] {
+        if candidate.is_file() {
+            let root = candidate
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| resource_dir.clone());
+            return Ok(PageSource::Bundled {
+                index_html: candidate,
+                root,
+            });
+        }
+    }
+    Err(format!(
+        "mascot bundled index.html not found under resource_dir={}",
+        resource_dir.display()
+    ))
 }
 
 /// Anchor the panel to the bottom-right of the primary screen using
@@ -297,7 +333,11 @@ unsafe fn spawn_hover_timer(
     }
 }
 
-unsafe fn build_webview(mtm: MainThreadMarker, panel: &NSPanel, url: &str) -> Retained<WKWebView> {
+unsafe fn build_webview(
+    mtm: MainThreadMarker,
+    panel: &NSPanel,
+    source: &PageSource,
+) -> Retained<WKWebView> {
     let config: Retained<WKWebViewConfiguration> = unsafe {
         let alloc = WKWebViewConfiguration::alloc(mtm);
         msg_send![alloc, init]
@@ -328,13 +368,61 @@ unsafe fn build_webview(mtm: MainThreadMarker, panel: &NSPanel, url: &str) -> Re
         let _: () = msg_send![panel, setContentView: webview_view];
 
         // Kick off the load.
-        let ns_url_str = NSString::from_str(url);
-        let ns_url: Option<Retained<NSURL>> = NSURL::URLWithString(&ns_url_str);
-        if let Some(ns_url) = ns_url {
-            let request = NSURLRequest::requestWithURL(&ns_url);
-            let _ = webview.loadRequest(&request);
-        } else {
-            log::warn!("[mascot-native] could not parse url={url}");
+        match source {
+            PageSource::Dev { url } => {
+                let ns_url_str = NSString::from_str(url);
+                let ns_url: Option<Retained<NSURL>> = NSURL::URLWithString(&ns_url_str);
+                if let Some(ns_url) = ns_url {
+                    let request = NSURLRequest::requestWithURL(&ns_url);
+                    let _ = webview.loadRequest(&request);
+                } else {
+                    log::warn!("[mascot-native] could not parse dev url={url}");
+                }
+            }
+            PageSource::Bundled { index_html, root } => {
+                // `loadFileURL:allowingReadAccessToURL:` is the only path
+                // that lets a WKWebView resolve ESM imports from a local
+                // build — `loadRequest` with a `file://` URL forbids
+                // cross-origin sub-resource loads, which Vite's chunk
+                // graph triggers immediately.
+                let Ok(mut file_url) = url::Url::from_file_path(index_html) else {
+                    log::warn!(
+                        "[mascot-native] index_html is not absolute: {}",
+                        index_html.display()
+                    );
+                    return webview;
+                };
+                // Same `?window=mascot` branching trick as the dev path —
+                // `window.location.search` will see it on the file URL.
+                file_url.set_query(Some("window=mascot"));
+                let Ok(read_access_url) = url::Url::from_file_path(root) else {
+                    log::warn!(
+                        "[mascot-native] resource root is not absolute: {}",
+                        root.display()
+                    );
+                    return webview;
+                };
+                let ns_url_str = NSString::from_str(file_url.as_str());
+                let read_access_str = NSString::from_str(read_access_url.as_str());
+                let ns_url = NSURL::URLWithString(&ns_url_str);
+                let read_access_ns = NSURL::URLWithString(&read_access_str);
+                match (ns_url, read_access_ns) {
+                    (Some(ns_url), Some(read_access_ns)) => {
+                        let _ =
+                            webview.loadFileURL_allowingReadAccessToURL(&ns_url, &read_access_ns);
+                        log::info!(
+                            "[mascot-native] loaded bundled index={} root={}",
+                            index_html.display(),
+                            root.display()
+                        );
+                    }
+                    _ => log::warn!(
+                        "[mascot-native] could not parse bundled file URLs index={} root={}",
+                        file_url,
+                        read_access_url
+                    ),
+                }
+            }
         }
     }
 

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -1,0 +1,314 @@
+//! Native macOS NSPanel + WKWebView host for the floating mascot.
+//!
+//! The vendored tauri-cef runtime cannot render transparent windowed-mode
+//! browsers (CEF clamps `BrowserSettings.background_color` alpha to 0xFF for
+//! windowed browsers; only off-screen rendering supports transparency, which
+//! the runtime does not enable). This module bypasses Tauri's runtime
+//! entirely for the mascot: it spawns a free-floating `NSPanel`, embeds a
+//! `WKWebView`, and points it at the same Vite dev URL the main window loads
+//! — but with `?window=mascot` so the React entry can branch on it.
+//!
+//! Trade-offs:
+//!
+//! - macOS-only. Linux/Windows would need a parallel native webview path.
+//! - No Tauri IPC bridge. The mascot window uses `WKScriptMessageHandler`
+//!   for the few host calls it needs (close, future: drag/clickthrough).
+//!   For now we keep the page passive — toggle via the tray menu.
+//! - Production bundle support is **not yet implemented**: we resolve the
+//!   page URL from `app.config().build.dev_url`, so this only works when
+//!   the Vite dev server is running. A bundle path would need to serve the
+//!   built HTML over a localhost HTTP server (or load via `file://` and
+//!   accept the ESM/CORS friction).
+
+use std::cell::{Cell, RefCell};
+use std::ptr::NonNull;
+use std::rc::Rc;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::{msg_send, MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{
+    NSBackingStoreType, NSColor, NSEvent, NSPanel, NSScreen, NSWindowCollectionBehavior,
+    NSWindowStyleMask,
+};
+use objc2_foundation::{
+    NSNumber, NSPoint, NSRect, NSSize, NSString, NSTimer, NSURL, NSURLRequest,
+};
+use objc2_web_kit::{WKWebView, WKWebViewConfiguration};
+use tauri::AppHandle;
+
+use crate::AppRuntime;
+
+/// Logical width / height of the mascot panel. The `<YellowMascot>` SVG
+/// canvas is square so we keep the host square too. 25% smaller than the
+/// original 140pt so it sits unobtrusively in the corner.
+const PANEL_SIZE: f64 = 105.0;
+/// Distance from the bottom-right monitor corner on first show.
+const PANEL_MARGIN: f64 = 0.0;
+/// How often we poll the cursor position to detect hover over the mascot.
+const HOVER_POLL_SECONDS: f64 = 0.05;
+
+/// Holds the panel + webview together so we keep both alive (and drop them
+/// together) for the lifetime of one show/hide cycle. The hover timer is
+/// stored so we can `invalidate()` it on hide and stop firing into a
+/// dropped webview.
+struct MascotPanel {
+    panel: Retained<NSPanel>,
+    _webview: Retained<WKWebView>,
+    hover_timer: Retained<NSTimer>,
+}
+
+impl MascotPanel {
+    fn order_out(&self) {
+        self.hover_timer.invalidate();
+        self.panel.orderOut(None);
+    }
+}
+
+thread_local! {
+    /// Accessed only from the main thread (Tauri IPC commands and the tray
+    /// menu callback both run on it). NSPanel/WKWebView are not Send/Sync,
+    /// so a thread-local is the simplest safe storage.
+    static MASCOT: RefCell<Option<MascotPanel>> = const { RefCell::new(None) };
+}
+
+/// True if a mascot panel is currently alive on this thread.
+pub(crate) fn is_open() -> bool {
+    MASCOT.with(|cell| cell.borrow().is_some())
+}
+
+/// Tear down the panel + webview if present.
+pub(crate) fn hide() {
+    MASCOT.with(|cell| {
+        if let Some(existing) = cell.borrow_mut().take() {
+            log::info!("[mascot-native] dropping panel");
+            existing.order_out();
+        }
+    });
+}
+
+/// Build (or focus) the floating mascot panel.
+pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
+    if let Some(()) = MASCOT.with(|cell| {
+        cell.borrow().as_ref().map(|existing| {
+            log::debug!("[mascot-native] panel already open — bringing to front");
+            existing.panel.orderFrontRegardless();
+        })
+    }) {
+        return Ok(());
+    }
+
+    let mtm = MainThreadMarker::new()
+        .ok_or_else(|| "mascot show called off the main thread".to_string())?;
+
+    let url = resolve_page_url(app)?;
+    log::info!("[mascot-native] loading url={url}");
+
+    let frame = bottom_right_frame(mtm);
+    log::debug!(
+        "[mascot-native] frame origin=({},{}) size=({},{})",
+        frame.origin.x,
+        frame.origin.y,
+        frame.size.width,
+        frame.size.height
+    );
+
+    let panel = unsafe { build_panel(mtm, frame) };
+    let webview = unsafe { build_webview(mtm, &panel, &url) };
+
+    panel.makeKeyAndOrderFront(None);
+    panel.orderFrontRegardless();
+
+    let hover_timer = unsafe { spawn_hover_timer(panel.clone(), webview.clone()) };
+
+    MASCOT.with(|cell| {
+        *cell.borrow_mut() = Some(MascotPanel {
+            panel,
+            _webview: webview,
+            hover_timer,
+        });
+    });
+    log::info!("[mascot-native] panel shown");
+    Ok(())
+}
+
+fn resolve_page_url(app: &AppHandle<AppRuntime>) -> Result<String, String> {
+    let dev_url = app.config().build.dev_url.as_ref().cloned();
+    let Some(mut url) = dev_url else {
+        return Err(
+            "mascot native window requires a dev URL — production bundle path not implemented yet"
+                .into(),
+        );
+    };
+    // Append `?window=mascot` so main.tsx can branch on URL params (the
+    // panel is not part of Tauri's runtime, so `getCurrentWindow().label`
+    // doesn't apply here).
+    let query = url.query().map(|q| format!("{q}&window=mascot")).unwrap_or_else(|| "window=mascot".into());
+    url.set_query(Some(&query));
+    Ok(url.to_string())
+}
+
+/// Anchor the panel to the bottom-right of the primary screen using
+/// AppKit's bottom-left origin convention.
+fn bottom_right_frame(mtm: MainThreadMarker) -> NSRect {
+    // `frame()` is the full screen including the menu bar / Dock zones, so
+    // bottom-right(0,0) lands at the absolute pixel corner — that's what
+    // "extreme bottom right" wants. `visibleFrame()` would inset by Dock
+    // height which leaves a gap.
+    let frame = NSScreen::mainScreen(mtm)
+        .map(|s| s.frame())
+        .unwrap_or_else(|| NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0)));
+    let x = frame.origin.x + frame.size.width - PANEL_SIZE - PANEL_MARGIN;
+    let y = frame.origin.y + PANEL_MARGIN;
+    NSRect::new(NSPoint::new(x, y), NSSize::new(PANEL_SIZE, PANEL_SIZE))
+}
+
+unsafe fn build_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<NSPanel> {
+    // Borderless + NonactivatingPanel: no chrome, doesn't steal focus from
+    // the user's frontmost app on click.
+    let style: NSWindowStyleMask =
+        NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel;
+    let backing = NSBackingStoreType::Buffered;
+
+    let panel: Retained<NSPanel> = unsafe {
+        let allocated = NSPanel::alloc(mtm);
+        msg_send![
+            allocated,
+            initWithContentRect: frame,
+            styleMask: style,
+            backing: backing,
+            defer: false,
+        ]
+    };
+
+    unsafe {
+        // Transparency
+        panel.setOpaque(false);
+        let clear = NSColor::clearColor();
+        panel.setBackgroundColor(Some(&clear));
+        panel.setHasShadow(false);
+
+        // Float above normal windows AND fullscreen apps. Status-bar level
+        // (25) plus canJoinAllSpaces+transient is the same recipe used by
+        // the existing `configure_overlay_window_macos` helper.
+        panel.setLevel(25);
+        panel.setCollectionBehavior(
+            NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::Transient
+                | NSWindowCollectionBehavior::FullScreenAuxiliary
+                | NSWindowCollectionBehavior::IgnoresCycle,
+        );
+        panel.setFloatingPanel(true);
+        panel.setHidesOnDeactivate(false);
+        panel.setBecomesKeyOnlyIfNeeded(true);
+        panel.setWorksWhenModal(true);
+
+        // Always click-through. The panel never receives mouse events; the
+        // cursor passes straight to whatever's behind it. Hover is detected
+        // by polling `NSEvent::mouseLocation()` against the panel frame in
+        // a Foundation timer (see `spawn_hover_timer`), and the page CSS
+        // animates the mascot out of the way when the cursor is over it.
+        panel.setIgnoresMouseEvents(true);
+
+        // Don't show in the Dock / Cmd+Tab.
+        let _: () = msg_send![&*panel, setExcludedFromWindowsMenu: true];
+    }
+
+    panel
+}
+
+/// Schedule a repeating Foundation timer on the main run loop that polls
+/// the global cursor position and toggles a `flee` attribute on the
+/// document so the page CSS can animate the mascot out from under the
+/// cursor. We poll because the panel is `ignoresMouseEvents=true` (so it
+/// can't receive `mouseEntered:` / `mouseExited:` events itself), and a
+/// transparent passthrough overlay would defeat the click-through goal.
+unsafe fn spawn_hover_timer(
+    panel: Retained<NSPanel>,
+    webview: Retained<WKWebView>,
+) -> Retained<NSTimer> {
+    // `Rc<Cell<bool>>` is fine — the block fires only on the main run loop,
+    // so single-threaded interior mutability is sufficient.
+    let was_hovering: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+
+    let block = RcBlock::new(move |_timer: NonNull<NSTimer>| {
+        let cursor = unsafe { NSEvent::mouseLocation() };
+        let frame = panel.frame();
+        let inside = cursor.x >= frame.origin.x
+            && cursor.x <= frame.origin.x + frame.size.width
+            && cursor.y >= frame.origin.y
+            && cursor.y <= frame.origin.y + frame.size.height;
+
+        if inside == was_hovering.get() {
+            return;
+        }
+        was_hovering.set(inside);
+
+        // Toggle `data-flee` on <html> so CSS in the page can react.
+        let js = if inside {
+            "document.documentElement.setAttribute('data-flee','1')"
+        } else {
+            "document.documentElement.removeAttribute('data-flee')"
+        };
+        let js_str = NSString::from_str(js);
+        unsafe {
+            webview.evaluateJavaScript_completionHandler(&js_str, None);
+        }
+    });
+
+    unsafe {
+        NSTimer::scheduledTimerWithTimeInterval_repeats_block(HOVER_POLL_SECONDS, true, &block)
+    }
+}
+
+unsafe fn build_webview(
+    mtm: MainThreadMarker,
+    panel: &NSPanel,
+    url: &str,
+) -> Retained<WKWebView> {
+    let config: Retained<WKWebViewConfiguration> = unsafe {
+        let alloc = WKWebViewConfiguration::alloc(mtm);
+        msg_send![alloc, init]
+    };
+
+    let frame = NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(PANEL_SIZE, PANEL_SIZE),
+    );
+    let webview: Retained<WKWebView> =
+        unsafe { WKWebView::initWithFrame_configuration(WKWebView::alloc(mtm), frame, &config) };
+
+    unsafe {
+        // Critical: turn off WKWebView's own background painting. Without
+        // this, the webview paints the system background color underneath
+        // the page even when both the panel and the page CSS are
+        // transparent. There is no public Swift/ObjC API for this on
+        // macOS — KVC against the private `drawsBackground` property is
+        // the canonical workaround (used by wry, wkwebview-rs, Electron).
+        let no = NSNumber::numberWithBool(false);
+        let key = NSString::from_str("drawsBackground");
+        let _: () = msg_send![&*webview, setValue: &*no, forKey: &*key];
+
+        // Auto-resize to fill the panel content view.
+        let _: () = msg_send![&*webview, setAutoresizingMask: 18u64]; // width|height
+
+        // Make the webview the panel's content view so it fills the frame.
+        let webview_ref: &objc2::runtime::AnyObject = &*webview;
+        let webview_view: *mut objc2::runtime::AnyObject =
+            webview_ref as *const _ as *mut objc2::runtime::AnyObject;
+        let _: () = msg_send![panel, setContentView: webview_view];
+
+        // Kick off the load.
+        let ns_url_str = NSString::from_str(url);
+        let ns_url: Option<Retained<NSURL>> = NSURL::URLWithString(&ns_url_str);
+        if let Some(ns_url) = ns_url {
+            let request = NSURLRequest::requestWithURL(&ns_url);
+            let _ = webview.loadRequest(&request);
+        } else {
+            log::warn!("[mascot-native] could not parse url={url}");
+        }
+    }
+
+    webview
+}
+

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -38,9 +38,9 @@ use tauri::AppHandle;
 use crate::AppRuntime;
 
 /// Logical width / height of the mascot panel. The `<YellowMascot>` SVG
-/// canvas is square so we keep the host square too. 25% smaller than the
-/// original 140pt so it sits unobtrusively in the corner.
-const PANEL_SIZE: f64 = 105.0;
+/// canvas is square so we keep the host square too. Down to ~79pt
+/// (140 → 105 → 79) so it sits unobtrusively in the corner.
+const PANEL_SIZE: f64 = 79.0;
 /// Distance from the bottom-right monitor corner on first show.
 const PANEL_MARGIN: f64 = 0.0;
 /// How often we poll the cursor position to detect hover over the mascot.

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -217,43 +217,87 @@ unsafe fn build_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<NSPanel>
     panel
 }
 
+/// Two right-edge resting spots one mascot-height apart. The mascot
+/// alternates between them when the cursor catches up — small hop, not a
+/// trip across the screen.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Slot {
+    Home,
+    HopUp,
+}
+
+impl Slot {
+    fn other(self) -> Slot {
+        match self {
+            Slot::Home => Slot::HopUp,
+            Slot::HopUp => Slot::Home,
+        }
+    }
+}
+
+fn slot_frame(mtm: MainThreadMarker, slot: Slot) -> NSRect {
+    let screen = NSScreen::mainScreen(mtm)
+        .map(|s| s.frame())
+        .unwrap_or_else(|| NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0)));
+    let x = screen.origin.x + screen.size.width - PANEL_SIZE - PANEL_MARGIN;
+    // AppKit origin is bottom-left. `Home` sits at the bottom; `HopUp`
+    // is one full panel-height above it so the mascot completely clears
+    // the cursor's previous position with no visible overlap.
+    let y_home = screen.origin.y + PANEL_MARGIN;
+    let y = match slot {
+        Slot::Home => y_home,
+        Slot::HopUp => y_home + PANEL_SIZE,
+    };
+    NSRect::new(NSPoint::new(x, y), NSSize::new(PANEL_SIZE, PANEL_SIZE))
+}
+
 /// Schedule a repeating Foundation timer on the main run loop that polls
-/// the global cursor position and toggles a `flee` attribute on the
-/// document so the page CSS can animate the mascot out from under the
-/// cursor. We poll because the panel is `ignoresMouseEvents=true` (so it
-/// can't receive `mouseEntered:` / `mouseExited:` events itself), and a
-/// transparent passthrough overlay would defeat the click-through goal.
+/// the global cursor position. When the cursor enters the mascot's panel
+/// frame, the panel hops to the *other* right-edge corner with an
+/// animated `setFrame:display:animate:` move so the user can keep working
+/// without the mascot covering the spot they were trying to click. The
+/// panel is `ignoresMouseEvents=true` regardless, so even mid-animation
+/// the cursor passes straight through.
 unsafe fn spawn_hover_timer(
     panel: Retained<NSPanel>,
-    webview: Retained<WKWebView>,
+    _webview: Retained<WKWebView>,
 ) -> Retained<NSTimer> {
-    // `Rc<Cell<bool>>` is fine — the block fires only on the main run loop,
-    // so single-threaded interior mutability is sufficient.
-    let was_hovering: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+    // Fixed reference rect: the mascot's home position. Cursor entering
+    // this rect makes the panel flee to `HopUp`; leaving it brings it
+    // back to `Home`. We compare against the home rect — not the panel's
+    // current frame — so the cursor moving away from the original spot
+    // is always what triggers the return, regardless of where the panel
+    // has currently hopped to.
+    let mtm_for_home = unsafe { MainThreadMarker::new_unchecked() };
+    let home_rect = slot_frame(mtm_for_home, Slot::Home);
+    let current_slot: Rc<Cell<Slot>> = Rc::new(Cell::new(Slot::Home));
 
     let block = RcBlock::new(move |_timer: NonNull<NSTimer>| {
-        let cursor = unsafe { NSEvent::mouseLocation() };
-        let frame = panel.frame();
-        let inside = cursor.x >= frame.origin.x
-            && cursor.x <= frame.origin.x + frame.size.width
-            && cursor.y >= frame.origin.y
-            && cursor.y <= frame.origin.y + frame.size.height;
+        // Safe: this block only fires on the main run loop the timer was
+        // scheduled on, which is the AppKit main thread.
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
 
-        if inside == was_hovering.get() {
+        let cursor = unsafe { NSEvent::mouseLocation() };
+        let inside_home = cursor.x >= home_rect.origin.x
+            && cursor.x <= home_rect.origin.x + home_rect.size.width
+            && cursor.y >= home_rect.origin.y
+            && cursor.y <= home_rect.origin.y + home_rect.size.height;
+
+        let desired = if inside_home { Slot::HopUp } else { Slot::Home };
+        if desired == current_slot.get() {
             return;
         }
-        was_hovering.set(inside);
-
-        // Toggle `data-flee` on <html> so CSS in the page can react.
-        let js = if inside {
-            "document.documentElement.setAttribute('data-flee','1')"
-        } else {
-            "document.documentElement.removeAttribute('data-flee')"
-        };
-        let js_str = NSString::from_str(js);
-        unsafe {
-            webview.evaluateJavaScript_completionHandler(&js_str, None);
-        }
+        current_slot.set(desired);
+        let target = slot_frame(mtm, desired);
+        log::debug!(
+            "[mascot-native] cursor {} home — moving to slot={}",
+            if inside_home { "entered" } else { "left" },
+            match desired {
+                Slot::Home => "Home",
+                Slot::HopUp => "HopUp",
+            }
+        );
+        panel.setFrame_display_animate(target, true, true);
     });
 
     unsafe {

--- a/app/src/features/human/Mascot/YellowMascot.tsx
+++ b/app/src/features/human/Mascot/YellowMascot.tsx
@@ -14,6 +14,14 @@ export interface YellowMascotProps {
   arm?: 'wave' | 'none';
   /** Override SVG element size; defaults to filling the parent. */
   size?: number | string;
+  /** Center opacity of the ground shadow gradient. Defaults to 0.35; bump
+   *  up when the mascot is rendered very small (floating mascot window) so
+   *  the shadow stays readable. */
+  groundShadowOpacity?: number;
+  /** Replace the warm yellow/amber arm inner-shadow tints with darker
+   *  neutrals — for very small renders where the warm tint reads as a
+   *  bright halo instead of a shadow. */
+  compactArmShading?: boolean;
 }
 
 const FPS = 30;
@@ -67,8 +75,20 @@ export const YellowMascot: FC<YellowMascotProps> = ({
   face = 'idle',
   arm = 'none',
   size = '100%',
+  groundShadowOpacity,
+  compactArmShading,
 }) => {
-  const { component, inputProps } = useMemo(() => variantForFace(face, arm), [face, arm]);
+  const { component, inputProps } = useMemo(() => {
+    const variant = variantForFace(face, arm);
+    return {
+      component: variant.component,
+      inputProps: {
+        ...variant.inputProps,
+        ...(groundShadowOpacity !== undefined && { groundShadowOpacity }),
+        ...(compactArmShading !== undefined && { compactArmShading }),
+      },
+    };
+  }, [face, arm, groundShadowOpacity, compactArmShading]);
   const playerRef = useRef<PlayerRef>(null);
 
   // Player's `autoPlay` prop is unreliable across browsers / strict-mode mounts

--- a/app/src/features/human/Mascot/yellow/MascotCharacter.tsx
+++ b/app/src/features/human/Mascot/yellow/MascotCharacter.tsx
@@ -37,7 +37,20 @@ type ThinkingTiming = {
   thinkOutEndSec?: number;
 };
 
-export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & ThinkingTiming> = ({
+export const MascotCharacter: React.FC<
+  MascotProps & {
+    idPrefix?: string;
+    /** Center opacity of the ground shadow gradient. Defaults to 0.35;
+     *  bump up (e.g. 0.75) when the mascot is rendered very small (e.g.
+     *  the floating mascot window) so the shadow stays readable. */
+    groundShadowOpacity?: number;
+    /** When true, replaces the warm yellow/amber arm inner-shadow tints
+     *  with darker neutrals so the under-arm shading reads as a real
+     *  shadow at very small render sizes (instead of looking like a
+     *  bright halo). */
+    compactArmShading?: boolean;
+  } & ThinkingTiming
+> = ({
   arm = 'wave',
   face = 'normal',
   talking = false,
@@ -47,11 +60,28 @@ export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & Thi
   recordingColor = '#ff3b30',
   loadingColor = '#ffffff',
   idPrefix = 'mascot',
+  groundShadowOpacity = 0.35,
+  compactArmShading = false,
   thinkInStartSec = 1.0,
   thinkInEndSec = 2.0,
   thinkOutStartSec,
   thinkOutEndSec,
 }) => {
+  // Arm-shadow color matrices. Default is the warm yellow→amber pair
+  // that matches the mascot's hand-painted look at full size; in
+  // compact mode (small render) we kill the yellow highlight and turn
+  // the amber shadow into a true black so the under-arm reads as a
+  // single dark mass instead of a noisy halo at low pixel counts.
+  const armHighlightMatrix = compactArmShading
+    ? '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+    : '0 0 0 0 0.973501 0 0 0 0 0.909066 0 0 0 0 0.671677 0 0 0 1 0';
+  const rightArmShadowMatrix = compactArmShading
+    ? '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0'
+    : '0 0 0 0 0.796078 0 0 0 0 0.576471 0 0 0 0 0.0980392 0 0 0 1 0';
+  const leftArmShadowMatrix = compactArmShading
+    ? '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0'
+    : '0 0 0 0 0.796078 0 0 0 0 0.576471 0 0 0 0 0.0980392 0 0 0 0.8 0';
+
   const frame = useCurrentFrame();
   const { fps, width, height, durationInFrames } = useVideoConfig();
 
@@ -261,9 +291,17 @@ export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & Thi
     <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center' }}>
       <svg width={size} height={size} viewBox="0 0 1000 1000" style={{ overflow: 'visible' }}>
         <defs>
-          {/* Ground shadow gradient */}
+          {/* Ground shadow gradient. Center opacity is configurable via
+              `groundShadowOpacity` so callers rendering the mascot at a
+              very small size (e.g. the floating mascot window) can darken
+              the shadow without affecting the full-size views. */}
           <radialGradient id={p('ground')} cx="0.5" cy="0.5" r="0.5">
-            <stop offset="0%" stopColor="#000000" stopOpacity="0.35" />
+            <stop offset="0%" stopColor="#000000" stopOpacity={groundShadowOpacity} />
+            <stop
+              offset="60%"
+              stopColor="#000000"
+              stopOpacity={Math.max(0, groundShadowOpacity * 0.45)}
+            />
             <stop offset="100%" stopColor="#000000" stopOpacity="0" />
           </radialGradient>
 
@@ -420,10 +458,7 @@ export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & Thi
             <feOffset dx="-11" dy="28" />
             <feGaussianBlur stdDeviation="11" />
             <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-            <feColorMatrix
-              type="matrix"
-              values="0 0 0 0 0.973501 0 0 0 0 0.909066 0 0 0 0 0.671677 0 0 0 1 0"
-            />
+            <feColorMatrix type="matrix" values={armHighlightMatrix} />
             <feBlend mode="normal" in2="shape" result="effect1_innerShadow" />
             <feColorMatrix
               in="SourceAlpha"
@@ -434,10 +469,7 @@ export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & Thi
             <feOffset dx="-8" dy="1" />
             <feGaussianBlur stdDeviation="4.25" />
             <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-            <feColorMatrix
-              type="matrix"
-              values="0 0 0 0 0.796078 0 0 0 0 0.576471 0 0 0 0 0.0980392 0 0 0 1 0"
-            />
+            <feColorMatrix type="matrix" values={rightArmShadowMatrix} />
             <feBlend mode="normal" in2="effect1_innerShadow" result="effect2_innerShadow" />
             <feTurbulence type="fractalNoise" baseFrequency="0.999" numOctaves={3} seed={8703} />
             <feDisplacementMap
@@ -474,10 +506,7 @@ export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & Thi
             <feOffset dx="1" dy="-20" />
             <feGaussianBlur stdDeviation="7.55" />
             <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-            <feColorMatrix
-              type="matrix"
-              values="0 0 0 0 0.973501 0 0 0 0 0.909066 0 0 0 0 0.671677 0 0 0 1 0"
-            />
+            <feColorMatrix type="matrix" values={armHighlightMatrix} />
             <feBlend mode="normal" in2="shape" result="effect1_innerShadow" />
             <feColorMatrix
               in="SourceAlpha"
@@ -488,10 +517,7 @@ export const MascotCharacter: React.FC<MascotProps & { idPrefix?: string } & Thi
             <feOffset dx="3" dy="-8" />
             <feGaussianBlur stdDeviation="3.55" />
             <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-            <feColorMatrix
-              type="matrix"
-              values="0 0 0 0 0.796078 0 0 0 0 0.576471 0 0 0 0 0.0980392 0 0 0 0.8 0"
-            />
+            <feColorMatrix type="matrix" values={leftArmShadowMatrix} />
             <feBlend mode="normal" in2="effect1_innerShadow" result="effect2_innerShadow" />
             <feTurbulence type="fractalNoise" baseFrequency="0.999" numOctaves={3} seed={8703} />
             <feDisplacementMap

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -43,10 +43,21 @@
 
   html[data-window='overlay'],
   html[data-window='overlay'] body,
-  html[data-window='overlay'] #root {
+  html[data-window='overlay'] #root,
+  html[data-window='mascot'],
+  html[data-window='mascot'] body,
+  html[data-window='mascot'] #root {
     background: transparent;
     overflow: hidden;
     user-select: none;
+  }
+
+  /* When the native host detects the cursor is over the mascot panel it
+     sets data-flee="1" on <html>; the mascot scales/translates out of the
+     way so the user can see what's underneath. */
+  html[data-window='mascot'][data-flee='1'] .mascot-flee-target {
+    transform: translate(40%, 40%) scale(0.5);
+    opacity: 0;
   }
 
   @keyframes overlay-bubble-in {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -52,7 +52,6 @@
     user-select: none;
   }
 
-
   @keyframes overlay-bubble-in {
     from {
       opacity: 0;

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -52,13 +52,6 @@
     user-select: none;
   }
 
-  /* When the native host detects the cursor is over the mascot panel it
-     sets data-flee="1" on <html>; the mascot scales/translates out of the
-     way so the user can see what's underneath. */
-  html[data-window='mascot'][data-flee='1'] .mascot-flee-target {
-    transform: translate(40%, 40%) scale(0.5);
-    opacity: 0;
-  }
 
   @keyframes overlay-bubble-in {
     from {

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -76,7 +76,15 @@ function bootRender() {
   root.render(<React.StrictMode>{tree}</React.StrictMode>);
 }
 
-getActiveUserIdFromCore()
+// The mascot lives in a native WKWebView (no Tauri IPC), so
+// `getActiveUserIdFromCore()` would just reject after a roundtrip and
+// delay first paint for nothing. Skip the bootstrap entirely in that
+// path — the mascot UI doesn't read user-scoped storage anyway.
+const activeUserBootstrap = isMascotWindow
+  ? Promise.resolve<string | null>(null)
+  : getActiveUserIdFromCore();
+
+activeUserBootstrap
   .then(id => primeActiveUserId(id))
   .catch(() => primeActiveUserId(null))
   .finally(bootRender);

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -7,6 +7,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { getCoreStateSnapshot } from './lib/coreState/store';
+import MascotWindowApp from './mascot/MascotWindowApp';
 import OverlayApp from './overlay/OverlayApp';
 import './polyfills';
 import { initSentry } from './services/analytics';
@@ -17,8 +18,26 @@ import { getActiveUserIdFromCore } from './utils/tauriCommands';
 
 setStoreForApiClient(() => getCoreStateSnapshot().snapshot.sessionToken);
 
-const currentWindowLabel = tauriRuntimeAvailable() ? getCurrentWindow().label : 'main';
+// The floating mascot is hosted in a native macOS NSPanel + WKWebView
+// that lives OUTSIDE Tauri's runtime (the vendored tauri-cef can't render
+// transparent windowed-mode browsers). That webview can't read a Tauri
+// window label, so the Rust shell appends `?window=mascot` to the URL it
+// loads. Detect it before we touch any Tauri APIs.
+const urlWindowParam = (() => {
+  try {
+    return new URLSearchParams(window.location.search).get('window');
+  } catch {
+    return null;
+  }
+})();
+const isMascotWindow = urlWindowParam === 'mascot';
+const currentWindowLabel = isMascotWindow
+  ? 'mascot'
+  : tauriRuntimeAvailable()
+    ? getCurrentWindow().label
+    : 'main';
 const isOverlayWindow = currentWindowLabel === 'overlay';
+const isStandaloneWindow = isOverlayWindow || isMascotWindow;
 
 const ensureDefaultHashRoute = () => {
   const hash = window.location.hash;
@@ -35,7 +54,7 @@ const ensureDefaultHashRoute = () => {
 initSentry();
 document.documentElement.dataset.window = currentWindowLabel;
 
-if (!isOverlayWindow) {
+if (!isStandaloneWindow) {
   ensureDefaultHashRoute();
 
   // Deep link listener — try/catch handles non-Tauri environments
@@ -53,7 +72,8 @@ if (!isOverlayWindow) {
 // namespace from the first storage call. (#900)
 function bootRender() {
   const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-  root.render(<React.StrictMode>{isOverlayWindow ? <OverlayApp /> : <App />}</React.StrictMode>);
+  const tree = isMascotWindow ? <MascotWindowApp /> : isOverlayWindow ? <OverlayApp /> : <App />;
+  root.render(<React.StrictMode>{tree}</React.StrictMode>);
 }
 
 getActiveUserIdFromCore()

--- a/app/src/mascot/MascotWindowApp.tsx
+++ b/app/src/mascot/MascotWindowApp.tsx
@@ -16,11 +16,7 @@ const DEFAULT_FACE: MascotFace = 'idle';
 const MascotWindowApp = () => {
   return (
     <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'transparent',
-      }}
+      style={{ position: 'fixed', inset: 0, background: 'transparent' }}
       data-face={DEFAULT_FACE}>
       <YellowMascot face={DEFAULT_FACE} />
     </div>

--- a/app/src/mascot/MascotWindowApp.tsx
+++ b/app/src/mascot/MascotWindowApp.tsx
@@ -1,0 +1,37 @@
+import { type MascotFace, YellowMascot } from '../features/human/Mascot';
+
+/**
+ * Hosted inside a native macOS NSPanel + WKWebView (see
+ * `app/src-tauri/src/mascot_native_window.rs`), NOT inside Tauri's runtime.
+ *
+ * - No `@tauri-apps/api/*` calls work here.
+ * - The panel is `ignoresMouseEvents=true` so the cursor passes straight
+ *   through. Hover is detected on the Rust side by polling
+ *   `NSEvent.mouseLocation()` against the panel frame; when the cursor is
+ *   over us, the host sets `data-flee="1"` on `<html>` and the CSS below
+ *   slides the mascot off-screen so it visibly gets out of the way.
+ * - Show/hide is driven from the tray menu in the main app.
+ *
+ * The mascot stays in `idle` (normal face) until we wire a script-message
+ * bridge back to the Rust shell that can push real agent state in.
+ */
+const DEFAULT_FACE: MascotFace = 'idle';
+
+const MascotWindowApp = () => {
+  return (
+    <div
+      className="mascot-flee-target"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'transparent',
+        transition: 'transform 220ms cubic-bezier(.4,.0,.2,1), opacity 220ms ease',
+        transformOrigin: '100% 100%',
+      }}
+      data-face={DEFAULT_FACE}>
+      <YellowMascot face={DEFAULT_FACE} />
+    </div>
+  );
+};
+
+export default MascotWindowApp;

--- a/app/src/mascot/MascotWindowApp.tsx
+++ b/app/src/mascot/MascotWindowApp.tsx
@@ -6,27 +6,20 @@ import { type MascotFace, YellowMascot } from '../features/human/Mascot';
  *
  * - No `@tauri-apps/api/*` calls work here.
  * - The panel is `ignoresMouseEvents=true` so the cursor passes straight
- *   through. Hover is detected on the Rust side by polling
- *   `NSEvent.mouseLocation()` against the panel frame; when the cursor is
- *   over us, the host sets `data-flee="1"` on `<html>` and the CSS below
- *   slides the mascot off-screen so it visibly gets out of the way.
+ *   through. When the Rust host sees the cursor enter the panel frame it
+ *   animates the whole NSPanel to the other right-edge corner, so the
+ *   mascot bounces out of the way without going off-screen.
  * - Show/hide is driven from the tray menu in the main app.
- *
- * The mascot stays in `idle` (normal face) until we wire a script-message
- * bridge back to the Rust shell that can push real agent state in.
  */
 const DEFAULT_FACE: MascotFace = 'idle';
 
 const MascotWindowApp = () => {
   return (
     <div
-      className="mascot-flee-target"
       style={{
         position: 'fixed',
         inset: 0,
         background: 'transparent',
-        transition: 'transform 220ms cubic-bezier(.4,.0,.2,1), opacity 220ms ease',
-        transformOrigin: '100% 100%',
       }}
       data-face={DEFAULT_FACE}>
       <YellowMascot face={DEFAULT_FACE} />

--- a/app/src/mascot/MascotWindowApp.tsx
+++ b/app/src/mascot/MascotWindowApp.tsx
@@ -18,7 +18,7 @@ const MascotWindowApp = () => {
     <div
       style={{ position: 'fixed', inset: 0, background: 'transparent' }}
       data-face={DEFAULT_FACE}>
-      <YellowMascot face={DEFAULT_FACE} />
+      <YellowMascot face={DEFAULT_FACE} groundShadowOpacity={0.75} compactArmShading />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Adds a tray-toggleable floating mascot anchored to the bottom-right pixel corner of the primary screen on macOS.
- Hosts the existing `<YellowMascot>` Remotion player inside a native `NSPanel` + `WKWebView` instead of a Tauri webview, so the window is actually transparent.
- Click-through is always-on (`ignoresMouseEvents=true`); a 20Hz Foundation timer detects when the cursor enters the home rect and animates the panel one mascot-height up the screen, returning home as soon as the cursor leaves.

## Problem

We wanted a "floating desktop character" that would live on top of any app, not block clicks, and politely move out of the way when the user reaches for something underneath it. Two things made this non-trivial:

1. The vendored `tauri-cef` runtime (drives every existing OpenHuman window) cannot render transparent windowed-mode browsers — CEF clamps `BrowserSettings.background_color` alpha to `0xFF` for windowed browsers, and the runtime doesn't enable off-screen rendering. A `transparent: true` Tauri `WebviewWindow` ends up opaque on screen.
2. Tauri's runtime is one-per-process: you can't selectively use `tauri-runtime-wry` (WKWebView/WebView2/etc.) for a single window inside a CEF app. Every Tauri-managed window in this codebase has to go through CEF.

## Solution

Bypass Tauri's runtime entirely for this one window on macOS:

- New `app/src-tauri/src/mascot_native_window.rs` (macOS-only) creates a borderless `NonactivatingPanel` + embedded `WKWebView` directly via `objc2-app-kit` / `objc2-web-kit`. The panel is non-opaque, status-bar-level, can-join-all-spaces+transient (so it floats above fullscreen apps), shadowless, and `ignoresMouseEvents=true`. The `WKWebView` uses the canonical `setValue:NO forKey:@"drawsBackground"` KVC trick so the page CSS shows through.
- The webview loads the same Vite dev URL as the main window, with `?window=mascot` appended. `app/src/main.tsx` was updated to detect that URL param **before** touching any Tauri API (since this webview lives outside Tauri's runtime) and mount a tiny `MascotWindowApp` that renders just `<YellowMascot face="idle" />`.
- New Tauri commands `mascot_window_show` / `mascot_window_hide` delegate to the native module on macOS and return an error elsewhere. A "Toggle floating mascot" entry was added to the existing tray menu.
- Hover-to-flee is implemented entirely on the Rust side: a Foundation `NSTimer` (50ms tick) compares `NSEvent.mouseLocation()` against the panel's home rect; entering it kicks off `setFrame:display:animate:` to a `HopUp` slot one panel-height above home, leaving brings it back. No JS bridge needed.

### Trade-offs

- **macOS only.** Linux/Windows would each need their own native webview path (webkit2gtk, WebView2). The Tauri commands return an error there for now.
- **Dev-only.** `resolve_page_url` reads `app.config().build.dev_url`; production bundle support needs either a tiny localhost HTTP server in the shell or `file://` loading with ESM/CORS workarounds. Documented in the module-level doc comment.
- **No IPC bridge yet.** The mascot face is hard-coded to `idle` until we wire a `WKScriptMessageHandler` to push real agent state in. Also means there's no in-page close button — toggle from the tray.
- **Click-through is always on**, so the panel can't be dragged. Acceptable since it's anchored to a fixed corner.

## Submission Checklist

- [ ] N/A: prototype-level macOS-native code with no testable surface — the Rust module is a thin wrapper around Cocoa/WebKit calls and the React entry is a 12-line component. Will add tests once the IPC bridge / production bundle path lands.
- [ ] N/A: changed lines are 100% native Cocoa/WebKit FFI and a passive React render — no testable logic for `diff-cover` to evaluate; coverage gate would not measure anything meaningful here.
- [ ] N/A: behaviour-only change; no feature added to the matrix yet (mascot panel is not a tracked product feature pending wiring to real state).
- [ ] N/A: no matrix feature IDs apply.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: not a release-cut surface — opt-in tray entry, not on a default user path.
- [ ] N/A: no linked issue.

## Impact

- **Platform**: macOS desktop only. Other desktops are unaffected (the tray entry still appears but `mascot_window_show` returns an error).
- **Runtime**: adds a 50ms repeating Foundation timer while the mascot is visible; trivial CPU cost. Adds two new macOS deps (`objc2-web-kit`, plus `NSTimer` + `block2` features on `objc2-foundation`). No new network deps.
- **Security**: WKWebView loads the same dev URL the main window uses, scoped to dev mode. The KVC `drawsBackground` private API is the standard wry/Electron approach; no new attack surface.
- **Migration**: none. Off by default; appears only when the user toggles the tray entry.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - Production bundle URL path (localhost server or `file://` + bundled HTML).
  - `WKScriptMessageHandler` bridge so the host can push real agent state (face changes, show/hide on context).
  - Linux + Windows native paths if we want the mascot cross-platform.
  - Lighter Vite entry (`mascot.html`) so first paint isn't gated on the full app bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating mascot window for macOS with tray-menu toggle to show/hide.
  * Mascot runs as a standalone transparent window and supports launching with ?window=mascot.
  * Interactive hover animations that animate the mascot along the right edge.
* **Enhancements**
  * Visual tuning options for mascot rendering (adjustable shadow opacity and compact arm shading).
* **Chores**
  * macOS dependency updated to explicitly enable NSTimer and block2 features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->