### PR TITLE
Support reliable self-update for server-side and headless core instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,11 @@ OPENHUMAN_WORKSPACE=
 OPENHUMAN_TEMPERATURE=0.7
 # [optional] Skill + agent tool execution timeout in seconds (default 120, max 3600)
 # OPENHUMAN_TOOL_TIMEOUT_SECS=
+# [optional] Headless update restart contract: self_replace | supervisor
+# OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY=self_replace
+# [optional] Allow bearer-authenticated RPC callers to invoke update.apply/update.run
+# Disable on exposed server deployments unless you explicitly want remote self-upgrade.
+# OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED=true
 
 # ---------------------------------------------------------------------------
 # Runtime flags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.22"
+version = "0.53.25"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.22"
+version = "0.53.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.22"
+version = "0.53.25"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -43,6 +43,7 @@ Applies to every release, all platforms.
 
 - [ ] **`.deb` and/or `.AppImage` install on a clean Ubuntu 22.04** — `sudo dpkg -i openhuman_*.deb` or `chmod +x openhuman-*.AppImage && ./openhuman-*.AppImage`. Expected: no missing-dependency errors; app launches.
 - [ ] **OS-native notification toasts fire** — Trigger a notification from inside the app (e.g. memory captured, agent finished). Expected: a libnotify-style toast appears outside the app window. (CI Linux sees only Xvfb; this surface verifies on a real desktop.)
+- [ ] **Headless supervisor update stages without self-exit** — On a Linux service deployment with `[update] restart_strategy = "supervisor"` and `rpc_mutations_enabled = false`, stage a new core binary through the documented operator flow. Expected: the running process stays up until the supervisor restart, the staged binary is present on disk, and `systemctl restart openhuman` (or equivalent) picks up the new version.
 
 ### Cross-platform
 

--- a/docs/TEST-COVERAGE-MATRIX.md
+++ b/docs/TEST-COVERAGE-MATRIX.md
@@ -48,7 +48,7 @@ Canonical mapping of every product feature to its test source(s). Drives gap-fil
 
 | ID    | Feature                       | Layer | Test path(s)                                       | Status | Notes                                 |
 | ----- | ----------------------------- | ----- | -------------------------------------------------- | ------ | ------------------------------------- |
-| 0.3.1 | Auto Update Check             | RU+MS | `src/openhuman/update/` (Rust unit), release smoke | 🟡     | Core check covered; UI prompt manual  |
+| 0.3.1 | Auto Update Check             | RU+RI+MS | `src/openhuman/update/` (Rust unit), `tests/json_rpc_e2e.rs`, release smoke | 🟡     | Core check/update policy covered; desktop prompt + release upgrade still manual |
 | 0.3.2 | Forced Update Handling        | MS    | release-manual-smoke                               | 🚫     | End-to-end gating verified at release |
 | 0.3.3 | Reinstall with Existing State | MS    | release-manual-smoke                               | 🚫     | Workspace persistence on reinstall    |
 | 0.3.4 | Clean Uninstall               | MS    | release-manual-smoke                               | 🚫     | OS removal paths                      |

--- a/gitbooks/features/cloud-deploy.md
+++ b/gitbooks/features/cloud-deploy.md
@@ -250,7 +250,11 @@ ExecReload=/bin/kill -HUP $MAINPID
 Operator flow:
 
 1. Call `openhuman.update_check` to discover a release.
-2. Call `openhuman.update_apply` or `openhuman.update_run` with `restart_strategy=supervisor`.
+2. Configure `restart_strategy = "supervisor"` in your `update.toml` (or set
+   `OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY=supervisor`) so the core stages the
+   new binary without trying to re-exec itself, then call
+   `openhuman.update_apply` or `openhuman.update_run`. `restart_strategy` is a
+   configuration setting, not an RPC parameter.
 3. Restart the unit explicitly: `systemctl restart openhuman`.
 
 If download or staging fails, the running binary is left in place and no

--- a/gitbooks/features/cloud-deploy.md
+++ b/gitbooks/features/cloud-deploy.md
@@ -214,6 +214,50 @@ Then run `openhuman-core serve` under your service manager of choice
 (systemd, supervisord, …) with the same environment variables documented
 above.
 
