### PR TITLE
Redact auth profile lock paths from errors

### DIFF
--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -452,9 +452,8 @@ impl AuthProfilesStore {
 
     fn acquire_lock(&self) -> Result<AuthProfileLockGuard> {
         if let Some(parent) = self.lock_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("Failed to create lock directory at {}", parent.display())
-            })?;
+            fs::create_dir_all(parent)
+                .with_context(|| "Failed to create auth profile lock directory".to_string())?;
         }
 
         let mut waited = 0_u64;
@@ -472,21 +471,14 @@ impl AuthProfilesStore {
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                     if waited >= LOCK_TIMEOUT_MS {
-                        anyhow::bail!(
-                            "Timed out waiting for auth profile lock at {}",
-                            self.lock_path.display()
-                        );
+                        anyhow::bail!("Timed out waiting for auth profile lock");
                     }
                     thread::sleep(Duration::from_millis(LOCK_WAIT_MS));
                     waited = waited.saturating_add(LOCK_WAIT_MS);
                 }
                 Err(e) => {
-                    return Err(e).with_context(|| {
-                        format!(
-                            "Failed to create auth profile lock at {}",
-                            self.lock_path.display()
-                        )
-                    });
+                    return Err(e)
+                        .with_context(|| "Failed to create auth profile lock".to_string());
                 }
             }
         }

--- a/src/openhuman/credentials/profiles_tests.rs
+++ b/src/openhuman/credentials/profiles_tests.rs
@@ -187,6 +187,20 @@ fn clear_active_profile() {
 }
 
 #[test]
+fn auth_profile_lock_errors_do_not_include_local_paths() {
+    let tmp = TempDir::new().unwrap();
+    let invalid_state_dir = tmp.path().join("not-a-directory");
+    std::fs::write(&invalid_state_dir, "occupied").unwrap();
+
+    let store = AuthProfilesStore::new(&invalid_state_dir, false);
+    let err = store.load().unwrap_err().to_string();
+
+    assert!(err.contains("Failed to create auth profile lock directory"));
+    assert!(!err.contains(&tmp.path().display().to_string()));
+    assert!(!err.contains(&invalid_state_dir.display().to_string()));
+}
+
+#[test]
 fn update_profile_modifies_in_place() {
     let tmp = TempDir::new().unwrap();
     let store = AuthProfilesStore::new(tmp.path(), false);


### PR DESCRIPTION
## Summary

- Remove absolute auth-profile lock paths from lock acquisition error strings in the Rust core.
- Keep the lock failures actionable with stable messages that do not embed per-user filesystem locations.
- Add a regression test that forces lock setup failure and asserts local paths are not present in the surfaced error.

## Problem

- Sentry was receiving auth-profile lock failures with the user's local home-directory path embedded in the error message.
- That leaks machine-specific filesystem information and also harms issue grouping because the path varies by user.

## Solution

- Replace the auth-profile lock error contexts with path-free, stable messages at the source in `AuthProfilesStore::acquire_lock`.
- Cover the failure path with a focused test that verifies the returned error string does not contain the temp directory or invalid state path.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. N/A: small Rust-only change; added focused regression test, full coverage gate will run in CI.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) N/A: behaviour-only change
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` N/A: no feature IDs affected by this credentials error-message fix
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) N/A: not a release-cut surface
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section N/A: no linked issue was provided for this request

## Impact

- Runtime impact is limited to the Rust core / desktop sidecar error text for auth-profile lock failures.
- Improves privacy in observability and should improve Sentry grouping for these lock-related failures.
- No behavior change to lock acquisition itself.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/redact-auth-profile-lock-paths`
- Commit SHA: `b47a5b39521b6073138d8a2bdef3c117e5d4ef81`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (ran via pre-push hook)
- [x] `pnpm typecheck` N/A: repo hook runs `pnpm --filter openhuman-app compile` for this path instead, which passed
- [x] Focused tests: `cargo test --manifest-path Cargo.toml auth_profile_lock_errors_do_not_include_local_paths -- --nocapture`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --all --check`
- [x] Tauri fmt/check (if changed): `pnpm --filter openhuman-app rust:check` (ran via pre-push hook)

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: auth-profile lock failures no longer surface absolute local filesystem paths in error messages
- User-visible effect: Sentry and any surfaced lock errors become path-free and more consistently grouped

### Parity Contract
- Legacy behavior preserved: lock creation, timeout, and failure handling semantics are unchanged; only message text was normalized
- Guard/fallback/dispatch parity checks: added a focused regression test for the lock-directory failure path

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during authentication profile lock handling to prevent exposure of internal filesystem paths.

* **Tests**
  * Added unit test to verify that authentication profile error messages do not leak local filesystem paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1515)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->