### PR TITLE
ci(release): ship Linux openhuman-core tarballs and push GHCR image

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -43,18 +43,18 @@ concurrency:
 #        │
 #        ├─── create-release
 #        │         │
-#        │    ┌────┴────────────┐
-#        │    │                 │
-#        │  build-desktop    build-docker
-#        │  (reusable wf)    (GHCR image)
-#        │    │                 │
-#        │    └────┬────────────┘
-#        │         │
-#        │    publish-updater-manifest
-#        │         │
-#        │    publish-release
-#        │         │
-#        │    record-sentry-deploy
+#        │    ┌────┴───────────────┬────────────────┐
+#        │    │                    │                │
+#        │  build-desktop    build-cli-linux    build-docker
+#        │  (reusable wf)    (Linux tarballs)   (GHCR image)
+#        │    │                    │                │
+#        │    └────────┬───────────┴────────────────┘
+#        │             │
+#        │      publish-updater-manifest
+#        │             │
+#        │      publish-release
+#        │             │
+#        │      record-sentry-deploy
 #        │
 #        └─── cleanup-failed-release (on failure)
 #
@@ -351,7 +351,17 @@ jobs:
       build_sidecar: false
 
   # =========================================================================
-  # Phase 3b: Build & push Docker image (runs parallel with build-desktop)
+  # Phase 3b: Build & push Docker image (runs parallel with build-desktop).
+  #
+  # Publishes `ghcr.io/tinyhumansai/openhuman-core` with three tags per release:
+  #   - :latest                — moves on every prod cut
+  #   - :v<version>            — matches the GitHub Release tag (e.g. v1.2.4)
+  #   - :<version>             — bare SemVer for tooling that strips the v
+  #
+  # linux/amd64 only for now. arm64 users pull the standalone CLI tarball
+  # (`build-cli-linux` matrix) or build the image from source. Adding arm64
+  # via QEMU here triples build time on Rust-heavy stages; revisit when an
+  # `ubuntu-24.04-arm` runner is wired into a per-arch matrix + manifest job.
   # =========================================================================
   build-docker:
     name: "Docker: build and push"
@@ -376,9 +386,120 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute image tags
+        id: image-tags
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          TAG: ${{ needs.prepare-build.outputs.tag }}
+          VERSION: ${{ needs.prepare-build.outputs.version }}
+        run: |
+          set -euo pipefail
+          base="${REGISTRY}/${IMAGE_NAME}"
+          {
+            echo "tags<<EOF"
+            echo "${base}:latest"
+            echo "${base}:${TAG}"
+            echo "${base}:${VERSION}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.image-tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.prepare-build.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.prepare-build.outputs.version }}
+            org.opencontainers.image.title=openhuman-core
+          cache-from: type=gha,scope=release-production
+          cache-to: type=gha,scope=release-production,mode=max
+      - name: Verify pushed image is pullable
+        run: |
+          set -euo pipefail
+          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare-build.outputs.tag }}"
+          docker pull "$image"
+          docker image inspect "$image" >/dev/null
 
   # =========================================================================
