### PR TITLE
fix(windows): silence conhost flashes from core-side spawns (#731/#1338 follow-up)

### DIFF
--- a/src/openhuman/doctor/core.rs
+++ b/src/openhuman/doctor/core.rs
@@ -509,17 +509,20 @@ fn available_disk_space_mb_windows(path: &Path) -> Option<u64> {
     // PowerShell is ubiquitous on supported Windows; `Get-PSDrive` needs no admin
     // and returns free bytes as a single integer line.
     let script = format!("(Get-PSDrive -Name {letter} -ErrorAction Stop).Free");
-    let output = std::process::Command::new("powershell")
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            &script,
-        ])
-        .output()
-        .ok()?;
+    let mut cmd = std::process::Command::new("powershell");
+    cmd.args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        &script,
+    ]);
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let output = cmd.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -729,11 +732,17 @@ fn check_command_available(
     cat: &'static str,
     items: &mut Vec<DiagnosticItem>,
 ) {
-    match std::process::Command::new(cmd)
+    let mut child_cmd = std::process::Command::new(cmd);
+    child_cmd
         .args(args)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
+        .stderr(std::process::Stdio::piped());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        child_cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    match child_cmd.output()
     {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout)

--- a/src/openhuman/doctor/core.rs
+++ b/src/openhuman/doctor/core.rs
@@ -742,8 +742,7 @@ fn check_command_available(
         use std::os::windows::process::CommandExt;
         child_cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
     }
-    match child_cmd.output()
-    {
+    match child_cmd.output() {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout)
                 .lines()

--- a/src/openhuman/local_ai/device.rs
+++ b/src/openhuman/local_ai/device.rs
@@ -99,12 +99,16 @@ fn detect_gpu(cpu_brand: &str, os_name: &str) -> (bool, Option<String>) {
 /// Probe for an NVIDIA GPU by running `nvidia-smi --query-gpu=name --format=csv,noheader`.
 /// Returns `Some("NVIDIA <name> (CUDA)")` on success, `None` if nvidia-smi is not available.
 fn probe_nvidia_smi() -> Option<String> {
-    let output = std::process::Command::new("nvidia-smi")
-        .args(["--query-gpu=name", "--format=csv,noheader"])
+    let mut cmd = std::process::Command::new("nvidia-smi");
+    cmd.args(["--query-gpu=name", "--format=csv,noheader"])
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
+        .stderr(std::process::Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let output = cmd.output().ok()?;
 
     if !output.status.success() {
         return None;

--- a/src/openhuman/local_ai/install.rs
+++ b/src/openhuman/local_ai/install.rs
@@ -37,6 +37,7 @@ fn build_install_command(install_dir: &Path) -> Result<tokio::process::Command, 
     #[cfg(target_os = "windows")]
     {
         let mut cmd = tokio::process::Command::new("powershell");
+        crate::openhuman::local_ai::process_util::apply_no_window(&mut cmd);
         cmd.env("OPENHUMAN_OLLAMA_INSTALL_DIR", install_dir);
         cmd.args([
             "-NoProfile",

--- a/src/openhuman/local_ai/mod.rs
+++ b/src/openhuman/local_ai/mod.rs
@@ -15,6 +15,7 @@ pub mod sentiment;
 mod install;
 pub(crate) mod model_ids;
 mod ollama_api;
+mod process_util;
 pub(crate) use ollama_api::{ollama_base_url, OLLAMA_BASE_URL};
 mod parse;
 pub(crate) mod paths;

--- a/src/openhuman/local_ai/process_util.rs
+++ b/src/openhuman/local_ai/process_util.rs
@@ -1,0 +1,40 @@
+//! Process-spawn helpers for local AI subsystems.
+//!
+//! On Windows every `Command::spawn` allocates a conhost for the child
+//! before stdio inheritance is applied — so a `Stdio::null()` redirect
+//! still flashes a console window. `apply_no_window` sets the
+//! `CREATE_NO_WINDOW` (0x0800_0000) process-creation flag which tells
+//! the OS to skip conhost allocation entirely.
+//!
+//! Mirrors the pattern established by #731 and #1338 for the Tauri-shell
+//! side (see `app/src-tauri/src/core_process.rs` and `process_kill.rs`).
+//! Without this every Ollama health-check / install attempt flashes a
+//! console on Windows; on a fresh install without Ollama present the
+//! flashes are continuous because the resolve-or-install loop retries.
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+#[cfg(windows)]
+pub(crate) fn apply_no_window(cmd: &mut tokio::process::Command) {
+    use std::os::windows::process::CommandExt;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+pub(crate) fn apply_no_window(_cmd: &mut tokio::process::Command) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_no_window_is_callable_on_every_platform() {
+        // The function is a no-op on non-Windows. On Windows it sets a
+        // creation flag we cannot directly read back from
+        // `tokio::process::Command`, so this test just guarantees the
+        // helper compiles and is callable from generic code.
+        let mut cmd = tokio::process::Command::new("does-not-need-to-exist");
+        apply_no_window(&mut cmd);
+    }
+}

--- a/src/openhuman/local_ai/service/ollama_admin.rs
+++ b/src/openhuman/local_ai/service/ollama_admin.rs
@@ -11,6 +11,7 @@ use crate::openhuman::local_ai::ollama_api::{
 };
 use crate::openhuman::local_ai::paths::{find_workspace_ollama_binary, workspace_ollama_binary};
 use crate::openhuman::local_ai::presets::{self, VisionMode};
+use crate::openhuman::local_ai::process_util::apply_no_window;
 
 use super::LocalAiService;
 
@@ -59,25 +60,26 @@ impl LocalAiService {
             return Ok(());
         }
 
-        if let Err(err) = tokio::process::Command::new(ollama_cmd)
+        let mut version_cmd = tokio::process::Command::new(ollama_cmd);
+        version_cmd
             .arg("--version")
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await
-        {
+            .stderr(std::process::Stdio::null());
+        apply_no_window(&mut version_cmd);
+        if let Err(err) = version_cmd.status().await {
             return Err(format!(
                 "Ollama binary not available ({}; error: {err}).",
                 ollama_cmd.display()
             ));
         }
 
-        match tokio::process::Command::new(ollama_cmd)
+        let mut serve_cmd = tokio::process::Command::new(ollama_cmd);
+        serve_cmd
             .arg("serve")
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
+            .stderr(std::process::Stdio::null());
+        apply_no_window(&mut serve_cmd);
+        match serve_cmd.spawn() {
             Ok(_) => {
                 log::debug!(
                     "[local_ai] spawned `ollama serve` from {}",
@@ -170,14 +172,12 @@ impl LocalAiService {
     }
 
     async fn command_works(&self, command: &Path) -> bool {
-        tokio::process::Command::new(command)
-            .arg("--version")
+        let mut cmd = tokio::process::Command::new(command);
+        cmd.arg("--version")
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false)
+            .stderr(std::process::Stdio::null());
+        apply_no_window(&mut cmd);
+        cmd.status().await.map(|s| s.success()).unwrap_or(false)
     }
 
     async fn download_and_install_ollama(&self, config: &Config) -> Result<(), String> {
@@ -895,12 +895,12 @@ impl LocalAiService {
         }
         #[cfg(windows)]
         {
-            let _ = tokio::process::Command::new("taskkill")
-                .args(["/F", "/IM", "ollama.exe"])
+            let mut cmd = tokio::process::Command::new("taskkill");
+            cmd.args(["/F", "/IM", "ollama.exe"])
                 .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .await;
+                .stderr(std::process::Stdio::null());
+            apply_no_window(&mut cmd);
+            let _ = cmd.status().await;
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
     }

--- a/src/openhuman/node_runtime/resolver.rs
+++ b/src/openhuman/node_runtime/resolver.rs
@@ -208,13 +208,17 @@ fn probe_subcommand_version(path: &std::path::Path, label: &str) -> Option<Strin
     use std::io::Read;
     use wait_timeout::ChildExt;
 
-    let mut child = Command::new(path)
-        .arg("--version")
+    let mut cmd = Command::new(path);
+    cmd.arg("--version")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .ok()?;
+        .stderr(Stdio::piped());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    let mut child = cmd.spawn().ok()?;
 
     let timeout = Duration::from_secs(5);
     let status = match child.wait_timeout(timeout).ok()? {

--- a/src/openhuman/service/common.rs
+++ b/src/openhuman/service/common.rs
@@ -102,7 +102,20 @@ pub(crate) fn xml_escape(input: &str) -> String {
         .replace('\'', "&apos;")
 }
 
+/// Suppress conhost allocation for Windows command spawns. Without this,
+/// every `schtasks /Query` polled by service status checks flashes a
+/// console — visible to users (#1475 follow-up to #731 + #1338).
+#[cfg(windows)]
+fn no_window(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+}
+
+#[cfg(not(windows))]
+fn no_window(_cmd: &mut Command) {}
+
 pub(crate) fn run_checked(cmd: &mut Command) -> Result<()> {
+    no_window(cmd);
     let status = cmd.status()?;
     if !status.success() {
         anyhow::bail!("command failed with status {status}");
@@ -111,6 +124,7 @@ pub(crate) fn run_checked(cmd: &mut Command) -> Result<()> {
 }
 
 pub(crate) fn run_capture(cmd: &mut Command) -> Result<String> {
+    no_window(cmd);
     let output = cmd.output()?;
     if !output.status.success() {
         anyhow::bail!("command failed with status {}", output.status);
@@ -120,6 +134,7 @@ pub(crate) fn run_capture(cmd: &mut Command) -> Result<String> {
 }
 
 pub(crate) fn run_best_effort(cmd: &mut Command) {
+    no_window(cmd);
     match cmd.stdout(Stdio::null()).stderr(Stdio::null()).status() {
         Ok(status) => {
             if !status.success() {
@@ -133,6 +148,7 @@ pub(crate) fn run_best_effort(cmd: &mut Command) {
 }
 
 pub(crate) fn run_check_silent(cmd: &mut Command) -> bool {
+    no_window(cmd);
     cmd.stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()

--- a/src/openhuman/service/windows.rs
+++ b/src/openhuman/service/windows.rs
@@ -131,8 +131,10 @@ pub(crate) fn uninstall(config: &Config) -> Result<ServiceStatus> {
 }
 
 fn is_task_exists_windows(task_name: &str) -> Result<bool> {
+    use std::os::windows::process::CommandExt;
     let result = Command::new("schtasks")
         .args(["/Query", "/TN", task_name])
+        .creation_flags(0x0800_0000) // CREATE_NO_WINDOW
         .output();
 
     match result {


### PR DESCRIPTION
## Summary

- Adds `CREATE_NO_WINDOW` (`creation_flags(0x0800_0000)`) to every core-side child-process spawn on Windows.
- Without this flag Windows allocates a conhost for each child via `CreateProcess`, causing a continuous terminal-flash storm when polled RPCs fan out into native command probes (e.g. `local_ai_device_profile` → `nvidia-smi`).
- New helper `src/openhuman/local_ai/process_util.rs` exposes `apply_no_window(&mut tokio::process::Command)` so call sites don't repeat the `cfg(windows)` block.
- Shell-side spawns were fixed in #731 and #1338; this patch covers the missed core-side sites.
- 9 files changed, 122 insertions, 45 deletions.

## Problem

On a fresh Windows install, any frontend-polled RPC that fans out into a native command probe (e.g. `local_ai_device_profile` → `nvidia-smi --query-gpu`) caused a continuous conhost flash storm — visible before the auth screen had even rendered.

`windows_subsystem = "windows"` on the parent process (Tauri shell) prevents that process from inheriting a console, but each `CreateProcess` call for a child still allocates a new conhost unless `CREATE_NO_WINDOW` is explicitly passed in `dwCreationFlags`. #731 fixed the core sidecar spawn; #1338 fixed `netstat`/`taskkill` in the shell. The core-side spawns were missed in both passes.

## Solution

- New helper `local_ai/process_util::apply_no_window` wraps the `#[cfg(windows)]` + `creation_flags(0x0800_0000)` detail; callers just call the helper on their `Command`.
- For `std::process::Command` sites and one-off cases, the `cfg` block is inlined directly.
- Sites patched:
  - `local_ai/install.rs`: PowerShell wrapper running `OllamaSetup.exe`
  - `local_ai/service/ollama_admin.rs`: `ollama --version`, `ollama serve`, `command_works` candidate probe, `taskkill /F /IM ollama.exe`
  - `local_ai/device.rs`: `nvidia-smi --query-gpu` — re-probed by `handle_local_ai_device_profile` on every poll (the main visible loop)
  - `doctor/core.rs`: PowerShell `Get-PSDrive` for disk space + `<cmd> --version` for `git`/`curl`/etc. in `check_command_available`
  - `node_runtime/resolver.rs`: `<bin> --version` in `probe_subcommand_version`
  - `service/common.rs` helpers (`run_checked`, `run_capture`, `run_best_effort`, `run_check_silent`) — silences every `schtasks` call at the helper boundary (covers status/start/stop/install/uninstall). Linux `systemctl` and macOS `launchctl` go through the same helpers; `no_window` is a `cfg(not(windows))` no-op on those targets.
  - `service/windows.rs:is_task_exists_windows`: bypasses the common helpers; patched directly with `creation_flags`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
  `process_util.rs` carries a smoke test asserting `apply_no_window` is callable on every platform. Assertable behavior beyond that requires inspecting Windows process-creation flags at the OS level, which is not reachable from Rust unit tests.
- [x] N/A: Diff coverage ≥ 80% — changes are Windows-only conditional-compilation glue around existing tested call sites; no new logic to cover with diff-cover on Linux CI runners.
- [x] N/A: Coverage matrix updated — behaviour-only change; no feature rows added/removed/renamed.
- [x] N/A: All affected feature IDs from the matrix are listed under `## Related` — no feature-matrix entries touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated — invisible-to-user fix; behavior matches the `windows_subsystem="windows"` linker attribute on the parent.
- [x] N/A: Linked issue closed via `Closes #NNN` — the core-side conhost flash bug was not tracked under its own issue; see `## Related` for prior-art references.

## Impact

Windows-only fix. On Windows, every core-side child-process spawn now sets `CREATE_NO_WINDOW`; no conhost is allocated. No behavior change on macOS or Linux — the `cfg(not(windows))` path is a no-op. No UI surface change, no new API, no migration needed.

## Related

- Prior art: #731 (conhost on core sidecar), #1338 (netstat/taskkill in shell)
- Surfaced during: #1475 (Windows rebuild verification)
- No issues auto-closed by this PR.
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/windows-conhost-flashes`
- Commit SHA: `61c724be51046ece40618811121c6b46791f4c60`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `process_util.rs` smoke test (callable on all platforms)
- [x] Rust fmt/check (if changed): `cargo check -p openhuman --target x86_64-pc-windows-msvc` clean (only pre-existing warnings in `slack_backfill.rs`); `cargo fmt --check` clean
- [x] N/A: Tauri fmt/check (if changed): N/A — no Tauri shell changes

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: All core-side child processes on Windows are spawned with `CREATE_NO_WINDOW`; no conhost window appears for any native probe.
- User-visible effect: Conhost flash storm gone — confirmed end-to-end on contributor's Windows machine, both with and without Ollama installed.

### Parity Contract
- Legacy behavior preserved: All spawn logic is unchanged on macOS and Linux; `apply_no_window` and inline `cfg` blocks are no-ops on non-Windows targets.
- Guard/fallback/dispatch parity checks: `service/common.rs` helpers used by Linux `systemctl` and macOS `launchctl` are unaffected; `creation_flags` path is Windows-only.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unexpected console windows appearing on Windows during background operations, including system diagnostics, device detection, service management, and installation processes.
  * Enhanced user experience and system responsiveness by eliminating visual interruptions from background processes.
  * Improved overall visual polish for a cleaner, more professional user interface on Windows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1498)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->