### PR TITLE
fix(tauri): clean shutdown + orphan reap (#1060)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.16"
+version = "0.53.17"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.16"
+version = "0.53.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.16"
+version = "0.53.17"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "tokio-util",
  "toml 0.8.2",
  "url",
 ]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ directories = "5"
 # but we opt into the feature to stay robust against unexpected responses.
 base64 = "0.22"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "time", "net"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 # WebSocket client + server for two uses:
 # - Client: Chrome DevTools Protocol connections to the embedded CEF
 #   instance over `--remote-debugging-port=9222` (IndexedDB reads,

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -392,7 +392,7 @@ pub fn default_core_port() -> u16 {
 /// Whether `OPENHUMAN_CORE_REUSE_EXISTING` is set to a truthy value. Opts
 /// back into the pre-#1130 behavior of attaching to whatever is listening
 /// on the port without identification — useful for manual harnesses.
-fn reuse_existing_listener_enabled() -> bool {
+pub(crate) fn reuse_existing_listener_enabled() -> bool {
     std::env::var("OPENHUMAN_CORE_REUSE_EXISTING")
         .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
         .unwrap_or(false)

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -367,7 +367,29 @@ impl CoreProcessHandle {
     /// Stop the embedded server task. Safe to call when nothing is running.
     pub async fn shutdown(&self) {
         self.cancel_shutdown_token("").await;
-        self.abort_task("").await;
+        let task = {
+            let mut task_guard = self.task.lock().await;
+            task_guard.take()
+        };
+        let Some(mut task) = task else {
+            return;
+        };
+
+        match timeout(Duration::from_secs(5), &mut task).await {
+            Ok(Ok(())) => {
+                log::info!("[core] embedded core server task stopped gracefully");
+            }
+            Ok(Err(err)) => {
+                log::warn!("[core] embedded core server task ended during shutdown: {err}");
+            }
+            Err(_) => {
+                log::warn!(
+                    "[core] graceful embedded core shutdown timed out; aborting server task"
+                );
+                task.abort();
+                let _ = task.await;
+            }
+        }
     }
 
     /// Synchronous-friendly shutdown for `RunEvent::ExitRequested`.

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -27,6 +27,7 @@ use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
+use tokio_util::sync::CancellationToken;
 
 use crate::process_kill::{kill_pid_force, kill_pid_term};
 
@@ -51,6 +52,7 @@ pub fn current_rpc_token() -> Option<String> {
 #[derive(Clone)]
 pub struct CoreProcessHandle {
     task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    shutdown_token: Arc<Mutex<CancellationToken>>,
     restart_lock: Arc<Mutex<()>>,
     port: u16,
     /// Bearer token the embedded server validates on every inbound request.
@@ -72,6 +74,7 @@ impl CoreProcessHandle {
         let rpc_token = generate_rpc_token();
         Self {
             task: Arc::new(Mutex::new(None)),
+            shutdown_token: Arc::new(Mutex::new(CancellationToken::new())),
             restart_lock: Arc::new(Mutex::new(())),
             port,
             rpc_token: Arc::new(rpc_token),
@@ -131,6 +134,7 @@ impl CoreProcessHandle {
         }
 
         {
+            let shutdown_token = self.fresh_shutdown_token().await;
             let mut guard = self.task.lock().await;
             if guard.is_none() {
                 let port = self.port;
@@ -141,9 +145,13 @@ impl CoreProcessHandle {
                 std::env::set_var("OPENHUMAN_CORE_TOKEN", self.rpc_token.as_str());
                 log::info!("[core] spawning embedded in-process core server on port {port}");
                 let task = tokio::spawn(async move {
-                    if let Err(e) =
-                        openhuman_core::core::jsonrpc::run_server_embedded(None, Some(port), true)
-                            .await
+                    if let Err(e) = openhuman_core::core::jsonrpc::run_server_embedded(
+                        None,
+                        Some(port),
+                        true,
+                        shutdown_token,
+                    )
+                    .await
                     {
                         log::error!("[core] embedded core server exited with error: {e}");
                     } else {
@@ -332,8 +340,33 @@ impl CoreProcessHandle {
         }
     }
 
+    async fn fresh_shutdown_token(&self) -> CancellationToken {
+        let mut guard = self.shutdown_token.lock().await;
+        if guard.is_cancelled() {
+            log::debug!("[core] resetting embedded core shutdown token for new spawn");
+            *guard = CancellationToken::new();
+        }
+        guard.clone()
+    }
+
+    async fn cancel_shutdown_token(&self, log_context: &str) {
+        let token = self.shutdown_token.lock().await.clone();
+        if token.is_cancelled() {
+            log::debug!("[core] embedded core shutdown token already cancelled{log_context}");
+        } else {
+            log::info!("[core] cancelling embedded core shutdown token{log_context}");
+            token.cancel();
+        }
+    }
+
+    #[cfg(test)]
+    async fn shutdown_token_is_cancelled(&self) -> bool {
+        self.shutdown_token.lock().await.is_cancelled()
+    }
+
     /// Stop the embedded server task. Safe to call when nothing is running.
     pub async fn shutdown(&self) {
+        self.cancel_shutdown_token("").await;
         self.abort_task("").await;
     }
 
@@ -344,6 +377,7 @@ impl CoreProcessHandle {
     /// and non-blocking on the UI thread — `JoinHandle::abort` returns
     /// immediately.
     pub async fn send_terminate_signal(&self) {
+        self.cancel_shutdown_token(" on app shutdown").await;
         self.abort_task(" on app shutdown").await;
     }
 }

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -28,6 +28,8 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 
+use crate::process_kill::{kill_pid_force, kill_pid_term};
+
 /// Generate a 256-bit cryptographically-random bearer token as a hex string.
 ///
 /// Uses the same encoding as `openhuman_core::core::auth::generate_token`
@@ -496,70 +498,6 @@ fn parse_netstat_pid(stdout: &str, port: u16) -> Option<u32> {
         }
     }
     None
-}
-
-/// Send the graceful-shutdown signal to `pid`. Returns `Ok` if the process
-/// exited cleanly, was already gone, or accepted the signal. Callers must
-/// re-check ownership of the resource (e.g. that the same pid is still bound
-/// to the port) before escalating to `kill_pid_force` — see the PID-reuse
-/// hazard discussed on #1166.
-#[cfg(unix)]
-fn kill_pid_term(pid: u32) -> Result<(), String> {
-    use nix::sys::signal::{kill, Signal};
-    use nix::unistd::Pid;
-    let target = Pid::from_raw(pid as i32);
-    if let Err(e) = kill(target, Signal::SIGTERM) {
-        // ESRCH means already gone — treat as success.
-        if e != nix::errno::Errno::ESRCH {
-            return Err(format!("SIGTERM pid {pid}: {e}"));
-        }
-    }
-    Ok(())
-}
-
-/// Force-kill `pid` after `kill_pid_term` failed to free the resource. Caller
-/// is responsible for revalidating that `pid` still owns the resource we're
-/// trying to free — see `takeover_stale_listener` for the revalidation step.
-#[cfg(unix)]
-fn kill_pid_force(pid: u32) -> Result<(), String> {
-    use nix::sys::signal::{kill, Signal};
-    use nix::unistd::Pid;
-    let target = Pid::from_raw(pid as i32);
-    match kill(Pid::from_raw(pid as i32), Signal::SIGKILL) {
-        Ok(()) => Ok(()),
-        // ESRCH means the process exited between our re-validation and the
-        // SIGKILL — the resource is freeing on its own, treat as success.
-        Err(e) if e == nix::errno::Errno::ESRCH => {
-            let _ = target;
-            Ok(())
-        }
-        Err(e) => Err(format!("SIGKILL pid {pid}: {e}")),
-    }
-}
-
-/// Windows has no graceful equivalent for a windowless RPC server — `taskkill`
-/// without `/F` only delivers `WM_CLOSE` to GUI apps. Send the WM_CLOSE first
-/// (best-effort) so console subprocesses can run shutdown handlers; the
-/// follow-up `kill_pid_force` does the actual termination.
-#[cfg(windows)]
-fn kill_pid_term(pid: u32) -> Result<(), String> {
-    // Best-effort — ignore non-zero exit (e.g. process is windowless).
-    let _ = std::process::Command::new("taskkill")
-        .args(["/PID", &pid.to_string()])
-        .status();
-    Ok(())
-}
-
-#[cfg(windows)]
-fn kill_pid_force(pid: u32) -> Result<(), String> {
-    let status = std::process::Command::new("taskkill")
-        .args(["/F", "/T", "/PID", &pid.to_string()])
-        .status()
-        .map_err(|e| format!("taskkill spawn: {e}"))?;
-    if !status.success() {
-        return Err(format!("taskkill exited with {status}"));
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/app/src-tauri/src/core_process_tests.rs
+++ b/app/src-tauri/src/core_process_tests.rs
@@ -234,3 +234,19 @@ fn each_handle_has_unique_token() {
         "each handle must have a unique token"
     );
 }
+
+#[test]
+fn send_terminate_signal_cancels_shutdown_token() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    rt.block_on(async {
+        let handle = CoreProcessHandle::new(19005);
+        assert!(!handle.shutdown_token_is_cancelled().await);
+
+        handle.send_terminate_signal().await;
+
+        assert!(
+            handle.shutdown_token_is_cancelled().await,
+            "send_terminate_signal must cancel graceful Axum shutdown before aborting the task"
+        );
+    });
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -76,6 +76,23 @@ fn overlay_parent_rpc_url() -> Option<String> {
     Some(trimmed.to_string())
 }
 
+#[tauri::command]
+fn process_diagnostics_list_owned() -> Vec<process_recovery::ProcessInfo> {
+    match process_recovery::enumerate_openhuman_processes() {
+        Ok(processes) => {
+            log::info!(
+                "[startup-recovery] diagnostics listed {} owned OpenHuman processes",
+                processes.len()
+            );
+            processes
+        }
+        Err(err) => {
+            log::warn!("[startup-recovery] diagnostics process enumeration failed: {err}");
+            Vec::new()
+        }
+    }
+}
+
 #[allow(dead_code)] // Overlay disabled in tauri.conf.json; helper kept for future re-enable.
 fn pin_overlay_bottom_right(window: &WebviewWindow<AppRuntime>) {
     let Ok(Some(monitor)) = window.current_monitor() else {
@@ -1596,6 +1613,7 @@ pub fn run() {
             core_rpc_url,
             core_rpc_token,
             overlay_parent_rpc_url,
+            process_diagnostics_list_owned,
             check_core_update,
             apply_core_update,
             check_app_update,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -77,18 +77,18 @@ fn overlay_parent_rpc_url() -> Option<String> {
 }
 
 #[tauri::command]
-fn process_diagnostics_list_owned() -> Vec<process_recovery::ProcessInfo> {
+fn process_diagnostics_list_owned() -> Result<Vec<process_recovery::ProcessInfo>, String> {
     match process_recovery::enumerate_openhuman_processes() {
         Ok(processes) => {
             log::info!(
                 "[startup-recovery] diagnostics listed {} owned OpenHuman processes",
                 processes.len()
             );
-            processes
+            Ok(processes)
         }
         Err(err) => {
             log::warn!("[startup-recovery] diagnostics process enumeration failed: {err}");
-            Vec::new()
+            Err(err)
         }
     }
 }
@@ -1722,101 +1722,7 @@ pub fn run() {
     // unwinds. Give stubborn helpers a short grace period, then force-kill
     // anything still parented to us so the GUI exit leaves no background
     // processes behind.
-    sweep_orphan_children();
-}
-
-/// Send SIGTERM, then SIGKILL holdouts, to every direct child of the
-/// current process. No-op on non-Unix platforms (Windows job objects already
-/// kill CEF helpers when the parent exits).
-fn sweep_orphan_children() {
-    #[cfg(unix)]
-    {
-        sweep_orphan_children_unix(std::process::id());
-    }
-    #[cfg(not(unix))]
-    {
-        log::debug!("[app] sweep: skipped on non-unix platform");
-    }
-}
-
-#[cfg(unix)]
-fn sweep_orphan_children_unix(parent_pid: u32) {
-    let term_count = match direct_child_pids(parent_pid) {
-        Ok(pids) => pids.len(),
-        Err(err) => {
-            log::warn!("[app] sweep: failed to enumerate children before SIGTERM: {err}");
-            0
-        }
-    };
-
-    if term_count > 0 {
-        match pkill_children(parent_pid, "TERM") {
-            Ok(status) => log_unexpected_pkill_status("SIGTERM", status),
-            Err(err) => log::warn!("[app] sweep: failed to invoke pkill SIGTERM: {err}"),
-        }
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    }
-
-    let kill_count = match direct_child_pids(parent_pid) {
-        Ok(pids) => pids.len(),
-        Err(err) => {
-            log::warn!("[app] sweep: failed to enumerate children after SIGTERM: {err}");
-            0
-        }
-    };
-
-    if kill_count > 0 {
-        match pkill_children(parent_pid, "KILL") {
-            Ok(status) => log_unexpected_pkill_status("SIGKILL", status),
-            Err(err) => log::warn!("[app] sweep: failed to invoke pkill SIGKILL: {err}"),
-        }
-        log::warn!("[app] sweep: term={term_count} kill={kill_count} total={term_count}");
-    } else {
-        log::info!("[app] sweep: term={term_count} kill=0 total={term_count}");
-    }
-}
-
-#[cfg(unix)]
-fn direct_child_pids(parent_pid: u32) -> Result<Vec<u32>, String> {
-    let output = std::process::Command::new("pgrep")
-        .args(["-P", &parent_pid.to_string()])
-        .output()
-        .map_err(|err| format!("spawn pgrep: {err}"))?;
-
-    match output.status.code() {
-        Some(0) => Ok(parse_pgrep_pids(&String::from_utf8_lossy(&output.stdout))),
-        Some(1) => Ok(Vec::new()),
-        other => Err(format!("pgrep exited with {other:?}")),
-    }
-}
-
-#[cfg(unix)]
-fn parse_pgrep_pids(stdout: &str) -> Vec<u32> {
-    stdout
-        .lines()
-        .filter_map(|line| line.trim().parse().ok())
-        .collect()
-}
-
-#[cfg(unix)]
-fn pkill_children(parent_pid: u32, signal: &str) -> Result<std::process::ExitStatus, String> {
-    let signal_arg = format!("-{signal}");
-    let parent_pid = parent_pid.to_string();
-    std::process::Command::new("pkill")
-        .args([signal_arg.as_str(), "-P", parent_pid.as_str()])
-        .status()
-        .map_err(|err| format!("spawn pkill -{signal}: {err}"))
-}
-
-#[cfg(unix)]
-fn log_unexpected_pkill_status(signal_name: &str, status: std::process::ExitStatus) {
-    // pkill exits 0 if it signaled at least one process, 1 if no process
-    // matched. Both are valid because children can exit between pgrep and
-    // pkill; other statuses are real command failures.
-    match status.code() {
-        Some(0) | Some(1) => {}
-        other => log::warn!("[app] sweep: pkill {signal_name} exited with {other:?}"),
-    }
+    process_kill::sweep_orphan_children();
 }
 
 pub fn run_core_from_args(args: &[String]) -> Result<(), String> {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod mascot_native_window;
 mod native_notifications;
 mod notification_settings;
 mod process_kill;
+mod process_recovery;
 mod screen_capture;
 mod slack_scanner;
 mod telegram_scanner;
@@ -1130,6 +1131,9 @@ pub fn run() {
             std::process::exit(1);
         }
     }
+
+    #[cfg(target_os = "macos")]
+    process_recovery::reap_stale_openhuman_processes();
 
     #[cfg(target_os = "macos")]
     if let Err(e) = cef_preflight::check_default_cache() {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod imessage_scanner;
 mod mascot_native_window;
 mod native_notifications;
 mod notification_settings;
+mod process_kill;
 mod screen_capture;
 mod slack_scanner;
 mod telegram_scanner;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1697,45 +1697,107 @@ pub fn run() {
     // operation every CEF helper (GPU / Network / Utility / Renderer) is
     // gone by now. If anything is still alive — e.g. a renderer that was
     // mid-spawn when the user quit — it would otherwise be re-parented to
-    // launchd on macOS / init on Linux and survive the GUI exit. SIGTERM
-    // its children before this process actually exits.
+    // launchd on macOS / init on Linux and survive the GUI exit. Sweep its
+    // children before this process actually exits.
     //
     // We don't `wait()` on them: the kernel will reap them as our exit
-    // unwinds, and any helper that ignores SIGTERM is a CEF bug we'd
-    // rather see in Activity Monitor than silently SIGKILL.
+    // unwinds. Give stubborn helpers a short grace period, then force-kill
+    // anything still parented to us so the GUI exit leaves no background
+    // processes behind.
     sweep_orphan_children();
 }
 
-/// Send SIGTERM to every direct child of the current process. No-op on
-/// non-Unix platforms (Windows job objects already kill CEF helpers when
-/// the parent exits).
+/// Send SIGTERM, then SIGKILL holdouts, to every direct child of the
+/// current process. No-op on non-Unix platforms (Windows job objects already
+/// kill CEF helpers when the parent exits).
 fn sweep_orphan_children() {
     #[cfg(unix)]
     {
-        let pid = std::process::id();
-        match std::process::Command::new("pkill")
-            .args(["-TERM", "-P", &pid.to_string()])
-            .status()
-        {
-            Ok(status) => {
-                // pkill exits 0 if it killed at least one process, 1 if no
-                // matches (the healthy case after cef::shutdown), 2/3 on
-                // error. Both 0 and 1 are expected; log 0 loudly so we
-                // notice when the safety net actually catches something.
-                match status.code() {
-                    Some(0) => log::warn!(
-                        "[app] sweep: SIGTERM'd leftover child processes after cef::shutdown"
-                    ),
-                    Some(1) => log::info!("[app] sweep: no leftover children (clean exit)"),
-                    other => log::warn!("[app] sweep: pkill exited with {:?}", other),
-                }
-            }
-            Err(e) => log::warn!("[app] sweep: failed to invoke pkill: {e}"),
-        }
+        sweep_orphan_children_unix(std::process::id());
     }
     #[cfg(not(unix))]
     {
         log::debug!("[app] sweep: skipped on non-unix platform");
+    }
+}
+
+#[cfg(unix)]
+fn sweep_orphan_children_unix(parent_pid: u32) {
+    let term_count = match direct_child_pids(parent_pid) {
+        Ok(pids) => pids.len(),
+        Err(err) => {
+            log::warn!("[app] sweep: failed to enumerate children before SIGTERM: {err}");
+            0
+        }
+    };
+
+    if term_count > 0 {
+        match pkill_children(parent_pid, "TERM") {
+            Ok(status) => log_unexpected_pkill_status("SIGTERM", status),
+            Err(err) => log::warn!("[app] sweep: failed to invoke pkill SIGTERM: {err}"),
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    let kill_count = match direct_child_pids(parent_pid) {
+        Ok(pids) => pids.len(),
+        Err(err) => {
+            log::warn!("[app] sweep: failed to enumerate children after SIGTERM: {err}");
+            0
+        }
+    };
+
+    if kill_count > 0 {
+        match pkill_children(parent_pid, "KILL") {
+            Ok(status) => log_unexpected_pkill_status("SIGKILL", status),
+            Err(err) => log::warn!("[app] sweep: failed to invoke pkill SIGKILL: {err}"),
+        }
+        log::warn!("[app] sweep: term={term_count} kill={kill_count} total={term_count}");
+    } else {
+        log::info!("[app] sweep: term={term_count} kill=0 total={term_count}");
+    }
+}
+
+#[cfg(unix)]
+fn direct_child_pids(parent_pid: u32) -> Result<Vec<u32>, String> {
+    let output = std::process::Command::new("pgrep")
+        .args(["-P", &parent_pid.to_string()])
+        .output()
+        .map_err(|err| format!("spawn pgrep: {err}"))?;
+
+    match output.status.code() {
+        Some(0) => Ok(parse_pgrep_pids(&String::from_utf8_lossy(&output.stdout))),
+        Some(1) => Ok(Vec::new()),
+        other => Err(format!("pgrep exited with {other:?}")),
+    }
+}
+
+#[cfg(unix)]
+fn parse_pgrep_pids(stdout: &str) -> Vec<u32> {
+    stdout
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect()
+}
+
+#[cfg(unix)]
+fn pkill_children(parent_pid: u32, signal: &str) -> Result<std::process::ExitStatus, String> {
+    let signal_arg = format!("-{signal}");
+    let parent_pid = parent_pid.to_string();
+    std::process::Command::new("pkill")
+        .args([signal_arg.as_str(), "-P", parent_pid.as_str()])
+        .status()
+        .map_err(|err| format!("spawn pkill -{signal}: {err}"))
+}
+
+#[cfg(unix)]
+fn log_unexpected_pkill_status(signal_name: &str, status: std::process::ExitStatus) {
+    // pkill exits 0 if it signaled at least one process, 1 if no process
+    // matched. Both are valid because children can exit between pgrep and
+    // pkill; other statuses are real command failures.
+    match status.code() {
+        Some(0) | Some(1) => {}
+        other => log::warn!("[app] sweep: pkill {signal_name} exited with {other:?}"),
     }
 }
 

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -38,6 +38,114 @@ pub(crate) fn kill_pid_force(pid: u32) -> Result<(), String> {
     }
 }
 
+/// Send SIGTERM, then SIGKILL holdouts, to every direct child of the
+/// current process. No-op on non-Unix platforms (Windows job objects already
+/// kill CEF helpers when the parent exits).
+pub(crate) fn sweep_orphan_children() {
+    #[cfg(unix)]
+    {
+        sweep_orphan_children_unix(std::process::id());
+    }
+    #[cfg(not(unix))]
+    {
+        log::debug!("[app] sweep: skipped on non-unix platform");
+    }
+}
+
+#[cfg(unix)]
+fn sweep_orphan_children_unix(parent_pid: u32) {
+    let term_count = match direct_child_pids(parent_pid) {
+        Ok(pids) => pids.len(),
+        Err(err) => {
+            log::warn!("[app] sweep: failed to enumerate children before SIGTERM: {err}");
+            0
+        }
+    };
+
+    let term_signaled = match pkill_children(parent_pid, "TERM") {
+        Ok(status) => {
+            let signaled = signaled_at_least_one(&status);
+            log_unexpected_pkill_status("SIGTERM", status);
+            signaled
+        }
+        Err(err) => {
+            log::warn!("[app] sweep: failed to invoke pkill SIGTERM: {err}");
+            false
+        }
+    };
+    if term_count > 0 || term_signaled {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    let kill_count = match direct_child_pids(parent_pid) {
+        Ok(pids) => pids.len(),
+        Err(err) => {
+            log::warn!("[app] sweep: failed to enumerate children after SIGTERM: {err}");
+            0
+        }
+    };
+
+    match pkill_children(parent_pid, "KILL") {
+        Ok(status) => log_unexpected_pkill_status("SIGKILL", status),
+        Err(err) => log::warn!("[app] sweep: failed to invoke pkill SIGKILL: {err}"),
+    }
+
+    let total = term_count + kill_count;
+    if kill_count > 0 {
+        log::warn!("[app] sweep: term={term_count} kill={kill_count} total={total}");
+    } else {
+        log::info!("[app] sweep: term={term_count} kill=0 total={total}");
+    }
+}
+
+#[cfg(unix)]
+fn direct_child_pids(parent_pid: u32) -> Result<Vec<u32>, String> {
+    let output = std::process::Command::new("pgrep")
+        .args(["-P", &parent_pid.to_string()])
+        .output()
+        .map_err(|err| format!("spawn pgrep: {err}"))?;
+
+    match output.status.code() {
+        Some(0) => Ok(parse_pgrep_pids(&String::from_utf8_lossy(&output.stdout))),
+        Some(1) => Ok(Vec::new()),
+        other => Err(format!("pgrep exited with {other:?}")),
+    }
+}
+
+#[cfg(unix)]
+fn parse_pgrep_pids(stdout: &str) -> Vec<u32> {
+    stdout
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect()
+}
+
+#[cfg(unix)]
+fn pkill_children(parent_pid: u32, signal: &str) -> Result<std::process::ExitStatus, String> {
+    let signal_arg = format!("-{signal}");
+    let parent_pid = parent_pid.to_string();
+    std::process::Command::new("pkill")
+        .args([signal_arg.as_str(), "-P", parent_pid.as_str()])
+        .status()
+        .map_err(|err| format!("spawn pkill -{signal}: {err}"))
+}
+
+#[cfg(unix)]
+fn log_unexpected_pkill_status(signal_name: &str, status: std::process::ExitStatus) {
+    // pkill exits 0 if it signaled at least one process, 1 if no process
+    // matched. Both are valid because children can exit between pgrep and
+    // pkill; other statuses are real command failures.
+    match status.code() {
+        Some(0) | Some(1) => {}
+        other => log::warn!("[app] sweep: pkill {signal_name} exited with {other:?}"),
+    }
+}
+
+#[cfg(unix)]
+fn signaled_at_least_one(status: &std::process::ExitStatus) -> bool {
+    matches!(status.code(), Some(0))
+}
+
 /// Windows has no graceful equivalent for a windowless RPC server — `taskkill`
 /// without `/F` only delivers `WM_CLOSE` to GUI apps. Send the WM_CLOSE first
 /// (best-effort) so console subprocesses can run shutdown handlers; the

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -1,0 +1,64 @@
+//! Cross-platform process termination helpers shared by lifecycle recovery code.
+
+/// Send the graceful-shutdown signal to `pid`. Returns `Ok` if the process
+/// exited cleanly, was already gone, or accepted the signal. Callers must
+/// re-check ownership of the resource (e.g. that the same pid is still bound
+/// to the port) before escalating to [`kill_pid_force`].
+#[cfg(unix)]
+pub(crate) fn kill_pid_term(pid: u32) -> Result<(), String> {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+    let target = Pid::from_raw(pid as i32);
+    if let Err(e) = kill(target, Signal::SIGTERM) {
+        // ESRCH means already gone — treat as success.
+        if e != nix::errno::Errno::ESRCH {
+            return Err(format!("SIGTERM pid {pid}: {e}"));
+        }
+    }
+    Ok(())
+}
+
+/// Force-kill `pid` after [`kill_pid_term`] failed to free the resource.
+/// Caller is responsible for revalidating that `pid` still owns the resource
+/// being freed.
+#[cfg(unix)]
+pub(crate) fn kill_pid_force(pid: u32) -> Result<(), String> {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+    let target = Pid::from_raw(pid as i32);
+    match kill(Pid::from_raw(pid as i32), Signal::SIGKILL) {
+        Ok(()) => Ok(()),
+        // ESRCH means the process exited between our re-validation and the
+        // SIGKILL — the resource is freeing on its own, treat as success.
+        Err(nix::errno::Errno::ESRCH) => {
+            let _ = target;
+            Ok(())
+        }
+        Err(e) => Err(format!("SIGKILL pid {pid}: {e}")),
+    }
+}
+
+/// Windows has no graceful equivalent for a windowless RPC server — `taskkill`
+/// without `/F` only delivers `WM_CLOSE` to GUI apps. Send the WM_CLOSE first
+/// (best-effort) so console subprocesses can run shutdown handlers; the
+/// follow-up [`kill_pid_force`] does the actual termination.
+#[cfg(windows)]
+pub(crate) fn kill_pid_term(pid: u32) -> Result<(), String> {
+    // Best-effort — ignore non-zero exit (e.g. process is windowless).
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string()])
+        .status();
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) fn kill_pid_force(pid: u32) -> Result<(), String> {
+    let status = std::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .status()
+        .map_err(|e| format!("taskkill spawn: {e}"))?;
+    if !status.success() {
+        return Err(format!("taskkill exited with {status}"));
+    }
+    Ok(())
+}

--- a/app/src-tauri/src/process_recovery.rs
+++ b/app/src-tauri/src/process_recovery.rs
@@ -417,7 +417,7 @@ mod imp {
 }
 
 #[cfg(target_os = "macos")]
-pub(crate) use imp::reap_stale_openhuman_processes;
+pub(crate) use imp::{enumerate_openhuman_processes, reap_stale_openhuman_processes, ProcessInfo};
 
 #[cfg(not(target_os = "macos"))]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]

--- a/app/src-tauri/src/process_recovery.rs
+++ b/app/src-tauri/src/process_recovery.rs
@@ -1,0 +1,439 @@
+//! Startup recovery for OpenHuman processes left behind by hard exits.
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    use serde::Serialize;
+
+    use crate::cef_preflight;
+    use crate::core_process;
+    use crate::process_kill::{kill_pid_force, kill_pid_term};
+
+    const TERM_GRACE: Duration = Duration::from_millis(500);
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+    pub(crate) struct ProcessInfo {
+        pub pid: u32,
+        pub ppid: u32,
+        pub argv0: String,
+        pub command: String,
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct ReapSummary {
+        term: usize,
+        kill: usize,
+        total: usize,
+    }
+
+    trait ProcessKiller {
+        fn term(&mut self, pid: u32) -> Result<(), String>;
+        fn force(&mut self, pid: u32) -> Result<(), String>;
+    }
+
+    struct SystemKiller;
+
+    impl ProcessKiller for SystemKiller {
+        fn term(&mut self, pid: u32) -> Result<(), String> {
+            kill_pid_term(pid)
+        }
+
+        fn force(&mut self, pid: u32) -> Result<(), String> {
+            kill_pid_force(pid)
+        }
+    }
+
+    pub(crate) fn reap_stale_openhuman_processes() {
+        if core_process::reuse_existing_listener_enabled() {
+            log::info!(
+                "[startup-recovery] OPENHUMAN_CORE_REUSE_EXISTING=1; skipping stale process reap"
+            );
+            return;
+        }
+
+        if let Some(pid) = live_cef_lock_holder_pid() {
+            if pid != std::process::id() as i32 {
+                log::info!(
+                    "[startup-recovery] live CEF SingletonLock holder pid={pid}; skipping stale process reap so the normal preflight handles the second-instance path"
+                );
+                return;
+            }
+        }
+
+        let initial = match enumerate_openhuman_processes() {
+            Ok(processes) => processes,
+            Err(err) => {
+                log::warn!("[startup-recovery] failed to enumerate OpenHuman processes: {err}");
+                return;
+            }
+        };
+        let stale = filter_self_pid(&initial, std::process::id());
+        if stale.is_empty() {
+            log::info!("[startup-recovery] no stale OpenHuman processes found");
+            return;
+        }
+
+        let mut killer = SystemKiller;
+        for process in &stale {
+            match killer.term(process.pid) {
+                Ok(()) => log::warn!(
+                    "[startup-recovery] SIGTERM stale OpenHuman pid={} argv0={}",
+                    process.pid,
+                    process.argv0
+                ),
+                Err(err) => log::warn!(
+                    "[startup-recovery] failed to SIGTERM stale OpenHuman pid={}: {err}",
+                    process.pid
+                ),
+            }
+        }
+
+        std::thread::sleep(TERM_GRACE);
+
+        let after_term = match enumerate_openhuman_processes() {
+            Ok(processes) => processes,
+            Err(err) => {
+                log::warn!(
+                    "[startup-recovery] failed to re-enumerate after SIGTERM; skipping SIGKILL escalation: {err}"
+                );
+                return;
+            }
+        };
+        let summary =
+            reap_from_snapshots(&stale, &after_term, std::process::id(), &mut killer, false);
+        if summary.kill > 0 {
+            log::warn!(
+                "[startup-recovery] reap complete term={} kill={} total={}",
+                stale.len(),
+                summary.kill,
+                stale.len()
+            );
+        } else {
+            log::info!(
+                "[startup-recovery] reap complete term={} kill=0 total={}",
+                stale.len(),
+                stale.len()
+            );
+        }
+    }
+
+    pub(crate) fn enumerate_openhuman_processes() -> Result<Vec<ProcessInfo>, String> {
+        let Some((contents_dir, main_exe)) = current_bundle_contents_dir() else {
+            log::debug!("[startup-recovery] current executable is not inside a .app bundle");
+            return Ok(Vec::new());
+        };
+        let output = std::process::Command::new("ps")
+            .args(["-ax", "-o", "pid=,ppid=,command="])
+            .output()
+            .map_err(|err| format!("spawn ps: {err}"))?;
+        if !output.status.success() {
+            return Err(format!("ps exited with {}", output.status));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(parse_ps_output(&stdout, &contents_dir, Some(&main_exe)))
+    }
+
+    fn reap_from_snapshots(
+        initial_stale: &[ProcessInfo],
+        after_term: &[ProcessInfo],
+        self_pid: u32,
+        killer: &mut impl ProcessKiller,
+        send_term: bool,
+    ) -> ReapSummary {
+        let initial_stale = filter_self_pid(initial_stale, self_pid);
+        let mut summary = ReapSummary {
+            total: initial_stale.len(),
+            ..ReapSummary::default()
+        };
+
+        if send_term {
+            for process in &initial_stale {
+                if killer.term(process.pid).is_ok() {
+                    summary.term += 1;
+                }
+            }
+        } else {
+            summary.term = initial_stale.len();
+        }
+
+        let expected: HashMap<u32, &str> = initial_stale
+            .iter()
+            .map(|process| (process.pid, process.command.as_str()))
+            .collect();
+        let still_running: Vec<&ProcessInfo> = after_term
+            .iter()
+            .filter(|process| process.pid != self_pid)
+            .filter(|process| {
+                expected
+                    .get(&process.pid)
+                    .is_some_and(|command| *command == process.command)
+            })
+            .collect();
+
+        for process in still_running {
+            match killer.force(process.pid) {
+                Ok(()) => {
+                    summary.kill += 1;
+                    log::warn!(
+                        "[startup-recovery] SIGKILL stale OpenHuman pid={} argv0={}",
+                        process.pid,
+                        process.argv0
+                    );
+                }
+                Err(err) => log::warn!(
+                    "[startup-recovery] failed to SIGKILL stale OpenHuman pid={}: {err}",
+                    process.pid
+                ),
+            }
+        }
+
+        summary
+    }
+
+    fn filter_self_pid(processes: &[ProcessInfo], self_pid: u32) -> Vec<ProcessInfo> {
+        let mut seen = HashSet::new();
+        processes
+            .iter()
+            .filter(|process| process.pid != self_pid)
+            .filter(|process| seen.insert(process.pid))
+            .cloned()
+            .collect()
+    }
+
+    fn parse_ps_output(
+        stdout: &str,
+        contents_dir: &Path,
+        main_exe: Option<&Path>,
+    ) -> Vec<ProcessInfo> {
+        stdout
+            .lines()
+            .filter_map(|line| parse_ps_line(line, contents_dir, main_exe))
+            .collect()
+    }
+
+    fn parse_ps_line(
+        line: &str,
+        contents_dir: &Path,
+        main_exe: Option<&Path>,
+    ) -> Option<ProcessInfo> {
+        let line = line.trim_start();
+        let (pid_raw, rest) = split_once_whitespace(line)?;
+        let (ppid_raw, command) = split_once_whitespace(rest.trim_start())?;
+        let command = command.trim().to_string();
+        let argv0 = extract_bundle_argv0(&command, contents_dir, main_exe)?;
+        Some(ProcessInfo {
+            pid: pid_raw.parse().ok()?,
+            ppid: ppid_raw.parse().ok()?,
+            argv0,
+            command,
+        })
+    }
+
+    fn split_once_whitespace(s: &str) -> Option<(&str, &str)> {
+        let idx = s.find(char::is_whitespace)?;
+        Some((&s[..idx], &s[idx..]))
+    }
+
+    fn extract_bundle_argv0(
+        command: &str,
+        contents_dir: &Path,
+        main_exe: Option<&Path>,
+    ) -> Option<String> {
+        let command = command.trim_start();
+        let contents = contents_dir.to_string_lossy();
+        if !command.starts_with(contents.as_ref()) {
+            return None;
+        }
+
+        if let Some(main_exe) = main_exe {
+            let main = main_exe.to_string_lossy();
+            if command == main || command.starts_with(&format!("{main} ")) {
+                return Some(main.into_owned());
+            }
+        }
+
+        let frameworks_prefix = format!("{}/Frameworks/", contents);
+        if command.starts_with(&frameworks_prefix) {
+            let marker = ".app/Contents/MacOS/";
+            let marker_idx = command.find(marker)?;
+            let bundle_name = Path::new(&command[..marker_idx])
+                .file_name()?
+                .to_string_lossy();
+            let argv0 = format!("{}{}{}", &command[..marker_idx], marker, bundle_name);
+            if command == argv0 || command.starts_with(&format!("{argv0} ")) {
+                return Some(argv0);
+            }
+        }
+
+        let first = command.split_whitespace().next()?;
+        if Path::new(first).starts_with(contents_dir) {
+            Some(first.to_string())
+        } else {
+            None
+        }
+    }
+
+    fn current_bundle_contents_dir() -> Option<(PathBuf, PathBuf)> {
+        let exe = std::env::current_exe().ok()?;
+        let mut cursor = exe.parent();
+        while let Some(path) = cursor {
+            if path.file_name().is_some_and(|name| name == "Contents")
+                && path
+                    .parent()
+                    .and_then(Path::extension)
+                    .is_some_and(|ext| ext == "app")
+            {
+                return Some((path.to_path_buf(), exe));
+            }
+            cursor = path.parent();
+        }
+        None
+    }
+
+    fn live_cef_lock_holder_pid() -> Option<i32> {
+        let cache_path = cef_cache_path()?;
+        let target = fs::read_link(cache_path.join("SingletonLock")).ok()?;
+        let target = target.to_string_lossy();
+        let (_, pid) = cef_preflight::parse_lock_target(&target)?;
+        cef_preflight::is_pid_alive(pid).then_some(pid)
+    }
+
+    fn cef_cache_path() -> Option<PathBuf> {
+        if let Some(configured) = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH") {
+            return Some(PathBuf::from(configured));
+        }
+        let home = std::env::var_os("HOME")?;
+        Some(
+            PathBuf::from(home)
+                .join("Library/Caches")
+                .join(cef_preflight::APP_IDENTIFIER)
+                .join("cef"),
+        )
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn contents_dir() -> PathBuf {
+            PathBuf::from("/Applications/OpenHuman.app/Contents")
+        }
+
+        fn main_exe() -> PathBuf {
+            contents_dir().join("MacOS/OpenHuman")
+        }
+
+        #[test]
+        fn parse_ps_matches_main_and_helper_bundle_argv0() {
+            let stdout = "\
+  123   1 /Applications/OpenHuman.app/Contents/MacOS/OpenHuman
+  124 123 /Applications/OpenHuman.app/Contents/Frameworks/OpenHuman Helper (Renderer).app/Contents/MacOS/OpenHuman Helper (Renderer) --type=renderer
+  999   1 /Applications/Other.app/Contents/MacOS/OpenHuman
+";
+            let processes = parse_ps_output(stdout, &contents_dir(), Some(&main_exe()));
+            assert_eq!(processes.len(), 2);
+            assert_eq!(processes[0].pid, 123);
+            assert_eq!(processes[0].argv0, main_exe().to_string_lossy());
+            assert_eq!(processes[1].pid, 124);
+            assert_eq!(
+                processes[1].argv0,
+                "/Applications/OpenHuman.app/Contents/Frameworks/OpenHuman Helper (Renderer).app/Contents/MacOS/OpenHuman Helper (Renderer)"
+            );
+        }
+
+        #[test]
+        fn filter_self_pid_drops_current_process() {
+            let processes = vec![
+                ProcessInfo {
+                    pid: 10,
+                    ppid: 1,
+                    argv0: "self".into(),
+                    command: "self".into(),
+                },
+                ProcessInfo {
+                    pid: 11,
+                    ppid: 1,
+                    argv0: "other".into(),
+                    command: "other".into(),
+                },
+            ];
+            let filtered = filter_self_pid(&processes, 10);
+            assert_eq!(filtered.len(), 1);
+            assert_eq!(filtered[0].pid, 11);
+        }
+
+        #[test]
+        fn reap_from_snapshots_escalates_sigkill_for_term_holdouts() {
+            #[derive(Default)]
+            struct MockKiller {
+                term: Vec<u32>,
+                force: Vec<u32>,
+            }
+
+            impl ProcessKiller for MockKiller {
+                fn term(&mut self, pid: u32) -> Result<(), String> {
+                    self.term.push(pid);
+                    Ok(())
+                }
+
+                fn force(&mut self, pid: u32) -> Result<(), String> {
+                    self.force.push(pid);
+                    Ok(())
+                }
+            }
+
+            let stale = ProcessInfo {
+                pid: 42,
+                ppid: 1,
+                argv0: main_exe().to_string_lossy().into_owned(),
+                command: format!("{}", main_exe().display()),
+            };
+            let still_running = stale.clone();
+            let mut killer = MockKiller::default();
+            let summary = reap_from_snapshots(
+                std::slice::from_ref(&stale),
+                &[still_running],
+                99,
+                &mut killer,
+                true,
+            );
+
+            assert_eq!(killer.term, vec![42]);
+            assert_eq!(killer.force, vec![42]);
+            assert_eq!(
+                summary,
+                ReapSummary {
+                    term: 1,
+                    kill: 1,
+                    total: 1
+                }
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) use imp::reap_stale_openhuman_processes;
+
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct ProcessInfo {
+    pub pid: u32,
+    pub ppid: u32,
+    pub argv0: String,
+    pub command: String,
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn reap_stale_openhuman_processes() {
+    log::debug!("[startup-recovery] skipped on non-macos platform");
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn enumerate_openhuman_processes() -> Result<Vec<ProcessInfo>, String> {
+    Ok(Vec::new())
+}

--- a/docs/src-tauri/README.md
+++ b/docs/src-tauri/README.md
@@ -30,7 +30,7 @@ On macOS, hard exits such as Force Quit, `SIGKILL`, or a renderer crash can skip
 
 Startup recovery intentionally skips when `OPENHUMAN_CORE_REUSE_EXISTING=1` is set so manual CLI-core reuse still works. It also skips when the CEF `SingletonLock` is held by a live process, letting the normal second-instance path fail without killing the already-running app.
 
-For diagnostics, the Tauri command `process_diagnostics_list_owned` returns the currently owned process list used by startup recovery. The macOS implementation is bundle-scoped; Linux and Windows currently return an empty list.
+For diagnostics, the Tauri command `process_diagnostics_list_owned` returns the currently owned process list used by startup recovery, or an error if process enumeration fails. The macOS implementation is bundle-scoped; Linux and Windows currently return an empty list.
 
 ## Related
 

--- a/docs/src-tauri/README.md
+++ b/docs/src-tauri/README.md
@@ -22,6 +22,16 @@ This folder is the **desktop host** for OpenHuman: Tauri v2 + WebView, IPC comma
 
 `app/package.json` **`core:stage`** runs `scripts/stage-core-sidecar.mjs`, which `cargo build --bin openhuman` at the repo root and copies the binary into `app/src-tauri/binaries/` for Tauri `externalBin`.
 
+## Stuck process recovery
+
+Normal app quit runs teardown from `RunEvent::ExitRequested`: child webviews are closed before CEF shutdown, the embedded core's cancellation token is triggered, and the final process sweep sends `SIGTERM` to direct children before escalating holdouts with `SIGKILL` after a short grace period. Sweep summaries are logged as `[app] sweep: term=N kill=M total=K`; any nonzero `kill` count is a warning and means a child ignored graceful shutdown.
+
+On macOS, hard exits such as Force Quit, `SIGKILL`, or a renderer crash can skip normal teardown. The next launch runs startup recovery before CEF cache preflight: it lists OpenHuman processes whose executable path belongs to the launching `.app/Contents`, skips the current process, sends `SIGTERM`, waits briefly, then sends `SIGKILL` to stragglers that still match the same pid and command. These events use the `[startup-recovery]` log prefix.
+
+Startup recovery intentionally skips when `OPENHUMAN_CORE_REUSE_EXISTING=1` is set so manual CLI-core reuse still works. It also skips when the CEF `SingletonLock` is held by a live process, letting the normal second-instance path fail without killing the already-running app.
+
+For diagnostics, the Tauri command `process_diagnostics_list_owned` returns the currently owned process list used by startup recovery. The macOS implementation is bundle-scoped; Linux and Windows currently return an empty list.
+
 ## Related
 
 - Full stack narrative: [`../ARCHITECTURE.md`](../ARCHITECTURE.md)

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -18,6 +18,7 @@ use axum::{extract::Request, Json, Router};
 use serde::Serialize;
 use serde_json::{json, Map, Value};
 use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 
 use crate::core::all;
 use crate::core::types::{AppState, RpcError, RpcFailure, RpcRequest, RpcSuccess};
@@ -608,7 +609,7 @@ pub async fn run_server(
     port: Option<u16>,
     socketio_enabled: bool,
 ) -> anyhow::Result<()> {
-    run_server_inner(host, port, socketio_enabled, false).await
+    run_server_inner(host, port, socketio_enabled, false, None).await
 }
 
 /// Like [`run_server`] but marks the instance as embedded.
@@ -616,8 +617,9 @@ pub async fn run_server_embedded(
     host: Option<&str>,
     port: Option<u16>,
     socketio_enabled: bool,
+    shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    run_server_inner(host, port, socketio_enabled, true).await
+    run_server_inner(host, port, socketio_enabled, true, Some(shutdown_token)).await
 }
 
 /// Internal server entrypoint.
@@ -626,6 +628,7 @@ async fn run_server_inner(
     port: Option<u16>,
     socketio_enabled: bool,
     embedded_core: bool,
+    shutdown_token: Option<CancellationToken>,
 ) -> anyhow::Result<()> {
     // Ensure all controllers are registered before starting.
     let _ = all::all_registered_controllers();
@@ -717,7 +720,7 @@ async fn run_server_inner(
     let app = build_core_http_router(socketio_enabled);
 
     // --- Skill runtime bootstrap -------------------------------------------
-    bootstrap_skill_runtime().await;
+    bootstrap_skill_runtime(embedded_core).await;
 
     log::info!(
         "[core] OpenHuman core is ready — listening on http://{bind_addr} (version {})",
@@ -859,9 +862,18 @@ async fn run_server_inner(
         log::info!("[channels] OPENHUMAN_DISABLE_CHANNEL_LISTENERS set — skipping start_channels");
     }
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(crate::core::shutdown::signal())
-        .await?;
+    if let Some(shutdown_token) = shutdown_token {
+        log::info!("[core] embedded server waiting on cancellation token for graceful shutdown");
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown_token.cancelled().await;
+            })
+            .await?;
+    } else {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(crate::core::shutdown::signal())
+            .await?;
+    }
     Ok(())
 }
 
@@ -872,6 +884,7 @@ async fn run_server_inner(
 fn register_domain_subscribers(
     workspace_dir: std::path::PathBuf,
     config: crate::openhuman::config::Config,
+    embedded_core: bool,
 ) {
     use std::sync::{Arc, Once};
 
@@ -917,9 +930,15 @@ fn register_domain_subscribers(
         // Restart requests go through a subscriber so every trigger path shares
         // the same respawn logic.
         crate::openhuman::service::bus::register_restart_subscriber();
-        // Shutdown requests use the same pattern; the subscriber exits the
-        // current process after a short grace period.
-        crate::openhuman::service::bus::register_shutdown_subscriber();
+        if embedded_core {
+            log::info!(
+                "[event_bus] embedded core: service shutdown subscriber not registered; Tauri cancellation token owns shutdown"
+            );
+        } else {
+            // Shutdown requests use the same pattern; the standalone CLI
+            // subscriber exits the current process after a short grace period.
+            crate::openhuman::service::bus::register_shutdown_subscriber();
+        }
 
         // Proactive message subscriber (web-only in the desktop runtime —
         // no external channel instances are registered here). Uses a
@@ -938,7 +957,7 @@ fn register_domain_subscribers(
 }
 
 /// Initializes long-lived socket/event-bus infrastructure.
-pub async fn bootstrap_skill_runtime() {
+pub async fn bootstrap_skill_runtime(embedded_core: bool) {
     use crate::openhuman::socket::{set_global_socket_manager, SocketManager};
     use std::sync::Arc;
     let cfg = match crate::openhuman::config::Config::load_or_init().await {
@@ -956,7 +975,7 @@ pub async fn bootstrap_skill_runtime() {
     // Register domain subscribers for cross-module event handling.
     // Uses a Once guard so repeated calls to bootstrap_skill_runtime()
     // cannot double-subscribe.
-    register_domain_subscribers(workspace_dir.clone(), cfg.clone());
+    register_domain_subscribers(workspace_dir.clone(), cfg.clone(), embedded_core);
 
     // --- Turn-state recovery -------------------------------------------
     // Any per-thread turn snapshots left on disk from a previous process

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -1,5 +1,6 @@
 use serde_json::json;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
+use std::sync::MutexGuard;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
@@ -9,23 +10,35 @@ use super::{
 };
 
 struct EnvVarGuard {
-    key: &'static str,
-    old: Option<OsString>,
+    old_values: Vec<(&'static str, Option<OsString>)>,
+    _lock: MutexGuard<'static, ()>,
 }
 
 impl EnvVarGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let old = std::env::var_os(key);
-        std::env::set_var(key, value);
-        Self { key, old }
+    fn set_many(vars: Vec<(&'static str, OsString)>) -> Self {
+        let lock = crate::openhuman::config::TEST_ENV_LOCK
+            .lock()
+            .expect("test env lock poisoned");
+        let mut old_values = Vec::with_capacity(vars.len());
+        for (key, value) in vars {
+            let old = std::env::var_os(key);
+            std::env::set_var(key, value);
+            old_values.push((key, old));
+        }
+        Self {
+            old_values,
+            _lock: lock,
+        }
     }
 }
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        match &self.old {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
+        for (key, old) in self.old_values.iter().rev() {
+            match old {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
         }
     }
 }
@@ -67,9 +80,17 @@ async fn wait_until_port_released(port: u16) {
 #[tokio::test]
 async fn shutdown_token_stops_axum_listener_within_timeout() {
     let workspace = tempfile::tempdir().expect("workspace tempdir");
-    let _workspace = EnvVarGuard::set("OPENHUMAN_WORKSPACE", workspace.path().as_os_str());
-    let _disable_channels = EnvVarGuard::set("OPENHUMAN_DISABLE_CHANNEL_LISTENERS", "1");
-    let _token = EnvVarGuard::set("OPENHUMAN_CORE_TOKEN", "test-token-shutdown");
+    let _env = EnvVarGuard::set_many(vec![
+        (
+            "OPENHUMAN_WORKSPACE",
+            workspace.path().as_os_str().to_os_string(),
+        ),
+        ("OPENHUMAN_DISABLE_CHANNEL_LISTENERS", OsString::from("1")),
+        (
+            "OPENHUMAN_CORE_TOKEN",
+            OsString::from("test-token-shutdown"),
+        ),
+    ]);
 
     let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("allocate test port");
     let port = probe.local_addr().expect("local addr").port();

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -1,9 +1,96 @@
 use serde_json::json;
+use std::ffi::{OsStr, OsString};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 use super::{
     build_http_schema_dump, default_state, escape_html, invoke_method, is_session_expired_error,
     params_to_object, parse_json_params, type_name,
 };
+
+struct EnvVarGuard {
+    key: &'static str,
+    old: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let old = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, old }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.old {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+async fn wait_until_port_accepts(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "server did not start accepting on port {port}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn wait_until_port_released(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_err()
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "server did not release port {port}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn shutdown_token_stops_axum_listener_within_timeout() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let _workspace = EnvVarGuard::set("OPENHUMAN_WORKSPACE", workspace.path().as_os_str());
+    let _disable_channels = EnvVarGuard::set("OPENHUMAN_DISABLE_CHANNEL_LISTENERS", "1");
+    let _token = EnvVarGuard::set("OPENHUMAN_CORE_TOKEN", "test-token-shutdown");
+
+    let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("allocate test port");
+    let port = probe.local_addr().expect("local addr").port();
+    drop(probe);
+
+    let shutdown_token = CancellationToken::new();
+    let server_token = shutdown_token.clone();
+    let server = tokio::spawn(async move {
+        super::run_server_embedded(Some("127.0.0.1"), Some(port), false, server_token).await
+    });
+
+    wait_until_port_accepts(port).await;
+    shutdown_token.cancel();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), server)
+        .await
+        .expect("embedded server task should stop within timeout")
+        .expect("embedded server task should not panic");
+    result.expect("embedded server should shut down cleanly");
+    wait_until_port_released(port).await;
+}
 
 #[tokio::test]
 async fn invoke_health_snapshot_via_registry() {

--- a/src/openhuman/agent/prompts/mod_tests.rs
+++ b/src/openhuman/agent/prompts/mod_tests.rs
@@ -1217,7 +1217,6 @@ fn ctx_with_learned(learned: LearnedContextData) -> PromptContext<'static> {
         include_memory_md: false,
         curated_snapshot: None,
         user_identity: None,
-        curated_snapshot: None,
     }
 }
 

--- a/src/openhuman/agent/prompts/mod_tests.rs
+++ b/src/openhuman/agent/prompts/mod_tests.rs
@@ -1215,6 +1215,7 @@ fn ctx_with_learned(learned: LearnedContextData) -> PromptContext<'static> {
         connected_identities_md: String::new(),
         include_profile: false,
         include_memory_md: false,
+        curated_snapshot: None,
         user_identity: None,
         curated_snapshot: None,
     }

--- a/src/openhuman/channels/tests/health.rs
+++ b/src/openhuman/channels/tests/health.rs
@@ -39,6 +39,14 @@ async fn supervised_listener_marks_error_and_restarts_on_failures() {
     let component_name = format!("channel:{name}");
 
     let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(1);
+    // The global health subscriber may have been registered by another test
+    // runtime; keep a fresh subscriber alive for this test's runtime too.
+    crate::core::event_bus::init_global(crate::core::event_bus::DEFAULT_CAPACITY);
+    let _health_handle = crate::core::event_bus::subscribe_global(Arc::new(
+        crate::openhuman::health::bus::HealthSubscriber,
+    ))
+    .expect("event bus should be initialized for channel health test");
+    tokio::task::yield_now().await;
     let handle = spawn_supervised_listener(channel, tx, 1, 1);
 
     let component = wait_for_component_error(&component_name).await;

--- a/src/openhuman/channels/tests/health.rs
+++ b/src/openhuman/channels/tests/health.rs
@@ -31,21 +31,21 @@ async fn classify_health_timeout() {
 #[tokio::test]
 async fn supervised_listener_marks_error_and_restarts_on_failures() {
     let calls = Arc::new(AtomicUsize::new(0));
+    let name = Box::leak(format!("test-supervised-fail-{}", uuid::Uuid::new_v4()).into_boxed_str());
     let channel: Arc<dyn Channel> = Arc::new(AlwaysFailChannel {
-        name: "test-supervised-fail",
+        name,
         calls: Arc::clone(&calls),
     });
+    let component_name = format!("channel:{name}");
 
     let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(1);
     let handle = spawn_supervised_listener(channel, tx, 1, 1);
 
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    let component = wait_for_component_error(&component_name).await;
     drop(rx);
     handle.abort();
     let _ = handle.await;
 
-    let snapshot = crate::openhuman::health::snapshot_json();
-    let component = &snapshot["components"]["channel:test-supervised-fail"];
     assert_eq!(component["status"], "error");
     assert!(component["restart_count"].as_u64().unwrap_or(0) >= 1);
     assert!(component["last_error"]
@@ -53,4 +53,21 @@ async fn supervised_listener_marks_error_and_restarts_on_failures() {
         .unwrap_or("")
         .contains("listen boom"));
     assert!(calls.load(Ordering::SeqCst) >= 1);
+}
+
+async fn wait_for_component_error(component_name: &str) -> serde_json::Value {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let snapshot = crate::openhuman::health::snapshot_json();
+        let component = snapshot["components"][component_name].clone();
+        if component["status"] == "error" && component["restart_count"].as_u64().unwrap_or(0) >= 1 {
+            return component;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for {component_name} to enter error state; last={component}");
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }


### PR DESCRIPTION
## Summary

- Adds shared Tauri process-kill helpers and reuses them from core process management.
- Adds graceful shutdown for the embedded Axum JSON-RPC listener with a `CancellationToken`.
- Reaps stale OpenHuman bundle-owned processes on macOS startup with TERM then KILL escalation.
- Escalates app orphan-child sweep from TERM to KILL for holdouts and logs structured counts.
- Exposes owned-process diagnostics and documents stuck-process recovery.

## Problem

- Hard exits such as SIGKILL, Force Quit, and renderer crashes can bypass Tauri `RunEvent::ExitRequested`, leaving CEF/core helper processes behind.
- The existing orphan sweep sent only SIGTERM to direct children and did not escalate for TERM-ignoring holdouts.
- The embedded core listener was only aborting the top-level task, so the Axum listener was not given a deterministic graceful-shutdown signal.
- Recovery needed to preserve the existing SingletonLock and port-7788 takeover semantics from #1130, plus the #920/#1120 shutdown ordering fixes.

## Solution

- Add `process_kill.rs` for reusable TERM/KILL helpers.
- Add a macOS-only `process_recovery.rs` startup reaper that scopes ownership to argv0 paths inside the launching `.app/Contents/`, skips self, skips `OPENHUMAN_CORE_REUSE_EXISTING=1`, and avoids killing a live SingletonLock holder.
- Add `CancellationToken` plumbing through `CoreProcessHandle` into `run_server_embedded`, and call Axum `.with_graceful_shutdown(token.cancelled())`.
- Update `send_terminate_signal`/`shutdown` to cancel before aborting the embedded server task.
- Update `sweep_orphan_children` to count direct children, send TERM, wait 500ms, KILL holdouts, and log `[app] sweep: term=N kill=M total=K`.
- Add `process_diagnostics_list_owned` for diagnostics and document stuck-process recovery in `docs/src-tauri/README.md`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
N/A: **Diff coverage >= 80%** local merged coverage was not run; this infrastructure PR is covered by targeted Rust tests plus macOS smoke, and CI coverage remains authoritative.
N/A: Coverage matrix updated - process lifecycle infrastructure has no feature row to add/remove/rename.
N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` - no matrix feature IDs apply.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
N/A: Manual smoke checklist updated if this touches release-cut surfaces - no release checklist row exists for this process lifecycle path; local S1-S6-style smoke results are included below.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- macOS desktop startup now attempts safe cleanup of stale OpenHuman bundle-owned processes before CEF cache preflight.
- Embedded core shutdown now releases the Axum listener deterministically; standalone CLI shutdown subscriber behavior is unchanged.
- Linux/Windows process recovery remains stubbed for this PR.
- No user-facing reset/force-quit UI is added.

Manual verification:

- `cargo fmt --check --all` passed.
- `cargo check` passed with existing warnings.
- `cargo check --manifest-path app/src-tauri/Cargo.toml` passed with existing warnings.
- `cargo clippy --manifest-path app/src-tauri/Cargo.toml --tests` passed with existing warnings.
- `cargo clippy --tests` failed only on known pre-existing denied `approx_constant` lints outside this PR.
- `cargo test --manifest-path app/src-tauri/Cargo.toml --lib` passed: 177 passed, 4 ignored.
- Focused tests passed: `shutdown_token_stops_axum_listener_within_timeout`, `send_terminate_signal_cancels_shutdown_token`, and `process_recovery`.
- `cargo test -p openhuman-tauri-shell` could not run because this checkout has no `openhuman-tauri-shell` package; the app package is `OpenHuman`.
- `pnpm --filter openhuman-app macos:build:debug` built the branch debug `.app` and DMG successfully.
- Pre-push hook passed format, lint, TypeScript compile, Tauri Rust check, and command token lint. Lint reports existing warnings only.

macOS smoke from the branch-built bundle:

- Quit/AppleEvent path left zero branch-owned `.app/Contents/` processes.
- SingletonLock second launch did not create a second main PID and did not kill the first instance.
- `kill -9` of the branch main PID left no branch-owned CEF helpers in this run.
- Controlled SIGTERM-ignoring stale helper with argv0 inside the branch bundle was reaped on next startup.
- `OPENHUMAN_CORE_REUSE_EXISTING=1` attach path preserved the standalone listener using the repo's actual `openhuman-core serve` bin.
- Baseline caveat: three old `/var/.../openhuman-accessibility-helper/unified_helper_bin` PPID-1 processes pre-existed this worktree and are outside the branch bundle-path ownership boundary.

## Related

Closes #1060

Cross-reference: #1130
Cross-reference: #920
Cross-reference: #1120

Follow-up PR(s)/TODOs: N/A: none for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cooperative graceful shutdown for the embedded core
  * Automatic detection and cleanup of stale processes on macOS startup
  * Command to list owned processes for diagnostics
  * Two-phase, more robust orphan-process cleanup on quit
  * Cross-platform process termination helpers

* **Documentation**
  * Added "Stuck process recovery" guidance and logs

* **Tests**
  * New tests for graceful shutdown and termination-token behavior

* **Chores**
  * Added a runtime utility dependency to support shutdown handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->