-  # Phase 3c: Generate and upload latest.json for the Tauri auto-updater.
+  # Phase 3c: Build standalone Linux openhuman-core tarballs and attach them
+  # to the GitHub Release. Operators on Linux servers without Docker pull a
+  # plain tarball + sha256 from the release page; cloud-deploy.md links here.
+  #
+  # arm64 uses GitHub-hosted ubuntu-24.04-arm to avoid QEMU emulation
+  # (matches release-packages.yml). If that runner is unavailable for the
+  # repo's plan, fall back to ubuntu-22.04 + cross-rs (see comment in
+  # release-packages.yml `build-cli-linux-arm64`).
+  # =========================================================================
+  build-cli-linux:
+    name: "CLI: ${{ matrix.target }}"
+    needs: [prepare-build, create-release]
+    if: needs.create-release.result == 'success'
+    environment: Production
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - name: Checkout build ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-build.outputs.build_ref }}
+          fetch-depth: 1
+          submodules: recursive
+      - name: Install Rust (rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}-release
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libssl-dev build-essential cmake \
+            libasound2-dev libxdo-dev libxtst-dev libx11-dev libevdev-dev \
+            clang
+      - name: Verify Sentry DSN is present
+        env:
+          OPENHUMAN_CORE_SENTRY_DSN: ${{ vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN }}
+        run: |
+          if [ -z "${OPENHUMAN_CORE_SENTRY_DSN}" ]; then
+            echo "::error::vars.OPENHUMAN_CORE_SENTRY_DSN (or legacy vars.OPENHUMAN_SENTRY_DSN) is empty — the Linux CLI tarball would ship without crash reporting."
+            exit 1
+          fi
+          echo "OPENHUMAN_CORE_SENTRY_DSN is set (length=${#OPENHUMAN_CORE_SENTRY_DSN})"
+      - name: Build openhuman-core binary
+        env:
+          OPENHUMAN_CORE_SENTRY_DSN: ${{ vars.OPENHUMAN_CORE_SENTRY_DSN || vars.OPENHUMAN_SENTRY_DSN }}
+          # Match the runtime release tag (`openhuman@<version>+<short_sha>`)
+          # baked elsewhere — see prepare-build.outputs.short_sha comment.
+          OPENHUMAN_BUILD_SHA: ${{ needs.prepare-build.outputs.short_sha }}
+          OPENHUMAN_APP_ENV: production
+        run: cargo build --release --bin openhuman-core
+      - name: Package and upload tarball to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPLOAD_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.prepare-build.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          bash scripts/release/package-cli-tarball.sh \
+            target/release/openhuman-core \
+            "$VERSION" \
+            "$TARGET"
+
+  # =========================================================================
+  # Phase 3d: Generate and upload latest.json for the Tauri auto-updater.
   # Runs after every platform has uploaded its updater artifact (.sig files
   # from createUpdaterArtifacts) so the manifest can reference all four
   # platform entries.
@@ -415,10 +536,12 @@ jobs:
       - prepare-build
       - create-release
       - build-desktop
+      - build-cli-linux
       - build-docker
       - publish-updater-manifest
     if: >-
       needs.build-desktop.result == 'success'
+      && needs.build-cli-linux.result == 'success'
       && needs.build-docker.result == 'success'
       && needs.publish-updater-manifest.result == 'success'
     steps:
@@ -442,6 +565,11 @@ jobs:
               // Auto-updater manifest — without this, installed clients can't
               // discover new releases via plugins.updater.endpoints.
               /^latest\.json$/,
+              // Linux standalone openhuman-core CLI tarballs (build-cli-linux).
+              // Operators on headless Linux servers pull these instead of the
+              // Tauri bundle; cloud-deploy.md documents both arches.
+              /^openhuman-core-.*-x86_64-unknown-linux-gnu\.tar\.gz$/,
+              /^openhuman-core-.*-aarch64-unknown-linux-gnu\.tar\.gz$/,
             ];
             const missing = requiredPatterns.filter((pattern) => !names.some((name) => pattern.test(name)));
             if (missing.length > 0) {
@@ -513,12 +641,15 @@ jobs:
       - prepare-build
       - create-release
       - build-desktop
+      - build-cli-linux
       - build-docker
       - publish-updater-manifest
     if: >-
       always()
       && needs.create-release.result == 'success'
       && (needs.build-desktop.result == 'failure' || needs.build-desktop.result ==
+      'cancelled'
+          || needs.build-cli-linux.result == 'failure' || needs.build-cli-linux.result ==
       'cancelled'
           || needs.build-docker.result == 'failure' || needs.build-docker.result ==
       'cancelled'
@@ -559,22 +690,31 @@ jobs:
                 throw e;
               }
             }
