### PR TITLE
feat(meet): join Google Meet calls with mascot virtual camera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.18"
+version = "0.53.19"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.18"
+version = "0.53.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.18"
+version = "0.53.19"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "reqwest 0.12.28",
+ "resvg",
  "rusqlite",
  "rustls",
  "sentry",
@@ -43,6 +44,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-runtime-cef",
  "tempfile",
+ "tiny-skia",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tokio-util",
@@ -236,6 +238,18 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -1263,6 +1277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2023,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2169,28 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -3111,6 +3171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "imap-proto"
 version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,6 +3463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3588,12 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -5022,6 +5105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5797,6 +5886,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5809,6 +5921,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rusqlite"
@@ -5950,6 +6068,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -6494,6 +6630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6510,6 +6655,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -6673,6 +6827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6743,6 +6906,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher 1.0.2",
+]
 
 [[package]]
 name = "swift-rs"
@@ -7389,6 +7562,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7839,6 +8038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7960,6 +8168,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7981,10 +8201,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -8098,6 +8330,33 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.2",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -9435,6 +9694,12 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xz2"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -98,6 +98,13 @@ anyhow = "1.0"
 parking_lot = "0.12"
 chrono = "0.4"
 async-trait = "0.1"
+# Mascot fake-camera pipeline (meet_call): rasterizes the OpenHuman
+# mascot SVG to a PNG once, converts it to a YUV420 Y4M frame, and
+# points CEF's `--use-file-for-fake-video-capture` flag at the cached
+# file so Meet sees the mascot as the agent's webcam. Pure Rust, no
+# system codecs needed.
+resvg = { version = "0.45", default-features = false, features = ["text", "system-fonts"] }
+tiny-skia = "0.11"
 # CEF + tauri-runtime-cef dependencies (always required).
 # `tauri-runtime-cef::notification::register` is how we hook native Web
 # Notification interception per webview, and `cef::Browser` is what we downcast

--- a/app/src-tauri/permissions/allow-core-process.toml
+++ b/app/src-tauri/permissions/allow-core-process.toml
@@ -74,5 +74,11 @@ allow = [
     # backing commands.
     "logs_folder_path",
     "reveal_logs_folder",
+    # Meet call: open / close a dedicated CEF webview window pointed at a
+    # https://meet.google.com/<code> URL with an isolated per-call data
+    # directory. Surfaced from Intelligence > Calls. Without these allow
+    # entries the invoke is rejected with "Command not found".
+    "meet_call_open_window",
+    "meet_call_close_window",
 ]
 deny = []

--- a/app/src-tauri/src/fake_camera/mod.rs
+++ b/app/src-tauri/src/fake_camera/mod.rs
@@ -1,0 +1,217 @@
+//! Mascot-as-webcam pipeline.
+//!
+//! Once at app startup we rasterize the OpenHuman mascot SVG into a
+//! 640×480 RGBA bitmap, convert it to YUV420, and write a single-frame
+//! YUV4MPEG2 (Y4M) file to the per-user data directory. The file is
+//! cached across launches keyed by source-SVG hash so subsequent boots
+//! skip the rasterization.
+//!
+//! At browser launch, `lib.rs` passes the cached path to CEF via
+//! `--use-file-for-fake-video-capture=<path>`. CEF reads it on every
+//! `getUserMedia({video:true})` call and loops on EOF, so a single
+//! frame produces a steady-state still image as the agent's "webcam".
+//!
+//! No JS is injected anywhere — this is a process-level Chromium flag,
+//! not page-level instrumentation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use resvg::usvg::{Options as UsvgOptions, Tree as UsvgTree};
+use tiny_skia::{Pixmap, Transform};
+
+/// Output webcam resolution. 640×480 is what every videoconferencing
+/// app expects to negotiate against; Meet downscales to whatever it
+/// wants from there.
+const WIDTH: u32 = 640;
+const HEIGHT: u32 = 480;
+const FRAMERATE: &str = "F30:1";
+
+/// Mascot SVG embedded at build time. The remotion bundle owns the
+/// canonical asset; we vendor a copy of its content via `include_str!`
+/// so the shell builds without needing the remotion tree at runtime.
+const MASCOT_SVG: &str = include_str!("../../../../remotion/public/mascot.svg");
+
+/// Top-level entrypoint. Returns the path to a Y4M file CEF can read,
+/// rasterizing the mascot if no cached version exists.
+///
+/// Errors are logged + returned as `String` so the caller (lib.rs)
+/// can decide whether to skip the fake-camera flag and let the user
+/// see the default "no camera" path. We do **not** panic — a missing
+/// fake camera is degraded but not fatal.
+pub fn ensure_mascot_y4m(data_dir: &Path) -> Result<PathBuf, String> {
+    let cache_dir = data_dir.join("cache").join("fake_camera");
+    fs::create_dir_all(&cache_dir).map_err(|e| format!("create cache dir: {e}"))?;
+
+    let svg_hash = stable_hash(MASCOT_SVG);
+    let y4m_path = cache_dir.join(format!("mascot-{WIDTH}x{HEIGHT}-{svg_hash:016x}.y4m"));
+
+    if y4m_path.exists() {
+        log::info!(
+            "[fake-camera] reusing cached mascot Y4M path={}",
+            y4m_path.display()
+        );
+        return Ok(y4m_path);
+    }
+
+    log::info!(
+        "[fake-camera] rasterizing mascot {}x{} -> {}",
+        WIDTH,
+        HEIGHT,
+        y4m_path.display()
+    );
+    let rgba = rasterize_svg(MASCOT_SVG)?;
+    let y4m_bytes = encode_single_frame_y4m(&rgba);
+
+    // Atomic-ish write: write to .partial then rename, so a crash
+    // mid-write never leaves CEF reading a half-finished Y4M.
+    let tmp_path = y4m_path.with_extension("y4m.partial");
+    fs::write(&tmp_path, &y4m_bytes).map_err(|e| format!("write y4m: {e}"))?;
+    fs::rename(&tmp_path, &y4m_path).map_err(|e| format!("rename y4m: {e}"))?;
+    Ok(y4m_path)
+}
+
+/// Render the SVG to a 640×480 RGBA8 bitmap, letterboxed onto a flat
+/// background so the mascot looks centered in the participant tile
+/// regardless of source aspect ratio.
+fn rasterize_svg(svg: &str) -> Result<Vec<u8>, String> {
+    let tree = UsvgTree::from_str(svg, &UsvgOptions::default())
+        .map_err(|e| format!("parse svg: {e}"))?;
+    let svg_size = tree.size();
+    let svg_w = svg_size.width();
+    let svg_h = svg_size.height();
+    if svg_w <= 0.0 || svg_h <= 0.0 {
+        return Err("mascot svg has zero size".into());
+    }
+
+    let mut pixmap = Pixmap::new(WIDTH, HEIGHT).ok_or_else(|| "alloc pixmap".to_string())?;
+    // Background fill — Meet's tile is rectangular and we want a clean
+    // backdrop, not transparent (which the YUV conversion would
+    // collapse to black anyway).
+    pixmap.fill(tiny_skia::Color::from_rgba8(247, 244, 238, 255));
+
+    // Fit the mascot inside the frame with a 12% margin so it doesn't
+    // get cropped at the corners by Meet's rounded mask.
+    let margin = 0.12;
+    let target_w = (WIDTH as f32) * (1.0 - 2.0 * margin);
+    let target_h = (HEIGHT as f32) * (1.0 - 2.0 * margin);
+    let scale = (target_w / svg_w).min(target_h / svg_h);
+    let drawn_w = svg_w * scale;
+    let drawn_h = svg_h * scale;
+    let tx = ((WIDTH as f32) - drawn_w) / 2.0;
+    let ty = ((HEIGHT as f32) - drawn_h) / 2.0;
+
+    let transform = Transform::from_scale(scale, scale).post_translate(tx, ty);
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    Ok(pixmap.take())
+}
+
+/// Convert an RGBA8 buffer (length WIDTH * HEIGHT * 4) to a Y4M file
+/// containing a single FRAME using BT.601 limited-range coefficients.
+/// Chromium's fake video capture re-reads the file in a loop, so one
+/// frame is enough for a steady image.
+fn encode_single_frame_y4m(rgba: &[u8]) -> Vec<u8> {
+    let header = format!(
+        "YUV4MPEG2 W{WIDTH} H{HEIGHT} {FRAMERATE} Ip A1:1 C420jpeg Xopenhuman-mascot\nFRAME\n"
+    );
+
+    let pixel_count = (WIDTH * HEIGHT) as usize;
+    let mut y_plane = Vec::with_capacity(pixel_count);
+    let chroma_count = ((WIDTH / 2) * (HEIGHT / 2)) as usize;
+    let mut u_plane = Vec::with_capacity(chroma_count);
+    let mut v_plane = Vec::with_capacity(chroma_count);
+
+    // Y plane: per-pixel luma.
+    for chunk in rgba.chunks_exact(4) {
+        let (r, g, b) = (chunk[0] as f32, chunk[1] as f32, chunk[2] as f32);
+        let y = (0.299 * r + 0.587 * g + 0.114 * b).clamp(0.0, 255.0) as u8;
+        y_plane.push(y);
+    }
+
+    // U/V planes: average each 2×2 block.
+    for by in (0..HEIGHT).step_by(2) {
+        for bx in (0..WIDTH).step_by(2) {
+            let mut r_sum = 0.0;
+            let mut g_sum = 0.0;
+            let mut b_sum = 0.0;
+            for dy in 0..2 {
+                for dx in 0..2 {
+                    let x = bx + dx;
+                    let y = by + dy;
+                    let idx = ((y * WIDTH + x) * 4) as usize;
+                    r_sum += rgba[idx] as f32;
+                    g_sum += rgba[idx + 1] as f32;
+                    b_sum += rgba[idx + 2] as f32;
+                }
+            }
+            let r = r_sum / 4.0;
+            let g = g_sum / 4.0;
+            let b = b_sum / 4.0;
+            let u = (-0.169 * r - 0.331 * g + 0.5 * b + 128.0).clamp(0.0, 255.0) as u8;
+            let v = (0.5 * r - 0.419 * g - 0.081 * b + 128.0).clamp(0.0, 255.0) as u8;
+            u_plane.push(u);
+            v_plane.push(v);
+        }
+    }
+
+    let mut out = Vec::with_capacity(header.len() + y_plane.len() + u_plane.len() + v_plane.len());
+    out.extend_from_slice(header.as_bytes());
+    out.extend_from_slice(&y_plane);
+    out.extend_from_slice(&u_plane);
+    out.extend_from_slice(&v_plane);
+    out
+}
+
+/// Stable, deterministic hash of a string — used to key the Y4M cache
+/// against the source SVG. We don't need cryptographic strength, just
+/// "did the SVG change?", so std's `DefaultHasher` is fine.
+fn stable_hash(s: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn y4m_header_includes_dimensions_and_colorspace() {
+        let dummy = vec![0u8; (WIDTH * HEIGHT * 4) as usize];
+        let bytes = encode_single_frame_y4m(&dummy);
+        let header_end = bytes.iter().position(|&b| b == b'\n').unwrap();
+        let header = std::str::from_utf8(&bytes[..header_end]).unwrap();
+        assert!(header.contains(&format!("W{WIDTH}")));
+        assert!(header.contains(&format!("H{HEIGHT}")));
+        assert!(header.contains("C420jpeg"));
+    }
+
+    #[test]
+    fn y4m_payload_size_matches_yuv420_layout() {
+        let dummy = vec![0u8; (WIDTH * HEIGHT * 4) as usize];
+        let bytes = encode_single_frame_y4m(&dummy);
+        // Header up to first newline, then "FRAME\n", then planes.
+        let frame_marker = b"FRAME\n";
+        let frame_idx = bytes
+            .windows(frame_marker.len())
+            .position(|w| w == frame_marker)
+            .expect("FRAME marker present");
+        let payload_len = bytes.len() - frame_idx - frame_marker.len();
+        let expected = (WIDTH * HEIGHT) as usize + 2 * ((WIDTH / 2) * (HEIGHT / 2)) as usize;
+        assert_eq!(payload_len, expected);
+    }
+
+    #[test]
+    fn rasterize_svg_produces_correctly_sized_buffer() {
+        let rgba = rasterize_svg(MASCOT_SVG).expect("rasterize");
+        assert_eq!(rgba.len(), (WIDTH * HEIGHT * 4) as usize);
+    }
+
+    #[test]
+    fn stable_hash_is_deterministic() {
+        assert_eq!(stable_hash("openhuman"), stable_hash("openhuman"));
+        assert_ne!(stable_hash("a"), stable_hash("b"));
+    }
+}

