### PR TITLE
fix(secrets): cache decoded key + retry transient reads (OPENHUMAN-TAURI-58)

### DIFF
--- a/src/openhuman/security/secrets.rs
+++ b/src/openhuman/security/secrets.rs
@@ -178,7 +178,12 @@ impl SecretStore {
     /// can occur when an AV scanner briefly locks the file — once we've read
     /// it successfully, we never need to read it again for this process.
     fn load_or_create_key(&self) -> Result<Vec<u8>> {
-        if let Some(cached) = cached_key(&self.key_path) {
+        // Normalize the path once so all callers share the same cache slot
+        // regardless of how `key_path` was spelled (relative vs absolute,
+        // symlinks, case-variants on Windows).
+        let cache_key_path = normalize_cache_path(&self.key_path);
+
+        if let Some(cached) = cached_key(&cache_key_path) {
             return Ok(cached);
         }
 
@@ -186,7 +191,12 @@ impl SecretStore {
             let hex_key = read_key_file_with_retry(&self.key_path)
                 .context("Failed to read secret key file")?;
             let key = hex_decode(hex_key.trim()).context("Secret key file is corrupt")?;
-            cache_key(&self.key_path, &key);
+            anyhow::ensure!(
+                key.len() == KEY_LEN,
+                "Secret key file has wrong length: expected {KEY_LEN} bytes, got {}",
+                key.len()
+            );
+            cache_key(&cache_key_path, &key);
             Ok(key)
         } else {
             let key = generate_random_key();
@@ -212,6 +222,7 @@ impl SecretStore {
                         "USERNAME environment variable is empty; \
                          cannot restrict key file permissions via icacls"
                     );
+                    cache_key(&cache_key_path, &key);
                     return Ok(key);
                 };
 
@@ -236,10 +247,21 @@ impl SecretStore {
                 }
             }
 
-            cache_key(&self.key_path, &key);
+            cache_key(&cache_key_path, &key);
             Ok(key)
         }
     }
+}
+
+/// Normalize a path into a stable cache key. Tries `canonicalize` first (so
+/// symlinks, relative paths, and Windows case-variants all collapse to the
+/// same key), falls back to `std::path::absolute` when the file does not yet
+/// exist (e.g. the create branch in `load_or_create_key`), and finally to the
+/// raw path so a normalization failure never breaks the cache.
+fn normalize_cache_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path)
+        .or_else(|_| std::path::absolute(path))
+        .unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Process-wide cache of decoded key bytes keyed by absolute path.
@@ -268,8 +290,9 @@ fn cache_key(path: &Path, key: &[u8]) {
 /// need to invalidate the cache, since the key file is write-once.
 #[cfg(test)]
 pub(super) fn clear_cached_key(path: &Path) {
+    let normalized = normalize_cache_path(path);
     if let Ok(mut cache) = key_cache().lock() {
-        cache.remove(path);
+        cache.remove(&normalized);
     }
 }
 

--- a/src/openhuman/security/secrets.rs
+++ b/src/openhuman/security/secrets.rs
@@ -23,8 +23,11 @@
 use anyhow::{Context, Result};
 use chacha20poly1305::aead::{Aead, KeyInit, OsRng};
 use chacha20poly1305::{AeadCore, ChaCha20Poly1305, Key, Nonce};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 /// Length of the random encryption key in bytes (256-bit, matches `ChaCha20`).
 const KEY_LEN: usize = 32;
@@ -168,11 +171,23 @@ impl SecretStore {
     }
 
     /// Load the encryption key from disk, or create one if it doesn't exist.
+    ///
+    /// The decoded key is cached process-wide keyed by `key_path`, so repeated
+    /// callers (e.g. every `app_state_snapshot` poll) hit memory instead of
+    /// disk. This also rides over transient Windows sharing violations that
+    /// can occur when an AV scanner briefly locks the file — once we've read
+    /// it successfully, we never need to read it again for this process.
     fn load_or_create_key(&self) -> Result<Vec<u8>> {
+        if let Some(cached) = cached_key(&self.key_path) {
+            return Ok(cached);
+        }
+
         if self.key_path.exists() {
-            let hex_key =
-                fs::read_to_string(&self.key_path).context("Failed to read secret key file")?;
-            hex_decode(hex_key.trim()).context("Secret key file is corrupt")
+            let hex_key = read_key_file_with_retry(&self.key_path)
+                .context("Failed to read secret key file")?;
+            let key = hex_decode(hex_key.trim()).context("Secret key file is corrupt")?;
+            cache_key(&self.key_path, &key);
+            Ok(key)
         } else {
             let key = generate_random_key();
             if let Some(parent) = self.key_path.parent() {
@@ -221,9 +236,73 @@ impl SecretStore {
                 }
             }
 
+            cache_key(&self.key_path, &key);
             Ok(key)
         }
     }
+}
+
+/// Process-wide cache of decoded key bytes keyed by absolute path.
+///
+/// Loading the key once per process is both faster and more reliable than
+/// re-reading `.secret_key` on every decrypt. On Windows the file can be
+/// transiently inaccessible (AV scanners holding a handle), and re-reading
+/// turned that transient failure into a perma-failure for every subsequent
+/// RPC call.
+fn key_cache() -> &'static Mutex<HashMap<PathBuf, Vec<u8>>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, Vec<u8>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_key(path: &Path) -> Option<Vec<u8>> {
+    key_cache().lock().ok()?.get(path).cloned()
+}
+
+fn cache_key(path: &Path, key: &[u8]) {
+    if let Ok(mut cache) = key_cache().lock() {
+        cache.insert(path.to_path_buf(), key.to_vec());
+    }
+}
+
+/// Clear the cached key for `path`. Test-only — production code should never
+/// need to invalidate the cache, since the key file is write-once.
+#[cfg(test)]
+pub(super) fn clear_cached_key(path: &Path) {
+    if let Ok(mut cache) = key_cache().lock() {
+        cache.remove(path);
+    }
+}
+
+/// Read the key file, retrying transient errors a handful of times.
+///
+/// Windows AV scanners (Defender, etc.) routinely hold short-lived read
+/// handles right after a file is created, which surfaces as
+/// `ERROR_SHARING_VIOLATION` (raw OS error 32) or `PermissionDenied`. A few
+/// short backoffs are enough to ride over the lock; the typical successful
+/// path returns on the first attempt with zero added latency.
+fn read_key_file_with_retry(path: &Path) -> std::io::Result<String> {
+    use std::io::ErrorKind;
+
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match fs::read_to_string(path) {
+            Ok(contents) => return Ok(contents),
+            Err(err) => {
+                let transient = matches!(
+                    err.kind(),
+                    ErrorKind::PermissionDenied | ErrorKind::Interrupted | ErrorKind::WouldBlock
+                ) || err.raw_os_error() == Some(32); // ERROR_SHARING_VIOLATION (Windows)
+                last_err = Some(err);
+                if !transient || attempt + 1 == MAX_ATTEMPTS {
+                    break;
+                }
+                let backoff_ms = 10u64 << attempt; // 10, 20, 40, 80 ms
+                std::thread::sleep(Duration::from_millis(backoff_ms));
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| std::io::Error::other("read_to_string failed")))
 }
 
 /// XOR cipher with repeating key. Same function for encrypt and decrypt.

