### PR TITLE
[Testing] Improve coverage for normalizeTeamUsage

### DIFF
--- a/app/src/services/api/__tests__/creditsApi.test.ts
+++ b/app/src/services/api/__tests__/creditsApi.test.ts
@@ -159,6 +159,40 @@ describe('normalizeTeamUsage', () => {
     expect(typeof result.cycleEndsAt).toBe('string');
   });
 
+  it('maps bypassRateLimit to bypassCycleLimit', () => {
+    const result = normalizeTeamUsage({ bypassRateLimit: true });
+    expect(result.bypassCycleLimit).toBe(true);
+  });
+
+  it('handles invalid payload types gracefully', () => {
+    expect(() => normalizeTeamUsage('string payload')).not.toThrow();
+    expect(() => normalizeTeamUsage(12345)).not.toThrow();
+    expect(() => normalizeTeamUsage(true)).not.toThrow();
+    expect(() => normalizeTeamUsage([])).not.toThrow();
+
+    const stringResult = normalizeTeamUsage('string payload');
+    expect(stringResult.remainingUsd).toBe(0);
+
+    const arrayResult = normalizeTeamUsage(['a', 'b']);
+    // Arrays pass typeof object check but don't have the expected properties
+    expect(arrayResult.remainingUsd).toBe(0);
+  });
+
+  it('falls back to current time for invalid date fields', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-10T12:00:00.000Z'));
+
+    const result = normalizeTeamUsage({
+      cycleStartDate: 12345, // invalid type
+      cycleEndsAt: null, // invalid type
+    });
+
+    expect(result.cycleStartDate).toBe('2026-05-10T12:00:00.000Z');
+    expect(result.cycleEndsAt).toBe('2026-05-10T12:00:00.000Z');
+
+    vi.useRealTimers();
+  });
+
   it('does not crash on null or undefined input', () => {
     expect(() => normalizeTeamUsage(null)).not.toThrow();
     expect(() => normalizeTeamUsage(undefined)).not.toThrow();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `normalizeTeamUsage` function lacked comprehensive tests for various edge cases, particularly when encountering invalid or unexpected payload types, as well as fallback scenarios for specific properties.

📊 **Coverage:** What scenarios are now tested
- Added a test to verify the correct fallback mapping of `bypassRateLimit` to `bypassCycleLimit`.
- Added tests to ensure the function gracefully handles invalid payload types (such as strings, numbers, booleans, and arrays) without throwing errors, properly falling back to default values.
- Added a test utilizing `vi.useFakeTimers()` to verify that invalid or missing date fields (`cycleStartDate`, `cycleEndsAt`) correctly fall back to the current system time.

✨ **Result:** The improvement in test coverage
The test coverage for `normalizeTeamUsage` and its surrounding code has been increased. The tests accurately capture the function's internal error-handling and fallback mechanisms, improving reliability and serving as a safety net for future refactors.

---
*PR created automatically by Jules for task [10392318791283606884](https://jules.google.com/task/10392318791283606884) started by @senamakel*