### PR TITLE
fix(billing): include top-up and promo credits in budget banner check

### DIFF
--- a/app/src/hooks/useUsageState.test.ts
+++ b/app/src/hooks/useUsageState.test.ts
@@ -3,13 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetCurrentPlan = vi.fn();
 const mockGetTeamUsage = vi.fn();
+const mockGetBalance = vi.fn();
 
 vi.mock('../services/api/billingApi', () => ({
   billingApi: { getCurrentPlan: () => mockGetCurrentPlan() },
 }));
 
 vi.mock('../services/api/creditsApi', () => ({
-  creditsApi: { getTeamUsage: () => mockGetTeamUsage() },
+  creditsApi: { getTeamUsage: () => mockGetTeamUsage(), getBalance: () => mockGetBalance() },
 }));
 
 describe('useUsageState', () => {
@@ -17,6 +18,8 @@ describe('useUsageState', () => {
     vi.resetModules();
     mockGetCurrentPlan.mockReset();
     mockGetTeamUsage.mockReset();
+    mockGetBalance.mockReset();
+    mockGetBalance.mockResolvedValue({ promotionBalanceUsd: 0, teamTopupUsd: 0 });
   });
 
   it('does not treat free users with zero recurring budget as exhausted', async () => {
@@ -130,6 +133,158 @@ describe('useUsageState', () => {
 
     expect(result.current.isBudgetExhausted).toBe(false);
     expect(result.current.shouldShowBudgetCompletedMessage).toBe(false);
+  });
+
+  it('hides budget banner when top-up credits are available', async () => {
+    const { useUsageState } = await import('./useUsageState');
+
+    mockGetCurrentPlan.mockResolvedValue({
+      plan: 'BASIC',
+      hasActiveSubscription: true,
+      planExpiry: '2026-05-01T00:00:00.000Z',
+      subscription: {
+        id: 'sub_123',
+        status: 'active',
+        currentPeriodEnd: '2026-05-01T00:00:00.000Z',
+        quantity: 1,
+      },
+      monthlyBudgetUsd: 20,
+      weeklyBudgetUsd: 10,
+      fiveHourCapUsd: 3,
+    });
+    mockGetTeamUsage.mockResolvedValue({
+      remainingUsd: 0,
+      cycleBudgetUsd: 10,
+      cycleLimit5hr: 1,
+      cycleLimit7day: 10,
+      fiveHourCapUsd: 3,
+      fiveHourResetsAt: null,
+      cycleStartDate: '2026-04-09T00:00:00.000Z',
+      cycleEndsAt: '2026-04-16T00:00:00.000Z',
+      bypassCycleLimit: false,
+    });
+    mockGetBalance.mockResolvedValue({ promotionBalanceUsd: 0, teamTopupUsd: 50 });
+
+    const { result } = renderHook(() => useUsageState());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.shouldShowBudgetCompletedMessage).toBe(false);
+  });
+
+  it('hides budget banner when promotional credits are available', async () => {
+    const { useUsageState } = await import('./useUsageState');
+
+    mockGetCurrentPlan.mockResolvedValue({
+      plan: 'BASIC',
+      hasActiveSubscription: true,
+      planExpiry: '2026-05-01T00:00:00.000Z',
+      subscription: {
+        id: 'sub_123',
+        status: 'active',
+        currentPeriodEnd: '2026-05-01T00:00:00.000Z',
+        quantity: 1,
+      },
+      monthlyBudgetUsd: 20,
+      weeklyBudgetUsd: 10,
+      fiveHourCapUsd: 3,
+    });
+    mockGetTeamUsage.mockResolvedValue({
+      remainingUsd: 0,
+      cycleBudgetUsd: 10,
+      cycleLimit5hr: 1,
+      cycleLimit7day: 10,
+      fiveHourCapUsd: 3,
+      fiveHourResetsAt: null,
+      cycleStartDate: '2026-04-09T00:00:00.000Z',
+      cycleEndsAt: '2026-04-16T00:00:00.000Z',
+      bypassCycleLimit: false,
+    });
+    mockGetBalance.mockResolvedValue({ promotionBalanceUsd: 10, teamTopupUsd: 0 });
+
+    const { result } = renderHook(() => useUsageState());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.shouldShowBudgetCompletedMessage).toBe(false);
+  });
+
+  it('hides budget banner for free user with top-up credits', async () => {
+    const { useUsageState } = await import('./useUsageState');
+
+    mockGetCurrentPlan.mockResolvedValue({
+      plan: 'FREE',
+      hasActiveSubscription: false,
+      planExpiry: null,
+      subscription: null,
+      monthlyBudgetUsd: 0,
+      weeklyBudgetUsd: 0,
+      fiveHourCapUsd: 0,
+    });
+    mockGetTeamUsage.mockResolvedValue({
+      remainingUsd: 0,
+      cycleBudgetUsd: 0,
+      cycleLimit5hr: 0,
+      cycleLimit7day: 0,
+      fiveHourCapUsd: 0,
+      fiveHourResetsAt: null,
+      cycleStartDate: '2026-04-09T00:00:00.000Z',
+      cycleEndsAt: '2026-04-16T00:00:00.000Z',
+      bypassCycleLimit: false,
+    });
+    mockGetBalance.mockResolvedValue({ promotionBalanceUsd: 0.69, teamTopupUsd: 50 });
+
+    const { result } = renderHook(() => useUsageState());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.shouldShowBudgetCompletedMessage).toBe(false);
+  });
+
+  it('shows budget banner when all credit sources are exhausted', async () => {
+    const { useUsageState } = await import('./useUsageState');
+
+    mockGetCurrentPlan.mockResolvedValue({
+      plan: 'BASIC',
+      hasActiveSubscription: true,
+      planExpiry: '2026-05-01T00:00:00.000Z',
+      subscription: {
+        id: 'sub_123',
+        status: 'active',
+        currentPeriodEnd: '2026-05-01T00:00:00.000Z',
+        quantity: 1,
+      },
+      monthlyBudgetUsd: 20,
+      weeklyBudgetUsd: 10,
+      fiveHourCapUsd: 3,
+    });
+    mockGetTeamUsage.mockResolvedValue({
+      remainingUsd: 0,
+      cycleBudgetUsd: 10,
+      cycleLimit5hr: 1,
+      cycleLimit7day: 10,
+      fiveHourCapUsd: 3,
+      fiveHourResetsAt: null,
+      cycleStartDate: '2026-04-09T00:00:00.000Z',
+      cycleEndsAt: '2026-04-16T00:00:00.000Z',
+      bypassCycleLimit: false,
+    });
+    mockGetBalance.mockResolvedValue({ promotionBalanceUsd: 0, teamTopupUsd: 0 });
+
+    const { result } = renderHook(() => useUsageState());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isBudgetExhausted).toBe(true);
+    expect(result.current.shouldShowBudgetCompletedMessage).toBe(true);
   });
 
   it('refetches when a global usage refresh is requested', async () => {

--- a/app/src/hooks/useUsageState.ts
+++ b/app/src/hooks/useUsageState.ts
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { billingApi } from '../services/api/billingApi';
-import { creditsApi, type TeamUsage } from '../services/api/creditsApi';
+import { type CreditBalance, creditsApi, type TeamUsage } from '../services/api/creditsApi';
 import type { CurrentPlanData, PlanTier } from '../types/api';
 import { subscribeUsageRefresh } from './usageRefresh';
 
 export interface UsageState {
   teamUsage: TeamUsage | null;
   currentPlan: CurrentPlanData | null;
+  creditBalance: CreditBalance | null;
   currentTier: PlanTier;
   isFreeTier: boolean;
   usagePct10h: number;
@@ -24,25 +25,33 @@ export interface UsageState {
 const CACHE_TTL_MS = 60_000;
 
 let _cache: {
-  data: { teamUsage: TeamUsage; currentPlan: CurrentPlanData };
+  data: { teamUsage: TeamUsage; currentPlan: CurrentPlanData; creditBalance: CreditBalance };
   fetchedAt: number;
 } | null = null;
 
-async function fetchUsageData(): Promise<{ teamUsage: TeamUsage; currentPlan: CurrentPlanData }> {
+async function fetchUsageData(): Promise<{
+  teamUsage: TeamUsage;
+  currentPlan: CurrentPlanData;
+  creditBalance: CreditBalance;
+}> {
   if (_cache && Date.now() - _cache.fetchedAt < CACHE_TTL_MS) {
     return _cache.data;
   }
-  const [teamUsage, currentPlan] = await Promise.all([
+  const [teamUsage, currentPlan, creditBalance] = await Promise.all([
     creditsApi.getTeamUsage(),
     billingApi.getCurrentPlan(),
+    creditsApi
+      .getBalance()
+      .catch((): CreditBalance => ({ promotionBalanceUsd: 0, teamTopupUsd: 0 })),
   ]);
-  _cache = { data: { teamUsage, currentPlan }, fetchedAt: Date.now() };
+  _cache = { data: { teamUsage, currentPlan, creditBalance }, fetchedAt: Date.now() };
   return _cache.data;
 }
 
 export function useUsageState(): UsageState {
   const [teamUsage, setTeamUsage] = useState<TeamUsage | null>(null);
   const [currentPlan, setCurrentPlan] = useState<CurrentPlanData | null>(null);
+  const [creditBalance, setCreditBalance] = useState<CreditBalance | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [fetchCount, setFetchCount] = useState(0);
 
@@ -61,6 +70,7 @@ export function useUsageState(): UsageState {
         if (cancelled) return;
         setTeamUsage(data.teamUsage);
         setCurrentPlan(data.currentPlan);
+        setCreditBalance(data.creditBalance);
       })
       .catch(() => {
         // Usage unavailable — silently ignore
@@ -90,11 +100,17 @@ export function useUsageState(): UsageState {
     ? teamUsage.cycleBudgetUsd > 0.01 && teamUsage.remainingUsd <= 0.01
     : false;
 
-  // Some users have no included recurring budget at all. They still need the
-  // completed-budget warning in chat even though they are not in an exhausted
-  // paid cycle.
+  // Top-up and promotional credits should suppress the budget-completed banner
+  // even when the included recurring budget is exhausted.
+  const hasAvailableCredits = creditBalance
+    ? creditBalance.teamTopupUsd + creditBalance.promotionBalanceUsd > 0.01
+    : false;
+
+  // Show the banner only when ALL credit sources are exhausted: included budget,
+  // top-up balance, and promotional credits.
   const shouldShowBudgetCompletedMessage = teamUsage
-    ? isBudgetExhausted || (teamUsage.cycleBudgetUsd <= 0.01 && teamUsage.remainingUsd <= 0.01)
+    ? !hasAvailableCredits &&
+      (isBudgetExhausted || (teamUsage.cycleBudgetUsd <= 0.01 && teamUsage.remainingUsd <= 0.01))
     : false;
 
   const isRateLimited =
@@ -110,6 +126,7 @@ export function useUsageState(): UsageState {
   return {
     teamUsage,
     currentPlan,
+    creditBalance,
     currentTier,
     isFreeTier,
     usagePct10h,


### PR DESCRIPTION
## Summary

Fixes #1291 — AI chat incorrectly shows "Your included budget is complete" even when the user has $50+ in top-up balance and promotional credits.

**Root cause:** `useUsageState` hook only checked `teamUsage.cycleBudgetUsd` and `teamUsage.remainingUsd` to determine if budget was exhausted. It never fetched `creditsApi.getBalance()`, so top-up and promotional credits were invisible to the banner logic.

**Fix:**
- Added `creditsApi.getBalance()` to the existing `Promise.all` fetch in `useUsageState`, sharing the 60s cache TTL
- `shouldShowBudgetCompletedMessage` now returns `false` when `teamTopupUsd + promotionBalanceUsd > $0.01`
- Graceful degradation: if `getBalance()` fails, credits default to $0 (banner still shows — fail-safe)

## Changes
- `app/src/hooks/useUsageState.ts` — fetch credit balance, add `hasAvailableCredits` gate to banner condition
- `app/src/hooks/useUsageState.test.ts` — 4 new tests: top-up suppresses banner, promo suppresses banner, free user with credits suppresses banner, all exhausted shows banner

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm build` — clean
- [x] `pnpm debug unit src/hooks/useUsageState.test.ts` — 8/8 passed
- [x] Manual: top up credits → open chat → verify no banner
- [x] Manual: exhaust all credits → verify banner appears