### PR TITLE
feat(tauri): make floating mascot draggable

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -143,6 +143,16 @@ Quick reference for anyone starting with Claude on this project. Updated by the 
 - **PR #745 (command palette) merged without its deps** — `@radix-ui/react-dialog`, `cmdk`, and `@testing-library/user-event` are missing from `package.json`. Install them if tsc fails after syncing main.
 - **Pre-push hooks fail on upstream lint warnings** — ESLint warns on `setState` in effects and unused `eslint-disable` directives inherited from upstream. Use `--no-verify` only when the lint errors are pre-existing upstream issues, not new code.
 
+## Mascot Native Window (macOS)
+
+- **Not a Tauri window** — The floating mascot is a native `NSPanel` + `WKWebView` in `app/src-tauri/src/mascot_native_window.rs`. It uses `ignoresMouseEvents=true` (click-through); interaction is detected by polling `NSEvent` via a Foundation timer. macOS-only, uses objc2 bindings.
+- **`MainThreadOnly` import must stay** — Required by `WKWebView::alloc()` and other AppKit allocators even if not explicitly referenced in user code. Removing it causes compile errors.
+- **`NSEvent::pressedMouseButtons` not in typed objc2-appkit bindings** — Must be called via `msg_send!(objc2::class!(NSEvent), pressedMouseButtons)` instead of the typed API.
+
+## PR Checklist CI
+
+- **N/A items need a checked checkbox** — `scripts/check-pr-checklist.mjs` requires `- [x] N/A: <reason>`. Using `- [ ] N/A:` (unchecked) fails the check even though the text starts with "N/A:".
+
 ## Environment
 
 - **Core sidecar port** — `7788` (default). Check with `lsof -i :7788`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Workflow docs (local only)
 workflow
 create_issue
+review_pr
 
 # Diagnostic harness output (scripts/diagnose-cef-runtime.mjs)
 diagnosis-*.json

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -11,9 +11,9 @@
 //! Trade-offs:
 //!
 //! - macOS-only. Linux/Windows would need a parallel native webview path.
-//! - No Tauri IPC bridge. The mascot window uses `WKScriptMessageHandler`
-//!   for the few host calls it needs (close, future: drag/clickthrough).
-//!   For now we keep the page passive — toggle via the tray menu.
+//! - No Tauri IPC bridge. Toggle via the tray menu. Drag-to-reposition is
+//!   handled entirely from Rust by polling `NSEvent::pressedMouseButtons()`
+//!   in the same Foundation timer that tracks the cursor.
 //! - Page source is dev-server in development, bundled `file://` in
 //!   production. The bundled path uses `loadFileURL:allowingReadAccessToURL:`
 //!   with the resource directory as the read-access root so ESM imports
@@ -43,22 +43,22 @@ use crate::AppRuntime;
 const PANEL_SIZE: f64 = 79.0;
 /// Distance from the bottom-right monitor corner on first show.
 const PANEL_MARGIN: f64 = 0.0;
-/// How often we poll the cursor position to detect hover over the mascot.
-const HOVER_POLL_SECONDS: f64 = 0.05;
+/// How often we poll the cursor position for drag tracking (~60 fps).
+const DRAG_POLL_SECONDS: f64 = 0.016;
 
 /// Holds the panel + webview together so we keep both alive (and drop them
-/// together) for the lifetime of one show/hide cycle. The hover timer is
+/// together) for the lifetime of one show/hide cycle. The drag timer is
 /// stored so we can `invalidate()` it on hide and stop firing into a
 /// dropped webview.
 struct MascotPanel {
     panel: Retained<NSPanel>,
     _webview: Retained<WKWebView>,
-    hover_timer: Retained<NSTimer>,
+    drag_timer: Retained<NSTimer>,
 }
 
 impl MascotPanel {
     fn order_out(&self) {
-        self.hover_timer.invalidate();
+        self.drag_timer.invalidate();
         self.panel.orderOut(None);
     }
 }
@@ -117,13 +117,13 @@ pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     panel.makeKeyAndOrderFront(None);
     panel.orderFrontRegardless();
 
-    let hover_timer = unsafe { spawn_hover_timer(panel.clone(), webview.clone()) };
+    let drag_timer = unsafe { spawn_drag_timer(panel.clone(), webview.clone()) };
 
     MASCOT.with(|cell| {
         *cell.borrow_mut() = Some(MascotPanel {
             panel,
             _webview: webview,
-            hover_timer,
+            drag_timer,
         });
     });
     log::info!("[mascot-native] panel shown");
