### PR TITLE
fix(human/mascot): consume orphan audio-stopped rejections (#1472)

### DIFF
--- a/app/src/features/human/useHumanMascot.lipsync.test.ts
+++ b/app/src/features/human/useHumanMascot.lipsync.test.ts
@@ -33,7 +33,16 @@ vi.mock('./voice/ttsClient', async () => {
   return { ...actual, synthesizeSpeech: vi.fn() };
 });
 
-vi.mock('./voice/audioPlayer', () => ({ playBase64Audio: vi.fn() }));
+vi.mock('./voice/audioPlayer', () => ({
+  playBase64Audio: vi.fn(),
+  // Hook's orphan `.catch(swallowAudioStop)` wiring runs in cleanup paths
+  // exercised here — mirror the real helper so stop sentinels are silenced.
+  swallowAudioStop: (err: unknown) => {
+    if (typeof err === 'object' && err !== null && (err as { stopped?: unknown }).stopped === true)
+      return;
+    throw err;
+  },
+}));
 
 let capturedListeners: ChatEventListeners | null = null;
 

--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatEventListeners } from '../../services/chatService';
 import { VISEMES } from './Mascot/visemes';
 import { ACK_FACE_HOLD_MS, pickViseme, useHumanMascot } from './useHumanMascot';
