### PR TITLE
feat(dev): Windows dev environment for `pnpm dev:app:win`

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "dev:web": "vite",
     "dev:app": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && bash ../scripts/setup-chromium-safe-storage.sh && source ../scripts/load-dotenv.sh && APPLE_SIGNING_IDENTITY='OpenHuman Dev Signer' cargo tauri dev",
+    "dev:app:win": "bash ../scripts/run-dev-win.sh",
     "dev:cef": "pnpm dev:app",
     "dev:wry": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && source ../scripts/load-dotenv.sh && cargo tauri dev --no-default-features --features wry",
     "core:stage": "echo '[core:stage] no-op — core is linked in-process; sidecar removed (PR #1061)'",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "compile": "pnpm --filter openhuman-app compile",
     "dev": "pnpm --filter openhuman-app dev",
     "dev:app": "pnpm --filter openhuman-app dev:app",
+    "dev:app:win": "pnpm --filter openhuman-app dev:app:win",
     "dev:cef": "pnpm --filter openhuman-app dev:cef",
     "format": "pnpm --filter openhuman-app format",
     "format:check": "pnpm --filter openhuman-app format:check",

--- a/scripts/run-dev-win.sh
+++ b/scripts/run-dev-win.sh
@@ -96,26 +96,34 @@ if ! command -v cl.exe >/dev/null 2>&1; then
     exit 1
   fi
   echo "[run-dev-win] MSVC env loaded (cl.exe at $(command -v cl.exe))"
-  # Pin the linker by absolute path. PATH ordering alone isn't reliable here:
-  # the bash-side reorder doesn't always survive into the Windows-side %PATH%
-  # that rustc sees when it resolves `link.exe`, so it can still find Git's
-  # `C:\Program Files\Git\usr\bin\link.exe` (GNU coreutils symlink utility)
-  # first and produce `/usr/bin/link: extra operand '...rcgu.o'`. Setting
-  # `CARGO_TARGET_<TRIPLE>_LINKER` makes cargo pass `-C linker=<path>` to
-  # rustc directly, no PATH lookup involved.
-  msvc_cl_dir="$(dirname "$(command -v cl.exe)")"
-  msvc_link_unix="$msvc_cl_dir/link.exe"
-  if [[ ! -x "$msvc_link_unix" ]]; then
-    echo "[run-dev-win] expected link.exe alongside cl.exe at $msvc_link_unix" >&2
-    exit 1
-  fi
-  msvc_link_win="$(cygpath -w "$msvc_link_unix")"
-  export CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER="$msvc_link_win"
-  # Also push MSVC bin to the front of PATH so any other tool that bare-resolves
-  # `link.exe` (CMake-driven builds, etc.) hits MSVC's, not Git's.
-  export PATH="$msvc_cl_dir:$PATH"
-  echo "[run-dev-win] linker pinned: $msvc_link_win"
 fi
+
+# Pin the linker by absolute path — runs whether or not we just bootstrapped
+# the MSVC env. PATH ordering alone isn't reliable: the bash-side reorder
+# doesn't always survive into the Windows-side %PATH% that rustc sees when
+# it resolves `link.exe`, so it can still find Git's
+# `C:\Program Files\Git\usr\bin\link.exe` (GNU coreutils symlink utility)
+# first and produce `/usr/bin/link: extra operand '...rcgu.o'`. Setting
+# `CARGO_TARGET_<TRIPLE>_LINKER` makes cargo pass `-C linker=<path>` to
+# rustc directly, no PATH lookup involved.
+#
+# This block sits outside the bootstrap `if` so the pin still runs when
+# the user launches from a shell that already has `cl.exe` on PATH (e.g.
+# the "x64 Native Tools Command Prompt for VS 2022"). Without that, a
+# ready-to-go MSVC shell would skip the linker pin and fall back to PATH
+# resolution, where Git's coreutils `link.exe` can still win.
+msvc_cl_dir="$(dirname "$(command -v cl.exe)")"
+msvc_link_unix="$msvc_cl_dir/link.exe"
+if [[ ! -x "$msvc_link_unix" ]]; then
+  echo "[run-dev-win] expected link.exe alongside cl.exe at $msvc_link_unix" >&2
+  exit 1
+fi
+msvc_link_win="$(cygpath -w "$msvc_link_unix")"
+export CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER="$msvc_link_win"
+# Also push MSVC bin to the front of PATH so any other tool that bare-resolves
+# `link.exe` (CMake-driven builds, etc.) hits MSVC's, not Git's.
+export PATH="$msvc_cl_dir:$PATH"
+echo "[run-dev-win] linker pinned: $msvc_link_win"
 
 # Pin Ninja as the CMake generator end-to-end. The default on Windows would be
 # the Visual Studio generator, which produces .sln/.vcxproj files; if anything

