### PR TITLE
[codex] Align E2E docs with CEF reality

### DIFF
--- a/.github/workflows/e2e-agent-review.yml
+++ b/.github/workflows/e2e-agent-review.yml
@@ -1,10 +1,11 @@
 ---
 name: E2E (Linux) - agent-review
-# DISABLED: Linux E2E via tauri-driver requires WebKitWebDriver (webkit2gtk),
-# but this app uses the CEF runtime (tauri-runtime-cef) which has no WebDriver
-# automation support. tauri-driver sessions time out because WebKitWebDriver
-# cannot drive a CEF-backed webview. Re-enable once the CEF fork adds a
-# ChromeDriver-based automation path or an alternative E2E harness is wired.
+# CEF LIMITATION: Linux E2E via tauri-driver requires WebKitWebDriver
+# (webkit2gtk), but this app uses the CEF runtime (tauri-runtime-cef).
+# WebKitWebDriver cannot drive a CEF-backed WebView, so Linux CEF E2E is not
+# a supported CI gate. Keep this workflow manual/diagnostic until the CEF fork
+# adds a ChromeDriver-based automation path or an alternative harness is wired.
+# Use macOS/Appium for supported local or manual desktop E2E runs.
 # See also: test.yml where the e2e-linux job is commented out for the same reason.
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,11 @@ jobs:
       - name: Test Tauri shell (OpenHuman)
         run: cargo test --manifest-path app/src-tauri/Cargo.toml
 
+  # E2E note: OpenHuman's default desktop runtime is CEF. Linux tauri-driver
+  # talks to WebKitWebDriver / webkit2gtk and cannot drive the CEF-backed
+  # WebView, so Linux CEF E2E remains commented out until a CEF-compatible
+  # driver or replacement harness exists. Use macOS/Appium for local or manual
+  # desktop E2E runs.
   # e2e-linux:
   #   name: E2E (Linux / tauri-driver)
   #   runs-on: ubuntu-22.04
@@ -145,7 +150,7 @@ jobs:
   #       uses: actions/setup-node@v4
   #       with:
   #         node-version: 24.x
-  #         cache: "yarn"
+  #         cache: "pnpm"
 
   #     - name: Install Rust (rust-toolchain.toml)
   #       uses: dtolnay/rust-toolchain@1.93.0
@@ -181,7 +186,7 @@ jobs:
   #       run: cargo install tauri-driver --version 2.0.5
 
   #     - name: Install JS dependencies
-  #       run: yarn install --frozen-lockfile
+  #       run: pnpm install --frozen-lockfile
 
   #     - name: Ensure .env exists for E2E build
   #       run: |
@@ -189,17 +194,10 @@ jobs:
   #         touch app/.env
 
   #     - name: Build E2E app
-  #       run: yarn workspace openhuman-app test:e2e:build
+  #       run: pnpm --filter openhuman-app test:e2e:build
 
-  #     - name: Stage sidecar next to app binary
-  #       run: |
-  #  # Tauri resolves externalBin relative to the running binary's directory.
-  #  # Copy the sidecar from binaries/ to target/debug/ so the app can find it.
-  #         cp app/src-tauri/binaries/openhuman-core-x86_64-unknown-linux-gnu \
-  #            app/src-tauri/target/debug/openhuman-core-x86_64-unknown-linux-gnu
-  #         chmod +x app/src-tauri/target/debug/openhuman-core-x86_64-unknown-linux-gnu
-  #         echo "Sidecar staged next to app binary:"
-  #         ls -la app/src-tauri/target/debug/openhuman-core-* app/src-tauri/target/debug/OpenHuman
+  #     # Core is linked in-process through the Tauri host; no extra binary
+  #     # staging step is required before launching the app.
 
   #     - name: Run E2E tests under Xvfb
   #       run: |
@@ -212,7 +210,7 @@ jobs:
   #         mkdir -p ~/.local/share/applications
   #         export RUST_BACKTRACE=1
   #         cd app
-  #  # Core specs — must pass on Linux CI
+  #  # Core specs for the old WebKit-compatible Linux harness
   #         FAILED=0
   #         for spec in \
   #           test/e2e/specs/login-flow.spec.ts \
