### PR TITLE
SYM-212: add foundational thread RPC query hooks

### DIFF
--- a/app/src/hooks/useThreadQueries.test.ts
+++ b/app/src/hooks/useThreadQueries.test.ts
@@ -1,0 +1,141 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Thread, ThreadMessage } from '../types/thread';
+
+const mockGetThreads = vi.fn();
+const mockGetThreadMessages = vi.fn();
+
+vi.mock('../services/api/threadApi', () => ({
+  threadApi: {
+    getThreads: () => mockGetThreads(),
+    getThreadMessages: (threadId: string) => mockGetThreadMessages(threadId),
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const thread: Thread = {
+  id: 'thread-1',
+  title: 'Planning',
+  chatId: null,
+  isActive: true,
+  messageCount: 1,
+  lastMessageAt: '2026-05-06T00:00:00.000Z',
+  createdAt: '2026-05-06T00:00:00.000Z',
+  labels: [],
+};
+
+const message: ThreadMessage = {
+  id: 'message-1',
+  content: 'hello',
+  type: 'text',
+  extraMetadata: {},
+  sender: 'user',
+  createdAt: '2026-05-06T00:00:00.000Z',
+};
+
+describe('useThreadQueries', () => {
+  beforeEach(() => {
+    mockGetThreads.mockReset();
+    mockGetThreadMessages.mockReset();
+  });
+
+  it('loads threads with loading and success state', async () => {
+    mockGetThreads.mockResolvedValue({ threads: [thread], count: 1 });
+    const { useThreads } = await import('./useThreadQueries');
+
+    const { result } = renderHook(() => useThreads());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.threads).toEqual([thread]);
+    expect(result.current.data?.count).toBe(1);
+    expect(result.current.error).toBeNull();
+    expect(mockGetThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces RPC errors without throwing from render', async () => {
+    mockGetThreads.mockRejectedValue(new Error('rpc failed'));
+    const { useThreads } = await import('./useThreadQueries');
+
+    const { result } = renderHook(() => useThreads());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+    expect(result.current.error?.message).toBe('rpc failed');
+  });
+
+  it('does not load messages when no thread id is available', async () => {
+    const { useThreadMessages } = await import('./useThreadQueries');
+
+    const { result, rerender } = renderHook(({ threadId }) => useThreadMessages(threadId), {
+      initialProps: { threadId: null as string | null },
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(mockGetThreadMessages).not.toHaveBeenCalled();
+
+    rerender({ threadId: '   ' });
+    expect(mockGetThreadMessages).not.toHaveBeenCalled();
+  });
+
+  it('loads and refetches thread messages', async () => {
+    mockGetThreadMessages
+      .mockResolvedValueOnce({ messages: [message], count: 1 })
+      .mockResolvedValueOnce({
+        messages: [{ ...message, id: 'message-2', content: 'updated' }],
+        count: 1,
+      });
+    const { useThreadMessages } = await import('./useThreadQueries');
+
+    const { result } = renderHook(() => useThreadMessages('thread-1'));
+
+    await waitFor(() => expect(result.current.data?.messages[0].id).toBe('message-1'));
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.data?.messages[0].id).toBe('message-2');
+    expect(mockGetThreadMessages).toHaveBeenNthCalledWith(1, 'thread-1');
+    expect(mockGetThreadMessages).toHaveBeenNthCalledWith(2, 'thread-1');
+  });
+
+  it('exposes refetching state while keeping previous data', async () => {
+    const nextMessages = deferred<{ messages: ThreadMessage[]; count: number }>();
+    mockGetThreadMessages
+      .mockResolvedValueOnce({ messages: [message], count: 1 })
+      .mockReturnValueOnce(nextMessages.promise);
+    const { useThreadMessages } = await import('./useThreadQueries');
+
+    const { result } = renderHook(() => useThreadMessages('thread-1'));
+
+    await waitFor(() => expect(result.current.data?.messages[0].id).toBe('message-1'));
+
+    let refetchPromise: Promise<unknown>;
+    act(() => {
+      refetchPromise = result.current.refetch();
+    });
+
+    expect(result.current.isRefetching).toBe(true);
+    expect(result.current.data?.messages[0].id).toBe('message-1');
+
+    nextMessages.resolve({ messages: [{ ...message, id: 'message-2' }], count: 1 });
+    await act(async () => {
+      await refetchPromise;
+    });
+
+    expect(result.current.isRefetching).toBe(false);
+    expect(result.current.data?.messages[0].id).toBe('message-2');
+  });
+});

--- a/app/src/hooks/useThreadQueries.test.ts
+++ b/app/src/hooks/useThreadQueries.test.ts
@@ -138,4 +138,54 @@ describe('useThreadQueries', () => {
     expect(result.current.isRefetching).toBe(false);
     expect(result.current.data?.messages[0].id).toBe('message-2');
   });
+
+  it('clears previous messages while loading a different thread id', async () => {
+    const nextMessages = deferred<{ messages: ThreadMessage[]; count: number }>();
+    mockGetThreadMessages
+      .mockResolvedValueOnce({ messages: [message], count: 1 })
+      .mockReturnValueOnce(nextMessages.promise);
+    const { useThreadMessages } = await import('./useThreadQueries');
+
+    const { result, rerender } = renderHook(({ threadId }) => useThreadMessages(threadId), {
+      initialProps: { threadId: 'thread-1' },
+    });
+
+    await waitFor(() => expect(result.current.data?.messages[0].id).toBe('message-1'));
+
+    rerender({ threadId: 'thread-2' });
+
+    await waitFor(() => expect(result.current.data).toBeNull());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.isRefetching).toBe(false);
+
+    nextMessages.resolve({ messages: [{ ...message, id: 'message-2' }], count: 1 });
+    await waitFor(() => expect(result.current.data?.messages[0].id).toBe('message-2'));
+    expect(mockGetThreadMessages).toHaveBeenNthCalledWith(1, 'thread-1');
+    expect(mockGetThreadMessages).toHaveBeenNthCalledWith(2, 'thread-2');
+  });
+
+  it('ignores stale message responses after switching thread ids', async () => {
+    const firstMessages = deferred<{ messages: ThreadMessage[]; count: number }>();
+    const secondMessages = deferred<{ messages: ThreadMessage[]; count: number }>();
+    mockGetThreadMessages
+      .mockReturnValueOnce(firstMessages.promise)
+      .mockReturnValueOnce(secondMessages.promise);
+    const { useThreadMessages } = await import('./useThreadQueries');
+
+    const { result, rerender } = renderHook(({ threadId }) => useThreadMessages(threadId), {
+      initialProps: { threadId: 'thread-1' },
+    });
+
+    rerender({ threadId: 'thread-2' });
+
+    secondMessages.resolve({ messages: [{ ...message, id: 'message-2' }], count: 1 });
+    await waitFor(() => expect(result.current.data?.messages[0].id).toBe('message-2'));
+
+    firstMessages.resolve({ messages: [{ ...message, id: 'message-1' }], count: 1 });
+    await act(async () => {
+      await firstMessages.promise;
+    });
+
+    expect(result.current.data?.messages[0].id).toBe('message-2');
+  });
 });

--- a/app/src/hooks/useThreadQueries.ts
+++ b/app/src/hooks/useThreadQueries.ts
@@ -1,0 +1,118 @@
+import debug from 'debug';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { threadApi } from '../services/api/threadApi';
+import type { ThreadMessagesData, ThreadsListData } from '../types/thread';
+
+const log = debug('hooks:threadQueries');
+
+export interface ThreadQueryState<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  isRefetching: boolean;
+  refetch: () => Promise<T | undefined>;
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function useThreadQuery<T>(
+  queryName: string,
+  load: () => Promise<T>,
+  enabled = true
+): ThreadQueryState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<Error | null>(null);
+  const [isRefetching, setIsRefetching] = useState(false);
+  const requestIdRef = useRef(0);
+  const dataRef = useRef<T | null>(null);
+
+  const execute = useCallback(
+    async (reason: 'initial' | 'refetch'): Promise<T | undefined> => {
+      if (!enabled) {
+        log('%s skip disabled reason=%s', queryName, reason);
+        return undefined;
+      }
+
+      const requestId = requestIdRef.current + 1;
+      requestIdRef.current = requestId;
+      const hasData = dataRef.current !== null;
+      log('%s start requestId=%d reason=%s hasData=%s', queryName, requestId, reason, hasData);
+
+      setError(null);
+      if (hasData || reason === 'refetch') {
+        setIsRefetching(true);
+      } else {
+        setLoading(true);
+      }
+
+      try {
+        const nextData = await load();
+        if (requestIdRef.current !== requestId) {
+          log('%s ignore stale success requestId=%d', queryName, requestId);
+          return nextData;
+        }
+        dataRef.current = nextData;
+        setData(nextData);
+        log('%s success requestId=%d', queryName, requestId);
+        return nextData;
+      } catch (caught) {
+        const nextError = normalizeError(caught);
+        if (requestIdRef.current !== requestId) {
+          log('%s ignore stale error requestId=%d error=%o', queryName, requestId, nextError);
+          return undefined;
+        }
+        setError(nextError);
+        log('%s error requestId=%d error=%o', queryName, requestId, nextError);
+        return undefined;
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setLoading(false);
+          setIsRefetching(false);
+        }
+      }
+    },
+    [enabled, load, queryName]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      requestIdRef.current += 1;
+      dataRef.current = null;
+      setData(null);
+      setError(null);
+      setLoading(false);
+      setIsRefetching(false);
+      return;
+    }
+    void execute('initial');
+  }, [enabled, execute]);
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+    },
+    []
+  );
+
+  const refetch = useCallback(() => execute('refetch'), [execute]);
+
+  return { data, loading, error, isRefetching, refetch };
+}
+
+export function useThreads(): ThreadQueryState<ThreadsListData> {
+  const load = useCallback(() => threadApi.getThreads(), []);
+  return useThreadQuery('threads.list', load);
+}
+
+export function useThreadMessages(threadId?: string | null): ThreadQueryState<ThreadMessagesData> {
+  const normalizedThreadId = threadId?.trim() || null;
+  const load = useCallback(
+    () => threadApi.getThreadMessages(normalizedThreadId ?? ''),
+    [normalizedThreadId]
+  );
+  return useThreadQuery('threads.messages', load, normalizedThreadId !== null);
+}

