### PR TITLE
fix(welcome): include bearer token in core RPC test-connection probe

### DIFF
--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import OAuthProviderButton from '../components/oauth/OAuthProviderButton';
 import { oauthProviderConfigs } from '../components/oauth/providerConfigs';
 import RotatingTetrahedronCanvas from '../components/RotatingTetrahedronCanvas';
-import { clearCoreRpcUrlCache } from '../services/coreRpcClient';
+import { clearCoreRpcUrlCache, getCoreRpcToken } from '../services/coreRpcClient';
 import { useDeepLinkAuthState } from '../store/deepLinkAuthState';
 import {
   clearStoredRpcUrl,
@@ -65,9 +65,18 @@ const Welcome = () => {
     setRpcUrlError(null);
 
     try {
+      // Include the per-process bearer token so the embedded core's auth
+      // middleware accepts the ping. Without this header the request is
+      // rejected with 401 even when the URL is correct, surfacing as a
+      // misleading "Connection failed" to the user.
+      const token = await getCoreRpcToken();
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
       const response = await fetch(normalized, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'openhuman.ping', params: {} }),
       });
 

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import OAuthProviderButton from '../components/oauth/OAuthProviderButton';
 import { oauthProviderConfigs } from '../components/oauth/providerConfigs';
 import RotatingTetrahedronCanvas from '../components/RotatingTetrahedronCanvas';
-import { clearCoreRpcUrlCache, getCoreRpcToken } from '../services/coreRpcClient';
+import { clearCoreRpcUrlCache, testCoreRpcConnection } from '../services/coreRpcClient';
 import { useDeepLinkAuthState } from '../store/deepLinkAuthState';
 import {
   clearStoredRpcUrl,
@@ -65,20 +65,7 @@ const Welcome = () => {
     setRpcUrlError(null);
 
     try {
-      // Include the per-process bearer token so the embedded core's auth
-      // middleware accepts the ping. Without this header the request is
-      // rejected with 401 even when the URL is correct, surfacing as a
-      // misleading "Connection failed" to the user.
-      const token = await getCoreRpcToken();
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (token) {
-        headers.Authorization = `Bearer ${token}`;
-      }
-      const response = await fetch(normalized, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'openhuman.ping', params: {} }),
-      });
+      const response = await testCoreRpcConnection(normalized);
 
       if (response.ok || response.status === 405) {
         setSaveSuccess(true);

--- a/app/src/services/__tests__/coreRpcClient.test.ts
+++ b/app/src/services/__tests__/coreRpcClient.test.ts
@@ -421,4 +421,76 @@ describe('coreRpcClient', () => {
     expect(tokenCalls).toBe(1);
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  describe('testCoreRpcConnection', () => {
+    test('POSTs an openhuman.ping JSON-RPC envelope to the supplied URL', async () => {
+      vi.resetModules();
+      vi.mocked(isTauri).mockReturnValue(false);
+      const { testCoreRpcConnection } = await import('../coreRpcClient');
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+      await testCoreRpcConnection('http://example.test:7788/rpc');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://example.test:7788/rpc');
+      const requestInit = init as RequestInit;
+      expect(requestInit.method).toBe('POST');
+      expect(JSON.parse(requestInit.body as string)).toMatchObject({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'openhuman.ping',
+        params: {},
+      });
+    });
+
+    test('omits Authorization header when no bearer token is available (non-Tauri)', async () => {
+      vi.resetModules();
+      vi.mocked(isTauri).mockReturnValue(false);
+      const { testCoreRpcConnection } = await import('../coreRpcClient');
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+      await testCoreRpcConnection('http://example.test:7788/rpc');
+
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+      const headers = requestInit.headers as Record<string, string>;
+      expect(headers).toMatchObject({ 'Content-Type': 'application/json' });
+      expect(headers).not.toHaveProperty('Authorization');
+    });
+
+    test('attaches Authorization: Bearer when the Tauri bearer token resolves', async () => {
+      vi.resetModules();
+      vi.mocked(isTauri).mockReturnValue(true);
+      vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === 'core_rpc_token') return 'deadbeef';
+        throw new Error(`unexpected command: ${cmd}`);
+      });
+      const { testCoreRpcConnection } = await import('../coreRpcClient');
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+      await testCoreRpcConnection('http://example.test:7788/rpc');
+
+      const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+      const headers = requestInit.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer deadbeef');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    test('returns the raw fetch Response so callers can inspect status/ok', async () => {
+      vi.resetModules();
+      vi.mocked(isTauri).mockReturnValue(false);
+      const { testCoreRpcConnection } = await import('../coreRpcClient');
+      const fetchMock = vi.mocked(fetch);
+      const probe = { ok: false, status: 405, statusText: 'Method Not Allowed' } as Response;
+      fetchMock.mockResolvedValueOnce(probe);
+
+      const response = await testCoreRpcConnection('http://example.test:7788/rpc');
+
+      expect(response).toBe(probe);
+      expect(response.status).toBe(405);
+    });
+  });
 });