@@ -227,9 +225,10 @@ jobs:
   #             FAILED=1
   #           }
   #         done
-  #  # Extended specs (auth, billing, gmail, notion, payments) are skipped
-  #  # on Linux CI — webkit2gtk text matching differences cause Settings
-  #  # page navigation timeouts. Full suite runs on macOS locally.
+  #  # Extended specs (auth, billing, gmail, notion, payments) were skipped
+  #  # on the old Linux harness because webkit2gtk text matching differences
+  #  # caused Settings page navigation timeouts. Full suite runs through
+  #  # macOS/Appium locally or in a manually dispatched workflow when enabled.
   #         if [ "$FAILED" -eq 1 ]; then
   #           echo "Core E2E specs failed"
   #           exit 1
@@ -251,13 +250,13 @@ jobs:
 #         uses: actions/setup-node@v4
 #         with:
 #           node-version: 24.x
-#           cache: "yarn"
+#           cache: "pnpm"
 
 #       - name: Install Rust (rust-toolchain.toml)
 #         uses: dtolnay/rust-toolchain@1.93.0
 
 #       - name: Install dependencies
-#         run: yarn install --frozen-lockfile
+#         run: pnpm install --frozen-lockfile
 
 #       - name: Ensure .env exists for E2E build
 #         run: |
@@ -270,7 +269,7 @@ jobs:
 #           appium driver install mac2
 
 #       - name: Build E2E app bundle
-#         run: yarn workspace openhuman-app test:e2e:build
+#         run: pnpm --filter openhuman-app test:e2e:build
 
 #       - name: Run all E2E flows
-#         run: yarn workspace openhuman-app test:e2e:all:flows
+#         run: pnpm --filter openhuman-app test:e2e:all:flows

--- a/app/scripts/e2e-agent-review.sh
+++ b/app/scripts/e2e-agent-review.sh
@@ -35,8 +35,8 @@ export E2E_ARTIFACT_LABEL="$LABEL"
 cd "$REPO_ROOT"
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
-  echo "[agent-review] building app + staging core sidecar"
-  yarn workspace openhuman-app test:e2e:build
+  echo "[agent-review] building E2E app with in-process core"
+  pnpm --filter openhuman-app test:e2e:build
 else
   echo "[agent-review] --skip-build set; reusing existing build"
 fi

--- a/app/scripts/e2e-run-all-flows.sh
+++ b/app/scripts/e2e-run-all-flows.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Run all E2E WDIO specs sequentially (Appium restarted per spec).
-# Requires a prior E2E app build: yarn test:e2e:build
+# Requires a prior E2E app build: pnpm --filter openhuman-app test:e2e:build
 #
 set -euo pipefail
 

--- a/app/scripts/e2e-run-spec.sh
+++ b/app/scripts/e2e-run-spec.sh
@@ -3,7 +3,7 @@
 # Run a single WebDriverIO E2E spec.
 #
 # - macOS: Appium mac2 driver (started locally, port 4723)
-# - Linux: tauri-driver (started locally, port 4444)
+# - Linux: tauri-driver (started locally, port 4444; blocked for default CEF builds)
 #
 # Usage:
 #   ./app/scripts/e2e-run-spec.sh test/e2e/specs/login-flow.spec.ts [log-suffix]
@@ -84,7 +84,7 @@ fi
 # Write config.toml into the default ~/.openhuman/ so the core process
 # uses the mock server URL. Appium Mac2 launches the .app via XCUITest
 # which does NOT inherit shell environment variables, so BACKEND_URL
-# never reaches the core sidecar. Writing api_url to the config file
+# never reaches the embedded core process. Writing api_url to the config file
 # is the reliable cross-platform approach.
 E2E_CONFIG_DIR="$HOME/.openhuman"
 E2E_CONFIG_FILE="$E2E_CONFIG_DIR/config.toml"
@@ -118,7 +118,7 @@ if ! grep -q "127.0.0.1:${E2E_MOCK_PORT}" "$DIST_JS"; then
 fi
 if ! grep -q "127.0.0.1:${E2E_MOCK_PORT}" "$DIST_JS"; then
   echo "ERROR: frontend bundle does NOT contain mock server URL (127.0.0.1:${E2E_MOCK_PORT})." >&2
