### PR TITLE
fix(ci): switch rabbit-retrigger to PAT in `Review` environment

### DIFF
--- a/.github/workflows/rabbit-retrigger.yml
+++ b/.github/workflows/rabbit-retrigger.yml
@@ -1,8 +1,9 @@
 ---
 name: CodeRabbit Retrigger
 # Periodically scans open PRs and posts `@coderabbitai review` on any whose
-# rate-limit window has elapsed. Uses the same GitHub App credentials as
-# release-production.yml so the comments are authored by the bot account.
+# rate-limit window has elapsed. CodeRabbit ignores comments authored by a
+# GitHub App, so this workflow uses a personal access token (`RABBIT_PAT`)
+# scoped to the `Review` environment.
 on:
   schedule:
     # Every 20 minutes. CodeRabbit Pro reviews 5 PRs/hr, so this gives
@@ -30,18 +31,13 @@ jobs:
   retrigger:
     name: Retrigger CodeRabbit
     runs-on: ubuntu-22.04
-    # XGITHUB_APP_ID / XGITHUB_APP_PRIVATE_KEY are scoped to the Production
-    # environment (same as release-production.yml). Without this declaration
-    # the secrets resolve to empty and tibdex/github-app-token errors with
-    # "Input required and not supplied: app_id".
-    environment: Production
+    # CodeRabbit ignores `@coderabbitai review` comments posted under a
+    # GitHub App identity, so this workflow uses a personal access token
+    # scoped to the `Review` environment instead. Set `RABBIT_PAT` on the
+    # `Review` environment in repo settings — a fine-grained PAT with
+    # `pull-requests: write` and `issues: write` on this repo is enough.
+    environment: Review
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.XGITHUB_APP_ID }}
-          private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -50,31 +46,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-      - name: Diagnose App token identity
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -e
-          echo "== gh auth status =="
-          gh auth status || true
-          echo
-          echo "== App installation identity =="
-          # `/installation/repositories` works for an installation access token
-          # and confirms which repos the App can write to. If this doesn't list
-          # tinyhumansai/openhuman or shows zero permissions, the App isn't
-          # installed on the repo (or the new perms haven't been accepted yet).
-          gh api /installation/repositories \
-            --jq '{total_count, perms: .repositories[0].permissions, repos: [.repositories[].full_name]}' \
-            || echo "(installation listing failed)"
-          echo
-          echo "== Posting permission probe =="
-          # GET on the comments endpoint requires `issues:read` (or pull-requests:read).
-          # POST requires `issues:write`. We only GET here so we don't pollute PRs.
-          gh api -i /repos/${GITHUB_REPOSITORY}/issues/1421/comments?per_page=1 \
-            2>&1 | head -20 || true
       - name: Run rabbit
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RABBIT_PAT }}
           RABBIT_REPO: ${{ github.repository }}
         run: |
           set -e


### PR DESCRIPTION
## Summary

- Drop the GitHub App token (and its diagnostic step) from `rabbit-retrigger.yml`.
- Authenticate with a personal access token `RABBIT_PAT` stored on a new `Review` environment.

## Problem

The earlier diagnostic confirmed the App token authenticates correctly and posts comments — but **CodeRabbit ignores `@coderabbitai review` comments authored by a GitHub App identity**. Comments go through, CR never reviews. The 5/hr rate-limit window keeps closing on retriggers that produce no work.

## Solution

Use a personal access token instead. CR treats PAT-authored comments as user activity and triggers a review.

`.github/workflows/rabbit-retrigger.yml`:

- Job `environment` changed from `Production` to `Review` (a new environment to be created in repo settings).
- `tibdex/github-app-token` step removed.
- Diagnostic step (`gh auth status`, `/installation/repositories`, comments probe) removed — root cause is now known.
- `GH_TOKEN` set to `${{ secrets.RABBIT_PAT }}`.
- Header comment updated to reflect the PAT-based design.

## Setup required (manual, repo settings)

1. **Settings → Environments → New environment** named `Review`.
2. Add a secret `RABBIT_PAT` to that environment. Use a fine-grained PAT scoped to `tinyhumansai/openhuman` with:
   - **Pull requests**: Read & write
   - **Issues**: Read & write
3. (Optional) Restrict the environment's deployment branches so only `main` can run the workflow.

After that the next `*/20 * * * *` tick (or a manual `workflow_dispatch`) will start posting under the PAT owner's identity, which CR will respect.

## Submission Checklist

- [x] N/A: CI-only change; no app/script logic touched.
- [x] N/A: no app/Rust source changed.
- [x] N/A: no feature row in coverage matrix.
- [x] N/A: no feature IDs touched.
- [x] No new external network dependencies introduced.
- [x] N/A: not a release-cut surface.
- [x] N/A: no linked issue.

## Impact

- Scheduled retriggers will be authored by the PAT owner (`@senamakel`) instead of the bot, which is what CodeRabbit needs to honor.
- The `Production` environment is no longer touched by this workflow.

## Related

- Follows up on #1425 (the schedule), #1426 (empty), #1427 (Production env scope — now obsolete for this workflow).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/rabbit-3
- Commit SHA: 5048e992

### Validation Run
- [x] N/A: CI-only.
- [x] N/A: CI-only.
- [x] Focused tests: confirmed via dispatch on the prior PR that App-authored comments are silently ignored by CR; switching identity is the only known remediation.
- [x] N/A: no Rust changes.
- [x] N/A: no Tauri changes.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: scheduled rabbit-retrigger posts under a PAT user identity so CR honors the retrigger.
- User-visible effect: CR reviews actually resume after rate-limit windows expire.

### Parity Contract
- Legacy behavior preserved: yes — same script, same schedule, only the auth identity changes.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this one
- Resolution: supersedes the App-token approach merged in #1427.