### PR TITLE
fix(tauri): prevent CEF init panic on second launch via single-instance plugin

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-runtime-cef",
  "tempfile",
@@ -7258,6 +7259,20 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?rev=c6561ab6b4f9e7f650d4fc8c53fd8acc9b65b9b2#c6561ab6b4f9e7f650d4fc8c53fd8acc9b65b9b2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -46,6 +46,12 @@ tauri-plugin-deep-link = "2.0.0"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = { path = "vendor/tauri-plugin-notification" }
 tauri-plugin-opener = "2"
+# Prevents a second launch from racing into CEF init and hitting the
+# `cef::initialize(...) != 1` cache-lock panic seen in production
+# (Sentry OPENHUMAN-TAURI-A). The plugin acquires a per-identifier
+# lock before any tauri::Builder work happens, so the secondary
+# process exits cleanly after handing its argv to the primary.
+tauri-plugin-single-instance = "2"
 # Auto-update for the Tauri shell itself. The core sidecar already has its own
 # updater (see `core_update.rs`); this plugin handles the .app/.exe/.AppImage
 # bundle. Both are needed because shipping a new RPC method requires both
@@ -188,6 +194,7 @@ tauri-plugin = { path = "vendor/tauri-cef/crates/tauri-plugin" }
 tauri-plugin-opener = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "c6561ab6b4f9e7f650d4fc8c53fd8acc9b65b9b2" }
 tauri-plugin-deep-link = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "c6561ab6b4f9e7f650d4fc8c53fd8acc9b65b9b2" }
 tauri-plugin-global-shortcut = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "c6561ab6b4f9e7f650d4fc8c53fd8acc9b65b9b2" }
+tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", rev = "c6561ab6b4f9e7f650d4fc8c53fd8acc9b65b9b2" }
 tauri-plugin-notification = { path = "vendor/tauri-plugin-notification" }
 
 [dev-dependencies]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1374,8 +1374,13 @@ pub fn run() {
         // — we just need to wake the primary so it observes them.
         .plugin(tauri_plugin_single_instance::init(
             |app: &AppHandle<AppRuntime>, args, cwd| {
+                // Don't log raw argv/cwd: deep-link callbacks (OAuth codes,
+                // magic links) can carry auth tokens that would otherwise leak
+                // into desktop logs and Sentry breadcrumbs. CodeRabbit on #1510.
                 log::info!(
-                    "[single-instance] secondary launch detected, focusing primary (argv={args:?}, cwd={cwd})"
+                    "[single-instance] secondary launch detected, focusing primary (argc={}, cwd_present={})",
+                    args.len(),
+                    !cwd.is_empty()
                 );
                 if let Err(err) = show_main_window(app) {
                     log::warn!("[single-instance] failed to focus main window: {err}");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1362,6 +1362,26 @@ pub fn run() {
     };
 
     let builder = builder
+        // Single-instance guard — MUST be the first plugin registered so the
+        // secondary-process exit path triggers before any other plugin setup
+        // (and before `Builder::build()` reaches `CefRuntime::init`). Without
+        // this, launching a second instance races into CEF init while the
+        // primary still holds the cache lock; `cef::initialize` returns 0 and
+        // the vendored runtime asserts (Sentry OPENHUMAN-TAURI-A — 442 events
+        // across Win10/11 + Linux, all releases). The callback receives the
+        // secondary's argv/cwd; we forward deep-link args and focus the main
+        // window. Deep-link payloads stay handled by `tauri-plugin-deep-link`
+        // — we just need to wake the primary so it observes them.
+        .plugin(tauri_plugin_single_instance::init(
+            |app: &AppHandle<AppRuntime>, args, cwd| {
+                log::info!(
+                    "[single-instance] secondary launch detected, focusing primary (argv={args:?}, cwd={cwd})"
+                );
+                if let Err(err) = show_main_window(app) {
+                    log::warn!("[single-instance] failed to focus main window: {err}");
+                }
+            },
+        ))
         // Explicitly disable `open_js_links_on_click`: tauri-plugin-opener
         // defaults to injecting `init-iife.js` into *every* webview — a
         // global click listener that invokes `plugin:opener|open_url` via


### PR DESCRIPTION
## Summary

- Add `tauri-plugin-single-instance` as the first plugin in the Tauri shell so a second app launch focuses the primary window and exits before CEF init runs.
- Bump `vendor/tauri-cef` submodule to pick up tinyhumansai/tauri-cef#13, which replaces the opaque `assertion left == right` panic in `CefRuntime::init` with a logged panic carrying the CEF return code + `cache_path`.

## Problem

Sentry [`OPENHUMAN-TAURI-A`](https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-A) — 442 fatal panics across 8 days, Win10/11 + Linux (Kali, Debian, CachyOS), every recent release (0.53.13 → 0.53.22). 0 users impacted because the panic is pre-auth.

Root cause: `app/src-tauri/vendor/tauri-cef/.../lib.rs:2071` does `assert_eq!(cef::initialize(...), 1)`. The shell registered no `tauri-plugin-single-instance`, so launching a second instance (auto-start, double-click, deep-link reopen) raced into `CefRuntime::init` while the primary still held the CEF cache lock, `cef::initialize` returned 0, and the assert panicked. The cross-OS, cross-release, pre-auth pattern matches cache-lock contention, not a code regression in any single release.

## Solution

Two layers, both needed:

1. **Primary fix** — register `tauri_plugin_single_instance::init(...)` as the first plugin in `run()` (before `tauri_plugin_opener`, `deep_link`, etc.). The plugin acquires a per-identifier lock before any other plugin setup. A secondary launch hands argv/cwd to the primary via the callback (which logs and focuses the main window via the existing `show_main_window` helper) and exits before `Builder::build()` reaches CEF init.
2. **Defense in depth** — submodule bump replaces the assert with a panic that includes the actual return code and `cache_path`, so any remaining CEF init failure (corrupt cache, missing helpers, sandbox denied) lands in Sentry with actionable context instead of `assertion left == right`.

Plugin is pinned to the same `plugins-workspace` rev (`c6561ab6…`) as the other Tauri plugins via the existing `[patch.crates-io]` block. Submodule PR: tinyhumansai/tauri-cef#13.

## Submission Checklist

- [x] N/A: behavior under contention is environment-dependent (race between two processes for a CEF cache lock); not feasible to assert in a Vitest/cargo-test harness. Smoke-tested via `cargo check --manifest-path app/src-tauri/Cargo.toml`.
- [x] N/A: change is in Rust shell startup code; coverage gate applies to Vitest + cargo-llvm-cov, neither of which exercise `Builder::build()` / `CefRuntime::init` paths.
- [x] N/A: behaviour-only change; no feature row added/removed in the coverage matrix.
- [x] N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] N/A: not a release-cut surface; affects pre-auth startup robustness only.
- [x] Linked issue: `Fixes OPENHUMAN-TAURI-A` (Sentry) — auto-resolves the Sentry issue on merge.

## Impact

- **Platforms**: desktop (Windows, macOS, Linux). No mobile/web/CLI impact.
- **Runtime**: a second invocation of the binary now exits cleanly after handing its argv to the primary, instead of crashing. The primary window comes to focus.
- **Compat**: `tauri-plugin-single-instance` uses a named mutex on Windows, a Unix domain socket on macOS, and dbus on Linux — all per `tauri.conf.json` `identifier` (`com.openhuman.app`). No collisions with existing infrastructure.
- **Security**: no new attack surface; the plugin's IPC channel is per-user and identifier-scoped.

## Related

- Closes: OPENHUMAN-TAURI-A (Sentry)
- Follow-up PR(s)/TODOs: tinyhumansai/tauri-cef#13 (submodule pointer bump depends on this landing)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A (Sentry-only)

### Commit & Branch
- Branch: `fix/cef-init-single-instance`
- Commit SHA: `0e33e619`

### Validation Run
- [x] N/A: no frontend changes (Rust/Tauri-only PR).
- [x] N/A: no frontend changes.
- [x] N/A: behavior under multi-process contention not unit-testable.
- [x] `cargo check --manifest-path app/src-tauri/Cargo.toml` — clean (pre-existing warnings only).
- [x] `cargo fmt` on the two touched Rust files.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: second app launch focuses the existing primary instead of crashing.
- User-visible effect: users who double-click the app or have auto-start enabled no longer see a fatal crash; the existing window comes forward.

### Parity Contract
- Legacy behavior preserved: primary-instance startup unchanged; only the secondary path is new (and the secondary path was previously "panic", so any well-defined behavior is strictly an improvement).
- Guard/fallback/dispatch parity checks: deep-link plugin still handles deep-link payloads; the single-instance callback only logs + focuses, leaving payload processing to `tauri-plugin-deep-link`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now enforces single-instance behavior: launching a second instance will focus the existing window instead of creating a duplicate.

* **Chores**
  * Pinned and aligned native plugin revisions and updated vendored components to improve startup robustness and prevent race conditions during initialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1510)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->