--- a/app/src-tauri/src/fake_camera/mod.rs
+++ b/app/src-tauri/src/fake_camera/mod.rs
@@ -67,8 +67,17 @@ pub fn ensure_mascot_y4m(data_dir: &Path) -> Result<PathBuf, String> {
     // mid-write never leaves CEF reading a half-finished Y4M.
     let tmp_path = y4m_path.with_extension("y4m.partial");
     fs::write(&tmp_path, &y4m_bytes).map_err(|e| format!("write y4m: {e}"))?;
-    fs::rename(&tmp_path, &y4m_path).map_err(|e| format!("rename y4m: {e}"))?;
-    Ok(y4m_path)
+    // Tolerate a concurrent writer landing first: if rename fails but the
+    // target already exists, the other writer wrote the same SVG-hash-keyed
+    // file and we can drop our temp copy.
+    match fs::rename(&tmp_path, &y4m_path) {
+        Ok(()) => Ok(y4m_path),
+        Err(_) if y4m_path.exists() => {
+            let _ = fs::remove_file(&tmp_path);
+            Ok(y4m_path)
+        }
+        Err(e) => Err(format!("rename y4m: {e}")),
+    }
 }
 
 /// Render the SVG to a 640×480 RGBA8 bitmap, letterboxed onto a flat

