### PR TITLE
fix(conversations): catch loadThreads rejection on mount to silence Sentry noise

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -288,6 +288,11 @@ const Conversations = ({ variant = 'page', composer = 'text' }: ConversationsPro
         } else {
           void handleCreateNewThread();
         }
+      })
+      .catch(err => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err?.message ?? err);
+        console.warn('[conversations] loadThreads failed on mount:', message);
       });
 
     return () => {


### PR DESCRIPTION
## Summary

- Adds a `.catch()` to the mount-time `dispatch(loadThreads()).unwrap().then(...)` chain in `Conversations.tsx` so a failed initial thread fetch no longer surfaces as an unhandled promise rejection.

## Problem

Sentry issue [OPENHUMAN-REACT-X](https://tinyhumans.sentry.io/issues/7475107389/) (`UnhandledRejection: Non-Error promise rejection captured with value: Core RPC openhuman.threads_list timed out after 30000ms`).

When the core RPC `openhuman.threads_list` timed out on app mount, the chain at `app/src/pages/Conversations.tsx:257` had no `.catch()`. `createAsyncThunk`'s `.unwrap()` re-throws Redux's `SerializedError` (a plain object, not an `Error` instance), so the rejection became unhandled and Sentry tagged it as a \"Non-Error promise rejection.\"

## Solution

- Attach a `.catch()` after the existing `.then()` that bails when the effect has been cancelled and otherwise logs the message via `console.warn`.
- No behavioral change: the slice's `loadThreads.rejected` case already drives UI state — this just suppresses the unhandled rejection at the promise boundary.

## Submission Checklist

- [x] N/A: pure rejection-handling fix on a one-shot mount effect with no new branches; the timeout path is already covered by the slice's `rejected` reducer
- [x] N/A: behavioural change is rejection-handling only; no new code paths exercised
- [x] N/A: behaviour-only change, no feature rows affected
- [x] N/A: no feature matrix rows touched
- [x] N/A: no new network calls introduced
- [x] N/A: no release-cut surfaces touched
- [x] N/A: no linked issue (Sentry-driven fix); Sentry issue id is OPENHUMAN-REACT-X

## Impact

- Desktop UI: a `threads_list` RPC timeout on app mount no longer produces an unhandled rejection or a Sentry event for the user; the failure is logged to the console and the UI continues with whatever empty/cached state the slice reducer left behind.
- No performance, security, or migration impact.

## Related

- Closes: Sentry OPENHUMAN-REACT-X
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/conversations-unhandled-threads-list-rejection
- Commit SHA: aa04aeb214e09d2d9fbdc0cb6bf6b401599f53dc

### Validation Run
- [x] N/A: format unchanged (single `.catch()` block added, Prettier-conformant)
- [x] `pnpm typecheck` (run as `npx tsc --noEmit` — clean)
- [x] N/A: no Vitest covers this mount-time IIFE branch today; behaviour-equivalent change
- [x] N/A: no Rust changes
- [x] N/A: no Tauri changes

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: a rejected `loadThreads` on mount is caught and logged instead of surfacing as an unhandled promise rejection.
- User-visible effect: no Sentry event / no browser-console \"Uncaught (in promise)\" when the initial `openhuman.threads_list` RPC fails or times out.

### Parity Contract
- Legacy behavior preserved: success path of the `.then()` chain is untouched; the rejected-action UI state from the slice still flows through reducers.
- Guard/fallback/dispatch parity checks: the new `.catch()` short-circuits when the effect's `cancelled` flag is set, matching the existing pattern in the `.then()` callback.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when loading conversations with improved logging for better visibility into issues.
  * Improved lifecycle management for the conversations view to prevent issues during navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1513)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
