### PR TITLE
fix(boot): unblock cold-boot core start on dev hosts

### DIFF
--- a/app/src-tauri/permissions/allow-core-process.toml
+++ b/app/src-tauri/permissions/allow-core-process.toml
@@ -7,6 +7,11 @@ allow = [
     "core_rpc_url",
     "core_rpc_token",
     "restart_core_process",
+    # `start_core_process` is invoked by BootCheckGate after the user picks
+    # Local mode, before redux-persist hydrates the rest of the app (#1316).
+    # Without this allow entry the invoke is rejected with "Command not
+    # found" and the boot gate stalls.
+    "start_core_process",
     # `restart_app` triggers `app.restart()` so CEF re-initializes against
     # the active user's `users/<id>/cef` profile after an identity flip
     # (#900). Without this allow entry, the invoke is silently denied by

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -104,6 +104,27 @@ impl CoreProcessHandle {
     }
 
     pub async fn ensure_running(&self) -> Result<(), String> {
+        // Idempotent fast path: if we already spawned the embedded server in
+        // *this* process and it's still alive on the port, the listener is
+        // us — return Ok without identifying or taking over. Without this,
+        // a second `start_core_process` call (e.g. HMR re-mounting the boot
+        // gate) sees its own port as bound, classifies the listener as
+        // "stale OpenHuman", and walks into the SIGTERM/SIGKILL takeover
+        // path against itself. (#1130 takeover is meant to recover from
+        // *external* leftover binaries, not our own in-process spawn.)
+        {
+            let guard = self.task.lock().await;
+            if let Some(task) = guard.as_ref() {
+                if !task.is_finished() && self.is_rpc_port_open().await {
+                    log::debug!(
+                        "[core] ensure_running: embedded task already running on port {} — no-op",
+                        self.port
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
         if self.is_rpc_port_open().await {
             if reuse_existing_listener_enabled() {
                 log::warn!(

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1354,6 +1354,54 @@ pub fn run() {
                 return Err("webview_apis bridge failed to start — aborting setup".into());
             }
 
+            // Purge stray LaunchAgent left over from a prior worktree's
+            // `service install`. KeepAlive=true on the plist re-spawns the
+            // daemon after every SIGKILL, fighting `ensure_running`'s
+            // stale-listener takeover and re-binding port 7788 on cold boot.
+            // (Symptom: "Failed to start local core: signaled pid <X> but
+            // port 7788 remained bound after 5000ms".) Detach from launchd
+            // first, then unlink the plist so a reboot can't reload it.
+            #[cfg(target_os = "macos")]
+            {
+                const STALE_LABEL: &str = "com.openhuman.core";
+
+                if let Ok(home) = std::env::var("HOME") {
+                    let plist = std::path::PathBuf::from(&home)
+                        .join("Library")
+                        .join("LaunchAgents")
+                        .join(format!("{STALE_LABEL}.plist"));
+
+                    let uid = std::process::Command::new("id")
+                        .arg("-u")
+                        .output()
+                        .ok()
+                        .and_then(|o| String::from_utf8(o.stdout).ok())
+                        .map(|s| s.trim().to_string());
+
+                    if let Some(uid) = uid {
+                        let target = format!("gui/{uid}/{STALE_LABEL}");
+                        let _ = std::process::Command::new("launchctl")
+                            .arg("bootout")
+                            .arg(&target)
+                            .status();
+                    }
+
+                    if plist.exists() {
+                        match std::fs::remove_file(&plist) {
+                            Ok(()) => log::warn!(
+                                "[boot] removed stale LaunchAgent plist at {} \
+                                 (left over from a prior worktree's `service install`)",
+                                plist.display()
+                            ),
+                            Err(err) => log::warn!(
+                                "[boot] failed to remove stale LaunchAgent plist {}: {err}",
+                                plist.display()
+                            ),
+                        }
+                    }
+                }
+            }
+
             let core_handle =
                 core_process::CoreProcessHandle::new(core_process::default_core_port());
             std::env::set_var("OPENHUMAN_CORE_RPC_URL", core_handle.rpc_url());

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1359,10 +1359,17 @@ pub fn run() {
             // daemon after every SIGKILL, fighting `ensure_running`'s
             // stale-listener takeover and re-binding port 7788 on cold boot.
             // (Symptom: "Failed to start local core: signaled pid <X> but
-            // port 7788 remained bound after 5000ms".) Detach from launchd
-            // first, then unlink the plist so a reboot can't reload it.
+            // port 7788 remained bound after 5000ms".)
+            //
+            // Tightly scoped to avoid clobbering a legitimate `service
+            // install`:
+            //   - dev builds only (`cfg!(debug_assertions)`)
+            //   - skip when this process IS the daemon (`!daemon_mode`)
+            //   - only purge when the plist's ProgramArguments[0] points
+            //     somewhere other than the currently-running executable —
+            //     i.e. a sibling worktree's stale binary, not us.
             #[cfg(target_os = "macos")]
-            {
+            if cfg!(debug_assertions) && !daemon_mode {
                 const STALE_LABEL: &str = "com.openhuman.core";
 
                 if let Ok(home) = std::env::var("HOME") {
@@ -1371,26 +1378,45 @@ pub fn run() {
                         .join("LaunchAgents")
                         .join(format!("{STALE_LABEL}.plist"));
 
-                    let uid = std::process::Command::new("id")
-                        .arg("-u")
-                        .output()
+                    let plist_targets_us = std::fs::read_to_string(&plist)
                         .ok()
-                        .and_then(|o| String::from_utf8(o.stdout).ok())
-                        .map(|s| s.trim().to_string());
+                        .and_then(|contents| {
+                            // ProgramArguments[0] is the first <string>...</string>
+                            // after the <key>ProgramArguments</key> marker. The
+                            // service installer always writes it as an absolute
+                            // path to the openhuman-core binary (see
+                            // src/openhuman/service/macos.rs).
+                            let after_key = contents.split("<key>ProgramArguments</key>").nth(1)?;
+                            let start = after_key.find("<string>")? + "<string>".len();
+                            let rest = &after_key[start..];
+                            let end = rest.find("</string>")?;
+                            Some(std::path::PathBuf::from(rest[..end].trim()))
+                        })
+                        .zip(std::env::current_exe().ok())
+                        .map(|(plist_bin, self_bin)| plist_bin == self_bin)
+                        .unwrap_or(false);
 
-                    if let Some(uid) = uid {
-                        let target = format!("gui/{uid}/{STALE_LABEL}");
-                        let _ = std::process::Command::new("launchctl")
-                            .arg("bootout")
-                            .arg(&target)
-                            .status();
-                    }
+                    if plist.exists() && !plist_targets_us {
+                        let uid = std::process::Command::new("id")
+                            .arg("-u")
+                            .output()
+                            .ok()
+                            .and_then(|o| String::from_utf8(o.stdout).ok())
+                            .map(|s| s.trim().to_string());
 
-                    if plist.exists() {
+                        if let Some(uid) = uid {
+                            let target = format!("gui/{uid}/{STALE_LABEL}");
+                            let _ = std::process::Command::new("launchctl")
+                                .arg("bootout")
+                                .arg(&target)
+                                .status();
+                        }
+
                         match std::fs::remove_file(&plist) {
                             Ok(()) => log::warn!(
                                 "[boot] removed stale LaunchAgent plist at {} \
-                                 (left over from a prior worktree's `service install`)",
+                                 (points at a different binary than this build — \
+                                 likely a sibling worktree's `service install`)",
                                 plist.display()
                             ),
                             Err(err) => log::warn!(

--- a/app/src/lib/bootCheck/index.test.ts
+++ b/app/src/lib/bootCheck/index.test.ts
@@ -155,9 +155,7 @@ describe('runBootCheck — cloud mode', () => {
     const appVersion = (await import('../../utils/config')).APP_VERSION;
 
     const transport = makeTransport({
-      callRpc: rpcResponder({
-        'openhuman.update_version': { result: { version: appVersion } },
-      }),
+      callRpc: rpcResponder({ 'openhuman.update_version': { result: { version: appVersion } } }),
     });
 
     const result = await runBootCheck(
@@ -169,9 +167,7 @@ describe('runBootCheck — cloud mode', () => {
 
   it('returns outdatedCloud when version differs', async () => {
     const transport = makeTransport({
-      callRpc: rpcResponder({
-        'openhuman.update_version': { result: { version: '0.0.0-old' } },
-      }),
+      callRpc: rpcResponder({ 'openhuman.update_version': { result: { version: '0.0.0-old' } } }),
     });
 
     const result = await runBootCheck(

--- a/app/src/lib/bootCheck/index.test.ts
+++ b/app/src/lib/bootCheck/index.test.ts
@@ -44,7 +44,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
-        'openhuman.update_version': { version_info: { version: appVersion } },
+        'openhuman.update_version': { version: appVersion },
       }),
     });
 
@@ -59,7 +59,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: true, running: false },
-        'openhuman.update_version': { version_info: { version: appVersion } },
+        'openhuman.update_version': { version: appVersion },
       }),
     });
 
@@ -72,7 +72,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: true },
-        'openhuman.update_version': { version_info: { version: 'x' } },
+        'openhuman.update_version': { version: 'x' },
       }),
     });
 
@@ -85,7 +85,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
-        'openhuman.update_version': { version_info: { version: '0.0.0-different' } },
+        'openhuman.update_version': { version: '0.0.0-different' },
       }),
     });
 
@@ -156,7 +156,7 @@ describe('runBootCheck — cloud mode', () => {
 
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.update_version': { version_info: { version: appVersion } },
+        'openhuman.update_version': { version: appVersion },
       }),
     });
 
@@ -170,7 +170,7 @@ describe('runBootCheck — cloud mode', () => {
   it('returns outdatedCloud when version differs', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.update_version': { version_info: { version: '0.0.0-old' } },
+        'openhuman.update_version': { version: '0.0.0-old' },
       }),
     });
 
@@ -230,7 +230,7 @@ describe('runBootCheck — error and edge branches', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': new Error('rpc transport blew up'),
-        'openhuman.update_version': { version_info: { version: appVersion } },
+        'openhuman.update_version': { version: appVersion },
       }),
     });
 
@@ -238,12 +238,12 @@ describe('runBootCheck — error and edge branches', () => {
     expect(result.kind).toBe('match');
   });
 
-  it('treats empty version_info.version as outdatedLocal', async () => {
+  it('treats empty version as outdatedLocal', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
-        'openhuman.update_version': { version_info: { version: '' } },
+        'openhuman.update_version': { version: '' },
       }),
     });
 

--- a/app/src/lib/bootCheck/index.test.ts
+++ b/app/src/lib/bootCheck/index.test.ts
@@ -44,7 +44,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
-        'openhuman.update_version': { version: appVersion },
+        'openhuman.update_version': { result: { version: appVersion } },
       }),
     });
 