-  echo "       Run 'yarn test:e2e:build' to rebuild with the mock URL." >&2
+  echo "       Run 'pnpm test:e2e:build' to rebuild with the mock URL." >&2
   exit 1
 fi
 echo "Verified: frontend bundle contains mock server URL."

--- a/gitbooks/developing/e2e-testing.md
+++ b/gitbooks/developing/e2e-testing.md
@@ -11,34 +11,34 @@ Desktop E2E tests use **WebDriverIO (WDIO)** to drive the Tauri app via two auto
 
 | Platform | Driver | Port | App format | Selectors |
 |----------|--------|------|------------|-----------|
-| **Linux (CI default)** | `tauri-driver` | 4444 | Debug binary | CSS / DOM |
-| **macOS (local dev)** | Appium Mac2 | 4723 | `.app` bundle | XPath / accessibility |
+| **Linux / CEF status** | `tauri-driver` | 4444 | Debug binary | CSS / DOM |
+| **macOS / Appium** | Appium Mac2 | 4723 | `.app` bundle | XPath / accessibility |
 
-**Linux is the default CI path** (`ubuntu-22.04`). macOS E2E is available for local development and as an optional CI workflow.
+OpenHuman's desktop app currently uses the CEF runtime (`tauri-runtime-cef`). Linux `tauri-driver` talks to WebKitWebDriver / webkit2gtk and cannot drive a CEF-backed WebView, so Linux CEF E2E is disabled in CI until a CEF-compatible driver or replacement harness exists. The supported path today is macOS/Appium for local runs, with manual macOS/Appium workflow runs when that workflow is enabled.
 
 ---
 
 ## Quick start
 
-### Linux (CI default)
+### Linux / CEF status
 
 ```bash
 # Install tauri-driver (one-time)
 cargo install tauri-driver
 
 # Build the E2E app
-pnpm workspace openhuman-app test:e2e:build
+pnpm --filter openhuman-app test:e2e:build
 
 # Run all flows
-pnpm workspace openhuman-app test:e2e:all:flows
+pnpm --filter openhuman-app test:e2e:all:flows
 
 # Run a single spec
 bash app/scripts/e2e-run-spec.sh test/e2e/specs/smoke.spec.ts smoke
 ```
 
-On headless Linux (CI), tests run under **Xvfb** for a virtual display.
+On headless Linux, the harness runs under **Xvfb** for a virtual display. This path is currently useful only for non-CEF / WebKit-compatible debugging; the default CEF app cannot be automated by WebKitWebDriver.
 
-### macOS (local dev)
+### macOS / Appium
 
 ```bash
 # Install Appium + Mac2 driver (one-time, needs Node 24+)
@@ -46,15 +46,15 @@ npm install -g appium
 appium driver install mac2
 
 # Build the .app bundle
-pnpm workspace openhuman-app test:e2e:build
+pnpm --filter openhuman-app test:e2e:build
 
 # Run all flows
-pnpm workspace openhuman-app test:e2e:all:flows
+pnpm --filter openhuman-app test:e2e:all:flows
 ```
 
-### Docker on macOS (Linux E2E locally)
+### Docker on macOS (Linux harness locally)
 
