### PR TITLE
🧪 Add tests for bearer_authorization_value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.20"
+version = "0.53.22"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src/api/jwt.rs
+++ b/src/api/jwt.rs
@@ -7,3 +7,26 @@ pub use crate::openhuman::credentials::{APP_SESSION_PROVIDER, DEFAULT_AUTH_PROFI
 pub fn bearer_authorization_value(token: &str) -> String {
     format!("Bearer {}", token.trim())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bearer_authorization_value() {
+        // Standard token
+        assert_eq!(bearer_authorization_value("my_token"), "Bearer my_token");
+
+        // Token with leading/trailing spaces
+        assert_eq!(bearer_authorization_value("  spaced_token  "), "Bearer spaced_token");
+
+        // Empty string
+        assert_eq!(bearer_authorization_value(""), "Bearer ");
+
+        // Whitespace only string
+        assert_eq!(bearer_authorization_value("   "), "Bearer ");
+
+        // Token with internal spaces (should not be trimmed)
+        assert_eq!(bearer_authorization_value("token with spaces"), "Bearer token with spaces");
+    }
+}

--- a/src/api/jwt.rs
+++ b/src/api/jwt.rs
@@ -18,7 +18,10 @@ mod tests {
         assert_eq!(bearer_authorization_value("my_token"), "Bearer my_token");
 
         // Token with leading/trailing spaces
-        assert_eq!(bearer_authorization_value("  spaced_token  "), "Bearer spaced_token");
+        assert_eq!(
+            bearer_authorization_value("  spaced_token  "),
+            "Bearer spaced_token"
+        );
 
         // Empty string
         assert_eq!(bearer_authorization_value(""), "Bearer ");
@@ -27,6 +30,9 @@ mod tests {
         assert_eq!(bearer_authorization_value("   "), "Bearer ");
 
         // Token with internal spaces (should not be trimmed)
-        assert_eq!(bearer_authorization_value("token with spaces"), "Bearer token with spaces");
+        assert_eq!(
+            bearer_authorization_value("token with spaces"),
+            "Bearer token with spaces"
+        );
     }
 }


### PR DESCRIPTION
🎯 **What:** Added tests for the `bearer_authorization_value` function in `src/api/jwt.rs` to address a testing gap.
📊 **Coverage:** The new test, `test_bearer_authorization_value`, covers standard tokens, tokens with leading/trailing spaces (to verify trimming), empty strings, whitespace-only strings, and tokens with internal spaces.
✨ **Result:** Improved test coverage and reliability for JWT token formatting, ensuring that the function behaves correctly across various input scenarios.

---
*PR created automatically by Jules for task [14864221432502655795](https://jules.google.com/task/14864221432502655795) started by @senamakel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for authorization token handling, including validation of standard tokens, whitespace trimming, and edge case scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1417)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->