### PR TITLE
fix(chat): sanitize agent/cron failures and add user-safe error fallback with Sentry reporting

### DIFF
--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -41,6 +41,8 @@ import { IS_PROD } from '../utils/config';
 import { formatTimelineEntry, promptFromArgsBuffer } from '../utils/toolTimelineFormatting';
 
 const logChatRuntime = debug('openhuman:chat-runtime');
+const USER_FACING_AGENT_ERROR_MESSAGE =
+  'Something went wrong. Please try again.\nThis error has been reported. You can also report it on Discord.\n<openhuman-link path="community/discord">Report on Discord</openhuman-link>';
 
 function rtLog(message: string, fields?: Record<string, string | number | null | undefined>) {
   if (IS_PROD) return;
@@ -718,14 +720,11 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
           const threadMessages = currentState.thread.messagesByThreadId[event.thread_id] ?? [];
           const lastMsg = threadMessages[threadMessages.length - 1];
           if (
-            !(
-              lastMsg?.sender === 'agent' &&
-              lastMsg?.content === 'Something went wrong — please try again.'
-            )
+            !(lastMsg?.sender === 'agent' && lastMsg?.content === USER_FACING_AGENT_ERROR_MESSAGE)
           ) {
             void dispatch(
               addInferenceResponse({
-                content: 'Something went wrong — please try again.',
+                content: USER_FACING_AGENT_ERROR_MESSAGE,
                 threadId: event.thread_id,
               })
             );

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -396,6 +396,50 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
         })
       );
     });
+
+    it('does not append duplicate fallback error bubble when the previous message already matches', async () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onError?.({
+          thread_id: 't-err-dedupe',
+          request_id: 'r1',
+          message: 'transport fail one',
+          error_type: 'inference',
+          round: 0,
+        });
+      });
+
+      await waitFor(() =>
+        expect(threadApi.appendMessage).toHaveBeenCalledWith(
+          't-err-dedupe',
+          expect.objectContaining({
+            content: expect.stringContaining('Something went wrong. Please try again.'),
+          })
+        )
+      );
+
+      act(() => {
+        listeners.onError?.({
+          thread_id: 't-err-dedupe',
+          request_id: 'r2',
+          message: 'transport fail two',
+          error_type: 'inference',
+          round: 0,
+        });
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const matchingCalls = vi
+        .mocked(threadApi.appendMessage)
+        .mock.calls.filter(
+          call =>
+            call[0] === 't-err-dedupe' &&
+            typeof call[1]?.content === 'string' &&
+            call[1].content.includes('Something went wrong. Please try again.')
+        );
+      expect(matchingCalls).toHaveLength(1);
+    });
   });
 
   // Live subagent activity (#1122) — the parent thread surfaces a

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -357,6 +357,45 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       expect(timeline[0]?.status).toBe('error');
       expect(store.getState().chatRuntime.inferenceStatusByThread['t-err']).toBeUndefined();
     });
+
+    it('adds a sanitized user-facing error bubble with Discord report action on chat_error', async () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onError?.({
+          thread_id: 't-err-sanitized',
+          request_id: 'r1',
+          message:
+            'agent job failed: error sending request for url (https://staging-api.alphahuman.xyz/openai/v1/chat/completions)',
+          error_type: 'inference',
+          round: 0,
+        });
+      });
+
+      await waitFor(() =>
+        expect(threadApi.appendMessage).toHaveBeenCalledWith(
+          't-err-sanitized',
+          expect.objectContaining({
+            sender: 'agent',
+            content: expect.stringContaining('Something went wrong. Please try again.'),
+          })
+        )
+      );
+      expect(threadApi.appendMessage).toHaveBeenCalledWith(
+        't-err-sanitized',
+        expect.objectContaining({
+          content: expect.stringContaining(
+            '<openhuman-link path="community/discord">Report on Discord</openhuman-link>'
+          ),
+        })
+      );
+      expect(threadApi.appendMessage).not.toHaveBeenCalledWith(
+        't-err-sanitized',
+        expect.objectContaining({
+          content: expect.stringContaining('https://staging-api.alphahuman.xyz'),
+        })
+      );
+    });
   });
 
   // Live subagent activity (#1122) — the parent thread surfaces a

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -429,16 +429,17 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
         });
       });
 