--- a/scripts/run-dev-win.sh
+++ b/scripts/run-dev-win.sh
@@ -24,6 +24,105 @@ fi
 
 export LIBCLANG_PATH="/c/Program Files/LLVM/bin"
 
+# Bootstrap the MSVC C++ build environment in this shell so cl.exe / link.exe /
+# Windows SDK headers are reachable without launching the "x64 Native Tools
+# Command Prompt for VS 2022" first. This is a no-op if the env is already
+# loaded (cl.exe is on PATH). Otherwise we discover the latest VS install via
+# vswhere, run `vcvars64.bat` inside cmd, and re-export the relevant variables
+# back into this bash session.
+#
+# Without this, the Ninja generator fails to find cl.exe and CMake-driven
+# native crates (whisper-rs-sys, etc.) error out at the C++ compilation step.
+if ! command -v cl.exe >/dev/null 2>&1; then
+  vswhere_exe="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+  if [[ ! -x "$vswhere_exe" ]]; then
+    echo "[run-dev-win] vswhere.exe not found at $vswhere_exe" >&2
+    echo "[run-dev-win] install Visual Studio 2022 Build Tools with the 'Desktop development with C++' workload." >&2
+    exit 1
+  fi
+  vs_install_path="$("$vswhere_exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath || true)"
+  if [[ -z "$vs_install_path" ]]; then
+    echo "[run-dev-win] no VS install with MSVC C++ tools found via vswhere" >&2
+    exit 1
+  fi
+  vcvars_bat="${vs_install_path}\\VC\\Auxiliary\\Build\\vcvars64.bat"
+  echo "[run-dev-win] loading MSVC env from $vcvars_bat"
+  # Git Bash's MSYS layer mangles inner quotes when we invoke `cmd //c`
+  # directly (the literal backslash-quotes get passed through to cmd, which
+  # rejects the path). Workaround: write a small launcher .bat to a temp
+  # file, then have cmd execute the file. Avoids inner quoting entirely.
+  vcvars_launcher="$(mktemp --suffix=.bat)"
+  vcvars_launcher_win="$(cygpath -w "$vcvars_launcher")"
+  # Note: we deliberately do NOT redirect vcvars64.bat's stdout to NUL — MSYS
+  # would rewrite `NUL` to `/dev/null` while writing the .bat. Instead we let
+  # vcvars64 print its banner and filter for `KEY=VALUE` lines below.
+  printf '@echo off\r\ncall "%s"\r\nset\r\n' "$vcvars_bat" > "$vcvars_launcher"
+  # Note: do NOT set MSYS_NO_PATHCONV here — disabling path conversion stops
+  # MSYS from rewriting `//c` to `/c`, leaving cmd to treat `//c` as an
+  # unknown switch and open an interactive shell instead of executing the
+  # launcher.
+  msvc_env="$(cmd //c "$vcvars_launcher_win" 2>&1 || true)"
+  rm -f "$vcvars_launcher"
+  # Strip lines that aren't key=value (vcvars banner, blank lines).
+  msvc_env="$(printf '%s\n' "$msvc_env" | grep -E '^[A-Za-z_][A-Za-z0-9_()]*=' || true)"
+  if [[ -z "$msvc_env" ]]; then
+    echo "[run-dev-win] failed to capture MSVC env from vcvars64.bat" >&2
+    exit 1
+  fi
+  while IFS='=' read -r key value; do
+    case "$key" in
+      PATH)
+        # cmd's PATH uses ; and Windows paths; convert each entry to bash form.
+        new_path=""
+        IFS=';' read -ra path_entries <<< "$value"
+        for entry in "${path_entries[@]}"; do
+          [[ -z "$entry" ]] && continue
+          unix_entry="$(cygpath -u "$entry" 2>/dev/null || printf '%s' "$entry")"
+          new_path="${new_path}${new_path:+:}${unix_entry}"
+        done
+        export PATH="$new_path"
+        ;;
+      INCLUDE|LIB|LIBPATH)
+        # Compiler/linker want Windows-style ;-separated paths — leave as-is.
+        export "$key=$value"
+        ;;
+      VSCMD_*|VS[0-9]*COMNTOOLS|VCToolsInstallDir|VCToolsRedistDir|VCINSTALLDIR|VSINSTALLDIR|WindowsSdkDir|WindowsSDKVersion|UCRTVersion|UniversalCRTSdkDir|Platform)
+        export "$key=$value"
+        ;;
+    esac
+  done <<< "$msvc_env"
+  if ! command -v cl.exe >/dev/null 2>&1; then
+    echo "[run-dev-win] MSVC env load failed — cl.exe still not on PATH" >&2
+    exit 1
+  fi
+  echo "[run-dev-win] MSVC env loaded (cl.exe at $(command -v cl.exe))"
+  # Pin the linker by absolute path. PATH ordering alone isn't reliable here:
+  # the bash-side reorder doesn't always survive into the Windows-side %PATH%
+  # that rustc sees when it resolves `link.exe`, so it can still find Git's
+  # `C:\Program Files\Git\usr\bin\link.exe` (GNU coreutils symlink utility)
+  # first and produce `/usr/bin/link: extra operand '...rcgu.o'`. Setting
+  # `CARGO_TARGET_<TRIPLE>_LINKER` makes cargo pass `-C linker=<path>` to
+  # rustc directly, no PATH lookup involved.
+  msvc_cl_dir="$(dirname "$(command -v cl.exe)")"
+  msvc_link_unix="$msvc_cl_dir/link.exe"
+  if [[ ! -x "$msvc_link_unix" ]]; then
+    echo "[run-dev-win] expected link.exe alongside cl.exe at $msvc_link_unix" >&2
+    exit 1
+  fi
+  msvc_link_win="$(cygpath -w "$msvc_link_unix")"
+  export CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER="$msvc_link_win"
+  # Also push MSVC bin to the front of PATH so any other tool that bare-resolves
+  # `link.exe` (CMake-driven builds, etc.) hits MSVC's, not Git's.
+  export PATH="$msvc_cl_dir:$PATH"
+  echo "[run-dev-win] linker pinned: $msvc_link_win"
+fi
+
+# Pin Ninja as the CMake generator end-to-end. The default on Windows would be
+# the Visual Studio generator, which produces .sln/.vcxproj files; if anything
+# downstream then invokes ninja (because CMAKE_MAKE_PROGRAM is set below),
+# you get the "ninja: error: loading 'build.ninja'" mismatch.
+export CMAKE_GENERATOR=Ninja
+
 # CEF runtime lives under LOCALAPPDATA on Windows.
 # ensure-tauri-cli.sh stages it here; fall back to a default if unset.
 CEF_PATH="${CEF_PATH:-$(cygpath -u "$LOCALAPPDATA")/tauri-cef}"

