### PR TITLE
fix(memory/tree): emit summary children as Obsidian wikilinks

### DIFF
--- a/src/openhuman/memory/tree/content_store/compose.rs
+++ b/src/openhuman/memory/tree/content_store/compose.rs
@@ -38,7 +38,7 @@
 
 use chrono::{DateTime, Utc};
 
-use crate::openhuman::memory::tree::content_store::paths::SummaryTreeKind;
+use crate::openhuman::memory::tree::content_store::paths::{sanitize_filename, SummaryTreeKind};
 use crate::openhuman::memory::tree::types::{Chunk, SourceKind};
 
 /// Compose the full file content (front-matter + body) for `chunk`.
@@ -310,13 +310,21 @@ fn build_summary_front_matter(r: &SummaryComposeInput<'_>) -> String {
     fm.push_str(&format!("tree_scope: {}\n", yaml_scalar(r.tree_scope)));
     fm.push_str(&format!("level: {}\n", r.level));
 
-    // children: YAML list
+    // children: YAML list of Obsidian wikilinks (`[[<basename>]]`) so the
+    // graph view draws summary→child edges. The wikilink target must match
+    // the actual file basename — for chunks that's the raw chunk_id (a SHA
+    // hash with no illegal chars), but for child summaries the structured id
+    // `summary:L<n>:UUID` is sanitised to `summary-L<n>-UUID` by
+    // `summary_rel_path` (colons are illegal on Windows NTFS). We apply the
+    // same sanitisation here so the link resolves. `yaml_scalar` auto-quotes
+    // because of the leading `[`, emitting `"[[<basename>]]"`.
     if r.child_ids.is_empty() {
         fm.push_str("children: []\n");
     } else {
         fm.push_str("children:\n");
         for id in r.child_ids {
-            fm.push_str(&format!("  - {}\n", yaml_scalar(id)));
+            let wikilink = format!("[[{}]]", sanitize_filename(id));
+            fm.push_str(&format!("  - {}\n", yaml_scalar(&wikilink)));
         }
     }
     fm.push_str(&format!("child_count: {}\n", r.child_count));
@@ -741,8 +749,14 @@ mod tests {
         );
         assert!(fm.contains("level: 1"), "must have level");
         assert!(fm.contains("child_count: 2"), "must have child_count");
-        assert!(fm.contains("  - child-1"), "must list child ids");
-        assert!(fm.contains("  - child-2"), "must list child ids");
+        assert!(
+            fm.contains("  - \"[[child-1]]\""),
+            "must list child ids as Obsidian wikilinks; got:\n{fm}"
+        );
+        assert!(
+            fm.contains("  - \"[[child-2]]\""),
+            "must list child ids as Obsidian wikilinks; got:\n{fm}"
+        );
         assert!(fm.contains("tags: []"), "must start with empty tags");
         // aliases must mention the scope
         assert!(fm.contains("aliases:"), "must have aliases");
@@ -751,6 +765,71 @@ mod tests {
             "body must be the summariser text"
         );
         assert!(composed.full.ends_with("This is the summariser output.\n"));
+    }
+
+    #[test]
+    fn children_are_emitted_as_obsidian_wikilinks() {
+        // Contract: every entry in `children:` must be wrapped in `[[…]]` so
+        // Obsidian's graph view draws a summary→child edge. The YAML scalar is
+        // quoted because of the leading `[` — both forms below are required.
+        let input = sample_summary_input(SummaryTreeKind::Source, "gmail:alice@x.com", 1);
+        let composed = compose_summary_md(&input);
+        let fm = &composed.front_matter;
+        for id in ["child-1", "child-2"] {
+            let expected = format!("  - \"[[{id}]]\"");
+            assert!(
+                fm.contains(&expected),
+                "child id {id} must be emitted as a quoted wikilink ({expected}); got:\n{fm}"
+            );
+            // Belt-and-braces: the bare id must NOT appear as a plain scalar
+            // (i.e. unwrapped). The wikilink form contains the id, so we
+            // search for the bare list-item form.
+            let plain = format!("  - {id}\n");
+            assert!(
+                !fm.contains(&plain),
+                "child id {id} must not be emitted as a plain scalar; got:\n{fm}"
+            );
+        }
+    }
+
+    #[test]
+    fn structured_child_summary_id_is_sanitised_in_wikilink() {
+        // Real-world case: an L2 summary lists child L1 summaries by their
+        // structured id (e.g. `summary:L1:UUID`). Colons are illegal in
+        // Windows NTFS filenames, so `summary_rel_path` writes the file as
+        // `summary-L1-UUID.md`. The wikilink target must match that basename
+        // — i.e. colons must be converted to dashes — otherwise Obsidian
+        // cannot resolve the link and the graph stays disconnected.
+        let ts = chrono::Utc.timestamp_millis_opt(1_700_000_000_000).unwrap();
+        let child_id = "summary:L1:b9fa5f08-bf79-41a7-a5c8-2d87883d5c01";
+        let expected_basename = "summary-L1-b9fa5f08-bf79-41a7-a5c8-2d87883d5c01";
+        let input = SummaryComposeInput {
+            summary_id: "summary:L2:cc9a1224",
+            tree_kind: SummaryTreeKind::Source,
+            tree_id: "t1",
+            tree_scope: "gmail:alice@x.com",
+            level: 2,
+            child_ids: &[child_id.to_string()],
+            child_count: 1,
+            time_range_start: ts,
+            time_range_end: ts,
+            sealed_at: ts,
+            body: "L2 body",
+        };
+        let composed = compose_summary_md(&input);
+        let fm = &composed.front_matter;
+        let expected = format!("  - \"[[{expected_basename}]]\"");
+        assert!(
+            fm.contains(&expected),
+            "structured child id must be sanitised to filename basename in wikilink; \
+             expected line: {expected}; got:\n{fm}"
+        );
+        // Raw colon-bearing id must NOT appear inside `[[…]]` — that wikilink
+        // would not resolve in Obsidian.
+        assert!(
+            !fm.contains(&format!("[[{child_id}]]")),
+            "raw structured id with colons must not appear inside wikilink; got:\n{fm}"
+        );
     }
 
     #[test]

