### PR TITLE
ci(release): checkout submodules in prepare-build step

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -104,6 +104,7 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -77,6 +77,7 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- The prepare-build job in both \`release-staging.yml\` and \`release-production.yml\` runs \`cargo update --workspace\` immediately after checkout. That fails on CI with:

  \`\`\`
  error: failed to load source for dependency \`tauri\`
  Caused by: Unable to update .../app/src-tauri/vendor/tauri-cef/crates/tauri
  Caused by: failed to read .../app/src-tauri/vendor/tauri-cef/crates/tauri/Cargo.toml
  Caused by: No such file or directory (os error 2)
  \`\`\`

- Root cause: \`Cargo.toml\` has a path dependency on the vendored \`tauri-cef\` submodule, but the prepare-build checkout step did not pass \`submodules: recursive\`, so the submodule contents weren't on disk.
- The downstream desktop-build job already uses \`submodules: recursive\` (which is why only the prepare phase was breaking).

## Test plan

- [ ] Trigger the staging release workflow and confirm the \`Refresh Cargo.lock files\` step passes.
- [ ] Trigger the production release workflow and confirm the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production and staging release workflows to check out Git submodules during the build process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1482)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->