### PR TITLE
🧪 [testing improvement] Add tests for decrypt_handoff_blob

### DIFF
--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,4 +1,4 @@
-use super::key_bytes_from_string;
+use super::{decrypt_handoff_blob, key_bytes_from_string};
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 
@@ -44,4 +44,72 @@ fn trims_whitespace() {
 fn rejects_wrong_length() {
     let err = key_bytes_from_string("tooshort").unwrap_err();
     assert!(err.to_string().contains("must decode to 32 raw bytes"));
+}
+
+#[test]
+fn decrypts_valid_blob() {
+    // Generated via Node.js crypto:
+    // Key: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
+    // B64: JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==
+    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+    let b64 = "JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==";
+    let decrypted = decrypt_handoff_blob(b64, key).unwrap();
+    assert_eq!(decrypted, "hello world");
+}
+
+#[test]
+fn decrypt_fails_if_too_short() {
+    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+    let b64 = STANDARD.encode([0u8; 31]);
+    let err = decrypt_handoff_blob(&b64, key).unwrap_err();
+    assert!(err.to_string().contains("encrypted payload too short"));
+}
+
+#[test]
+fn decrypt_fails_on_invalid_base64() {
+    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+    let err = decrypt_handoff_blob("not-base64!!!", key).unwrap_err();
+    assert!(err.to_string().contains("base64-decode encrypted payload"));
+}
+
+#[test]
+fn decrypt_fails_on_wrong_key() {
+    let key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; // wrong key
+    let b64 = "JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==";
+    let err = decrypt_handoff_blob(b64, key).unwrap_err();
+    assert!(err.to_string().contains("AES-GCM decrypt failed"));
+}
+
+#[test]
+fn decrypt_fails_on_tampered_ciphertext() {
+    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+    let mut combined = STANDARD.decode("JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==").unwrap();
+    // Tamper with the last byte of ciphertext
+    let last = combined.len() - 1;
+    combined[last] ^= 0xFF;
+    let b64 = STANDARD.encode(combined);
+    let err = decrypt_handoff_blob(&b64, key).unwrap_err();
+    assert!(err.to_string().contains("AES-GCM decrypt failed"));
+}
+
+#[test]
+fn decrypt_fails_on_invalid_utf8() {
+    // Need a valid AES-GCM payload that decrypts to non-UTF8 bytes
+    // Using Node.js to generate:
+    // const crypto = require('crypto');
+    // const key = Buffer.alloc(32, 'B');
+    // const iv = Buffer.alloc(16, '$');
+    // const plaintext = Buffer.from([0xFF, 0xFE, 0xFD]);
+    // const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    // let ct = cipher.update(plaintext);
+    // ct = Buffer.concat([ct, cipher.final()]);
+    // const tag = cipher.getAuthTag();
+    // const combined = Buffer.concat([iv, tag, ct]);
+    // console.log(combined.toString('base64'));
+    // -> JCQkJCQkJCQkJCQkJCQkJI9mD7G5mIu67Hq+f565+ZpQ784=
+
+    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+    let b64 = "JCQkJCQkJCQkJCQkJCQkJI9mD7G5mIu67Hq+f565+ZpQ784=";
+    let err = decrypt_handoff_blob(b64, key).unwrap_err();
+    assert!(err.to_string().contains("handoff plaintext is not UTF-8"));
 }

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -78,16 +78,16 @@ fn decrypts_valid_blob() {
 
 #[test]
 fn decrypt_fails_if_too_short() {
-    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+    let key_str = STANDARD.encode([0x42u8; 32]);
     let b64 = STANDARD.encode([0u8; 31]);
-    let err = decrypt_handoff_blob(&b64, key).unwrap_err();
+    let err = decrypt_handoff_blob(&b64, &key_str).unwrap_err();
     assert!(err.to_string().contains("encrypted payload too short"));
 }
 
 #[test]
 fn decrypt_fails_on_invalid_base64() {
-    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
-    let err = decrypt_handoff_blob("not-base64!!!", key).unwrap_err();
+    let key_str = STANDARD.encode([0x42u8; 32]);
+    let err = decrypt_handoff_blob("not-base64!!!", &key_str).unwrap_err();
     assert!(err.to_string().contains("base64-decode encrypted payload"));
 }
 

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -2,6 +2,13 @@ use super::{decrypt_handoff_blob, key_bytes_from_string};
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 
+// We need these for internal encryption in tests to ensure fixtures match the implementation
+use aes_gcm::aead::generic_array::typenum::U16;
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::aes::Aes256;
+use aes_gcm::AesGcm;
+type Aes256Gcm16 = AesGcm<Aes256, U16>;
+
 #[test]
 fn decodes_base64url_no_pad() {
     // A 32-byte key that, when base64url-encoded, contains both `-` and `_`.
@@ -48,13 +55,25 @@ fn rejects_wrong_length() {
 
 #[test]
 fn decrypts_valid_blob() {
-    // Generated via Node.js crypto:
-    // Key: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
-    // B64: JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==
-    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
-    let b64 = "JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==";
-    let decrypted = decrypt_handoff_blob(b64, key).unwrap();
-    assert_eq!(decrypted, "hello world");
+    let key_bytes = [0x42u8; 32];
+    let iv_bytes = [0x24u8; 16];
+    let plain = "hello world";
+
+    let cipher = Aes256Gcm16::new_from_slice(&key_bytes).unwrap();
+    let nonce = aes_gcm::aead::generic_array::GenericArray::from_slice(&iv_bytes);
+    let encrypted = cipher.encrypt(nonce, plain.as_bytes()).unwrap();
+    let (ciphertext, tag) = encrypted.split_at(encrypted.len() - 16);
+
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&iv_bytes);
+    combined.extend_from_slice(tag);
+    combined.extend_from_slice(ciphertext);
+
+    let b64 = STANDARD.encode(combined);
+    let key_str = STANDARD.encode(key_bytes);
+
+    let decrypted = decrypt_handoff_blob(&b64, &key_str).unwrap();
+    assert_eq!(decrypted, plain);
 }
 
 #[test]
@@ -74,42 +93,73 @@ fn decrypt_fails_on_invalid_base64() {
 
 #[test]
 fn decrypt_fails_on_wrong_key() {
-    let key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; // wrong key
-    let b64 = "JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==";
-    let err = decrypt_handoff_blob(b64, key).unwrap_err();
+    let key_bytes = [0x42u8; 32];
+    let iv_bytes = [0x24u8; 16];
+    let plain = "hello world";
+
+    let cipher = Aes256Gcm16::new_from_slice(&key_bytes).unwrap();
+    let nonce = aes_gcm::aead::generic_array::GenericArray::from_slice(&iv_bytes);
+    let encrypted = cipher.encrypt(nonce, plain.as_bytes()).unwrap();
+    let (ciphertext, tag) = encrypted.split_at(encrypted.len() - 16);
+
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&iv_bytes);
+    combined.extend_from_slice(tag);
+    combined.extend_from_slice(ciphertext);
+
+    let b64 = STANDARD.encode(combined);
+    let wrong_key = STANDARD.encode([0u8; 32]);
+
+    let err = decrypt_handoff_blob(&b64, &wrong_key).unwrap_err();
     assert!(err.to_string().contains("AES-GCM decrypt failed"));
 }
 
 #[test]
 fn decrypt_fails_on_tampered_ciphertext() {
-    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
-    let mut combined = STANDARD.decode("JCQkJCQkJCQkJCQkJCQkJO0jqP9aSaielDGEQULvHaKPe7g8HW8rFwWa2g==").unwrap();
+    let key_bytes = [0x42u8; 32];
+    let iv_bytes = [0x24u8; 16];
+    let plain = "hello world";
+
+    let cipher = Aes256Gcm16::new_from_slice(&key_bytes).unwrap();
+    let nonce = aes_gcm::aead::generic_array::GenericArray::from_slice(&iv_bytes);
+    let encrypted = cipher.encrypt(nonce, plain.as_bytes()).unwrap();
+    let (ciphertext, tag) = encrypted.split_at(encrypted.len() - 16);
+
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&iv_bytes);
+    combined.extend_from_slice(tag);
+    combined.extend_from_slice(ciphertext);
+
     // Tamper with the last byte of ciphertext
     let last = combined.len() - 1;
     combined[last] ^= 0xFF;
+
     let b64 = STANDARD.encode(combined);
-    let err = decrypt_handoff_blob(&b64, key).unwrap_err();
+    let key_str = STANDARD.encode(key_bytes);
+
+    let err = decrypt_handoff_blob(&b64, &key_str).unwrap_err();
     assert!(err.to_string().contains("AES-GCM decrypt failed"));
 }
 
 #[test]
 fn decrypt_fails_on_invalid_utf8() {
-    // Need a valid AES-GCM payload that decrypts to non-UTF8 bytes
-    // Using Node.js to generate:
-    // const crypto = require('crypto');
-    // const key = Buffer.alloc(32, 'B');
-    // const iv = Buffer.alloc(16, '$');
-    // const plaintext = Buffer.from([0xFF, 0xFE, 0xFD]);
-    // const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-    // let ct = cipher.update(plaintext);
-    // ct = Buffer.concat([ct, cipher.final()]);
-    // const tag = cipher.getAuthTag();
-    // const combined = Buffer.concat([iv, tag, ct]);
-    // console.log(combined.toString('base64'));
-    // -> JCQkJCQkJCQkJCQkJCQkJI9mD7G5mIu67Hq+f565+ZpQ784=
+    let key_bytes = [0x42u8; 32];
+    let iv_bytes = [0x24u8; 16];
+    let plain = [0xFFu8, 0xFE, 0xFD];
 
-    let key = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
-    let b64 = "JCQkJCQkJCQkJCQkJCQkJI9mD7G5mIu67Hq+f565+ZpQ784=";
-    let err = decrypt_handoff_blob(b64, key).unwrap_err();
+    let cipher = Aes256Gcm16::new_from_slice(&key_bytes).unwrap();
+    let nonce = aes_gcm::aead::generic_array::GenericArray::from_slice(&iv_bytes);
+    let encrypted = cipher.encrypt(nonce, plain.as_ref()).unwrap();
+    let (ciphertext, tag) = encrypted.split_at(encrypted.len() - 16);
+
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&iv_bytes);
+    combined.extend_from_slice(tag);
+    combined.extend_from_slice(ciphertext);
+
+    let b64 = STANDARD.encode(combined);
+    let key_str = STANDARD.encode(key_bytes);
+
+    let err = decrypt_handoff_blob(&b64, &key_str).unwrap_err();
     assert!(err.to_string().contains("handoff plaintext is not UTF-8"));
 }

--- a/test_anyhow.rs
+++ b/test_anyhow.rs
@@ -1,8 +1,0 @@
-use anyhow::{Context, Result};
-
-fn main() -> Result<()> {
-    let err = anyhow::anyhow!("inner").context("outer");
-    println!("to_string: {}", err.to_string());
-    println!("Display: {}");
-    Ok(())
-}

--- a/test_anyhow.rs
+++ b/test_anyhow.rs
@@ -1,0 +1,8 @@
+use anyhow::{Context, Result};
+
+fn main() -> Result<()> {
+    let err = anyhow::anyhow!("inner").context("outer");
+    println!("to_string: {}", err.to_string());
+    println!("Display: {}");
+    Ok(())
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Added unit tests for `decrypt_handoff_blob` in `src/api/rest.rs`.

📊 **Coverage:** What scenarios are now tested
- Happy path: Successful decryption of a valid AES-256-GCM blob.
- Error path: Payload too short (less than 32 bytes).
- Error path: Invalid base64 input.
- Error path: Authentication failure (wrong key).
- Error path: Authentication failure (tampered ciphertext).
- Error path: UTF-8 decoding failure of the decrypted plaintext.

✨ **Result:** Improved reliability and coverage for cryptographic token handoff.

---
*PR created automatically by Jules for task [14953444737016356940](https://jules.google.com/task/14953444737016356940) started by @senamakel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for decryption functionality to validate proper behavior under normal and error conditions, ensuring data integrity and system reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1422)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->