--- a/src/openhuman/memory/tree/content_store/paths.rs
+++ b/src/openhuman/memory/tree/content_store/paths.rs
@@ -96,7 +96,12 @@ pub fn summary_rel_path(
 /// Illegal characters: `\`, `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|`.
 /// (Forward slash is not replaced since `summary_id` should not contain path
 /// separators, but we sanitize it anyway for safety.)
-fn sanitize_filename(s: &str) -> String {
+///
+/// Exposed at crate scope so [`super::compose`] can convert structured IDs
+/// like `summary:L1:UUID` into the basename used by [`summary_rel_path`]
+/// (`summary-L1-UUID`) when emitting Obsidian wikilinks. This keeps a single
+/// source of truth for the id→filename mapping.
+pub(crate) fn sanitize_filename(s: &str) -> String {
     s.chars()
         .map(|c| match c {
             '\\' | '/' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '-',


### PR DESCRIPTION
## Summary

- Summary `.md` files now emit `children:` as Obsidian wikilinks (`[[<basename>]]`) instead of bare YAML scalars, so the graph view draws summary→child edges across all three trees (source / global / topic).
- Structured ids like `summary:L1:UUID` are sanitised to match the on-disk basename `summary-L1-UUID` (colons are illegal on Windows NTFS), reusing the existing `sanitize_filename` from `paths.rs`.
- Body bytes are unchanged — the SHA-256 invariant verified by existing tests holds.

## Problem

The chunk and summary `.md` files written by `memory::tree::content_store` are intended to live inside an Obsidian vault, but the graph view showed zero connections — every node sat isolated. Inspecting a real vault (45 summary files across 4 source-trees + a global digest):

```yaml
children:
  - 9e9c7e4c2a5767c9310c8cc6ecaa9bb9        # plain string, not a link
```

Obsidian's link cache only counts `[[…]]` (or markdown links) when building graph edges. Bare YAML scalars are clickable in the Properties panel UI but do not register as links, so the graph stayed disconnected even though the structural tree existed in SQLite.

A second subtlety: L2+ summaries reference child summaries by their structured id `summary:L1:UUID`, which `summary_rel_path` already sanitises to `summary-L1-UUID` for the file basename. A naive `[[summary:L1:UUID]]` wikilink would not resolve.

## Solution

Single change in `compose.rs::build_summary_front_matter` — wrap each child id in `[[…]]` after applying `sanitize_filename`, so the link target matches the actual file basename. `yaml_scalar` auto-quotes because of the leading `[`, emitting `"  - \"[[<basename>]]\""`.

`paths.rs::sanitize_filename` is now `pub(crate)` so compose can share the single source of truth for the id→basename mapping (instead of duplicating the illegal-character set).

Chunk files are unaffected — chunks have no `children:` field, only summaries do.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — new `children_are_emitted_as_obsidian_wikilinks` (plain ids, asserts wrapped form AND that bare form must NOT appear) + new `structured_child_summary_id_is_sanitised_in_wikilink` (colon-bearing ids, asserts dash conversion AND that the colon form must NOT appear inside `[[…]]`). Existing `compose_source_summary_has_required_front_matter` updated to demand the wrapped form. Body-SHA roundtrip in `read.rs::read_summary_file_returns_body_and_sha` continues to pass.
- [x] **Diff coverage ≥ 80%** — both touched lines in `compose.rs` and the visibility tweak in `paths.rs` are exercised by the new tests; ~10 changed production lines covered by 2 dedicated tests + the existing roundtrip suite.
- [x] Coverage matrix updated — N/A: behaviour-only change to existing writer output; no new feature ID added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: see above.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — N/A: not a release-cut surface; pure file-content change inside the memory tree's content store.
- [x] Linked issue closed via `Closes #NNN` — N/A: exploratory fix surfaced while inspecting the vault graph view; no GitHub issue tracks it.

## Impact

- **Runtime**: zero — same write path, same number of bytes worth of front-matter (slightly larger by `[[]]` and quotes), same fsync/rename semantics. Body SHA invariant preserved by construction (front-matter only).
- **Migration**: existing summary `.md` files keep their plain-scalar `children:` until rewritten. They remain readable; only the graph-view edges are missing for already-written files. A throwaway one-shot Python rewriter (off-repo) handled my local vault — happy to add an in-repo backfill RPC if useful, but most users would just delete the content dir and let new ingests repopulate.
- **Performance / security / compatibility**: none.

## Related

- Closes: N/A (exploratory)
- Follow-up PR(s)/TODOs: optional `parent: "[[<summary-id>]]"` backlink on chunk front-matter (would give bidirectional graph edges); deferred — current change gives a clean top-down tree which was the requested view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Child entries in summary front-matter are now displayed as Obsidian wikilinks (e.g., `[[child-id]]`) for improved vault navigation.
  * Special characters in child identifiers are properly sanitized to match on-disk filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->