### PR TITLE
fix(sentry): resolve verifier path correctly on Windows

### DIFF
--- a/scripts/release/verify-sentry-sourcemaps.mjs
+++ b/scripts/release/verify-sentry-sourcemaps.mjs
@@ -14,9 +14,15 @@
 // ran — either a `// debugId=<uuid>` pragma comment OR an injected
 // `_sentryDebugIds` runtime map.
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = resolve(new URL('..', import.meta.url).pathname, '..');
+// Use `fileURLToPath` rather than `new URL(...).pathname` — on Windows the
+// latter returns a leading-slash path like `/D:/a/openhuman/...` which
+// `path.resolve` then mangles into `D:\D:\a\...` (duplicate drive letter),
+// causing the verifier to ENOENT on `dist/assets`.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..', '..');
 const ASSETS = join(ROOT, 'app', 'dist', 'assets');
 // The pragma comment `//# debugId=<uuid>` is what @sentry/vite-plugin
 // appends to chunks, but Vite/esbuild minification strips it from many


### PR DESCRIPTION
## Summary

- `scripts/release/verify-sentry-sourcemaps.mjs` derived its repo root from `new URL('..', import.meta.url).pathname`, which on Windows returns a leading-slash path like `/D:/a/openhuman/openhuman/scripts/`. Feeding that into `path.resolve` produces a duplicated drive letter (`D:\D:\a\openhuman\openhuman\app\dist\assets`) and the verifier ENOENTs.
- Switch to `fileURLToPath(import.meta.url)` so URL→path conversion is correct on every platform.

Failure observed on the Windows leg of staging release [25614993136](https://github.com/tinyhumansai/openhuman/actions/runs/25614993136):

```
[verify-sentry-sourcemaps] D:\D:\a\openhuman\openhuman\app\dist\assets not found — did Vite build succeed?
ENOENT: no such file or directory, scandir 'D:\D:\a\openhuman\openhuman\app\dist\assets'
Error: Process completed with exit code 2.
```

Follow-up to #1448 (which relaxed the debug-ID/runtime-map check). Linux + macOS builds in that same staging run already passed the relaxed check and uploaded source maps; only Windows tripped on this path bug.

## Test plan

- [ ] Re-run Release Staging; the Windows desktop job's "Verify Sentry source-map upload (frontend)" step finds `app/dist/assets` and exits 0.
- [ ] Linux + macOS legs continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform path resolution in the release verification system, fixing build failures on Windows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1452)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->