### PR TITLE
docs: fix README typos and copy bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ OpenHuman is an open-source agentic assistant designed to integrate with you in 
 
 - **Batteries included**: web search, a web-fetch [scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), a full coder toolset (filesystem, git, lint, test, grep), and [native voice](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT in, ElevenLabs TTS out, mascot lip-sync, live Google Meet agent) are wired in by default. [Model routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) sends each task to the right LLM (reasoning, fast, or vision) under one subscription. No "install a plugin to read files" friction. [Optional local AI via Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) for on-device workloads.
 
-- **[Smart token compression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: every tool call, scrape result, email body, and search payload is run through a token compression layer before it touches any LLM Model. HTML is converted to Markdown, long URLs are shortened, non-Asccii characters are removed etc... You get the same information but at a fraction of the tokens. Reducing costs &amp; increasing latency by upto 80%.
+- **[Smart token compression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: every tool call, scrape result, email body, and search payload is run through a token compression layer before it touches any LLM Model. HTML is converted to Markdown, long URLs are shortened, non-ASCII characters are removed etc... You get the same information but at a fraction of the tokens. Reducing cost &amp; latency by up to 80%.
 
 - **[Messaging channels](https://tinyhumans.gitbook.io/openhuman/features/integrations#messaging-channels)** and **[privacy & security](https://tinyhumans.gitbook.io/openhuman/features/privacy-and-security)**: inbound/outbound across the channels you already use, with workflow data that stays on device, encrypted locally, treated as yours.
 
@@ -70,9 +70,9 @@ OpenHuman is the first agent harness that gets to know you in minutes. Inspired 
 
 > OpenHuman summarizes and compresses all your documents, emails & chats; and creates a memory graph that lets your agent remember everything about you.
 
-OpenHuman skips the wait. Connect your accounts, let [auto-fetch](https://tinyhumans.gitbook.io/openhuman/features/integrations/auto-fetch) pull data locally on a 20-minute loop, and then have [Memory Trees](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) compresses everything into Markdown files stored intelligently in a [Karpathy-style Obsidian wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki).
+OpenHuman skips the wait. Connect your accounts, let [auto-fetch](https://tinyhumans.gitbook.io/openhuman/features/integrations/auto-fetch) pull data locally on a 20-minute loop, and then have [Memory Trees](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) compress everything into Markdown files stored intelligently in a [Karpathy-style Obsidian wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki).
 
-In just one sync pass and the agent has full (compressed) context your inbox, your calendar, your repos, your docs, your messages. No training period. No "give it a few weeks.". It becomes you, controlled by you.
+In just one sync pass, the agent has full (compressed) context of your inbox, your calendar, your repos, your docs, your messages. No training period. No "give it a few weeks.". It becomes you, controlled by you.
 
 ## OpenHuman vs Other Agent Harnesses
 


### PR DESCRIPTION
## Summary

- Fix three copy bugs in `README.md` — no code changes.
- Notably, the TokenJuice bullet was claiming the layer *increases* latency (the opposite of intent).

## Problem

- `non-Asccii` typo (line 57).
- TokenJuice bullet (line 57): `Reducing costs & increasing latency by upto 80%` — reads as a regression and contains `upto`.
- Memory Trees sentence (line 73): `have [Memory Trees](…) compresses everything` — subject/verb disagreement under the `have X do Y` construction.
- Intro sentence (line 75): `In just one sync pass and the agent has full (compressed) context your inbox…` — dangling `and`, and missing `of` after `context`.

## Solution

- `non-Asccii` → `non-ASCII`.
- `Reducing costs & increasing latency by upto 80%` → `Reducing cost & latency by up to 80%`.
- `have Memory Trees compresses` → `have Memory Trees compress`.
- `In just one sync pass and the agent has full (compressed) context your inbox…` → `In just one sync pass, the agent has full (compressed) context of your inbox…`.

## Submission Checklist

- [x] Tests added or updated — **N/A: README copy fix, no behavior change.**
- [x] **Diff coverage ≥ 80%** — **N/A: documentation-only change, no executable lines.**
- [x] Coverage matrix updated — **N/A: behaviour-only change** (no feature added/removed/renamed).
- [x] All affected feature IDs listed under `## Related` — **N/A: no feature touched.**
- [x] No new external network dependencies introduced — **N/A: no code change.**
- [x] Manual smoke checklist updated — **N/A: not a release-cut surface.**
- [x] Linked issue closed via `Closes #NNN` — **N/A: no tracking issue.**

## Impact

- Documentation only. No runtime/platform impact.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `docs/readme-typos`
- Commit SHA: `54f2f038`

---

### Note to reviewers

Pre-push hook (`pnpm format:check`) failed locally with `sh: cargo: command not found` in its `rust:format:check` step — environment issue, unrelated to this README-only change. Prettier itself reported "All matched files use Prettier code style!" before the cargo step failed. Pushed with `--no-verify` per the project's documented policy for pre-existing/unrelated hook failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature descriptions for clarity and accuracy
  * Refined explanation of smart token compression benefits and cost/latency reductions
  * Clarified how context compression and storage works

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1500)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->