### PR TITLE
Isolate global autocomplete engine in tests

### DIFF
--- a/src/openhuman/autocomplete/ops.rs
+++ b/src/openhuman/autocomplete/ops.rs
@@ -394,24 +394,19 @@ pub async fn autocomplete_start_cli(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
+    use tokio::sync::Mutex;
+
+    /// Global lock to serialize tests that touch the shared autocomplete engine singleton.
+    static TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     // ── autocomplete_status ────────────────────────────────────────────────────
-    //
-    // TODO: These tests share the process-global autocomplete::global_engine()
-    // singleton (via autocomplete_status / autocomplete_stop / autocomplete_start).
-    // They are currently stable because start() always errors on non-macOS, keeping
-    // the engine in an idle state. Once macOS support lands -- or if concurrent tests
-    // transition the engine -- races on the global state will cause flakiness.
-    //
-    // Fix when that happens: serialize engine-touching tests with a
-    // process-wide tokio::sync::Mutex guard (or the `serial_test` crate), or
-    // refactor to accept an injected engine instance instead of going through
-    // global_engine().
 
     /// Happy path: `autocomplete_status` always succeeds and produces exactly
     /// two log lines with the expected key tokens.
     #[tokio::test]
     async fn status_returns_outcome_with_two_log_lines() {
+        let _lock = TEST_LOCK.lock().await;
         let outcome = autocomplete_status()
             .await
             .expect("autocomplete_status must not return Err");
@@ -437,6 +432,7 @@ mod tests {
     /// The status payload has the expected boolean/string fields and a non-empty phase.
     #[tokio::test]
     async fn status_payload_has_expected_fields() {
+        let _lock = TEST_LOCK.lock().await;
         let outcome = autocomplete_status()
             .await
             .expect("autocomplete_status must not return Err");
@@ -462,6 +458,7 @@ mod tests {
     /// and produces two log lines.
     #[tokio::test]
     async fn stop_without_reason_returns_stopped_true_and_two_logs() {
+        let _lock = TEST_LOCK.lock().await;
         let outcome = autocomplete_stop(None)
             .await
             .expect("autocomplete_stop must not return Err");
@@ -486,6 +483,7 @@ mod tests {
     /// When a `reason` is supplied, the structured log line must include it.
     #[tokio::test]
     async fn stop_with_reason_includes_reason_in_log() {
+        let _lock = TEST_LOCK.lock().await;
         let payload = Some(AutocompleteStopParams {
             reason: Some("test-shutdown".to_string()),
         });
@@ -505,6 +503,7 @@ mod tests {
     /// When no reason is supplied, the structured log line must record "none".
     #[tokio::test]
     async fn stop_without_reason_logs_none_as_reason() {
+        let _lock = TEST_LOCK.lock().await;
         let outcome = autocomplete_stop(None)
             .await
             .expect("autocomplete_stop must not return Err");
@@ -525,6 +524,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[tokio::test]
     async fn start_returns_err_on_non_macos() {
+        let _lock = TEST_LOCK.lock().await;
         let result = autocomplete_start(AutocompleteStartParams { debounce_ms: None }).await;
         assert!(
             result.is_err(),
@@ -544,6 +544,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[tokio::test]
     async fn start_cli_plain_path_returns_err_on_non_macos() {
+        let _lock = TEST_LOCK.lock().await;
         let opts = AutocompleteStartCliOptions {
             debounce_ms: None,
             serve: false,


### PR DESCRIPTION
This PR addresses the flakiness in autocomplete operation tests caused by concurrent access to the process-global engine singleton.

### Changes
- Introduced a static `TEST_LOCK` using `once_cell::sync::Lazy` and `tokio::sync::Mutex` within the `tests` module of `src/openhuman/autocomplete/ops.rs`.
- Updated all tests that interact with `global_engine()` (directly or via `autocomplete_*` functions) to acquire this lock before proceeding.
- Removed the now-obsolete TODO comment in `src/openhuman/autocomplete/ops.rs` that described the problem and suggested this serialization fix.

### Verification Results
- **Manual Review**: The code change correctly implements the serialization pattern suggested in the original TODO and follows Rust best practices for async test synchronization.
- **Code Review**: Received a "#Correct#" rating from the automated code review tool.
- **Automated Tests**: Execution was attempted but blocked by network-related environment issues (unable to download the pinned Rust toolchain and git-based dependencies like `whisper-rs-sys`). Logic verification was performed manually.

---
*PR created automatically by Jules for task [8822273227118319460](https://jules.google.com/task/8822273227118319460) started by @senamakel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for internal testing infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1443)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->