-Run the same Linux-based E2E stack from macOS using Docker:
+Run the same Linux-based harness from macOS using Docker. The same CEF limitation applies: this is not a supported path for the default CEF runtime until a CEF-compatible driver exists.
 
 ```bash
 # Build + run all E2E flows
@@ -62,7 +62,7 @@ docker compose -f e2e/docker-compose.yml run --rm e2e
 
 # Build the app first (if needed)
 docker compose -f e2e/docker-compose.yml run --rm e2e \
-  pnpm workspace openhuman-app test:e2e:build
+  pnpm --filter openhuman-app test:e2e:build
 
 # Run a single spec
 docker compose -f e2e/docker-compose.yml run --rm e2e \
@@ -133,17 +133,19 @@ Requires Docker Desktop or Colima. The repo is bind-mounted so builds persist be
 
 ## CI workflows
 
-### Default (every push/PR)
+### Push / PR checks
 
-The `e2e-linux` job runs on `ubuntu-22.04`:
+The default `test.yml` workflow runs frontend unit tests and Rust checks. Its Linux `tauri-driver` E2E job is commented out because WebKitWebDriver cannot drive the CEF-backed WebView.
+
+The disabled Linux E2E job used to:
 1. Installs system deps (webkit2gtk, Xvfb, dbus)
 2. Installs `tauri-driver` via cargo
 3. Builds the app with mock server URL baked in
 4. Runs all E2E flows under Xvfb
 
-### Optional macOS E2E
+### macOS / Appium
 
-The `e2e-macos` job runs only via **manual dispatch** (`workflow_dispatch` with `run_macos_e2e: true`):
+macOS/Appium is the supported automation backend for the current CEF desktop app. Run it locally, or through a manually dispatched macOS workflow when that workflow is enabled:
 1. Installs Appium + Mac2 driver
 2. Builds the `.app` bundle
 3. Runs all E2E flows
@@ -153,6 +155,8 @@ The `e2e-macos` job runs only via **manual dispatch** (`workflow_dispatch` with 
 ## Troubleshooting
 
 ### Linux: "WebView not ready" timeout
+
+For the default CEF runtime, this usually means the unsupported Linux `tauri-driver` path is trying to drive a CEF-backed WebView through WebKitWebDriver. Use macOS/Appium, or wait for a CEF-compatible Linux driver.
 
 Ensure `DISPLAY` is set and Xvfb is running:
 ```bash
@@ -198,7 +202,7 @@ Tests notification RPC methods via the live core sidecar and the Notifications U
 bash app/scripts/e2e-run-spec.sh test/e2e/specs/notifications.spec.ts notifications
 ```
 
-**Platform note**: RPC tests (`notification_ingest`, `notification_list`, `notification_mark_read`, `notification_stats`) run on both Linux (tauri-driver) and macOS (Appium Mac2). UI assertions (Notifications page sections) require Linux / tauri-driver because `browser.execute()` is unavailable on Mac2, those tests auto-skip when `supportsExecuteScript()` returns `false`.
+**Platform note**: RPC tests (`notification_ingest`, `notification_list`, `notification_mark_read`, `notification_stats`) are written for both Linux/tauri-driver and macOS/Appium Mac2, but Linux execution is disabled for the default CEF runtime until a CEF-compatible driver exists. UI assertions (Notifications page sections) require `browser.execute()` support, so they auto-skip on Mac2 when `supportsExecuteScript()` returns `false`.
 
 ---
 
@@ -211,4 +215,3 @@ bash app/scripts/e2e-agent-review.sh
 ```
 
 Artifacts land in `app/test/e2e/artifacts/<timestamp>-agent-review/`. Full details + helper API: [`AGENT-OBSERVABILITY.md`](AGENT-OBSERVABILITY.md). Any failing test triggers `wdio.conf.ts`'s `afterTest` hook, which writes `failure-*.png` + `failure-*.source.xml` into the same run dir.
-


### PR DESCRIPTION
## Summary

Updates E2E scripts, GitBook docs, and workflow comments to use pnpm wording and describe current CEF automation limits accurately.

## Impact

Prevents agents and CI readers from treating disabled Linux WebDriver paths as the default supported route.

## Validation

```bash
bash -n app/scripts/e2e-agent-review.sh app/scripts/e2e-run-spec.sh app/scripts/e2e-run-all-flows.sh && ! rg -n 'staging core sidecar|yarn .*test:e2e|Linux \(CI default\)|default CI path' app/scripts gitbooks/developing/e2e-testing.md .github/workflows/test.yml .github/workflows/e2e-agent-review.yml
```

Wave I replacement branch: `codex/100x-impl-openhuman-e2e-cef-docs-upstream`
Commit: `4405ff6c76f0b347f77c66256bd00efcfff6deef`

Opened as draft for review; no deploys, merges, or tracker mutations were performed. Supersedes #1463, which was based on a stale fork branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified E2E testing platform support limitations for the default app configuration.

* **Chores**
  * Updated build and testing scripts to use the current package manager.
  * Updated CI workflow configuration comments and documentation guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1464)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->