--- a/app/src/services/coreRpcClient.ts
+++ b/app/src/services/coreRpcClient.ts
@@ -142,7 +142,7 @@ export async function getCoreRpcUrl(): Promise<string> {
  * Returns `null` in non-Tauri environments (e.g. Vitest) where the command
  * is not available so existing tests remain unaffected.
  */
-async function getCoreRpcToken(): Promise<string | null> {
+export async function getCoreRpcToken(): Promise<string | null> {
   if (didResolveCoreRpcToken) return resolvedCoreRpcToken;
   if (!coreIsTauri()) return null;
   if (resolvingCoreRpcToken) return resolvingCoreRpcToken;

--- a/app/src/services/coreRpcClient.ts
+++ b/app/src/services/coreRpcClient.ts
@@ -142,7 +142,7 @@ export async function getCoreRpcUrl(): Promise<string> {
  * Returns `null` in non-Tauri environments (e.g. Vitest) where the command
  * is not available so existing tests remain unaffected.
  */
-export async function getCoreRpcToken(): Promise<string | null> {
+async function getCoreRpcToken(): Promise<string | null> {
   if (didResolveCoreRpcToken) return resolvedCoreRpcToken;
   if (!coreIsTauri()) return null;
   if (resolvingCoreRpcToken) return resolvingCoreRpcToken;
@@ -165,6 +165,30 @@ export async function getCoreRpcToken(): Promise<string | null> {
   })();
 
   return resolvingCoreRpcToken;
+}
+
+/**
+ * Probe an arbitrary core RPC URL with `openhuman.ping`. Used by the
+ * Welcome page's "Test Connection" affordance to validate a user-entered
+ * RPC URL without going through the cached `getCoreRpcUrl` resolution.
+ *
+ * Encapsulates the bearer-token + JSON-RPC envelope assembly that would
+ * otherwise sit in the calling component, keeping all RPC client behavior
+ * inside the service per the project guideline ("Keep Tauri IPC and RPC
+ * client calls localized to services … do not scatter `invoke()` or
+ * direct RPC calls throughout components").
+ */
+export async function testCoreRpcConnection(url: string): Promise<Response> {
+  const token = await getCoreRpcToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'openhuman.ping', params: {} }),
+  });
 }
 
 export async function getCoreHttpBaseUrl(): Promise<string> {


### PR DESCRIPTION
## Summary

- Welcome page's "Test Connection" RPC probe now sends `Authorization: Bearer <token>`, so it stops being rejected with 401 when the URL is correct.
- Exports `getCoreRpcToken` from `coreRpcClient.ts` so other call sites can attach the bearer header without going through `callCoreRpc`.

## Problem

Clicking **Test Connection** in the welcome page's "Configure RPC URL (Advanced)" section fired a raw `fetch()` with only `Content-Type` — no `Authorization` header. The embedded core's auth middleware rejected every probe with 401, regardless of whether the URL was actually correct, surfacing to the user as a misleading "Connection failed". Every other core RPC caller in the app already attaches the bearer; this one path was the outlier.

## Solution

Resolve the per-process bearer token via the existing `getCoreRpcToken` helper (now exported) and attach `Authorization: Bearer <token>` to the ping. Behavior matches every other core RPC caller in the app.

## Submission Checklist

- [ ] N/A: behaviour is gated on a manual click of an Advanced UI button; covered by manual smoke when an end user customises the RPC URL
- [ ] N/A: 12-line UI fix, change is too small to move the diff-coverage gate meaningfully
- [ ] N/A: behaviour-only change to an existing dev-only UI surface
- [ ] N/A: no feature IDs touched
- [x] No new external network dependencies introduced
- [ ] N/A: not a release-cut surface
- [ ] N/A: no linked issue

## Impact

- Desktop only. Affects the Welcome page's "Configure RPC URL (Advanced)" → "Test Connection" path. No runtime behavior change for users who don't customise the RPC URL.

## Related

- Closes:
- Follow-up PR(s)/TODOs: separate PR for ``dev:app:win`` Windows dev-environment plumbing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection tester now sends authenticated requests when a token is available and uses a unified routine for improved reliability while preserving existing success/failure UI behavior.

* **Tests**
  * Added tests validating connection behavior with and without authentication across environments, ensuring request format and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