-      await new Promise(resolve => setTimeout(resolve, 0));
-      const matchingCalls = vi
-        .mocked(threadApi.appendMessage)
-        .mock.calls.filter(
-          call =>
-            call[0] === 't-err-dedupe' &&
-            typeof call[1]?.content === 'string' &&
-            call[1].content.includes('Something went wrong. Please try again.')
-        );
-      expect(matchingCalls).toHaveLength(1);
+      await waitFor(() => {
+        const matchingCalls = vi
+          .mocked(threadApi.appendMessage)
+          .mock.calls.filter(
+            call =>
+              call[0] === 't-err-dedupe' &&
+              typeof call[1]?.content === 'string' &&
+              call[1].content.includes('Something went wrong. Please try again.')
+          );
+        expect(matchingCalls).toHaveLength(1);
+      });
     });
   });
 

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -86,6 +86,9 @@ static THREAD_SESSIONS: Lazy<Mutex<HashMap<String, SessionEntry>>> =
 
 static IN_FLIGHT: Lazy<Mutex<HashMap<String, InFlightEntry>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+#[cfg(test)]
+static TEST_FORCED_RUN_CHAT_TASK_ERROR: Lazy<Mutex<Option<String>>> =
+    Lazy::new(|| Mutex::new(None));
 static BUDGET_ERROR_NORMALIZE_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"[-_\s]+").expect("budget normalize regex"));
 static BUDGET_ERROR_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
@@ -137,6 +140,12 @@ fn prompt_guard_user_message(action: PromptEnforcementAction) -> &'static str {
             "Your message was flagged for security review and was not processed. Please rephrase the request in a direct, task-focused way."
         }
     }
