### PR TITLE
Add UTM tracking params to website links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 
 > **Early Beta**: Under active development. Expect rough edges.
 
-To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman) or run
+To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
 
 ```
-# Download DMG, EXEs over at https://tinyhumans.ai/openhuman or run in from your terminal
+# Download DMG, EXEs over at https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme or run in from your terminal
 
 # For MacOS/Linux
 curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
 
-```
+```bash
 # Download DMG, EXEs over at https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme or run in from your terminal
 
 # For MacOS/Linux


### PR DESCRIPTION
## Summary

Append `?utm_source=github\&utm_medium=readme` to both 
`tinyhumans.ai/openhuman` URLs in the root README so 
repo-sourced traffic can be distinguished in analytics.

## Changes

- `README.md`: Updated 2 URL instances with UTM tracking parameters

Closes #1557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved installation/get‑started section formatting.
  * Wrapped download and setup instructions in a fenced code block for clarity.
  * Added an explicit "Download DMG, EXEs..." line inside the code block.
  * Updated download links to current resource URLs (with tracking parameters).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1562)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->