### PR TITLE
fix(chat): release composer lock on socket disconnect (Windows lockout)

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -370,25 +370,26 @@ const Conversations = ({ variant = 'page', composer = 'text' }: ConversationsPro
     if (sendingTimeoutRef.current) clearTimeout(sendingTimeoutRef.current);
     sendingThreadIdRef.current = threadId;
     sendingTimeoutRef.current = setTimeout(() => {
-      console.warn('[chat] silence timeout: no inference signal for 600s');
+      console.warn('[chat] silence timeout: no inference signal for 120s');
       setSendError(
         chatSendError(
           'safety_timeout',
-          'No response from the agent after 10 minutes. Try again or check your connection.'
+          'No response from the agent after 2 minutes. Try again or check your connection.'
         )
       );
       dispatch(clearRuntimeForThread({ threadId }));
       dispatch(setActiveThread(null));
       sendingTimeoutRef.current = null;
       sendingThreadIdRef.current = null;
-    }, 600_000);
+    }, 120_000);
   };
 
-  // Rearm the silence timer on every inference status change for the
-  // sending thread (tool_call, tool_result, iteration_start, subagent_*
-  // all update inferenceStatusByThread). When the status is cleared
-  // (chat_done / chat_error), drop the timer — the completion handlers
-  // take over UI cleanup.
+  // Rearm the silence timer on every inference signal for the sending
+  // thread. Tool / iteration / subagent events bump `inferenceStatusByThread`;
+  // pure-text streams (no tools) only bump `streamingAssistantByThread`, so
+  // both must be watched — otherwise a long text stream would trip the
+  // safety timer mid-reply. When the status is cleared (chat_done /
+  // chat_error), drop the timer — the completion handlers own UI cleanup.
   useEffect(() => {
     const threadId = sendingThreadIdRef.current;
     if (!threadId || !sendingTimeoutRef.current) return;
@@ -401,9 +402,9 @@ const Conversations = ({ variant = 'page', composer = 'text' }: ConversationsPro
     }
     armSilenceTimer(threadId);
     // armSilenceTimer is stable (refs + dispatch); depending on the
-    // selector reference is enough to rearm on every progress event.
+    // selector references is enough to rearm on every progress event.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inferenceStatusByThread]);
+  }, [inferenceStatusByThread, streamingAssistantByThread]);
 
   useEffect(() => {
     if (

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -870,6 +870,41 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
     };
   }, [dispatch, resolveVisibleThreadForProactive, socketStatus, refetchSnapshot]);
 
+  // Socket-disconnect reconciliation.
+  //
+  // `activeThreadId` and the per-thread inference lifecycle are only ever
+  // cleared by `chat_done` / `chat_error` events. If the socket drops
+  // mid-turn (Windows sleep/wake, network change, VPN flap) those events
+  // fire on the dead session and never reach us, so the composer stays
+  // disabled until the 2-minute silence timer expires — users perceive
+  // this as being "locked out" of typing.
+  //
+  // When the socket leaves the `connected` state, treat any in-flight
+  // turn on the previous session as unrecoverable: clear the live
+  // inference status, end the lifecycle row, and release `activeThreadId`
+  // so the composer is immediately typeable again. Streaming assistant
+  // text is preserved so the partial reply stays visible.
+  useEffect(() => {
+    if (socketStatus === 'connected') return;
+    const state = store.getState();
+    const lifecycles = state.chatRuntime.inferenceTurnLifecycleByThread;
+    const threadIds = Object.keys(lifecycles);
+    const activeThreadId = state.thread.activeThreadId;
+    if (threadIds.length === 0 && !activeThreadId) return;
+    rtLog('socket_disconnect_reconcile', {
+      socket: socketStatus,
+      inFlight: threadIds.length,
+      active: activeThreadId,
+    });
+    for (const threadId of threadIds) {
+      dispatch(clearInferenceStatusForThread({ threadId }));
+      dispatch(endInferenceTurn({ threadId }));
+    }
+    if (activeThreadId) {
+      dispatch(setActiveThread(null));
+    }
+  }, [socketStatus, dispatch]);
+
   return <>{children}</>;
 };
 

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -741,4 +741,76 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       expect(timeline).toHaveLength(0);
     });
   });
