### PR TITLE
feat(scripts): add `pnpm rabbit` to retrigger CodeRabbit after rate limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mock:api": "node scripts/mock-api-server.mjs",
     "mascot:render": "pnpm --dir remotion render:runtime-assets",
     "pr:checklist": "node scripts/check-pr-checklist.mjs",
+    "rabbit": "bash scripts/rabbit/cli.sh",
     "review": "bash scripts/review/cli.sh",
     "work": "bash scripts/work/cli.sh",
     "debug": "bash scripts/debug/cli.sh",

--- a/scripts/rabbit/README.md
+++ b/scripts/rabbit/README.md
@@ -1,0 +1,43 @@
+# scripts/rabbit
+
+Auto-retrigger CodeRabbit reviews on PRs whose rate-limit window has elapsed.
+
+CodeRabbit (Pro) reviews **5 PRs/hr** per developer. When you push a flurry of
+commits across several PRs, CR posts a "Rate limit exceeded — please wait
+N minutes" comment instead of reviewing. Once the wait elapses you have to
+manually comment `@coderabbitai review` on each PR. This script does that pass
+for you.
+
+## Usage
+
+```sh
+pnpm rabbit                # default: scan + retrigger up to 5 PRs
+pnpm rabbit list           # report-only; no comments posted
+pnpm rabbit run --dry-run  # show what would be retriggered
+pnpm rabbit run --max 3    # cap retriggers this run
+pnpm rabbit run --pr 1409  # one PR only
+pnpm rabbit run --grace 60 # wait 60s past CR's stated time before retriggering
+```
+
+Pair with `/loop` to drain a backlog automatically:
+
+```
+/loop 15m pnpm rabbit run --max 5
+```
+
+## How it works
+
+For each open PR:
+
+1. Pull `issues/<pr>/comments`, find CodeRabbit's latest comment.
+2. If it carries the marker `<!-- rate limited by coderabbit.ai -->`, parse the
+   stated wait (`Please wait **46 seconds**…`).
+3. Skip if CR has posted a non-rate-limit comment since (it recovered) or if
+   anyone has already commented `@coderabbitai review` after the rate-limit
+   notice (in flight).
+4. If `created_at + wait + grace` is in the past, post `@coderabbitai review`.
+
+## Config
+
+- `RABBIT_REPO=owner/name` — override target repo (default: `upstream` remote).
+- Requires `gh` and `node`.

