### PR TITLE
fix(ui): move Intelligence and Webhooks to Developer Options, clean up nav

### DIFF
--- a/app/src/AppRoutes.tsx
+++ b/app/src/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import DefaultRedirect from './components/DefaultRedirect';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -7,14 +7,12 @@ import HumanPage from './features/human/HumanPage';
 import Accounts from './pages/Accounts';
 import Channels from './pages/Channels';
 import Home from './pages/Home';
-import Intelligence from './pages/Intelligence';
 import Invites from './pages/Invites';
 import Notifications from './pages/Notifications';
 import Onboarding from './pages/onboarding/Onboarding';
 import Rewards from './pages/Rewards';
 import Settings from './pages/Settings';
 import Skills from './pages/Skills';
-import Webhooks from './pages/Webhooks';
 import Welcome from './pages/Welcome';
 import { APP_ENVIRONMENT } from './utils/config';
 
@@ -65,14 +63,7 @@ const AppRoutes = () => {
         />
       )}
 
-      <Route
-        path="/intelligence"
-        element={
-          <ProtectedRoute requireAuth={true}>
-            <Intelligence />
-          </ProtectedRoute>
-        }
-      />
+      <Route path="/intelligence" element={<Navigate to="/settings/intelligence" replace />} />
 
       <Route
         path="/skills"
@@ -130,14 +121,7 @@ const AppRoutes = () => {
         }
       />
 
-      <Route
-        path="/webhooks"
-        element={
-          <ProtectedRoute requireAuth={true}>
-            <Webhooks />
-          </ProtectedRoute>
-        }
-      />
+      <Route path="/webhooks" element={<Navigate to="/settings/webhooks-triggers" replace />} />
 
       <Route
         path="/settings/*"

--- a/app/src/components/BottomTabBar.tsx
+++ b/app/src/components/BottomTabBar.tsx
@@ -73,22 +73,6 @@ const tabs = [
       </svg>
     ),
   },
