### PR TITLE
fix(ci): install pnpm before setup-node in release workflows

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -168,6 +168,8 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 1
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -105,6 +105,8 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -78,6 +78,8 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
- `actions/setup-node@v5` auto-detects the `packageManager` field in `package.json` and invokes `pnpm` at setup time. Without pnpm on PATH the step fails with `Unable to locate executable file: pnpm`, which broke the most recent production release run (https://github.com/tinyhumansai/openhuman/actions/runs/25697647563).
- Add `pnpm/action-setup@v5` before `setup-node@v5` in the three release workflows that check out the repo: `release-production.yml`, `release-staging.yml`, and `release-packages.yml` (the `publish-npm` job). Mirrors the existing pattern in `build-desktop.yml` / `e2e-agent-review.yml`.
- `release-packages.yml`'s `smoke-npm` job is intentionally left alone — it never checks out the repo, so `setup-node` has no `package.json` to inspect.

## Test plan
- [ ] Re-run the Release Production workflow on `main` and confirm the `Prepare build context` job's `Setup Node.js` step now succeeds.
- [ ] Next staging release passes the equivalent step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to configure pnpm setup during release and package publishing processes across staging, production, and npm environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1507)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->