### PR TITLE
fix(ci): disable pnpm cache in setup-node and bump deprecated app-token action

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24.x
-          cache: yarn
+          package-manager-cache: false
       - name: Install Rust (1.93.0)
         uses: dtolnay/rust-toolchain@1.93.0
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -175,6 +175,7 @@ jobs:
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - name: Set version and publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -94,10 +94,10 @@ jobs:
           exit 1
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.XGITHUB_APP_ID }}
-          private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.XGITHUB_APP_ID }}
+          private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
       - name: Checkout main
         uses: actions/checkout@v5
         with:
@@ -111,6 +111,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24.x
+          package-manager-cache: false
       - name: Configure Git
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -67,10 +67,10 @@ jobs:
           exit 1
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.XGITHUB_APP_ID }}
-          private_key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.XGITHUB_APP_ID }}
+          private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
       - name: Checkout main
         uses: actions/checkout@v5
         with:
@@ -84,6 +84,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24.x
+          package-manager-cache: false
       - name: Configure Git
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Release Staging was failing on `Post Setup Node.js` with `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`. `actions/setup-node@v5` defaults `package-manager-cache: true`, detects this repo's `packageManager: pnpm`, and tries to save the pnpm store on post — but the release workflows never run `pnpm install`, so the store path doesn't exist and the post-step fails the whole job. Set `package-manager-cache: false` on every `setup-node` step in workflows that don't install JS deps (release-staging, release-production, release-packages publish job, build-windows).
- Drop the stale `cache: yarn` on build-windows — repo migrated to pnpm, no `yarn.lock` anymore.
- Replace the deprecated `tibdex/github-app-token@v1` (Node 20) with `actions/create-github-app-token@v2` (Node 24) in release-staging and release-production. Same `outputs.token`; inputs renamed `app_id`/`private_key` → `app-id`/`private-key`.

Failing run: https://github.com/tinyhumansai/openhuman/actions/runs/25733716099/job/75565105164

## Test plan

- [ ] Manually re-run Release Staging from the Actions tab once merged; the `Prepare build context` job should complete cleanly with no `Post Setup Node.js` error.
- [ ] Confirm the App token step still authenticates (push to `main`, tag creation succeeds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Adjusted dependency caching configurations across multiple CI/CD workflows, including Windows build processes, npm package publishing, and production/staging deployment pipelines, for optimized performance.
- Updated authentication mechanisms in production and staging release workflows to use the latest GitHub App token generation approach for improved maintainability and security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1572)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->