### PR TITLE
chore(readme): add UTM tracking params to download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 
 > **Early Beta**: Under active development. Expect rough edges.
 
-To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman) or run
+To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
 
 ```
-# Download DMG, EXEs over at https://tinyhumans.ai/openhuman or run in from your terminal
+# Download DMG, EXEs over at https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme or run in from your terminal
 
 # For MacOS/Linux
 curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash


### PR DESCRIPTION
## Summary

- Appends `?utm_source=github&utm_medium=readme` to the two `tinyhumans.ai/openhuman` links in `README.md` so we can track traffic from the repo.

Closes #1557

## Test plan

- [x] Verify the markdown link on line 33 renders correctly and points to the UTM-tagged URL
- [x] Verify the code comment on line 36 contains the UTM-tagged URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "install or get started" section with revised installation instructions and clearer formatting for downloading or running the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1559)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->