--- a/scripts/setup-chromium-safe-storage.sh
+++ b/scripts/setup-chromium-safe-storage.sh
@@ -5,6 +5,17 @@
 # Idempotent: if the entry already exists, leaves the encryption key alone
 # (so existing cookies/IndexedDB stay decryptable) and only re-applies the
 # permissive ACL via partition-list.
+#
+# macOS-only: the `security` CLI and the "Chromium Safe Storage" keychain
+# entry are macOS Keychain concepts. On Linux Chromium uses kwallet/gnome
+# keyring (or the basic password store via `--password-store=basic`, which
+# the Tauri shell sets unconditionally), and on Windows it uses DPAPI. We
+# no-op on every non-Darwin platform so this script can sit unconditionally
+# in the cross-platform `dev:app` pipeline.
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
 set -euo pipefail
 
 SVC="Chromium Safe Storage"


### PR DESCRIPTION
## Summary

- Promote ``scripts/run-dev-win.sh`` from a hidden helper into a discoverable ``pnpm dev:app:win`` script (alongside the macOS ``dev:app``).
- Auto-bootstrap the MSVC C++ environment inside the launcher so it works from any plain Git Bash, not just from the "x64 Native Tools Command Prompt for VS 2022".
- Make ``setup-chromium-safe-storage.sh`` a clean no-op on non-Darwin platforms so the cross-platform ``dev:app`` pipeline stops trying to call ``security`` on Windows / Linux.
- Pin the CMake generator (``Ninja``) and the rustc linker (MSVC ``link.exe`` absolute path) so they can't disagree or get shadowed by Git's coreutils ``link.exe``.

## Problem

