### PR TITLE
fix(embeddings): silence Ollama-not-running Sentry noise (OPENHUMAN-TAURI-B7)

### DIFF
--- a/src/openhuman/embeddings/ollama.rs
+++ b/src/openhuman/embeddings/ollama.rs
@@ -170,11 +170,20 @@ impl EmbeddingProvider for OllamaEmbedding {
                     "ollama embed request failed (is Ollama running at {}?): {e}",
                     self.base_url
                 );
-                crate::core::observability::report_error(
-                    message.as_str(),
-                    "embeddings",
-                    "ollama_embed",
-                    &[("model", self.model.as_str()), ("failure", "transport")],
+                // Transport failure (connection refused, DNS, timeout) almost
+                // always means the user simply doesn't have Ollama running
+                // locally — an expected environment state, not a bug. Log a
+                // warning but skip Sentry to avoid alerting on every user
+                // without Ollama installed. Non-2xx responses below still
+                // funnel through `report_error` because those indicate Ollama
+                // is up but something is wrong.
+                tracing::warn!(
+                    target: "embeddings.ollama",
+                    domain = "embeddings",
+                    operation = "ollama_embed",
+                    failure = "transport",
+                    model = %self.model,
+                    "[embeddings] {message}"
                 );
                 anyhow::anyhow!(message)
             })?;


### PR DESCRIPTION
## Summary

- Transport-layer failures from the Ollama embedding provider (`localhost:11434` connection refused / DNS / timeout) no longer report to Sentry — they were generating 226 events/day across **0 impacted users**, all from a perfectly normal state: the user simply hasn't installed Ollama.
- Non-2xx HTTP responses (Ollama is up but errored) still funnel through `report_error` — those remain actionable.
- Callers still receive the same `anyhow::Error` with the `"is Ollama running at <url>?"` message; only the Sentry side effect is removed and the log severity is reduced from `error` to `warn`.

## Problem

Sentry issue `OPENHUMAN-TAURI-B7` ([link](https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-B7)) was firing on every embed call for any user who didn't have Ollama running locally — 226 occurrences in a single day, 0 users affected by an actual product defect. Every embed retry generated another event, drowning out genuine alerts. Local-provider \"server isn't installed\" is an expected user environment state, not a bug.

## Solution

In `src/openhuman/embeddings/ollama.rs` the `.send()` failure branch previously called `crate::core::observability::report_error(...)`, which is a thin wrapper around `tracing::error!` + `sentry::with_scope`. Switched that branch to a direct `tracing::warn!` with the same structured fields (`domain`, `operation`, `failure=transport`, `model`). The `sentry-tracing` integration captures `error`-level events; `warn` is logged locally but not forwarded. The non-2xx branch is unchanged.

Test `embed_connection_refused` already covers this path — the assertion on the returned error message still passes because we only removed the Sentry side effect, not the `anyhow!` return.

## Submission Checklist

- [x] Tests added or updated — existing `embed_connection_refused` covers the transport-failure path; assertion on the user-visible error message is unchanged.
- [x] **Diff coverage ≥ 80%** — 14 changed lines in `ollama.rs`; transport-failure branch covered by `embed_connection_refused`, non-2xx branch still covered by `embed_server_error_with_body` / `embed_server_error_empty_body`.
- [x] Coverage matrix updated — N/A: behaviour-only change to observability path, no feature added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix entries touched.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` — N/A: tracked in Sentry (`Fixes OPENHUMAN-TAURI-B7`), not GitHub Issues.

## Impact

- Desktop only (Ollama embeddings provider is only invoked from the core sidecar).
- Performance: nil — the error path is rare and now does strictly less work.
- Security/migration/compat: none.
- Operational: Sentry signal-to-noise on `openhuman-tauri` improves substantially; one of the top noisy issues stops firing.

## Related

- Closes: Fixes OPENHUMAN-TAURI-B7 (Sentry)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A (tracked in Sentry)
- URL: https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-B7

### Commit & Branch
- Branch: `fix/ollama-embed-transport-noise`
- Commit SHA: `c91afff7cc11779daee226467dc3639215b54b2e`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed in pre-push hook
- [x] `pnpm typecheck` — passed in pre-push hook
- [x] Focused tests: `cargo test --lib openhuman::embeddings::ollama` → 23 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt -- --check` passed; `cargo check` clean (only pre-existing unrelated warnings)
- [x] Tauri fmt/check (if changed): N/A — no Tauri shell files touched

### Validation Blocked
- N/A

### Behavior Changes
- Intended behavior change: stop emitting Sentry events when Ollama isn't running locally.
- User-visible effect: none — the embed call still fails with the same `anyhow::Error` (`is Ollama running at <url>?`); only a server-side telemetry side-effect is removed and the local log severity drops from `error` to `warn`.

### Parity Contract
- Legacy behavior preserved: returned error type and message unchanged; non-2xx Sentry reporting unchanged.
- Guard/fallback/dispatch parity checks: transport-failure error message format is byte-identical to the previous version; `embed_connection_refused` assertion still passes.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging for Ollama embedding failures with improved diagnostic information when connection issues occur.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1546)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->