### PR TITLE
fix(ci): scope rabbit-retrigger to Production environment

### DIFF
--- a/.github/workflows/rabbit-retrigger.yml
+++ b/.github/workflows/rabbit-retrigger.yml
@@ -30,6 +30,11 @@ jobs:
   retrigger:
     name: Retrigger CodeRabbit
     runs-on: ubuntu-22.04
+    # XGITHUB_APP_ID / XGITHUB_APP_PRIVATE_KEY are scoped to the Production
+    # environment (same as release-production.yml). Without this declaration
+    # the secrets resolve to empty and tibdex/github-app-token errors with
+    # "Input required and not supplied: app_id".
+    environment: Production
     steps:
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- Add `environment: Production` to the `retrigger` job in `.github/workflows/rabbit-retrigger.yml`.

## Problem

The first scheduled run after #1425 merged failed with:

```
Error: Input required and not supplied: app_id
```

`XGITHUB_APP_ID` and `XGITHUB_APP_PRIVATE_KEY` are scoped to the **Production** environment in repo settings — `release-production.yml` references them only from jobs that declare `environment: Production` (lines 71, 291, 361, …). Without that declaration the secrets resolve to empty strings and `tibdex/github-app-token@v1` rejects the request.

(Reference: prior empty PR #1426 with the same intended title was a no-op — 0 file changes — so this needs to actually land.)

## Solution

Add `environment: Production` to the `retrigger` job. Same pattern as `prepare-build`, `create-release`, etc. in `release-production.yml`.

## Submission Checklist

- [x] N/A: CI-only change; no app/script logic touched.
- [x] N/A: no app/Rust source changed.
- [x] N/A: no feature row in coverage matrix.
- [x] N/A: no feature IDs touched.
- [x] No new external network dependencies introduced.
- [x] N/A: not a release-cut surface.
- [x] N/A: no linked issue.

## Impact

- The scheduled rabbit retrigger workflow can now obtain a GitHub App token and post `@coderabbitai review` comments under the bot identity.

## Related

- Follows up on #1425.
- Supersedes the empty merge of #1426.
- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/rabbit-workflow-env
- Commit SHA: 372dfe23

### Validation Run
- [x] N/A: CI-only.
- [x] N/A: CI-only.
- [x] Focused tests: verified the failure mode against run 25612055247 (`Input required and not supplied: app_id`); fix matches the pattern in `release-production.yml`.
- [x] N/A: no Rust changes.
- [x] N/A: no Tauri changes.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: scheduled rabbit-retrigger workflow can now load the App secrets it already references.
- User-visible effect: scheduled CodeRabbit retriggers actually run.

### Parity Contract
- Legacy behavior preserved: yes — config-only addition.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): #1426 (empty, merged as no-op)
- Canonical PR: this one
- Resolution: this PR carries the actual fix.