### PR TITLE
feat(agent): enforce subagent role contract with concise delegated outputs

### DIFF
--- a/docs/agent-subagent-tool-flow.md
+++ b/docs/agent-subagent-tool-flow.md
@@ -65,6 +65,7 @@ There are two related but distinct execution tiers:
 
 2. `run_subagent`
    This is an isolated delegated run. It does not become a nested full `Agent` session. It runs a smaller inner loop and returns a single compact text result to the parent as a normal tool result.
+   Every typed subagent prompt now also appends a shared "Sub-agent Role Contract" suffix that explicitly states sub-agent role expectations and requires concise, synthesis-ready outputs.
 
 That distinction matters when debugging. A subagent is not a second copy of the full session runtime.
 

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -33,6 +33,46 @@ use crate::openhuman::memory::conversations::ConversationMessage;
 use crate::openhuman::providers::{ChatMessage, ChatRequest, Provider, ToolCall};
 use crate::openhuman::tools::{Tool, ToolCategory, ToolSpec};
 
+/// Prompt suffix injected into every typed sub-agent run.
+///
+/// Purpose:
+/// - make the child explicitly aware it is acting as a sub-agent
+/// - keep delegated outputs concise so parent-context growth stays bounded
+/// - discourage verbose restatement of the delegated task/context
+const SUBAGENT_ROLE_CONTRACT_SUFFIX: &str = "## Sub-agent Role Contract\n\n\
+You are a sub-agent working for a parent OpenHuman agent, not a direct end-user assistant.\n\
+- Stay tightly scoped to the delegated task.\n\
+- Keep tool arguments and follow-up prompts compact, include only required fields/context.\n\
+- Keep your final response concise and synthesis-ready for the parent, prefer short bullets or short paragraphs.\n\
+- Do not restate the full task/context unless strictly required for correctness.\n";
+
+fn append_subagent_role_contract(base_prompt: String, agent_id: &str) -> String {
+    if base_prompt.contains("## Sub-agent Role Contract") {
+        tracing::debug!(
+            agent_id = %agent_id,
+            base_chars = base_prompt.chars().count(),
+            "[subagent_runner] sub-agent role contract already present in system prompt"
+        );
+        return base_prompt;
+    }
+
+    let mut prompt = base_prompt;
+    if !prompt.ends_with('\n') {
+        prompt.push('\n');
+    }
+    prompt.push('\n');
+    prompt.push_str(SUBAGENT_ROLE_CONTRACT_SUFFIX);
+
+    tracing::debug!(
+        agent_id = %agent_id,
+        suffix_chars = SUBAGENT_ROLE_CONTRACT_SUFFIX.chars().count(),
+        final_chars = prompt.chars().count(),
+        "[subagent_runner] appended sub-agent role contract to system prompt"
+    );
+
+    prompt
+}
+
 /// Lazy resolver that lets `integrations_agent` recover when the model
 /// calls a Composio action slug that exists in the bound toolkit's full
 /// catalogue but was filtered out of the up-front fuzzy top-K. On a
@@ -674,6 +714,8 @@ async fn run_typed_mode(
             )
         }
     };