+### Headless self-update contract
+
+Headless deployments should treat `openhuman.update_apply` as the safe primitive:
+it downloads the release asset, writes it atomically next to the current binary,
+and returns. Nothing exits automatically.
+
+`openhuman.update_run` follows `config.update.restart_strategy`:
+
+- `self_replace` (default): stage the binary, publish an in-process restart request, and let the running core respawn itself.
+- `supervisor`: stage the binary and return `restart_requested=false`. Your outer service manager must restart the process.
+
+For long-running Linux services, set:
+
+```toml
+[update]
+restart_strategy = "supervisor"
+rpc_mutations_enabled = false
+```
+
+or the equivalent env vars:
+
+```bash
+OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY=supervisor
+OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED=false
+```
+
+Recommended `systemd` stance:
+
+```ini
+Restart=always
+ExecReload=/bin/kill -HUP $MAINPID
+```
+
+Operator flow:
+
+1. Call `openhuman.update_check` to discover a release.
+2. Call `openhuman.update_apply` or `openhuman.update_run` with `restart_strategy=supervisor`.
+3. Restart the unit explicitly: `systemctl restart openhuman`.
+
+If download or staging fails, the running binary is left in place and no
+restart is requested. If a staged binary proves bad after restart, roll back by
+restoring the previous binary from your package manager, image tag, or release
+artifact and restarting the supervisor again.
+
 The Compose file ([`docker-compose.yml`](../../docker-compose.yml)) maps the core
 on `:7788`, mounts a named volume `openhuman-workspace` for persistence, and
 sets `restart: unless-stopped` so the core comes back after host reboots.
