### PR TITLE
feat(agents): assign #1208 coding-harness tools to relevant built-in agents

### DIFF
--- a/src/openhuman/agent/agents/code_executor/agent.toml
+++ b/src/openhuman/agent/agents/code_executor/agent.toml
@@ -14,4 +14,30 @@ omit_skills_catalog = true
 hint = "coding"
 
 [tools]
-named = ["shell", "file_read", "file_write", "git_operations", "node_exec", "npm_exec", "curl"]
+# Coding-harness primitives from #1208 (grep/glob/list/edit/apply_patch/
+# todowrite/plan_exit/web_fetch/lsp) sit alongside the legacy
+# shell/file_read/file_write surface. The new tools are strictly better
+# for navigation (grep/glob/list vs. ad-hoc shell `find` / `rg`) and
+# precise editing (edit / apply_patch vs. whole-file `file_write`); the
+# old tools stay so the agent can still drop down to a shell when the
+# task genuinely needs it. `lsp` is capability-gated by
+# OPENHUMAN_LSP_ENABLED — listing it here is harmless when the gate is
+# off (the tool is simply not registered).
+named = [
+    "shell",
+    "file_read",
+    "file_write",
+    "git_operations",
+    "node_exec",
+    "npm_exec",
+    "curl",
+    "grep",
+    "glob",
+    "list",
+    "edit",
+    "apply_patch",
+    "todowrite",
+    "plan_exit",
+    "web_fetch",
+    "lsp",
+]

--- a/src/openhuman/agent/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent/agents/orchestrator/agent.toml
@@ -95,4 +95,14 @@ named = [
     "cron_list",
     "cron_remove",
     "schedule",
+    # Coding-harness coordination primitives from #1208. `todowrite`
+    # gives the orchestrator a shared todo store to track multi-step
+    # work across delegations; `plan_exit` is the stable marker that
+    # the (forthcoming) plan→build mode runner consumes when a planner
+    # subagent hands a plan back up. Editing/navigation primitives
+    # (grep/glob/edit/apply_patch/lsp) intentionally stay with
+    # downstream agents — the orchestrator coordinates, it doesn't
+    # touch files itself.
+    "todowrite",
+    "plan_exit",
 ]

--- a/src/openhuman/agent/agents/planner/agent.toml
+++ b/src/openhuman/agent/agents/planner/agent.toml
@@ -28,6 +28,17 @@ hint = "reasoning"
 # actions slip past the gate.
 named = [
     "file_read",
+    # Read-only nav primitives from #1208. `edit`, `apply_patch`, `lsp`
+    # are intentionally NOT included — sandbox_mode = "read_only" above
+    # forbids workspace mutations, and downstream agents do the writing.
+    # `todowrite` + `plan_exit` let the planner emit a structured
+    # todo list and a stable [plan_exit] marker for the orchestrator.
+    "grep",
+    "glob",
+    "list",
+    "todowrite",
+    "plan_exit",
+    "web_fetch",
     "memory_recall",
     "web_search_tool",
     # Grounded research + market-data lookups so plans can be anchored in

--- a/src/openhuman/agent/agents/researcher/agent.toml
+++ b/src/openhuman/agent/agents/researcher/agent.toml
@@ -20,6 +20,14 @@ named = [
     "web_search",
     "web_search_tool",
     "file_read",
+    # Coding-harness read-only primitives from #1208. `web_fetch` is the
+    # simple URL-GET sibling of `http_request` (capped body, same
+    # allowed_domains gate); grep/glob/list let the researcher navigate
+    # cached docs in the workspace without falling through to shell.
+    "web_fetch",
+    "grep",
+    "glob",
+    "list",
     "memory_recall",
     # Parallel — full surface (search/extract are also delegated by web_search_tool;
     # chat/research/enrich/dataset unlock grounded answers and deep multi-step research).


### PR DESCRIPTION
## Summary

- #1208 added 9 coding-harness primitives (`grep`, `glob`, `list`, `edit`, `apply_patch`, `todowrite`, `plan_exit`, `web_fetch`, `lsp`) to the global `all_tools` registry, but did not wire them into any agent's `[tools] named` allowlist.
- Result: only `wildcard = {}` agents (e.g. `tools_agent`) could actually see them. The agents that would benefit most — `code_executor`, `planner`, `researcher`, `orchestrator` — were silently still on the legacy surface.
- This PR distributes the new tools per-agent based on each agent's role and `sandbox_mode`.

## Distribution

| Agent | Sandbox | Added |
| --- | --- | --- |
| `code_executor` | `sandboxed` | full set: `grep`, `glob`, `list`, `edit`, `apply_patch`, `todowrite`, `plan_exit`, `web_fetch`, `lsp` |
| `planner` | `read_only` | read-only nav (`grep`, `glob`, `list`) + `todowrite` + `plan_exit` + `web_fetch` |
| `researcher` | `none` | read-only nav (`grep`, `glob`, `list`) + `web_fetch` (the simple URL-GET sibling of `http_request`, same `allowed_domains` gate) |
| `orchestrator` | n/a | `todowrite` + `plan_exit` only — the orchestrator coordinates, it doesn't edit files |

`planner` deliberately does NOT receive `edit` / `apply_patch` / `lsp` — `sandbox_mode = "read_only"` forbids workspace mutations and downstream agents do the writing.

Other agents (`archivist`, `critic`, `summarizer`, `help`, `welcome`, `integrations_agent`, `tool_maker`, `trigger_triage`, `trigger_reactor`, `morning_briefing`) are intentionally untouched — their narrow named allowlists reflect domain-specific surfaces (memory ops, composio meta-tools, gitbooks, onboarding) that the new coding primitives don't fit.

`lsp` is capability-gated by `OPENHUMAN_LSP_ENABLED`; listing it in `code_executor`'s allowlist is harmless when the gate is off (the tool is simply not registered into the runtime).

## Test plan

- [x] `cargo test --lib agent::agents::loader` — 20/20 pass (covers `code_executor_*`, `planner_is_read_only_with_composio_meta_tools`, `researcher_has_curl_for_artifact_downloads`, `orchestrator_has_reasoning_hint_and_named_tools`, `all_builtins_parse`)
- [x] `cargo check --manifest-path Cargo.toml` clean
- [ ] Manual: spin up a coding session, confirm `code_executor` actually sees `grep` / `edit` / `apply_patch` in its tool catalog

## Impact

- TOML-only change to 4 agent definitions. No code, no schema, no migration.
- Backwards compatible: pure additions to existing `named = [...]` allowlists.
- Branch was pushed with `--no-verify` because the repo's pre-push hook fails on **pre-existing** app/ ESLint warnings (mascot / commands code) and a Tailwind class lint check — none of which this PR touches. Per CLAUDE.md (`If a pre-push hook fails on something unrelated to your changes ... push with --no-verify and call it out in the PR body.`)

## Related

- Follows up #1208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Enhanced Agent Capabilities**
  * Expanded toolsets across multiple system agents with new navigation, search, and analysis tools
  * Code executor gains enhanced editing and task coordination support
  * Planner and researcher agents equipped with improved search and research primitives
  * System-wide improvements to agent coordination and workflow management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->