### PR TITLE
chore: add review_pr to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Workflow docs (local only)
 workflow
 create_issue
+review_pr
 
 # Diagnostic harness output (scripts/diagnose-cef-runtime.mjs)
 diagnosis-*.json


### PR DESCRIPTION
## Summary

- Add `review_pr/` to `.gitignore` alongside existing `workflow/` and `create_issue/` entries
- Local-only PR review workflow docs, not tracked in git

## Test plan

- [x] No code changes — gitignore only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration files.

**Note:** This release contains no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1481)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->