+}
+
+#[cfg(test)]
+pub(super) async fn set_test_forced_run_chat_task_error(message: Option<&str>) {
+    let mut slot = TEST_FORCED_RUN_CHAT_TASK_ERROR.lock().await;
+    *slot = message.map(str::to_string);
 }
 
 pub async fn start_chat(
@@ -275,7 +284,12 @@ pub async fn start_chat(
                     detailed.as_str(),
                     "web_channel",
                     "run_chat_task",
-                    &[("channel", "web"), ("error_type", "inference")],
+                    &[
+                        ("channel", "web"),
+                        ("error_type", "inference"),
+                        ("thread_id", thread_id_task.as_str()),
+                        ("request_id", request_id_task.as_str()),
+                    ],
                 );
                 publish_web_channel_event(WebChannelEvent {
                     event: "chat_error".to_string(),
@@ -406,6 +420,20 @@ async fn run_chat_task(
     model_override: Option<String>,
     temperature: Option<f64>,
 ) -> Result<WebChatTaskResult, String> {
+    #[cfg(test)]
+    {
+        let mut slot = TEST_FORCED_RUN_CHAT_TASK_ERROR.lock().await;
+        if let Some(forced) = slot.take() {
+            log::debug!(
+                "[web-channel][test] forced run_chat_task failure client_id={} thread_id={} request_id={}",
+                client_id,
+                thread_id,
+                request_id
+            );
+            return Err(forced);
+        }
+    }
+
     let config = config_rpc::load_config_with_timeout().await?;
     let map_key = key_for(client_id, thread_id);
     let model_override = normalize_model_override(model_override);

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -123,6 +123,10 @@ fn inference_budget_exceeded_user_message() -> &'static str {
     "I don't have any budget available right now. Please top up your credits or choose a plan to continue."
 }
 
+fn generic_inference_error_user_message() -> &'static str {
+    "Something went wrong. Please try again.\nThis error has been reported. You can also report it on Discord.\n<openhuman-link path=\"community/discord\">Report on Discord</openhuman-link>"
+}
+
 fn prompt_guard_user_message(action: PromptEnforcementAction) -> &'static str {
     match action {
         PromptEnforcementAction::Allow => "Message accepted.",
@@ -263,13 +267,23 @@ pub async fn start_chat(
                     request_id_task,
                     err
                 );
+                let detailed = format!(
+                    "run_chat_task failed client_id={} thread_id={} request_id={} error={}",
+                    client_id_task, thread_id_task, request_id_task, err
+                );
+                crate::core::observability::report_error(
+                    detailed.as_str(),
+                    "web_channel",
+                    "run_chat_task",
+                    &[("channel", "web"), ("error_type", "inference")],
+                );
                 publish_web_channel_event(WebChannelEvent {
                     event: "chat_error".to_string(),
                     client_id: client_id_task.clone(),
                     thread_id: thread_id_task.clone(),
                     request_id: request_id_task.clone(),
                     full_response: None,
-                    message: Some(err),
+                    message: Some(generic_inference_error_user_message().to_string()),
                     error_type: Some("inference".to_string()),
                     tool_name: None,
                     skill_id: None,

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -3,7 +3,7 @@ use super::{
     event_session_id_for, generic_inference_error_user_message,
     inference_budget_exceeded_user_message, is_inference_budget_exceeded_error, json_output,
     key_for, normalize_model_override, optional_f64, optional_string, required_string, schemas,
-    start_chat, subscribe_web_channel_events,
+    set_test_forced_run_chat_task_error, start_chat, subscribe_web_channel_events,
 };
 use crate::core::TypeSchema;
 use tokio::time::{timeout, Duration};
@@ -61,6 +61,11 @@ async fn cancel_chat_validates_required_fields() {
 
 #[tokio::test]
 async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
+    set_test_forced_run_chat_task_error(Some(
+        "error sending request for url (https://staging-api.alphahuman.xyz/openai/v1/chat/completions)",
+    ))
+    .await;
+
     let mut rx = subscribe_web_channel_events();
     let request_id = start_chat(
         "coverage-client",
@@ -94,6 +99,9 @@ async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
         !message.contains("error sending request for url"),
         "chat error payload must not expose raw transport details"
     );
+
+    // Defensive cleanup so later tests cannot inherit forced failure state.
+    set_test_forced_run_chat_task_error(None).await;
 }
 
 #[test]

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -1,9 +1,9 @@
 use super::{
     all_web_channel_controller_schemas, all_web_channel_registered_controllers, cancel_chat,
-    event_session_id_for, inference_budget_exceeded_user_message,
-    is_inference_budget_exceeded_error, json_output, key_for, normalize_model_override,
-    optional_f64, optional_string, required_string, schemas, start_chat,
-    subscribe_web_channel_events,
+    event_session_id_for, generic_inference_error_user_message,
+    inference_budget_exceeded_user_message, is_inference_budget_exceeded_error, json_output,
+    key_for, normalize_model_override, optional_f64, optional_string, required_string, schemas,
+    start_chat, subscribe_web_channel_events,
 };
 use crate::core::TypeSchema;
 
@@ -76,6 +76,15 @@ fn budget_exceeded_copy_mentions_top_up() {
     let message = inference_budget_exceeded_user_message();
     assert!(message.contains("top up"));
     assert!(message.contains("credits"));
+}
+
+#[test]
+fn generic_error_copy_is_sanitized_and_has_discord_report_action() {
+    let message = generic_inference_error_user_message();
+    assert!(message.contains("Something went wrong. Please try again."));
+    assert!(message.contains("This error has been reported."));
+    assert!(message
+        .contains("<openhuman-link path=\"community/discord\">Report on Discord</openhuman-link>"));
 }
 
 // ── Schema catalog ────────────────────────────────────────────

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -8,6 +8,18 @@ use super::{
 use crate::core::TypeSchema;
 use tokio::time::{timeout, Duration};
 
+/// Ensures the test-only forced run_chat_task failure toggle is always reset,
+/// even if the test panics before reaching explicit cleanup code.
+struct TestForcedRunChatTaskErrorGuard;
+
+impl Drop for TestForcedRunChatTaskErrorGuard {
+    fn drop(&mut self) {
+        tokio::spawn(async {
+            set_test_forced_run_chat_task_error(None).await;
+        });
+    }
+}
+
 #[tokio::test]
 async fn start_chat_validates_required_fields() {
     let err = start_chat("", "thread", "hello", None, None)
@@ -65,6 +77,7 @@ async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
         "error sending request for url (https://staging-api.alphahuman.xyz/openai/v1/chat/completions)",
     ))
     .await;
+    let _forced_error_guard = TestForcedRunChatTaskErrorGuard;
 
     let mut rx = subscribe_web_channel_events();
     let request_id = start_chat(
@@ -99,9 +112,6 @@ async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
         !message.contains("error sending request for url"),
         "chat error payload must not expose raw transport details"
     );
-
-    // Defensive cleanup so later tests cannot inherit forced failure state.
-    set_test_forced_run_chat_task_error(None).await;
 }
 
 #[test]

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -74,7 +74,7 @@ async fn cancel_chat_validates_required_fields() {
 #[tokio::test]
 async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
     set_test_forced_run_chat_task_error(Some(
-        "error sending request for url (https://staging-api.alphahuman.xyz/openai/v1/chat/completions)",
+        "error sending request for url (https://internal-api.example.invalid/openai/v1/chat/completions)",
     ))
     .await;
     let _forced_error_guard = TestForcedRunChatTaskErrorGuard;

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -6,6 +6,7 @@ use super::{
     start_chat, subscribe_web_channel_events,
 };
 use crate::core::TypeSchema;
+use tokio::time::{timeout, Duration};
 
 #[tokio::test]
 async fn start_chat_validates_required_fields() {
@@ -56,6 +57,43 @@ async fn cancel_chat_validates_required_fields() {
         .await
         .expect_err("thread id should be required");
     assert!(err.contains("thread_id is required"));
+}
+
+#[tokio::test]
+async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
+    let mut rx = subscribe_web_channel_events();
+    let request_id = start_chat(
+        "coverage-client",
+        "coverage-thread",
+        "Please summarize this in one line.",
+        None,
+        None,
+    )
+    .await
+    .expect("start_chat should accept valid request");
+
+    let expected = generic_inference_error_user_message().to_string();
+    let recv = timeout(Duration::from_secs(20), async move {
+        loop {
+            let event = rx.recv().await.expect("event stream should stay open");
+            if event.event != "chat_error" {
+                continue;
+            }
+            if event.request_id != request_id {
+                continue;
+            }
+            return event;
+        }
+    })
+    .await
+    .expect("expected chat_error event for started chat request");
+
+    let message = recv.message.unwrap_or_default();
+    assert_eq!(message, expected);
+    assert!(
+        !message.contains("error sending request for url"),
+        "chat error payload must not expose raw transport details"
+    );
 }
 
 #[test]

--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -111,6 +111,23 @@ async fn execute_job_with_retry(
         }
     }
 
+    if matches!(job.job_type, JobType::Agent) {
+        crate::core::observability::report_error(
+            last_output.as_str(),
+            "cron",
+            "agent_job",
+            &[
+                ("job_id", job.id.as_str()),
+                ("agent_id", job.agent_id.as_deref().unwrap_or("none")),
+                (
+                    "session_target",
+                    agent_session_target_tag(&job.session_target),
+                ),
+                ("failure", "retries_exhausted"),
+            ],
+        );
+    }
+
     (false, last_output)
 }
 
@@ -258,23 +275,7 @@ async fn run_agent_job(config: &Config, job: &CronJob) -> (bool, String) {
                 response
             },
         ),
-        Err(e) => {
-            crate::core::observability::report_error(
-                &e,
-                "cron",
-                "agent_job",
-                &[
-                    ("job_id", job.id.as_str()),
-                    ("agent_id", job.agent_id.as_deref().unwrap_or("none")),
-                    (
-                        "session_target",
-                        agent_session_target_tag(&job.session_target),
-                    ),
-                    ("failure", "execution"),
-                ],
-            );
-            (false, AGENT_JOB_USER_FAILURE_MESSAGE.to_string())
-        }
+        Err(_) => (false, AGENT_JOB_USER_FAILURE_MESSAGE.to_string()),
     }
 }
 

