### PR TITLE
fix(ci): switch rabbit-retrigger to a PAT in `Review` environment

### DIFF
--- a/.github/workflows/rabbit-retrigger.yml
+++ b/.github/workflows/rabbit-retrigger.yml
@@ -1,8 +1,9 @@
 ---
 name: CodeRabbit Retrigger
 # Periodically scans open PRs and posts `@coderabbitai review` on any whose
-# rate-limit window has elapsed. Uses the same GitHub App credentials as
-# release-production.yml so the comments are authored by the bot account.
+# rate-limit window has elapsed. CodeRabbit ignores comments authored by a
+# GitHub App, so this workflow uses a personal access token (`RABBIT_PAT`)
+# scoped to the `Review` environment.
 on:
   schedule:
     # Every 20 minutes. CodeRabbit Pro reviews 5 PRs/hr, so this gives
@@ -30,18 +31,13 @@ jobs:
   retrigger:
     name: Retrigger CodeRabbit
     runs-on: ubuntu-22.04
-    # XGITHUB_APP_ID / XGITHUB_APP_PRIVATE_KEY are scoped to the Production
-    # environment (same as release-production.yml). Without this declaration
-    # the secrets resolve to empty and tibdex/github-app-token errors with
-    # "Input required and not supplied: app_id".
-    environment: Production
+    # CodeRabbit ignores `@coderabbitai review` comments posted under a
+    # GitHub App identity, so this workflow uses a personal access token
+    # scoped to the `Review` environment instead. Set `RABBIT_PAT` on the
+    # `Review` environment in repo settings — a fine-grained PAT with
+    # `pull-requests: write` and `issues: write` on this repo is enough.
+    environment: Review
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.XGITHUB_APP_ID }}
-          private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -50,31 +46,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-      - name: Diagnose App token identity
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -e
-          echo "== gh auth status =="
-          gh auth status || true
-          echo
-          echo "== App installation identity =="
-          # `/installation/repositories` works for an installation access token
-          # and confirms which repos the App can write to. If this doesn't list
-          # tinyhumansai/openhuman or shows zero permissions, the App isn't
-          # installed on the repo (or the new perms haven't been accepted yet).
-          gh api /installation/repositories \
-            --jq '{total_count, perms: .repositories[0].permissions, repos: [.repositories[].full_name]}' \
-            || echo "(installation listing failed)"
-          echo
-          echo "== Posting permission probe =="
-          # GET on the comments endpoint requires `issues:read` (or pull-requests:read).
-          # POST requires `issues:write`. We only GET here so we don't pollute PRs.
-          gh api -i /repos/${GITHUB_REPOSITORY}/issues/1421/comments?per_page=1 \
-            2>&1 | head -20 || true
       - name: Run rabbit
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RABBIT_PAT }}
           RABBIT_REPO: ${{ github.repository }}
         run: |
           set -e


### PR DESCRIPTION
CodeRabbit ignores `@coderabbitai review` posted under a GitHub App identity, so the App token approach (and its diagnostic) won't work no matter which permissions the App holds. Switch to a personal access token (`RABBIT_PAT`) stored in a new `Review` environment, drop the App-token generation step and the diagnostic block.

Setup: add `RABBIT_PAT` (fine-grained PAT with `pull-requests: write` and `issues: write` on this repo) as a secret on the `Review` environment in repo settings.

## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [ ] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key:
- URL:

### Commit & Branch
- Branch:
- Commit SHA:

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check`
- [ ] `pnpm typecheck`
- [ ] Focused tests:
- [ ] Rust fmt/check (if changed):
- [ ] Tauri fmt/check (if changed):

### Validation Blocked
- `command:`
- `error:`
- `impact:`

### Behavior Changes
- Intended behavior change:
- User-visible effect:

### Parity Contract
- Legacy behavior preserved:
- Guard/fallback/dispatch parity checks:

### Duplicate / Superseded PR Handling
- Duplicate PR(s):
- Canonical PR:
- Resolution (closed/superseded/updated):