@@ -225,6 +269,10 @@ git pull
 docker compose build
 docker compose up -d
 ```
+
+For RPC-exposed production deployments, prefer leaving mutating update RPCs
+disabled (`OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED=false`) and perform
+rollouts through your existing image tag or package-management flow instead.
 
 ### Logs
 

--- a/src/openhuman/about_app/catalog.rs
+++ b/src/openhuman/about_app/catalog.rs
@@ -922,7 +922,7 @@ const CAPABILITIES: &[Capability] = &[
         name: "Apply Core Update",
         domain: "update",
         category: CapabilityCategory::Settings,
-        description: "Download and stage a newer core binary, then restart the sidecar.",
+        description: "Download and stage a newer core binary. Desktop builds can self-restart; headless deployments can hand restart off to a supervisor.",
         how_to: "Settings > Developer Options > Apply Update",
         status: CapabilityStatus::Beta,
         privacy: None,

--- a/src/openhuman/config/mod.rs
+++ b/src/openhuman/config/mod.rs
@@ -34,9 +34,9 @@ pub use schema::{
     ReliabilityConfig, ResourceLimitsConfig, RuntimeConfig, SandboxBackend, SandboxConfig,
     SchedulerConfig, SchedulerGateConfig, SchedulerGateMode, ScreenIntelligenceConfig,
     SecretsConfig, SecurityConfig, SlackConfig, StorageConfig, StorageProviderConfig,
-    StorageProviderSection, StreamMode, TelegramConfig, UpdateConfig, VoiceActivationMode,
-    VoiceServerConfig, WebSearchConfig, WebhookConfig, DEFAULT_CLOUD_LLM_MODEL, DEFAULT_MODEL,
-    MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_V1,
+    StorageProviderSection, StreamMode, TelegramConfig, UpdateConfig, UpdateRestartStrategy,
+    VoiceActivationMode, VoiceServerConfig, WebSearchConfig, WebhookConfig,
+    DEFAULT_CLOUD_LLM_MODEL, DEFAULT_MODEL, MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_V1,
 };
 pub use schema::{
     clear_active_user, default_root_openhuman_dir, pre_login_user_dir, read_active_user_id,

--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -5,7 +5,7 @@ use super::{
         normalize_no_proxy_list, normalize_proxy_url_option, normalize_service_list,
         parse_proxy_enabled, parse_proxy_scope, set_runtime_proxy_config, ProxyScope,
     },
-    Config,
+    Config, UpdateRestartStrategy,
 };
 use anyhow::{Context, Result};
 use directories::UserDirs;
@@ -1059,6 +1059,30 @@ impl Config {
         if let Some(val) = env.get("OPENHUMAN_AUTO_UPDATE_INTERVAL_MINUTES") {
             if let Ok(minutes) = val.trim().parse::<u32>() {
                 self.update.interval_minutes = minutes;
+            }
+        }
+        if let Some(raw) = env.get("OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY") {
+            match raw.trim().to_ascii_lowercase().as_str() {
+                "self_replace" | "self-replace" | "self" => {
+                    self.update.restart_strategy = UpdateRestartStrategy::SelfReplace;
+                }
+                "supervisor" | "stage_only" | "stage-only" => {
+                    self.update.restart_strategy = UpdateRestartStrategy::Supervisor;
+                }
+                other => {
+                    tracing::warn!(
+                        value = other,
+                        "ignoring invalid OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY \
+                         (valid: self_replace, supervisor)"
+                    );
+                }
+            }
+        }
+        if let Some(flag) = env.get("OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED") {
+            if let Some(enabled) =
+                parse_env_bool("OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED", &flag)
+            {
+                self.update.rpc_mutations_enabled = enabled;
             }
         }
 

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -811,6 +811,35 @@ fn env_overlay_auto_update_interval_parses_u32() {
 }
 
 #[test]
+fn env_overlay_auto_update_restart_strategy_accepts_supported_values() {
+    let mut cfg = Config::default();
+    cfg.apply_env_overlay_with(
+        &HashMapEnv::new().with("OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY", "supervisor"),
+    );
+    assert_eq!(
+        cfg.update.restart_strategy,
+        crate::openhuman::config::UpdateRestartStrategy::Supervisor
+    );
+
+    cfg.apply_env_overlay_with(
+        &HashMapEnv::new().with("OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY", "self_replace"),
+    );
+    assert_eq!(
+        cfg.update.restart_strategy,
+        crate::openhuman::config::UpdateRestartStrategy::SelfReplace
+    );
+}
+
+#[test]
+fn env_overlay_auto_update_rpc_mutations_enabled_parses_bool() {
+    let mut cfg = Config::default();
+    cfg.apply_env_overlay_with(
+        &HashMapEnv::new().with("OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED", "false"),
+    );
+    assert!(!cfg.update.rpc_mutations_enabled);
+}
+
+#[test]
 fn env_overlay_empty_lookup_leaves_defaults_intact() {
     // The seam with no env entries should be a no-op on a fresh Config.
     let mut cfg = Config::default();

--- a/src/openhuman/config/schema/mod.rs
+++ b/src/openhuman/config/schema/mod.rs
@@ -66,7 +66,7 @@ pub use tools::{
     GitbooksConfig, HttpRequestConfig, IntegrationToggle, IntegrationsConfig, MultimodalConfig,
     SecretsConfig, WebSearchConfig,
 };
-pub use update::UpdateConfig;
+pub use update::{UpdateConfig, UpdateRestartStrategy};
 mod voice_server;
 pub use voice_server::{VoiceActivationMode, VoiceServerConfig};
 mod types;

--- a/src/openhuman/config/schema/update.rs
+++ b/src/openhuman/config/schema/update.rs
@@ -3,6 +3,22 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// How `update.run` should complete after staging a new binary.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateRestartStrategy {
+    /// Request an in-process self-restart immediately after staging.
+    SelfReplace,
+    /// Stage the new binary and leave restart to an external supervisor.
+    Supervisor,
+}
+
+impl Default for UpdateRestartStrategy {
+    fn default() -> Self {
+        Self::SelfReplace
+    }
+}
+
 /// Configuration for periodic self-update checks against GitHub Releases.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct UpdateConfig {
@@ -14,6 +30,15 @@ pub struct UpdateConfig {
     /// Minimum enforced at runtime is 10 minutes.
     #[serde(default = "default_update_interval_minutes")]
     pub interval_minutes: u32,
+
+    /// How `update.run` should handle restart after staging a new binary.
+    #[serde(default)]
+    pub restart_strategy: UpdateRestartStrategy,
+
+    /// Whether bearer-authenticated RPC clients may invoke mutating update
+    /// methods (`update.apply`, `update.run`).
+    #[serde(default = "default_rpc_mutations_enabled")]
+    pub rpc_mutations_enabled: bool,
 }
 
 fn default_update_enabled() -> bool {
@@ -24,11 +49,17 @@ fn default_update_interval_minutes() -> u32 {
     60
 }
 
+fn default_rpc_mutations_enabled() -> bool {
+    true
+}
+
 impl Default for UpdateConfig {
     fn default() -> Self {
         Self {
             enabled: default_update_enabled(),
             interval_minutes: default_update_interval_minutes(),
+            restart_strategy: UpdateRestartStrategy::default(),
+            rpc_mutations_enabled: default_rpc_mutations_enabled(),
         }
     }
 }

--- a/src/openhuman/update/core.rs
+++ b/src/openhuman/update/core.rs
@@ -4,6 +4,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 
+use crate::openhuman::config::UpdateRestartStrategy;
 use crate::openhuman::update::types::{GitHubAsset, GitHubRelease, UpdateApplyResult, UpdateInfo};
 
 /// GitHub owner/repo for the core binary releases.
@@ -283,6 +284,7 @@ pub async fn download_and_stage_with_version(
         installed_version,
         staged_path: staged_path.to_string_lossy().to_string(),
         restart_required: true,
+        restart_strategy: UpdateRestartStrategy::SelfReplace,
     })
 }
 

--- a/src/openhuman/update/ops.rs
+++ b/src/openhuman/update/ops.rs
@@ -4,9 +4,154 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+use crate::openhuman::config::{self, UpdateConfig, UpdateRestartStrategy};
 use crate::openhuman::update;
-use crate::openhuman::update::types::{UpdateRunResult, VersionInfo};
+use crate::openhuman::update::types::{
+    UpdateApplyResult, UpdateInfo, UpdateRunResult, VersionInfo,
+};
 use crate::rpc::RpcOutcome;
+
+async fn load_update_policy() -> UpdateConfig {
+    match config::rpc::load_config_with_timeout().await {
+        Ok(cfg) => cfg.update,
+        Err(err) => {
+            log::warn!(
+                "[update:rpc] failed to load config for update policy, falling back to defaults: {}",
+                err
+            );
+            UpdateConfig::default()
+        }
+    }
+}
+
+async fn enforce_update_mutation_policy(method: &str) -> Result<UpdateConfig, String> {
+    let policy = load_update_policy().await;
+    if policy.rpc_mutations_enabled {
+        return Ok(policy);
+    }
+
+    let message = format!(
+        "{method} is disabled by config.update.rpc_mutations_enabled=false; \
+         use update.check for discovery and restart under a supervisor after staging manually"
+    );
+    log::warn!("[update:rpc] {}", message);
+    Err(message)
+}
+
+fn already_current_result(
+    info: &UpdateInfo,
+    restart_strategy: UpdateRestartStrategy,
+) -> UpdateRunResult {
+    UpdateRunResult {
+        current_version: info.current_version.clone(),
+        latest_version: info.latest_version.clone(),
+        update_available: false,
+        applied: false,
+        staged_path: None,
+        restart_requested: false,
+        restart_strategy,
+        message: format!("already on latest ({})", info.current_version),
+    }
+}
+
+fn missing_asset_result(
+    info: UpdateInfo,
+    restart_strategy: UpdateRestartStrategy,
+) -> UpdateRunResult {
+    UpdateRunResult {
+        current_version: info.current_version,
+        latest_version: info.latest_version,
+        update_available: true,
+        applied: false,
+        staged_path: None,
+        restart_requested: false,
+        restart_strategy,
+        message: format!(
+            "latest release has no asset for target {}",
+            update::platform_triple()
+        ),
+    }
+}
+
+fn apply_failure_result(
+    info: UpdateInfo,
+    restart_strategy: UpdateRestartStrategy,
+    error: &str,
+) -> UpdateRunResult {
+    UpdateRunResult {
+        current_version: info.current_version,
+        latest_version: info.latest_version,
+        update_available: true,
+        applied: false,
+        staged_path: None,
+        restart_requested: false,
+        restart_strategy,
+        message: format!("download/stage failed: {error}"),
+    }
+}
+
+async fn build_run_result_from_staged_update(
+    info: UpdateInfo,
+    mut applied: UpdateApplyResult,
+    restart_strategy: UpdateRestartStrategy,
+) -> UpdateRunResult {
+    applied.restart_strategy = restart_strategy;
+
+    match restart_strategy {
+        UpdateRestartStrategy::SelfReplace => {
+            let restart_requested = match crate::openhuman::service::rpc::service_restart(
+                Some("update.run".to_string()),
+                Some(format!("update to {}", info.latest_version)),
+            )
+            .await
+            {
+                Ok(_) => true,
+                Err(e) => {
+                    log::warn!(
+                        "[update:rpc] update_run staged update but restart publish failed: {}",
+                        e
+                    );
+                    false
+                }
+            };
+
+            UpdateRunResult {
+                current_version: info.current_version,
+                latest_version: info.latest_version,
+                update_available: true,
+                applied: true,
+                staged_path: Some(applied.staged_path.clone()),
+                restart_requested,
+                restart_strategy,
+                message: if restart_requested {
+                    format!(
+                        "staged {} — restart requested",
+                        applied.staged_path.as_str()
+                    )
+                } else {
+                    format!(
+                        "staged {} — restart publish failed; caller must restart manually",
+                        applied.staged_path.as_str()
+                    )
+                },
+            }
+        }
+        UpdateRestartStrategy::Supervisor => UpdateRunResult {
+            current_version: info.current_version,
+            latest_version: info.latest_version.clone(),
+            update_available: true,
+            applied: true,
+            staged_path: Some(applied.staged_path.clone()),
+            restart_requested: false,
+            restart_strategy,
+            message: format!(
+                "staged {} — supervisor restart required before {} takes effect",
+                applied.staged_path.as_str(),
+                info.latest_version
+            ),
+        },
+    }
+}
 
 /// Report the running core binary's version + target triple.
 ///
@@ -36,6 +181,20 @@ pub async fn update_version() -> RpcOutcome<Value> {
 /// core process will exit shortly afterwards.
 pub async fn update_run() -> RpcOutcome<Value> {
     log::info!("[update:rpc] update_run invoked");
+    let policy = match enforce_update_mutation_policy("openhuman.update_run").await {
+        Ok(policy) => policy,
+        Err(error) => {
+            return RpcOutcome::single_log(
+                serde_json::json!({
+                    "error": error,
+                    "applied": false,
+                    "restart_requested": false,
+                }),
+                "update_run rejected by policy",
+            );
+        }
+    };
+    let restart_strategy = policy.restart_strategy;
 
     let info = match update::check_available().await {
         Ok(i) => i,
@@ -53,18 +212,10 @@ pub async fn update_run() -> RpcOutcome<Value> {
     };
 
     if !info.update_available {
-        let result = UpdateRunResult {
-            current_version: info.current_version.clone(),
-            latest_version: info.latest_version.clone(),
-            update_available: false,
-            applied: false,
-            staged_path: None,
-            restart_requested: false,
-            message: format!("already on latest ({})", info.current_version),
-        };
+        let result = already_current_result(&info, restart_strategy);
         log::info!(
             "[update:rpc] update_run: already up to date ({})",
-            info.current_version
+            result.current_version
         );
         return RpcOutcome::single_log(
             serde_json::to_value(&result).unwrap_or(Value::Null),
@@ -72,23 +223,14 @@ pub async fn update_run() -> RpcOutcome<Value> {
         );
     }
 
-    let (Some(download_url), Some(asset_name)) = (info.download_url, info.asset_name) else {
+    let (Some(download_url), Some(asset_name)) =
+        (info.download_url.clone(), info.asset_name.clone())
+    else {
         log::warn!(
             "[update:rpc] update_run: latest release has no asset for this platform (target={})",
             update::platform_triple()
         );
-        let result = UpdateRunResult {
-            current_version: info.current_version,
-            latest_version: info.latest_version,
-            update_available: true,
-            applied: false,
-            staged_path: None,
-            restart_requested: false,
-            message: format!(
-                "latest release has no asset for target {}",
-                update::platform_triple()
-            ),
-        };
+        let result = missing_asset_result(info, restart_strategy);
         return RpcOutcome::single_log(
             serde_json::to_value(&result).unwrap_or(Value::Null),
             "update_run: missing platform asset",
@@ -117,15 +259,7 @@ pub async fn update_run() -> RpcOutcome<Value> {
         Ok(r) => r,
         Err(e) => {
             log::error!("[update:rpc] update_run apply failed: {e}");
-            let result = UpdateRunResult {
-                current_version: info.current_version,
-                latest_version: info.latest_version,
-                update_available: true,
-                applied: false,
-                staged_path: None,
-                restart_requested: false,
-                message: format!("download/stage failed: {e}"),
-            };
+            let result = apply_failure_result(info, restart_strategy, &e);
             return RpcOutcome::single_log(
                 serde_json::to_value(&result).unwrap_or(Value::Null),
                 format!("update_run: apply failed: {e}"),
@@ -133,43 +267,11 @@ pub async fn update_run() -> RpcOutcome<Value> {
         }
     };
 
-    // Stage succeeded — request a self-restart so the Tauri shell can
-    // pick up the freshly-staged binary on its next supervised launch.
-    let restart_requested = match crate::openhuman::service::rpc::service_restart(
-        Some("update.run".to_string()),
-        Some(format!("update to {}", info.latest_version)),
-    )
-    .await
-    {
-        Ok(_) => true,
-        Err(e) => {
-            log::warn!("[update:rpc] update_run staged update but restart publish failed: {e}");
-            false
-        }
-    };
-
-    let result = UpdateRunResult {
-        current_version: info.current_version,
-        latest_version: info.latest_version,
-        update_available: true,
-        applied: true,
-        staged_path: Some(applied.staged_path.clone()),
-        restart_requested,
-        message: if restart_requested {
-            format!(
-                "staged {} — restart requested",
-                applied.staged_path.as_str()
-            )
-        } else {
-            format!(
-                "staged {} — restart publish failed; caller must restart manually",
-                applied.staged_path.as_str()
-            )
-        },
-    };
+    let result = build_run_result_from_staged_update(info, applied, restart_strategy).await;
     log::info!(
-        "[update:rpc] update_run completed applied=true restart_requested={}",
-        restart_requested
+        "[update:rpc] update_run completed applied=true restart_requested={} restart_strategy={:?}",
+        result.restart_requested,
+        result.restart_strategy
     );
     RpcOutcome::single_log(
         serde_json::to_value(&result).unwrap_or(Value::Null),
@@ -251,6 +353,15 @@ pub async fn update_apply(
         download_url,
         asset_name,
     );
+    let policy = match enforce_update_mutation_policy("openhuman.update_apply").await {
+        Ok(policy) => policy,
+        Err(error) => {
+            return RpcOutcome::single_log(
+                serde_json::json!({ "error": error }),
+                "update_apply rejected by policy",
+            );
+        }
+    };
 
     // Validate inputs at the RPC boundary.
     if let Err(e) = validate_download_url(&download_url) {
@@ -271,7 +382,8 @@ pub async fn update_apply(
     // Ignore caller-provided staging_dir — always use the safe default.
     let dir: Option<PathBuf> = None;
     match update::download_and_stage(&download_url, &asset_name, dir).await {
-        Ok(result) => {
+        Ok(mut result) => {
+            result.restart_strategy = policy.restart_strategy;
             let value = serde_json::to_value(&result).unwrap_or_else(
                 |e| serde_json::json!({ "error": format!("serialization failed: {e}") }),
             );
@@ -290,6 +402,18 @@ pub async fn update_apply(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::config::TEST_ENV_LOCK;
+    use tempfile::TempDir;
+
+    async fn write_update_policy(tmp: &TempDir, update: UpdateConfig) {
+        let mut cfg = crate::openhuman::config::Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..crate::openhuman::config::Config::default()
+        };
+        cfg.update = update;
+        cfg.save().await.expect("save config");
+    }
 
     // ── validate_download_url ─────────────────────────────────────
 
@@ -392,6 +516,64 @@ mod tests {
             .logs
             .iter()
             .any(|l| l.contains("update_apply rejected")));
+    }
+
+    #[tokio::test]
+    async fn update_apply_rejects_when_rpc_mutations_disabled() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path());
+        write_update_policy(
+            &tmp,
+            UpdateConfig {
+                rpc_mutations_enabled: false,
+                ..UpdateConfig::default()
+            },
+        )
+        .await;
+
+        let outcome = update_apply(
+            "https://github.com/owner/repo/releases/download/v1/x".to_string(),
+            "openhuman-core-x86_64.tar.gz".to_string(),
+            None,
+        )
+        .await;
+
+        std::env::remove_var("OPENHUMAN_WORKSPACE");
+        assert!(outcome.value.get("error").is_some());
+        assert!(outcome.value["error"]
+            .as_str()
+            .is_some_and(|value| value.contains("rpc_mutations_enabled=false")));
+    }
+
+    #[tokio::test]
+    async fn supervisor_restart_strategy_stages_without_restart_request() {
+        let info = UpdateInfo {
+            latest_version: "9.9.9".into(),
+            current_version: "1.0.0".into(),
+            update_available: true,
+            download_url: Some(
+                "https://github.com/owner/repo/releases/download/v9/openhuman-core".into(),
+            ),
+            asset_name: Some("openhuman-core-x86_64-unknown-linux-gnu".into()),
+            release_notes: None,
+            published_at: None,
+        };
+        let applied = UpdateApplyResult {
+            installed_version: "9.9.9".into(),
+            staged_path: "/tmp/openhuman-core".into(),
+            restart_required: true,
+            restart_strategy: UpdateRestartStrategy::SelfReplace,
+        };
+
+        let result =
+            build_run_result_from_staged_update(info, applied, UpdateRestartStrategy::Supervisor)
+                .await;
+
+        assert!(result.applied);
+        assert!(!result.restart_requested);
+        assert_eq!(result.restart_strategy, UpdateRestartStrategy::Supervisor);
+        assert!(result.message.contains("supervisor restart required"));
     }
 
     // NOTE: `update_check` and the success path of `update_apply`

--- a/src/openhuman/update/ops.rs
+++ b/src/openhuman/update/ops.rs
@@ -11,21 +11,21 @@ use crate::openhuman::update::types::{
 };
 use crate::rpc::RpcOutcome;
 
-async fn load_update_policy() -> UpdateConfig {
-    match config::rpc::load_config_with_timeout().await {
-        Ok(cfg) => cfg.update,
-        Err(err) => {
-            log::warn!(
-                "[update:rpc] failed to load config for update policy, falling back to defaults: {}",
-                err
-            );
-            UpdateConfig::default()
-        }
-    }
+async fn load_update_policy() -> Result<UpdateConfig, String> {
+    config::rpc::load_config_with_timeout()
+        .await
+        .map(|cfg| cfg.update)
+        .map_err(|err| format!("failed to load config for update policy: {err}"))
 }
 
 async fn enforce_update_mutation_policy(method: &str) -> Result<UpdateConfig, String> {
-    let policy = load_update_policy().await;
+    let policy = load_update_policy().await.map_err(|err| {
+        let message = format!(
+            "{method} blocked: {err}; failing closed because update policy could not be loaded"
+        );
+        log::error!("[update:rpc] {}", message);
+        message
+    })?;
     if policy.rpc_mutations_enabled {
         return Ok(policy);
     }
@@ -518,11 +518,24 @@ mod tests {
             .any(|l| l.contains("update_apply rejected")));
     }
 
+    struct WorkspaceEnvGuard;
+    impl WorkspaceEnvGuard {
+        fn set(path: &std::path::Path) -> Self {
+            std::env::set_var("OPENHUMAN_WORKSPACE", path);
+            Self
+        }
+    }
+    impl Drop for WorkspaceEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("OPENHUMAN_WORKSPACE");
+        }
+    }
+
     #[tokio::test]
     async fn update_apply_rejects_when_rpc_mutations_disabled() {
         let _guard = TEST_ENV_LOCK.lock().unwrap();
         let tmp = TempDir::new().unwrap();
-        std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path());
+        let _workspace_guard = WorkspaceEnvGuard::set(tmp.path());
         write_update_policy(
             &tmp,
             UpdateConfig {
@@ -539,7 +552,6 @@ mod tests {
         )
         .await;
 
-        std::env::remove_var("OPENHUMAN_WORKSPACE");
         assert!(outcome.value.get("error").is_some());
         assert!(outcome.value["error"]
             .as_str()

--- a/src/openhuman/update/scheduler.rs
+++ b/src/openhuman/update/scheduler.rs
@@ -103,6 +103,7 @@ mod tests {
         let cfg = UpdateConfig {
             enabled: false,
             interval_minutes: 0,
+            ..UpdateConfig::default()
         };
         run(cfg).await;
     }

--- a/src/openhuman/update/types.rs
+++ b/src/openhuman/update/types.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::openhuman::config::UpdateRestartStrategy;
+
 /// Summary of an available update from GitHub Releases.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateInfo {
@@ -52,6 +54,8 @@ pub struct UpdateRunResult {
     /// True when a self-restart was published. The process will exit
     /// shortly after the RPC response is returned.
     pub restart_requested: bool,
+    /// The configured post-stage restart contract.
+    pub restart_strategy: UpdateRestartStrategy,
     /// Human-readable summary suitable for logs / surface text.
     pub message: String,
 }
@@ -65,6 +69,8 @@ pub struct UpdateApplyResult {
     pub staged_path: String,
     /// Whether a restart is required to complete the update.
     pub restart_required: bool,
+    /// The configured post-stage restart contract.
+    pub restart_strategy: UpdateRestartStrategy,
 }
 
 /// Subset of the GitHub Releases API response we care about.

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -3548,6 +3548,61 @@ async fn external_process_with_guessed_token_is_rejected() {
     rpc_join.abort();
 }
 
+#[tokio::test]
+async fn rpc_update_apply_can_be_disabled_by_config_policy() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    ensure_test_rpc_auth();
+
+    let tmp = tempdir().expect("tempdir");
+    let _workspace_guard = EnvVarGuard::set_to_path("OPENHUMAN_WORKSPACE", tmp.path());
+
+    let mut config = openhuman_core::openhuman::config::Config {
+        workspace_dir: tmp.path().join("workspace"),
+        config_path: tmp.path().join("config.toml"),
+        ..openhuman_core::openhuman::config::Config::default()
+    };
+    config.update.rpc_mutations_enabled = false;
+    config
+        .save()
+        .await
+        .expect("persist config with update rpc disabled");
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://{rpc_addr}/rpc"))
+        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))
+        .header("Content-Type", "application/json")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "openhuman.update_apply",
+            "params": {
+                "download_url": "https://github.com/owner/repo/releases/download/v1/x",
+                "asset_name": "openhuman-core-x86_64-unknown-linux-gnu"
+            }
+        }))
+        .send()
+        .await
+        .expect("request");
+
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.expect("json body");
+    let error_msg = body
+        .get("result")
+        .and_then(|outer| outer.get("result"))
+        .and_then(|inner| inner.get("error"))
+        .and_then(Value::as_str)
+        .expect("policy error result message");
+    assert!(
+        error_msg.contains("rpc_mutations_enabled=false"),
+        "unexpected error: {body}"
+    );
+
+    rpc_join.abort();
+}
+
 /// End-to-end coverage for issue #1149: storing a managed-DM channel
 /// credential under `channel:<slug>:<mode>` and immediately observing
 /// `connected:true` from `openhuman.channels_status`.


### PR DESCRIPTION
## Summary

- Added a headless-safe update policy in `config.update` with `restart_strategy` and `rpc_mutations_enabled`.
- Made `openhuman.update_run` respect supervisor-managed deployments by staging updates without forcing in-process restart when configured.
- Added an RPC policy gate so `openhuman.update_apply` and `openhuman.update_run` can be disabled on exposed server deployments.
- Extended Rust unit and JSON-RPC integration coverage for the new policy paths, and documented the Linux/headless operator flow.

## Problem

- `update.run` assumed the desktop/Tauri sidecar lifecycle and always tried to request a self-restart after staging a new binary.
- That behavior is not operationally safe for long-running headless services, containers, and VM deployments where an external supervisor owns restart.
- Mutating update RPCs also lacked an explicit production lock-down path for bearer-authenticated server deployments.

## Solution

- Added `config.update.restart_strategy = "self_replace" | "supervisor"` and env overrides so the same update domain can either self-restart or hand restart off to a supervisor.
- Kept `update.apply` as the safe stage-only primitive, and annotated update results with the configured restart strategy for clearer operator feedback.
- Added `config.update.rpc_mutations_enabled` and rejected `openhuman.update_apply` / `openhuman.update_run` early when remote self-upgrade is disabled.
- Updated cloud/headless deployment docs, capability text, release smoke guidance, and coverage metadata to match the new contract.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. N/A: not fully measured locally in this environment; focused Rust tests were added for the changed lines.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust core update flow for desktop, server, and headless deployments.
- Security: production operators can now disable mutating update RPCs while keeping `update.check` available.
- Compatibility: default behavior remains `self_replace`, so desktop/self-managed flows keep the current restart behavior unless config opts into supervisor mode.

## Related

- Closes: #1436
- Feature IDs: 0.3.1
- Follow-up PR(s)/TODOs: None.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `issue/1436-support-reliable-self-update-for-server`
- Commit SHA: `a1d70033bf8648c67c2d898e9d434b908acd6b4f`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (via pre-push hook)
- [x] `pnpm typecheck` N/A: no `app/` TypeScript behavior changed; pre-push hook ran `pnpm --filter openhuman-app compile`
- [x] Focused tests: `cargo test --manifest-path Cargo.toml update:: --lib`; `cargo test --manifest-path Cargo.toml --test json_rpc_e2e rpc_update_apply_can_be_disabled_by_config_policy`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --all --check`
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` source changes; pre-push hook ran `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: `openhuman.update_run` can now stage updates for supervisor-managed headless deployments without forcing in-process restart, and mutating update RPCs can be disabled by config.
- User-visible effect: server operators get a documented/stable headless update contract; desktop flows keep the default self-restart behavior.

### Parity Contract
- Legacy behavior preserved: `config.update.restart_strategy = "self_replace"` remains the default, so existing desktop/self-managed update flows still request restart after staging.
- Guard/fallback/dispatch parity checks: `update.check` stays read-only; `update.apply` remains stage-only; controller registry and JSON-RPC method names are unchanged.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): New PR opened for issue #1436.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configuration options to control auto-update restart behavior and to enable/disable RPC-triggered update mutations.

* **Documentation**
  * Added headless/cloud deployment guidance covering restart strategies, operator workflows, and RPC security recommendations.
  * Added a per-release Linux smoke-check to verify supervisor-managed update staging behavior.

* **Tests**
  * Expanded test matrix and added integration tests covering RPC mutation policy and restart strategies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1458)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->