### PR TITLE
chore(ci): bump deprecated Node 20 GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -126,7 +126,7 @@ jobs:
       VITE_TELEGRAM_BOT_USERNAME: ${{ inputs.telegram_bot_username }}
     steps:
       - name: Checkout build ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.build_ref }}
           fetch-depth: 1
@@ -137,11 +137,11 @@ jobs:
         with:
           xcode-version: latest-stable
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           cache: true
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
       - name: Install Rust (rust-toolchain.toml)
@@ -183,7 +183,7 @@ jobs:
         run: |
           echo "hash=$(tail -n +8 Cargo.lock | openssl dgst -sha256 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - name: Cache Cargo registry and git sources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -197,7 +197,7 @@ jobs:
       # runs. Default path is `dirs::cache_dir()/tauri-cef`.
       - name: Cache CEF binary distribution (unix)
         if: matrix.settings.platform != 'windows-latest'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/tauri-cef
@@ -207,7 +207,7 @@ jobs:
             cef-${{ matrix.settings.target }}-
       - name: Cache CEF binary distribution (windows)
         if: matrix.settings.platform == 'windows-latest'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/AppData/Local/tauri-cef
           key: cef-${{ matrix.settings.target }}-${{ hashFiles('app/src-tauri/Cargo.toml') }}
@@ -220,14 +220,14 @@ jobs:
       - name: Cache vendored tauri-cli binary (unix)
         if: matrix.settings.platform != 'windows-latest'
         id: tauri-cli-cache-unix
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri
           key: vendored-tauri-cli-${{ runner.os }}-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
       - name: Cache vendored tauri-cli binary (windows)
         if: matrix.settings.platform == 'windows-latest'
         id: tauri-cli-cache-windows
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri.exe
           key: vendored-tauri-cli-${{ runner.os }}-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
@@ -283,7 +283,7 @@ jobs:
         # `KEYPAIR_ALIAS` (Windows DigiCert sign command). Pubkey + endpoint
         # come from the static `app/src-tauri/tauri.conf.json`.
         id: config-overrides
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           BASE_URL: ${{ inputs.base_url }}
           WITH_UPDATER: ${{ inputs.with_updater && 'true' || 'false' }}