-      - name: Delete staging Docker image
+      - name: Delete published Docker image versions
+        # If `build-docker` already pushed but a downstream phase failed, the
+        # GHCR image would otherwise outlive the GitHub Release. Walk the
+        # `:v<version>` and `:<version>` tags we just pushed and remove the
+        # underlying package version. `:latest` is left alone — the previous
+        # release is still pointed at it, and clobbering the moving tag here
+        # would orphan downstream pulls.
         continue-on-error: true
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare-build.outputs.tag }}
+          VERSION: ${{ needs.prepare-build.outputs.version }}
         run: |-
+          set -uo pipefail
           PACKAGE="openhuman-core"
-          STAGING_TAG="staging-${TAG}"
-          echo "Attempting to delete staging Docker tag: ${STAGING_TAG}"
-          # List package versions and find the staging tag
-          VERSION_ID="$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/orgs/tinyhumansai/packages/container/${PACKAGE}/versions" \
-            --paginate --jq ".[] | select(.metadata.container.tags[] == \"${STAGING_TAG}\") | .id" 2>/dev/null | head -1)"
-          if [ -n "$VERSION_ID" ]; then
-            gh api -X DELETE "/orgs/tinyhumansai/packages/container/${PACKAGE}/versions/${VERSION_ID}" || true
-            echo "Deleted staging image version ${VERSION_ID}"
-          else
-            echo "Staging tag ${STAGING_TAG} not found or already deleted"
-          fi
+          for IMAGE_TAG in "${TAG}" "${VERSION}"; do
+            echo "Attempting to delete Docker tag: ${IMAGE_TAG}"
+            VERSION_ID="$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/orgs/tinyhumansai/packages/container/${PACKAGE}/versions" \
+              --paginate --jq ".[] | select(.metadata.container.tags[]? == \"${IMAGE_TAG}\") | .id" 2>/dev/null | head -1)"
+            if [ -n "$VERSION_ID" ]; then
+              gh api -X DELETE "/orgs/tinyhumansai/packages/container/${PACKAGE}/versions/${VERSION_ID}" || true
+              echo "Deleted image version ${VERSION_ID} (tag ${IMAGE_TAG})"
+            else
+              echo "Tag ${IMAGE_TAG} not found or already deleted"
+            fi
+          done

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -353,10 +353,20 @@ jobs:
   # =========================================================================
   # Phase 3b: Build & push Docker image (runs parallel with build-desktop).
   #
-  # Publishes `ghcr.io/tinyhumansai/openhuman-core` with three tags per release:
-  #   - :latest                — moves on every prod cut
+  # Publishes `ghcr.io/tinyhumansai/openhuman-core` with two immutable tags
+  # per release:
   #   - :v<version>            — matches the GitHub Release tag (e.g. v1.2.4)
   #   - :<version>             — bare SemVer for tooling that strips the v
+  #
+  # `:latest` is intentionally NOT pushed here. If a downstream phase
+  # (build-cli-linux, publish-updater-manifest, the asset-validation gate
+  # in publish-release) fails, the immutable tags are deleted by
+  # cleanup-failed-release while the release is rolled back. Pushing
+  # :latest in this job would move the moving tag onto an image whose
+  # release got cleaned up, leaving downstream `docker pull …:latest`
+  # consumers on a build that has no GitHub Release behind it. The
+  # `tag-docker-latest` job below promotes :latest only after
+  # `publish-release` succeeds.
   #
   # linux/amd64 only for now. arm64 users pull the standalone CLI tarball
   # (`build-cli-linux` matrix) or build the image from source. Adding arm64
