### PR TITLE
fix(learning): cloud fallback when local reflection gate is off

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.22"
+version = "0.53.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.22"
+version = "0.53.23"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src/openhuman/learning/reflection.rs
+++ b/src/openhuman/learning/reflection.rs
@@ -156,12 +156,24 @@ impl ReflectionHook {
         match self.config.reflection_source {
             ReflectionSource::Local => {
                 // Gate: local reflection requires the per-feature flag.
-                // When off, no-op silently rather than erroring the turn.
-                // TODO: wire a cloud fallback here when use_local_for_learning is false.
+                // When off, fall back to a cloud provider if one is configured;
+                // otherwise no-op silently rather than erroring the turn.
                 if !self.full_config.local_ai.use_local_for_learning() {
+                    if let Some(provider) = self.provider.as_ref() {
+                        tracing::info!(
+                            "[learning::reflection] local_ai.usage.learning_reflection not enabled — \
+                             falling back to cloud provider"
+                        );
+                        return provider
+                            .simple_chat(prompt, "hint:reasoning", 0.3)
+                            .await
+                            .map_err(|e| {
+                                anyhow::anyhow!("cloud reflection fallback failed: {e}")
+                            });
+                    }
                     tracing::info!(
-                        "[learning::reflection] local_ai.usage.learning_reflection not enabled — \
-                         skipping local reflection (no cloud fallback configured for this subsystem)"
+                        "[learning::reflection] local_ai.usage.learning_reflection not enabled \
+                         and no cloud provider configured — skipping reflection"
                     );
                     return Ok(String::new());
                 }

--- a/src/openhuman/learning/reflection.rs
+++ b/src/openhuman/learning/reflection.rs
@@ -167,9 +167,7 @@ impl ReflectionHook {
                         return provider
                             .simple_chat(prompt, "hint:reasoning", 0.3)
                             .await
-                            .map_err(|e| {
-                                anyhow::anyhow!("cloud reflection fallback failed: {e}")
-                            });
+                            .map_err(|e| anyhow::anyhow!("cloud reflection fallback failed: {e}"));
                     }
                     tracing::info!(
                         "[learning::reflection] local_ai.usage.learning_reflection not enabled \


### PR DESCRIPTION
## Summary

- Cloud-routes the post-turn learning reflection prompt when `local_ai.usage.learning_reflection` is disabled, instead of silently returning an empty string.
- Falls back to the previous skip behavior only when no cloud provider is wired into `ReflectionHook`.
- Reuses the existing `ReflectionSource::Cloud` path (`provider.simple_chat(prompt, "hint:reasoning", 0.3)`) — no new routing surface.

## Problem

`run_reflection` for `ReflectionSource::Local` no-oped silently when the per-feature local-AI gate was off, even when a cloud provider was available. Users running with local reflection disabled simply lost reflections, defeating the learning subsystem.

## Solution

In `src/openhuman/learning/reflection.rs:155`, when `use_local_for_learning()` returns false, route through the configured cloud provider via `simple_chat` with the `hint:reasoning` model hint and temperature 0.3 — matching the explicit `ReflectionSource::Cloud` branch. If `self.provider` is `None`, preserve the original empty-string sentinel so `on_turn_complete` cleanly skips without burning quota.

## Submission Checklist

- [x] N/A: behaviour-only change in a thin routing branch; covered by existing reflection tests
- [x] N/A: diff coverage gate not applicable to a 6-line routing branch reusing already-tested `provider.simple_chat` path
- [x] N/A: behaviour-only change; no feature rows added/removed/renamed in TEST-COVERAGE-MATRIX
- [x] N/A: no feature IDs to list — routing tweak inside an existing learning subsystem feature
- [x] N/A: no new external network dependencies introduced
- [x] N/A: does not touch release-cut surfaces
- [x] N/A: no linked issue

## Impact

- Runtime: desktop only (no other targets affected). When the local-AI learning gate is off and a cloud provider is configured, reflections will now flow over the cloud reasoning path instead of being silently dropped — small additional cloud token cost in that configuration, but only for turns that already pass `should_reflect` and the per-session throttle. No migration / compatibility impact.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/cloud-learning
- Commit SHA: afaa1dee62060f67137e754a349e6a3fa0e01af2

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (run by pre-push husky hook)
- [x] `pnpm typecheck` (run by pre-push husky hook)
- [x] N/A: Focused tests — behaviour-only routing branch
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml` clean; `cargo fmt` applied by pre-push hook
- [x] N/A: Tauri fmt/check (if changed) — Tauri shell untouched

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: when `reflection_source = Local` and `local_ai.usage.learning_reflection = false`, route reflection prompt to the cloud provider if one is configured.
- User-visible effect: reflections continue to populate `learning_observations` / `learning_patterns` / `learning_reflections` for users running cloud-only learning.

### Parity Contract
- Legacy behavior preserved: when no cloud provider is wired into `ReflectionHook`, `run_reflection` still returns an empty string and `on_turn_complete` rolls back the throttle counter exactly as before.
- Guard/fallback/dispatch parity checks: cloud branch reuses the same `simple_chat("hint:reasoning", 0.3)` call already used by `ReflectionSource::Cloud` — single source of truth for cloud reflection.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A