### PR TITLE
🧪 Add tests for `summarize_rpc_result`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.20"
+version = "0.53.22"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src/core/rpc_log.rs
+++ b/src/core/rpc_log.rs
@@ -82,3 +82,27 @@ fn is_sensitive_key(key: &str) -> bool {
             | "client_secret"
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_summarize_rpc_result() {
+        assert_eq!(
+            summarize_rpc_result(&json!({"b": 2, "a": 1})),
+            "object(keys=a,b)"
+        );
+        assert_eq!(summarize_rpc_result(&json!({})), "object(keys=)");
+        assert_eq!(summarize_rpc_result(&json!([1, 2, 3])), "array(len=3)");
+        assert_eq!(summarize_rpc_result(&json!([])), "array(len=0)");
+        assert_eq!(summarize_rpc_result(&json!("hello")), "string(len=5)");
+        assert_eq!(summarize_rpc_result(&json!("")), "string(len=0)");
+        assert_eq!(summarize_rpc_result(&json!(true)), "bool(true)");
+        assert_eq!(summarize_rpc_result(&json!(false)), "bool(false)");
+        assert_eq!(summarize_rpc_result(&json!(42)), "number(42)");
+        assert_eq!(summarize_rpc_result(&json!(3.14)), "number(3.14)");
+        assert_eq!(summarize_rpc_result(&json!(null)), "null");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `summarize_rpc_result` in `src/core/rpc_log.rs` has been addressed. The function was previously lacking unit tests, making it vulnerable to regressions.

📊 **Coverage:** The new tests cover all possible `serde_json::Value` variants handled by the function:
- Objects (including key sorting logic)
- Arrays
- Strings
- Booleans
- Numbers
- Null values

✨ **Result:** Test coverage for `src/core/rpc_log.rs` has been improved, and we now have deterministic guarantees that `summarize_rpc_result` produces the correct summarized string format for each JSON type without causing accidental panics.

---
*PR created automatically by Jules for task [856030723458581258](https://jules.google.com/task/856030723458581258) started by @senamakel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for RPC result summarization, validating correct handling of various JSON data types including objects, arrays, strings, booleans, numbers, floats, and null values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1418)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->