### PR TITLE
feat: handle dontShowAgain preference storage in ConfirmationModal

### DIFF
--- a/app/src/components/intelligence/ConfirmationModal.tsx
+++ b/app/src/components/intelligence/ConfirmationModal.tsx
@@ -2,6 +2,28 @@ import { useState } from 'react';
 
 import type { ConfirmationModal as ConfirmationModalType } from '../../types/intelligence';
 
+const DONT_SHOW_AGAIN_PREFIX = 'openhuman:dontShowAgain:';
+
+export function hasDontShowAgainPreference(key: string): boolean {
+  try {
+    return localStorage.getItem(`${DONT_SHOW_AGAIN_PREFIX}${key}`) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setDontShowAgainPreference(key: string, value: boolean): void {
+  try {
+    if (value) {
+      localStorage.setItem(`${DONT_SHOW_AGAIN_PREFIX}${key}`, 'true');
+    } else {
+      localStorage.removeItem(`${DONT_SHOW_AGAIN_PREFIX}${key}`);
+    }
+  } catch {
+    console.warn('Failed to save dontShowAgain preference to localStorage');
+  }
+}
+
 interface ConfirmationModalProps {
   modal: ConfirmationModalType;
   onClose: () => void;
@@ -15,9 +37,9 @@ export function ConfirmationModal({ modal, onClose }: ConfirmationModalProps) {
   const handleConfirm = () => {
     modal.onConfirm();
     onClose();
-    // TODO: Handle dontShowAgain preference storage
     if (dontShowAgain) {
-      console.log('User chose to not show similar confirmations again');
+      const key = modal.dontShowAgainKey || modal.title;
+      setDontShowAgainPreference(key, true);
     }
   };
 

--- a/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
+++ b/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ConfirmationModal,
+  hasDontShowAgainPreference,
+  setDontShowAgainPreference,
+} from '../ConfirmationModal';
+
+describe('ConfirmationModal preferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('hasDontShowAgainPreference', () => {
+    it('returns false when no preference is set', () => {
+      expect(hasDontShowAgainPreference('test-key')).toBe(false);
+    });
+
+    it('returns true when preference is set', () => {
+      localStorage.setItem('openhuman:dontShowAgain:test-key', 'true');
+      expect(hasDontShowAgainPreference('test-key')).toBe(true);
+    });
+
+    it('returns false when localStorage throws', () => {
+      const getItemMock = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('Quota exceeded');
+      });
+      expect(hasDontShowAgainPreference('test-key')).toBe(false);
+      getItemMock.mockRestore();
+    });
+  });
+
+  describe('setDontShowAgainPreference', () => {
+    it('sets the preference in localStorage', () => {
+      setDontShowAgainPreference('test-key', true);
+      expect(localStorage.getItem('openhuman:dontShowAgain:test-key')).toBe('true');
+    });
+
+    it('removes the preference from localStorage', () => {
+      localStorage.setItem('openhuman:dontShowAgain:test-key', 'true');
+      setDontShowAgainPreference('test-key', false);
+      expect(localStorage.getItem('openhuman:dontShowAgain:test-key')).toBeNull();
+    });
+
+    it('handles localStorage errors gracefully', () => {
+      const warnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const setItemMock = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('Quota exceeded');
+      });
+
+      expect(() => setDontShowAgainPreference('test-key', true)).not.toThrow();
+      expect(warnMock).toHaveBeenCalledWith(
+        'Failed to save dontShowAgain preference to localStorage',
+      );
+
+      setItemMock.mockRestore();
+      warnMock.mockRestore();
+    });
+  });
+
+  describe('ConfirmationModal component', () => {
+    const baseModal = {
+      isOpen: true,
+      title: 'Test Modal',
+      message: 'Test message',
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+      showDontShowAgain: true,
+      dontShowAgainKey: 'custom-key',
+    };
+
+    it('saves preference using dontShowAgainKey when checked and confirmed', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmationModal modal={baseModal} onClose={vi.fn()} />);
+
+      const checkbox = screen.getByRole('checkbox', { name: /don't show similar/i });
+      await user.click(checkbox);
+
+      const confirmButton = screen.getByRole('button', { name: /confirm/i });
+      await user.click(confirmButton);
+
+      expect(localStorage.getItem('openhuman:dontShowAgain:custom-key')).toBe('true');
+    });
+
+    it('falls back to title if dontShowAgainKey is not provided', async () => {
+      const user = userEvent.setup();
+      const modalWithoutKey = { ...baseModal, dontShowAgainKey: undefined };
+      render(<ConfirmationModal modal={modalWithoutKey} onClose={vi.fn()} />);
+
+      const checkbox = screen.getByRole('checkbox', { name: /don't show similar/i });
+      await user.click(checkbox);
+
+      const confirmButton = screen.getByRole('button', { name: /confirm/i });
+      await user.click(confirmButton);
+
+      expect(localStorage.getItem('openhuman:dontShowAgain:Test Modal')).toBe('true');
+    });
+
+    it('does not save preference if checkbox is not checked', async () => {
+      const user = userEvent.setup();
+      render(<ConfirmationModal modal={baseModal} onClose={vi.fn()} />);
+
+      const confirmButton = screen.getByRole('button', { name: /confirm/i });
+      await user.click(confirmButton);
+
+      expect(localStorage.getItem('openhuman:dontShowAgain:custom-key')).toBeNull();
+    });
+  });
+});

--- a/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
+++ b/app/src/components/intelligence/__tests__/ConfirmationModal.test.tsx
@@ -53,7 +53,7 @@ describe('ConfirmationModal preferences', () => {
 
       expect(() => setDontShowAgainPreference('test-key', true)).not.toThrow();
       expect(warnMock).toHaveBeenCalledWith(
-        'Failed to save dontShowAgain preference to localStorage',
+        'Failed to save dontShowAgain preference to localStorage'
       );
 
       setItemMock.mockRestore();

--- a/app/src/types/intelligence.ts
+++ b/app/src/types/intelligence.ts
@@ -99,6 +99,7 @@ export interface ConfirmationModal {
   onCancel: () => void;
   destructive?: boolean;
   showDontShowAgain?: boolean;
+  dontShowAgainKey?: string;
 }
 
 // Chat message type


### PR DESCRIPTION
Resolves the TODO in `ConfirmationModal` by persisting the "Don't show again" user preference.

- Added `dontShowAgainKey?: string` to `ConfirmationModal` interface.
- Implemented `hasDontShowAgainPreference` and `setDontShowAgainPreference` helper functions to safely store values in `localStorage`.
- Updated `handleConfirm` to save the preference, using `modal.dontShowAgainKey` or defaulting to `modal.title`.

---
*PR created automatically by Jules for task [8051465356393478955](https://jules.google.com/task/8051465356393478955) started by @senamakel*