--- a/scripts/rabbit/cli.mjs
+++ b/scripts/rabbit/cli.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+// Scan open PRs for CodeRabbit rate-limit comments and retrigger reviews
+// once the stated wait window has elapsed.
+//
+// CodeRabbit's rate-limit comment looks like:
+//   <!-- rate limited by coderabbit.ai -->
+//   ...Please wait **46 seconds** before requesting another review.
+// We parse the wait, add a small grace, and if `comment.created_at + wait`
+// is in the past — and no one has already retriggered — we post
+// `@coderabbitai review`.
+//
+// Pro plan limits CR to 5 PRs/hr, so cap retriggers per run.
+
+import { execFileSync } from "node:child_process";
+
+const RATE_LIMIT_MARKER = "rate limited by coderabbit.ai";
+const RETRIGGER_BODY = "@coderabbitai review";
+const CR_LOGINS = new Set(["coderabbitai", "coderabbitai[bot]"]);
+
+function gh(args, { input } = {}) {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    input,
+    stdio: input ? ["pipe", "pipe", "inherit"] : ["ignore", "pipe", "inherit"],
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+function resolveRepo() {
+  if (process.env.RABBIT_REPO) return process.env.RABBIT_REPO;
+  for (const remote of ["upstream", "origin"]) {
+    try {
+      const url = execFileSync("git", ["remote", "get-url", remote], {
+        encoding: "utf8",
+      }).trim();
+      const m = url.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+      if (m) return m[1];
+    } catch {
+      // try next
+    }
+  }
+  throw new Error("could not resolve repo (set RABBIT_REPO=owner/name)");
+}
+
+function parseArgs(argv) {
+  const out = {
+    cmd: argv[0] ?? "run",
+    max: 5,
+    dryRun: false,
+    pr: null,
+    graceSec: 30,
+  };
+  for (let i = 1; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--max") out.max = Number(argv[++i]);
+    else if (a === "--pr") out.pr = Number(argv[++i]);
+    else if (a === "--grace") out.graceSec = Number(argv[++i]);
+    else if (a === "-h" || a === "--help") {
+      out.cmd = "help";
+    } else {
+      throw new Error(`unknown arg: ${a}`);
+    }
+  }
+  return out;
+}
+
+// Convert "1 hour and 5 minutes and 30 seconds" / "46 seconds" / "5 minutes"
+// to seconds. CR uses `**46 seconds**` style — strip markdown asterisks first.
+function parseWaitSeconds(body) {
+  const m = body.match(/Please wait\s+([^.<]+?)\s+before requesting/i);
+  if (!m) return null;
+  const raw = m[1].replace(/\*+/g, "").trim();
+  const parts = raw.split(/\s*(?:,|and)\s*/i);
+  let total = 0;
+  for (const part of parts) {
+    const pm = part.match(/^(\d+)\s*(second|minute|hour)s?$/i);
+    if (!pm) return null;
+    const n = Number(pm[1]);
+    const unit = pm[2].toLowerCase();
+    total += n * (unit === "second" ? 1 : unit === "minute" ? 60 : 3600);
+  }
+  return total > 0 ? total : null;
+}
+
+function fetchOpenPrs(repo) {
+  const out = gh([
+    "pr",
+    "list",
+    "-R",
+    repo,
+    "--state",
+    "open",
+    "--json",
+    "number,title,author,isDraft",
+    "--limit",
+    "100",
+  ]);
+  return JSON.parse(out);
+}
+
+function fetchIssueComments(repo, pr) {
+  const out = gh([
+    "api",
+    "--paginate",
+    `repos/${repo}/issues/${pr}/comments?per_page=100`,
+  ]);
+  // gh --paginate concatenates JSON arrays; parse leniently.
+  try {
+    return JSON.parse(out);
+  } catch {
+    // Fallback: split on `][` boundary inserted between pages.
+    return JSON.parse("[" + out.replace(/\]\s*\[/g, ",").slice(1, -1) + "]");
+  }
+}
+
+function postComment(repo, pr, body) {
+  gh(
+    [
+      "api",
+      "-X",
+      "POST",
+      `repos/${repo}/issues/${pr}/comments`,
+      "-f",
+      `body=${body}`,
+    ],
+    {},
+  );
+}
+
+// For one PR: returns { status, ... } describing what to do.
+//   status: "no-cr" | "no-rate-limit" | "already-retriggered"
+//         | "review-since" | "waiting" | "ready"
+function analyzePr(comments, graceSec) {
+  const crComments = comments.filter((c) => CR_LOGINS.has(c.user?.login));
+  if (crComments.length === 0) return { status: "no-cr" };
+
+  // Latest CR comment overall.
+  const latestCr = crComments[crComments.length - 1];
+  const latestRateLimit = [...crComments]
+    .reverse()
+    .find((c) => c.body.includes(RATE_LIMIT_MARKER));
+
+  if (!latestRateLimit) return { status: "no-rate-limit" };
+
+  // If CR has already posted a non-rate-limit comment AFTER the rate limit,
+  // it has effectively recovered — skip.
+  if (
+    latestCr !== latestRateLimit &&
+    new Date(latestCr.created_at) > new Date(latestRateLimit.created_at) &&
+    !latestCr.body.includes(RATE_LIMIT_MARKER)
+  ) {
+    return { status: "review-since" };
+  }
+
+  // If anyone (us or otherwise) has already posted `@coderabbitai review`
+  // after the rate limit, don't double-trigger.
+  const retriggerSince = comments.find(
+    (c) =>
+      new Date(c.created_at) > new Date(latestRateLimit.created_at) &&
+      c.body.trim().toLowerCase().startsWith(RETRIGGER_BODY),
+  );
+  if (retriggerSince) {
+    return { status: "already-retriggered", at: retriggerSince.created_at };
+  }
+
+  const waitSec = parseWaitSeconds(latestRateLimit.body);
+  if (waitSec == null) {
+    return { status: "ready", reason: "unparseable wait — assuming elapsed" };
+  }
+
+  const expiresAt =
+    new Date(latestRateLimit.created_at).getTime() +
+    (waitSec + graceSec) * 1000;
+  const now = Date.now();
+  if (now < expiresAt) {
+    return {
+      status: "waiting",
+      remainingSec: Math.ceil((expiresAt - now) / 1000),
+      ratedLimitedAt: latestRateLimit.created_at,
+    };
+  }
+
+  return {
+    status: "ready",
+    waitSec,
+    ratedLimitedAt: latestRateLimit.created_at,
+  };
+}
+
+function fmtAge(iso) {
+  const sec = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (sec < 60) return `${Math.round(sec)}s ago`;
+  if (sec < 3600) return `${Math.round(sec / 60)}m ago`;
+  return `${(sec / 3600).toFixed(1)}h ago`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.cmd === "help") {
+    console.log("Usage: pnpm rabbit [run|list] [--max N] [--dry-run] [--pr N] [--grace SEC]");
+    return;
+  }
+
+  const repo = resolveRepo();
+  console.log(`[rabbit] repo: ${repo}`);
+
+  let prs = fetchOpenPrs(repo);
+  if (args.pr) prs = prs.filter((p) => p.number === args.pr);
+
+  let triggered = 0;
+  const summary = [];
+
+  for (const pr of prs) {
+    if (args.cmd === "run" && triggered >= args.max) {
+      summary.push(`#${pr.number}  skipped (max ${args.max} reached)`);
+      continue;
+    }
+
+    let comments;
+    try {
+      comments = fetchIssueComments(repo, pr.number);
+    } catch (e) {
+      summary.push(`#${pr.number}  error fetching comments: ${e.message}`);
+      continue;
+    }
+
+    const result = analyzePr(comments, args.graceSec);
+    const tag = `#${pr.number}`.padEnd(7);
+
+    switch (result.status) {
+      case "no-cr":
+        summary.push(`${tag} no CodeRabbit comments`);
+        break;
+      case "no-rate-limit":
+        summary.push(`${tag} no rate limit`);
+        break;
+      case "review-since":
+        summary.push(`${tag} CR reviewed since rate-limit`);
+        break;
+      case "already-retriggered":
+        summary.push(
+          `${tag} already retriggered (${fmtAge(result.at)}) — waiting for CR`,
+        );
+        break;
+      case "waiting": {
+        const m = Math.floor(result.remainingSec / 60);
+        const s = result.remainingSec % 60;
+        summary.push(
+          `${tag} rate-limited (${fmtAge(result.ratedLimitedAt)}); ${m}m${s}s left`,
+        );
+        break;
+      }
+      case "ready":
+        if (args.cmd === "list" || args.dryRun) {
+          summary.push(`${tag} READY — would retrigger`);
+        } else {
+          try {
+            postComment(repo, pr.number, RETRIGGER_BODY);
+            triggered += 1;
+            summary.push(`${tag} retriggered (${triggered}/${args.max})`);
+          } catch (e) {
+            summary.push(`${tag} retrigger failed: ${e.message}`);
+          }
+        }
+        break;
+      default:
+        summary.push(`${tag} unknown state`);
+    }
+  }
+
+  console.log("\n" + summary.join("\n"));
+  console.log(
+    `\n[rabbit] ${args.cmd === "run" ? "retriggered" : "ready"}: ${
+      args.cmd === "run" ? triggered : summary.filter((l) => l.includes("READY")).length
+    }`,
+  );
+}
+
+main().catch((e) => {
+  console.error(`[rabbit] fatal: ${e.stack || e.message}`);
+  process.exit(1);
+});