@@ -398,7 +408,6 @@ jobs:
           base="${REGISTRY}/${IMAGE_NAME}"
           {
             echo "tags<<EOF"
-            echo "${base}:latest"
             echo "${base}:${TAG}"
             echo "${base}:${VERSION}"
             echo "EOF"
@@ -569,7 +578,9 @@ jobs:
               // Operators on headless Linux servers pull these instead of the
               // Tauri bundle; cloud-deploy.md documents both arches.
               /^openhuman-core-.*-x86_64-unknown-linux-gnu\.tar\.gz$/,
+              /^openhuman-core-.*-x86_64-unknown-linux-gnu\.tar\.gz\.sha256$/,
               /^openhuman-core-.*-aarch64-unknown-linux-gnu\.tar\.gz$/,
+              /^openhuman-core-.*-aarch64-unknown-linux-gnu\.tar\.gz\.sha256$/,
             ];
             const missing = requiredPatterns.filter((pattern) => !names.some((name) => pattern.test(name)));
             if (missing.length > 0) {
@@ -590,6 +601,47 @@ jobs:
               draft: false,
             });
             core.info(`Published release ${releaseId}`);
+
+  # =========================================================================
+  # Phase 4b: Promote :latest to the just-published image.
+  #
+  # `build-docker` only pushed the immutable :v<version> / :<version> tags.
+  # We delay :latest until publish-release has actually flipped the GitHub
+  # Release out of draft, so a downstream failure (build-cli-linux,
+  # publish-updater-manifest, the asset-validation gate) cleans up the
+  # tagged image without leaving :latest pointing at a build that has no
+  # release behind it. Uses `docker buildx imagetools create` to add the
+  # extra tag without re-pulling the build context — it operates against
+  # the registry manifest, not local layers.
+  # =========================================================================
+  tag-docker-latest:
+    name: "Docker: tag :latest"
+    runs-on: ubuntu-latest
+    environment: Production
+    needs: [prepare-build, publish-release]
+    if: needs.publish-release.result == 'success'
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: tinyhumansai/openhuman-core
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Promote :latest
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          TAG: ${{ needs.prepare-build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          src="${REGISTRY}/${IMAGE_NAME}:${TAG}"
+          dst="${REGISTRY}/${IMAGE_NAME}:latest"
+          docker buildx imagetools create --tag "$dst" "$src"
 
   # =========================================================================
   # Phase 5: Record a single Sentry deploy marker once the release has

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -182,11 +182,13 @@ jobs:
       # No publish-updater-manifest job in staging — producing .sig artifacts
       # would just leave them stranded in the Actions artifact tree.
       with_updater: false
-      # Standalone openhuman-core CLI is shipped via the production GHCR
-      # docker image (build-docker in release-production.yml) and via
-      # brew / homebrew packages updated manually — the staging Actions
-      # artifact had no real consumer. Set `build_sidecar: true` here to
-      # re-enable the matrix-built CLI artifact + its Sentry DIF upload.
+      # Standalone openhuman-core CLI ships from the production cut only:
+      # `build-docker` pushes `ghcr.io/tinyhumansai/openhuman-core` and
+      # `build-cli-linux` attaches Linux x86_64 / aarch64 tarballs to the
+      # GitHub Release (see release-production.yml). Staging does not
+      # publish either surface — the matrix-built sidecar artifact had no
+      # real consumer. Set `build_sidecar: true` to re-enable a per-platform
+      # CLI Actions artifact + its Sentry DIF upload for QA spot-checks.
       build_sidecar: false
 
   # =========================================================================

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -15,7 +15,8 @@ concurrency:
 #
 #   prepare-build
 #        │
-#   build-desktop          (delegated to .github/workflows/build-desktop.yml)
+#        ├── build-desktop      (delegated to .github/workflows/build-desktop.yml)
+#        ├── build-docker       (build only — no GHCR push on staging)
 #        │
 #   record-sentry-deploy
 #        │
@@ -192,6 +193,45 @@ jobs:
       build_sidecar: false
 
   # =========================================================================
+  # Phase 2b: Build the openhuman-core Docker image without pushing.
+  # Mirrors the production `build-docker` job so a Dockerfile regression
+  # surfaces on the staging cut — no GHCR push, no `:staging-*` tag
+  # pollution. `deploy-smoke.yml` already covers the build path on PRs
+  # that touch Dockerfile / src; this is the equivalent gate at the
+  # staging-tag boundary so a green staging cut means the next prod
+  # promotion's GHCR push will succeed too.
+  # =========================================================================
+  build-docker:
+    name: "Docker: build (no push)"
+    needs: [prepare-build]
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Checkout build ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-build.outputs.build_ref }}
+          fetch-depth: 1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: openhuman-core:staging-${{ needs.prepare-build.outputs.tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.prepare-build.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.prepare-build.outputs.version }}
+            org.opencontainers.image.title=openhuman-core
+          cache-from: type=gha,scope=release-staging
+          cache-to: type=gha,scope=release-staging,mode=max
+
+  # =========================================================================
   # Phase 3: Record a single Sentry deploy marker once the matrix is
   # complete. Lives in its own job (not inside the reusable workflow)
   # because `sentry-cli releases deploys ... new` does NOT deduplicate by