--- a/app/src/hooks/useThreadQueries.ts
+++ b/app/src/hooks/useThreadQueries.ts
@@ -21,7 +21,8 @@ function normalizeError(error: unknown): Error {
 function useThreadQuery<T>(
   queryName: string,
   load: () => Promise<T>,
-  enabled = true
+  enabled = true,
+  queryKey = queryName
 ): ThreadQueryState<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(enabled);
@@ -29,6 +30,7 @@ function useThreadQuery<T>(
   const [isRefetching, setIsRefetching] = useState(false);
   const requestIdRef = useRef(0);
   const dataRef = useRef<T | null>(null);
+  const queryKeyRef = useRef(queryKey);
 
   const execute = useCallback(
     async (reason: 'initial' | 'refetch'): Promise<T | undefined> => {
@@ -79,6 +81,15 @@ function useThreadQuery<T>(
   );
 
   useEffect(() => {
+    if (queryKeyRef.current !== queryKey) {
+      requestIdRef.current += 1;
+      queryKeyRef.current = queryKey;
+      dataRef.current = null;
+      setData(null);
+      setError(null);
+      setIsRefetching(false);
+    }
+
     if (!enabled) {
       requestIdRef.current += 1;
       dataRef.current = null;
@@ -89,7 +100,7 @@ function useThreadQuery<T>(
       return;
     }
     void execute('initial');
-  }, [enabled, execute]);
+  }, [enabled, execute, queryKey]);
 
   useEffect(
     () => () => {
@@ -114,5 +125,10 @@ export function useThreadMessages(threadId?: string | null): ThreadQueryState<Th
     () => threadApi.getThreadMessages(normalizedThreadId ?? ''),
     [normalizedThreadId]
   );
-  return useThreadQuery('threads.messages', load, normalizedThreadId !== null);
+  return useThreadQuery(
+    'threads.messages',
+    load,
+    normalizedThreadId !== null,
+    `threads.messages:${normalizedThreadId ?? 'disabled'}`
+  );
 }


### PR DESCRIPTION
## Summary

- Adds `useThreads()` and `useThreadMessages(threadId)` hook foundations over the existing `threadApi` RPC client.
- Exposes `data`, `loading`, `error`, `isRefetching`, and `refetch()` states without migrating chat/runtime consumers yet.
- Adds request sequencing so stale async results do not overwrite the latest query result.
- Covers success, RPC error, disabled/no-thread-id, refetch, and refetching-with-prior-data behavior.

## Problem

The broader thread cache migration is too large for one PR. The app needs a small tested hook layer over the existing thread RPC API before consumers can migrate safely.

## Solution

A new `app/src/hooks/useThreadQueries.ts` module wraps `threadApi.getThreads()` and `threadApi.getThreadMessages()` with lightweight React state and debug logging. This PR does not change `ChatRuntimeProvider`, streaming behavior, or `Conversations.tsx` consumers.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated - added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (N/A: internal hook foundation only)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` (N/A: no matrix feature IDs affected)
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) (N/A: not a release-cut surface)
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section (N/A: Linear issue plus upstream tracking issue only)

## Impact

No user-visible behavior change. This is a foundation for later thread UI/cache migration work.

## Related

- Linear: https://linear.app/symphony-test-jwalin/issue/SYM-212/relaunch-openhuman-add-thread-rpc-query-hook-foundation
- Upstream issue: https://github.com/tinyhumansai/openhuman/issues/1197
- Closes: N/A
- Follow-up PR(s)/TODOs: migrate selected thread-list consumers to `useThreads()`; migrate non-streaming message reads to `useThreadMessages(threadId)` after reviewing runtime ownership.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: SYM-212
- URL: https://linear.app/symphony-test-jwalin/issue/SYM-212/relaunch-openhuman-add-thread-rpc-query-hook-foundation

### Commit & Branch
- Branch: `codex/SYM-212-thread-rpc-query-hooks`
- Commit SHA: `01fb74cfa1b041f3d35766a44531dfbe3ab7105e`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` via focused `pnpm --dir app exec prettier --check src/hooks/useThreadQueries.ts src/hooks/useThreadQueries.test.ts`
- [x] `pnpm typecheck` via `pnpm --filter openhuman-app compile`

- [x] Blocker regression: `pnpm --dir app exec vitest run src/hooks/useThreadQueries.test.ts --config test/vitest.config.ts`
- [x] Focused format after blocker patch: `pnpm --dir app exec prettier --check src/hooks/useThreadQueries.ts src/hooks/useThreadQueries.test.ts`
- [x] TypeScript compile after blocker patch: `pnpm --filter openhuman-app compile`
- [x] Rust fmt/check (if changed): N/A, no Rust changed
- [x] Tauri fmt/check (if changed): N/A, no Tauri changed

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: none for current UI consumers.
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: existing `threadApi` RPC methods remain the backing source of truth.
- Guard/fallback/dispatch parity checks: no provider/runtime migration in this slice; hook tests cover disabled, error, success, and refetch states.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A