@@ -253,11 +253,10 @@ unsafe fn build_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<NSPanel>
         panel.setBecomesKeyOnlyIfNeeded(true);
         panel.setWorksWhenModal(true);
 
-        // Always click-through. The panel never receives mouse events; the
-        // cursor passes straight to whatever's behind it. Hover is detected
-        // by polling `NSEvent::mouseLocation()` against the panel frame in
-        // a Foundation timer (see `spawn_hover_timer`), and the page CSS
-        // animates the mascot out of the way when the cursor is over it.
+        // Click-through: the panel never receives mouse events directly.
+        // Drag-to-reposition is detected by polling
+        // `NSEvent::pressedMouseButtons()` + `mouseLocation()` against the
+        // panel frame in a Foundation timer (see `spawn_drag_timer`).
         panel.setIgnoresMouseEvents(true);
 
         // Don't show in the Dock / Cmd+Tab.
@@ -267,80 +266,58 @@ unsafe fn build_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<NSPanel>
     panel
 }
 
-/// Two right-edge resting spots one mascot-height apart. The mascot
-/// alternates between them when the cursor catches up — small hop, not a
-/// trip across the screen.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Slot {
-    Home,
-    HopUp,
-}
-
-fn slot_frame(mtm: MainThreadMarker, slot: Slot) -> NSRect {
-    let screen = primary_screen_frame(mtm);
-    let x = screen.origin.x + screen.size.width - PANEL_SIZE - PANEL_MARGIN;
-    // AppKit origin is bottom-left. `Home` sits at the bottom; `HopUp`
-    // is one full panel-height above it so the mascot completely clears
-    // the cursor's previous position with no visible overlap.
-    let y_home = screen.origin.y + PANEL_MARGIN;
-    let y = match slot {
-        Slot::Home => y_home,
-        Slot::HopUp => y_home + PANEL_SIZE,
-    };
-    NSRect::new(NSPoint::new(x, y), NSSize::new(PANEL_SIZE, PANEL_SIZE))
-}
-
 /// Schedule a repeating Foundation timer on the main run loop that polls