--- a/src/openhuman/security/secrets_tests.rs
+++ b/src/openhuman/security/secrets_tests.rs
@@ -579,6 +579,28 @@ fn key_loaded_once_then_cached() {
     );
 }
 
+#[test]
+fn malformed_key_file_rejected_not_panic() {
+    // hex_decode only checks the string is even-length, so a truncated /
+    // padded key file would previously sail through and panic later inside
+    // `Key::from_slice` (ChaCha20-Poly1305 requires exactly 32 bytes).
+    // Verify we now reject with a clean error.
+    let tmp = TempDir::new().unwrap();
+    let store = SecretStore::new(tmp.path(), true);
+
+    // Write a 30-byte hex key (60 chars, even, decodes cleanly, wrong length).
+    fs::create_dir_all(&tmp.path()).unwrap();
+    fs::write(&store.key_path, "aa".repeat(30)).unwrap();
+    super::clear_cached_key(&store.key_path);
+
+    let err = store.encrypt("anything").unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("wrong length"),
+        "expected wrong-length error, got: {msg}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn key_file_has_restricted_permissions() {

--- a/src/openhuman/security/secrets_tests.rs
+++ b/src/openhuman/security/secrets_tests.rs
@@ -549,6 +549,36 @@ fn generate_random_key_has_no_uuid_fixed_bits() {
     );
 }
 
