### PR TITLE
fix(release): refresh Cargo.lock on bump, attach uid to core Sentry, hide debug settings

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -128,6 +128,15 @@ jobs:
       - name: Verify release version sync (main_head)
         if: inputs.release_source == 'main_head'
         run: node scripts/release/verify-version-sync.js "${{ steps.bump.outputs.version }}"
+      - name: Refresh Cargo.lock files (main_head)
+        if: inputs.release_source == 'main_head'
+        # Cargo.toml [package].version is bumped above but the matching
+        # entries in both Cargo.lock files are not — without this step the
+        # lockfiles stay pinned to the previous version and the next local
+        # `cargo` invocation rewrites them, leaving an uncommitted diff.
+        run: |
+          cargo update --workspace --manifest-path Cargo.toml
+          cargo update --workspace --manifest-path app/src-tauri/Cargo.toml
       - name: Ensure tag does not already exist (main_head)
         if: inputs.release_source == 'main_head'
         env:
@@ -148,7 +157,7 @@ jobs:
           VERSION: ${{ steps.bump.outputs.version }}
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
-          git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.toml
+          git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.toml app/src-tauri/Cargo.lock Cargo.lock
           git commit -m "chore(release): v${VERSION}"
           git push origin main
           git tag -a "$TAG" -m "Release $TAG"

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -102,6 +102,14 @@ jobs:
         run: node scripts/release/bump-version.js patch
       - name: Verify version sync
         run: node scripts/release/verify-version-sync.js "${{ steps.bump.outputs.version }}"
+      - name: Refresh Cargo.lock files
+        # Cargo.toml [package].version is bumped above but the matching
+        # entries in both Cargo.lock files are not — without this step the
+        # lockfiles stay pinned to the previous version and the next local
+        # `cargo` invocation rewrites them, leaving an uncommitted diff.
+        run: |
+          cargo update --workspace --manifest-path Cargo.toml
+          cargo update --workspace --manifest-path app/src-tauri/Cargo.toml
       - name: Compute staging tag
         id: tagname
         env:
@@ -127,7 +135,7 @@ jobs:
           VERSION: ${{ steps.bump.outputs.version }}
           TAG: ${{ steps.tagname.outputs.tag }}
         run: |
-          git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.toml
+          git add app/package.json app/src-tauri/tauri.conf.json app/src-tauri/Cargo.toml Cargo.toml app/src-tauri/Cargo.lock Cargo.lock
           git commit -m "chore(staging): v${VERSION}"
           git push origin main
           git tag -a "$TAG" -m "Staging cut $TAG"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhuman"
-version = "0.53.25"
+version = "0.53.26"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenHuman"
-version = "0.53.23"
+version = "0.53.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.53.25"
+version = "0.53.26"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
+++ b/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
@@ -57,22 +57,24 @@ const developerItems = [
       </svg>
     ),
   },
-  {
-    id: 'screen-awareness-debug',
-    title: 'Screen Awareness Debug',
-    description: 'FPS tuning, vision model config, capture tests, and session diagnostics',
-    route: 'screen-awareness-debug',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M3 5h18v12H3zM8 21h8m-4-4v4"
-        />
-      </svg>
-    ),
-  },
+  // Screen Awareness Debug, Memory Data, and Memory Debug hidden — routes
+  // retained in `pages/Settings.tsx` for re-enable.
+  // {
+  //   id: 'screen-awareness-debug',
+  //   title: 'Screen Awareness Debug',
+  //   description: 'FPS tuning, vision model config, capture tests, and session diagnostics',
+  //   route: 'screen-awareness-debug',
+  //   icon: (
+  //     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //         strokeWidth={2}
+  //         d="M3 5h18v12H3zM8 21h8m-4-4v4"
+  //       />
+  //     </svg>
+  //   ),
+  // },
   // Autocomplete Debug + Voice Debug hidden per #717 (routes retained for re-enable).
   {
     id: 'local-model-debug',
@@ -106,38 +108,38 @@ const developerItems = [
       </svg>
     ),
   },