--- a/app/src-tauri/src/fake_camera/mod.rs
+++ b/app/src-tauri/src/fake_camera/mod.rs
@@ -75,8 +75,8 @@ pub fn ensure_mascot_y4m(data_dir: &Path) -> Result<PathBuf, String> {
 /// background so the mascot looks centered in the participant tile
 /// regardless of source aspect ratio.
 fn rasterize_svg(svg: &str) -> Result<Vec<u8>, String> {
-    let tree = UsvgTree::from_str(svg, &UsvgOptions::default())
-        .map_err(|e| format!("parse svg: {e}"))?;
+    let tree =
+        UsvgTree::from_str(svg, &UsvgOptions::default()).map_err(|e| format!("parse svg: {e}"))?;
     let svg_size = tree.size();
     let svg_w = svg_size.width();
     let svg_h = svg_size.height();

--- a/app/src-tauri/src/file_logging.rs
+++ b/app/src-tauri/src/file_logging.rs
@@ -35,7 +35,7 @@ pub fn init() {
 /// `dirs::home_dir` to return `None`), falls back to `<temp>/openhuman`
 /// rather than a relative `.openhuman` whose final location depends on the
 /// shell's CWD at launch time.
-fn resolve_data_dir() -> PathBuf {
+pub(crate) fn resolve_data_dir() -> PathBuf {
     if let Ok(workspace) = std::env::var("OPENHUMAN_WORKSPACE") {
         if !workspace.is_empty() {
             return PathBuf::from(workspace);

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod gmessages_scanner;
 mod imessage_scanner;
 #[cfg(target_os = "macos")]
 mod mascot_native_window;
+mod meet_call;
 mod native_notifications;
 mod notification_settings;
 mod process_kill;
@@ -1319,6 +1320,7 @@ pub fn run() {
     let builder = builder.manage(discord_scanner::ScannerRegistry::new());
     let builder = builder.manage(telegram_scanner::ScannerRegistry::new());
     let builder = builder.manage(screen_capture::ScreenShareState::new());
+    let builder = builder.manage(meet_call::MeetCallState::new());
     builder
         .setup(move |app| {
             #[cfg(any(windows, target_os = "linux"))]
@@ -1809,7 +1811,9 @@ pub fn run() {
             mascot_window_show,
             mascot_window_hide,
             file_logging::reveal_logs_folder,
-            file_logging::logs_folder_path
+            file_logging::logs_folder_path,
+            meet_call::meet_call_open_window,
+            meet_call::meet_call_close_window
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod gmessages_scanner;
 mod imessage_scanner;
 #[cfg(target_os = "macos")]
 mod mascot_native_window;
+mod fake_camera;
 mod meet_call;
 mod meet_scanner;
 mod native_notifications;
@@ -1257,6 +1258,41 @@ pub fn run() {
             // silently disappears and huddle/call buttons no-op.
             ("--enable-features", Some("SharedArrayBuffer")),
         ];
+        // Mascot fake-camera: bake the SVG into a one-frame Y4M and
+        // point Chromium's fake-video-capture pipeline at it so any
+        // CEF webview that calls `getUserMedia({video:true})` sees the
+        // mascot as the agent's webcam. `--use-fake-ui-for-media-stream`
+        // auto-allows the permission prompt so Meet's join page doesn't
+        // get stuck behind it. The flags are process-level (affect every
+        // CEF webview), which is fine today: only the Meet call window
+        // intentionally requests a camera, and other webviews don't ask
+        // for one. The path string is leaked with `Box::leak` so its
+        // `&str` outlives the args vec we hand to `command_line_args`.
+        let fake_camera_arg: Option<&'static str> = match fake_camera::ensure_mascot_y4m(
+            &file_logging::resolve_data_dir(),
+        ) {
+            Ok(path) => {
+                let leaked: &'static str = Box::leak(
+                    path.to_string_lossy()
+                        .into_owned()
+                        .into_boxed_str(),
+                );
+                log::info!("[cef-startup] fake-camera y4m path={leaked}");
+                Some(leaked)
+            }
+            Err(err) => {
+                log::warn!(
+                    "[cef-startup] mascot fake-camera unavailable: {err} \
+                     (Meet will see no camera)"
+                );
+                None
+            }
+        };
+        if let Some(path) = fake_camera_arg {
+            args.push(("--use-fake-device-for-media-stream", None));
+            args.push(("--use-fake-ui-for-media-stream", None));
+            args.push(("--use-file-for-fake-video-capture", Some(path)));
+        }
         // Always expose the CDP port, not just in debug. The webview-accounts
         // CDP session opener navigates each embedded provider webview from its
         // `about:blank#openhuman-acct-...` placeholder to the real provider URL

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod imessage_scanner;
 #[cfg(target_os = "macos")]
 mod mascot_native_window;
 mod meet_call;
+mod meet_scanner;
 mod native_notifications;
 mod notification_settings;
 mod process_kill;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -9,12 +9,12 @@ mod core_process;
 mod core_rpc;
 mod dictation_hotkeys;
 mod discord_scanner;
+mod fake_camera;
 mod file_logging;
 mod gmessages_scanner;
 mod imessage_scanner;
 #[cfg(target_os = "macos")]
 mod mascot_native_window;
-mod fake_camera;
 mod meet_call;
 mod meet_scanner;
 mod native_notifications;
@@ -1268,26 +1268,22 @@ pub fn run() {
         // intentionally requests a camera, and other webviews don't ask
         // for one. The path string is leaked with `Box::leak` so its
         // `&str` outlives the args vec we hand to `command_line_args`.
-        let fake_camera_arg: Option<&'static str> = match fake_camera::ensure_mascot_y4m(
-            &file_logging::resolve_data_dir(),
-        ) {
-            Ok(path) => {
-                let leaked: &'static str = Box::leak(
-                    path.to_string_lossy()
-                        .into_owned()
-                        .into_boxed_str(),
-                );
-                log::info!("[cef-startup] fake-camera y4m path={leaked}");
-                Some(leaked)
-            }
-            Err(err) => {
-                log::warn!(
-                    "[cef-startup] mascot fake-camera unavailable: {err} \
+        let fake_camera_arg: Option<&'static str> =
+            match fake_camera::ensure_mascot_y4m(&file_logging::resolve_data_dir()) {
+                Ok(path) => {
+                    let leaked: &'static str =
+                        Box::leak(path.to_string_lossy().into_owned().into_boxed_str());
+                    log::info!("[cef-startup] fake-camera y4m path={leaked}");
+                    Some(leaked)
+                }
+                Err(err) => {
+                    log::warn!(
+                        "[cef-startup] mascot fake-camera unavailable: {err} \
                      (Meet will see no camera)"
-                );
-                None
-            }
-        };
+                    );
+                    None
+                }
+            };
         if let Some(path) = fake_camera_arg {
             args.push(("--use-fake-device-for-media-stream", None));
             args.push(("--use-fake-ui-for-media-stream", None));

--- a/app/src-tauri/src/meet_call/mod.rs
+++ b/app/src-tauri/src/meet_call/mod.rs
@@ -1,0 +1,239 @@
+//! Tauri command surface for the "Join a Google Meet call" feature.
+//!
+//! The core (`src/openhuman/meet/`) validates the meet URL + display name
+//! and mints a `request_id`. The frontend then invokes
+//! [`meet_call_open_window`] to actually pop a top-level CEF webview that
+//! navigates to the Meet URL with a fresh data directory so the join is
+//! anonymous (no leaked cookies from any other Google session).
+//!
+//! ## Why a top-level window and not a child of the main webview?
+//!
+//! Meet calls are a discrete activity the user wants to see (and resize /
+//! position) independently of the OpenHuman main window. The existing
+//! `webview_accounts` machinery is account-bound and embeds child
+//! webviews inside the main window — the wrong shape for an ad-hoc call.
+//!
+//! ## What about CDP automation (typing the name, clicking "Ask to
+//! join")?
+//!
+//! Out of scope for this initial cut. The window opens at the Meet URL;
+//! the user (or, in a follow-up, a `meet_scanner` module mirroring the
+//! `whatsapp_scanner` pattern) handles the join page. No JS is injected
+//! into this webview — per the project rule for embedded provider
+//! webviews.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tauri::{webview::WebviewWindowBuilder, AppHandle, Emitter, Manager, Runtime, WebviewUrl};
+use url::Url;
+
+/// Per-process registry of open Meet webview windows, keyed by
+/// `request_id` so the frontend can ask us to close a specific call.
+#[derive(Default)]
+pub struct MeetCallState {
+    inner: Mutex<std::collections::HashMap<String, String>>, // request_id -> window label
+}
+
+impl MeetCallState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenWindowArgs {
+    pub request_id: String,
+    pub meet_url: String,
+    pub display_name: String,
+}
+
+/// Open a dedicated top-level CEF webview window pointed at the Meet URL.
+///
+/// The window label is derived from `request_id` so concurrent calls
+/// don't collide. A fresh `app_local_data_dir/meet_call/<request_id>`
+/// directory keeps cookies isolated — Google Meet treats us as a brand
+/// new anonymous user. The window emits `meet-call:closed` when the user
+/// closes it so the frontend can clean up its in-flight call list.
+#[tauri::command]
+pub async fn meet_call_open_window<R: Runtime>(
+    app: AppHandle<R>,
+    state: tauri::State<'_, MeetCallState>,
+    args: OpenWindowArgs,
+) -> Result<String, String> {
+    let request_id = sanitize_request_id(&args.request_id)?;
+    let parsed = Url::parse(args.meet_url.trim())
+        .map_err(|e| format!("[meet-call] invalid meet_url: {e}"))?;
+    if parsed.scheme() != "https" || parsed.host_str() != Some("meet.google.com") {
+        return Err("[meet-call] only https://meet.google.com URLs are accepted".into());
+    }
+
+    let label = window_label_for(&request_id);
+
+    if let Some(existing) = app.get_webview_window(&label) {
+        log::info!("[meet-call] reusing existing window label={label} request_id={request_id}");
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        return Ok(label);
+    }
+
+    let data_dir = data_directory_for(&app, &request_id)?;
+    if let Err(err) = std::fs::create_dir_all(&data_dir) {
+        log::warn!(
+            "[meet-call] failed to create data dir {}: {}",
+            data_dir.display(),
+            err
+        );
+    }
+
+    log::info!(
+        "[meet-call] opening window label={label} request_id={request_id} url_host={} display_name_chars={}",
+        parsed.host_str().unwrap_or(""),
+        args.display_name.chars().count()
+    );
+
+    let title = format!("Meet — {}", truncate_for_title(&args.display_name));
+    let builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::External(parsed.clone()))
+        .title(title)
+        .inner_size(1100.0, 760.0)
+        .resizable(true)
+        .data_directory(data_dir);
+
+    let window = builder
+        .build()
+        .map_err(|e| format!("[meet-call] WebviewWindowBuilder.build failed: {e}"))?;
+
+    state
+        .inner
+        .lock()
+        .unwrap()
+        .insert(request_id.clone(), label.clone());
+
+    // Emit a `closed` event when the user dismisses the window so the
+    // frontend can drop the call from its in-flight list.
+    {
+        let app_for_event = app.clone();
+        let label_for_event = label.clone();
+        let request_id_for_event = request_id.clone();
+        window.on_window_event(move |event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                if let Some(state) = app_for_event.try_state::<MeetCallState>() {
+                    state.inner.lock().unwrap().remove(&request_id_for_event);
+                }
+                if let Err(err) = app_for_event.emit(
+                    "meet-call:closed",
+                    serde_json::json!({
+                        "request_id": request_id_for_event,
+                        "label": label_for_event,
+                    }),
+                ) {
+                    log::debug!("[meet-call] emit closed failed: {err}");
+                }
+                log::info!(
+                    "[meet-call] window destroyed label={label_for_event} request_id={request_id_for_event}"
+                );
+            }
+        });
+    }
+
+    Ok(label)
+}
+
+#[tauri::command]
+pub async fn meet_call_close_window<R: Runtime>(
+    app: AppHandle<R>,
+    state: tauri::State<'_, MeetCallState>,
+    request_id: String,
+) -> Result<bool, String> {
+    let request_id = sanitize_request_id(&request_id)?;
+    let label = match state.inner.lock().unwrap().get(&request_id).cloned() {
+        Some(label) => label,
+        None => return Ok(false),
+    };
+    if let Some(window) = app.get_webview_window(&label) {
+        window
+            .close()
+            .map_err(|e| format!("[meet-call] window.close failed: {e}"))?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn window_label_for(request_id: &str) -> String {
+    format!("meet-call-{request_id}")
+}
+
+fn data_directory_for<R: Runtime>(app: &AppHandle<R>, request_id: &str) -> Result<PathBuf, String> {
+    let base = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| format!("[meet-call] app_local_data_dir: {e}"))?;
+    Ok(base.join("meet_call").join(request_id))
+}
+
+fn sanitize_request_id(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("[meet-call] request_id must not be empty".into());
+    }
+    if trimmed.len() > 64 {
+        return Err("[meet-call] request_id exceeds 64 characters".into());
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("[meet-call] request_id contains forbidden characters".into());
+    }
+    Ok(trimmed.to_string())
+}
+
+fn truncate_for_title(name: &str) -> String {
+    let trimmed = name.trim();
+    if trimmed.chars().count() <= 32 {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(32).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_request_id_rejects_path_traversal() {
+        assert!(sanitize_request_id("..").is_err());
+        assert!(sanitize_request_id("a/b").is_err());
+        assert!(sanitize_request_id("a b").is_err());
+        assert!(sanitize_request_id("").is_err());
+    }
+
+    #[test]
+    fn sanitize_request_id_accepts_uuids_and_simple_ids() {
+        sanitize_request_id("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        sanitize_request_id("abc_123").unwrap();
+    }
+
+    #[test]
+    fn window_label_has_predictable_prefix() {
+        let label = window_label_for("abc-123");
+        assert!(label.starts_with("meet-call-"));
+        assert!(label.contains("abc-123"));
+    }
+
+    #[test]
+    fn truncate_for_title_caps_long_names() {
+        let long = "a".repeat(40);
+        let truncated = truncate_for_title(&long);
+        assert!(truncated.chars().count() <= 33); // 32 + ellipsis
+        assert!(truncated.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_for_title_passes_short_names_through() {
+        assert_eq!(truncate_for_title("Alice"), "Alice");
+    }
+}

--- a/app/src-tauri/src/meet_call/mod.rs
+++ b/app/src-tauri/src/meet_call/mod.rs
@@ -29,6 +29,8 @@ use serde::Deserialize;
 use tauri::{webview::WebviewWindowBuilder, AppHandle, Emitter, Manager, Runtime, WebviewUrl};
 use url::Url;
 
+use crate::meet_scanner;
+
 /// Per-process registry of open Meet webview windows, keyed by
 /// `request_id` so the frontend can ask us to close a specific call.
 #[derive(Default)]
@@ -109,6 +111,11 @@ pub async fn meet_call_open_window<R: Runtime>(
         .lock()
         .unwrap()
         .insert(request_id.clone(), label.clone());
+
+    // Kick off the CDP-driven join automation: dismiss the device-check,
+    // type the display name, and click "Ask to join". Fire-and-forget —
+    // the user can finish manually if any step times out.
+    meet_scanner::spawn(app.clone(), request_id.clone(), args.display_name.clone());
 
     // Emit a `closed` event when the user dismisses the window so the
     // frontend can drop the call from its in-flight list.

--- a/app/src-tauri/src/meet_call/mod.rs
+++ b/app/src-tauri/src/meet_call/mod.rs
@@ -100,7 +100,7 @@ pub async fn meet_call_open_window<R: Runtime>(
         .title(title)
         .inner_size(1100.0, 760.0)
         .resizable(true)
-        .data_directory(data_dir);
+        .data_directory(data_dir.clone());
 
     let window = builder
         .build()
@@ -114,15 +114,26 @@ pub async fn meet_call_open_window<R: Runtime>(
 
     // Kick off the CDP-driven join automation: dismiss the device-check,
     // type the display name, and click "Ask to join". Fire-and-forget —
-    // the user can finish manually if any step times out.
-    meet_scanner::spawn(app.clone(), request_id.clone(), args.display_name.clone());
+    // the user can finish manually if any step times out. Pass the
+    // normalised URL so the scanner can attach to the right CEF target
+    // when more than one Meet window is open.
+    meet_scanner::spawn(
+        app.clone(),
+        request_id.clone(),
+        parsed.to_string(),
+        args.display_name.clone(),
+    );
 
-    // Emit a `closed` event when the user dismisses the window so the
-    // frontend can drop the call from its in-flight list.
+    // Emit a `closed` event when the user dismisses the window AND clean
+    // up the per-call data directory. The data dir holds an isolated CEF
+    // profile (cookies, cache) we explicitly want to throw away after
+    // each call so the next anonymous join doesn't reuse stale state and
+    // disk doesn't grow unboundedly across many calls.
     {
         let app_for_event = app.clone();
         let label_for_event = label.clone();
         let request_id_for_event = request_id.clone();
+        let data_dir_for_event = data_dir.clone();
         window.on_window_event(move |event| {
             if let tauri::WindowEvent::Destroyed = event {
                 if let Some(state) = app_for_event.try_state::<MeetCallState>() {
@@ -140,6 +151,19 @@ pub async fn meet_call_open_window<R: Runtime>(
                 log::info!(
                     "[meet-call] window destroyed label={label_for_event} request_id={request_id_for_event}"
                 );
+                // CEF may still be flushing the profile to disk on
+                // teardown; do the rmdir off the UI thread so any
+                // last-second writes don't race the delete.
+                let dir_to_purge = data_dir_for_event.clone();
+                let request_id_for_purge = request_id_for_event.clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Err(err) = std::fs::remove_dir_all(&dir_to_purge) {
+                        log::debug!(
+                            "[meet-call] data-dir cleanup skipped request_id={request_id_for_purge} dir={} err={err}",
+                            dir_to_purge.display()
+                        );
+                    }
+                });
             }
         });
     }

--- a/app/src-tauri/src/meet_scanner/mod.rs
+++ b/app/src-tauri/src/meet_scanner/mod.rs
@@ -1,0 +1,255 @@
+//! CDP-driven Meet join automation.
+//!
+//! Runs once per call, after `meet_call::meet_call_open_window` has
+//! successfully built the dedicated CEF webview. Connects to CEF's
+//! browser-level WebSocket, attaches to the new Meet target, and walks
+//! through the join page in three phases:
+//!
+//!  1. Dismiss the device-check ("Continue without microphone and camera").
+//!  2. Type the supplied guest display name into the "Your name" input.
+//!  3. Click "Ask to join".
+//!
+//! All steps go through CDP from this scanner side — there is **no**
+//! init-script JS injected into the webview. `Runtime.evaluate` is used
+//! to find candidate elements by visible text / aria-label, and
+//! `Input.insertText` to inject the display name as a synthetic IME
+//! event so Meet's React-controlled `<input>` actually picks it up.
+//!
+//! The whole sequence is best-effort: if any phase times out we log and
+//! bail without crashing the window — the user can finish joining
+//! manually. Future work: emit lifecycle events back to the frontend so
+//! the UI can show "asking host…" / "joined" status.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Runtime};
+
+use crate::cdp::{self, CdpConn};
+
+/// Wait at most this long for CEF to surface the new Meet page target
+/// after `WebviewWindowBuilder::build()` returns. CEF lazy-creates the
+/// renderer-side target a few hundred ms after the host-side window is
+/// ready.
+const TARGET_DISCOVERY_BUDGET: Duration = Duration::from_secs(20);
+const TARGET_DISCOVERY_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Per-phase polling budgets. Meet's join page is JS-heavy and a cold
+/// renderer can take several seconds before the first interactive
+/// elements paint, so the device-check phase gets the most generous
+/// budget.
+const DEVICE_CHECK_BUDGET: Duration = Duration::from_secs(45);
+const NAME_INPUT_BUDGET: Duration = Duration::from_secs(30);
+const JOIN_BUTTON_BUDGET: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Spawn the CDP-driven join automation. Fire-and-forget — the caller
+/// (the Tauri command that just opened the window) doesn't wait for it.
+pub fn spawn<R: Runtime>(_app: AppHandle<R>, request_id: String, display_name: String) {
+    tauri::async_runtime::spawn(async move {
+        match run(&request_id, &display_name).await {
+            Ok(()) => log::info!("[meet-scanner] join sequence completed request_id={request_id}"),
+            Err(err) => {
+                log::warn!("[meet-scanner] join sequence aborted request_id={request_id} err={err}")
+            }
+        }
+    });
+}
+
+async fn run(request_id: &str, display_name: &str) -> Result<(), String> {
+    let (mut cdp, session) = wait_for_meet_target().await?;
+    log::info!("[meet-scanner] attached to meet target request_id={request_id} session={session}");
+
+    // `Runtime.enable` is required before `Runtime.evaluate` returns
+    // structured results in some CEF builds. `Page.enable` is harmless
+    // and gives us frame-lifecycle events for free if a future PR wants
+    // them. Both are best-effort — if they fail we still try to evaluate.
+    let _ = cdp.call("Page.enable", json!({}), Some(&session)).await;
+    let _ = cdp.call("Runtime.enable", json!({}), Some(&session)).await;
+
+    // Phase 1 — dismiss the device-check screen.
+    //
+    // Meet's exact copy varies by region/A-B test; we try the canonical
+    // English variants. The button is usually `[role="button"]` not
+    // `<button>`, so `wait_and_click_text` looks at both.
+    if let Err(err) = wait_and_click_text(
+        &mut cdp,
+        &session,
+        &[
+            "Continue without microphone and camera",
+            "Continue without microphone",
+            "Continue without camera",
+        ],
+        DEVICE_CHECK_BUDGET,
+    )
+    .await
+    {
+        log::info!("[meet-scanner] device-check dismissal not needed or unavailable: {err}");
+    }
+
+    // Phase 2 — type the display name.
+    type_into_named_input(&mut cdp, &session, "Your name", display_name).await?;
+
+    // Phase 3 — request to join.
+    wait_and_click_text(
+        &mut cdp,
+        &session,
+        &["Ask to join", "Join now"],
+        JOIN_BUTTON_BUDGET,
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Poll CEF's target list until a page whose URL is on `meet.google.com`
+/// shows up, then attach a CDP session to it. We can't filter on the
+/// per-call `request_id` because Meet uses opaque meeting codes in the
+/// URL, but in practice only the just-opened webview hits this host
+/// inside the per-call data directory, so a host match is enough.
+async fn wait_for_meet_target() -> Result<(CdpConn, String), String> {
+    let deadline = tokio::time::Instant::now() + TARGET_DISCOVERY_BUDGET;
+    let mut last_err = String::new();
+    while tokio::time::Instant::now() < deadline {
+        match cdp::connect_and_attach_matching(|t| t.url.starts_with("https://meet.google.com/"))
+            .await
+        {
+            Ok(pair) => return Ok(pair),
+            Err(err) => {
+                last_err = err;
+                tokio::time::sleep(TARGET_DISCOVERY_INTERVAL).await;
+            }
+        }
+    }
+    Err(format!(
+        "timeout waiting for meet.google.com target: {last_err}"
+    ))
+}
+
+/// Repeatedly evaluate a click-by-text helper in the page until either
+/// a click lands or `budget` elapses.
+async fn wait_and_click_text(
+    cdp: &mut CdpConn,
+    session: &str,
+    labels: &[&str],
+    budget: Duration,
+) -> Result<(), String> {
+    let labels_js = serde_json::to_string(labels).map_err(|e| format!("labels json: {e}"))?;
+    let expression = format!(
+        r#"
+        (() => {{
+          const labels = {labels_js};
+          const want = labels.map(l => l.toLowerCase());
+          const candidates = document.querySelectorAll(
+            'button, [role="button"], a[role="button"]'
+          );
+          for (const el of candidates) {{
+            if (el.disabled || el.getAttribute('aria-disabled') === 'true') continue;
+            const text = ((el.innerText || el.textContent) || '').trim().toLowerCase();
+            if (!text) continue;
+            if (!want.some(w => text.includes(w))) continue;
+            const rect = el.getBoundingClientRect();
+            if (rect.width === 0 || rect.height === 0) continue;
+            el.scrollIntoView({{ block: 'center', inline: 'center' }});
+            el.click();
+            return text;
+          }}
+          return null;
+        }})()
+        "#
+    );
+
+    let deadline = tokio::time::Instant::now() + budget;
+    let mut last_value = Value::Null;
+    while tokio::time::Instant::now() < deadline {
+        let res = cdp
+            .call(
+                "Runtime.evaluate",
+                json!({
+                    "expression": expression,
+                    "returnByValue": true,
+                    "awaitPromise": false,
+                }),
+                Some(session),
+            )
+            .await?;
+        let value = res
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .cloned()
+            .unwrap_or(Value::Null);
+        if value.is_string() {
+            log::info!(
+                "[meet-scanner] clicked element matching {labels:?} text={}",
+                value.as_str().unwrap_or("")
+            );
+            return Ok(());
+        }
+        last_value = value;
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(format!(
+        "timeout waiting for clickable element matching {labels:?} (last={last_value})"
+    ))
+}
+
+/// Focus an `<input>` whose `aria-label` or `placeholder` contains
+/// `hint`, then dispatch the supplied text via `Input.insertText` so
+/// Meet's React-controlled input picks it up as a real keystroke.
+async fn type_into_named_input(
+    cdp: &mut CdpConn,
+    session: &str,
+    hint: &str,
+    text: &str,
+) -> Result<(), String> {
+    let hint_js = serde_json::to_string(hint).map_err(|e| format!("hint json: {e}"))?;
+    let focus_expr = format!(
+        r#"
+        (() => {{
+          const hint = {hint_js}.toLowerCase();
+          const inputs = document.querySelectorAll('input');
+          for (const inp of inputs) {{
+            const t = (inp.getAttribute('type') || 'text').toLowerCase();
+            if (t !== 'text' && t !== 'search') continue;
+            const aria = (inp.getAttribute('aria-label') || '').toLowerCase();
+            const ph = (inp.placeholder || '').toLowerCase();
+            if (!aria.includes(hint) && !ph.includes(hint)) continue;
+            inp.focus();
+            inp.click();
+            // Clear any value already there so we don't append to a
+            // half-typed name from a previous attempt.
+            try {{ inp.select(); }} catch (_) {{}}
+            return true;
+          }}
+          return false;
+        }})()
+        "#
+    );
+
+    let deadline = tokio::time::Instant::now() + NAME_INPUT_BUDGET;
+    while tokio::time::Instant::now() < deadline {
+        let res = cdp
+            .call(
+                "Runtime.evaluate",
+                json!({ "expression": focus_expr, "returnByValue": true }),
+                Some(session),
+            )
+            .await?;
+        let focused = res
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if focused {
+            cdp.call("Input.insertText", json!({ "text": text }), Some(session))
+                .await?;
+            log::info!(
+                "[meet-scanner] inserted display name (hint={hint} chars={})",
+                text.chars().count()
+            );
+            return Ok(());
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(format!("timeout waiting for input matching hint={hint}"))
+}

--- a/app/src-tauri/src/meet_scanner/mod.rs
+++ b/app/src-tauri/src/meet_scanner/mod.rs
@@ -48,9 +48,18 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Spawn the CDP-driven join automation. Fire-and-forget — the caller
 /// (the Tauri command that just opened the window) doesn't wait for it.
-pub fn spawn<R: Runtime>(_app: AppHandle<R>, request_id: String, display_name: String) {
+///
+/// `meet_url` is the exact normalised URL the window was navigated to;
+/// the scanner uses it as a target-URL prefix so two concurrent calls
+/// each attach to their own CEF target instead of cross-controlling.
+pub fn spawn<R: Runtime>(
+    _app: AppHandle<R>,
+    request_id: String,
+    meet_url: String,
+    display_name: String,
+) {
     tauri::async_runtime::spawn(async move {
-        match run(&request_id, &display_name).await {
+        match run(&request_id, &meet_url, &display_name).await {
             Ok(()) => log::info!("[meet-scanner] join sequence completed request_id={request_id}"),
             Err(err) => {
                 log::warn!("[meet-scanner] join sequence aborted request_id={request_id} err={err}")
@@ -59,8 +68,8 @@ pub fn spawn<R: Runtime>(_app: AppHandle<R>, request_id: String, display_name: S
     });
 }
 
-async fn run(request_id: &str, display_name: &str) -> Result<(), String> {
-    let (mut cdp, session) = wait_for_meet_target().await?;
+async fn run(request_id: &str, meet_url: &str, display_name: &str) -> Result<(), String> {
+    let (mut cdp, session) = wait_for_meet_target(meet_url).await?;
     log::info!("[meet-scanner] attached to meet target request_id={request_id} session={session}");
 
     // `Runtime.enable` is required before `Runtime.evaluate` returns
@@ -105,18 +114,15 @@ async fn run(request_id: &str, display_name: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Poll CEF's target list until a page whose URL is on `meet.google.com`
-/// shows up, then attach a CDP session to it. We can't filter on the
-/// per-call `request_id` because Meet uses opaque meeting codes in the
-/// URL, but in practice only the just-opened webview hits this host
-/// inside the per-call data directory, so a host match is enough.
-async fn wait_for_meet_target() -> Result<(CdpConn, String), String> {
+/// Poll CEF's target list until a page whose URL starts with `meet_url`
+/// shows up, then attach a CDP session to it. Filtering by the full
+/// per-call URL prefix (rather than just the host) keeps two concurrent
+/// Meet calls from cross-controlling each other when both are open.
+async fn wait_for_meet_target(meet_url: &str) -> Result<(CdpConn, String), String> {
     let deadline = tokio::time::Instant::now() + TARGET_DISCOVERY_BUDGET;
     let mut last_err = String::new();
     while tokio::time::Instant::now() < deadline {
-        match cdp::connect_and_attach_matching(|t| t.url.starts_with("https://meet.google.com/"))
-            .await
-        {
+        match cdp::connect_and_attach_matching(|t| t.url.starts_with(meet_url)).await {
             Ok(pair) => return Ok(pair),
             Err(err) => {
                 last_err = err;

--- a/app/src-tauri/src/meet_scanner/mod.rs
+++ b/app/src-tauri/src/meet_scanner/mod.rs
@@ -34,11 +34,14 @@ use crate::cdp::{self, CdpConn};
 const TARGET_DISCOVERY_BUDGET: Duration = Duration::from_secs(20);
 const TARGET_DISCOVERY_INTERVAL: Duration = Duration::from_millis(500);
 
-/// Per-phase polling budgets. Meet's join page is JS-heavy and a cold
-/// renderer can take several seconds before the first interactive
-/// elements paint, so the device-check phase gets the most generous
-/// budget.
-const DEVICE_CHECK_BUDGET: Duration = Duration::from_secs(45);
+/// Per-phase polling budgets. With the mascot fake-camera flag set
+/// process-wide in `lib.rs`, Meet sees a "real" webcam and does NOT
+/// show the "Continue without microphone and camera" screen at all,
+/// so the device-check phase becomes a quick best-effort probe rather
+/// than a meaningful wait. We still keep the phase in case a future
+/// build runs without the fake-camera flag (or the Y4M failed to
+/// rasterize), but cap it tight so the join flow doesn't stall.
+const DEVICE_CHECK_BUDGET: Duration = Duration::from_secs(6);
 const NAME_INPUT_BUDGET: Duration = Duration::from_secs(30);
 const JOIN_BUTTON_BUDGET: Duration = Duration::from_secs(30);
 const POLL_INTERVAL: Duration = Duration::from_millis(500);

--- a/app/src/components/intelligence/IntelligenceCallsTab.test.tsx
+++ b/app/src/components/intelligence/IntelligenceCallsTab.test.tsx
@@ -119,4 +119,29 @@ describe('IntelligenceCallsTab', () => {
       expect(screen.queryByRole('button', { name: /Leave/i })).not.toBeInTheDocument()
     );
   });
+
+  it('keeps the row when closeMeetCall returns false (window stayed open)', async () => {
+    vi.mocked(joinMeetCall).mockResolvedValueOnce({
+      requestId: 'req-3',
+      meetUrl: VALID_URL,
+      displayName: 'OpenHuman Agent',
+      windowLabel: 'meet-call-req-3',
+    });
+    vi.mocked(closeMeetCall).mockResolvedValueOnce(false);
+
+    render(<IntelligenceCallsTab />);
+    fireEvent.change(screen.getByPlaceholderText(/meet\.google\.com/i), {
+      target: { value: VALID_URL },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Join call/i }));
+
+    const leaveBtn = await screen.findByRole('button', { name: /Leave/i });
+    fireEvent.click(leaveBtn);
+
+    await waitFor(() => expect(closeMeetCall).toHaveBeenCalledWith('req-3'));
+    // Row stays so the user can retry; the meet-call:closed event listener
+    // would still drop it later if the shell ends up tearing the window
+    // down on its own.
+    expect(screen.getByRole('button', { name: /Leave/i })).toBeInTheDocument();
+  });
 });

--- a/app/src/components/intelligence/IntelligenceCallsTab.test.tsx
+++ b/app/src/components/intelligence/IntelligenceCallsTab.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeMeetCall, joinMeetCall } from '../../services/meetCallService';
+import IntelligenceCallsTab from './IntelligenceCallsTab';
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => () => undefined) }));
+
+vi.mock('../../services/meetCallService', () => ({
+  joinMeetCall: vi.fn(),
+  closeMeetCall: vi.fn(),
+}));
+
+const VALID_URL = 'https://meet.google.com/abc-defg-hij';
+
+describe('IntelligenceCallsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders form with URL + display name inputs and a disabled join button', () => {
+    render(<IntelligenceCallsTab />);
+
+    expect(screen.getByRole('heading', { name: /Join a Google Meet call/i })).toBeInTheDocument();
+    const urlInput = screen.getByPlaceholderText(/meet\.google\.com/i);
+    expect(urlInput).toBeInTheDocument();
+    // Display name has a default value, so the join button is enabled only
+    // once the URL field is also non-empty. With an empty URL it stays
+    // disabled.
+    expect(screen.getByRole('button', { name: /Join call/i })).toBeDisabled();
+  });
+
+  it('calls joinMeetCall on submit and adds the result to the active-call list', async () => {
+    vi.mocked(joinMeetCall).mockResolvedValueOnce({
+      requestId: 'req-1',
+      meetUrl: VALID_URL,
+      displayName: 'OpenHuman Agent',
+      windowLabel: 'meet-call-req-1',
+    });
+
+    const onToast = vi.fn();
+    render(<IntelligenceCallsTab onToast={onToast} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/meet\.google\.com/i), {
+      target: { value: VALID_URL },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Join call/i }));
+
+    await waitFor(() => expect(joinMeetCall).toHaveBeenCalledTimes(1));
+    expect(joinMeetCall).toHaveBeenCalledWith({
+      meetUrl: VALID_URL,
+      displayName: 'OpenHuman Agent',
+    });
+
+    // Active call appears with a Leave button.
+    await screen.findByText('OpenHuman Agent');
+    expect(screen.getByRole('button', { name: /Leave/i })).toBeInTheDocument();
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'Joining call' })
+    );
+  });
+
+  it('renders the rejection reason in the form when joinMeetCall throws', async () => {
+    vi.mocked(joinMeetCall).mockRejectedValueOnce(new Error('Core rejected the request'));
+    const onToast = vi.fn();
+
+    render(<IntelligenceCallsTab onToast={onToast} />);
+    fireEvent.change(screen.getByPlaceholderText(/meet\.google\.com/i), {
+      target: { value: VALID_URL },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Join call/i }));
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert')).toHaveTextContent(/Core rejected the request/i);
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', title: 'Could not start call' })
+    );
+  });
+
+  it('falls back to a generic error message for non-Error rejections', async () => {
+    // joinMeetCall throws a non-Error value (e.g. a raw string) — the
+    // component should still surface a sane message instead of crashing.
+    vi.mocked(joinMeetCall).mockRejectedValueOnce('boom');
+
+    render(<IntelligenceCallsTab />);
+    fireEvent.change(screen.getByPlaceholderText(/meet\.google\.com/i), {
+      target: { value: VALID_URL },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Join call/i }));
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert')).toHaveTextContent(/Failed to start Meet call/i);
+  });
+
+  it('removes the call from the list when the user clicks Leave', async () => {
+    vi.mocked(joinMeetCall).mockResolvedValueOnce({
+      requestId: 'req-2',
+      meetUrl: VALID_URL,
+      displayName: 'OpenHuman Agent',
+      windowLabel: 'meet-call-req-2',
+    });
+    vi.mocked(closeMeetCall).mockResolvedValueOnce(true);
+
+    render(<IntelligenceCallsTab />);
+    fireEvent.change(screen.getByPlaceholderText(/meet\.google\.com/i), {
+      target: { value: VALID_URL },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Join call/i }));
+
+    const leaveBtn = await screen.findByRole('button', { name: /Leave/i });
+    fireEvent.click(leaveBtn);
+
+    await waitFor(() => expect(closeMeetCall).toHaveBeenCalledWith('req-2'));
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Leave/i })).not.toBeInTheDocument()
+    );
+  });
+});

--- a/app/src/components/intelligence/IntelligenceCallsTab.tsx
+++ b/app/src/components/intelligence/IntelligenceCallsTab.tsx
@@ -1,0 +1,183 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useEffect, useState } from 'react';
+
+import { closeMeetCall, joinMeetCall } from '../../services/meetCallService';
+
+type ActiveCall = { requestId: string; meetUrl: string; displayName: string };
+
+type Props = {
+  onToast?: (toast: {
+    type: 'success' | 'error' | 'info';
+    title: string;
+    message?: string;
+  }) => void;
+};
+
+const PLACEHOLDER_URL = 'https://meet.google.com/abc-defg-hij';
+
+/**
+ * Calls tab on the Intelligence page.
+ *
+ * Lets the user paste a Google Meet link, choose a display name, and have
+ * the agent join the call as an anonymous guest in a dedicated CEF
+ * webview window. The window itself is opened by the Tauri shell — this
+ * component just collects inputs, fires the RPC + invoke pair, and
+ * tracks active calls so the user can close them from the same surface.
+ */
+export default function IntelligenceCallsTab({ onToast }: Props) {
+  const [meetUrl, setMeetUrl] = useState('');
+  const [displayName, setDisplayName] = useState('OpenHuman Agent');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeCalls, setActiveCalls] = useState<ActiveCall[]>([]);
+
+  // Listen for shell-emitted close events so the in-flight list stays
+  // accurate when the user closes a Meet window directly. Outside the
+  // Tauri shell `listen` rejects with a transport error — we swallow it.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+
+    listen<{ request_id: string }>('meet-call:closed', event => {
+      const closedId = event.payload?.request_id;
+      if (!closedId) return;
+      setActiveCalls(prev => prev.filter(call => call.requestId !== closedId));
+    })
+      .then(stop => {
+        if (cancelled) stop();
+        else unlisten = stop;
+      })
+      .catch(() => {
+        // Browser dev surface — no Tauri event bridge available.
+      });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = await joinMeetCall({ meetUrl, displayName });
+      setActiveCalls(prev => [
+        ...prev.filter(call => call.requestId !== result.requestId),
+        { requestId: result.requestId, meetUrl: result.meetUrl, displayName: result.displayName },
+      ]);
+      setMeetUrl('');
+      onToast?.({
+        type: 'success',
+        title: 'Joining call',
+        message: 'Opening the Meet window — admit the agent from the host side.',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start Meet call.';
+      setError(message);
+      onToast?.({ type: 'error', title: 'Could not start call', message });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleClose = async (requestId: string) => {
+    try {
+      await closeMeetCall(requestId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to close call.';
+      onToast?.({ type: 'error', title: 'Could not close call', message });
+    } finally {
+      setActiveCalls(prev => prev.filter(call => call.requestId !== requestId));
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold text-stone-900">Join a Google Meet call</h2>
+        <p className="mt-1 text-sm text-stone-500">
+          Paste a Meet link and the agent will join the call as a named guest in a separate window.
+          The host needs to admit the agent from the Meet waiting room.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="block">
+          <span className="text-xs font-medium uppercase tracking-wide text-stone-500">
+            Meet link
+          </span>
+          <input
+            type="url"
+            inputMode="url"
+            autoComplete="off"
+            spellCheck={false}
+            value={meetUrl}
+            onChange={e => setMeetUrl(e.target.value)}
+            placeholder={PLACEHOLDER_URL}
+            className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            required
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-medium uppercase tracking-wide text-stone-500">
+            Display name
+          </span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={e => setDisplayName(e.target.value)}
+            maxLength={64}
+            className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100"
+            required
+          />
+        </label>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-xl border border-coral-200 bg-coral-50 px-3 py-2 text-sm text-coral-700">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !meetUrl.trim() || !displayName.trim()}
+          className="inline-flex items-center justify-center rounded-xl border border-primary-600 bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-soft transition hover:bg-primary-500 disabled:cursor-not-allowed disabled:opacity-50">
+          {submitting ? 'Opening Meet…' : 'Join call'}
+        </button>
+      </form>
+
+      {activeCalls.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-stone-500">
+            Active calls
+          </h3>
+          <ul className="space-y-2">
+            {activeCalls.map(call => (
+              <li
+                key={call.requestId}
+                className="flex items-center justify-between gap-3 rounded-xl border border-stone-200 bg-stone-50 px-3 py-2">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-stone-900">
+                    {call.displayName}
+                  </div>
+                  <div className="truncate text-xs text-stone-500">{call.meetUrl}</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleClose(call.requestId)}
+                  className="shrink-0 rounded-lg border border-stone-200 bg-white px-3 py-1 text-xs text-stone-600 hover:border-coral-300 hover:text-coral-600">
+                  Leave
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/intelligence/IntelligenceCallsTab.tsx
+++ b/app/src/components/intelligence/IntelligenceCallsTab.tsx
@@ -84,12 +84,16 @@ export default function IntelligenceCallsTab({ onToast }: Props) {
 
   const handleClose = async (requestId: string) => {
     try {
-      await closeMeetCall(requestId);
+      const closed = await closeMeetCall(requestId);
+      if (closed) {
+        // Only drop the row when the shell confirms the window is gone.
+        // The `meet-call:closed` event listener also clears the row, so
+        // a manual window-close still keeps the list accurate.
+        setActiveCalls(prev => prev.filter(call => call.requestId !== requestId));
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to close call.';
       onToast?.({ type: 'error', title: 'Could not close call', message });
-    } finally {
-      setActiveCalls(prev => prev.filter(call => call.requestId !== requestId));
     }
   };
 

--- a/app/src/pages/Intelligence.tsx
+++ b/app/src/pages/Intelligence.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { ConfirmationModal } from '../components/intelligence/ConfirmationModal';
+import IntelligenceCallsTab from '../components/intelligence/IntelligenceCallsTab';
 import IntelligenceDreamsTab from '../components/intelligence/IntelligenceDreamsTab';
 import IntelligenceSettingsTab from '../components/intelligence/IntelligenceSettingsTab';
 import IntelligenceSubconsciousTab from '../components/intelligence/IntelligenceSubconsciousTab';
@@ -20,7 +21,7 @@ import type {
   ToastNotification,
 } from '../types/intelligence';
 
-type IntelligenceTab = 'memory' | 'subconscious' | 'dreams' | 'settings';
+type IntelligenceTab = 'memory' | 'subconscious' | 'calls' | 'dreams' | 'settings';
 
 export default function Intelligence() {
   const { aiStatus } = useIntelligenceStats();
@@ -130,6 +131,7 @@ export default function Intelligence() {
   const tabs: { id: IntelligenceTab; label: string; comingSoon?: boolean }[] = [
     { id: 'memory', label: 'Memory' },
     { id: 'subconscious', label: 'Subconscious' },
+    { id: 'calls', label: 'Calls' },
     { id: 'dreams', label: 'Dreams', comingSoon: true },
     { id: 'settings', label: 'Settings' },
   ];
@@ -238,6 +240,8 @@ export default function Intelligence() {
                 triggering={subconsciousTriggering}
               />
             )}
+
+            {activeTab === 'calls' && <IntelligenceCallsTab onToast={addToast} />}
 
             {activeTab === 'dreams' && <IntelligenceDreamsTab />}
 

--- a/app/src/services/__tests__/meetCallService.test.ts
+++ b/app/src/services/__tests__/meetCallService.test.ts
@@ -1,0 +1,108 @@
+import { invoke, isTauri } from '@tauri-apps/api/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { callCoreRpc } from '../coreRpcClient';
+import { closeMeetCall, joinMeetCall } from '../meetCallService';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(), isTauri: vi.fn() }));
+
+vi.mock('../coreRpcClient', () => ({ callCoreRpc: vi.fn() }));
+
+describe('joinMeetCall', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isTauri).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects empty inputs without contacting the core', async () => {
+    await expect(joinMeetCall({ meetUrl: '   ', displayName: 'Alice' })).rejects.toThrow(
+      /Meet link/i
+    );
+    await expect(
+      joinMeetCall({ meetUrl: 'https://meet.google.com/abc-defg-hij', displayName: '' })
+    ).rejects.toThrow(/display name/i);
+    expect(callCoreRpc).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('chains the core RPC into the Tauri window-open command', async () => {
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      ok: true,
+      request_id: 'req-1',
+      meet_url: 'https://meet.google.com/abc-defg-hij',
+      display_name: 'Agent Alice',
+    } as never);
+    vi.mocked(invoke).mockResolvedValueOnce('meet-call-req-1');
+
+    const result = await joinMeetCall({
+      meetUrl: 'https://meet.google.com/abc-defg-hij',
+      displayName: 'Agent Alice',
+    });
+
+    expect(callCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.meet_join_call',
+      params: { meet_url: 'https://meet.google.com/abc-defg-hij', display_name: 'Agent Alice' },
+    });
+    expect(invoke).toHaveBeenCalledWith('meet_call_open_window', {
+      args: {
+        request_id: 'req-1',
+        meet_url: 'https://meet.google.com/abc-defg-hij',
+        display_name: 'Agent Alice',
+      },
+    });
+    expect(result).toEqual({
+      requestId: 'req-1',
+      meetUrl: 'https://meet.google.com/abc-defg-hij',
+      displayName: 'Agent Alice',
+      windowLabel: 'meet-call-req-1',
+    });
+  });
+
+  it('throws if core rejects the request', async () => {
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({ ok: false } as never);
+    await expect(
+      joinMeetCall({ meetUrl: 'https://meet.google.com/abc-defg-hij', displayName: 'Agent Alice' })
+    ).rejects.toThrow(/Core rejected/);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('refuses to open a window outside the desktop shell', async () => {
+    vi.mocked(isTauri).mockReturnValue(false);
+    vi.mocked(callCoreRpc).mockResolvedValueOnce({
+      ok: true,
+      request_id: 'req-1',
+      meet_url: 'https://meet.google.com/abc-defg-hij',
+      display_name: 'Agent Alice',
+    } as never);
+
+    await expect(
+      joinMeetCall({ meetUrl: 'https://meet.google.com/abc-defg-hij', displayName: 'Agent Alice' })
+    ).rejects.toThrow(/desktop app/);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe('closeMeetCall', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards the request_id and returns the shell result', async () => {
+    vi.mocked(isTauri).mockReturnValue(true);
+    vi.mocked(invoke).mockResolvedValueOnce(true);
+
+    await expect(closeMeetCall('req-1')).resolves.toBe(true);
+    expect(invoke).toHaveBeenCalledWith('meet_call_close_window', { requestId: 'req-1' });
+  });
+
+  it('is a no-op outside the desktop shell', async () => {
+    vi.mocked(isTauri).mockReturnValue(false);
+
+    await expect(closeMeetCall('req-1')).resolves.toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/services/meetCallService.ts
+++ b/app/src/services/meetCallService.ts
@@ -1,0 +1,71 @@
+// Frontend service for the "Join a Google Meet call" feature.
+//
+// Two-phase request:
+//  1. Call the core RPC `openhuman.meet_join_call` to validate inputs and
+//     mint a stable `request_id`. The core also logs the request — useful
+//     for an eventual call audit trail.
+//  2. Invoke the Tauri command `meet_call_open_window` to actually open
+//     the dedicated CEF webview window at the Meet URL.
+//
+// Splitting it this way keeps platform-specific window code in the shell
+// while the validation rules live (and are tested) in the core.
+import { invoke, isTauri } from '@tauri-apps/api/core';
+
+import { callCoreRpc } from './coreRpcClient';
+
+export type MeetJoinCallInput = { meetUrl: string; displayName: string };
+
+export type MeetJoinCallResult = {
+  requestId: string;
+  meetUrl: string;
+  displayName: string;
+  windowLabel: string;
+};
+
+type CoreJoinResponse = { ok: boolean; request_id: string; meet_url: string; display_name: string };
+
+export async function joinMeetCall(input: MeetJoinCallInput): Promise<MeetJoinCallResult> {
+  const meetUrl = input.meetUrl.trim();
+  const displayName = input.displayName.trim();
+
+  if (!meetUrl) throw new Error('Please paste a Google Meet link.');
+  if (!displayName) throw new Error('Please enter a display name.');
+
+  const rpcResult = await callCoreRpc<CoreJoinResponse>({
+    method: 'openhuman.meet_join_call',
+    params: { meet_url: meetUrl, display_name: displayName },
+  });
+
+  if (!rpcResult?.ok || !rpcResult.request_id) {
+    throw new Error('Core rejected the meet_join_call request.');
+  }
+
+  if (!isTauri()) {
+    // Outside the desktop shell we can't actually open a CEF window;
+    // surface this clearly so the dev knows the join is a no-op in the
+    // browser dev surface (`pnpm dev` web view).
+    throw new Error(
+      'Joining a Meet call requires the desktop app. Run `pnpm tauri dev` and try again.'
+    );
+  }
+
+  const windowLabel = await invoke<string>('meet_call_open_window', {
+    args: {
+      request_id: rpcResult.request_id,
+      meet_url: rpcResult.meet_url,
+      display_name: rpcResult.display_name,
+    },
+  });
+
+  return {
+    requestId: rpcResult.request_id,
+    meetUrl: rpcResult.meet_url,
+    displayName: rpcResult.display_name,
+    windowLabel,
+  };
+}
+
+export async function closeMeetCall(requestId: string): Promise<boolean> {
+  if (!isTauri()) return false;
+  return invoke<boolean>('meet_call_close_window', { requestId });
+}

--- a/app/src/services/meetCallService.ts
+++ b/app/src/services/meetCallService.ts
@@ -30,6 +30,14 @@ export async function joinMeetCall(input: MeetJoinCallInput): Promise<MeetJoinCa
 
   if (!meetUrl) throw new Error('Please paste a Google Meet link.');
   if (!displayName) throw new Error('Please enter a display name.');
+  // Refuse early outside the desktop shell so the browser dev surface
+  // (`pnpm dev`) doesn't mint a stray request_id on the core for a join
+  // attempt that has no chance of opening a CEF window.
+  if (!isTauri()) {
+    throw new Error(
+      'Joining a Meet call requires the desktop app. Run `pnpm tauri dev` and try again.'
+    );
+  }
 
   const rpcResult = await callCoreRpc<CoreJoinResponse>({
     method: 'openhuman.meet_join_call',
@@ -38,15 +46,6 @@ export async function joinMeetCall(input: MeetJoinCallInput): Promise<MeetJoinCa
 
   if (!rpcResult?.ok || !rpcResult.request_id) {
     throw new Error('Core rejected the meet_join_call request.');
-  }
-
-  if (!isTauri()) {
-    // Outside the desktop shell we can't actually open a CEF window;
-    // surface this clearly so the dev knows the join is a no-op in the
-    // browser dev surface (`pnpm dev` web view).
-    throw new Error(
-      'Joining a Meet call requires the desktop app. Run `pnpm tauri dev` and try again.'
-    );
   }
 
   let windowLabel: string;

--- a/app/src/services/meetCallService.ts
+++ b/app/src/services/meetCallService.ts
@@ -49,13 +49,29 @@ export async function joinMeetCall(input: MeetJoinCallInput): Promise<MeetJoinCa
     );
   }
 
-  const windowLabel = await invoke<string>('meet_call_open_window', {
-    args: {
-      request_id: rpcResult.request_id,
-      meet_url: rpcResult.meet_url,
-      display_name: rpcResult.display_name,
-    },
-  });
+  let windowLabel: string;
+  try {
+    windowLabel = await invoke<string>('meet_call_open_window', {
+      args: {
+        request_id: rpcResult.request_id,
+        meet_url: rpcResult.meet_url,
+        display_name: rpcResult.display_name,
+      },
+    });
+  } catch (err) {
+    // Tauri v2 rejects with a String (the Err side of `Result<_, String>`),
+    // not a JS Error. Wrap so the UI catch block — which checks
+    // `instanceof Error` — surfaces the real reason instead of a fallback.
+    const reason =
+      err instanceof Error
+        ? err.message
+        : typeof err === 'string'
+          ? err
+          : JSON.stringify(err);
+    // eslint-disable-next-line no-console
+    console.error('[meet-call] meet_call_open_window invoke rejected:', err);
+    throw new Error(`meet_call_open_window failed: ${reason}`);
+  }
 
   return {
     requestId: rpcResult.request_id,

--- a/app/src/services/meetCallService.ts
+++ b/app/src/services/meetCallService.ts
@@ -63,11 +63,7 @@ export async function joinMeetCall(input: MeetJoinCallInput): Promise<MeetJoinCa
     // not a JS Error. Wrap so the UI catch block — which checks
     // `instanceof Error` — surfaces the real reason instead of a fallback.
     const reason =
-      err instanceof Error
-        ? err.message
-        : typeof err === 'string'
-          ? err
-          : JSON.stringify(err);
+      err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
     // eslint-disable-next-line no-console
     console.error('[meet-call] meet_call_open_window invoke rejected:', err);
     throw new Error(`meet_call_open_window failed: ${reason}`);

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -207,6 +207,8 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     );
     // Integration notification ingest, triage, and per-provider settings
     controllers.extend(crate::openhuman::notifications::all_notifications_registered_controllers());
+    // Google Meet call-join request validation (shell handles the webview)
+    controllers.extend(crate::openhuman::meet::all_meet_registered_controllers());
     // Structured WhatsApp Web data — agent-facing read-only controllers (list/search).
     // The write-path ingest controller is registered separately in build_internal_only_controllers.
     controllers.extend(crate::openhuman::whatsapp_data::all_whatsapp_data_registered_controllers());
@@ -285,6 +287,8 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
     );
     // Integration notification ingest, triage, and per-provider settings
     schemas.extend(crate::openhuman::notifications::all_notifications_controller_schemas());
+    // Google Meet call-join request validation
+    schemas.extend(crate::openhuman::meet::all_meet_controller_schemas());
     // Structured WhatsApp Web data — local SQLite store, agent-queryable
     schemas.extend(crate::openhuman::whatsapp_data::all_whatsapp_data_controller_schemas());
     schemas
@@ -372,6 +376,10 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         "notification" => Some(
             "Integration notification ingest, triage scoring, listing, read-state, \
              and per-provider routing settings.",
+        ),
+        "meet" => Some(
+            "Validate Google Meet call-join requests and mint a request_id; the desktop \
+             shell opens the embedded CEF webview that joins the call as an anonymous guest.",
         ),
         "whatsapp_data" => Some(
             "Structured WhatsApp conversation and message store — list chats, read messages, and search across WhatsApp Web data.",

--- a/src/openhuman/about_app/catalog.rs
+++ b/src/openhuman/about_app/catalog.rs
@@ -859,6 +859,24 @@ const CAPABILITIES: &[Capability] = &[
         privacy: None,
     },
     // ── Update ──────────────────────────────────────────────────────────────
+    // ── Meet ────────────────────────────────────────────────────────────────
+    Capability {
+        id: "meet.join_call",
+        name: "Join Google Meet Calls",
+        domain: "meet",
+        category: CapabilityCategory::Channels,
+        description: "Join a Google Meet call as an anonymous guest in a dedicated CEF webview \
+                      window with an isolated profile. The host admits the agent from the \
+                      Meet waiting room.",
+        how_to: "Intelligence > Calls",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::Metadata,
+            destinations: &["Google Meet"],
+        }),
+    },
+    // ── Update ──────────────────────────────────────────────────────────────
     Capability {
         id: "update.check",
         name: "Check for Core Updates",

--- a/src/openhuman/about_app/catalog.rs
+++ b/src/openhuman/about_app/catalog.rs
@@ -866,8 +866,9 @@ const CAPABILITIES: &[Capability] = &[
         domain: "meet",
         category: CapabilityCategory::Channels,
         description: "Join a Google Meet call as an anonymous guest in a dedicated CEF webview \
-                      window with an isolated profile. The host admits the agent from the \
-                      Meet waiting room.",
+                      window with an isolated profile. The agent automatically dismisses the \
+                      device-check, types its display name, and clicks Ask-to-join via CDP; the \
+                      host admits the agent from the Meet waiting room.",
         how_to: "Intelligence > Calls",
         status: CapabilityStatus::Beta,
         privacy: Some(CapabilityPrivacy {

--- a/src/openhuman/about_app/catalog_tests.rs
+++ b/src/openhuman/about_app/catalog_tests.rs
@@ -78,6 +78,7 @@ fn catalog_includes_additional_user_facing_surfaces() {
         "auth.configure_tool_access",
         "settings.manage_service",
         "settings.clear_app_data",
+        "meet.join_call",
     ] {
         assert!(
             ids.contains(expected),

--- a/src/openhuman/meet/mod.rs
+++ b/src/openhuman/meet/mod.rs
@@ -1,0 +1,32 @@
+//! Google Meet integration domain.
+//!
+//! Lets a user ask the agent to join a Google Meet call as an anonymous
+//! guest. The core's responsibility is narrow:
+//!
+//!  - Validate that the supplied URL is a Google Meet meeting URL.
+//!  - Validate / trim the guest display name.
+//!  - Mint a `request_id` the desktop shell uses to label the per-call
+//!    webview window and its data directory.
+//!
+//! Everything to do with actually opening a CEF webview, driving Meet's
+//! join page over CDP, or surfacing a virtual camera lives in the Tauri
+//! shell (`app/src-tauri/src/...`) — keeping platform-specific code out
+//! of the core.
+//!
+//! ## Module layout
+//!
+//! - [`types`]   — request/response types for the join RPC
+//! - [`ops`]     — pure validation helpers (URL + display-name)
+//! - [`rpc`]     — async JSON-RPC handler functions
+//! - [`schemas`] — controller schema definitions and registered handler wrappers
+
+pub mod ops;
+pub mod rpc;
+pub mod schemas;
+pub mod types;
+
+pub use schemas::{
+    all_controller_schemas as all_meet_controller_schemas,
+    all_registered_controllers as all_meet_registered_controllers,
+};
+pub use types::*;

--- a/src/openhuman/meet/ops.rs
+++ b/src/openhuman/meet/ops.rs
@@ -1,0 +1,116 @@
+//! Pure helpers for the `meet` domain.
+//!
+//! Validation lives here so it can be unit-tested without standing up the
+//! full RPC machinery.
+
+/// Validate that a string is a Google Meet call URL we're willing to hand
+/// to the embedded webview.
+///
+/// We accept:
+///  - `https://meet.google.com/<code>` where `<code>` looks like a Meet
+///    meeting code (three lowercase-letter groups separated by `-`).
+///  - `https://meet.google.com/lookup/<id>` (Calendar deep links).
+///
+/// We reject any other host or scheme to keep the surface small — this
+/// RPC is *not* a generic "open any URL in CEF" entrypoint.
+pub fn validate_meet_url(raw: &str) -> Result<url::Url, String> {
+    let url = url::Url::parse(raw.trim()).map_err(|e| format!("invalid meet_url: {e}"))?;
+
+    if url.scheme() != "https" {
+        return Err(format!(
+            "invalid meet_url: scheme `{}` not allowed (only https)",
+            url.scheme()
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "invalid meet_url: missing host".to_string())?;
+    if host != "meet.google.com" {
+        return Err(format!(
+            "invalid meet_url: host `{host}` not allowed (only meet.google.com)"
+        ));
+    }
+
+    let path = url.path().trim_matches('/');
+    let allowed_path = is_meet_code(path) || path.starts_with("lookup/");
+    if !allowed_path {
+        return Err(format!(
+            "invalid meet_url: path `/{path}` is not a Meet meeting code or lookup link"
+        ));
+    }
+
+    Ok(url)
+}
+
+/// Trim and validate the display name. Meet's "Your name" field accepts a
+/// wide range, but we cap length to a sane value so a malformed payload
+/// can't push a 10MB string into the webview.
+pub fn validate_display_name(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("display_name must not be empty".into());
+    }
+    if trimmed.chars().count() > 64 {
+        return Err("display_name exceeds 64 characters".into());
+    }
+    if trimmed.chars().any(|c| c.is_control()) {
+        return Err("display_name contains control characters".into());
+    }
+    Ok(trimmed.to_string())
+}
+
+fn is_meet_code(path: &str) -> bool {
+    let parts: Vec<&str> = path.split('-').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    let lengths_ok = parts[0].len() >= 3 && parts[1].len() >= 3 && parts[2].len() >= 3;
+    let alpha_only = parts
+        .iter()
+        .all(|p| p.chars().all(|c| c.is_ascii_lowercase()));
+    lengths_ok && alpha_only
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_canonical_meet_code_url() {
+        let u = validate_meet_url("https://meet.google.com/abc-defg-hij").unwrap();
+        assert_eq!(u.host_str(), Some("meet.google.com"));
+    }
+
+    #[test]
+    fn accepts_lookup_url() {
+        validate_meet_url("https://meet.google.com/lookup/abcdef1234").unwrap();
+    }
+
+    #[test]
+    fn rejects_http_scheme() {
+        assert!(validate_meet_url("http://meet.google.com/abc-defg-hij").is_err());
+    }
+
+    #[test]
+    fn rejects_other_hosts() {
+        assert!(validate_meet_url("https://example.com/abc-defg-hij").is_err());
+        assert!(validate_meet_url("https://meet.google.evil.com/abc-defg-hij").is_err());
+    }
+
+    #[test]
+    fn rejects_nonsense_paths() {
+        assert!(validate_meet_url("https://meet.google.com/").is_err());
+        assert!(validate_meet_url("https://meet.google.com/foo").is_err());
+        assert!(validate_meet_url("https://meet.google.com/AB-CD-EF").is_err());
+    }
+
+    #[test]
+    fn trims_and_validates_display_name() {
+        assert_eq!(validate_display_name("  Alice  ").unwrap(), "Alice");
+        assert!(validate_display_name("").is_err());
+        assert!(validate_display_name("   ").is_err());
+        assert!(validate_display_name(&"x".repeat(65)).is_err());
+        assert!(validate_display_name("hi\nthere").is_err());
+    }
+}

--- a/src/openhuman/meet/ops.rs
+++ b/src/openhuman/meet/ops.rs
@@ -33,7 +33,7 @@ pub fn validate_meet_url(raw: &str) -> Result<url::Url, String> {
     }
 
     let path = url.path().trim_matches('/');
-    let allowed_path = is_meet_code(path) || path.starts_with("lookup/");
+    let allowed_path = is_meet_code(path) || is_lookup_path(path);
     if !allowed_path {
         return Err(format!(
             "invalid meet_url: path `/{path}` is not a Meet meeting code or lookup link"
@@ -41,6 +41,17 @@ pub fn validate_meet_url(raw: &str) -> Result<url::Url, String> {
     }
 
     Ok(url)
+}
+
+/// Accept exactly `lookup/<id>` with a single non-empty segment. Permitting
+/// nested paths under `lookup/` would broaden the attack surface beyond a
+/// call deep-link.
+fn is_lookup_path(path: &str) -> bool {
+    let mut parts = path.split('/');
+    matches!(
+        (parts.next(), parts.next(), parts.next()),
+        (Some("lookup"), Some(id), None) if !id.is_empty()
+    )
 }
 
 /// Trim and validate the display name. Meet's "Your name" field accepts a
@@ -103,6 +114,10 @@ mod tests {
         assert!(validate_meet_url("https://meet.google.com/").is_err());
         assert!(validate_meet_url("https://meet.google.com/foo").is_err());
         assert!(validate_meet_url("https://meet.google.com/AB-CD-EF").is_err());
+        // Nested paths under `lookup/` must stay rejected — only a single
+        // non-empty id segment is allowed.
+        assert!(validate_meet_url("https://meet.google.com/lookup/").is_err());
+        assert!(validate_meet_url("https://meet.google.com/lookup/abc/extra").is_err());
     }
 
     #[test]

--- a/src/openhuman/meet/rpc.rs
+++ b/src/openhuman/meet/rpc.rs
@@ -1,0 +1,47 @@
+//! JSON-RPC handler for the `meet` domain.
+//!
+//! `openhuman.meet_join_call` validates the request, mints a `request_id`,
+//! and returns a normalized echo. Opening the actual CEF webview window
+//! happens on the Tauri shell side, keyed by `request_id`. Keeping the
+//! RPC narrow lets the core stay platform-agnostic and lets future
+//! callers (CLI, scripts, RPC tests) reach the validation layer without
+//! pulling in the desktop shell.
+
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+use crate::rpc::RpcOutcome;
+
+use super::ops;
+use super::types::MeetJoinCallRequest;
+
+/// Handle `openhuman.meet_join_call`.
+pub async fn handle_join_call(params: Map<String, Value>) -> Result<Value, String> {
+    let req: MeetJoinCallRequest = serde_json::from_value(Value::Object(params))
+        .map_err(|e| format!("[meet] invalid join_call params: {e}"))?;
+
+    let normalized_url =
+        ops::validate_meet_url(&req.meet_url).map_err(|e| format!("[meet] {e}"))?;
+    let display_name =
+        ops::validate_display_name(&req.display_name).map_err(|e| format!("[meet] {e}"))?;
+
+    let request_id = Uuid::new_v4().to_string();
+    tracing::info!(
+        request_id = %request_id,
+        host = %normalized_url.host_str().unwrap_or(""),
+        path = %normalized_url.path(),
+        display_name_chars = display_name.chars().count(),
+        "[meet] meet_join_call accepted; awaiting shell handoff"
+    );
+
+    let outcome = RpcOutcome::new(
+        json!({
+            "ok": true,
+            "request_id": request_id,
+            "meet_url": normalized_url.as_str(),
+            "display_name": display_name,
+        }),
+        vec![],
+    );
+    outcome.into_cli_compatible_json()
+}

--- a/src/openhuman/meet/rpc.rs
+++ b/src/openhuman/meet/rpc.rs
@@ -26,10 +26,12 @@ pub async fn handle_join_call(params: Map<String, Value>) -> Result<Value, Strin
         ops::validate_display_name(&req.display_name).map_err(|e| format!("[meet] {e}"))?;
 
     let request_id = Uuid::new_v4().to_string();
+    // Path contains the meeting code, which is the secret that grants
+    // access to the call. Treat it like a credential and keep it out of
+    // logs — host + display-name length is enough for diagnostics.
     tracing::info!(
         request_id = %request_id,
         host = %normalized_url.host_str().unwrap_or(""),
-        path = %normalized_url.path(),
         display_name_chars = display_name.chars().count(),
         "[meet] meet_join_call accepted; awaiting shell handoff"
     );

--- a/src/openhuman/meet/schemas.rs
+++ b/src/openhuman/meet/schemas.rs
@@ -1,0 +1,175 @@
+//! Controller schema definitions and registered handlers for the `meet`
+//! domain.
+//!
+//! Mirrors the pattern used by `src/openhuman/notifications/schemas.rs`.
+
+use serde_json::{Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+
+type SchemaBuilder = fn() -> ControllerSchema;
+type ControllerHandler = fn(Map<String, Value>) -> ControllerFuture;
+
+struct MeetControllerDef {
+    function: &'static str,
+    schema: SchemaBuilder,
+    handler: ControllerHandler,
+}
+
+const MEET_CONTROLLER_DEFS: &[MeetControllerDef] = &[MeetControllerDef {
+    function: "join_call",
+    schema: schema_join_call,
+    handler: handle_join_call_wrap,
+}];
+
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    MEET_CONTROLLER_DEFS
+        .iter()
+        .map(|def| (def.schema)())
+        .collect()
+}
+
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    MEET_CONTROLLER_DEFS
+        .iter()
+        .map(|def| RegisteredController {
+            schema: (def.schema)(),
+            handler: def.handler,
+        })
+        .collect()
+}
+
+pub fn schemas(function: &str) -> ControllerSchema {
+    if let Some(def) = MEET_CONTROLLER_DEFS
+        .iter()
+        .find(|def| def.function == function)
+    {
+        return (def.schema)();
+    }
+    schema_unknown()
+}
+
+fn schema_join_call() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "meet",
+        function: "join_call",
+        description: "Validate a Google Meet URL and mint a request_id so the desktop \
+                          shell can open a dedicated CEF webview that joins the call as an \
+                          anonymous guest. Returns immediately — actual webview lifecycle \
+                          is handled by the Tauri shell, not the core.",
+        inputs: vec![
+            FieldSchema {
+                name: "meet_url",
+                ty: TypeSchema::String,
+                comment: "Full https://meet.google.com/<code> or /lookup/<id> URL.",
+                required: true,
+            },
+            FieldSchema {
+                name: "display_name",
+                ty: TypeSchema::String,
+                comment: "Display name shown to other participants when Meet prompts \
+                              for a guest name. Trimmed; max 64 characters; no control chars.",
+                required: true,
+            },
+        ],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "True when the request was validated and accepted.",
+                required: true,
+            },
+            FieldSchema {
+                name: "request_id",
+                ty: TypeSchema::String,
+                comment: "Stable UUID for this join attempt; used by the shell as the \
+                              webview-window label and per-call data directory.",
+                required: true,
+            },
+            FieldSchema {
+                name: "meet_url",
+                ty: TypeSchema::String,
+                comment: "Normalized Meet URL the shell should navigate to.",
+                required: true,
+            },
+            FieldSchema {
+                name: "display_name",
+                ty: TypeSchema::String,
+                comment: "Trimmed display name to use when joining.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn schema_unknown() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "meet",
+        function: "unknown",
+        description: "Unknown meet controller function.",
+        inputs: vec![FieldSchema {
+            name: "function",
+            ty: TypeSchema::String,
+            comment: "Unknown function requested.",
+            required: true,
+        }],
+        outputs: vec![FieldSchema {
+            name: "error",
+            ty: TypeSchema::String,
+            comment: "Lookup error details.",
+            required: true,
+        }],
+    }
+}
+
+fn handle_join_call_wrap(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::rpc::handle_join_call(params).await })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_call_schema_requires_meet_url_and_display_name() {
+        let s = schema_join_call();
+        assert_eq!(s.namespace, "meet");
+        assert_eq!(s.function, "join_call");
+        let required: Vec<_> = s
+            .inputs
+            .iter()
+            .filter(|f| f.required)
+            .map(|f| f.name)
+            .collect();
+        assert_eq!(required, vec!["meet_url", "display_name"]);
+    }
+
+    #[test]
+    fn registered_controllers_match_schemas() {
+        let schema_fns: Vec<_> = all_controller_schemas()
+            .into_iter()
+            .map(|s| s.function)
+            .collect();
+        let handler_fns: Vec<_> = all_registered_controllers()
+            .into_iter()
+            .map(|c| c.schema.function)
+            .collect();
+        assert_eq!(schema_fns, handler_fns);
+        assert_eq!(schema_fns, vec!["join_call"]);
+    }
+
+    #[test]
+    fn lookup_returns_unknown_for_missing_function() {
+        assert_eq!(schemas("nope").function, "unknown");
+    }
+
+    #[test]
+    fn join_call_outputs_include_request_id() {
+        let s = schema_join_call();
+        assert!(s
+            .outputs
+            .iter()
+            .any(|f| f.name == "request_id" && f.required));
+    }
+}

--- a/src/openhuman/meet/types.rs
+++ b/src/openhuman/meet/types.rs
@@ -1,0 +1,37 @@
+//! Request / response types for the `meet` domain.
+//!
+//! The `meet` domain captures the user's intent to have the agent join a
+//! Google Meet call as an anonymous guest. The actual webview lifecycle is
+//! handled by the Tauri shell — core's role is to validate the request,
+//! mint a stable `request_id`, and emit a domain event so any interested
+//! observer (frontend status pill, future audit log, the Tauri shell over
+//! the socket bridge) can react to it.
+
+use serde::{Deserialize, Serialize};
+
+/// Inputs to `openhuman.meet_join_call`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MeetJoinCallRequest {
+    /// Full Google Meet URL the agent should join, e.g.
+    /// `https://meet.google.com/abc-defg-hij`.
+    pub meet_url: String,
+    /// Display name used by the agent when prompted by Meet's
+    /// "Your name" field. Required because guest joins always need a name.
+    pub display_name: String,
+}
+
+/// Outputs from `openhuman.meet_join_call`.
+#[derive(Debug, Clone, Serialize)]
+pub struct MeetJoinCallResponse {
+    /// True when the request was accepted and a `request_id` was minted.
+    pub ok: bool,
+    /// Stable identifier for the join attempt. The Tauri shell uses this
+    /// as the per-call data-directory and webview-window label so multiple
+    /// concurrent calls don't collide.
+    pub request_id: String,
+    /// Echoed normalized URL, useful so the frontend can confirm what was
+    /// accepted and surface it in the call list/UI.
+    pub meet_url: String,
+    /// Echoed display name for the same reason.
+    pub display_name: String,
+}

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -37,6 +37,7 @@ pub mod heartbeat;
 pub mod integrations;
 pub mod learning;
 pub mod local_ai;
+pub mod meet;
 pub mod memory;
 pub mod migration;
 pub mod node_runtime;

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -3852,3 +3852,78 @@ async fn voice_cloud_transcribe_registered_e2e() {
     mock_join.abort();
     rpc_join.abort();
 }
+
+#[tokio::test]
+async fn json_rpc_meet_join_call_validates_and_returns_request_id() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{}", rpc_addr);
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // --- happy path: validates, returns ok + request_id + normalized echo ---
+    let ok = post_json_rpc(
+        &rpc_base,
+        9001,
+        "openhuman.meet_join_call",
+        json!({
+            "meet_url": "https://meet.google.com/abc-defg-hij",
+            "display_name": "  Agent Alice  "
+        }),
+    )
+    .await;
+    let result = assert_no_jsonrpc_error(&ok, "meet_join_call ok");
+    let body = result.get("result").unwrap_or(result);
+    assert_eq!(body.get("ok"), Some(&json!(true)));
+    let request_id = body
+        .get("request_id")
+        .and_then(|v| v.as_str())
+        .expect("request_id present");
+    assert!(!request_id.is_empty(), "request_id must not be empty");
+    assert_eq!(
+        body.get("meet_url").and_then(|v| v.as_str()),
+        Some("https://meet.google.com/abc-defg-hij"),
+        "echoed meet_url should be the normalized URL"
+    );
+    assert_eq!(
+        body.get("display_name").and_then(|v| v.as_str()),
+        Some("Agent Alice"),
+        "display_name should be trimmed before echo"
+    );
+
+    // --- bad host: rejected as JSON-RPC error ---
+    let bad_host = post_json_rpc(
+        &rpc_base,
+        9002,
+        "openhuman.meet_join_call",
+        json!({
+            "meet_url": "https://example.com/abc-defg-hij",
+            "display_name": "Agent"
+        }),
+    )
+    .await;
+    assert_jsonrpc_error(&bad_host, "meet_join_call bad_host");
+
+    // --- empty display name: rejected ---
+    let bad_name = post_json_rpc(
+        &rpc_base,
+        9003,
+        "openhuman.meet_join_call",
+        json!({
+            "meet_url": "https://meet.google.com/abc-defg-hij",
+            "display_name": "   "
+        }),
+    )
+    .await;
+    assert_jsonrpc_error(&bad_name, "meet_join_call bad_name");
+
+    rpc_join.abort();
+}


### PR DESCRIPTION
## Summary

- New **Intelligence > Calls** tab lets a user paste a Google Meet link and have the agent join the call as a named anonymous guest in a dedicated CEF webview window with an isolated profile.
- The agent walks the join page autonomously via CDP — types the display name, clicks "Ask to join" — without injecting any JS into the third-party origin.
- Process-level CEF launch flags (`--use-fake-device-for-media-stream` + `--use-file-for-fake-video-capture`) feed Chromium a one-frame Y4M rasterized from `remotion/public/mascot.svg`, so Meet sees the OpenHuman mascot as the agent's webcam.
- New `openhuman.meet_join_call` core RPC validates the URL/display name and mints a `request_id`; new `meet_call_open_window` / `meet_call_close_window` Tauri commands open/close the per-call webview keyed by that id.
- Capability catalog adds `meet.join_call` (Channels / Beta).

## Problem

The agent had no way to attend live conversations the user is asked to. We wanted a desktop path to drop the agent into a Meet call as a named guest, with a recognisable mascot face on camera, mic muted, and the entire join flow automated so the user doesn't have to hand-hold each step.

## Solution

Five layers, each with a single concern:

1. **`src/openhuman/meet/`** (Rust core) — pure validation domain. `openhuman.meet_join_call { meet_url, display_name }` enforces `https://meet.google.com/<code>` or `/lookup/<id>`, trims/length-checks the display name, mints a UUID `request_id`, returns the normalised echo. Wired into the controller registry the same way every other domain is.
2. **`app/src-tauri/src/meet_call/`** (shell) — `meet_call_open_window` / `meet_call_close_window` Tauri commands. Top-level `WebviewWindowBuilder` (separate window, not a child of the main window) with `<app_local_data_dir>/meet_call/<request_id>/` as a fresh data directory per call, so cookies stay isolated and Meet sees a brand-new anonymous user every time. Window-destroyed event emits `meet-call:closed` so the React tab keeps its in-flight list accurate.
3. **`app/src-tauri/src/meet_scanner/`** (shell) — fire-and-forget tokio task spawned right after the window builds. Connects to CEF's browser-level WebSocket (already exposed by the existing scanner infrastructure on `127.0.0.1:19222`), attaches to the new Meet target, then drives a three-phase state machine via `Runtime.evaluate` + `Input.insertText`:
   - dismiss the device-check screen (best-effort; with the fake camera in place this is a no-op),
   - focus the "Your name" input and inject the display name as a synthetic IME event,
   - click "Ask to join" (or "Join now").

   No init-script JS is injected — all driving runs from the scanner side per the project's CEF rule.
4. **`app/src-tauri/src/fake_camera/`** (shell) — at app startup, rasterises the OpenHuman mascot SVG into a 640×480 RGBA bitmap (via `resvg` + `tiny-skia`), converts it to YUV420 with BT.601 coefficients, and writes a one-frame YUV4MPEG2 file under `<data_dir>/cache/fake_camera/`. The path is passed to CEF via three launch flags so any webview that calls `getUserMedia({video:true})` reads the mascot frame in a loop. Cached across launches, keyed by SVG hash. Pure Rust, no system codecs.
5. **`app/src/components/intelligence/IntelligenceCallsTab.tsx`** + **`app/src/services/meetCallService.ts`** (frontend) — new "Calls" tab on the Intelligence page collects URL + display name, calls the core RPC, then invokes the Tauri command with the returned `request_id`. Listens to `meet-call:closed` so manual window-close clears the active-calls list.

End-to-end smoke run against a real Meet link: click → window opens → mascot in self-view → name typed → "Ask to join" pressed in ~6 seconds, all autonomously.

### Two debugging fixes that surfaced during the rollout (separate commits in this branch):

- `permissions/allow-core-process.toml` — Tauri v2 ACL gate. Custom commands registered in `invoke_handler!` still need explicit allow entries; without them the IPC layer rejects with `"Command not found"` before the Rust handler runs.
- `meetCallService.ts` — Tauri rejects with a `String` (the `Err` side of `Result<_, String>`), not a JS `Error`. The component's `instanceof Error` catch was dropping the real reason and falling back to a generic message; wrap+rethrow as a real `Error` plus `console.error` for the dev console.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only addition, no rows changed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: behaviour-only addition, no rows changed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy))
- [x] N/A: this PR adds an Intelligence-page surface, not release-cut wiring; `docs/RELEASE-MANUAL-SMOKE.md` does not need a new row.
- [x] N/A: no linked issue — this is a self-initiated feature.

## Impact

- **Desktop only.** The Tauri shell module guards itself with the existing `compile_error!` for non-desktop targets; the React surface refuses to open a window outside `isTauri()` with an explicit user-facing message.
- **Process-level CEF flags.** `--use-fake-device-for-media-stream` and `--use-file-for-fake-video-capture` apply to every CEF webview in the process. Today only the Meet call window deliberately requests a camera; existing provider webviews (WhatsApp, Telegram, Slack, Discord, Gmail, LinkedIn) don't call `getUserMedia({video:true})`, so this is a no-op for them. If a future feature needs a *real* camera in any webview, that surface will need to opt out of the fake stream.
- **Performance.** Mascot rasterisation runs once per launch (cached by SVG hash) and takes a few hundred ms in debug. Y4M file is ~460 KB. CEF reads it on demand and loops on EOF — no streaming pipeline is alive between calls.
- **Security.** All third-party-origin work runs from the scanner side (CDP); nothing host-controlled is injected into `meet.google.com`. The Tauri command sanitises `request_id` against path traversal before joining it into the data-directory path.
- **Migration / compatibility.** Adds `meet_call_open_window`, `meet_call_close_window` to `permissions/allow-core-process.toml` — required for Tauri v2 ACL.

## Related

- Closes:
- Follow-up PR(s)/TODOs: live mascot frames (Remotion → real virtual camera via macOS CoreMediaIO Extension); audio/TTS for full duplex agent presence; CDP-driven re-attempt if Meet times out the "Ask to join" request.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/gmeet
- Commit SHA: 9b79b7f0

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib openhuman::meet`, `cargo test --test json_rpc_e2e -- meet_join_call`, `cargo test --manifest-path app/src-tauri/Cargo.toml --lib meet_call`, `cargo test --manifest-path app/src-tauri/Cargo.toml --lib fake_camera`, `pnpm --filter openhuman-app test:unit run app/src/services/__tests__/meetCallService.test.ts`
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: new Calls tab on Intelligence page; new core RPC + two Tauri commands; CEF process-level fake camera flags.
- User-visible effect: paste Meet link → agent joins as anonymous guest in separate window with mascot on camera, mic muted, name pre-filled, "Ask to join" auto-clicked.

### Parity Contract
- Legacy behavior preserved: yes — no existing route/command/RPC altered.
- Guard/fallback/dispatch parity checks: fake-camera failure is non-fatal (logged, flags omitted); Tauri command rejects URLs that aren't on `meet.google.com`; scanner phases each fail-soft so the user can always finish manually.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Calls" tab to Intelligence for joining Google Meet calls with a custom display name.
  * Users can open and manage isolated per-call windows (Join / Leave) for Meet sessions.
  * Automated join assistance fills name and helps progress the join flow for convenience.
  * Optional mascot virtual camera feed can be used as a fake camera during Meet calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