--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -15,6 +15,14 @@ use tokio::time::{self, Duration};
 
 const MIN_POLL_SECONDS: u64 = 5;
 const SHELL_JOB_TIMEOUT_SECS: u64 = 120;
+const AGENT_JOB_USER_FAILURE_MESSAGE: &str = "Something went wrong. Please try again.\nThis error has been reported. You can also report it on Discord.\n<openhuman-link path=\"community/discord\">Report on Discord</openhuman-link>";
+
+fn agent_session_target_tag(target: &SessionTarget) -> &'static str {
+    match target {
+        SessionTarget::Main => "main",
+        SessionTarget::Isolated => "isolated",
+    }
+}
 
 pub async fn run(config: Config) -> Result<()> {
     // Ensure the global event bus is initialized so cron delivery events
@@ -250,7 +258,23 @@ async fn run_agent_job(config: &Config, job: &CronJob) -> (bool, String) {
                 response
             },
         ),
-        Err(e) => (false, format!("agent job failed: {e}")),
+        Err(e) => {
+            crate::core::observability::report_error(
+                &e,
+                "cron",
+                "agent_job",
+                &[
+                    ("job_id", job.id.as_str()),
+                    ("agent_id", job.agent_id.as_deref().unwrap_or("none")),
+                    (
+                        "session_target",
+                        agent_session_target_tag(&job.session_target),
+                    ),
+                    ("failure", "execution"),
+                ],
+            );
+            (false, AGENT_JOB_USER_FAILURE_MESSAGE.to_string())
+        }
     }
 }
 

