### PR TITLE
fix(credentials): quarantine corrupt auth profile store

### DIFF
--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -373,13 +373,19 @@ impl AuthProfilesStore {
             return Ok(PersistedAuthProfiles::default());
         }
 
-        let mut persisted: PersistedAuthProfiles =
-            serde_json::from_slice(&bytes).with_context(|| {
-                format!(
-                    "Failed to parse auth profile store at {}",
-                    self.path.display()
-                )
-            })?;
+        let mut persisted: PersistedAuthProfiles = match serde_json::from_slice(&bytes) {
+            Ok(p) => p,
+            Err(err) => {
+                let quarantined = quarantine_corrupt_store(&self.path)?;
+                tracing::warn!(
+                    path = %self.path.display(),
+                    quarantined = %quarantined.display(),
+                    error = %err,
+                    "[credentials] auth profile store unparseable; quarantined and reset to empty"
+                );
+                return Ok(PersistedAuthProfiles::default());
+            }
+        };
 
         if persisted.schema_version == 0 {
             persisted.schema_version = CURRENT_SCHEMA_VERSION;
@@ -596,6 +602,33 @@ fn parse_datetime_with_fallback(value: &str) -> DateTime<Utc> {
 
 pub fn profile_id(provider: &str, profile_name: &str) -> String {
     format!("{}:{}", provider.trim(), profile_name.trim())
+}
+
+fn quarantine_corrupt_store(path: &Path) -> Result<PathBuf> {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("auth-profiles");
+    let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("json");
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let mut candidate = parent.join(format!("{stem}.corrupt-{ts}.{ext}"));
+    let mut suffix = 0u32;
+    while candidate.exists() {
+        suffix += 1;
+        candidate = parent.join(format!("{stem}.corrupt-{ts}-{suffix}.{ext}"));
+    }
+    fs::rename(path, &candidate).with_context(|| {
+        format!(
+            "Failed to quarantine corrupt auth profile store {} -> {}",
+            path.display(),
+            candidate.display()
+        )
+    })?;
+    Ok(candidate)
 }
 
 #[cfg(test)]

--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -377,9 +377,13 @@ impl AuthProfilesStore {
             Ok(p) => p,
             Err(err) => {
                 let quarantined = quarantine_corrupt_store(&self.path)?;
+                let quarantined_file = quarantined
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("auth-profiles.corrupt");
                 tracing::warn!(
-                    path = %self.path.display(),
-                    quarantined = %quarantined.display(),
+                    path_file = PROFILES_FILENAME,
+                    quarantined_file = quarantined_file,
                     error = %err,
                     "[credentials] auth profile store unparseable; quarantined and reset to empty"
                 );

--- a/src/openhuman/credentials/profiles_tests.rs
+++ b/src/openhuman/credentials/profiles_tests.rs
@@ -128,6 +128,33 @@ fn auth_profiles_data_default() {
 }
 
 #[test]
+fn corrupt_store_is_quarantined_and_reset() {
+    let tmp = TempDir::new().unwrap();
+    let store = AuthProfilesStore::new(tmp.path(), false);
+    let path = store.path().to_path_buf();
+
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, b"{ not valid json").unwrap();
+
+    let data = store.load().unwrap();
+    assert!(data.profiles.is_empty());
+    assert_eq!(data.schema_version, CURRENT_SCHEMA_VERSION);
+
+    let parent = path.parent().unwrap();
+    let quarantined: Vec<_> = std::fs::read_dir(parent)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().contains(".corrupt-"))
+        .collect();
+    assert_eq!(quarantined.len(), 1, "expected one quarantined file");
+
+    let profile = AuthProfile::new_token("openai", "default", "tok".into());
+    store.upsert_profile(profile, true).unwrap();
+    let reloaded = store.load().unwrap();
+    assert_eq!(reloaded.profiles.len(), 1);
+}
+
+#[test]
 fn remove_nonexistent_profile_returns_false() {
     let tmp = TempDir::new().unwrap();
     let store = AuthProfilesStore::new(tmp.path(), false);


### PR DESCRIPTION
## Summary

- Self-heal when `~/.openhuman/users/<id>/auth-profiles.json` is unparseable: rename the bad file aside to `auth-profiles.corrupt-<unix_ms>.json` and continue with defaults.
- Logs a single `tracing::warn!` with the underlying serde error and the quarantine path instead of bubbling `Failed to parse auth profile store …` up through every RPC.
- Stops Sentry flooding from `app_state_snapshot` re-tries (issue OPENHUMAN-TAURI-B6 saw 658 occurrences from a single user, escalating).

## Problem

`AuthProfilesStore::read_persisted_locked` returns an `Err` whenever `serde_json::from_slice` fails on the profile store. `openhuman.app_state_snapshot` polls credentials on a tight cadence, so a corrupt or truncated JSON file causes:

1. The error to be re-raised by every poll → Sentry spam (OPENHUMAN-TAURI-B6, 658 occurrences, one user, escalating).
2. The user to be stuck — even `upsert_profile` calls `load_locked` first, so they cannot re-authenticate without manually deleting the file.

The profile store is recoverable state (the user can re-auth providers); it is not the master record. Failing closed on a parse error trades a known recoverable corruption for an unrecoverable user-facing wedge.

## Solution

In `read_persisted_locked` (`src/openhuman/credentials/profiles.rs`), on serde parse failure:

1. Call a new `quarantine_corrupt_store` helper that `fs::rename`s the bad file to `<stem>.corrupt-<unix_ms>.<ext>` in the same directory (collision-safe via a numeric suffix).
2. Emit one `tracing::warn!` carrying `path`, `quarantined`, and the underlying serde error so the failure is still diagnosable from logs.
3. Return `PersistedAuthProfiles::default()` so the next `upsert_profile` writes a fresh, valid file.

Tradeoffs: we throw away the in-place bytes on parse failure rather than attempting partial recovery — the bytes are preserved on disk in the quarantine file for forensics, but profiles still need to be re-added by the user. That is the correct behavior given the store contains live OAuth/token state we cannot trust if the encoding is malformed.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — new `quarantine_corrupt_store` path and the parse-failure branch are exercised by `corrupt_store_is_quarantined_and_reset`.
- [x] N/A: behaviour-only change — no new/removed/renamed user-facing features.
- [x] N/A: no feature IDs apply to this change.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut surfaces.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: desktop only — fixes a corruption-recovery bug in the Rust core. No protocol/RPC surface changes.
- **Compatibility**: existing valid `auth-profiles.json` files behave identically. Only the unparseable case changes (previously: error every call; now: rename aside + warn + reset).
- **Security**: the quarantined file inherits the original file's permissions via `fs::rename` (no copy). No new disclosure surface.

## Related

- Closes: OPENHUMAN-TAURI-B6 (Sentry issue id 7475057470)
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A (Sentry-tracked, not Linear)
- URL: https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-B6

### Commit & Branch
- Branch: fix/auth-profiles-corrupt-quarantine
- Commit SHA: 2a56f876ead50c947984913cb07f7df30d99872a

### Validation Run
- [x] N/A: only Rust files changed
- [x] N/A: only Rust files changed
- [x] Focused tests: `cargo test --lib openhuman::credentials::profiles` — 18 passed (incl. new `corrupt_store_is_quarantined_and_reset`)
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml` clean; rustfmt applied via pre-push hook.
- [x] N/A: Tauri shell untouched.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: parse failure on `auth-profiles.json` no longer propagates; file is quarantined and store resets to empty.
- User-visible effect: previously-wedged users recover automatically on next launch; they must re-authenticate providers (their tokens were already unreadable).

### Parity Contract
- Legacy behavior preserved: valid stores load identically; `load` still returns `Result` and still errors on schema-version mismatches and decryption failures.
- Guard/fallback/dispatch parity checks: `load_locked` callers (`upsert_profile`, `remove_profile`, `set_active_profile`, `clear_active_profile`, `update_profile`) all continue to work after recovery via the empty default.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for corrupted credential profile files. When a profile configuration file becomes corrupted, it is now automatically quarantined with a timestamp suffix and the system gracefully continues with a fresh empty store instead of raising an error.

* **Tests**
  * Added test coverage for corrupted profile file quarantine and recovery behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1514)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
