### PR TITLE
fix(auth): treat missing backend session token as auth-expired

### DIFF
--- a/app/src/services/__tests__/coreRpcClient.test.ts
+++ b/app/src/services/__tests__/coreRpcClient.test.ts
@@ -500,6 +500,13 @@ describe('classifyRpcError', () => {
     ['GET /teams failed (401 Unauthorized): {"success":false}', undefined, 'auth_expired'],
     ['Session expired. Please log in again.', undefined, 'auth_expired'],
     ['some prefix Session expired suffix', undefined, 'auth_expired'],
+    [
+      'composio unavailable: no backend session token. Sign in first (auth_store_session).',
+      undefined,
+      'auth_expired',
+    ],
+    ['no backend session token; run auth_store_session first', undefined, 'auth_expired'],
+    ['NO BACKEND SESSION TOKEN', undefined, 'auth_expired'],
     ['HTTP 429 rate-limit exceeded', undefined, 'rate_limited'],
     ['Budget exceeded for current period', undefined, 'budget_exceeded'],
     ['Insufficient budget for request', undefined, 'budget_exceeded'],

--- a/app/src/services/coreRpcClient.ts
+++ b/app/src/services/coreRpcClient.ts
@@ -77,6 +77,12 @@ export function classifyRpcError(message: string, httpStatus?: number): CoreRpcE
   if (httpStatus === 401) return 'auth_expired';
   if (httpStatus === 429) return 'rate_limited';
   if (/\(401\b.*Unauthorized\)|Session expired/i.test(message)) return 'auth_expired';
+  // Core-side "no backend session token" → the auth profile is gone but the
+  // frontend may still hold a stale sessionToken from an optimistic post-login
+  // patch. Treat as auth-expired so `CoreStateProvider` clears the session and
+  // `ProtectedRoute` bounces the user back to `/` (login) instead of trapping
+  // them on an onboarding step that polls a failing RPC every 5 s.
+  if (/no backend session token/i.test(message)) return 'auth_expired';
   if (/429.*rate.?limit/i.test(message)) return 'rate_limited';
   if (/Budget exceeded|Insufficient budget/i.test(message)) return 'budget_exceeded';
   if (/error sending request|client error \(Connect\)|timed out|ECONNREFUSED/i.test(message)) {

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -118,10 +118,20 @@ pub async fn invoke_method(state: AppState, method: &str, params: Value) -> Resu
 }
 
 /// Helper to determine if an error message indicates an expired or invalid session.
+///
+/// "No backend session token" is also treated as a session-expired signal: the
+/// auth profile is missing entirely (the user was never signed in, or their
+/// stored profile was wiped between login and the next RPC). The frontend may
+/// still believe it holds a session token from an optimistic post-login patch,
+/// so we want the same auto-cleanup + UI-level re-auth path to fire instead of
+/// repeatedly reporting this as a hard error to Sentry. See #1465-ish: users
+/// stuck on the onboarding `SkillsStep` would spam `composio_list_connections`
+/// failures every 5 s without ever being bounced back to the login screen.
 fn is_session_expired_error(msg: &str) -> bool {
     let lower = msg.to_lowercase();
     (lower.contains("401") && lower.contains("unauthorized"))
         || lower.contains("invalid token")
+        || lower.contains("no backend session token")
         || msg.contains("SESSION_EXPIRED")
 }
 

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -579,6 +579,25 @@ fn is_session_expired_error_does_not_match_unrelated_errors() {
 }
 
 #[test]
+fn is_session_expired_error_matches_missing_backend_session_token() {
+    // Composio / web search / billing / team / webhooks / referral all surface
+    // a "no backend session token" variant when the auth profile is gone. Each
+    // of these should funnel into the auto-cleanup path instead of being
+    // reported to Sentry as a fresh error on every 5 s poll.
+    assert!(is_session_expired_error(
+        "composio unavailable: no backend session token. Sign in first (auth_store_session)."
+    ));
+    assert!(is_session_expired_error(
+        "no backend session token; run auth_store_session first"
+    ));
+    assert!(is_session_expired_error(
+        "Web search unavailable: no backend session token. Sign in first so the server can proxy search."
+    ));
+    // Case-insensitive match — the helper lowercases first.
+    assert!(is_session_expired_error("NO BACKEND SESSION TOKEN"));
+}
+
+#[test]
 fn escape_html_escapes_all_special_chars() {
     let raw = r#"<script>alert("x&y'z")</script>"#;
     let escaped = escape_html(raw);


### PR DESCRIPTION
## Summary

- Classify the core's "no backend session token" error as auth-expired in both Rust ($`is_session_expired_error`$) and the frontend ($`classifyRpcError`$) so it stops being treated as a hard error.
- Stops Sentry spam from the 5 s $`useComposioIntegrations`$ poll (253 occurrences on a single user in OPENHUMAN-TAURI-1N).
- Lets the existing $`core-rpc-auth-expired`$ event flow bounce the renderer back to $`/`$ (login) instead of trapping the user on an onboarding step that polls a failing RPC forever.

## Problem

Users on the onboarding $`SkillsStep`$ kept seeing $`composio_list_connections`$ fail with $`"composio unavailable: no backend session token. Sign in first (auth_store_session)."`$ every 5 s. Two consequences:

1. The Rust core's $`is_session_expired_error`$ helper didn't match the pattern, so each failure was reported to Sentry as a fresh ERROR via $`report_error`$. One user generated 253 events in $`OPENHUMAN-TAURI-1N`$ on $`openhuman.composio_list_connections`$ alone.
2. The frontend's $`classifyRpcError`$ also didn't match it, so the kind was $`'unknown'`$. The existing $`core-rpc-auth-expired`$ → $`CoreStateProvider.clearSession`$ → $`ProtectedRoute`$ → $`/`$ (login) cascade never fired. The renderer kept its stale optimistic $`sessionToken`$ patch and the user stayed stuck on $`SkillsStep`$ — no path back to the login page.

The same "no backend session token" pattern is produced by $`webhooks`$, $`billing`$, $`team`$, $`referral`$, $`web_search`$, etc., so they all benefit from the same fix.

## Solution

- $`src/core/jsonrpc.rs`$: extend $`is_session_expired_error`$ to also match $`"no backend session token"`$ (case-insensitive). This routes the message through the existing auto-cleanup path ($`clear_session`$) and downgrades the Sentry log line to $`info`$.
- $`app/src/services/coreRpcClient.ts`$: extend $`classifyRpcError`$ with the same pattern so the RPC throws $`CoreRpcError(kind='auth_expired')`$. The existing handler in $`CoreStateProvider`$ fires $`clearSession`$, $`ProtectedRoute`$ sees $`sessionToken=null`$, and the user lands on the login screen.
- Unit tests added on both sides (Rust: 4-assertion table; Vitest: 3 new table rows in $`classifyRpcError`$).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: ≥ 80% diff coverage — change is two one-line predicate extensions, both fully covered by the new table tests.
- [x] N/A: coverage-matrix update — no new feature row; existing auth-expired flow extended.
- [x] N/A: feature IDs in $`## Related`$ — no matrix feature added.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: release-cut smoke surface untouched — error classification only.
- [x] N/A: no linked issue — Sentry-driven fix (OPENHUMAN-TAURI-1N).

## Impact

- Desktop only path (web doesn't hit the Rust composio handler). Stops the 253-event-per-user Sentry burst on $`OPENHUMAN-TAURI-1N`$ and similar groups.
- Existing $`auth_expired`$ behaviour is unchanged for current callers (401, $`Session expired`$, $`Invalid Token`$, $`SESSION_EXPIRED`$).
- No migration, no perf cost, no security implication — server-side path also runs $`clear_session`$, which is a no-op when there is no profile to clear.

## Related

- Closes:
- Follow-up PR(s)/TODOs: investigate why the frontend ends up with a stale $`sessionToken`$ while the Rust auth profile is empty (root cause for the optimistic-patch-vs-backend divergence). This PR is the safety net.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: $`fix/missing-backend-session-token-auth-expired`$
- Commit SHA: $`0910662e6490989220ee5c47c6ba00bc5f287b94`$

### Validation Run
- [x] N/A: $`pnpm --filter openhuman-app format:check`$ — pre-commit hook ran prettier + eslint on this branch and passed.
- [x] N/A: $`pnpm typecheck`$ — pre-commit hook covers it.
- [x] Focused tests: $`pnpm debug unit src/services/__tests__/coreRpcClient.test.ts -t classifyRpcError`$ (16 passed); $`cargo test --lib is_session_expired`$ (6 passed).
- [x] Rust fmt/check (if changed): cargo test build path included $`cargo check`$ equivalent; no new warnings introduced on touched files.
- [x] N/A: Tauri fmt/check (if changed) — $`app/src-tauri`$ not touched.

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: surface "no backend session token" RPC failures as auth-expired instead of as hard errors.
- User-visible effect: users whose backend session is gone are now redirected from onboarding back to the login screen instead of being trapped on a polling step that keeps failing.

### Parity Contract
- Legacy behavior preserved: 401/Unauthorized/SESSION_EXPIRED/Invalid Token paths unchanged; existing classifier test rows kept.
- Guard/fallback/dispatch parity checks: $`invoke_method`$ continues to call $`clear_session`$ for any session-expired classification; $`CoreStateProvider`$ continues to debounce $`core-rpc-auth-expired`$ within a 10 s window.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error classification to properly handle missing backend session token errors, triggering automatic session cleanup and user re-authentication instead of reporting as hard failures.

* **Tests**
  * Added test coverage for the missing backend session error classification scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1504)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