-/// the global cursor position. When the cursor enters the mascot's panel
-/// frame, the panel hops to the *other* right-edge corner with an
-/// animated `setFrame:display:animate:` move so the user can keep working
-/// without the mascot covering the spot they were trying to click. The
-/// panel is `ignoresMouseEvents=true` regardless, so even mid-animation
-/// the cursor passes straight through.
-unsafe fn spawn_hover_timer(
+/// the global cursor position and mouse-button state. When the user holds
+/// the left mouse button while the cursor is inside the panel frame, the
+/// panel tracks the cursor (drag-to-reposition). On release the panel
+/// stays at the new position. The panel remains `ignoresMouseEvents=true`
+/// throughout — the initial click passes through to the window behind,
+/// but the visual drag starts on the next timer tick (~16 ms).
+unsafe fn spawn_drag_timer(
     panel: Retained<NSPanel>,
     _webview: Retained<WKWebView>,
 ) -> Retained<NSTimer> {
-    // Fixed reference rect: the mascot's home position. Cursor entering
-    // this rect makes the panel flee to `HopUp`; leaving it brings it
-    // back to `Home`. We compare against the home rect — not the panel's
-    // current frame — so the cursor moving away from the original spot
-    // is always what triggers the return, regardless of where the panel
-    // has currently hopped to.
-    let mtm_for_home = unsafe { MainThreadMarker::new_unchecked() };
-    let home_rect = slot_frame(mtm_for_home, Slot::Home);
-    let current_slot: Rc<Cell<Slot>> = Rc::new(Cell::new(Slot::Home));
+    let dragging: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+    // Offset from cursor to panel origin at drag start so the panel
+    // doesn't snap its corner to the cursor.
+    let drag_offset: Rc<Cell<(f64, f64)>> = Rc::new(Cell::new((0.0, 0.0)));
 
     let block = RcBlock::new(move |_timer: NonNull<NSTimer>| {
-        // Safe: this block only fires on the main run loop the timer was
-        // scheduled on, which is the AppKit main thread.
-        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        let cursor = NSEvent::mouseLocation();
+        let left_down: bool = {
+            let buttons: u64 = unsafe { msg_send![objc2::class!(NSEvent), pressedMouseButtons] };
+            buttons & 1 != 0
+        };
+        let frame = panel.frame();
+        let cursor_in_panel = cursor.x >= frame.origin.x
+            && cursor.x <= frame.origin.x + frame.size.width
+            && cursor.y >= frame.origin.y
+            && cursor.y <= frame.origin.y + frame.size.height;
 
-        let cursor = unsafe { NSEvent::mouseLocation() };
-        let inside_home = cursor.x >= home_rect.origin.x
-            && cursor.x <= home_rect.origin.x + home_rect.size.width
-            && cursor.y >= home_rect.origin.y
-            && cursor.y <= home_rect.origin.y + home_rect.size.height;
-
-        let desired = if inside_home { Slot::HopUp } else { Slot::Home };
-        if desired == current_slot.get() {
-            return;
-        }
-        current_slot.set(desired);
-        let target = slot_frame(mtm, desired);
-        log::debug!(
-            "[mascot-native] cursor {} home — moving to slot={}",
-            if inside_home { "entered" } else { "left" },
-            match desired {
-                Slot::Home => "Home",
-                Slot::HopUp => "HopUp",
+        if dragging.get() {
+            if left_down {
+                // Continue drag — move panel to track cursor.
+                let (ox, oy) = drag_offset.get();
+                let new_origin = NSPoint::new(cursor.x - ox, cursor.y - oy);
+                unsafe {
+                    let _: () = msg_send![&*panel, setFrameOrigin: new_origin];
+                }
+            } else {
+                // Mouse released — end drag, panel stays put.
+                dragging.set(false);
+                let pos = panel.frame().origin;
+                log::debug!("[mascot-native] drag ended at ({:.0},{:.0})", pos.x, pos.y);
             }
-        );
-        panel.setFrame_display_animate(target, true, true);
+        } else if cursor_in_panel && left_down {
+            // Start drag.
+            dragging.set(true);
+            drag_offset.set((cursor.x - frame.origin.x, cursor.y - frame.origin.y));
+            log::debug!("[mascot-native] drag started");
+        }
     });
 
     unsafe {
-        NSTimer::scheduledTimerWithTimeInterval_repeats_block(HOVER_POLL_SECONDS, true, &block)
+        NSTimer::scheduledTimerWithTimeInterval_repeats_block(DRAG_POLL_SECONDS, true, &block)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the fixed two-slot hover-hop mascot behavior with drag-to-reposition.
- Users can now click and hold the mascot, drag it anywhere on screen, and release to leave it in place.
- Poll interval reduced from 50 ms to ~16 ms (~60 fps) for smooth drag tracking.

## Problem

- The floating mascot was pinned to the bottom-right corner with only a two-position hop when the cursor entered its rect.
- Users had no way to reposition the mascot — it could only toggle on/off from the tray menu.

## Solution

- Reuse the existing Foundation timer to poll `NSEvent::pressedMouseButtons()` alongside cursor position.
- When left-click is held over the panel frame, track drag offset and move the panel with `setFrameOrigin` each tick.
- Remove the `Slot` enum and `slot_frame` function entirely — user controls position now.
- Panel stays `ignoresMouseEvents=true` (click-through when not dragging); initial click passes through, which is acceptable for a decorative 79pt mascot.

## Submission Checklist

- [x] N/A: Pure Rust/macOS-native change — no testable behavior without a running NSPanel. Manual testing required.
- [x] N/A: No Vitest or cargo test coverage applies — this is macOS-only NSPanel code using raw ObjC bindings.
- [x] N/A: behaviour-only change
- [x] N/A: No feature IDs affected in the coverage matrix.
- [x] N/A: No new external network dependencies.
- [x] N/A: No release-cut surfaces touched.
- [x] Linked issue closed via `Closes #1484` in the Related section

## Impact

- **Desktop (macOS only)**: floating mascot is now draggable. No change on Linux/Windows (mascot is macOS-only).
- No performance/security/migration implications. Timer frequency increased from 20fps to 60fps but only runs while the mascot panel is visible.

## Related

- Closes #1484

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/draggable-mascot
- Commit SHA: dc6e7487

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend changes
- [x] N/A: `pnpm typecheck` — no frontend changes
- [x] N/A: Focused tests — no testable units (raw ObjC NSPanel code)
- [x] N/A: Rust fmt/check — no core Rust changes
- [x] Tauri fmt/check: `cargo check` and `cargo fmt --check` pass

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Mascot can be dragged to any screen position instead of hopping between two fixed slots.
- User-visible effect: Click-hold on mascot → drag → release → mascot stays at new position.

### Parity Contract
- Legacy behavior preserved: Tray menu toggle (show/hide) unchanged. Initial position (bottom-right) unchanged.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None
- Canonical PR: This one
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The macOS mascot window can now be dragged to reposition it on screen (replaces previous hover-based behavior).

* **Documentation**
  * Added notes describing the native mascot window implementation and updated PR checklist guidance.

* **Chores**
  * Updated workflow configuration to ignore local workflow docs entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1485)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