+#[test]
+fn key_loaded_once_then_cached() {
+    // After the first read, subsequent decrypts must not depend on the key
+    // file being readable. This is the property that protects us from
+    // transient Windows sharing violations on `.secret_key` (Sentry
+    // OPENHUMAN-TAURI-58: "Failed to read secret key file" hammering
+    // app_state_snapshot).
+    let tmp = TempDir::new().unwrap();
+    let store = SecretStore::new(tmp.path(), true);
+
+    let encrypted = store.encrypt("cached-secret").unwrap();
+    assert!(store.key_path.exists());
+
+    // Make the file unreadable by deleting it — the in-memory cache should
+    // still satisfy the decrypt.
+    fs::remove_file(&store.key_path).unwrap();
+    let decrypted = store.decrypt(&encrypted).unwrap();
+    assert_eq!(decrypted, "cached-secret");
+
+    // After clearing the cache, the disappearance is visible again: the
+    // store falls back to the "create new key" branch and decryption with
+    // the original ciphertext fails.
+    super::clear_cached_key(&store.key_path);
+    let result = store.decrypt(&encrypted);
+    assert!(
+        result.is_err(),
+        "Without cache and without file, decrypt must fail"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn key_file_has_restricted_permissions() {


### PR DESCRIPTION
## Summary

- Cache decoded `.secret_key` bytes process-wide so every decrypt no longer hits disk.
- Retry transient Windows read errors (`ERROR_SHARING_VIOLATION`, `PermissionDenied`, `Interrupted`, `WouldBlock`) with short backoff.
- Add regression test that proves decrypt still succeeds after the key file is deleted post-cache.

## Problem

Sentry [OPENHUMAN-TAURI-58](https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-58) — 1467 occurrences of `rpc.invoke_method failed: Failed to read secret key file` on a single Windows 10 host. Every `openhuman.app_state_snapshot` poll calls `load_config_with_timeout` → `decrypt_optional_secret` → `SecretStore::load_or_create_key` → `fs::read_to_string(.secret_key)`. A transient read failure (AV scanner holding a sharing-violation lock on Windows is the canonical cause) turned into a permanent per-poll failure because the key was re-read on every decrypt.

## Solution

- `SecretStore::load_or_create_key` now checks a process-wide `OnceLock<Mutex<HashMap<PathBuf, Vec<u8>>>>` cache first. The cache is populated after the first successful read (or after key creation), keyed by absolute `key_path`. Subsequent decrypts hit memory only — no IO, no AV interaction.
- New `read_key_file_with_retry` rides over transient sharing/permission errors with up to 5 attempts and 10/20/40/80 ms backoff. The happy path still returns on attempt 1 with zero added latency.
- Added `key_loaded_once_then_cached` test in `secrets_tests.rs` that exercises the cache by deleting the key file after the first encrypt and asserting the next decrypt still works.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — no feature rows added/removed/renamed, so no coverage-matrix update needed.
- [x] N/A: no feature IDs touched by this fix (caching/retry inside an existing internal helper).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: no release-cut surfaces touched — `SecretStore` is an internal helper invisible to the user.
- [x] N/A: no Linear issue — root cause traced from Sentry OPENHUMAN-TAURI-58; `Closes` keyword only auto-closes GitHub issues.

## Impact

- **Platform**: Windows fix in particular (sharing-violation tolerance), but the cache benefits all platforms — every `app_state_snapshot` poll previously re-read `.secret_key` once per encrypted config field.
- **Performance**: removes repeated disk reads from a hot RPC path.
- **Security**: no change. Key bytes were already held in memory transiently for each decrypt; the cache just keeps them resident. Cache scope is process-wide, same as the existing decrypt scope.
- **Migration / compatibility**: none. Wire format unchanged.

## Related

- Closes: OPENHUMAN-TAURI-58 (Sentry issue, not GitHub — won't auto-close)
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A (Sentry-driven fix, no Linear ticket)
- URL: N/A

### Commit & Branch
- Branch: `fix/secrets-key-cache-windows`
- Commit SHA: `fe4093ab3b70eced71e5a4513fcea8334bf95c39`

### Validation Run
- [x] N/A: no frontend code changed.
- [x] N/A: no TypeScript code changed.
- [x] Focused tests: `cargo test --lib openhuman::security::secrets` — 41 passed (incl. new `key_loaded_once_then_cached`).
- [x] Rust fmt/check (if changed): `cargo fmt` + `cargo check --lib --manifest-path Cargo.toml` (clean for changed crate).
- [x] N/A: no Tauri shell code changed.

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: `SecretStore` reads `.secret_key` once per process per path, with bounded retry on transient read errors.
- User-visible effect: Windows users hitting `Failed to read secret key file` storms stop seeing them; `app_state_snapshot` no longer fails after a single transient AV lock.

### Parity Contract
- Legacy behavior preserved: same encrypt/decrypt semantics, same on-disk format, same plaintext / `enc:` / `enc2:` handling.
- Guard/fallback/dispatch parity checks: cache is purely additive; on first call the path is identical to before (read → decode → use).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized encryption key handling to reduce disk I/O operations, improving performance.
  * Mitigated potential file-locking issues on Windows systems during secret encryption and decryption operations.
  * Implemented intelligent caching for faster and more reliable secret access.

* **Tests**
  * Added comprehensive test coverage for encryption key caching behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1509)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->