-import { playBase64Audio } from './voice/audioPlayer';
+import { type PlaybackHandle, playBase64Audio } from './voice/audioPlayer';
 import { synthesizeSpeech } from './voice/ttsClient';
 
 vi.mock('../../services/chatService', () => ({
@@ -30,7 +30,25 @@ vi.mock('./voice/ttsClient', () => ({
   proceduralVisemes: (text: string, durationMs: number) => proceduralVisemesMock(text, durationMs),
 }));
 
-vi.mock('./voice/audioPlayer', () => ({ playBase64Audio: vi.fn() }));
+class FakeAudioStoppedError extends Error {
+  readonly stopped = true;
+  constructor() {
+    super('stopped');
+    this.name = 'AudioStoppedError';
+  }
+}
+
+vi.mock('./voice/audioPlayer', () => ({
+  playBase64Audio: vi.fn(),
+  // Mirror the real helper so the hook's orphan `.catch(swallowAudioStop)`
+  // wiring actually executes — otherwise stop sentinels would slip through
+  // as unhandledrejections under test and the regression coverage is moot.
+  swallowAudioStop: (err: unknown) => {
+    if (typeof err === 'object' && err !== null && (err as { stopped?: unknown }).stopped === true)
+      return;
+    throw err;
+  },
+}));
 
 function makeFakePlayback(durationMs = 100) {
   let stopped = false;
@@ -47,7 +65,7 @@ function makeFakePlayback(durationMs = 100) {
       metadataReady: Promise.resolve(),
       stop: () => {
         stopped = true;
-        rejectEnded(new Error('stopped'));
+        rejectEnded(new FakeAudioStoppedError());
       },
       ended,
     },
@@ -400,6 +418,69 @@ describe('useHumanMascot TTS playback', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+  });
+
+  it('does not surface an unhandledrejection when a newer turn cancels in-flight playback (#1472)', async () => {
+    // Two back-to-back turns: the first reaches the `await playBase64Audio`
+    // point and then a second onDone bumps the playback seq. When the first
+    // play() finally resolves, the hook takes the `!isStillCurrent()` branch
+    // and calls `handle.stop()` + early-returns. Before the fix, that left
+    // the resulting `handle.ended` rejection un-attached → unhandledrejection
+    // → Sentry. The fix attaches `.catch(swallowAudioStop)` at each such site.
+    vi.useRealTimers();
+    const fake1 = makeFakePlayback();
+    const fake2 = makeFakePlayback();
+    let resolveFirstPlay!: (h: PlaybackHandle) => void;
+    const firstPlay = new Promise<PlaybackHandle>(r => {
+      resolveFirstPlay = r;
+    });
+    (synthesizeSpeech as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        audio_base64: 'AAA=',
+        audio_mime: 'audio/mpeg',
+        visemes: [{ viseme: 'aa', start_ms: 0, end_ms: 100 }],
+      })
+      .mockResolvedValueOnce({
+        audio_base64: 'BBB=',
+        audio_mime: 'audio/mpeg',
+        visemes: [{ viseme: 'aa', start_ms: 0, end_ms: 100 }],
+      });
+    (playBase64Audio as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(() => firstPlay)
+      .mockResolvedValueOnce(fake2.handle);
+
+    const unhandled: PromiseRejectionEvent[] = [];
+    const handler = (e: PromiseRejectionEvent) => unhandled.push(e);
+    window.addEventListener('unhandledrejection', handler);
+    try {
+      renderHook(() => useHumanMascot({ speakReplies: true }));
+      // Turn 1 enters startTtsPlayback and blocks on playBase64Audio.
+      await act(async () => {
+        capturedListeners?.onDone?.(fakeDone('first'));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Turn 2 fires, bumps playbackSeqRef, awaits its own (resolved) play.
+      await act(async () => {
+        capturedListeners?.onDone?.(fakeDone('second'));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Now resolve turn-1's play: its handle is stale → hook stops + bails.
+      await act(async () => {
+        resolveFirstPlay(fake1.handle as unknown as PlaybackHandle);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        // Macrotask hop so jsdom can dispatch any pending unhandledrejection.
+        await new Promise(r => setTimeout(r, 0));
+      });
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      window.removeEventListener('unhandledrejection', handler);
+      vi.useFakeTimers();
+    }
   });
 
   it('shows concerned (not happy) when synthesizeSpeech rejects', async () => {

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { subscribeChatEvents } from '../../services/chatService';
 import type { MascotFace } from './Mascot';
 import { lerpViseme, VISEMES, type VisemeShape } from './Mascot/visemes';
-import { type PlaybackHandle, playBase64Audio } from './voice/audioPlayer';
+import { type PlaybackHandle, playBase64Audio, swallowAudioStop } from './voice/audioPlayer';
 import {
   proceduralVisemes,
   synthesizeSpeech,
@@ -187,8 +187,15 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       onError: () => {
         // Bump seq to invalidate any in-flight startTtsPlayback awaiters.
         playbackSeqRef.current++;
-        playbackRef.current?.stop();
+        const orphan = playbackRef.current;
         playbackRef.current = null;
+        if (orphan) {
+          orphan.stop();
+          // We're early-returning instead of awaiting `orphan.ended`, so the
+          // stop()-sentinel rejection has no handler — attach one explicitly
+          // or it surfaces as an unhandledrejection in Sentry (#1472).
+          orphan.ended.catch(swallowAudioStop);
+        }
         visemeFramesRef.current = [];
         holdThenIdle('concerned');
       },
@@ -198,16 +205,24 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       clearAckTimer();
       // Same — invalidate in-flight callbacks before tearing down.
       playbackSeqRef.current++;
-      playbackRef.current?.stop();
+      const orphan = playbackRef.current;
       playbackRef.current = null;
+      if (orphan) {
+        orphan.stop();
+        orphan.ended.catch(swallowAudioStop);
+      }
     };
   }, []);
 
   async function startTtsPlayback(text: string): Promise<void> {
     // Cancel any in-flight playback so its handle.ended callback can't reset
     // state belonging to the new run.
-    playbackRef.current?.stop();
+    const prev = playbackRef.current;
     playbackRef.current = null;
+    if (prev) {
+      prev.stop();
+      prev.ended.catch(swallowAudioStop);
+    }
     visemeFramesRef.current = [];
     visemeCursorRef.current = 0;
     clearAckTimer();
@@ -252,6 +267,7 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       const handle = await playBase64Audio(tts.audio_base64, tts.audio_mime ?? 'audio/mpeg');
       if (!isStillCurrent()) {
         handle.stop();
+        handle.ended.catch(swallowAudioStop);
         return;
       }
       if (frames.length === 0) {
@@ -277,8 +293,10 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
       );
       try {
         await handle.ended;
-      } catch {
-        // Promise rejects when stop() is called — fall through to cleanup.
+      } catch (err) {
+        // Stop sentinel is expected when a newer turn cancels playback —
+        // rethrow anything else so real decoder errors aren't masked.
+        swallowAudioStop(err);
       }
     } finally {
       if (isStillCurrent()) {

--- a/app/src/features/human/voice/audioPlayer.test.ts
+++ b/app/src/features/human/voice/audioPlayer.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { playBase64Audio } from './audioPlayer';
+import {
+  AudioStoppedError,
+  isAudioStopped,
+  playBase64Audio,
+  swallowAudioStop,
+} from './audioPlayer';
 
 /**
  * Minimal HTMLAudioElement stand-in so we can drive metadata loading and
@@ -125,7 +130,7 @@ describe('playBase64Audio', () => {
     expect(playedSynchronously).toBe(true);
   });
 
-  it('stop() pauses, cleans up the blob URL, and rejects ended', async () => {
+  it('stop() pauses, cleans up the blob URL, and rejects ended with AudioStoppedError', async () => {
     installAudio(url => {
       const a = new FakeAudio(url);
       a.duration = 1;
@@ -135,8 +140,60 @@ describe('playBase64Audio', () => {
     handle.stop();
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
     expect(handle.currentMs()).toBe(-1);
-    await expect(handle.ended).rejects.toThrow('stopped');
+    // Sentry was firing on these orphan rejections because callers couldn't
+    // distinguish "we intentionally stopped" from a real decoder error. The
+    // typed sentinel + `.stopped` brand makes the cancellation case trivially
+    // detectable by `isAudioStopped` / `swallowAudioStop` consumers (#1472).
+    const err = await handle.ended.catch(e => e);
+    expect(err).toBeInstanceOf(AudioStoppedError);
+    expect(err).toMatchObject({ stopped: true, name: 'AudioStoppedError' });
     // Idempotent — second stop() is a no-op.
     handle.stop();
+  });
+});
+
+describe('isAudioStopped / swallowAudioStop', () => {
+  it('isAudioStopped recognizes AudioStoppedError instances', () => {
+    expect(isAudioStopped(new AudioStoppedError())).toBe(true);
+  });
+
+  it('isAudioStopped accepts the structural `.stopped === true` brand', () => {
+    // Defends against bundle-duplication: a second copy of audioPlayer.ts
+    // would produce a different class identity but the brand still matches.
+    expect(isAudioStopped({ stopped: true })).toBe(true);
+    expect(isAudioStopped(Object.assign(new Error('x'), { stopped: true }))).toBe(true);
+  });
+
+  it('isAudioStopped rejects plain errors', () => {
+    expect(isAudioStopped(new Error('audio playback error'))).toBe(false);
+    expect(isAudioStopped(null)).toBe(false);
+    expect(isAudioStopped(undefined)).toBe(false);
+    expect(isAudioStopped('stopped')).toBe(false);
+  });
+
+  it('swallowAudioStop returns void on AudioStoppedError', () => {
+    expect(() => swallowAudioStop(new AudioStoppedError())).not.toThrow();
+  });
+
+  it('swallowAudioStop rethrows non-stop errors so real failures stay visible', () => {
+    const real = new Error('audio playback error');
+    expect(() => swallowAudioStop(real)).toThrow(real);
+  });
+
+  it('attached as .catch(swallowAudioStop), it consumes orphan stop rejections without unhandledrejection', async () => {
+    const unhandled: PromiseRejectionEvent[] = [];
+    const handler = (e: PromiseRejectionEvent) => unhandled.push(e);
+    window.addEventListener('unhandledrejection', handler);
+    try {
+      installAudio(url => new FakeAudio(url));
+      const handle = await playBase64Audio('AAA=');
+      handle.stop();
+      handle.ended.catch(swallowAudioStop);
+      // Let microtasks + a macrotask flush so any unhandledrejection would fire.
+      await new Promise(r => setTimeout(r, 0));
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      window.removeEventListener('unhandledrejection', handler);
+    }
   });
 });

--- a/app/src/features/human/voice/audioPlayer.ts
+++ b/app/src/features/human/voice/audioPlayer.ts
@@ -2,6 +2,35 @@
  * Lightweight base64 → playable HTMLAudio wrapper. We don't need WebAudio
  * graph here; the viseme scheduler reads `currentTime` directly.
  */
+
+/**
+ * Sentinel thrown by the `ended` promise when `stop()` is called. Callers that
+ * intentionally cancel playback (e.g. swapping to a new utterance) can detect
+ * this and silence the rejection without masking real audio decoder errors.
+ */
+export class AudioStoppedError extends Error {
+  readonly stopped = true;
+  constructor() {
+    super('stopped');
+    this.name = 'AudioStoppedError';
+  }
+}
+
+export function isAudioStopped(err: unknown): err is AudioStoppedError {
+  if (err instanceof AudioStoppedError) return true;
+  return typeof err === 'object' && err !== null && (err as { stopped?: unknown }).stopped === true;
+}
+
+/**
+ * Use as `.catch(swallowAudioStop)` on an orphan `handle.ended` promise, or
+ * `catch (err) { swallowAudioStop(err); }` around an awaited one. Swallows the
+ * stop sentinel; rethrows anything else so real decoder errors stay visible.
+ */
+export function swallowAudioStop(err: unknown): void {
+  if (isAudioStopped(err)) return;
+  throw err;
+}
+
 export interface PlaybackHandle {
   /** ms elapsed since audio started. Returns -1 after playback ends. */
   currentMs(): number;
@@ -92,7 +121,7 @@ export async function playBase64Audio(
       stopped = true;
       audio.pause();
       cleanup();
-      rejectEnded(new Error('stopped'));
+      rejectEnded(new AudioStoppedError());
     },
     ended,
   };


### PR DESCRIPTION
## Summary

- Replace anonymous `new Error('stopped')` in `audioPlayer.stop()` with a typed `AudioStoppedError` sentinel + `isAudioStopped` typeguard + `swallowAudioStop` helper.
- Attach `.catch(swallowAudioStop)` to every orphan `handle.ended` promise in `useHumanMascot` (4 sites: `onError`, effect cleanup, `startTtsPlayback` prev-handle replace, seq-stale early return).
- Tighten the awaited `try { await handle.ended } catch {}` block to route through `swallowAudioStop` so real decoder errors aren't masked alongside stop sentinels.
- Adds focused tests for the helpers + a `useHumanMascot` regression test that asserts zero `unhandledrejection` events during the two-back-to-back-turn cancel path.

## Problem

`OPENHUMAN-REACT-V` and `OPENHUMAN-REACT-P` were firing as Sentry `Uncaught (in promise) Error: stopped` events. Root cause: `audioPlayer.ts:95` rejected the `ended` promise with a plain `Error('stopped')` whenever the caller cancelled playback, and four code paths in `useHumanMascot.ts` called `handle.stop()` without ever attaching a handler to the resulting rejection:

1. `onError` (chat error) — bumps `playbackSeqRef`, calls `stop()`, then early-returns into `holdThenIdle('concerned')`.
2. Effect cleanup on unmount / re-subscribe.
3. `startTtsPlayback` replacing the previous in-flight handle before launching a new one.
4. `startTtsPlayback` discovering `!isStillCurrent()` after `playBase64Audio` resolves and stopping the just-built handle on the way out.

In every case the rejection had no handler at end of microtask turn, so the browser's `onunhandledrejection` global handler fired and Sentry's `auto.browser.global_handlers.onunhandledrejection` mechanism captured it — even though the cancellation was intentional.

## Solution

- **`audioPlayer.ts`** — added `AudioStoppedError extends Error` with a `.stopped === true` brand, `isAudioStopped` typeguard (checks both `instanceof` and the structural brand so module duplication doesn't break detection), and `swallowAudioStop(err)` that returns void on a stop sentinel and rethrows everything else. The single `rejectEnded(new Error('stopped'))` call now constructs an `AudioStoppedError`.
- **`useHumanMascot.ts`** — at each orphan site, capture the handle into a local, null the ref, then call `stop()` followed by `handle.ended.catch(swallowAudioStop)`. The awaited-`handle.ended` block at the bottom of `startTtsPlayback` now does `catch (err) { swallowAudioStop(err); }` so genuine decoder errors propagate to the outer `.catch(() => {})` at the dispatch site instead of being silently absorbed by a bare `catch {}`.
- Helpers are pure additions; `playBase64Audio`'s natural-finish path is unchanged. Behavior on legitimate decoder errors (`audio.addEventListener('error', …)` → `rejectEnded(new Error('audio playback error'))`) is unchanged — those still reject and now propagate visibly through the `swallowAudioStop` rethrow.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-preserving bug fix to existing matrix-tracked surface (voice mascot playback cancel); no feature added/removed/renamed. Original item: Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change.
- [x] N/A: no new feature IDs; see Coverage matrix N/A above. Original item: All affected feature IDs from the matrix are listed in the PR description under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: existing voice-mascot smoke step already exercises this code path; failure was Sentry-only (no UX symptom) so manual smoke unchanged. Original item: Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)).
- [x] Linked issue closed via `Closes` in the `## Related` section (Sentry IDs; parent tracker `#1472` stays open until tauri-side work lands — `Refs` only)

## Impact

- **Runtime**: desktop (macOS/Win/Linux CEF) — applies wherever the voice-mascot TTS path runs. No CLI / mobile impact.
- **Behavior change**: zero — every flow that previously called `handle.stop()` still cancels playback identically; only the resulting rejection now has an attached handler. Mascot face-state transitions, viseme scheduling, and natural-completion flow are untouched.
- **Performance**: nil — adds one synchronous `.catch` attach per cancel.
- **Security / migration**: none.
- **Sentry expectation**: occurrence counts on `OPENHUMAN-REACT-V` + `OPENHUMAN-REACT-P` stop incrementing post-deploy on releases ≥ this commit. Pre-deploy baseline both are 1 event / 1 user each; any new event with this release tag means a path was missed.

## Related

- Closes OPENHUMAN-REACT-V
- Closes OPENHUMAN-REACT-P
- Refs #1472 (parent tracker — stays open until tauri-side Sentry items also land)
- Follow-up PR(s)/TODOs: separate Sentry items in #1472 batch (PR-A `openUrl IPC guard` in flight as `fix/1472-react-openurl-ipc-guard`; PRs C–F parked).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/1472-react-audio-stopped-sentinel`
- Commit SHA: `9a9912bc9c0bdef572501f7f5595fc1d7347d5ae`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — clean on changed files (only pre-existing `app/src/pages/Home.tsx` skip-worktree badge surfaces; not staged)
- [x] `pnpm typecheck` — clean
- [x] Focused tests: `pnpm debug unit src/features/human/voice/audioPlayer.test.ts` → 11/11 pass; `pnpm debug unit src/features/human/useHumanMascot.test.ts` → 25/25 pass
- [x] N/A: TypeScript-only change; no Rust core sources modified. Original item: Rust fmt/check (if changed).
- [x] N/A: TypeScript-only change; no Tauri shell sources modified. Original item: Tauri fmt/check (if changed).

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: silence Sentry capture of the stop-sentinel rejection; preserve all observable mascot/audio behavior.
- User-visible effect: none directly; Sentry noise drop is the only externally observable change.

### Parity Contract
- Legacy behavior preserved: `playBase64Audio` API surface and rejection-on-stop semantics unchanged (still rejects `ended`; only the error class is now typed). All four `handle.stop()` callers still stop synchronously.
- Guard/fallback/dispatch parity checks: `isAudioStopped` falls back to a structural `.stopped === true` brand so module duplication or future subclassing doesn't break detection; `swallowAudioStop` rethrows non-stop errors so the `audio.addEventListener('error', …)` path remains visible.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback cancellation handling to prevent unhandled rejection errors when playback is stopped or overlapping audio requests occur.
  * Enhanced cleanup behavior to properly manage concurrent audio playback scenarios without surfacing spurious error events to users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1494)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->