--- a/scripts/rabbit/cli.sh
+++ b/scripts/rabbit/cli.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Dispatcher for `pnpm rabbit <cmd>`.
+# Commands: run (default) | list
+
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: pnpm rabbit [command] [args]
+
+Commands:
+  run           Scan open PRs, retrigger CodeRabbit on any whose rate-limit
+                window has elapsed. Default command.
+                Flags:
+                  --max N        Cap retriggers this run (default: 5).
+                  --dry-run      Print what would be done; post nothing.
+                  --pr <num>     Only consider this PR.
+                  --grace <sec>  Extra seconds past CR's stated wait before
+                                 retriggering (default: 30).
+  list          Print rate-limit status for each open PR; post nothing.
+
+Env:
+  RABBIT_REPO=owner/name        Override target repo (default: upstream remote).
+
+CodeRabbit Pro reviews 5 PRs/hr — keep --max in line with your plan.
+EOF
+}
+
+cmd="${1:-run}"
+case "$cmd" in
+  -h|--help) usage; exit 0 ;;
+  run|list) shift || true ;;
+  *)
+    # Treat unknown first arg as flags to `run`.
+    cmd="run"
+    ;;
+esac
+
+exec node "$here/cli.mjs" "$cmd" "$@"


### PR DESCRIPTION
## Summary

