### PR TITLE
[codex] Fix Composio connected integration matching

### DIFF
--- a/src/openhuman/composio/bus.rs
+++ b/src/openhuman/composio/bus.rs
@@ -444,7 +444,7 @@ async fn wait_for_connection_active(
         match client.list_connections().await {
             Ok(resp) => {
                 if let Some(conn) = resp.connections.into_iter().find(|c| c.id == connection_id) {
-                    if matches!(conn.status.as_str(), "ACTIVE" | "CONNECTED") {
+                    if conn.is_active() {
                         return Ok(conn.status);
                     }
                     last_status = Some(conn.status);

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -77,11 +77,7 @@ pub async fn composio_list_connections(
         .list_connections()
         .await
         .map_err(|e| format!("[composio] list_connections failed: {e:#}"))?;
-    let active = resp
-        .connections
-        .iter()
-        .filter(|c| matches!(c.status.as_str(), "ACTIVE" | "CONNECTED"))
-        .count();
+    let active = resp.connections.iter().filter(|c| c.is_active()).count();
     let total = resp.connections.len();
     // Reconcile the chat-runtime integrations cache against this fresh
     // snapshot. The desktop UI polls this RPC every 5 s, so any OAuth
@@ -613,8 +609,9 @@ fn connected_toolkit_set(integrations: &[ConnectedIntegration]) -> HashSet<Strin
 fn sync_cache_with_connections(connections: &[super::types::ComposioConnection]) {
     let live_active: HashSet<String> = connections
         .iter()
-        .filter(|c| matches!(c.status.as_str(), "ACTIVE" | "CONNECTED"))
-        .map(|c| c.toolkit.clone())
+        .filter(|c| c.is_active())
+        .map(|c| c.normalized_toolkit())
+        .filter(|toolkit| !toolkit.is_empty())
         .collect();
 
     // Read once to decide whether any cache entry is out of sync. We
@@ -800,7 +797,12 @@ async fn fetch_connected_integrations_uncached(
     // during startup would silently break delegation for the whole
     // session.
     let allowlisted_toolkits: Vec<String> = match client.list_toolkits().await {
-        Ok(resp) => resp.toolkits,
+        Ok(resp) => resp
+            .toolkits
+            .into_iter()
+            .map(|toolkit| toolkit.trim().to_ascii_lowercase())
+            .filter(|toolkit| !toolkit.is_empty())
+            .collect(),
         Err(e) => {
             tracing::warn!("[composio] fetch_connected_integrations: list_toolkits failed: {e}");
             return None;
@@ -827,8 +829,9 @@ async fn fetch_connected_integrations_uncached(
     // Active connection slugs (status filter mirrors the original logic).
     let connected_slugs: std::collections::HashSet<String> = connections
         .iter()
-        .filter(|c| c.status == "ACTIVE" || c.status == "CONNECTED")
-        .map(|c| c.toolkit.clone())
+        .filter(|c| c.is_active())
+        .map(|c| c.normalized_toolkit())
+        .filter(|toolkit| !toolkit.is_empty())
         .collect();
 
     // Fetch available tool schemas — only for the connected slugs,

--- a/src/openhuman/composio/ops_tests.rs
+++ b/src/openhuman/composio/ops_tests.rs
@@ -442,6 +442,77 @@ async fn fetch_connected_integrations_via_mock_aggregates_tools() {
 }
 
 #[tokio::test]
+async fn fetch_connected_integrations_treats_slack_and_telegram_status_like_ui() {
+    let _guard = CACHE_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let app = Router::new()
+        .route(
+            "/agent-integrations/composio/toolkits",
+            get(|| async {
+                Json(json!({
+                    "success": true,
+                    "data": {"toolkits": [" Slack ", "telegram"]}
+                }))
+            }),
+        )
+        .route(
+            "/agent-integrations/composio/connections",
+            get(|| async {
+                Json(json!({
+                    "success": true,
+                    "data": {"connections": [
+                        {"id":"c-slack","toolkit":" Slack ","status":"connected"},
+                        {"id":"c-telegram","toolkit":"telegram","status":" active "}
+                    ]}
+                }))
+            }),
+        )
+        .route(
+            "/agent-integrations/composio/tools",
+            get(|| async {
+                Json(json!({
+                    "success": true,
+                    "data": {"tools": [
+                        {"type":"function","function":{
+                            "name":"SLACK_FETCH_CONVERSATION_HISTORY",
+                            "description":"Read Slack channel history"
+                        }},
+                        {"type":"function","function":{
+                            "name":"TELEGRAM_GET_CHAT_HISTORY",
+                            "description":"Read Telegram chat history"
+                        }},
+                        {"type":"function","function":{
+                            "name":"SLACK_DELETE_CHANNEL",
+                            "description":"Delete a channel"
+                        }}
+                    ]}
+                }))
+            }),
+        );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+    invalidate_connected_integrations_cache();
+
+    let integrations = fetch_connected_integrations(&config).await;
+
+    let slack = integrations
+        .iter()
+        .find(|i| i.toolkit == "slack")
+        .expect("slack integration should be present");
+    assert!(slack.connected);
+    assert_eq!(slack.tools.len(), 1);
+    assert_eq!(slack.tools[0].name, "SLACK_FETCH_CONVERSATION_HISTORY");
+
+    let telegram = integrations
+        .iter()
+        .find(|i| i.toolkit == "telegram")
+        .expect("telegram integration should be present");
+    assert!(telegram.connected);
+    assert_eq!(telegram.tools.len(), 1);
+    assert_eq!(telegram.tools[0].name, "TELEGRAM_GET_CHAT_HISTORY");
+}
+
+#[tokio::test]
 async fn fetch_connected_integrations_via_mock_returns_empty_with_no_active() {
     let _guard = CACHE_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
     let app = Router::new().route(

--- a/src/openhuman/composio/periodic.rs
+++ b/src/openhuman/composio/periodic.rs
@@ -154,11 +154,12 @@ pub(crate) async fn run_one_tick() -> Result<(), String> {
         considered += 1;
 
         // Skip connections that aren't actually live yet.
-        if !matches!(conn.status.as_str(), "ACTIVE" | "CONNECTED") {
+        if !conn.is_active() {
             continue;
         }
 
-        let Some(provider) = get_provider(&conn.toolkit) else {
+        let toolkit = conn.normalized_toolkit();
+        let Some(provider) = get_provider(&toolkit) else {
             // No provider registered for this toolkit — that's fine,
             // we just don't have native code for it. Tools still work
             // through `composio_execute`.
@@ -170,7 +171,7 @@ pub(crate) async fn run_one_tick() -> Result<(), String> {
             continue;
         };
 
-        let key = (conn.toolkit.clone(), conn.id.clone());
+        let key = (toolkit.clone(), conn.id.clone());
         let due = {
             let map = sync_map.lock().unwrap_or_else(|e| e.into_inner());
             match map.get(&key) {
@@ -186,7 +187,7 @@ pub(crate) async fn run_one_tick() -> Result<(), String> {
         let ctx = ProviderContext {
             config: Arc::clone(&config),
             client: client.clone(),
-            toolkit: conn.toolkit.clone(),
+            toolkit: toolkit.clone(),
             connection_id: Some(conn.id.clone()),
         };
 

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -356,11 +356,7 @@ impl Tool for ComposioListConnectionsTool {
                 // `fetch_connected_integrations_uncached` so the tool
                 // output and the prompt's Delegation Guide agree on
                 // what counts as "connected".
-                resp.connections.retain(|c| {
-                    let status = c.status.trim();
-                    status.eq_ignore_ascii_case("ACTIVE")
-                        || status.eq_ignore_ascii_case("CONNECTED")
-                });
+                resp.connections.retain(|c| c.is_active());
                 Ok(ToolResult::success(
                     serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into()),
                 ))
@@ -536,12 +532,8 @@ impl Tool for ComposioListToolsTool {
                             let connected: std::collections::HashSet<String> = conns
                                 .connections
                                 .iter()
-                                .filter(|c| {
-                                    let s = c.status.trim();
-                                    s.eq_ignore_ascii_case("ACTIVE")
-                                        || s.eq_ignore_ascii_case("CONNECTED")
-                                })
-                                .map(|c| c.toolkit.trim().to_ascii_lowercase())
+                                .filter(|c| c.is_active())
+                                .map(|c| c.normalized_toolkit())
                                 .filter(|t| !t.is_empty())
                                 .collect();
                             let dropped = retain_connected_tools(&mut resp, &connected);

--- a/src/openhuman/composio/types.rs
+++ b/src/openhuman/composio/types.rs
@@ -87,6 +87,25 @@ pub struct ComposioConnection {
     pub created_at: Option<String>,
 }
 
+impl ComposioConnection {
+    /// Return the toolkit slug in the canonical form used by provider
+    /// lookup, prompt injection, and tool-action prefix matching.
+    pub fn normalized_toolkit(&self) -> String {
+        self.toolkit.trim().to_ascii_lowercase()
+    }
+
+    /// Whether this row represents a usable connection.
+    ///
+    /// The web UI already treats status case-insensitively. Keep the
+    /// core-side chat/runtime filters aligned so a backend spelling such
+    /// as `connected` cannot display as connected in Settings while
+    /// disappearing from the agent's integration surface.
+    pub fn is_active(&self) -> bool {
+        let status = self.status.trim();
+        status.eq_ignore_ascii_case("ACTIVE") || status.eq_ignore_ascii_case("CONNECTED")
+    }
+}
+
 /// Response body of `GET /agent-integrations/composio/connections`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ComposioConnectionsResponse {
@@ -354,6 +373,40 @@ pub struct ComposioTriggerHistoryResult {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn connection_is_active_matches_ui_status_normalization() {
+        for status in ["ACTIVE", "CONNECTED", "active", "connected", " connected "] {
+            let conn = ComposioConnection {
+                id: "c1".into(),
+                toolkit: "slack".into(),
+                status: status.into(),
+                created_at: None,
+            };
+            assert!(conn.is_active(), "status {status:?} should be active");
+        }
+
+        for status in ["PENDING", "INITIATED", "FAILED", ""] {
+            let conn = ComposioConnection {
+                id: "c1".into(),
+                toolkit: "slack".into(),
+                status: status.into(),
+                created_at: None,
+            };
+            assert!(!conn.is_active(), "status {status:?} should not be active");
+        }
+    }
+
+    #[test]
+    fn connection_normalizes_toolkit_for_runtime_matching() {
+        let conn = ComposioConnection {
+            id: "c1".into(),
+            toolkit: " Slack ".into(),
+            status: "ACTIVE".into(),
+            created_at: None,
+        };
+        assert_eq!(conn.normalized_toolkit(), "slack");
+    }
 
     #[test]
     fn toolkits_response_defaults_to_empty() {

--- a/src/openhuman/memory/slack_ingestion/rpc.rs
+++ b/src/openhuman/memory/slack_ingestion/rpc.rs
@@ -59,10 +59,7 @@ pub async fn sync_trigger_rpc(
     let mut candidates: Vec<_> = connections
         .connections
         .into_iter()
-        .filter(|c| {
-            c.toolkit.eq_ignore_ascii_case("slack")
-                && matches!(c.status.as_str(), "ACTIVE" | "CONNECTED")
-        })
+        .filter(|c| c.normalized_toolkit() == "slack" && c.is_active())
         .collect();
 
     if let Some(ref wanted) = req.connection_id {
@@ -150,10 +147,10 @@ pub async fn sync_status_rpc(
 
     let mut rows = Vec::new();
     for conn in connections.connections {
-        if !conn.toolkit.eq_ignore_ascii_case("slack") {
+        if conn.normalized_toolkit() != "slack" {
             continue;
         }
-        if !matches!(conn.status.as_str(), "ACTIVE" | "CONNECTED") {
+        if !conn.is_active() {
             continue;
         }
         let state = match SyncState::load(&memory, "slack", &conn.id).await {


### PR DESCRIPTION
## Summary

- Normalizes Composio connection status checks in the Rust runtime to match the existing UI behavior.
- Normalizes toolkit slugs before cache reconciliation, tool discovery, periodic sync, and Slack ingestion checks.
- Adds regression coverage for Slack/Telegram connections with lowercase/whitespace status and toolkit values.

## Problem

- Settings could show Slack or Telegram as connected while chat/runtime code dropped the integration because backend status/toolkit strings were compared too literally.
- This made connected read tools unavailable to the agent even though the user had completed the connection flow.

## Solution

- Added `ComposioConnection::is_active()` and `ComposioConnection::normalized_toolkit()` as the boundary helpers for external Composio strings.
- Replaced raw active-status/toolkit comparisons in the relevant Composio and Slack ingestion paths.
- Added a mock-backend regression test that keeps Slack/Telegram read tools available while still filtering an admin Slack tool.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: **Diff coverage ≥ 80%** — not run locally; expected from CI.
- [ ] N/A: Coverage matrix updated — behavior-only runtime bug fix for existing Composio integration behavior.
- [ ] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix feature ID identified for this narrow bug fix.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: Manual smoke checklist updated if this touches release-cut surfaces — no release smoke checklist change required.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime impact: connected Slack/Telegram integrations should be exposed to chat consistently with Settings UI connection state.
- Compatibility: only broadens accepted external Composio status/toolkit spelling at the boundary; does not add new tool permissions.
- Local validation: `pnpm debug rust composio -- --nocapture` and `cargo check --manifest-path Cargo.toml` passed earlier on this branch; no further Rust validation was run after machine-memory constraints were identified.

## Related

- Closes #1151
- Follow-up PR(s)/TODOs: none



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection status detection to properly handle whitespace and case variations, ensuring connections are accurately identified as active or inactive regardless of formatting inconsistencies.

* **Refactor**
  * Standardized toolkit name handling across the system to consistently normalize names by removing whitespace and converting to lowercase, enhancing reliability of connection and toolkit matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->