@@ -204,7 +244,7 @@ jobs:
     name: Record Sentry deploy marker
     runs-on: ubuntu-latest
     environment: Production
-    needs: [prepare-build, build-desktop]
+    needs: [prepare-build, build-desktop, build-docker]
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
@@ -242,11 +282,12 @@ jobs:
     name: Remove staging tag if build failed
     runs-on: ubuntu-latest
     environment: Production
-    needs: [prepare-build, build-desktop]
+    needs: [prepare-build, build-desktop, build-docker]
     if: >-
       always()
       && needs.prepare-build.result == 'success'
-      && (needs.build-desktop.result == 'failure' || needs.build-desktop.result == 'cancelled')
+      && (needs.build-desktop.result == 'failure' || needs.build-desktop.result == 'cancelled'
+          || needs.build-docker.result == 'failure' || needs.build-docker.result == 'cancelled')
     steps:
       - name: Delete remote staging tag
         uses: actions/github-script@v7

--- a/gitbooks/features/cloud-deploy.md
+++ b/gitbooks/features/cloud-deploy.md
@@ -109,6 +109,33 @@ doctl apps update <app-id> --spec .do/app.yaml
 Works on any host with Docker Engine ≥ 24 and the Compose plugin.
 DigitalOcean Droplet, Hetzner, Linode, EC2, a home server.
 
+Each production release publishes a multi-tagged image to GHCR:
+
+```bash
+docker pull ghcr.io/tinyhumansai/openhuman-core:latest        # tracks the latest prod cut
+docker pull ghcr.io/tinyhumansai/openhuman-core:v1.2.4        # pinned by GitHub Release tag
+docker pull ghcr.io/tinyhumansai/openhuman-core:1.2.4         # pinned by SemVer
+```
+
+The image is `linux/amd64`. arm64 hosts pull the standalone tarball
+attached to the same GitHub Release (`openhuman-core-<version>-aarch64-unknown-linux-gnu.tar.gz`)
+or build the image from source on an arm64 builder.
+
+Quick run with a published image:
+
+```bash
+docker run -d --name openhuman-core -p 7788:7788 \
+  -e OPENHUMAN_CORE_TOKEN="$(openssl rand -hex 32)" \
+  -e BACKEND_URL=https://api.tinyhumans.ai \
+  -e OPENHUMAN_APP_ENV=production \
+  -v openhuman-workspace:/home/openhuman/.openhuman \
+  ghcr.io/tinyhumansai/openhuman-core:latest
+```
+
+Or use the in-repo Compose file (still builds the image locally from
+`Dockerfile`; switch the `image:` field to `ghcr.io/tinyhumansai/openhuman-core:latest`
+in `docker-compose.yml` to consume the published image instead):
+
 ```bash
 # On the server:
 git clone https://github.com/tinyhumansai/openhuman.git
@@ -128,6 +155,29 @@ docker compose up -d
 docker compose ps
 curl -fsS http://localhost:7788/health
 ```