- Add `pnpm rabbit` — a small Node script that scans open PRs, finds CodeRabbit rate-limit comments, and posts `@coderabbitai review` once the stated wait window has elapsed.
- Wire it into the existing `scripts/<area>/cli.sh` pattern alongside `pnpm review` / `pnpm work`.
- Defaults cap retriggers at 5/run to match CodeRabbit Pro's 5 PRs/hr limit; pair with `/loop 15m pnpm rabbit run` to drain a backlog.

## Problem

When several PRs get pushes in quick succession, CodeRabbit (Pro plan) hits its 5 PRs/hr cap and posts a "Rate limit exceeded — please wait N seconds" comment instead of reviewing. After the wait elapses you have to remember which PRs were rate-limited and manually post `@coderabbitai review` on each. Easy to forget, and easy to over-trigger and lose another slot to the same hourly cap.

## Solution

`scripts/rabbit/cli.mjs`:

1. Lists open PRs (filtered to `--pr <num>` if given).
2. For each, pulls issue comments and finds CodeRabbit's latest comment.
3. Detects the rate-limit marker (`<!-- rate limited by coderabbit.ai -->`) and parses the stated wait (`Please wait **46 seconds**…` / minutes / hours, with `,`/`and` separators).
4. Skips PRs where CR has posted a non-rate-limit comment since (it recovered) or where someone has already commented `@coderabbitai review` after the rate limit (in flight).
5. If `created_at + wait + grace` is in the past, posts `@coderabbitai review` via `gh api`.

Flags: `list` (report-only), `--dry-run`, `--max N`, `--pr N`, `--grace SEC`. Repo resolves from the `upstream` remote (override with `RABBIT_REPO`).

Smoke-tested against the live PR list — correctly identified 3 rate-limited PRs whose window had elapsed and skipped 1 where CR had already reviewed since.

## Submission Checklist

- [x] N/A: tooling-only script with no runtime/product code paths; no unit-test harness exists for `scripts/*`.
- [x] N/A: no app/Rust source touched, so the diff-coverage gate (Vitest + cargo-llvm-cov) doesn't apply.
- [x] N/A: behaviour-only/dev-tooling change, no feature row in the coverage matrix.
- [x] N/A: no feature IDs touched.
- [x] No new external network dependencies introduced — uses only `gh` CLI which is already required by sibling scripts.
- [x] N/A: not a release-cut surface.
- [x] N/A: no linked issue.

## Impact

- Dev-tooling only. No runtime, app, or core changes.
- New top-level command: `pnpm rabbit` (and `pnpm rabbit list`).
- Requires `gh` and `node` (both already required by `scripts/review/`).

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/rabbit-coderabbit-retrigger
- Commit SHA: 5e33d7b6

### Validation Run
- [x] N/A: tooling-only, no app sources changed.
- [x] N/A: tooling-only, no app sources changed.
- [x] Focused tests: `pnpm rabbit list` against live `tinyhumansai/openhuman` open PRs — output verified.
- [x] N/A: no Rust changes.
- [x] N/A: no Tauri changes.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: adds a new `pnpm rabbit` command; no existing behavior changed.
- User-visible effect: developers can run `pnpm rabbit` to auto-retrigger CodeRabbit on rate-limited PRs.

### Parity Contract
- Legacy behavior preserved: yes — purely additive.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `rabbit` automation tool that automatically scans and re-triggers CodeRabbit reviews on pull requests once their rate-limit windows have elapsed, reducing manual intervention.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1421)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