--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -85,15 +85,22 @@ async fn execute_job_with_retry(
     job: &CronJob,
 ) -> (bool, String) {
     let mut last_output = String::new();
+    let mut last_agent_error: Option<String> = None;
     let retries = config.reliability.scheduler_retries;
     let mut backoff_ms = config.reliability.provider_backoff_ms.max(200);
 
     for attempt in 0..=retries {
-        let (success, output) = match job.job_type {
-            JobType::Shell => run_job_command(config, security, job).await,
+        let (success, output, agent_error) = match job.job_type {
+            JobType::Shell => {
+                let (success, output) = run_job_command(config, security, job).await;
+                (success, output, None)
+            }
             JobType::Agent => run_agent_job(config, job).await,
         };
         last_output = output;
+        if agent_error.is_some() {
+            last_agent_error = agent_error;
+        }
 
         if success {
             return (true, last_output);
@@ -112,8 +119,11 @@ async fn execute_job_with_retry(
     }
 
     if matches!(job.job_type, JobType::Agent) {
+        let report_message = last_agent_error
+            .as_deref()
+            .unwrap_or_else(|| last_output.as_str());
         crate::core::observability::report_error(
-            last_output.as_str(),
+            report_message,
             "cron",
             "agent_job",
             &[
@@ -195,7 +205,7 @@ async fn execute_and_persist_job(
     (job.id.clone(), success, failure_message)
 }
 
-async fn run_agent_job(config: &Config, job: &CronJob) -> (bool, String) {
+async fn run_agent_job(config: &Config, job: &CronJob) -> (bool, String, Option<String>) {
     use crate::openhuman::agent::Agent;
 
     let name = job.name.clone().unwrap_or_else(|| "cron-job".to_string());
@@ -274,8 +284,13 @@ async fn run_agent_job(config: &Config, job: &CronJob) -> (bool, String) {
             } else {
                 response
             },
+            None,
         ),
-        Err(_) => (false, AGENT_JOB_USER_FAILURE_MESSAGE.to_string()),
+        Err(e) => (
+            false,
+            AGENT_JOB_USER_FAILURE_MESSAGE.to_string(),
+            Some(e.to_string()),
+        ),
     }
 }
 

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -219,11 +219,17 @@ async fn run_agent_job_returns_error_without_provider_key() {
     job.job_type = JobType::Agent;
     job.prompt = Some("Say hello".into());
 
-    let (success, output) = run_agent_job(&config, &job).await;
+    let (success, output, raw_error) = run_agent_job(&config, &job).await;
     assert!(!success, "Agent job without provider key should fail");
     assert!(output.contains("Something went wrong. Please try again."));
     assert!(output.contains("This error has been reported."));
     assert!(output.contains("Report on Discord"));
+    assert!(
+        raw_error
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
+        "Expected raw agent error for observability after retries are exhausted"
+    );
     assert!(
         !output.contains("error sending request for url"),
         "Expected sanitized output without raw transport details"

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -205,9 +205,12 @@ async fn run_agent_job_returns_error_without_provider_key() {
 
     let (success, output) = run_agent_job(&config, &job).await;
     assert!(!success, "Agent job without provider key should fail");
+    assert!(output.contains("Something went wrong. Please try again."));
+    assert!(output.contains("This error has been reported."));
+    assert!(output.contains("Report on Discord"));
     assert!(
-        !output.is_empty(),
-        "Expected non-empty error output from failed agent job"
+        !output.contains("error sending request for url"),
+        "Expected sanitized output without raw transport details"
     );
 }
 

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -45,6 +45,22 @@ fn test_job(command: &str) -> CronJob {
     }
 }
 
+#[test]
+fn agent_failure_copy_mentions_retry_reporting_and_discord() {
+    assert!(AGENT_JOB_USER_FAILURE_MESSAGE.contains("Something went wrong. Please try again."));
+    assert!(AGENT_JOB_USER_FAILURE_MESSAGE.contains("This error has been reported."));
+    assert!(AGENT_JOB_USER_FAILURE_MESSAGE.contains("Report on Discord"));
+}
+
+#[test]
+fn agent_session_target_tag_matches_expected_values() {
+    assert_eq!(agent_session_target_tag(&SessionTarget::Main), "main");
+    assert_eq!(
+        agent_session_target_tag(&SessionTarget::Isolated),
+        "isolated"
+    );
+}
+
 #[cfg(not(windows))]
 #[tokio::test]
 async fn run_job_command_success() {


### PR DESCRIPTION
# Summary

- Replaced raw technical agent failure text in chat with a user-friendly fallback message

- Added consistent error UX:
  - “Something went wrong…”
  - “This error has been reported…”
  - “Report on Discord” action

- Sanitized web-channel `chat_error` payloads:
  - Prevent internal URLs and transport details from leaking to users

- Added structured observability reporting:
  - Web-channel inference failures
  - Cron agent job failures
  - Includes Sentry context/tags

- Updated cron agent job failures:
  - Return sanitized user-safe content
  - Avoid raw transport/infrastructure errors

- Added/updated tests:
  - Prevent regression of technical error leakage in user-visible chat surfaces

---

# Problem

- Agent and cron failures could expose:
  - Internal API URLs
  - Transport-layer errors
  - Raw infrastructure/debug strings

- Resulted in:
  - Poor UX
  - Unnecessary internal detail exposure
  - Weak incident visibility

- Needed:
  - Safe user-facing messaging
  - Preserved developer diagnostics

---

# Solution

- Introduced user-facing fallback error messaging:
  - Applied in chat runtime
  - Applied in web-channel error publishing

- Standardized fallback copy:
  - Includes Discord escalation path via:
    - `<openhuman-link path="community/discord">Report on Discord</openhuman-link>`

- Added backend observability reporting:
  - `core::observability::report_error(...)`
  - Used for:
    - failed web-channel turns
    - cron agent execution failures

- Improved cron scheduler behavior:
  - Failed jobs now emit sanitized output
  - Prevent raw `error sending request for url (...)` exposure

- Added regression coverage:
  - Chat error sanitization
  - Discord link presence
  - Generic fallback message contract
  - Cron failure sanitization

---

# Tradeoffs

- Existing historical chat messages are not rewritten
- Sanitization applies only to new events and future runs

---

# Submission Checklist

- **Tests**
  - Added/updated per `docs/TESTING-STRATEGY.md`
  - Includes:
    - happy paths
    - failure/edge cases

- **Coverage**
  - Diff coverage ≥ 80%
  - Enforced via:
    - `.github/workflows/coverage.yml`
  - Commands:
    - `pnpm test:coverage`
    - `pnpm test:rust`

- **Coverage Matrix**
  - Updated in:
    - `docs/TEST-COVERAGE-MATRIX.md`
  - Or marked N/A where appropriate

- **Feature IDs**
  - Listed under `## Related`

- **Network Dependencies**
  - No new external dependencies
  - Uses mock backend per testing strategy

- **Manual Smoke Checklist**
  - Updated if release surfaces affected:
    - `docs/RELEASE-MANUAL-SMOKE.md`

- **Linked Issues**
  - Added via:
    - `Closes #NNN`

---

# Impact

- **Platform / Runtime**
  - Affects:
    - desktop chat UX
    - cron-delivered chat notifications
  - No protocol/schema breaking changes

- **Security**
  - Reduces exposure of:
    - internal URLs
    - technical error strings

- **Observability**
  - Improves production debugging:
    - structured reporting
    - tags/context in Sentry

- **Compatibility**
  - Backward compatible
  - Existing historical messages unchanged

- **Performance**
  - Negligible overhead
  - Small formatting/reporting cost on failure paths only

## Related

- Closes: #1319 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and sanitized user-facing error messages across chat, web channel, and scheduled agent jobs to remove raw/internal transport details.
  * Prevented duplicate fallback error bubbles from being appended.
  * Added a “Report on Discord” action and confirmation in user-facing failure copy.

* **Tests**
  * Added tests for sanitized error messages, deduplication behavior, and scheduler/agent failure messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->