### PR TITLE
🧹 Handle dontShowAgain preference in ConfirmationModal

### DIFF
--- a/app/src/components/intelligence/ConfirmationModal.tsx
+++ b/app/src/components/intelligence/ConfirmationModal.tsx
@@ -13,11 +13,15 @@ export function ConfirmationModal({ modal, onClose }: ConfirmationModalProps) {
   if (!modal.isOpen) return null;
 
   const handleConfirm = () => {
-    modal.onConfirm();
+    modal.onConfirm(dontShowAgain);
     onClose();
-    // TODO: Handle dontShowAgain preference storage
-    if (dontShowAgain) {
-      console.log('User chose to not show similar confirmations again');
+
+    if (dontShowAgain && modal.preferenceKey) {
+      try {
+        localStorage.setItem(modal.preferenceKey, 'true');
+      } catch (err) {
+        console.warn('Failed to save dontShowAgain preference to localStorage:', err);
+      }
     }
   };
 

--- a/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
+++ b/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { ConfirmationModal } from '../ConfirmationModal';
 
 describe('ConfirmationModal', () => {
@@ -60,11 +61,7 @@ describe('ConfirmationModal', () => {
     render(
       <ConfirmationModal
         {...defaultProps}
-        modal={{
-          ...defaultProps.modal,
-          showDontShowAgain: true,
-          onConfirm: onConfirmMock,
-        }}
+        modal={{ ...defaultProps.modal, showDontShowAgain: true, onConfirm: onConfirmMock }}
       />
     );
 

--- a/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
+++ b/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConfirmationModal } from '../ConfirmationModal';
 
 describe('ConfirmationModal', () => {

--- a/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
+++ b/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmationModal } from '../ConfirmationModal';
+
+describe('ConfirmationModal', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const defaultProps = {
+    modal: {
+      isOpen: true,
+      title: 'Test Modal',
+      message: 'Test Message',
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+    },
+    onClose: vi.fn(),
+  };
+
+  it('renders correctly', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    expect(screen.getByText('Test Message')).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Confirm'));
+    expect(defaultProps.modal.onConfirm).toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('handles dontShowAgain preference if showDontShowAgain is true', () => {
+    const onConfirmMock = vi.fn();
+    render(
+      <ConfirmationModal
+        {...defaultProps}
+        modal={{
+          ...defaultProps.modal,
+          showDontShowAgain: true,
+          preferenceKey: 'test-pref',
+          onConfirm: onConfirmMock,
+        }}
+      />
+    );
+
+    // Toggle the checkbox
+    fireEvent.click(screen.getByLabelText(/Don't show similar suggestions/i));
+
+    // Click confirm
+    fireEvent.click(screen.getByText('Confirm'));
+
+    expect(onConfirmMock).toHaveBeenCalledWith(true);
+    expect(localStorage.getItem('test-pref')).toBe('true');
+  });
+
+  it('does not store preference if preferenceKey is missing', () => {
+    const onConfirmMock = vi.fn();
+    render(
+      <ConfirmationModal
+        {...defaultProps}
+        modal={{
+          ...defaultProps.modal,
+          showDontShowAgain: true,
+          onConfirm: onConfirmMock,
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText(/Don't show similar suggestions/i));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    expect(onConfirmMock).toHaveBeenCalledWith(true);
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/app/src/types/intelligence.ts
+++ b/app/src/types/intelligence.ts
@@ -95,10 +95,11 @@ export interface ConfirmationModal {
   message: string;
   confirmText?: string;
   cancelText?: string;
-  onConfirm: () => void;
+  onConfirm: (dontShowAgain?: boolean) => void;
   onCancel: () => void;
   destructive?: boolean;
   showDontShowAgain?: boolean;
+  preferenceKey?: string;
 }
 
 // Chat message type


### PR DESCRIPTION
🎯 **What:** Handled the `dontShowAgain` preference storage inside `ConfirmationModal.tsx` utilizing `localStorage`, adding a safe fallback. Modified `ConfirmationModal` type by adding a `preferenceKey` parameter and updating `onConfirm` payload.
💡 **Why:** To improve code health by closing a lingering `TODO` and properly storing the user's preference boolean flag instead of writing to the console.
✅ **Verification:** Verified by ensuring format and linter pass and full `npm run test` suite runs without introducing regression failures.
✨ **Result:** Better UI reliability as "Don't show again" preferences are cleanly persisted on the user's machine securely.

---
*PR created automatically by Jules for task [11325387571019448931](https://jules.google.com/task/11325387571019448931) started by @senamakel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Confirmation dialogs now include a "don't show again" option. Users can choose to permanently dismiss recurring prompts, with their preferences automatically saved and persisted across sessions. This enhancement reduces unnecessary interruptions and provides a more streamlined experience when dealing with repetitive confirmation requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1410)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->