### PR TITLE
fix(store): keep coreMode unscoped so the local/cloud picker persists

### DIFF
--- a/app/src/store/userScopedStorage.ts
+++ b/app/src/store/userScopedStorage.ts
@@ -31,6 +31,27 @@ function safeGetActiveUserIdSync(): string | null {
 
 let activeUserId: string | null = safeGetActiveUserIdSync();
 
+// Recover from a prior buggy build that moved `persist:coreMode` into the
+// user-scoped namespace via `migrateLegacyPersistKeys`. The unscoped key is
+// authoritative; if it's missing but a scoped copy exists, copy it back so
+// the boot picker stops re-prompting on every launch.
+(function recoverUnscopedCoreMode(): void {
+  try {
+    if (localStorage.getItem('persist:coreMode') !== null) return;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !key.endsWith(':persist:coreMode')) continue;
+      const value = localStorage.getItem(key);
+      if (value === null) continue;
+      localStorage.setItem('persist:coreMode', value);
+      localStorage.removeItem(key);
+      break;
+    }
+  } catch {
+    // best-effort
+  }
+})();
+
 // Gate redux-persist's rehydrate on the boot prime from main.tsx
 // (which reads the authoritative id from `~/.openhuman/active_user.toml`
 // via the Rust core). The localStorage value used at module load is
@@ -115,11 +136,17 @@ export function setActiveUserId(id: string | null): void {
  */
 function migrateLegacyPersistKeys(id: string): void {
   const LEGACY_PREFIXES = ['persist:'];
+  // Keys that are intentionally pre-login / un-scoped and must NOT be moved
+  // into the per-user namespace. `persist:coreMode` is the local-vs-cloud
+  // mode picker — it lives in plain localStorage so it survives across user
+  // switches, and migrating it away makes the picker re-prompt every launch.
+  const UNSCOPED_KEYS = new Set(['persist:coreMode']);
   try {
     const legacyKeys: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
       if (!key) continue;
+      if (UNSCOPED_KEYS.has(key)) continue;
       if (LEGACY_PREFIXES.some(p => key.startsWith(p))) {
         legacyKeys.push(key);
       }


### PR DESCRIPTION
## Summary

- Stop the BootCheckGate local/cloud picker from re-prompting on every launch by keeping `persist:coreMode` out of the per-user namespace.
- Add a one-shot recovery shim that restores any previously-migrated `${userId}:persist:coreMode` back to the unscoped slot, so users already hit by the bug auto-heal on next launch.

## Problem

`coreMode` is intentionally pre-login / un-scoped — it's persisted via `localStorageAdapter` (plain `localStorage`) in `app/src/store/index.ts` so the user's choice survives across user switches. `migrateLegacyPersistKeys` in `app/src/store/userScopedStorage.ts` was indiscriminately migrating every `persist:*` key into `${userId}:persist:*` on the first identity assignment after launch, including `persist:coreMode`. Once moved (and removed from the unscoped slot), redux-persist couldn't find it on the next boot, rehydrated `coreMode` to `unset`, and the picker re-prompted every launch.

## Solution

- Maintain an `UNSCOPED_KEYS` set inside `migrateLegacyPersistKeys` and skip `persist:coreMode` so it stays where the unscoped `localStorageAdapter` expects it.
- Run a small `recoverUnscopedCoreMode` IIFE at module load: if the unscoped key is missing but a `*:persist:coreMode` scoped copy exists, copy it back to `persist:coreMode` and remove the scoped one. Best-effort, swallow storage errors.

## Submission Checklist

- [ ] N/A: bugfix is a one-line set-membership guard + a recovery shim — pending ask if maintainers want a Vitest spec for both branches before merge.
- [ ] N/A: changed-line coverage gate may flag the recovery IIFE; will add tests if CI fails the threshold.
- [ ] N/A: no feature rows added/removed/renamed.
- [ ] N/A: no matrix-listed feature IDs touched.
- [ ] N/A: no new network dependencies; storage layer only.
- [ ] N/A: no release-cut smoke surfaces touched.
- [x] No issue linked — surfaced in chat by the maintainer.

## Impact

- Desktop only (storage adapter is browser `localStorage` inside the Tauri webview). No migration required for fresh installs; users already in the broken state recover automatically on next launch via the recovery shim.
- No security or performance impact — single `localStorage` read on module load and one extra `Set.has` check per migrated key.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/coremode-picker-persistence`
- Commit SHA: `b7e63fee0f0a6331d359428142de6332d50a84c7`

### Validation Run
- [ ] N/A: `pnpm --filter openhuman-app format:check` — relying on CI; pre-existing repo-wide lint/format/TS warnings on `main` (e.g. missing `remotion` / `@remotion/zod-types` modules) make the pre-push hook fail on unrelated code.
- [ ] N/A: `pnpm typecheck` — pre-existing errors on `main` (missing `remotion` / `@remotion/*` packages in `MascotCharacter.tsx` etc.) unrelated to this PR. Pushed with `--no-verify` per `CLAUDE.md` policy.
- [ ] N/A: focused tests — no existing test file for `userScopedStorage`; can add one if reviewers want.
- [ ] N/A: Rust fmt/check — no Rust changes.
- [ ] N/A: Tauri fmt/check — no Tauri changes.

### Validation Blocked
- `command:` `pnpm compile`
- `error:` `Cannot find module '@remotion/zod-types' / 'remotion' / '@remotion/player'` in `app/src/features/human/Mascot/**` — pre-existing on `main`, unrelated to this change.
- `impact:` Pre-push hook bypassed with `--no-verify`. Local change typechecks cleanly in isolation.

### Behavior Changes
- Intended behavior change: BootCheckGate picker is shown only on first launch (or after explicit "Switch mode" / data wipe), not every cold boot.
- User-visible effect: Users no longer have to re-pick local/cloud on every app start.

### Parity Contract
- Legacy behavior preserved: All other `persist:*` keys still migrate to the user-scoped namespace exactly as before.
- Guard/fallback/dispatch parity checks: Recovery shim is best-effort and try/catches around `localStorage`; a no-op if the unscoped key already exists or no scoped copy is found.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A