### PR TITLE
fix(macos/plist): add Bluetooth + privacy keys to prevent Gmeet sign-in crash (#1288)

### DIFF
--- a/app/src-tauri/Info.plist
+++ b/app/src-tauri/Info.plist
@@ -10,6 +10,18 @@
 	<string>OpenHuman uses Apple Events to read the focused text field for inline autocomplete suggestions and to detect the active app for context-aware features. You can manage this in System Settings &gt; Privacy &amp; Security &gt; Automation.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>OpenHuman uses Bluetooth for cross-device passkey sign-in (for example, when signing in to Google with your phone as an authenticator) and to detect connected audio devices (AirPods, headsets) in voice and video calls inside embedded apps (Google Meet, Discord, Slack).</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>OpenHuman shares your approximate location only when an embedded app (Google Meet, Discord) requests it — for example, to suggest nearby meeting rooms or set a default region. You can deny this without affecting other features.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>OpenHuman accesses the Documents folder only when you pick or save a file there from inside an embedded app (Slack, Discord, Telegram).</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>OpenHuman accesses the Downloads folder only when you pick or save a file there from inside an embedded app (Slack, Discord, Telegram).</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>OpenHuman accesses the Desktop folder only when you pick or save a file there from inside an embedded app (Slack, Discord, Telegram).</string>
+	<key>NSContactsUsageDescription</key>
+	<string>OpenHuman accesses Contacts only when an embedded app (Slack, Google Meet) explicitly asks to import or invite people from your address book.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>OpenHuman accesses your calendar only when an embedded app (Google Meet) asks to read or create events on your behalf.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/app/src-tauri/Info.plist
+++ b/app/src-tauri/Info.plist
@@ -8,6 +8,8 @@
 	<string>OpenHuman uses the camera for video calls and huddles inside embedded apps (Google Meet, Discord, Slack).</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>OpenHuman uses Apple Events to read the focused text field for inline autocomplete suggestions and to detect the active app for context-aware features. You can manage this in System Settings &gt; Privacy &amp; Security &gt; Automation.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>OpenHuman uses Bluetooth for cross-device passkey sign-in (for example, when signing in to Google with your phone as an authenticator) and to detect connected audio devices (AirPods, headsets) in voice and video calls inside embedded apps (Google Meet, Discord, Slack).</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/app/src-tauri/entitlements.sidecar.plist
+++ b/app/src-tauri/entitlements.sidecar.plist
@@ -32,5 +32,14 @@
          consent dialog. -->
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <!-- Required so embedded Chromium can enumerate Bluetooth audio devices
+         (AirPods, headsets) inside getUserMedia() / enumerateDevices() calls
+         on macOS 11+. The companion `NSBluetoothAlwaysUsageDescription` in
+         `Info.plist` supplies the user-facing text shown in the consent
+         dialog; the entitlement is belt-and-braces under the Hardened
+         Runtime — harmless when non-sandboxed, future-safe if Apple
+         tightens the sandbox. Tracked in #1288. -->
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
 </dict>
 </plist>

--- a/app/test/info-plist-required-keys.test.ts
+++ b/app/test/info-plist-required-keys.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const INFO_PLIST_PATH = path.resolve(HERE, '..', 'src-tauri', 'Info.plist');
+
+const REQUIRED_PRIVACY_KEYS = [
+  'NSMicrophoneUsageDescription',
+  'NSCameraUsageDescription',
+  'NSAppleEventsUsageDescription',
+  'NSBluetoothAlwaysUsageDescription',
+  'NSLocationWhenInUseUsageDescription',
+  'NSDocumentsFolderUsageDescription',
+  'NSDownloadsFolderUsageDescription',
+  'NSDesktopFolderUsageDescription',
+  'NSContactsUsageDescription',
+  'NSCalendarsUsageDescription',
+] as const;
+
+const MIN_DESCRIPTION_LEN = 30;
+
+function parsePlistKeyValuePairs(xml: string): Map<string, string> {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+  const parserError = doc.querySelector('parsererror');
+  if (parserError) {
+    throw new Error(`Info.plist XML parse failed: ${parserError.textContent ?? 'unknown'}`);
+  }
+
+  const root = doc.querySelector('plist > dict');
+  if (!root) {
+    throw new Error('Info.plist missing top-level <plist><dict>');
+  }
+
+  const map = new Map<string, string>();
+  const children = Array.from(root.children);
+  for (let i = 0; i < children.length; i++) {
+    const node = children[i];
+    if (node.tagName !== 'key') continue;
+    const keyName = (node.textContent ?? '').trim();
+    const valueNode = children[i + 1];
+    if (!valueNode || valueNode.tagName !== 'string') continue;
+    map.set(keyName, (valueNode.textContent ?? '').trim());
+  }
+  return map;
+}
+
+describe('app/src-tauri/Info.plist macOS privacy keys', () => {
+  const xml = readFileSync(INFO_PLIST_PATH, 'utf8');
+  const pairs = parsePlistKeyValuePairs(xml);
+
+  it.each(REQUIRED_PRIVACY_KEYS)('declares %s with non-empty user-facing copy', key => {
+    const value = pairs.get(key);
+    expect(value, `Missing required privacy key '${key}' in Info.plist`).toBeDefined();
+    expect(
+      (value ?? '').length,
+      `Privacy key '${key}' description must be ≥ ${MIN_DESCRIPTION_LEN} chars (placeholder check)`
+    ).toBeGreaterThanOrEqual(MIN_DESCRIPTION_LEN);
+  });
+
+  it('has the same key count as REQUIRED_PRIVACY_KEYS or strictly more', () => {
+    const declared = REQUIRED_PRIVACY_KEYS.filter(k => pairs.has(k)).length;
+    expect(declared).toBe(REQUIRED_PRIVACY_KEYS.length);
+  });
+});

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -29,6 +29,9 @@ Applies to every release, all platforms.
 - [ ] **Input Monitoring prompt fires on first hotkey use** — Press the registered global hotkey for the first time. Expected: `Input Monitoring` prompt; granting it makes the hotkey trigger; denying it does not crash the app.
 - [ ] **Screen Recording prompt fires on first screen-share** — Use the screen-share skill or `getDisplayMedia` shim. Expected: `Screen Recording` prompt; granted → picker shows windows + screens; denied → in-app message explaining the requirement.
 - [ ] **Microphone prompt fires on first voice capture** — Start a voice session. Expected: standard mic prompt; granted → capture begins; denied → fallback message, no panic.
+- [ ] **Bluetooth prompt fires on first Gmeet call (regression watch — see #1288)** — Open the Google Meet webview account and join a meeting from a fresh install. Expected: macOS prompts `OpenHuman would like to use Bluetooth` the first time the device picker enumerates audio peripherals; granted → AirPods/headsets appear in the picker; denied → fallback to built-in mic, no crash. Hard fail mode (key absent) is a SIGABRT before the prompt can render.
+- [ ] **Location prompt does not crash on Gmeet room-finder probe** — If Gmeet surfaces nearby-room suggestions, the first probe should trigger `OpenHuman would like to use your current location`; granting or denying must NOT crash the app. (Probe path is webview-driven; only verify the no-crash invariant here.)
+- [ ] **File picker does not crash on Documents/Downloads/Desktop selections** — From an embedded app (Slack, Discord, Telegram), trigger a file upload and pick a file from `Documents`, `Downloads`, and `Desktop` in turn. Expected: macOS prompts `OpenHuman would like to access files in your <Folder> folder` the first time per folder; deny + retry must not crash.
 
 ### Windows
 


### PR DESCRIPTION
## Summary

- Adds `NSBluetoothAlwaysUsageDescription` to the macOS bundle `Info.plist` so embedded Chromium's WebAuthn caBLE / hybrid-transport probe (and `enumerateDevices()` Bluetooth audio listing) no longer SIGABRTs the production app on Google Meet sign-in.
- Audits and ships six sibling preventative privacy keys (Location, Documents/Downloads/Desktop, Contacts, Calendars) in the same edit so future probes from embedded webviews can't crash the app.
- Adds `com.apple.security.device.bluetooth` entitlement under the Hardened Runtime as belt-and-braces.
- New Vitest unit test asserts all required `NS*UsageDescription` keys are present with non-empty descriptions — catches accidental removal.
- Extends `docs/RELEASE-MANUAL-SMOKE.md` with three macOS line items covering the new privacy prompts.

## Problem

Production OpenHuman desktop app on macOS 12.7.6 crashes on Google Meet web login (#1288). The crash report names the missing key:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data.

Root cause: macOS TCC enforces a hard `SIGABRT` (not graceful denial) when a non-sandboxed Hardened Runtime app probes a privacy-sensitive resource without the matching `NS*UsageDescription` key. Embedded Chromium walks CoreBluetooth via the WebAuthn caBLE/hybrid transport when Google sign-in offers cross-device passkey authentication ("use your phone as an authenticator"). The same probe is also reachable via `getUserMedia()` / `enumerateDevices()` audio peripheral listing on later macOS versions, so the description covers both surfaces.

Audit revealed six sibling privacy keys exposed to the same crash class — any embedded webview probe (Gmeet/Slack/Discord/Telegram) into Location, Documents/Downloads/Desktop folders, Contacts, or Calendars on macOS 11+ would SIGABRT a non-sandboxed Hardened Runtime app without the matching key. Fixing them in one PR prevents next-week QA crashes on a sibling key.

## Solution

`app/src-tauri/Info.plist` now declares 10 privacy keys (was 3):

| Key | User-facing copy summary |
| --- | --- |
| `NSMicrophoneUsageDescription` | unchanged |
| `NSCameraUsageDescription` | unchanged |
| `NSAppleEventsUsageDescription` | unchanged (#985) |
| `NSBluetoothAlwaysUsageDescription` | cross-device passkey sign-in + audio device enumeration (NEW — Tier 1, fixes #1288) |
| `NSLocationWhenInUseUsageDescription` | embedded webview geolocation (NEW — Tier 2) |
| `NSDocumentsFolderUsageDescription` | embedded webview file picker (NEW — Tier 2) |
| `NSDownloadsFolderUsageDescription` | embedded webview file picker (NEW — Tier 2) |
| `NSDesktopFolderUsageDescription` | embedded webview file picker (NEW — Tier 2) |
| `NSContactsUsageDescription` | embedded webview address book access (NEW — Tier 2) |
| `NSCalendarsUsageDescription` | embedded webview calendar access (NEW — Tier 2) |

`app/src-tauri/entitlements.sidecar.plist` adds `com.apple.security.device.bluetooth` (harmless under non-sandboxed Hardened Runtime, future-safe if Apple tightens the sandbox model).

`app/test/info-plist-required-keys.test.ts` (new): reads `app/src-tauri/Info.plist`, parses XML via `DOMParser`, asserts the 10 required keys exist with non-empty descriptions ≥ 30 chars (cheap placeholder check). Would have caught #1288 had it been in place pre-incident.

`docs/RELEASE-MANUAL-SMOKE.md`: three new macOS line items — Bluetooth prompt on first Gmeet sign-in (regression watch — hard fail mode is SIGABRT), Location no-crash invariant on Gmeet room-finder probe, file picker no-crash invariant for Documents/Downloads/Desktop.

Note on copy: macOS only fires the system prompt when the resource is actually probed — adding the keys does NOT pre-emptively annoy users.

### Verification

- ✅ `plutil -lint` both plists OK.
- ✅ Vitest privacy-keys test passes 11/11.
- ✅ Signed DMG built locally with `APPLE_SIGNING_IDENTITY="OpenHuman Dev Signer"` (per `feedback_macos_release_build_signing.md`). Bundle confirms:
  - `flags=0x10000(runtime)` — Hardened Runtime active
  - `Authority=OpenHuman Dev Signer`
  - All 10 `NS*UsageDescription` keys embedded in bundled `Info.plist`
  - `com.apple.security.device.bluetooth` entitlement embedded
- ✅ Local repro on prod v0.53.17 (macOS 26.2, Apple M5) confirmed the SIGABRT — `Termination Reason: Namespace TCC, Code 0` with the exact missing-key error text; faulting stack pinned to `+[IOBluetoothDevice pairedDevices]` → `-[IOBluetoothCoreBluetoothCoordinator init]` from the CEF WebAuthn caBLE / passkey path during Google sign-in. Bug class is NOT Monterey-only — current macOS still hard-crashes on missing key.
- ✅ **Smoke pass on dev build with this PR**: same machine, same Google sign-in flow that just crashed. Bundle reinstalled to `/Applications/OpenHuman.app`, BLE probe fired the proper TCC consent dialog instead of SIGABRT. Prompt rendered with title `"OpenHuman" would like to use Bluetooth.` and the body copy from the new `NSBluetoothAlwaysUsageDescription` string verbatim. Allow / Don't Allow both complete normally — no crash.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: Diff coverage ≥ 80% — changed lines are XML plists + a markdown checklist + a Vitest test file (itself excluded from coverage). `lcov` does not instrument plist/markdown.
- [ ] N/A: Coverage matrix updated — behaviour-only crash fix, no new feature row required in `TEST-COVERAGE-MATRIX.md`.
- [ ] N/A: All affected feature IDs from the matrix listed under `## Related` — no matrix row touched.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platforms affected**: macOS only. Windows/Linux bundles ignore `NS*UsageDescription` keys — no behavioural change on those platforms.
- **Runtime**: zero. Plist edits land in the bundled `.app` at build time, no Rust/TS code path changes. macOS only renders prompts when a resource is probed, so users see no surprise dialogs unless an embedded webview triggers the corresponding probe.
- **Security**: positive — declared keys + matching entitlement convert hard SIGABRT crashes into the standard TCC consent flow (allow/deny). User retains full control via System Settings > Privacy & Security.
- **Migration**: none. Existing installs simply gain prompt paths on next probe.
- **Performance**: none.

## Related

- Closes: #1288
- Adjacent context: #985 (`NSAppleEventsUsageDescription` + `com.apple.security.automation.apple-events`) — same Hardened Runtime / TCC crash class, different resource.
- Follow-up TODOs:
  - QA verify on macOS 12.7.6 (original repro environment) that the prompt copy renders as expected on first Gmeet cross-device passkey sign-in.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/1288-macos-bluetooth-privacy-keys`
- Commit SHA: c1da0c78


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS now requests user permissions for Bluetooth, location, documents, downloads, desktop, contacts, and calendars access.

* **Tests**
  * Added validation to ensure required macOS privacy descriptions are properly configured.

* **Documentation**
  * Updated macOS release checklist with new smoke test items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
