### PR TITLE
fix(observability): render full anyhow chain so Sentry events are diagnosable

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -35,7 +35,14 @@ pub fn report_error<E: Display + ?Sized>(
     operation: &str,
     extra: &[Tag<'_>],
 ) {
-    let message = err.to_string();
+    // Use the alternate format specifier so `anyhow::Error` renders its full
+    // context chain (outer context + every wrapped cause, joined by ": ").
+    // Plain `Display` impls fall back to the standard representation. Without
+    // this, anyhow's default `to_string()` only emits the outermost context
+    // and the underlying cause (e.g. a `toml::de::Error` with line/column) is
+    // dropped — making the captured Sentry event undiagnosable. See
+    // OPENHUMAN-TAURI-B2 for an instance where this masked the real failure.
+    let message = format!("{err:#}");
     sentry::with_scope(
         |scope| {
             scope.set_tag("domain", domain);
@@ -70,6 +77,16 @@ mod tests {
         report_error(&io_err, "test", "io_shape", &[("kind", "io")]);
 
         report_error("plain message", "test", "str_shape", &[]);
+    }
+
+    #[test]
+    fn anyhow_chain_is_rendered_in_full() {
+        // Regression guard: `err.to_string()` on an anyhow chain only emits
+        // the outermost context. Using `{:#}` joins every cause, which is
+        // what Sentry needs to actually diagnose wrapped failures.
+        let inner = std::io::Error::other("inner cause");
+        let wrapped = anyhow::Error::from(inner).context("outer ctx");
+        assert_eq!(format!("{wrapped:#}"), "outer ctx: inner cause");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`core::observability::report_error` renders the error via `err.to_string()`. For `anyhow::Error`, that emits **only the outermost context** — every wrapped cause is dropped before the event reaches Sentry. This switches to `format!(\"{err:#}\")`, which on anyhow joins the full chain with \`\": \"\` and is a no-op for plain `Display` impls (`&str`, `io::Error`, …).

## Problem

[OPENHUMAN-TAURI-B2](https://tinyhumansai.sentry.io/issues/OPENHUMAN-TAURI-B2) has fired ~500 times in production on v0.53.22 with the identical message:

> Failed to parse config file /Users/…/.openhuman/users/&lt;id&gt;/config.toml

That string is the outer `.with_context(...)` wrapped around a `toml::de::Error` in `Config::load_or_init` (`src/openhuman/config/schema/load.rs`). The actual TOML error (line/column + what was wrong) never makes it into Sentry, so every event looks the same and the root cause is undiagnosable.

PR #1497 already added a corruption-recovery fallback (back up to `.toml.bak`, reset to defaults) — but that only ships in v0.53.23+ staging. In the meantime any future \"X failed\" event funneled through `report_error` is going to be just as opaque as this one if it wraps a cause.

## Solution

One-line change in `report_error`: render `format!(\"{err:#}\")` instead of `err.to_string()`. Adds a regression test that asserts the chain is joined.

## Impact

- Future Sentry events emitted through `report_error` carry the full anyhow context chain.
- No behavior change for non-anyhow errors.
- Lets us actually diagnose the next batch of OPENHUMAN-TAURI-B2 events once a build with this fix reaches users.

## Test plan

- [x] `cargo test --lib core::observability::` — all pass (including new `anyhow_chain_is_rendered_in_full`).
- [ ] After release: confirm a fresh OPENHUMAN-TAURI-B2 event now includes the underlying `toml::de::Error` message.

Resolves OPENHUMAN-TAURI-B2 (the next release will both surface the cause and benefit from #1497's recovery once that ships).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error reporting now displays the complete error context chain, including all nested causes, for improved diagnostics and faster troubleshooting.

* **Tests**
  * Added unit test verifying that error context chains are properly rendered with all outer and inner error causes included.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1511)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->