+
+### Headless install without Docker
+
+If you can't run Docker on the host, grab the standalone CLI tarball
+attached to the latest [GitHub Release](https://github.com/tinyhumansai/openhuman/releases/latest):
+
+```bash
+# Pick the tarball that matches your host arch.
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  TARGET=x86_64-unknown-linux-gnu  ;;
+  aarch64) TARGET=aarch64-unknown-linux-gnu ;;
+  *) echo "Unsupported arch: $ARCH"; exit 1 ;;
+esac
+VERSION=1.2.4   # set to the release you want
+curl -fsSL "https://github.com/tinyhumansai/openhuman/releases/download/v${VERSION}/openhuman-core-${VERSION}-${TARGET}.tar.gz" \
+  | tar -xz -C /usr/local/bin
+openhuman-core --version
+```
+
+Then run `openhuman-core serve` under your service manager of choice
+(systemd, supervisord, …) with the same environment variables documented
+above.
 
 The Compose file ([`docker-compose.yml`](../../docker-compose.yml)) maps the core
 on `:7788`, mounts a named volume `openhuman-workspace` for persistence, and


### PR DESCRIPTION
## Summary

- Production `build-docker` now actually builds and pushes `ghcr.io/tinyhumansai/openhuman-core` (`:latest`, `:v<version>`, `:<version>`) instead of just logging into GHCR and exiting.
- New `build-cli-linux` matrix builds standalone `openhuman-core` for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` and attaches `openhuman-core-<version>-<target>.tar.gz` (+ `.sha256`) to the GitHub Release.
- `publish-release` asset validation now requires both Linux tarballs alongside the Tauri installers; `cleanup-failed-release` deletes the pushed GHCR image versions if a downstream phase fails.
- Mirror non-pushing `build-docker` job in `release-staging.yml` so a Dockerfile regression fails staging before promotion.
- Updated stale staging comment about future GHCR work and pointed `cloud-deploy.md` at the actually-published image plus a no-Docker tarball install path.

## Problem

`release-production.yml` invoked `build-desktop.yml` with `build_sidecar: false`, so the optional Linux `openhuman-core` artifact path never ran on the production cut, and `build-docker` stopped after `docker login` — no `docker build` / `docker push` step. Self-hosters following `gitbooks/features/cloud-deploy.md`, anyone automating headless Linux servers, and release hygiene (one tag = all shipping surfaces) all paid the cost.

## Solution

- **GHCR**: complete `build-docker` with `docker/build-push-action` (linux/amd64), three tags per release, OCI labels (`source`, `revision`, `version`, `title`), GHA-scoped buildx cache, and a post-push `docker pull`/`docker image inspect` smoke step. Stayed single-arch — QEMU emulation triples Rust build time; arm64 users pull the standalone tarball or build from source. Documented as a follow-up.
- **Linux CLI tarballs**: new `build-cli-linux` matrix using `ubuntu-22.04` (x86_64) and `ubuntu-24.04-arm` (aarch64). Reuses the existing `scripts/release/package-cli-tarball.sh` (the same script `release-packages.yml` already drives), with the same Sentry DSN guard, `OPENHUMAN_BUILD_SHA` (12-char) baking, and `OPENHUMAN_APP_ENV=production`.
- **Wiring**: added both jobs to `publish-release.needs` + `if`. Asset validation appends `openhuman-core-.*-x86_64-unknown-linux-gnu.tar.gz` and `...-aarch64-...tar.gz`. `cleanup-failed-release` walks the freshly pushed `:v<version>` and `:<version>` GHCR tags and deletes their package versions (`:latest` is left alone — clobbering the moving tag would orphan downstream pulls of the previous release).
- **Staging parity**: added a `build-docker` job to `release-staging.yml` that mirrors the production build but with `push: false, load: true`. `deploy-smoke.yml` already covers Dockerfile regressions on PRs that touch core sources; this is the equivalent gate at the staging-tag boundary so a green staging cut means the next prod promotion's GHCR push will succeed.
- **Docs**: rewrote the staging comment in `release-staging.yml` (no longer claims GHCR is future work). Cloud-deploy doc now leads with `docker pull ghcr.io/tinyhumansai/openhuman-core:latest` and adds a no-Docker tarball install snippet.

## Submission Checklist

- [x] N/A: pure CI YAML + markdown change. The `Verify pushed image is pullable` step plus `publish-release` asset validation enforce both new outputs at run time, and the staging `build-docker` job exercises the Dockerfile build path on every staging cut.
- [x] N/A: pure YAML + markdown change, no executable source under `app/src` or `src/` modified. Issue #1439 acceptance criteria explicitly exempts pure YAML from the diff-coverage gate.
- [x] N/A: behaviour-only release-pipeline change — no feature rows added, removed, or renamed.
- [x] N/A: no feature IDs from the coverage matrix are touched by this PR.
- [x] N/A: no new external network dependencies. `docker/build-push-action` and `docker/login-action` are already used in `deploy-smoke.yml`; `actions/checkout`, `Swatinem/rust-cache`, and `dtolnay/rust-toolchain` mirror what `release-packages.yml` already pins.
- [x] N/A in this PR: will sweep `docs/RELEASE-MANUAL-SMOKE.md` once the next prod cut produces real GHCR + tarball artifacts to verify against.
- [x] Linked issue closed via `Closes #1439` in the `## Related` section.

## Impact

- **Runtime**: desktop bundles unchanged. New surfaces are headless: GHCR image + Linux core tarballs. arm64 hosts that previously had nothing now have a shipped tarball.
- **Performance**: `build-cli-linux` adds ~one cargo release build per arch in parallel. `build-docker` adds the cached image build. No effect on `build-desktop` runtime.
- **Security**: GHCR push uses the workflow's existing `packages: write` permission and `secrets.GITHUB_TOKEN`; OCI labels expose the build SHA + version for provenance. Sentry DSN validation matches the pattern already used by `release-packages.yml`.
- **Migration**: tagged `:latest` will start moving on the next prod cut. Compose users who pinned to a built-locally image are unaffected; those who switch to `image: ghcr.io/tinyhumansai/openhuman-core:latest` (now documented) get the published bits.

## Related

- Closes: #1439
- Follow-up PR(s)/TODOs: arm64 GHCR image (separate per-arch build + manifest job once the prod runner mix is green); switching the in-repo `docker-compose.yml` to default to the published image with a documented "build locally" override.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `issue/1439-production-release-workflow-should-ship`
- Commit SHA: f65978fadc7d9f7377985fcb12e321a44284a37e

### Validation Run
- [x] N/A: pure YAML / markdown change — `pnpm --filter openhuman-app format:check` not affected.
- [x] N/A: `pnpm typecheck` — no TypeScript modified.
- [x] N/A: focused tests — no executable source modified.
- [x] N/A: Rust fmt/check — no Rust touched.
- [x] N/A: Tauri fmt/check — no Tauri code touched.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: production releases now actually publish a GHCR image and Linux `openhuman-core` tarballs in addition to Tauri desktop installers; staging cuts now also exercise the Dockerfile build path (without pushing).
- User-visible effect: `docker pull ghcr.io/tinyhumansai/openhuman-core:vX.Y.Z` works; release pages list `openhuman-core-<version>-{x86_64,aarch64}-unknown-linux-gnu.tar.gz`.

### Parity Contract
- Legacy behavior preserved: desktop matrix invocation is unchanged (`build_sidecar` stays `false`); existing macOS / Windows / Linux `.deb` outputs and `latest.json` validation are untouched. `release-packages.yml` is left disabled — its `build-cli-linux-arm64` job is the model the new matrix mirrors but does not duplicate.
- Guard/fallback/dispatch parity checks: `publish-release` still requires every existing installer pattern; the two new patterns are additive. `cleanup-failed-release` retains its existing tag/release deletion and only refines the GHCR cleanup that was previously dead code.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none known
- Canonical PR: this PR
- Resolution: N/A
