### PR TITLE
feat(walkthrough): end guided tour on chat page with pre-seeded welcome message

### DIFF
--- a/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
+++ b/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
@@ -28,6 +28,18 @@ import { createWalkthroughSteps, waitForTarget } from '../walkthroughSteps';
 
 import WalkthroughTooltip from '../WalkthroughTooltip';
 
+vi.mock('../../../store', () => ({
+  store: {
+    dispatch: vi.fn(() => ({ unwrap: vi.fn().mockResolvedValue({ id: 'thread-welcome-123' }) })),
+  },
+}));
+
+vi.mock('../../../store/threadSlice', () => ({
+  createNewThread: vi.fn(() => ({ type: 'thread/createNewThread' })),
+  setSelectedThread: vi.fn((id: string) => ({ type: 'thread/setSelectedThread', payload: id })),
+  addMessageLocal: vi.fn(() => ({ type: 'thread/addMessageLocal' })),
+}));
+
 // ── Mock react-joyride so tests don't need a real DOM with
 //    positioned elements for each step target. ─────────────────────────────
 //    The mock captures the `onEvent` callback so individual tests can
@@ -519,11 +531,11 @@ describe('createWalkthroughSteps', () => {
     expect(steps[0].target).toBe('[data-walkthrough="home-card"]');
   });
 