+
+  // Regression: on Windows users report being "locked out" of the composer
+  // after sleep/wake or a network flap — the in-flight turn's `chat_done`
+  // never arrives on the new socket, so `activeThreadId` and the
+  // `started`/`streaming` lifecycle stay set and the textarea remains
+  // disabled. The reconcile effect releases them on disconnect so the
+  // composer becomes typeable again immediately.
+  describe('socket-disconnect reconciliation (#WindowsLockout)', () => {
+    it('clears activeThreadId and in-flight lifecycle when the socket drops mid-turn', async () => {
+      const threadId = 't-disconnect';
+      renderProvider();
+
+      await act(async () => {
+        const { setActiveThread } = await import('../../store/threadSlice');
+        const { beginInferenceTurn, setInferenceStatusForThread } =
+          await import('../../store/chatRuntimeSlice');
+        store.dispatch(setActiveThread(threadId));
+        store.dispatch(beginInferenceTurn({ threadId }));
+        store.dispatch(
+          setInferenceStatusForThread({
+            threadId,
+            status: { phase: 'thinking', iteration: 1, maxIterations: 10 },
+          })
+        );
+      });
+
+      expect(store.getState().thread.activeThreadId).toBe(threadId);
+      expect(store.getState().chatRuntime.inferenceTurnLifecycleByThread[threadId]).toBe('started');
+
+      await act(async () => {
+        store.dispatch(setStatusForUser({ userId: '__pending__', status: 'disconnected' }));
+      });
+
+      await waitFor(() => {
+        expect(store.getState().thread.activeThreadId).toBeNull();
+        expect(
+          store.getState().chatRuntime.inferenceTurnLifecycleByThread[threadId]
+        ).toBeUndefined();
+        expect(store.getState().chatRuntime.inferenceStatusByThread[threadId]).toBeUndefined();
+      });
+    });
+
+    it('preserves streamingAssistant text so the partial reply stays visible after disconnect', async () => {
+      const threadId = 't-disconnect-streaming';
+      renderProvider();
+
+      await act(async () => {
+        const { setActiveThread } = await import('../../store/threadSlice');
+        const { beginInferenceTurn, setStreamingAssistantForThread } =
+          await import('../../store/chatRuntimeSlice');
+        store.dispatch(setActiveThread(threadId));
+        store.dispatch(beginInferenceTurn({ threadId }));
+        store.dispatch(
+          setStreamingAssistantForThread({
+            threadId,
+            streaming: { requestId: 'req-1', content: 'Hello there, partial', thinking: '' },
+          })
+        );
+      });
+
+      await act(async () => {
+        store.dispatch(setStatusForUser({ userId: '__pending__', status: 'disconnected' }));
+      });
+
+      await waitFor(() => {
+        expect(store.getState().thread.activeThreadId).toBeNull();
+      });
+      expect(store.getState().chatRuntime.streamingAssistantByThread[threadId]).toMatchObject({
+        content: 'Hello there, partial',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Composer no longer stays disabled after a mid-turn socket drop (Windows sleep/wake, network change, VPN flap) — `activeThreadId` and in-flight inference lifecycle now reconcile when the socket leaves the `connected` state.
- Silence-timeout safety net shortened 10min → 2min, and now also rearms on streamed-text deltas (previously only `inferenceStatusByThread`, so pure text streams couldn't rearm — that's why the cap had to be 10min).
- Partial assistant text from the dead session is preserved so the user still sees what was streamed.
- Adds two regression tests for the disconnect path in `ChatRuntimeProvider`.

## Problem

Users on Windows report being "locked out" of the chat input — they cannot type after sending a message. Root cause: the composer is gated on `activeThreadId` (set on send in `Conversations.tsx:575`), which is **only** cleared by socket `chat_done` / `chat_error` events (`ChatRuntimeProvider.tsx:292, 863`). If the socket drops mid-turn — common on Windows due to sleep/wake or network changes — the completion event fires on the dead session and never reaches the client. The only safety net was a 10-minute silence timer; users perceive that as a lockout.

## Solution

- **`ChatRuntimeProvider`** — new effect: when `socketStatus` leaves `connected`, clear `activeThreadId`, end any in-flight inference turn lifecycle, and clear stale inference status. Streaming-assistant state is intentionally preserved (the partial reply remains visible). Even if the original socket later delivers a `chat_done` after reconnect, the dispatches are idempotent.
- **`Conversations`** — silence timer: 600s → 120s; effect now also depends on `streamingAssistantByThread` so token-by-token text streams rearm the timer instead of tripping it.
- **Tests** — two new cases in `ChatRuntimeProvider.test.tsx` covering (a) lifecycle + `activeThreadId` clearing on disconnect, and (b) streaming-text preservation across disconnect.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — no feature rows added/removed/renamed in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)
- [x] N/A: no matrix feature IDs touched (see above)
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: chat-composer reliability fix, not a release-cut surface in [`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)
- [x] N/A: no linked issue — reported via user feedback, not GitHub

## Impact

- **Platform**: desktop (all OSes, but Windows users will notice the biggest UX win).
- **Performance**: negligible — one extra `useEffect` keyed on `socketStatus`, no extra renders during the steady-state.
- **Security/migration**: none.
- **Compat**: `chat_done`/`chat_error` handlers remain authoritative for the normal-path teardown; the disconnect effect only fires when the socket is actually down.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/windows-composer-lockout-on-socket-disconnect`
- Commit SHA: `60491253ce126232c27d73026fcf21985d87b471`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit ChatRuntimeProvider` (21/21), `pnpm debug unit Conversations` (48/48)
- [x] N/A: no Rust changes
- [x] N/A: no Tauri changes

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: composer becomes typeable again immediately on socket disconnect, instead of waiting up to 10 minutes for the silence timer.
- User-visible effect: no more "I can't type after my laptop wakes up" lockout. Partial streamed reply stays visible.

### Parity Contract
- Legacy behavior preserved: `chat_done`/`chat_error` still drive normal-path lifecycle teardown; safety timer still exists, just tighter and rearmed by more signals.
- Guard/fallback/dispatch parity checks: idempotent — `endInferenceTurn` and `setActiveThread(null)` are safe to re-dispatch if the original socket's completion event ever arrives later.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A