Windows dev today is gated on undocumented setup. ``pnpm dev:app`` is the macOS-flavored launcher (sets ``$HOME/Library/Caches/tauri-cef``, runs ``setup-chromium-safe-storage.sh`` which calls macOS-only ``security``, sets ``APPLE_SIGNING_IDENTITY``); it surfaces in ``pnpm run`` and looks like the canonical dev entry point. The only Windows-aware launcher (``scripts/run-dev-win.sh``) lives off-script with no entry in ``package.json``, so a Windows dev who follows the obvious path hits a chain of obscure failures:

- ``security: command not found`` (mac keychain CLI invoked unconditionally)
- ``ninja: error: loading 'build.ninja'`` (CMake configured with VS generator but build step invokes ``ninja`` because ``CMAKE_MAKE_PROGRAM`` was set without ``CMAKE_GENERATOR``)
- ``/usr/bin/link: extra operand '...rcgu.o'`` (rustc resolves bare ``link.exe`` to Git's coreutils symlink utility instead of MSVC's linker)

Even when devs *do* find ``run-dev-win.sh``, it required manually launching the "x64 Native Tools Command Prompt for VS 2022" first or the C++ toolchain would be invisible.

## Solution

**Discoverability.** Add ``dev:app:win`` to both ``app/package.json`` and ``package.json`` (root proxy) so ``pnpm run`` lists it next to ``dev:app``. Same script-naming convention as the existing ``macos:*`` entries.

**Cross-platform setup-chromium-safe-storage.** Add a ``[[ "$(uname -s)" != "Darwin" ]] && exit 0`` guard at the top. macOS Keychain logic is preserved verbatim below the guard. Linux's password store is already configured via ``--password-store=basic`` from the Tauri shell; Windows uses DPAPI and doesn't need any seeding.

**Auto-bootstrap MSVC env in run-dev-win.sh.** When ``cl.exe`` isn't on PATH, the script:

1. Locates the latest VS install via ``vswhere.exe -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64``.
2. Writes a tiny launcher ``.bat`` that ``call``s ``vcvars64.bat`` then dumps ``set`` (a temp ``.bat`` avoids MSYS's quote-mangling of ``cmd //c "call \"...\""`` invocations).
3. Re-exports the captured env into the bash session — ``PATH`` gets Windows-to-Unix conversion per entry, ``INCLUDE/LIB/LIBPATH`` stay in Windows form for ``cl.exe``, and the VS-specific vars (``VSCMD_*``, ``VCToolsInstallDir``, ``WindowsSdkDir``, ``UCRTVersion``, …) come along.
4. Verifies ``cl.exe`` is reachable; fails fast with a clear error if not.

**Pin the CMake generator and the linker.** After the env load:

- ``export CMAKE_GENERATOR=Ninja`` — without this, CMake auto-picks the VS generator on Windows (creates ``.sln`` files), but the ``cmake --build`` step invokes ``ninja`` because ``CMAKE_MAKE_PROGRAM`` is set, leading to "build.ninja not found".
- ``export CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=<absolute path to MSVC link.exe>`` — derived from ``dirname "$(command -v cl.exe)"``. cargo passes this to rustc as ``-C linker=<path>`` directly, bypassing PATH lookup entirely so Git's ``/usr/bin/link.exe`` can never win.

## Submission Checklist

- [ ] N/A: dev-environment plumbing — no runtime code paths exercised
- [ ] N/A: dev-environment plumbing
- [ ] N/A: no feature surface added or removed
- [ ] N/A: no feature IDs touched
- [x] No new external network dependencies introduced
- [ ] N/A: not a release-cut surface
- [ ] N/A: no linked issue

## Impact

- Windows dev only. No effect on macOS / Linux dev or on the shipped product (release builds use ``pnpm tauri:build:ui`` / ``macos:build:*`` paths, none of which this PR touches).
- macOS ``dev:app`` is unchanged; the chromium-safe-storage script behaves identically on Darwin (the guard is a leading early-exit on non-Darwin only).
- First-time Windows ``pnpm dev:app:win`` may take an extra few seconds while the MSVC env loads; subsequent runs in the same shell are no-ops because ``cl.exe`` is already detected.

## Related

- Closes:
- Follow-up PR(s)/TODOs: companion fix in #1301 (Welcome page bearer token); both surfaced while debugging Windows dev together


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows-specific development script to simplify starting the app in Windows environments.
  * Integrated MSVC toolchain support into the Windows dev setup for more reliable native builds.
  * Added a macOS-only guard to the Chromium safe-storage setup to avoid running macOS keychain steps on other platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->