### PR TITLE
feat(tools/whatsapp_data): expose local WhatsApp store to agent (#1341)

### DIFF
--- a/docs/TEST-COVERAGE-MATRIX.md
+++ b/docs/TEST-COVERAGE-MATRIX.md
@@ -327,6 +327,7 @@ Canonical mapping of every product feature to its test source(s). Drives gap-fil
 | ------ | ------------------------- | ----- | ----------------------------------------------------- | ------ | ----- |
 | 10.3.1 | Incoming Message Sync     | RU+WD | `src/openhuman/channels/tests/`, `gmail-flow.spec.ts` | ✅     |       |
 | 10.3.2 | Message Deduplication     | RU    | `src/openhuman/channels/tests/`                       | ✅     |       |
+| 10.3.3 | WhatsApp Agent Retrieval  | RU    | `src/openhuman/tools/impl/whatsapp_data/` (this PR), `tests/json_rpc_e2e.rs::whatsapp_data_agent_tools_e2e_1341` (this PR) | ✅     | Three read-only agent tools wrap the local SQLite store; ingest stays internal-only. See [`docs/whatsapp-data-flow.md`](whatsapp-data-flow.md). |
 | 10.3.3 | Real-Time vs Delayed Sync | RU    | `src/openhuman/channels/tests/runtime_dispatch.rs`    | ✅     |       |
 
 ### 10.4 Messaging Operations

--- a/docs/TEST-COVERAGE-MATRIX.md
+++ b/docs/TEST-COVERAGE-MATRIX.md
@@ -328,7 +328,7 @@ Canonical mapping of every product feature to its test source(s). Drives gap-fil
 | 10.3.1 | Incoming Message Sync     | RU+WD | `src/openhuman/channels/tests/`, `gmail-flow.spec.ts` | ✅     |       |
 | 10.3.2 | Message Deduplication     | RU    | `src/openhuman/channels/tests/`                       | ✅     |       |
 | 10.3.3 | WhatsApp Agent Retrieval  | RU    | `src/openhuman/tools/impl/whatsapp_data/` (this PR), `tests/json_rpc_e2e.rs::whatsapp_data_agent_tools_e2e_1341` (this PR) | ✅     | Three read-only agent tools wrap the local SQLite store; ingest stays internal-only. See [`docs/whatsapp-data-flow.md`](whatsapp-data-flow.md). |
-| 10.3.3 | Real-Time vs Delayed Sync | RU    | `src/openhuman/channels/tests/runtime_dispatch.rs`    | ✅     |       |
+| 10.3.4 | Real-Time vs Delayed Sync | RU    | `src/openhuman/channels/tests/runtime_dispatch.rs`    | ✅     |       |
 
 ### 10.4 Messaging Operations
 

--- a/docs/whatsapp-data-flow.md
+++ b/docs/whatsapp-data-flow.md
@@ -6,7 +6,7 @@ This document describes how WhatsApp Web data captured by the desktop scanner be
 
 ## Pipeline at a glance
 
-```
+```text
 ┌────────────────────────┐
 │ WhatsApp Web (CEF view)│
 └────────────┬───────────┘

--- a/docs/whatsapp-data-flow.md
+++ b/docs/whatsapp-data-flow.md
@@ -1,0 +1,78 @@
+# WhatsApp data flow — scanner, store, agent
+
+**Issue:** [#1341](https://github.com/tinyhumansai/openhuman/issues/1341)
+
+This document describes how WhatsApp Web data captured by the desktop scanner becomes available to the agent. It exists to clear up the most common confusion: there are **two** local storage paths and they are intentional, not duplicates — each backs a different agent capability.
+
+## Pipeline at a glance
+
+```
+┌────────────────────────┐
+│ WhatsApp Web (CEF view)│
+└────────────┬───────────┘
+             │  CDP scan tick
+             ▼
+┌────────────────────────────────────┐
+│ app/src-tauri/src/whatsapp_scanner │
+│ (DOM + IndexedDB merge)            │
+└─────┬───────────────────────┬──────┘
+      │ exact rows            │ canonicalised transcript
+      ▼                       ▼
+┌──────────────────────┐ ┌──────────────────────────┐
+│ openhuman.whatsapp_  │ │ openhuman.memory_doc_    │
+│ data_ingest          │ │ ingest                   │
+│ (internal-only RPC)  │ │ (internal-only RPC)      │
+└──────────┬───────────┘ └─────────────┬────────────┘
+           ▼                           ▼
+┌──────────────────────┐ ┌──────────────────────────┐
+│ whatsapp_data.db     │ │ memory tree              │
+│ (SQLite, per-account)│ │ (per-source summaries +  │
+│  - wa_chats          │ │  embeddings)             │
+│  - wa_messages       │ │                          │
+└──────────┬───────────┘ └─────────────┬────────────┘
+           ▼                           ▼
+┌──────────────────────┐ ┌──────────────────────────┐
+│ Agent tools          │ │ Agent tools              │
+│  whatsapp_data_*     │ │  memory_tree_*           │
+│  (exact lookup)      │ │  (semantic / cross-src)  │
+└──────────────────────┘ └──────────────────────────┘
+```
+
+Both ingest endpoints fire on every scan tick; both are `tokio::spawn` fire-and-forget so the scanner never blocks on either HTTP call.
+
+## Why two paths
+
+| Path | Backing store | Strength | Use it for |
+|------|---------------|----------|------------|
+| **Direct** | `whatsapp_data.db` (SQLite) | Exact, structured, paginated | "List my WhatsApp chats", "show the last 50 messages with Alice", "search for `invoice` across WhatsApp" |
+| **Memory tree** | Per-source memory tree + embeddings | Semantic, cross-source | "Summarise this week of WhatsApp", "find action items across email and WhatsApp", "what did the team agree on?" |
+
+The same scan tick populates both stores. Idempotency keys make the dual-write safe to retry:
+
+- `whatsapp_data_ingest` keys on `(account_id, chat_id, message_id)` — UPSERT.
+- `memory_doc_ingest` keys on `(namespace, key)` where namespace is `whatsapp-web:<account_id>` and key is `<chat_id>:<day>` — also UPSERT.
+
+If one path fails (network blip, store init race), the other still progresses. The next scan tick converges both stores.
+
+## Read-only boundary
+
+The scanner write-path RPCs are registered as **internal-only** in [`src/core/all.rs`](../src/core/all.rs) under `build_internal_only_controllers`. They are reachable over JSON-RPC but invisible to the agent's tool catalog and to schema discovery (`all_controller_schemas`). The agent has **no** way to call `whatsapp_data_ingest` or `memory_doc_ingest` — accidentally or otherwise.
+
+The agent surfaces are exclusively read-only:
+
+- [`src/openhuman/tools/impl/whatsapp_data/`](../src/openhuman/tools/impl/whatsapp_data/) — `whatsapp_data_list_chats`, `whatsapp_data_list_messages`, `whatsapp_data_search_messages`. All three wrap their RPC counterparts and emit a `"provider": "whatsapp"` tag in the response so the agent can cite WhatsApp as the source.
+- [`src/openhuman/tools/impl/memory/tree/`](../src/openhuman/tools/impl/memory/tree/) — generic `memory_tree_*` tools. Filter by `source_kind: "chat"` or query directly; WhatsApp chat-day transcripts are tagged `whatsapp` so they surface in cross-source flows.
+
+## Why the orchestrator only lists three of these
+
+The orchestrator's `agent.toml` exposes the three direct WhatsApp tools alongside the generic `memory_tree_*` family. That choice is deliberate — adding more provider-specific tools would compete with the memory-tree tools for the same intents and fragment routing. The combination satisfies the three real shapes of WhatsApp request:
+
+1. **Exact lookup** ("what was my last message with Bob") → `whatsapp_data_list_messages` after `whatsapp_data_list_chats`.
+2. **Keyword search** ("did anyone mention `Q3` on WhatsApp") → `whatsapp_data_search_messages`.
+3. **Summarisation / action items / cross-source** ("what came up across WhatsApp and email this week") → `memory_tree_query_source { source_kind: "chat" }` or `memory_tree_query_global`.
+
+If a future intent doesn't fit any of these, the right move is usually a new memory-tree retrieval primitive, not a new provider-specific tool.
+
+## What this fix changed (#1341)
+
+Prior to #1341 the read-only RPC controllers existed and were callable over JSON-RPC, but no `Tool` impl wrapped them and the orchestrator didn't list them — so the agent could see WhatsApp data only through the memory tree. That worked for summaries but failed on exact-lookup intents because the memory tree's per-day transcript granularity loses the structure the user asks about (sender JID, exact `chat_id`, per-message timestamp). Adding the three direct tools closed that gap without adding any new ingest path.

--- a/src/openhuman/agent/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent/agents/orchestrator/agent.toml
@@ -80,6 +80,16 @@ named = [
     "memory_tree_query_global",
     "memory_tree_drill_down",
     "memory_tree_fetch_leaves",
+    # WhatsApp local-data tools (issue #1341). The scanner ingests chats
+    # and messages into `whatsapp_data.db` on the user's machine; these
+    # three read-only tools let the orchestrator quote, summarise and
+    # search that local data without exposing the scanner's
+    # `whatsapp_data_ingest` write-path. Pair with the `memory_tree_*`
+    # tools above for cross-source / action-item flows once the scanner
+    # also forwards messages into the memory tree.
+    "whatsapp_data_list_chats",
+    "whatsapp_data_list_messages",
+    "whatsapp_data_search_messages",
     "read_workspace_state",
     "ask_user_clarification",
     "spawn_subagent",

--- a/src/openhuman/tools/impl/mod.rs
+++ b/src/openhuman/tools/impl/mod.rs
@@ -6,6 +6,7 @@ pub mod filesystem;
 pub mod memory;
 pub mod network;
 pub mod system;
+pub mod whatsapp_data;
 
 pub use agent::*;
 pub use browser::*;
@@ -15,3 +16,4 @@ pub use filesystem::*;
 pub use memory::*;
 pub use network::*;
 pub use system::*;
+pub use whatsapp_data::*;

--- a/src/openhuman/tools/impl/whatsapp_data/list_chats.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/list_chats.rs
@@ -50,11 +50,22 @@ impl Tool for WhatsAppDataListChatsTool {
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         log::debug!("[tool][whatsapp_data] list_chats invoked");
-        let req: ListChatsRequest = serde_json::from_value(args)
-            .map_err(|e| anyhow::anyhow!("invalid arguments for whatsapp_data_list_chats: {e}"))?;
+        let req: ListChatsRequest = serde_json::from_value(args).map_err(|e| {
+            log::debug!("[tool][whatsapp_data] list_chats invalid_args error={e}");
+            anyhow::anyhow!("invalid arguments for whatsapp_data_list_chats: {e}")
+        })?;
+        log::debug!(
+            "[tool][whatsapp_data] list_chats args has_account={} limit={:?} offset={:?}",
+            req.account_id.is_some(),
+            req.limit,
+            req.offset,
+        );
         let outcome = whatsapp_rpc::whatsapp_data_list_chats(req)
             .await
-            .map_err(|e| anyhow::anyhow!("whatsapp_data_list_chats: {e}"))?;
+            .map_err(|e| {
+                log::warn!("[tool][whatsapp_data] list_chats rpc_error error={e}");
+                anyhow::anyhow!("whatsapp_data_list_chats: {e}")
+            })?;
         let chats = outcome.value;
         log::debug!(
             "[tool][whatsapp_data] list_chats returning count={}",

--- a/src/openhuman/tools/impl/whatsapp_data/list_chats.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/list_chats.rs
@@ -13,13 +13,17 @@ impl Tool for WhatsAppDataListChatsTool {
     }
 
     fn description(&self) -> &str {
-        "List WhatsApp chats stored locally on this device, newest activity \
-         first. Use ONLY when the user asks about WhatsApp conversations or \
-         which WhatsApp contacts/groups they have been talking to. Each chat \
-         carries `chat_id`, `display_name`, `is_group`, `last_message_ts`, \
-         and `message_count`; use those to drive `whatsapp_data_list_messages` \
-         or `whatsapp_data_search_messages` afterwards. Returns provider \
-         provenance so replies can cite WhatsApp."
+        "List WhatsApp chats stored locally on this device, sorted by \
+         `last_message_ts` DESC (most recent activity first). USE THIS for \
+         intents about recent WhatsApp activity, identifying who the user \
+         spoke to recently, or resolving a contact/group name to a `chat_id`. \
+         Examples: 'who did I talk to on WhatsApp in the last 3 hours', \
+         'find my chat with Alice', 'which WhatsApp groups are active'. \
+         Each chat carries `chat_id`, `display_name`, `is_group`, \
+         `last_message_ts`, and `message_count`. After getting the chat \
+         list, drive `whatsapp_data_list_messages` (with the `chat_id`, \
+         optionally bounded by `since_ts`) for the message contents. \
+         Returns provider provenance so replies can cite WhatsApp."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/whatsapp_data/list_chats.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/list_chats.rs
@@ -1,0 +1,108 @@
+use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::whatsapp_data::rpc as whatsapp_rpc;
+use crate::openhuman::whatsapp_data::types::ListChatsRequest;
+use async_trait::async_trait;
+use serde_json::json;
+
+pub struct WhatsAppDataListChatsTool;
+
+#[async_trait]
+impl Tool for WhatsAppDataListChatsTool {
+    fn name(&self) -> &str {
+        "whatsapp_data_list_chats"
+    }
+
+    fn description(&self) -> &str {
+        "List WhatsApp chats stored locally on this device, newest activity \
+         first. Use ONLY when the user asks about WhatsApp conversations or \
+         which WhatsApp contacts/groups they have been talking to. Each chat \
+         carries `chat_id`, `display_name`, `is_group`, `last_message_ts`, \
+         and `message_count`; use those to drive `whatsapp_data_list_messages` \
+         or `whatsapp_data_search_messages` afterwards. Returns provider \
+         provenance so replies can cite WhatsApp."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "description": "Optional WhatsApp account JID. Omit to span every connected WhatsApp account."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum chats to return (default 50)."
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Pagination offset (default 0)."
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        log::debug!("[tool][whatsapp_data] list_chats invoked");
+        let req: ListChatsRequest = serde_json::from_value(args)
+            .map_err(|e| anyhow::anyhow!("invalid arguments for whatsapp_data_list_chats: {e}"))?;
+        let outcome = whatsapp_rpc::whatsapp_data_list_chats(req)
+            .await
+            .map_err(|e| anyhow::anyhow!("whatsapp_data_list_chats: {e}"))?;
+        let chats = outcome.value;
+        log::debug!(
+            "[tool][whatsapp_data] list_chats returning count={}",
+            chats.len()
+        );
+        let body = serde_json::to_string(&json!({
+            "provider": "whatsapp",
+            "count": chats.len(),
+            "chats": chats,
+        }))?;
+        Ok(ToolResult::success(body))
+    }
+
+    fn is_concurrency_safe(&self, _args: &serde_json::Value) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::tools::traits::{PermissionLevel, ToolScope};
+
+    #[test]
+    fn metadata_advertises_whatsapp() {
+        let tool = WhatsAppDataListChatsTool;
+        assert_eq!(tool.name(), "whatsapp_data_list_chats");
+        assert!(tool.description().contains("WhatsApp"));
+        assert_eq!(tool.permission_level(), PermissionLevel::ReadOnly);
+        assert_eq!(tool.scope(), ToolScope::All);
+        assert!(tool.is_concurrency_safe(&serde_json::Value::Null));
+    }
+
+    #[test]
+    fn parameters_schema_is_object_with_optional_fields() {
+        let schema = WhatsAppDataListChatsTool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        let props = &schema["properties"];
+        for key in ["account_id", "limit", "offset"] {
+            assert!(props.get(key).is_some(), "missing property {key}");
+        }
+        // No `required` array — every parameter is optional.
+        assert!(schema.get("required").is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_invalid_args() {
+        let tool = WhatsAppDataListChatsTool;
+        let err = tool
+            .execute(json!({ "limit": "not-a-number" }))
+            .await
+            .expect_err("expected invalid-args error");
+        assert!(err.to_string().contains("whatsapp_data_list_chats"));
+    }
+}

--- a/src/openhuman/tools/impl/whatsapp_data/list_messages.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/list_messages.rs
@@ -66,11 +66,23 @@ impl Tool for WhatsAppDataListMessagesTool {
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         log::debug!("[tool][whatsapp_data] list_messages invoked");
         let req: ListMessagesRequest = serde_json::from_value(args).map_err(|e| {
+            log::debug!("[tool][whatsapp_data] list_messages invalid_args error={e}");
             anyhow::anyhow!("invalid arguments for whatsapp_data_list_messages: {e}")
         })?;
+        log::debug!(
+            "[tool][whatsapp_data] list_messages args has_account={} has_chat=true limit={:?} offset={:?} has_since={} has_until={}",
+            req.account_id.is_some(),
+            req.limit,
+            req.offset,
+            req.since_ts.is_some(),
+            req.until_ts.is_some(),
+        );
         let outcome = whatsapp_rpc::whatsapp_data_list_messages(req)
             .await
-            .map_err(|e| anyhow::anyhow!("whatsapp_data_list_messages: {e}"))?;
+            .map_err(|e| {
+                log::warn!("[tool][whatsapp_data] list_messages rpc_error error={e}");
+                anyhow::anyhow!("whatsapp_data_list_messages: {e}")
+            })?;
         let messages = outcome.value;
         log::debug!(
             "[tool][whatsapp_data] list_messages returning count={}",

--- a/src/openhuman/tools/impl/whatsapp_data/list_messages.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/list_messages.rs
@@ -1,0 +1,121 @@
+use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::whatsapp_data::rpc as whatsapp_rpc;
+use crate::openhuman::whatsapp_data::types::ListMessagesRequest;
+use async_trait::async_trait;
+use serde_json::json;
+
+pub struct WhatsAppDataListMessagesTool;
+
+#[async_trait]
+impl Tool for WhatsAppDataListMessagesTool {
+    fn name(&self) -> &str {
+        "whatsapp_data_list_messages"
+    }
+
+    fn description(&self) -> &str {
+        "Return WhatsApp messages for one chat, ordered oldest-first within \
+         the requested time window. Use ONLY for WhatsApp summarisation, \
+         action-item extraction or quoting tasks where the user identifies a \
+         specific chat (group or contact). Pass the `chat_id` returned by \
+         `whatsapp_data_list_chats` (or `whatsapp_data_search_messages`); \
+         optionally bound the range with `since_ts` / `until_ts` (Unix \
+         seconds). Returns provider provenance so replies can cite WhatsApp."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string",
+                    "description": "WhatsApp chat JID, e.g. `1234567890@c.us` for a contact or `<id>@g.us` for a group. Required."
+                },
+                "account_id": {
+                    "type": "string",
+                    "description": "Optional WhatsApp account JID. Omit to span every connected account."
+                },
+                "since_ts": {
+                    "type": "integer",
+                    "description": "Lower bound (Unix seconds, inclusive) on message timestamp."
+                },
+                "until_ts": {
+                    "type": "integer",
+                    "description": "Upper bound (Unix seconds, inclusive) on message timestamp."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum messages to return (default 100)."
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Pagination offset (default 0)."
+                }
+            },
+            "required": ["chat_id"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        log::debug!("[tool][whatsapp_data] list_messages invoked");
+        let req: ListMessagesRequest = serde_json::from_value(args).map_err(|e| {
+            anyhow::anyhow!("invalid arguments for whatsapp_data_list_messages: {e}")
+        })?;
+        let outcome = whatsapp_rpc::whatsapp_data_list_messages(req)
+            .await
+            .map_err(|e| anyhow::anyhow!("whatsapp_data_list_messages: {e}"))?;
+        let messages = outcome.value;
+        log::debug!(
+            "[tool][whatsapp_data] list_messages returning count={}",
+            messages.len()
+        );
+        let body = serde_json::to_string(&json!({
+            "provider": "whatsapp",
+            "count": messages.len(),
+            "messages": messages,
+        }))?;
+        Ok(ToolResult::success(body))
+    }
+
+    fn is_concurrency_safe(&self, _args: &serde_json::Value) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::tools::traits::{PermissionLevel, ToolScope};
+
+    #[test]
+    fn metadata_advertises_whatsapp() {
+        let tool = WhatsAppDataListMessagesTool;
+        assert_eq!(tool.name(), "whatsapp_data_list_messages");
+        assert!(tool.description().contains("WhatsApp"));
+        assert_eq!(tool.permission_level(), PermissionLevel::ReadOnly);
+        assert_eq!(tool.scope(), ToolScope::All);
+        assert!(tool.is_concurrency_safe(&serde_json::Value::Null));
+    }
+
+    #[test]
+    fn parameters_schema_requires_chat_id() {
+        let schema = WhatsAppDataListMessagesTool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"]
+            .as_array()
+            .expect("required array present");
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert_eq!(names, vec!["chat_id"]);
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_missing_chat_id() {
+        let tool = WhatsAppDataListMessagesTool;
+        let err = tool
+            .execute(json!({}))
+            .await
+            .expect_err("expected missing chat_id error");
+        assert!(err.to_string().contains("whatsapp_data_list_messages"));
+    }
+}

--- a/src/openhuman/tools/impl/whatsapp_data/list_messages.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/list_messages.rs
@@ -14,12 +14,18 @@ impl Tool for WhatsAppDataListMessagesTool {
 
     fn description(&self) -> &str {
         "Return WhatsApp messages for one chat, ordered oldest-first within \
-         the requested time window. Use ONLY for WhatsApp summarisation, \
-         action-item extraction or quoting tasks where the user identifies a \
-         specific chat (group or contact). Pass the `chat_id` returned by \
-         `whatsapp_data_list_chats` (or `whatsapp_data_search_messages`); \
-         optionally bound the range with `since_ts` / `until_ts` (Unix \
-         seconds). Returns provider provenance so replies can cite WhatsApp."
+         the requested time window. USE THIS for any WhatsApp request scoped \
+         to a specific chat — summarisation, action-item extraction, \
+         quoting, or 'show me the last N messages with <person>'. ALSO use \
+         this (paired with `since_ts` from `current_time` minus N hours) for \
+         time-window reads like 'what did <person> message me in the last 3 \
+         hours' AFTER resolving the chat via `whatsapp_data_list_chats`. The \
+         `chat_id` arg is required — get it from `whatsapp_data_list_chats` \
+         (or `whatsapp_data_search_messages`); optionally bound the range \
+         with `since_ts` / `until_ts` (Unix seconds). Do NOT use \
+         `whatsapp_data_search_messages` for time-only queries — that tool \
+         is keyword-based, not time-based. Returns provider provenance so \
+         replies can cite WhatsApp."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/whatsapp_data/mod.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/mod.rs
@@ -1,0 +1,21 @@
+//! LLM-callable wrappers for the local WhatsApp data store (issue #1341).
+//!
+//! Each tool is a thin shim over one of the read-only RPC handlers in
+//! [`crate::openhuman::whatsapp_data::rpc`], unwrapping the `RpcOutcome`
+//! envelope and emitting a compact JSON object that includes a
+//! `"provider": "whatsapp"` provenance tag. The agent can then cite
+//! WhatsApp as the source without depending on field-level guessing.
+//!
+//! The write-path controller `whatsapp_data_ingest` is intentionally
+//! NOT wrapped here — it is registered as an internal-only controller
+//! in `src/core/all.rs` (the scanner is the only legitimate caller).
+//! Adding a Tool impl for it would reopen the read-only boundary that
+//! this module exists to preserve, so the omission is load-bearing.
+
+mod list_chats;
+mod list_messages;
+mod search_messages;
+
+pub use list_chats::WhatsAppDataListChatsTool;
+pub use list_messages::WhatsAppDataListMessagesTool;
+pub use search_messages::WhatsAppDataSearchMessagesTool;

--- a/src/openhuman/tools/impl/whatsapp_data/search_messages.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/search_messages.rs
@@ -13,12 +13,17 @@ impl Tool for WhatsAppDataSearchMessagesTool {
     }
 
     fn description(&self) -> &str {
-        "Case-insensitive substring search across stored WhatsApp message \
-         bodies, newest-first. Use ONLY for WhatsApp lookups by keyword, \
-         person name appearing in text, or topic phrase (e.g. \"what did \
-         <person> say on WhatsApp about <topic>\"). Optionally narrow with \
-         `chat_id` and/or `account_id`. Returns provider provenance so \
-         replies can cite WhatsApp."
+        "Case-insensitive substring search across stored WhatsApp messages, \
+         newest-first. Matches BOTH the message body AND the sender name, so \
+         a query of 'Alice' returns Alice's own messages even when the body \
+         does not contain the word 'Alice'. USE THIS for keyword lookups \
+         (specific words, phrases, project names, URLs in messages) and for \
+         'what did <person> say about <topic>' style intents. \
+         Do NOT use this for time-window queries like 'what did <person> say \
+         in the last 3 hours' — those go through `whatsapp_data_list_chats` \
+         to resolve the chat, then `whatsapp_data_list_messages` with \
+         `since_ts`. Optionally narrow with `chat_id` and/or `account_id`. \
+         Returns provider provenance so replies can cite WhatsApp."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/whatsapp_data/search_messages.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/search_messages.rs
@@ -56,11 +56,22 @@ impl Tool for WhatsAppDataSearchMessagesTool {
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         log::debug!("[tool][whatsapp_data] search_messages invoked");
         let req: SearchMessagesRequest = serde_json::from_value(args).map_err(|e| {
+            log::debug!("[tool][whatsapp_data] search_messages invalid_args error={e}");
             anyhow::anyhow!("invalid arguments for whatsapp_data_search_messages: {e}")
         })?;
+        log::debug!(
+            "[tool][whatsapp_data] search_messages args has_account={} has_chat={} limit={:?} query_len={}",
+            req.account_id.is_some(),
+            req.chat_id.is_some(),
+            req.limit,
+            req.query.len(),
+        );
         let outcome = whatsapp_rpc::whatsapp_data_search_messages(req)
             .await
-            .map_err(|e| anyhow::anyhow!("whatsapp_data_search_messages: {e}"))?;
+            .map_err(|e| {
+                log::warn!("[tool][whatsapp_data] search_messages rpc_error error={e}");
+                anyhow::anyhow!("whatsapp_data_search_messages: {e}")
+            })?;
         let messages = outcome.value;
         log::debug!(
             "[tool][whatsapp_data] search_messages returning count={}",

--- a/src/openhuman/tools/impl/whatsapp_data/search_messages.rs
+++ b/src/openhuman/tools/impl/whatsapp_data/search_messages.rs
@@ -1,0 +1,111 @@
+use crate::openhuman::tools::traits::{Tool, ToolResult};
+use crate::openhuman::whatsapp_data::rpc as whatsapp_rpc;
+use crate::openhuman::whatsapp_data::types::SearchMessagesRequest;
+use async_trait::async_trait;
+use serde_json::json;
+
+pub struct WhatsAppDataSearchMessagesTool;
+
+#[async_trait]
+impl Tool for WhatsAppDataSearchMessagesTool {
+    fn name(&self) -> &str {
+        "whatsapp_data_search_messages"
+    }
+
+    fn description(&self) -> &str {
+        "Case-insensitive substring search across stored WhatsApp message \
+         bodies, newest-first. Use ONLY for WhatsApp lookups by keyword, \
+         person name appearing in text, or topic phrase (e.g. \"what did \
+         <person> say on WhatsApp about <topic>\"). Optionally narrow with \
+         `chat_id` and/or `account_id`. Returns provider provenance so \
+         replies can cite WhatsApp."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Substring to match against message bodies (case-insensitive). Required."
+                },
+                "chat_id": {
+                    "type": "string",
+                    "description": "Optional WhatsApp chat JID to scope the search."
+                },
+                "account_id": {
+                    "type": "string",
+                    "description": "Optional WhatsApp account JID. Omit to span every connected account."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum messages to return (default 20)."
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        log::debug!("[tool][whatsapp_data] search_messages invoked");
+        let req: SearchMessagesRequest = serde_json::from_value(args).map_err(|e| {
+            anyhow::anyhow!("invalid arguments for whatsapp_data_search_messages: {e}")
+        })?;
+        let outcome = whatsapp_rpc::whatsapp_data_search_messages(req)
+            .await
+            .map_err(|e| anyhow::anyhow!("whatsapp_data_search_messages: {e}"))?;
+        let messages = outcome.value;
+        log::debug!(
+            "[tool][whatsapp_data] search_messages returning count={}",
+            messages.len()
+        );
+        let body = serde_json::to_string(&json!({
+            "provider": "whatsapp",
+            "count": messages.len(),
+            "messages": messages,
+        }))?;
+        Ok(ToolResult::success(body))
+    }
+
+    fn is_concurrency_safe(&self, _args: &serde_json::Value) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::tools::traits::{PermissionLevel, ToolScope};
+
+    #[test]
+    fn metadata_advertises_whatsapp() {
+        let tool = WhatsAppDataSearchMessagesTool;
+        assert_eq!(tool.name(), "whatsapp_data_search_messages");
+        assert!(tool.description().contains("WhatsApp"));
+        assert_eq!(tool.permission_level(), PermissionLevel::ReadOnly);
+        assert_eq!(tool.scope(), ToolScope::All);
+        assert!(tool.is_concurrency_safe(&serde_json::Value::Null));
+    }
+
+    #[test]
+    fn parameters_schema_requires_query() {
+        let schema = WhatsAppDataSearchMessagesTool.parameters_schema();
+        let required = schema["required"]
+            .as_array()
+            .expect("required array present");
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert_eq!(names, vec!["query"]);
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_missing_query() {
+        let tool = WhatsAppDataSearchMessagesTool;
+        let err = tool
+            .execute(json!({}))
+            .await
+            .expect_err("expected missing query error");
+        assert!(err.to_string().contains("whatsapp_data_search_messages"));
+    }
+}

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -140,6 +140,13 @@ pub fn all_tools_with_runtime(
         Box::new(MemoryTreeQueryGlobalTool),
         Box::new(MemoryTreeDrillDownTool),
         Box::new(MemoryTreeFetchLeavesTool),
+        // WhatsApp data store — read-only agent surface (issue #1341).
+        // The matching `whatsapp_data_ingest` write-path stays internal-only
+        // (registered in `src/core/all.rs::build_internal_only_controllers`)
+        // and is intentionally NOT wrapped here.
+        Box::new(WhatsAppDataListChatsTool),
+        Box::new(WhatsAppDataListMessagesTool),
+        Box::new(WhatsAppDataSearchMessagesTool),
         Box::new(ScheduleTool::new(security.clone(), root_config.clone())),
         Box::new(ProxyConfigTool::new(config.clone(), security.clone())),
         Box::new(GitOperationsTool::new(

--- a/src/openhuman/whatsapp_data/global.rs
+++ b/src/openhuman/whatsapp_data/global.rs
@@ -14,20 +14,28 @@
 //! ```
 
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, RwLock};
 
 use crate::openhuman::whatsapp_data::store::WhatsAppDataStore;
 
 /// Shared, thread-safe reference to the store.
 pub type WhatsAppDataStoreRef = Arc<WhatsAppDataStore>;
 
-static GLOBAL_STORE: OnceLock<WhatsAppDataStoreRef> = OnceLock::new();
+// `RwLock<Option<…>>` rather than `OnceLock` so tests can swap workspaces
+// between runs (each test uses its own temp dir; without reset, the second
+// test would attach to a dropped sqlite path). Production callers still get
+// strict idempotency: `init` is a no-op once a store is set.
+static GLOBAL_STORE: RwLock<Option<WhatsAppDataStoreRef>> = RwLock::new(None);
 
 /// Initialise the global store from a workspace directory. Idempotent —
 /// only the first call has any effect; subsequent calls return the existing
 /// instance.
 pub fn init(workspace_dir: PathBuf) -> Result<WhatsAppDataStoreRef, String> {
-    if let Some(existing) = GLOBAL_STORE.get() {
+    if let Some(existing) = GLOBAL_STORE
+        .read()
+        .map_err(|e| format!("[whatsapp_data:global] read lock poisoned: {e}"))?
+        .as_ref()
+    {
         log::debug!("[whatsapp_data:global] already initialised");
         return Ok(Arc::clone(existing));
     }
@@ -39,19 +47,44 @@ pub fn init(workspace_dir: PathBuf) -> Result<WhatsAppDataStoreRef, String> {
         WhatsAppDataStore::new(&workspace_dir)
             .map_err(|e| format!("[whatsapp_data] store init failed: {e}"))?,
     );
-    let _ = GLOBAL_STORE.set(Arc::clone(&store));
-    Ok(GLOBAL_STORE.get().cloned().unwrap_or(store))
+    let mut guard = GLOBAL_STORE
+        .write()
+        .map_err(|e| format!("[whatsapp_data:global] write lock poisoned: {e}"))?;
+    // Race-resolve: another caller may have inited while we were building.
+    if let Some(existing) = guard.as_ref() {
+        return Ok(Arc::clone(existing));
+    }
+    *guard = Some(Arc::clone(&store));
+    Ok(store)
 }
 
 /// Return the global store. Errors if [`init`] has not been called yet.
 pub fn store() -> Result<WhatsAppDataStoreRef, String> {
-    GLOBAL_STORE.get().cloned().ok_or_else(|| {
-        "whatsapp_data global store accessed before init — call init(workspace) at startup"
-            .to_string()
-    })
+    GLOBAL_STORE
+        .read()
+        .map_err(|e| format!("[whatsapp_data:global] read lock poisoned: {e}"))?
+        .as_ref()
+        .map(Arc::clone)
+        .ok_or_else(|| {
+            "whatsapp_data global store accessed before init — call init(workspace) at startup"
+                .to_string()
+        })
 }
 
 /// Return the global store if already initialised, without error.
 pub fn store_if_ready() -> Option<WhatsAppDataStoreRef> {
-    GLOBAL_STORE.get().cloned()
+    GLOBAL_STORE.read().ok()?.as_ref().map(Arc::clone)
+}
+
+/// Drop any currently-installed store handle so the next [`init`] re-binds
+/// the global to a fresh workspace. Reachable from integration tests under
+/// `tests/`, which see the crate as an external consumer and therefore can't
+/// use a `#[cfg(test)]`-only symbol. Production callers MUST NOT invoke this
+/// at runtime — the SQLite connection used by in-flight handlers would be
+/// released mid-call. Hidden from rustdoc to discourage misuse.
+#[doc(hidden)]
+pub fn reset_for_tests() {
+    if let Ok(mut guard) = GLOBAL_STORE.write() {
+        *guard = None;
+    }
 }

--- a/src/openhuman/whatsapp_data/global.rs
+++ b/src/openhuman/whatsapp_data/global.rs
@@ -79,9 +79,13 @@ pub fn store_if_ready() -> Option<WhatsAppDataStoreRef> {
 /// Drop any currently-installed store handle so the next [`init`] re-binds
 /// the global to a fresh workspace. Reachable from integration tests under
 /// `tests/`, which see the crate as an external consumer and therefore can't
-/// use a `#[cfg(test)]`-only symbol. Production callers MUST NOT invoke this
-/// at runtime — the SQLite connection used by in-flight handlers would be
-/// released mid-call. Hidden from rustdoc to discourage misuse.
+/// use a `#[cfg(test)]`-only symbol. Gated behind `cfg(any(test,
+/// debug_assertions))` so the symbol is compiled out of release builds —
+/// `cargo test` and dev builds keep `debug_assertions` on, `--release` turns
+/// it off. Production callers MUST NOT invoke this at runtime — the SQLite
+/// connection used by in-flight handlers would be released mid-call. Hidden
+/// from rustdoc to discourage misuse.
+#[cfg(any(test, debug_assertions))]
 #[doc(hidden)]
 pub fn reset_for_tests() {
     if let Ok(mut guard) = GLOBAL_STORE.write() {

--- a/src/openhuman/whatsapp_data/store.rs
+++ b/src/openhuman/whatsapp_data/store.rs
@@ -361,9 +361,11 @@ impl WhatsAppDataStore {
         let limit = req.limit.unwrap_or(20) as i64;
         let pattern = format!("%{}%", req.query.replace('%', "\\%").replace('_', "\\_"));
 
-        // Build the query dynamically depending on optional filters.
-        // Each branch binds to a local `rows` variable so `stmt` is dropped
-        // before the result is returned (fixes E0597 borrow lifetimes).
+        // Match against both `body` and `sender` so person-name queries like
+        // "what did Alice say" surface Alice's messages even when "Alice"
+        // does not appear in any message body. Branches are kept explicit so
+        // the bind indices stay readable; each `pattern` bind is duplicated
+        // because rusqlite does not resolve same-named placeholders for us.
         let msgs: Vec<WhatsAppMessage> = match (&req.account_id, &req.chat_id) {
             (Some(acct), Some(chat_id)) => {
                 let mut stmt = conn.prepare(
@@ -372,7 +374,7 @@ impl WhatsAppDataStore {
                      FROM wa_messages
                      WHERE account_id = ?1
                        AND chat_id    = ?2
-                       AND body LIKE ?3 ESCAPE '\\'
+                       AND (body LIKE ?3 ESCAPE '\\' OR sender LIKE ?3 ESCAPE '\\')
                      ORDER BY timestamp DESC
                      LIMIT ?4",
                 )?;
@@ -388,7 +390,7 @@ impl WhatsAppDataStore {
                             body, timestamp, message_type, source
                      FROM wa_messages
                      WHERE account_id = ?1
-                       AND body LIKE ?2 ESCAPE '\\'
+                       AND (body LIKE ?2 ESCAPE '\\' OR sender LIKE ?2 ESCAPE '\\')
                      ORDER BY timestamp DESC
                      LIMIT ?3",
                 )?;
@@ -404,7 +406,7 @@ impl WhatsAppDataStore {
                             body, timestamp, message_type, source
                      FROM wa_messages
                      WHERE chat_id = ?1
-                       AND body LIKE ?2 ESCAPE '\\'
+                       AND (body LIKE ?2 ESCAPE '\\' OR sender LIKE ?2 ESCAPE '\\')
                      ORDER BY timestamp DESC
                      LIMIT ?3",
                 )?;
@@ -419,7 +421,7 @@ impl WhatsAppDataStore {
                     "SELECT account_id, chat_id, message_id, sender, sender_jid, from_me,
                             body, timestamp, message_type, source
                      FROM wa_messages
-                     WHERE body LIKE ?1 ESCAPE '\\'
+                     WHERE body LIKE ?1 ESCAPE '\\' OR sender LIKE ?1 ESCAPE '\\'
                      ORDER BY timestamp DESC
                      LIMIT ?2",
                 )?;
@@ -609,6 +611,59 @@ mod tests {
         let results = store.search_messages(&req).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].body.contains("umbrella"));
+    }
+
+    #[test]
+    fn search_messages_matches_sender_name() {
+        // Person-name queries ("what did Alice say") only return rows when
+        // search also looks at the `sender` column, because the sender's own
+        // name almost never appears in the message body.
+        let (store, _tmp) = make_store();
+        let mut chats = HashMap::new();
+        chats.insert(
+            "chat-alice@c.us".to_string(),
+            ChatMeta {
+                name: Some("Alice Q".to_string()),
+            },
+        );
+        store.upsert_chats("acct1", &chats).unwrap();
+
+        let msgs = vec![
+            IngestMessage {
+                message_id: "alice-1".to_string(),
+                chat_id: "chat-alice@c.us".to_string(),
+                sender: Some("Alice".to_string()),
+                sender_jid: Some("alice@c.us".to_string()),
+                from_me: Some(false),
+                // Body has no "Alice" — match must come from the sender column.
+                body: Some("running 5 minutes late".to_string()),
+                timestamp: Some(1_700_001_000),
+                message_type: None,
+                source: Some("cdp-dom".to_string()),
+            },
+            IngestMessage {
+                message_id: "me-1".to_string(),
+                chat_id: "chat-alice@c.us".to_string(),
+                sender: Some("me".to_string()),
+                sender_jid: None,
+                from_me: Some(true),
+                body: Some("no problem".to_string()),
+                timestamp: Some(1_700_001_100),
+                message_type: None,
+                source: Some("cdp-dom".to_string()),
+            },
+        ];
+        store.upsert_messages("acct1", &msgs).unwrap();
+
+        let req = SearchMessagesRequest {
+            query: "Alice".to_string(),
+            chat_id: None,
+            account_id: None,
+            limit: None,
+        };
+        let results = store.search_messages(&req).unwrap();
+        assert_eq!(results.len(), 1, "expected sender-name match: {results:?}");
+        assert_eq!(results[0].sender, "Alice");
     }
 
     #[test]

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -3416,6 +3416,9 @@ async fn whatsapp_data_ingest_and_query_e2e() {
     write_min_config(&openhuman_home, &mock_origin);
 
     // Init the whatsapp_data global before the router handles any requests.
+    // Reset first so we attach to *this* test's tempdir even if a sibling
+    // test left a stale handle pointing at an already-dropped tempdir.
+    openhuman_core::openhuman::whatsapp_data::global::reset_for_tests();
     openhuman_core::openhuman::whatsapp_data::global::init(openhuman_home.clone())
         .expect("whatsapp_data global init");
 
@@ -4091,4 +4094,235 @@ async fn json_rpc_meet_agent_session_lifecycle() {
     assert_jsonrpc_error(&bogus, "stop_session unknown");
 
     rpc_join.abort();
+}
+
+/// End-to-end coverage for the WhatsApp agent tool wrappers shipped in
+/// issue #1341. Verifies that:
+///
+/// 1. Each of the three read-only tools (`whatsapp_data_list_chats`,
+///    `whatsapp_data_list_messages`, `whatsapp_data_search_messages`)
+///    correctly forwards into the existing RPC handlers and returns
+///    the rows ingested into `whatsapp_data.db`.
+/// 2. Every successful response carries the `"provider": "whatsapp"`
+///    provenance tag so the agent can cite WhatsApp as the source.
+/// 3. The internal-only `whatsapp_data_ingest` controller is **NOT**
+///    advertised in the agent-facing controller schema list, locking
+///    the read-only boundary the issue requires.
+#[tokio::test(flavor = "multi_thread")]
+async fn whatsapp_data_agent_tools_e2e_1341() {
+    use openhuman_core::openhuman::tools::traits::Tool;
+    use openhuman_core::openhuman::tools::{
+        WhatsAppDataListChatsTool, WhatsAppDataListMessagesTool, WhatsAppDataSearchMessagesTool,
+    };
+    use openhuman_core::openhuman::whatsapp_data::{
+        all_whatsapp_data_controller_schemas, global as wa_global, ops as wa_ops,
+        types::{ChatMeta, IngestMessage, IngestRequest},
+    };
+
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let openhuman_home = tmp.path().join(".openhuman");
+    std::fs::create_dir_all(&openhuman_home).expect("create openhuman home");
+
+    // The whatsapp_data global store is process-wide. Reset before init so
+    // we attach to *this* test's tempdir even if a sibling test already
+    // initialised the global to a tempdir that has since been dropped (which
+    // would leave the SQLite handle pointing at an unlinked file).
+    wa_global::reset_for_tests();
+    wa_global::init(openhuman_home.clone()).expect("whatsapp_data global init");
+
+    // ── 1. Ingest fixture data through the same path the scanner uses ─────
+    let now_ts = chrono::Utc::now().timestamp();
+    let mut chats = std::collections::HashMap::new();
+    chats.insert(
+        "alice@c.us".to_string(),
+        ChatMeta {
+            name: Some("Alice".to_string()),
+        },
+    );
+    chats.insert(
+        "team@g.us".to_string(),
+        ChatMeta {
+            name: Some("Team Group".to_string()),
+        },
+    );
+    let store = wa_global::store().expect("store ref");
+    wa_ops::ingest(
+        &store,
+        IngestRequest {
+            account_id: "agent-tools-acct@c.us".to_string(),
+            chats,
+            messages: vec![
+                IngestMessage {
+                    message_id: "m-alice-1".to_string(),
+                    chat_id: "alice@c.us".to_string(),
+                    sender: Some("Alice".to_string()),
+                    sender_jid: Some("alice@c.us".to_string()),
+                    from_me: Some(false),
+                    body: Some("Send the umbrella report by Friday".to_string()),
+                    timestamp: Some(now_ts - 3600),
+                    message_type: Some("chat".to_string()),
+                    source: Some("cdp-dom".to_string()),
+                },
+                IngestMessage {
+                    message_id: "m-alice-2".to_string(),
+                    chat_id: "alice@c.us".to_string(),
+                    sender: Some("me".to_string()),
+                    sender_jid: None,
+                    from_me: Some(true),
+                    body: Some("Got it, will share tomorrow".to_string()),
+                    timestamp: Some(now_ts - 3500),
+                    message_type: Some("chat".to_string()),
+                    source: Some("cdp-dom".to_string()),
+                },
+                IngestMessage {
+                    message_id: "m-team-1".to_string(),
+                    chat_id: "team@g.us".to_string(),
+                    sender: Some("Bob".to_string()),
+                    sender_jid: Some("bob@c.us".to_string()),
+                    from_me: Some(false),
+                    body: Some("Standup moved to 10am".to_string()),
+                    timestamp: Some(now_ts - 1800),
+                    message_type: Some("chat".to_string()),
+                    source: Some("cdp-indexeddb".to_string()),
+                },
+            ],
+        },
+    )
+    .expect("ingest");
+
+    // Helper: parse a successful Tool response back into JSON.
+    fn parse_tool_output(result: openhuman_core::openhuman::skills::types::ToolResult) -> Value {
+        assert!(!result.is_error, "tool returned error: {result:?}");
+        serde_json::from_str(&result.output()).expect("tool output is valid JSON")
+    }
+
+    // ── 2. list_chats — both fixture chats present, provider tag set ──────
+    let chats_body = parse_tool_output(
+        WhatsAppDataListChatsTool
+            .execute(json!({ "account_id": "agent-tools-acct@c.us" }))
+            .await
+            .expect("list_chats execute"),
+    );
+    assert_eq!(chats_body["provider"], "whatsapp");
+    assert_eq!(chats_body["count"], 2);
+    let chat_ids: Vec<&str> = chats_body["chats"]
+        .as_array()
+        .expect("chats array")
+        .iter()
+        .filter_map(|c| c["chat_id"].as_str())
+        .collect();
+    assert!(
+        chat_ids.contains(&"alice@c.us"),
+        "missing alice: {chats_body}"
+    );
+    assert!(
+        chat_ids.contains(&"team@g.us"),
+        "missing team: {chats_body}"
+    );
+
+    // ── 3. list_messages — chat_id required, returns chronological rows ───
+    let alice_body = parse_tool_output(
+        WhatsAppDataListMessagesTool
+            .execute(json!({
+                "chat_id": "alice@c.us",
+                "account_id": "agent-tools-acct@c.us"
+            }))
+            .await
+            .expect("list_messages execute"),
+    );
+    assert_eq!(alice_body["provider"], "whatsapp");
+    assert_eq!(alice_body["count"], 2);
+    let bodies: Vec<&str> = alice_body["messages"]
+        .as_array()
+        .expect("messages array")
+        .iter()
+        .filter_map(|m| m["body"].as_str())
+        .collect();
+    assert!(
+        bodies.iter().any(|b| b.contains("umbrella report")),
+        "expected umbrella message: {alice_body}"
+    );
+
+    // Missing chat_id should surface as an error.
+    let missing_chat = WhatsAppDataListMessagesTool
+        .execute(json!({}))
+        .await
+        .expect_err("expected missing chat_id error");
+    assert!(missing_chat
+        .to_string()
+        .contains("whatsapp_data_list_messages"));
+
+    // ── 4. search_messages — case-insensitive substring with scoping ──────
+    let search_body = parse_tool_output(
+        WhatsAppDataSearchMessagesTool
+            .execute(json!({
+                "query": "umbrella",
+                "account_id": "agent-tools-acct@c.us"
+            }))
+            .await
+            .expect("search_messages execute"),
+    );
+    assert_eq!(search_body["provider"], "whatsapp");
+    assert_eq!(search_body["count"], 1);
+    let hit = &search_body["messages"][0];
+    assert_eq!(hit["chat_id"], "alice@c.us");
+    assert_eq!(hit["account_id"], "agent-tools-acct@c.us");
+
+    // Empty-result search keeps the same envelope shape (scoped to this
+    // test's account so leftover rows from sibling tests can't interfere).
+    let empty_body = parse_tool_output(
+        WhatsAppDataSearchMessagesTool
+            .execute(json!({
+                "query": "no-such-token-anywhere",
+                "account_id": "agent-tools-acct@c.us"
+            }))
+            .await
+            .expect("search_messages empty execute"),
+    );
+    assert_eq!(empty_body["provider"], "whatsapp");
+    assert_eq!(empty_body["count"], 0);
+    assert!(empty_body["messages"]
+        .as_array()
+        .map(|a| a.is_empty())
+        .unwrap_or(false));
+
+    // ── 5. Boundary lock — agent-facing schemas exclude `whatsapp_data.ingest` ─
+    // ControllerSchema exposes `(namespace, function)` rather than a single
+    // method string. The agent-facing list MUST contain only the read-only
+    // verbs and MUST NOT advertise `ingest` (the scanner write path).
+    let advertised: Vec<(&'static str, &'static str)> = all_whatsapp_data_controller_schemas()
+        .iter()
+        .map(|s| (s.namespace, s.function))
+        .collect();
+    assert!(
+        !advertised.iter().any(|(_, f)| *f == "ingest"),
+        "ingest must NOT be advertised to agents: {advertised:?}"
+    );
+    for read_only in ["list_chats", "list_messages", "search_messages"] {
+        assert!(
+            advertised
+                .iter()
+                .any(|(ns, f)| *ns == "whatsapp_data" && *f == read_only),
+            "expected whatsapp_data.{read_only} in advertised schemas: {advertised:?}"
+        );
+    }
+
+    // ── 6. Tool metadata — names/descriptions reachable for downstream wiring ─
+    assert_eq!(WhatsAppDataListChatsTool.name(), "whatsapp_data_list_chats");
+    assert_eq!(
+        WhatsAppDataListMessagesTool.name(),
+        "whatsapp_data_list_messages"
+    );
+    assert_eq!(
+        WhatsAppDataSearchMessagesTool.name(),
+        "whatsapp_data_search_messages"
+    );
+    assert!(WhatsAppDataListChatsTool.description().contains("WhatsApp"));
+    assert!(WhatsAppDataListMessagesTool
+        .description()
+        .contains("WhatsApp"));
+    assert!(WhatsAppDataSearchMessagesTool
+        .description()
+        .contains("WhatsApp"));
 }


### PR DESCRIPTION
## Summary

- Adds three read-only agent tools — `whatsapp_data_list_chats`, `whatsapp_data_list_messages`, `whatsapp_data_search_messages` — wrapping the existing JSON-RPC handlers so the orchestrator can route exact-lookup, per-chat read, and keyword-search intents to the local SQLite store.
- Registers them in the default tool catalog and the orchestrator's `[tools].named` list. The internal-only `whatsapp_data_ingest` write path stays out of the agent surface.
- Each response is wrapped with `"provider": "whatsapp"` so replies can cite WhatsApp as the source.
- Documents the two-path storage model (direct store + memory tree) in `docs/whatsapp-data-flow.md` and adds matrix row `10.3.3`.
- Test-isolation fix: swaps `whatsapp_data::global` from `OnceLock` to `RwLock<Option<...>>` and adds a hidden `reset_for_tests()` so suites using their own tempdirs no longer inherit a stale sqlite handle.

## Problem

`whatsapp_data` already persists chats/messages locally and exposes read-only RPC handlers (`whatsapp_data_list_chats`, `whatsapp_data_list_messages`, `whatsapp_data_search_messages`), but the orchestrator could not reach them: no `Tool` impl wrapped them, and `src/openhuman/agent/agents/orchestrator/agent.toml` didn't list them. The agent could only see WhatsApp through the memory tree, which is great for summaries but loses the per-message structure (sender JID, exact `chat_id`, individual timestamps) that exact-lookup intents like "what did Alice say last Friday" need. Closes #1341.

## Solution

Three thin Tool impls under `src/openhuman/tools/impl/whatsapp_data/`, each modelled on `src/openhuman/tools/impl/memory/tree/query_global.rs`:

1. Deserialise args into the matching `*Request` from `whatsapp_data::types`.
2. Forward to `whatsapp_data::rpc::*`, unwrap the `RpcOutcome` envelope (the LLM does not need the logs side-channel).
3. Emit a compact JSON object: `{ provider: "whatsapp", count, chats|messages: [...] }` so provenance is unambiguous.

The new tools are registered in `all_tools_with_runtime` (`src/openhuman/tools/ops.rs`) alongside the `memory_tree_*` family; they are added to the orchestrator's named list. `whatsapp_data_ingest` is intentionally NOT wrapped — adding a Tool impl for it would reopen the read-only boundary that `src/core/all.rs::build_internal_only_controllers` enforces. A regression assertion in the new e2e test enforces that contract.

The `whatsapp_data::global` refactor was incidental: `OnceLock` plus per-call sqlite open meant a second e2e test using its own tempdir would inherit a handle pointing at an unlinked file ("Unable to open the database file"). Switching to `RwLock<Option<...>>` and adding `#[doc(hidden)] pub fn reset_for_tests()` keeps production semantics (init is a no-op once set) while letting tests rebind cleanly. The pre-existing `whatsapp_data_ingest_and_query_e2e` now resets before init too, so the suite is order-independent.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#failure-path-requirement) — new `whatsapp_data_agent_tools_e2e_1341` covers list/search/per-chat reads, missing-arg failures, empty-result envelope, and a boundary regression that asserts `whatsapp_data_ingest` is absent from the agent-facing schema set.
- [x] **Diff coverage ≥ 80%** — Each new Tool impl has unit tests for metadata, schema, and the invalid-args branch; `whatsapp_data_agent_tools_e2e_1341` exercises every `execute` path. Local quality gates green: `cargo test --lib openhuman::tools::implementations::whatsapp_data` (9/9), `cargo test --lib openhuman::whatsapp_data` (8/8), `cargo test --test json_rpc_e2e whatsapp` (3/3). Coverage gate enforced in CI by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml).
- [x] Coverage matrix updated — added row `10.3.3 WhatsApp Agent Retrieval` to [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md).
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [`docs/TESTING-STRATEGY.md`](../docs/TESTING-STRATEGY.md#mock-policy)).
- [x] N/A: this change does not alter release-cut surfaces — agent tooling is core-only and the existing WhatsApp scanner pipeline is unchanged.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Runtime**: desktop core only. Adds three Tool entries to the default catalog and three names to the orchestrator's tool list. No new background tasks, no new IPC, no UI surface.
- **Performance**: each tool call is one `RwLock::read` plus one sqlite `open_conn` (existing pattern from the RPC layer). No additional sync overhead.
- **Security**: read-only boundary is unchanged at the registry level, and explicitly tested. Local data stays local — no new network transport, no scanner write surface exposed.
- **Migration**: none. The `whatsapp_data::global` change is an internal refactor; the public API (`init`, `store`, `store_if_ready`) preserved.
- **Compatibility**: `reset_for_tests()` is `pub` so it is reachable from integration tests but doc-hidden and explicitly annotated as not for production use.

## Related

- Closes #1341
- Coverage matrix rows: `10.1.2 WhatsApp Connection` (existing, untouched), `10.3.1 Incoming Message Sync` (existing, untouched), `10.3.3 WhatsApp Agent Retrieval` (new, this PR).
- Architecture write-up: [`docs/whatsapp-data-flow.md`](../docs/whatsapp-data-flow.md).
- Follow-up PR(s)/TODOs: none planned. If a future intent surfaces that the existing tools cannot serve cleanly (e.g. group-aware ranking), the right next step is a new `memory_tree_*` retrieval primitive rather than a new provider-specific tool.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A — GitHub issue only
- URL: N/A

### Commit & Branch
- Branch: `feat/1341-whatsapp-agent-tools`
- Commit SHA: `7b4443d1` (tip)

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — frontend untouched.
- [x] N/A: `pnpm typecheck` — frontend untouched.
- [x] Focused tests: `cargo test --lib openhuman::tools::implementations::whatsapp_data` (9/9), `cargo test --lib openhuman::whatsapp_data` (8/8), `cargo test --test json_rpc_e2e whatsapp` (3/3 incl. the new `whatsapp_data_agent_tools_e2e_1341`).
- [x] Rust fmt/check (if changed): `cargo fmt -- --check` clean on the seven changed core files; `cargo check --tests` clean (only pre-existing warnings on `main`).
- [x] N/A: Tauri fmt/check — `app/src-tauri/` untouched in this PR.

### Validation Blocked
- N/A — all gates green locally.

### Behavior Changes
- Intended behavior change: orchestrator can now answer WhatsApp exact-lookup, per-chat read, and keyword-search intents directly against the local store; replies cite WhatsApp via the new `provider` provenance tag.
- User-visible effect: prompts like "summarise my WhatsApp messages with Alice" or "find action items from my WhatsApp" stop bouncing — they get grounded answers.

### Parity Contract
- Legacy behavior preserved: `memory_tree_*` tools continue to surface WhatsApp data via the scanner's existing `memory_doc_ingest` dual-write; the read-only/internal-only boundary at `src/core/all.rs::build_internal_only_controllers` is unchanged and explicitly tested.
- Guard/fallback/dispatch parity checks: regression test asserts `whatsapp_data_ingest` is not advertised in `all_whatsapp_data_controller_schemas()`; existing `whatsapp_data_ingest_and_query_e2e` and `whatsapp_memory_doc_ingest_e2e` continue to pass after the global refactor.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found.
- Canonical PR: this one.
- Resolution: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three read-only WhatsApp query tools: list chats, list messages for a chat, and search messages.

* **Documentation**
  * Added doc describing the WhatsApp ingestion pipeline, storage layout, and agent-facing retrieval surfaces.

* **Bug Fixes / Improvements**
  * Search now matches sender names as well as message text for more complete results.

* **Tests**
  * Added end-to-end tests validating tool behavior, provenance, schemas, ordering, search semantics, and improved test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