-  // Memory tab hidden until Intelligence feature is ready (#976)
-  {
-    id: 'intelligence',
-    label: 'Memory',
-    path: '/intelligence',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.8}
-          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-        />
-      </svg>
-    ),
-  },
   {
     id: 'notifications',
     label: 'Alerts',

--- a/app/src/components/settings/hooks/useSettingsNavigation.ts
+++ b/app/src/components/settings/hooks/useSettingsNavigation.ts
@@ -31,7 +31,9 @@ export type SettingsRoute =
   | 'voice-debug'
   | 'local-model-debug'
   | 'notifications'
-  | 'notification-routing';
+  | 'notification-routing'
+  | 'intelligence'
+  | 'webhooks-triggers';
 
 export interface BreadcrumbItem {
   label: string;
@@ -96,6 +98,8 @@ export const useSettingsNavigation = (): SettingsNavigationHook => {
     if (path.includes('/settings/memory-data')) return 'memory-data';
     if (path.includes('/settings/memory-debug')) return 'memory-debug';
     if (path.includes('/settings/webhooks-debug')) return 'webhooks-debug';
+    if (path.includes('/settings/webhooks-triggers')) return 'webhooks-triggers';
+    if (path.includes('/settings/intelligence')) return 'intelligence';
     if (path.includes('/settings/recovery-phrase')) return 'recovery-phrase';
     if (path.includes('/settings/agent-chat')) return 'agent-chat';
     // Notification routes must be checked in specificity order so the more
@@ -208,6 +212,8 @@ export const useSettingsNavigation = (): SettingsNavigationHook => {
       case 'webhooks-debug':
       case 'memory-data':
       case 'memory-debug':
+      case 'intelligence':
+      case 'webhooks-triggers':
         return [settingsCrumb, developerCrumb];
 
       // Developer options section page

--- a/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
+++ b/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
@@ -136,6 +136,38 @@ const developerItems = [
       </svg>
     ),
   },
+  {
+    id: 'intelligence',
+    title: 'Intelligence',
+    description: 'Memory workspace, subconscious engine, dreams, and settings',
+    route: 'intelligence',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'webhooks-triggers',
+    title: 'ComposeIO Triggers',
+    description: 'View ComposeIO trigger history and archive',
+    route: 'webhooks-triggers',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13.828 10.172a4 4 0 010 5.656l-2 2a4 4 0 01-5.656-5.656l1-1m5-5a4 4 0 015.656 5.656l-1 1m-5 5l5-5"
+        />
+      </svg>
+    ),
+  },
 ];
 
 type SentryTestStatus =

--- a/app/src/lib/commands/globalActions.ts
+++ b/app/src/lib/commands/globalActions.ts
@@ -35,7 +35,7 @@ export function registerGlobalActions(
       label: 'Go to Intelligence',
       group: 'Navigation',
       shortcut: 'mod+3',
-      handler: nav('/intelligence'),
+      handler: nav('/settings/intelligence'),
       keywords: ['memory', 'knowledge'],
     },
     {

--- a/app/src/lib/nativeNotifications/__tests__/service.test.ts
+++ b/app/src/lib/nativeNotifications/__tests__/service.test.ts
@@ -70,14 +70,14 @@ describe('nativeNotifications service', () => {
       category: 'system',
       title: 'Webhook error',
       body: 'skill-x webhook returned HTTP 500',
-      deep_link: '/webhooks',
+      deep_link: '/settings/webhooks-triggers',
       timestamp_ms: 1,
     });
     const items = store.getState().notifications.items;
     expect(items).toHaveLength(1);
     expect(items[0].id).toBe('webhook:s:1');
     expect(items[0].category).toBe('system');
-    expect(items[0].deepLink).toBe('/webhooks');
+    expect(items[0].deepLink).toBe('/settings/webhooks-triggers');
   });
 
   it('ignores core_notification payloads missing id/title', () => {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -32,6 +32,8 @@ import WebhooksDebugPanel from '../components/settings/panels/WebhooksDebugPanel
 import SettingsHome from '../components/settings/SettingsHome';
 import SettingsSectionPage from '../components/settings/SettingsSectionPage';
 import { APP_VERSION } from '../utils/config';
+import Intelligence from './Intelligence';
+import Webhooks from './Webhooks';
 
 const accountSettingsItems = [
   {
@@ -295,6 +297,8 @@ const Settings = () => {
         <Route path="webhooks-debug" element={wrapSettingsPage(<WebhooksDebugPanel />)} />
         <Route path="memory-data" element={wrapSettingsPage(<MemoryDataPanel />)} />
         <Route path="memory-debug" element={wrapSettingsPage(<MemoryDebugPanel />)} />
+        <Route path="intelligence" element={<Intelligence />} />
+        <Route path="webhooks-triggers" element={<Webhooks />} />
         {/* About / updates */}
         <Route path="about" element={wrapSettingsPage(<AboutPanel />)} />
         {/* Fallback */}

--- a/app/test/e2e/helpers/shared-flows.ts
+++ b/app/test/e2e/helpers/shared-flows.ts
@@ -113,7 +113,7 @@ const HASH_TO_SIDEBAR_LABEL = {
   '/conversations': 'Conversations',
   '/notifications': 'Alerts',
   '/settings': 'Settings',
-  '/intelligence': 'Intelligence',
+  '/settings/intelligence': 'Intelligence',
 };
 
 export async function navigateViaHash(hash) {
@@ -271,7 +271,7 @@ export async function navigateToSkills() {
 }
 
 export async function navigateToIntelligence() {
-  await navigateViaHash('/intelligence');
+  await navigateViaHash('/settings/intelligence');
 }
 
 export async function navigateToConversations() {

--- a/app/test/e2e/specs/insights-dashboard.spec.ts
+++ b/app/test/e2e/specs/insights-dashboard.spec.ts
@@ -57,7 +57,7 @@ describe('Insights dashboard smoke', () => {
 
   it('mounts the /intelligence route and renders the Memory tab', async () => {
     stepLog('navigating to /intelligence');
-    await navigateViaHash('/intelligence');
+    await navigateViaHash('/settings/intelligence');
 
     // Tabs / page chrome — Memory is the canonical first view.
     await waitForText('Memory', 15_000);

--- a/app/test/e2e/specs/webhooks-tunnel-flow.spec.ts
+++ b/app/test/e2e/specs/webhooks-tunnel-flow.spec.ts
@@ -202,7 +202,7 @@ describe('Webhook tunnel CRUD (UI + core RPC + mock backend)', () => {
 
   it('Webhooks page loads (ComposeIO trigger history surface)', async () => {
     await authenticateAndReachShell();
-    await navigateViaHash('/webhooks');
+    await navigateViaHash('/settings/webhooks-triggers');
 
     await browser.waitUntil(
       async () => {
@@ -218,7 +218,7 @@ describe('Webhook tunnel CRUD (UI + core RPC + mock backend)', () => {
 
     if (supportsExecuteScript()) {
       const hash = await browser.execute(() => window.location.hash);
-      expect(String(hash)).toContain('/webhooks');
+      expect(String(hash)).toContain('/settings/webhooks-triggers');
     }
 
     const visible =

--- a/src/openhuman/notifications/bus.rs
+++ b/src/openhuman/notifications/bus.rs
@@ -103,7 +103,7 @@ pub fn event_to_notification(event: &DomainEvent) -> Option<CoreNotificationEven
                         "{skill_id} webhook returned HTTP {status_code} after {elapsed_ms}ms"
                     ),
                 },
-                deep_link: Some("/webhooks".into()),
+                deep_link: Some("/settings/webhooks-triggers".into()),
                 timestamp_ms: ts,
             })
         }


### PR DESCRIPTION
## Summary

- Move `/intelligence` and `/webhooks` from top-level routes into the Developer Options settings section
- Remove the "Memory" tab from the bottom tab bar — nav now only shows production-ready sections
- Old routes (`/intelligence`, `/webhooks`) redirect to their new settings paths
- Update keyboard shortcut (Mod+3), notification deep links, and E2E tests

## Changes

| File | Change |
|------|--------|
| `AppRoutes.tsx` | Remove top-level routes, add `<Navigate>` redirects |
| `BottomTabBar.tsx` | Remove Memory tab |
| `DeveloperOptionsPanel.tsx` | Add Intelligence + ComposeIO Triggers entries |
| `Settings.tsx` | Add routes for both pages |
| `useSettingsNavigation.ts` | Add type, path matching, breadcrumbs |
| `globalActions.ts` | Update intelligence shortcut path |
| `notifications/bus.rs` | Update webhook deep link |
| E2E tests | Update route references |

## Test plan

- [x] Navigate to Settings → Developer Options → Intelligence — page renders with all tabs
- [x] Navigate to Settings → Developer Options → ComposeIO Triggers — page renders
- [x] Bottom tab bar no longer shows Memory tab
- [x] Old `/intelligence` URL redirects to `/settings/intelligence`
- [x] Old `/webhooks` URL redirects to `/settings/webhooks-triggers`
- [x] Mod+3 keyboard shortcut opens Intelligence in settings
- [x] Existing Developer Options items (AI Config, Agent Chat, Cron Jobs, etc.) unchanged

Closes #1216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Changes**
  * Intelligence and Webhooks features have been reorganized and are now accessible through Settings under Developer Options.
  * Intelligence tab has been removed from bottom tab navigation.

* **Developer Options**
  * Added Intelligence and ComposeIO Triggers menu items for convenient access to these settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->