+
+    let system_prompt = append_subagent_role_contract(system_prompt, &definition.id);
 
     // ── Build the user message (with optional context prefix) ──────────
     // Merge explicit orchestrator context with the parent's auto-loaded

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -47,7 +47,7 @@ You are a sub-agent working for a parent OpenHuman agent, not a direct end-user 
 - Do not restate the full task/context unless strictly required for correctness.\n";
 
 fn append_subagent_role_contract(base_prompt: String, agent_id: &str) -> String {
-    if base_prompt.contains("## Sub-agent Role Contract") {
+    if base_prompt.contains(SUBAGENT_ROLE_CONTRACT_SUFFIX.trim()) {
         tracing::debug!(
             agent_id = %agent_id,
             base_chars = base_prompt.chars().count(),

--- a/src/openhuman/agent/harness/subagent_runner/ops_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops_tests.rs
@@ -115,6 +115,21 @@ fn subagent_mode_as_str_roundtrip() {
     assert_eq!(SubagentMode::Typed.as_str(), "typed");
 }
 
+#[test]
+fn append_subagent_role_contract_adds_role_and_brevity_rules() {
+    let rendered = append_subagent_role_contract("base prompt".to_string(), "researcher");
+    assert!(rendered.contains("## Sub-agent Role Contract"));
+    assert!(rendered.contains("You are a sub-agent working for a parent OpenHuman agent"));
+    assert!(rendered.contains("Keep your final response concise and synthesis-ready"));
+}
+
+#[test]
+fn append_subagent_role_contract_is_idempotent() {
+    let once = append_subagent_role_contract("base prompt".to_string(), "researcher");
+    let twice = append_subagent_role_contract(once.clone(), "researcher");
+    assert_eq!(once, twice, "contract suffix should only appear once");
+}
+
 // ── End-to-end runner tests with mock provider ────────────────────────
 
 use crate::openhuman::agent::harness::fork_context::with_parent_context;
@@ -315,6 +330,38 @@ async fn typed_mode_injects_current_date_and_time_into_user_message() {
         "subagent user message must include current date/time context, got: {}",
         user_msg.content
     );
+}
+
+#[tokio::test]
+async fn typed_mode_system_prompt_includes_subagent_role_contract() {
+    let provider = ScriptedProvider::new(vec![text_response("ok")]);
+    let parent = make_parent(provider.clone(), vec![stub("file_read")]);
+    let def = make_def_named_tools(&[]);
+
+    let _ = with_parent_context(parent, async {
+        run_subagent(
+            &def,
+            "the actual task prompt",
+            SubagentRunOptions::default(),
+        )
+        .await
+    })
+    .await
+    .unwrap();
+
+    let captured = provider.captured.lock();
+    let system_msg = captured[0]
+        .messages
+        .iter()
+        .find(|m| m.role == "system")
+        .expect("system message should be present");
+    assert!(system_msg.content.contains("## Sub-agent Role Contract"));
+    assert!(system_msg
+        .content
+        .contains("You are a sub-agent working for a parent OpenHuman agent"));
+    assert!(system_msg
+        .content
+        .contains("Keep your final response concise and synthesis-ready"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Summary

- Added a shared **Sub-agent Role Contract** suffix to typed subagent system prompts:
  - Explicitly tells child agents they are subagents

- Enforced concise, synthesis-ready subagent responses:
  - Reduced verbosity
  - Reduced noisy tool-call context

- Injected contract centrally in `subagent_runner`:
  - Applies to:
    - dynamic prompts
    - legacy prompt sources

- Added debug diagnostics:
  - Contract injection status
  - Idempotency checks
  - Prompt-size context

- Added/updated tests:
  - Contract content
  - Idempotency
  - End-to-end typed prompt inclusion

- Updated subagent flow documentation:
  - Reflects new prompt contract behavior

---

# Problem

- Delegated subagents were not consistently informed they are subordinate workers
- Could produce:
  - Verbose responses
  - End-user-style outputs

- Verbose outputs caused:
  - Larger context growth
  - Noisier parent synthesis
  - Reduced efficiency

- No centralized enforcement layer:
  - Behavior could drift across:
    - archetypes
    - prompt sources

---

# Solution

- Introduced centralized prompt suffix:
  - **Sub-agent Role Contract**
  - Implemented in:
    - `subagent_runner/ops.rs`

- Automatically appended to typed subagent system prompts

- Added idempotent append helper:
  - Prevents duplicate contract insertion

- Added debug logging:
  - Injection decisions
  - Prompt size after injection

- Added tests:
  - Contract presence
  - Idempotency
  - Typed runner prompt validation
  - Existing typed-mode regression checks

---

# Tradeoffs

- Slight increase in system prompt size
- Expected benefit:
  - More disciplined delegated responses
  - Smaller synthesized context overall

---

# Submission Checklist

- **Tests**
  - Added/updated per `docs/TESTING-STRATEGY.md`
  - Includes:
    - happy paths
    - failure/edge cases

- **Coverage**
  - Diff coverage ≥ 80%
  - Enforced via:
    - `.github/workflows/coverage.yml`
  - Commands:
    - `pnpm test:coverage`
    - `pnpm test:rust`

- **Coverage Matrix**
  - N/A:
    - Behavior-only prompt-contract update
    - No feature-row additions/removals

- **Feature IDs**
  - N/A:
    - No matrix feature mapping changes

- **Network Dependencies**
  - No new external dependencies
  - Uses mock backend per testing strategy

- **Manual Smoke Checklist**
  - N/A:
    - Not a release-cut surface change

- **Linked Issues**
  - `Closes #NNN`
  - Replace with actual issue before merge

---

# Related

- **Feature IDs**
  - N/A (behavior-only subagent prompt contract update)

- **Issues**
  - `Closes #NNN`

---

# Impact

- **Runtime / Platform**
  - Affects Rust core agent harness behavior
  - Impacts:
    - desktop app
    - CLI flows using typed subagent harness

- **Performance**
  - Negligible overhead from small prompt suffix
  - Expected net gain from shorter delegated outputs

- **Security**
  - No permission, network, or secret-handling changes

- **Compatibility / Migration**
  - Backward compatible
  - No schema/API migrations required

## Related

- Closes: #688 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typed sub-agents now append a "Sub-agent Role Contract" to their system prompts, ensuring focused and synthesis-ready outputs.

* **Documentation**
  * Updated sub-agent flow documentation to describe the Sub-agent Role Contract behavior.

* **Tests**
  * Added unit tests for Sub-agent Role Contract functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->