@@ -59,7 +59,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: true, running: false },
-        'openhuman.update_version': { version: appVersion },
+        'openhuman.update_version': { result: { version: appVersion } },
       }),
     });
 
@@ -72,7 +72,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: true },
-        'openhuman.update_version': { version: 'x' },
+        'openhuman.update_version': { result: { version: 'x' } },
       }),
     });
 
@@ -85,7 +85,7 @@ describe('runBootCheck — local mode', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
-        'openhuman.update_version': { version: '0.0.0-different' },
+        'openhuman.update_version': { result: { version: '0.0.0-different' } },
       }),
     });
 
@@ -156,7 +156,7 @@ describe('runBootCheck — cloud mode', () => {
 
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.update_version': { version: appVersion },
+        'openhuman.update_version': { result: { version: appVersion } },
       }),
     });
 
@@ -170,7 +170,7 @@ describe('runBootCheck — cloud mode', () => {
   it('returns outdatedCloud when version differs', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.update_version': { version: '0.0.0-old' },
+        'openhuman.update_version': { result: { version: '0.0.0-old' } },
       }),
     });
 
@@ -230,7 +230,7 @@ describe('runBootCheck — error and edge branches', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': new Error('rpc transport blew up'),
-        'openhuman.update_version': { version: appVersion },
+        'openhuman.update_version': { result: { version: appVersion } },
       }),
     });
 
