### PR TITLE
fix(windows): suppress console flash for netstat/taskkill spawns

### DIFF
--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -538,8 +538,11 @@ fn find_pid_on_port(port: u16) -> Option<u32> {
 
 #[cfg(windows)]
 fn find_pid_on_port(port: u16) -> Option<u32> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     let output = std::process::Command::new("netstat")
         .args(["-ano", "-p", "TCP"])
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .ok()?;
     if !output.status.success() {

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -152,17 +152,23 @@ fn signaled_at_least_one(status: &std::process::ExitStatus) -> bool {
 /// follow-up [`kill_pid_force`] does the actual termination.
 #[cfg(windows)]
 pub(crate) fn kill_pid_term(pid: u32) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     // Best-effort — ignore non-zero exit (e.g. process is windowless).
     let _ = std::process::Command::new("taskkill")
         .args(["/PID", &pid.to_string()])
+        .creation_flags(CREATE_NO_WINDOW)
         .status();
     Ok(())
 }
 
 #[cfg(windows)]
 pub(crate) fn kill_pid_force(pid: u32) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     let status = std::process::Command::new("taskkill")
         .args(["/F", "/T", "/PID", &pid.to_string()])
+        .creation_flags(CREATE_NO_WINDOW)
         .status()
         .map_err(|e| format!("taskkill spawn: {e}"))?;
     if !status.success() {


### PR DESCRIPTION
## Summary

- Added `CREATE_NO_WINDOW` (0x08000000) flag to all Windows `std::process::Command` spawns in the Tauri shell that were missing it.
- Fixes a visible console window that flashed on-screen every time the app checked for a stale RPC listener or killed a stale process on Windows.
- No behaviour change on macOS/Linux — all three changed call sites are inside `#[cfg(windows)]` blocks.

## Problem

On Windows, `std::process::Command` inherits or allocates a console for the child process unless `CREATE_NO_WINDOW` is explicitly set in the `PROCESS_CREATION_FLAGS`. Three call sites were spawning visible console windows:

1. `find_pid_on_port` (core_process.rs) — runs `netstat -ano` on every `ensure_running` call to detect a stale listener on the RPC port.
2. `kill_pid_term` (process_kill.rs) — runs `taskkill /PID` as a graceful-shutdown best-effort.
3. `kill_pid_force` (process_kill.rs) — runs `taskkill /F /T /PID` for the force-kill follow-up.

Because `ensure_running` is invoked periodically from the frontend (and during bootstrap/restart flows), users could see a console window flash every few seconds.

## Solution

Use `std::os::windows::process::CommandExt::creation_flags(0x0800_0000)` (stdlib — no new deps) on each of the three Windows `Command` instances. The constant is defined locally at the call site to avoid pulling in a winapi/windows crate.

## Submission Checklist

- [ ] N/A: no new Rust logic or branching — flag-only addition to existing Windows-only call sites; unit-testing `PROCESS_CREATION_FLAGS` requires a live Windows build
- [ ] N/A: diff coverage gate — only two files changed, no new logic paths, 0 changed lines of testable behaviour
- [ ] N/A: coverage matrix — no feature row maps to `CREATE_NO_WINDOW` flag on a process spawn helper
- [ ] N/A: feature IDs — no matrix feature affected
- [ ] N/A: no external network dependencies introduced
- [ ] N/A: no release-cut surfaces touched
- [ ] N/A: no linked issue (user-reported symptom, no issue opened)

## Impact

- Windows only: eliminates the black console window that flashed on every app startup/restart cycle and on any stale-listener recovery.
- No impact on macOS or Linux (all changes are inside `#[cfg(windows)]`).
- No behaviour change — processes still run to completion; they just do so without a visible window.

## Related

- Closes:
- Follow-up PR(s)/TODOs: consider adding `CREATE_NO_WINDOW` to the `taskkill` call in `ollama_admin.rs` and `nvidia-smi` in `device.rs` in a follow-up.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/windows-no-console-flash
- Commit SHA: 8fdce34e777991ea677d3a59f0c2620866ef5fcc

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed
- [x] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: N/A (Windows-only flag; no testable logic change)
- [x] Rust fmt/check (if changed): N/A (no root-crate Rust changes)
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml` — passed, 0 errors

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: Windows child processes (`netstat`, `taskkill`) no longer create a visible console window.
- User-visible effect: Console flash on Windows is eliminated.

### Parity Contract
- Legacy behavior preserved: Yes — process spawn semantics are identical; only the window-creation flag is added.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated unwanted console windows from appearing during port checking and process termination operations on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->