### PR TITLE
test: add comprehensive coverage for normalizeRedeemedCoupon

### DIFF
--- a/app/src/services/api/__tests__/creditsApi.test.ts
+++ b/app/src/services/api/__tests__/creditsApi.test.ts
@@ -41,6 +41,65 @@ describe('creditsApi coupon helpers', () => {
     });
   });
 
+  it('normalizes redeemed coupon handles null/undefined/empty object safely', () => {
+    const expectedDefaults = {
+      code: '',
+      amountUsd: 0,
+      redeemedAt: null,
+      activationType: 'IMMEDIATE',
+      fulfilled: false,
+      fulfilledAt: null,
+      activationCondition: null,
+    };
+    expect(normalizeRedeemedCoupon(null)).toEqual(expectedDefaults);
+    expect(normalizeRedeemedCoupon(undefined)).toEqual(expectedDefaults);
+    expect(normalizeRedeemedCoupon({})).toEqual(expectedDefaults);
+  });
+
+  it('normalizes redeemed coupon falls back to couponCode if code is absent or empty', () => {
+    expect(normalizeRedeemedCoupon({ couponCode: 'FALLBACK-CODE' }).code).toBe('FALLBACK-CODE');
+    expect(normalizeRedeemedCoupon({ code: '  ', couponCode: 'FALLBACK-CODE' }).code).toBe('FALLBACK-CODE');
+  });
+
+  it('normalizes redeemed coupon handles camelCase variants of fields', () => {
+    expect(
+      normalizeRedeemedCoupon({
+        code: 'CAMEL',
+        amountUsd: 10,
+        redeemedAt: '2026-04-10T12:00:00.000Z',
+        activationType: 'MANUAL',
+        fulfilledAt: '2026-04-10T12:05:00.000Z',
+        activationCondition: 'SOME_CONDITION',
+      })
+    ).toEqual({
+      code: 'CAMEL',
+      amountUsd: 10,
+      redeemedAt: '2026-04-10T12:00:00.000Z',
+      activationType: 'MANUAL',
+      fulfilled: false,
+      fulfilledAt: '2026-04-10T12:05:00.000Z',
+      activationCondition: 'SOME_CONDITION',
+    });
+  });
+
+  it('normalizes redeemed coupon coerces fulfilled to boolean', () => {
+    expect(normalizeRedeemedCoupon({ fulfilled: 1 }).fulfilled).toBe(true);
+    expect(normalizeRedeemedCoupon({ fulfilled: 'yes' }).fulfilled).toBe(true);
+    expect(normalizeRedeemedCoupon({ fulfilled: 0 }).fulfilled).toBe(false);
+    expect(normalizeRedeemedCoupon({ fulfilled: '' }).fulfilled).toBe(false);
+  });
+
+  it('normalizes redeemed coupon handles empty strings as null for nullable string fields', () => {
+    const result = normalizeRedeemedCoupon({
+      redeemedAt: '   ',
+      fulfilledAt: '',
+      activationCondition: ' ',
+    });
+    expect(result.redeemedAt).toBeNull();
+    expect(result.fulfilledAt).toBeNull();
+    expect(result.activationCondition).toBeNull();
+  });
+
   it('redeemCoupon unwraps and normalizes the core RPC payload', async () => {
     mockCallCoreCommand.mockResolvedValueOnce({
       couponCode: 'APRL-2026',

--- a/app/src/services/api/__tests__/creditsApi.test.ts
+++ b/app/src/services/api/__tests__/creditsApi.test.ts
@@ -58,7 +58,9 @@ describe('creditsApi coupon helpers', () => {
 
   it('normalizes redeemed coupon falls back to couponCode if code is absent or empty', () => {
     expect(normalizeRedeemedCoupon({ couponCode: 'FALLBACK-CODE' }).code).toBe('FALLBACK-CODE');
-    expect(normalizeRedeemedCoupon({ code: '  ', couponCode: 'FALLBACK-CODE' }).code).toBe('FALLBACK-CODE');
+    expect(normalizeRedeemedCoupon({ code: '  ', couponCode: 'FALLBACK-CODE' }).code).toBe(
+      'FALLBACK-CODE'
+    );
   });
 
   it('normalizes redeemed coupon handles camelCase variants of fields', () => {


### PR DESCRIPTION
## 🎯 What
Added missing unit tests for `normalizeRedeemedCoupon` in `creditsApi.ts` to improve the reliability of the codebase.

## 📊 Coverage
The new tests cover the following scenarios:
- Handling of `null`, `undefined`, and empty object (`{}`) inputs safely.
- Proper fallback behavior for the `code` field (using `couponCode` as a fallback).
- Correct handling of standard `camelCase` properties compared to backend `snake_case` properties.
- Value coercion for the `fulfilled` boolean flag, checking truthy vs falsy logic.
- Transforming empty or whitespace-only strings into `null`.

## ✨ Result
Increased test coverage for `creditsApi.ts`, ensuring that `normalizeRedeemedCoupon` acts robustly and predictably against varied backend response formats.

---
*PR created automatically by Jules for task [853945774531006177](https://jules.google.com/task/853945774531006177) started by @senamakel*