-  {
-    id: 'memory-data',
-    title: 'Memory Data',
-    description: 'Knowledge graph, insights, activity heatmap, and file management',
-    route: 'memory-data',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-        />
-      </svg>
-    ),
-  },
-  {
-    id: 'memory-debug',
-    title: 'Memory Debug',
-    description: 'Inspect memory documents, namespaces, and test query/recall',
-    route: 'memory-debug',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M9 12h6m2 8H7a2 2 0 01-2-2V6a2 2 0 012-2h6l6 6v8a2 2 0 01-2 2z"
-        />
-      </svg>
-    ),
-  },
+  // {
+  //   id: 'memory-data',
+  //   title: 'Memory Data',
+  //   description: 'Knowledge graph, insights, activity heatmap, and file management',
+  //   route: 'memory-data',
+  //   icon: (
+  //     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //         strokeWidth={2}
+  //         d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+  //       />
+  //     </svg>
+  //   ),
+  // },
+  // {
+  //   id: 'memory-debug',
+  //   title: 'Memory Debug',
+  //   description: 'Inspect memory documents, namespaces, and test query/recall',
+  //   route: 'memory-debug',
+  //   icon: (
+  //     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path
+  //         strokeLinecap="round"
+  //         strokeLinejoin="round"
+  //         strokeWidth={2}
+  //         d="M9 12h6m2 8H7a2 2 0 01-2-2V6a2 2 0 012-2h6l6 6v8a2 2 0 01-2 2z"
+  //       />
+  //     </svg>
+  //   ),
+  // },
   {
     id: 'intelligence',
     title: 'Intelligence',

--- a/app/src/components/settings/panels/ScreenIntelligencePanel.tsx
+++ b/app/src/components/settings/panels/ScreenIntelligencePanel.tsx
@@ -20,7 +20,7 @@ const formatRemaining = (remainingMs: number | null): string => {
 };
 
 const ScreenIntelligencePanel = () => {
-  const { navigateBack, navigateToSettings, breadcrumbs } = useSettingsNavigation();
+  const { navigateBack, breadcrumbs } = useSettingsNavigation();
   const {
     status,
     lastRestartSummary,
@@ -237,7 +237,8 @@ const ScreenIntelligencePanel = () => {
           </div>
         )}
 
-        <button
+        {/* Screen Awareness Debug entry hidden alongside Developer Options entries. */}
+        {/* <button
           type="button"
           onClick={() => navigateToSettings('screen-awareness-debug')}
           className="flex items-center gap-1.5 text-xs text-stone-400 hover:text-stone-600 transition-colors">
@@ -245,7 +246,7 @@ const ScreenIntelligencePanel = () => {
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
-        </button>
+        </button> */}
       </div>
     </div>
   );

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,17 @@ fn main() {
         before_send: Some(std::sync::Arc::new(|mut event| {
             // Strip server_name (hostname) to avoid leaking machine identity
             event.server_name = None;
-            // Strip user context entirely
-            event.user = None;
+            // Attach the cached account uid so Sentry can count unique users
+            // affected by an issue. We only carry `id` — never email, name,
+            // or IP — so this stays consistent with `send_default_pii: false`.
+            // Empty/missing on early-startup events (cache populates after
+            // the first `auth_get_me` RPC); that's expected.
+            event.user = openhuman_core::openhuman::app_state::peek_cached_current_user_identity()
+                .and_then(|identity| identity.id)
+                .map(|id| sentry::User {
+                    id: Some(id),
+                    ..Default::default()
+                });
             // Scrub exception messages for secrets
             for exc in &mut event.exception.values {
                 if let Some(ref value) = exc.value {


### PR DESCRIPTION
## Summary

- Release workflows now refresh `Cargo.lock` / `app/src-tauri/Cargo.lock` after the version bump and stage them in the release commit, so the lockfiles no longer drift on every release.
- Core `before_send` (`src/main.rs`) attaches the cached account uid (`peek_cached_current_user_identity().id` only — no name/email/IP) so Sentry can group issues by user and report "users affected".
- Settings → Developer Options: Memory Data, Memory Debug, and Screen Awareness Debug entries commented out (routes retained for re-enable).

## Problem

- Every staging/prod release left an uncommitted `Cargo.lock` diff because `bump-version.js` updates `Cargo.toml` but never refreshes the matching `[package].version` entries in the lockfiles. The next local `cargo` invocation rewrote them and dirtied the tree.
- The Rust core's Sentry `before_send` had `event.user = None;`, so even though the React side already attaches `event.user = { id }`, no core-side event carried a uid. Sentry could not count unique users affected by core errors.
- Three debug-only settings entries were exposed in Developer Options that should not ship to end users right now.

## Solution

- **Workflows** (`release-staging.yml`, `release-production.yml`): added a `cargo update --workspace --manifest-path …` step on both manifests after the bump, then included both lockfiles in the `git add` line of the release commit. `--workspace` constrains updates to workspace members only, so transitive dep churn stays out.
- **Core Sentry** (`src/main.rs`): replaced `event.user = None;` with a lookup against the existing `peek_cached_current_user_identity()` (which already strips everything but `id` / `name` / `email`). Only `id` is attached; consistent with `send_default_pii: false`. Empty on early-startup events before the `auth_get_me` cache populates — same trade-off the frontend has.
- **Settings**: commented out the three entries in `DeveloperOptionsPanel.tsx` and the "Advanced settings" shortcut on `ScreenIntelligencePanel.tsx`. Removed the now-unused `navigateToSettings` from the destructure. Routes in `pages/Settings.tsx` are intact, matching the Autocomplete/Voice Debug precedent (#717).

## Submission Checklist

- [x] N/A: workflow + small UI hide + Sentry scope tweak — no behavioural code paths added that warrant new tests; the lockfile refresh is observable end-to-end via the next release run
- [x] N/A: changed lines are CI workflow YAML, comment-only TSX edits, and a single Sentry `before_send` branch — diff-cover scope is minimal
- [x] N/A: no feature rows added/removed in the coverage matrix
- [x] N/A: no feature IDs touched
- [x] No new external network dependencies introduced
- [x] N/A: release-cut surfaces unchanged at the user level
- [x] N/A: no linked issue

## Impact

- Desktop: hidden Developer Options entries are no longer visible; routes still resolvable by direct URL.
- Sentry dashboard: core events will start carrying `user.id`, enabling "users affected" rollups across React + Rust surfaces.
- Release pipeline: next staging/prod cut will commit refreshed lockfiles and stop leaving an uncommitted diff locally.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/may-10
- Commit SHA: 20a183c9

### Validation Run
- [x] \`pnpm lint\` — 0 errors (38 pre-existing warnings)
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] N/A: Focused tests — no behavioural code paths added
- [x] Rust fmt/check (if changed): \`cargo check --bin openhuman-core\` clean
- [x] N/A: Tauri fmt/check — Tauri shell unchanged

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended behavior change: Sentry events from the Rust core now carry an account uid; three debug-settings entries are no longer linked from the Developer Options menu; release commits include refreshed Cargo.lock files.
- User-visible effect: Three settings entries disappear; no other user-visible change.

### Parity Contract
- Legacy behavior preserved: Routes for hidden settings panels remain reachable by direct URL; \`send_default_pii: false\` policy preserved (only \`id\` is added).
- Guard/fallback/dispatch parity checks: Sentry \`before_send\` still strips secrets and \`server_name\`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A