@@ -623,7 +623,7 @@ jobs:
       # ---- Actions-artifact uploads (when not pushing to a GH Release) ------
       - name: Upload desktop bundles as Actions artifact
         if: "!inputs.with_release_upload"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name:
             desktop-bundles-${{ matrix.settings.platform }}-${{ matrix.settings.artifact_suffix
@@ -633,7 +633,7 @@ jobs:
             target/${{ matrix.settings.target }}/${{ inputs.build_profile }}/bundle/**
       - name: Upload standalone CLI artifact
         if: inputs.build_sidecar && !inputs.with_release_upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name:
             standalone-bins-${{ matrix.settings.platform }}-${{ matrix.settings.artifact_suffix

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,12 +17,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: yarn
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "hash=$(tail -n +8 Cargo.lock | openssl dgst -sha256 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - name: Cache Cargo registry and git sources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -50,7 +50,7 @@ jobs:
       # CEF runtime auto-downloads via cef-dll-sys / vendored tauri-cli. Cache
       # it so we don't re-fetch ~400MB every run.
       - name: Cache CEF binary distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/AppData/Local/tauri-cef
           key: cef-windows-${{ hashFiles('app/src-tauri/Cargo.toml') }}
@@ -58,7 +58,7 @@ jobs:
             cef-windows-
       - name: Cache vendored tauri-cli binary
         id: tauri-cli-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri.exe
           key: vendored-tauri-cli-windows-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
@@ -79,7 +79,7 @@ jobs:
         # command at this point (`WITH_UPDATER` defaults to off here so
         # this PR-build matrix doesn't try to mint signed updater
         # artifacts it has no key for).
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const workspacePath = process.env.GITHUB_WORKSPACE.replace(/\\/g, '/');
@@ -103,21 +103,21 @@ jobs:
         run: |
           NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build -c "$TAURI_CONFIG_OVERRIDE" --target x86_64-pc-windows-msvc
       - name: Upload MSI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: windows-msi
           path: |
             app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
             target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
       - name: Upload NSIS artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: windows-nsis
           path: |
             app/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
             target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
       - name: Upload standalone CLI binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: windows-cli
           path: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
@@ -37,7 +37,7 @@ jobs:
       # cef-dll-sys + the vendored tauri-cli. Cache it across builds — the
       # payload is ~400MB per platform and fetching every run is painful.
       - name: Cache CEF binary distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/tauri-cef
           key: cef-ubuntu-22.04-${{ hashFiles('app/src-tauri/Cargo.toml') }}
@@ -49,7 +49,7 @@ jobs:
       # .github/Dockerfile), so `cargo tauri build` below resolves to the
       # fork without any per-run compile step.
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,11 +26,11 @@ jobs:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -53,7 +53,7 @@ jobs:
           sed -i -E 's#^SF:(src/)#SF:app/\1#' app/coverage/lcov.info
           sed -i -E 's#^SF:(\./src/)#SF:app/src/#' app/coverage/lcov.info
       - name: Upload frontend lcov
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lcov-frontend
           path: app/coverage/lcov.info
@@ -71,7 +71,7 @@ jobs:
       # skip it for coverage runs and rely on Swatinem/rust-cache for warmup.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
@@ -86,7 +86,7 @@ jobs:
       - name: Run cargo llvm-cov for openhuman core
         run: cargo llvm-cov -p openhuman --lcov --output-path lcov-core.info
       - name: Upload core lcov
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lcov-rust-core
           path: lcov-core.info
@@ -102,7 +102,7 @@ jobs:
       CARGO_INCREMENTAL: '0'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
@@ -115,7 +115,7 @@ jobs:
           cache-on-failure: true
           key: tauri-coverage
       - name: Cache CEF binary distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/tauri-cef
           key: cef-ubuntu-22.04-${{ hashFiles('app/src-tauri/Cargo.toml') }}
@@ -126,7 +126,7 @@ jobs:
       - name: Run cargo llvm-cov for Tauri shell
         run: cargo llvm-cov --manifest-path app/src-tauri/Cargo.toml --lcov --output-path lcov-tauri.info
       - name: Upload tauri lcov
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lcov-rust-tauri
           path: lcov-tauri.info
@@ -140,20 +140,20 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # diff-cover needs full history for the merge-base with the PR base.
           fetch-depth: 0
       - name: Fetch PR base branch
         run: git fetch origin "${{ github.base_ref }}" --depth=200
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install diff-cover
         run: pip install 'diff-cover>=9.2.0'
       - name: Download all lcov artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: lcov-artifacts
           pattern: lcov-*
@@ -183,7 +183,7 @@ jobs:
             --markdown-report diff-coverage.md
       - name: Upload diff-cover report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: diff-coverage-report
           path: |

--- a/.github/workflows/deploy-smoke.yml
+++ b/.github/workflows/deploy-smoke.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: false

--- a/.github/workflows/docker-ci-image.yml
+++ b/.github/workflows/docker-ci-image.yml
@@ -19,7 +19,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # vendored tauri-cef fork is compiled into the image
           submodules: recursive

--- a/.github/workflows/e2e-agent-review.yml
+++ b/.github/workflows/e2e-agent-review.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
@@ -36,12 +36,12 @@ jobs:
           fi
       - name: Setup pnpm
         if: steps.gate.outputs.present == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           cache: true
       - name: Setup Node.js 24.x
         if: steps.gate.outputs.present == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
       - name: Install Rust (rust-toolchain.toml)
@@ -65,7 +65,7 @@ jobs:
           echo "hash=$(tail -n +8 Cargo.lock | openssl dgst -sha256 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - name: Cache Cargo registry and build
         if: steps.gate.outputs.present == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -108,7 +108,7 @@ jobs:
           fi
       - name: Upload E2E artifacts
         if: always() && steps.gate.outputs.present == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-agent-review-artifacts
           path: |

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -19,7 +19,7 @@ jobs:
         os: [macos-latest, ubuntu-22.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run installer dry-run
         run: bash scripts/install.sh --dry-run --verbose
 
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Unit tests (MSI args / asset selection)
         shell: pwsh

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Verify Submission Checklist
@@ -38,7 +38,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Verify Coverage Matrix
@@ -50,7 +50,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Lychee link check

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 1
@@ -94,12 +94,12 @@ jobs:
     needs: [build-cli-linux-arm64]
     steps:
       - name: Checkout main repo (for formula template)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
           path: src
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: tinyhumansai/homebrew-openhuman
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
     needs: [build-cli-linux-arm64]
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 1
@@ -141,7 +141,7 @@ jobs:
           echo "$APT_SIGNING_KEY" | gpg --batch --import
           gpg --list-secret-keys
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
           path: gh-pages
@@ -164,12 +164,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 1
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
@@ -240,7 +240,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
       - name: Wait for npm propagation, then install
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create issue if it doesn't exist
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |-
             const { owner, repo } = context.repo;

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -99,14 +99,14 @@ jobs:
           app_id: ${{ secrets.XGITHUB_APP_ID }}
           private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
       - name: Configure Git
@@ -306,7 +306,7 @@ jobs:
     steps:
       - name: Create draft release with generated notes
         id: create
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const tag = '${{ needs.prepare-build.outputs.tag }}';
@@ -394,7 +394,7 @@ jobs:
       IMAGE_NAME: tinyhumansai/openhuman-core
     steps:
       - name: Checkout build ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
@@ -470,7 +470,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     steps:
       - name: Checkout build ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
@@ -531,7 +531,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout build ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
@@ -565,7 +565,7 @@ jobs:
       && needs.publish-updater-manifest.result == 'success'
     steps:
       - name: Validate required installer assets exist
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const releaseId = Number('${{ needs.create-release.outputs.release_id }}');
@@ -600,7 +600,7 @@ jobs:
             core.info('All required installer assets are present.');
 
       - name: Publish release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const releaseId = Number('${{ needs.create-release.outputs.release_id }}');
@@ -719,7 +719,7 @@ jobs:
       == 'cancelled')
     steps:
       - name: Delete GitHub release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -736,7 +736,7 @@ jobs:
               core.warning(`deleteRelease failed: ${e.message}`);
             }
       - name: Delete remote tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -72,14 +72,14 @@ jobs:
           app_id: ${{ secrets.XGITHUB_APP_ID }}
           private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
       - name: Configure Git
@@ -217,7 +217,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout build ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
@@ -299,7 +299,7 @@ jobs:
           || needs.build-docker.result == 'failure' || needs.build-docker.result == 'cancelled')
     steps:
       - name: Delete remote staging tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -45,7 +45,7 @@ jobs:
           NODE_ENV: test
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: coverage
@@ -67,7 +67,7 @@ jobs:
       SCCACHE_GHA_ENABLED: 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
@@ -96,7 +96,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           # Required for app/src-tauri/vendor/tauri-cef — the fork supplies
@@ -116,7 +116,7 @@ jobs:
       # links the Chromium dylib via cef-dll-sys. Cache the download to avoid
       # re-fetching ~400MB every PR run.
       - name: Cache CEF binary distribution
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/tauri-cef
           key: cef-ubuntu-22.04-${{ hashFiles('app/src-tauri/Cargo.toml') }}
@@ -141,13 +141,13 @@ jobs:
   #   timeout-minutes: 60
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v5
   #       with:
   #         fetch-depth: 1
   #         submodules: recursive
 
   #     - name: Setup Node.js 24.x
-  #       uses: actions/setup-node@v4
+  #       uses: actions/setup-node@v5
   #       with:
   #         node-version: 24.x
   #         cache: "pnpm"
@@ -172,7 +172,7 @@ jobs:
   #         echo "hash=$(tail -n +8 Cargo.lock | openssl dgst -sha256 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
   #     - name: Cache Cargo registry and build
-  #       uses: actions/cache@v4
+  #       uses: actions/cache@v5
   #       with:
   #         path: |
   #           ~/.cargo/registry
@@ -241,13 +241,13 @@ jobs:
 #     timeout-minutes: 90
 #     steps:
 #       - name: Checkout code
-#         uses: actions/checkout@v4
+#         uses: actions/checkout@v5
 #         with:
 #           fetch-depth: 1
 #           submodules: recursive
 
 #       - name: Setup Node.js 24.x
-#         uses: actions/setup-node@v4
+#         uses: actions/setup-node@v5
 #         with:
 #           node-version: 24.x
 #           cache: "pnpm"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -19,11 +19,11 @@ jobs:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -50,7 +50,7 @@ jobs:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Cache Rust build artifacts

--- a/.github/workflows/weekly-code-review.yml
+++ b/.github/workflows/weekly-code-review.yml
@@ -31,12 +31,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache cargo-audit binary
         id: cache-cargo-audit
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Image sets CARGO_HOME=/usr/local/cargo, so cargo install drops the
           # binary there — not in $HOME/.cargo/bin.
@@ -63,14 +63,14 @@ jobs:
         run: bash scripts/weekly-code-review.sh weekly-code-review-out
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: weekly-code-review-${{ github.run_id }}
           path: weekly-code-review-out
           retention-days: 90
 
       - name: Open or update tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

- Bumps every GitHub Action pinned at a Node-20-runtime major to its current Node-24-compatible major.
- Silences the runner-wide deprecation warning across all 15 workflows in `.github/workflows/`.
- No workflow logic changes — version bumps only.

## Problem

GitHub announced that Node.js 20 actions are deprecated. Starting **2026-06-02** the runner will force Node 20 actions onto Node 24, and on **2026-09-16** Node 20 is removed entirely. Our workflows currently emit the warning:

> The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/github-script@v7, actions/setup-node@v4, actions/upload-artifact@v4, pnpm/action-setup@v4.

Left unaddressed, CI breaks at the cutover.

## Solution

Bump each affected action to the current major (all of which use Node 24):

- `actions/checkout` v4 → v5
- `actions/cache` v4 → v5
- `actions/setup-node` v4 → v5
- `actions/upload-artifact` v4 → v5
- `actions/download-artifact` v4 → v5
- `actions/github-script` v7 → v8
- `actions/setup-python` v5 → v6
- `pnpm/action-setup` v4 → v5

Applied uniformly across all workflows so nothing is left straddling Node-20-era versions.

## Submission Checklist

- [x] N/A: CI-only version bump — no product code paths exercised, behaviour unchanged.
- [x] N/A: No app code touched; diff coverage gate doesn't apply to `.github/workflows/*.yml`.
- [x] N/A: No feature surface added/removed; coverage matrix unaffected.
- [x] N/A: No feature IDs related.
- [x] N/A: No new external network deps; only existing first-party GitHub-published actions bumped.
- [x] N/A: Doesn't touch release-cut surfaces — workflow runtime bump only.
- [x] N/A: No linked issue — proactive deprecation cleanup.

## Impact

- CI only. No runtime/desktop/mobile/web/CLI behaviour change.
- Some bumped majors carry small behaviour changes worth watching on the first green run:
  - `actions/upload-artifact@v5` requires artifact names unique per job within a workflow.
  - `actions/checkout@v5` drops Node 20 compat for any custom composite actions that depend on it.
- Mitigates a hard CI break in June/September 2026.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: chore/bump-actions-node24
- Commit SHA: 13c3974e

### Validation Run
- [x] N/A: CI-only workflow YAML edits; validated by GitHub Actions itself on this PR.
- [x] N/A: format:check not applicable to workflow YAML edits.
- [x] N/A: typecheck not applicable to workflow YAML edits.
- [x] N/A: no focused tests — workflow YAML edits only.
- [x] N/A: no Rust changes.

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: None at runtime; CI uses newer action majors on Node 24.
- User-visible effect: None.

### Parity Contract
- Legacy behavior preserved: Yes — workflow steps and arguments unchanged, only `@vN` bumped.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A