-  it('last step targets tab-settings', () => {
+  it('last step targets chat-agent-panel', () => {
     const navigate = vi.fn();
     const steps = createWalkthroughSteps(navigate);
     const last = steps[steps.length - 1];
-    expect(last.target).toBe('[data-walkthrough="tab-settings"]');
+    expect(last.target).toBe('[data-walkthrough="chat-agent-panel"]');
   });
 
   it('all steps have a title and content', () => {
@@ -539,8 +551,8 @@ describe('createWalkthroughSteps', () => {
     const navigate = vi.fn();
     const steps = createWalkthroughSteps(navigate);
 
-    // Steps: 2=chat, 3=integrations, 4=channels, 5=intelligence, 6=settings, 7=home-return
-    const crossPageIndices = [2, 3, 4, 5, 6, 7];
+    // Steps: 2=chat, 3=integrations, 4=channels, 5=intelligence, 6=settings, 7=home-return, 9=chat-welcome
+    const crossPageIndices = [2, 3, 4, 5, 6, 7, 9];
     for (const idx of crossPageIndices) {
       expect(typeof steps[idx].before, `step[${idx}] should have a before fn`).toBe('function');
     }
@@ -550,8 +562,8 @@ describe('createWalkthroughSteps', () => {
     const navigate = vi.fn();
     const steps = createWalkthroughSteps(navigate);
 
-    // Steps: 0=home-card, 1=home-cta, 8=tab-notifications, 9=tab-settings
-    const homeOnlyIndices = [0, 1, 8, 9];
+    // Steps: 0=home-card, 1=home-cta, 8=tab-notifications (step 9 now has a before hook)
+    const homeOnlyIndices = [0, 1, 8];
     for (const idx of homeOnlyIndices) {
       expect(steps[idx].before, `step[${idx}] should not have a before fn`).toBeUndefined();
     }
@@ -564,6 +576,7 @@ describe('createWalkthroughSteps', () => {
     { idx: 5, route: '/intelligence', target: 'intelligence-header' },
     { idx: 6, route: '/settings', target: 'settings-menu' },
     { idx: 7, route: '/home', target: 'tab-chat' },
+    { idx: 9, route: '/chat', target: 'chat-agent-panel' },
   ])('before hook for step $idx calls navigate("$route")', async ({ idx, route, target }) => {
     const navigate = vi.fn();
 
@@ -577,6 +590,52 @@ describe('createWalkthroughSteps', () => {
       if (route) {
         expect(navigate).toHaveBeenCalledWith(route);
       }
+    } finally {
+      document.body.removeChild(el);
+    }
+  });
+
+  it('final step before hook creates thread and seeds welcome message', async () => {
+    const { store } = await import('../../../store');
+    const { createNewThread, addMessageLocal, setSelectedThread } =
+      await import('../../../store/threadSlice');
+
+    const navigate = vi.fn();
+    const el = document.createElement('div');
+    el.setAttribute('data-walkthrough', 'chat-agent-panel');
+    document.body.appendChild(el);
+
+    try {
+      const steps = createWalkthroughSteps(navigate);
+      const lastStep = steps[steps.length - 1];
+      await (lastStep.before as unknown as () => Promise<void>)();
+
+      expect(store.dispatch).toHaveBeenCalled();
+      expect(createNewThread).toHaveBeenCalled();
+      expect(addMessageLocal).toHaveBeenCalled();
+      expect(setSelectedThread).toHaveBeenCalledWith('thread-welcome-123');
+      expect(navigate).toHaveBeenCalledWith('/chat');
+    } finally {
+      document.body.removeChild(el);
+    }
+  });
+
+  it('final step before hook still navigates to /chat when thread creation fails', async () => {
+    const { store } = await import('../../../store');
+    vi.mocked(store.dispatch).mockReturnValueOnce({
+      unwrap: vi.fn().mockRejectedValue(new Error('Network error')),
+    } as any);
+
+    const navigate = vi.fn();
+    const el = document.createElement('div');
+    el.setAttribute('data-walkthrough', 'chat-agent-panel');
+    document.body.appendChild(el);
+
+    try {
+      const steps = createWalkthroughSteps(navigate);
+      const lastStep = steps[steps.length - 1];
+      await (lastStep.before as unknown as () => Promise<void>)();
+      expect(navigate).toHaveBeenCalledWith('/chat');
     } finally {
       document.body.removeChild(el);
     }

--- a/app/src/components/walkthrough/walkthroughSteps.ts
+++ b/app/src/components/walkthrough/walkthroughSteps.ts
@@ -1,6 +1,11 @@
 import type { Step } from 'react-joyride';
 import type { NavigateFunction } from 'react-router-dom';
 
+import { TOUR_WELCOME_MESSAGE } from '../../constants/onboardingChat';
+import { store } from '../../store';
+import { addMessageLocal, createNewThread, setSelectedThread } from '../../store/threadSlice';
+import type { ThreadMessage } from '../../types/thread';
+
 /**
  * Polls via setTimeout until `[data-walkthrough="<selector>"]` appears in the
  * DOM, then resolves. Rejects after `timeout` ms (default 3000).
@@ -38,7 +43,7 @@ export function waitForTarget(selector: string, timeout = 3000): Promise<void> {
 }
 
 /**
- * Factory that produces the 9-step walkthrough sequence.
+ * Factory that produces the 10-step walkthrough sequence.
  *
  * Steps that navigate to a different page receive a `before` async hook that
  * calls `navigate(path)` and then waits for the target element to appear in
@@ -159,13 +164,36 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
       skipBeacon: true,
     },
 
-    // ── Step 9 — /home (already there) ───────────────────────────────────
+    // ── Step 9 — /chat (pre-seeded welcome message) ───────────────────────
     {
-      target: '[data-walkthrough="tab-settings"]',
-      title: "That's the tour!",
-      content: "You're all set! Go explore. Restart this tour anytime from Settings.",
-      placement: 'top',
+      target: '[data-walkthrough="chat-agent-panel"]',
+      title: "You're all set!",
+      content:
+        'Your assistant left you a welcome note — this is your space to chat, ask questions, or brainstorm. Have fun!',
+      placement: 'bottom',
       skipBeacon: true,
+      before: async () => {
+        try {
+          const thread = await store.dispatch(createNewThread()).unwrap();
+          const welcomeMessage: ThreadMessage = {
+            id: `msg_${crypto.randomUUID()}`,
+            content: TOUR_WELCOME_MESSAGE,
+            type: 'text',
+            sender: 'agent',
+            createdAt: new Date().toISOString(),
+            extraMetadata: {},
+          };
+          await store
+            .dispatch(addMessageLocal({ threadId: thread.id, message: welcomeMessage }))
+            .unwrap();
+          store.dispatch(setSelectedThread(thread.id));
+          navigate('/chat');
+        } catch (err) {
+          console.debug('[walkthrough] step-9 before hook failed, falling back to /chat', err);
+          navigate('/chat');
+        }
+        await waitForTarget('chat-agent-panel');
+      },
     },
   ];
 }

--- a/app/src/constants/onboardingChat.ts
+++ b/app/src/constants/onboardingChat.ts
@@ -10,3 +10,11 @@
 
 /** @deprecated [#1123] — kept for any remaining imports; use empty string as placeholder */
 export const ONBOARDING_WELCOME_THREAD_LABEL = 'onboarding';
+
+/**
+ * Pre-seeded welcome message shown in the chat panel at the end of the guided
+ * tour (#1217). Surfaced as the agent's first message so new users land on
+ * /chat with something to respond to.
+ */
+export const TOUR_WELCOME_MESSAGE =
+  "Hey! Welcome to OpenHuman 👋 You just finished setting up, and I'm here whenever you need me. Ask me anything, get summaries from your connected apps, or just say hi — what would you like to explore first?";


### PR DESCRIPTION
## Summary

- The final tour step now navigates to `/chat` and seeds a welcome message from the AI assistant into a new thread
- Users land on a warm first conversation instead of an empty chat page after completing the guided tour
- Graceful degradation: if thread creation fails, the tour still navigates to `/chat`

## Changes

| File | Change |
|------|--------|
| `app/src/constants/onboardingChat.ts` | Added `TOUR_WELCOME_MESSAGE` constant |
| `app/src/components/walkthrough/walkthroughSteps.ts` | Replaced final step — navigates to `/chat` with `before` hook that creates thread + seeds agent message |
| `app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx` | Updated step target tests, added seeding + degradation tests |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (0 errors)
- [x] `pnpm format:check` — clean
- [x] `pnpm build` — succeeds
- [x] All 46 walkthrough tests pass
- [x] Manual: complete guided tour → verify welcome message appears in chat

Closes #1217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced onboarding walkthrough with an additional step that automatically creates a chat thread, delivers a personalized welcome message, and seamlessly transitions users to the chat interface.

* **Tests**
  * Updated walkthrough test suite to validate the new onboarding step, including thread creation, message seeding, and proper navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->