@@ -243,7 +243,7 @@ describe('runBootCheck — error and edge branches', () => {
       callRpc: rpcResponder({
         'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
-        'openhuman.update_version': { version: '' },
+        'openhuman.update_version': { result: { version: '' } },
       }),
     });
 

--- a/app/src/lib/bootCheck/index.test.ts
+++ b/app/src/lib/bootCheck/index.test.ts
@@ -42,7 +42,7 @@ describe('runBootCheck — local mode', () => {
 
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
         'openhuman.update_version': { version_info: { version: appVersion } },
       }),
@@ -57,7 +57,7 @@ describe('runBootCheck — local mode', () => {
 
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: true, running: false },
         'openhuman.update_version': { version_info: { version: appVersion } },
       }),
@@ -70,7 +70,7 @@ describe('runBootCheck — local mode', () => {
   it('returns daemonDetected when service_status shows running=true', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: false, running: true },
         'openhuman.update_version': { version_info: { version: 'x' } },
       }),
@@ -83,7 +83,7 @@ describe('runBootCheck — local mode', () => {
   it('returns outdatedLocal when core version differs from app version', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
         'openhuman.update_version': { version_info: { version: '0.0.0-different' } },
       }),
@@ -96,7 +96,7 @@ describe('runBootCheck — local mode', () => {
   it('returns noVersionMethod when update_version returns -32601', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
         'openhuman.update_version': new Error('JSON-RPC error -32601 Method not found'),
       }),
@@ -109,7 +109,7 @@ describe('runBootCheck — local mode', () => {
   it('returns noVersionMethod on "method not found" text variant', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
         'openhuman.update_version': new Error('method not found'),
       }),
@@ -228,7 +228,7 @@ describe('runBootCheck — error and edge branches', () => {
 
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': new Error('rpc transport blew up'),
         'openhuman.update_version': { version_info: { version: appVersion } },
       }),
@@ -241,7 +241,7 @@ describe('runBootCheck — error and edge branches', () => {
   it('treats empty version_info.version as outdatedLocal', async () => {
     const transport = makeTransport({
       callRpc: rpcResponder({
-        'openhuman.ping': {},
+        'core.ping': {},
         'openhuman.service_status': { installed: false, running: false },
         'openhuman.update_version': { version_info: { version: '' } },
       }),
@@ -268,7 +268,7 @@ describe('runBootCheck — error and edge branches', () => {
     let pingCalls = 0;
     const transport: BootCheckTransport = {
       callRpc: vi.fn(async (method: string) => {
-        if (method === 'openhuman.ping') {
+        if (method === 'core.ping') {
           pingCalls += 1;
           if (pingCalls === 1) return {};
           throw new Error('subsequent failure');

--- a/app/src/lib/bootCheck/index.ts
+++ b/app/src/lib/bootCheck/index.ts
@@ -135,11 +135,13 @@ type VersionCheckResult = 'match' | 'outdated' | 'noVersionMethod' | 'unreachabl
 
 async function checkVersion(callRpc: BootCheckTransport['callRpc']): Promise<VersionCheckResult> {
   try {
-    const result = await callRpc<{ version_info?: { version?: string } }>(
-      'openhuman.update_version',
-      {}
-    );
-    const coreVersion = result?.version_info?.version ?? '';
+    // `openhuman.update_version` returns a flat VersionInfo
+    // ({ version, target_triple, asset_prefix }) — see
+    // src/openhuman/update/ops.rs::update_version. The previous reader
+    // looked under a `version_info` wrapper that doesn't exist, so
+    // coreVersion was always '' and every boot reported "outdated local".
+    const result = await callRpc<{ version?: string }>('openhuman.update_version', {});
+    const coreVersion = result?.version ?? '';
     log('[boot-check] version_check app=%s core=%s', APP_VERSION, coreVersion);
 
     if (!coreVersion) {

--- a/app/src/lib/bootCheck/index.ts
+++ b/app/src/lib/bootCheck/index.ts
@@ -135,13 +135,18 @@ type VersionCheckResult = 'match' | 'outdated' | 'noVersionMethod' | 'unreachabl
 
 async function checkVersion(callRpc: BootCheckTransport['callRpc']): Promise<VersionCheckResult> {
   try {
-    // `openhuman.update_version` returns a flat VersionInfo
-    // ({ version, target_triple, asset_prefix }) — see
-    // src/openhuman/update/ops.rs::update_version. The previous reader
-    // looked under a `version_info` wrapper that doesn't exist, so
-    // coreVersion was always '' and every boot reported "outdated local".
-    const result = await callRpc<{ version?: string }>('openhuman.update_version', {});
-    const coreVersion = result?.version ?? '';
+    // `openhuman.update_version` is wrapped by RpcOutcome::single_log
+    // (see src/openhuman/update/ops.rs + src/rpc/mod.rs::into_cli_compatible_json):
+    // when logs are present the response shape is `{ result: VersionInfo, logs }`,
+    // and VersionInfo is `{ version, target_triple, asset_prefix }`. Earlier
+    // attempts read `result.version_info.version` (no such field) and then
+    // `result.version` (skipped the RpcOutcome `result` wrapper) — both
+    // yielded '' and pinned every boot to "outdated local".
+    const response = await callRpc<{ result?: { version?: string } }>(
+      'openhuman.update_version',
+      {}
+    );
+    const coreVersion = response?.result?.version ?? '';
     log('[boot-check] version_check app=%s core=%s', APP_VERSION, coreVersion);
 
     if (!coreVersion) {

--- a/app/src/lib/bootCheck/index.ts
+++ b/app/src/lib/bootCheck/index.ts
@@ -64,8 +64,12 @@ function isMethodNotFound(err: unknown): boolean {
 }
 
 /**
- * Poll `openhuman.ping` with exponential back-off until the core responds or
- * we exhaust the budget.
+ * Poll `core.ping` with exponential back-off until the core responds or we
+ * exhaust the budget. `core.ping` is a Tier-1 dispatcher method (see
+ * `src/core/dispatch.rs`) that responds before any domain controller is
+ * registered, which is exactly what we want for a liveness probe — it tells
+ * us "the HTTP server is up and the dispatcher is wired" without coupling to
+ * any specific subsystem's readiness.
  *
  * Returns true when the core is reachable, false on timeout.
  */
@@ -79,7 +83,7 @@ async function waitForCore(
     const elapsedAtStart = Date.now() - startedAt;
     try {
       log('[boot-check] ping attempt elapsed=%dms', elapsedAtStart);
-      await callRpc('openhuman.ping', {});
+      await callRpc('core.ping', {});
       log('[boot-check] ping succeeded elapsed=%dms', elapsedAtStart);
       return true;
     } catch {
@@ -164,7 +168,7 @@ async function checkVersion(callRpc: BootCheckTransport['callRpc']): Promise<Ver
  *
  * Local mode:
  *   1. Invoke `start_core_process` Tauri command to spawn the embedded core.
- *   2. Poll `openhuman.ping` until reachable (≤10 s).
+ *   2. Poll `core.ping` until reachable (≤10 s).
  *   3. Check for a legacy daemon via `service_status`.
  *   4. Version-check via `update_version`.
  *

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -10,6 +10,7 @@ import {
   REGISTER,
   REHYDRATE,
 } from 'redux-persist';
+
 import { IS_DEV } from '../utils/config';
 import accountsReducer from './accountsSlice';
 import channelConnectionsReducer from './channelConnectionsSlice';

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -10,8 +10,6 @@ import {
   REGISTER,
   REHYDRATE,
 } from 'redux-persist';
-import defaultStorage from 'redux-persist/lib/storage';
-
 import { IS_DEV } from '../utils/config';
 import accountsReducer from './accountsSlice';
 import channelConnectionsReducer from './channelConnectionsSlice';
@@ -30,7 +28,46 @@ const storage = userScopedStorage;
 
 // coreMode is pre-login and not user-scoped — use plain localStorage so the
 // setting survives across user switches without leaking per-user state.
-const coreModePersistConfig = { key: 'coreMode', storage: defaultStorage, whitelist: ['mode'] };
+// Inline adapter rather than `redux-persist/lib/storage`'s default export,
+// which Vite's CJS dep-pre-bundling can resolve to the module namespace
+// (then `storage.getItem` is undefined and rehydrate throws on cold boot).
+const localStorageAdapter = {
+  getItem: (key: string) =>
+    Promise.resolve(
+      (() => {
+        try {
+          return localStorage.getItem(key);
+        } catch {
+          return null;
+        }
+      })()
+    ),
+  setItem: (key: string, value: string) =>
+    Promise.resolve(
+      (() => {
+        try {
+          localStorage.setItem(key, value);
+        } catch {
+          /* ignore quota / unavailable */
+        }
+      })()
+    ),
+  removeItem: (key: string) =>
+    Promise.resolve(
+      (() => {
+        try {
+          localStorage.removeItem(key);
+        } catch {
+          /* ignore */
+        }
+      })()
+    ),
+};
+const coreModePersistConfig = {
+  key: 'coreMode',
+  storage: localStorageAdapter,
+  whitelist: ['mode'],
+};
 const persistedCoreModeReducer = persistReducer(coreModePersistConfig, coreModeReducer);
 
 const channelConnectionsPersistConfig = {


### PR DESCRIPTION
## Summary

- Replace `redux-persist/lib/storage` default import with an inline `localStorage` adapter (Vite CJS dep pre-bundling resolved it to the module namespace, so cold boot threw `storage.getItem is not a function` before rehydrate).
- Add `start_core_process` to the Tauri capability ACL so the BootCheckGate's spawn invoke is no longer rejected with "Command not found" (it was already a registered handler — just unreferenced in `allow-core-process.toml`).
- Purge a stray `~/Library/LaunchAgents/com.openhuman.core.plist` left by a prior worktree's `service install` during Tauri startup so its `KeepAlive=true` daemon stops re-binding port 7788 on every SIGKILL.
- Switch the boot liveness probe from `openhuman.ping` (unregistered) to `core.ping` (Tier-1 dispatcher in `src/core/dispatch.rs`).
- Skip the #1130 stale-listener takeover when the embedded task is already alive on the port — fixes self-takeover loop on second `start_core_process` invocation (HMR re-mount).
- Read core version from `response.result.version` — `update_version` is wrapped by `RpcOutcome::single_log`, so the JSON-RPC body is `{ result: VersionInfo, logs }`. Earlier readers used `result.version_info.version` and then `result.version`; both fell through to '' and pinned every boot to "outdated local".

## Problem

After #1316 added the BootCheckGate, cold boot on a dev macOS host failed in six different ways stacked on top of each other:

1. Vite's optimized-deps bundle of `redux-persist/lib/storage` exposed only the module namespace, so `coreMode`'s persist adapter had no `getItem` and the renderer crashed before paint with `Uncaught TypeError: storage.getItem is not a function`.
2. The new `start_core_process` Tauri command was registered but missing from the capability ACL → `Command not found`.
3. A stray launchd agent from a sibling worktree (`KeepAlive=true`) re-spawned the daemon after every SIGKILL, defeating the #1130 stale-listener takeover and producing `signaled pid <X> but port 7788 remained bound after 5000ms`.
4. The boot probe polled `openhuman.ping`, which the core doesn't register — every retry returned `-32601 Method not found`, the 10s budget elapsed, and the gate showed "Local core did not respond in time" with a healthy core sitting underneath.
5. After (4) was fixed, a second `start_core_process` (HMR re-mounting BootCheckGate) saw the embedded server's own port as bound and walked into the takeover path against itself, producing `port 7788 rebounded to pid <X> after terminating pid <Y>; refusing to kill a different process`.
6. After (5), the gate kept showing "Local core needs a restart" because the version reader navigated to a path that didn't exist in the JSON-RPC response (RpcOutcome wraps the value in `{ result, logs }`).

End result: the BootCheckGate was effectively unreachable on a freshly-checked-out dev tree.

## Solution

Six narrow, root-cause fixes — one per failure mode, each with a code comment naming the symptom so the next person hitting it can grep their way back here:

- `app/src/store/index.ts` — inline `localStorage` adapter for `coreMode`, matching the shape of `userScopedStorage`. Same async semantics as the redux-persist default; just doesn't depend on Vite's CJS interop.
- `app/src-tauri/permissions/allow-core-process.toml` — add `start_core_process`.
- `app/src-tauri/src/lib.rs` — `setup` closure now runs a best-effort `launchctl bootout` + `fs::remove_file` on `~/Library/LaunchAgents/com.openhuman.core.plist` before `CoreProcessHandle::new`. Best-effort: missing `HOME`, missing `id`, plist already absent — all degrade silently. macOS-only via `cfg(target_os = "macos")`.
- `app/src/lib/bootCheck/index.ts` — probe `core.ping` (Tier-1), read `response.result.version`. Doc comments reference the upstream contracts (`src/core/dispatch.rs`, `src/openhuman/update/ops.rs`, `src/rpc/mod.rs`).
- `app/src-tauri/src/core_process.rs` — idempotent fast path at the top of `ensure_running`: if `self.task` is `Some` and unfinished and the port is open, return `Ok` without identifying or killing the listener. Takeover path stays intact for genuinely external leftover binaries.
- Test fixtures in `app/src/lib/bootCheck/index.test.ts` updated to match the wrapped response shape and `core.ping` method name.

Verified end-to-end on a real cold boot under `pnpm dev:app`: `start_core_process` invokes once → embedded core binds 7788 → `core.ping` succeeds → `update_version` returns `{ result: { version: '0.53.18', ... } }` → gate transitions to `match` and renders children. `restart_core_process` and HMR re-mount paths also exercise the new self-takeover guard cleanly.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [ ] N/A: behaviour-only fix wiring across already-tested layers — boot-check unit tests updated in lockstep but no new diff coverage to chase here; Rust core-process change is a guard around an existing path
- [ ] N/A: behaviour-only change — capability catalog (`src/openhuman/about_app/`) doesn't track ACL/persist-adapter wiring
- [ ] N/A: no new feature IDs touched
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [ ] N/A: cold-boot fix below the release-smoke surface
- [ ] N/A: no linked issue — discovered while running `pnpm dev:app` on the boot-gated branch

## Impact

- Runtime: desktop dev hosts on macOS were the failure surface; CI Linux + production builds didn't hit it because (1) ships an existing optimized bundle, and (3) is a per-developer launchd artifact. Fix is no-op on hosts that didn't have the stray plist.
- Migration: none — the inline storage adapter writes/reads the same `localStorage` keys redux-persist's default did.
- Security: launchd-plist purge is bounded to the `com.openhuman.core` label and lives in the user's `~/Library/LaunchAgents`. No privileged paths touched.
- Performance: removed an HTTP round-trip per boot tick (`openhuman.ping` was failing instantly with `-32601`, now `core.ping` succeeds on the first try).

## Related

- Closes:
- Follow-up PR(s)/TODOs: the `[imessage] core RPC token is not initialized` warning during boot is a benign startup race in the imessage scanner — worth a small `wait_for_token` gate but out of scope here. The `DaemonHealth - setting status to disconnected` warning under `pnpm dev:app` likely needs the legacy daemon-mode health check disabled now that the core is always embedded.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: \`feat/memory-v5\`
- Commit SHA: \`8b0a8012\`

### Validation Run
- [x] \`pnpm --filter openhuman-app format:check\`
- [x] \`pnpm typecheck\`
- [x] Focused tests: \`pnpm exec vitest run src/lib/bootCheck/index.test.ts\` (18/18)
- [x] Rust fmt/check (if changed): \`cargo check --manifest-path app/src-tauri/Cargo.toml\`
- [x] Tauri fmt/check (if changed): same as above

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended behavior change: BootCheckGate now resolves to the running app on cold boot instead of looping on "Local core needs a restart" / "did not respond".
- User-visible effect: dev-host cold boot works without manually killing daemons or removing launchd plists.

### Parity Contract
- Legacy behavior preserved: stale-listener takeover (#1130) still fires for genuinely external leftover binaries; only same-process self-takeover is short-circuited. `redux-persist` storage shape is unchanged (same async \`getItem/setItem/removeItem\` contract, same key prefixes).
- Guard/fallback/dispatch parity checks: \`waitForCore\` retry loop unchanged; \`checkVersion\` still returns \`noVersionMethod\` on \`-32601\` and \`unreachable\` on transport failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented self-takeover and duplicate startup of the local core process.
  * Fixed macOS startup by removing stale service entries that could block boot.
  * Ensured local core can be invoked when needed (startup permission added).
  * Improved resilience for persisted settings to avoid crashes on cold boot or storage errors.

* **Tests**
  * Updated boot-check tests to cover new RPC behavior and additional failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->