### PR TITLE
fix(release): publish linux-x86_64 AppImage asset and validate latest.json

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,7 +112,7 @@ jobs:
             target: x86_64-apple-darwin
             artifact_suffix: x86_64-apple-darwin
           - platform: ubuntu-22.04
-            args: --target x86_64-unknown-linux-gnu --bundles deb
+            args: --target x86_64-unknown-linux-gnu --bundles deb appimage
             target: x86_64-unknown-linux-gnu
             artifact_suffix: ubuntu
           - platform: windows-latest
@@ -524,6 +524,8 @@ jobs:
               "$root"/deb/*.deb \
               "$root"/appimage/*.AppImage \
               "$root"/appimage/*.AppImage.sig \
+              "$root"/appimage/*.AppImage.tar.gz \
+              "$root"/appimage/*.AppImage.tar.gz.sig \
               "$root"/msi/*.msi \
               "$root"/msi/*.msi.sig \
               "$root"/nsis/*-setup.exe \

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -567,6 +567,27 @@ jobs:
       && needs.build-docker.result == 'success'
       && needs.publish-updater-manifest.result == 'success'
     steps:
+      - name: Checkout validation scripts
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare-build.outputs.build_ref }}
+          fetch-depth: 1
+
+      - name: Validate release assets match latest.json
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare-build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" > /tmp/openhuman-release.json
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern latest.json \
+            --dir /tmp \
+            --clobber
+          scripts/validate-release-assets.sh /tmp/openhuman-release.json /tmp/latest.json
+
       - name: Validate required installer assets exist
         uses: actions/github-script@v8
         with:
@@ -584,6 +605,9 @@ jobs:
               /OpenHuman_.*_aarch64\.dmg$/,
               /OpenHuman_.*_x64\.dmg$/,
               /(OpenHuman_.*_x64-setup\.exe$|OpenHuman_.*_x64.*\.msi$)/,
+              // Linux desktop installer consumed by scripts/install.sh and
+              // advertised in latest.json as linux-x86_64.
+              /OpenHuman_.*_amd64\.AppImage$/,
               // Auto-updater manifest — without this, installed clients can't
               // discover new releases via plugins.updater.endpoints.
               /^latest\.json$/,

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To install or get started, either download from the website over at [tinyhumans.
 ```
 # Download DMG, EXEs over at https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme or run in from your terminal
 
-# For MacOS/Linux
+# For macOS or Linux x64
 curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash
 
 # For Windows

--- a/gitbooks/developing/getting-set-up.md
+++ b/gitbooks/developing/getting-set-up.md
@@ -49,7 +49,7 @@ For local development instead of production build:
 pnpm dev
 ```
 
-## Install latest stable release (macOS/Linux)
+## Install latest stable release (macOS/Linux x64)
 
 Primary install command:
 
@@ -63,7 +63,7 @@ Installer behavior:
 - Validates artifact digest when available
 - Installs locally (no sudo by default)
 - macOS: installs `OpenHuman.app` into `~/Applications`
-- Linux: installs AppImage as `~/.local/bin/openhuman` and writes a desktop entry
+- Linux x64: installs AppImage as `~/.local/bin/openhuman` and writes a desktop entry
 
 Useful flags:
 

--- a/gitbooks/features/platform.md
+++ b/gitbooks/features/platform.md
@@ -17,7 +17,7 @@ OpenHuman is a native desktop application, not a browser extension, not an Elect
 | ----------- | -------------------- | -------------------------- |
 | **macOS**   | Intel, Apple Silicon | `.dmg` installer, Homebrew |
 | **Windows** | x64, ARM64           | `.msi` installer           |
-| **Linux**   | x64, ARM64           | AppImage, `.deb`, apt      |
+| **Linux**   | x64                  | AppImage, `.deb`           |
 
 ***
 

--- a/scripts/release/publish-updater-manifest.sh
+++ b/scripts/release/publish-updater-manifest.sh
@@ -91,11 +91,11 @@ read_sig() {
 #
 # Naming conventions emitted by tauri-bundler with createUpdaterArtifacts:
 #   darwin  : <AppName>_<version>_<arch>.app.tar.gz
-#   linux   : <AppName>_<version>_amd64.AppImage.tar.gz
-#   windows : <AppName>_<version>_x64-setup.nsis.zip
+#   linux   : <AppName>_<version>_amd64.AppImage
+#   windows : <AppName>_<version>_x64-setup.exe
 MAC_AARCH64=$(find_asset "^OpenHuman(_| ).*aarch64(-apple-darwin)?\.app\.tar\.gz$")
 MAC_X86_64=$(find_asset  "^OpenHuman(_| ).*(x64|x86_64)(-apple-darwin)?\.app\.tar\.gz$")
-LIN_X86_64=$(find_asset  "^OpenHuman(_| ).*amd64\.AppImage(\.tar\.gz)?$")
+LIN_X86_64=$(find_asset  "^OpenHuman(_| ).*amd64\.AppImage$")
 WIN_X86_64=$(find_asset "^OpenHuman(_| ).*x64-setup\.exe$")
 
 echo "[updater] Resolved updater bundles:"
@@ -134,11 +134,16 @@ add_platform "darwin-x86_64"  "$MAC_X86_64"
 add_platform "linux-x86_64"   "$LIN_X86_64"
 add_platform "windows-x86_64" "$WIN_X86_64"
 
-# Require at least one platform so we don't publish an empty manifest that
-# would mislead installed clients into thinking no update is ever available.
-platforms=$(jq -r '.platforms | keys | length' "$MANIFEST")
-if [ "$platforms" = "0" ]; then
-  echo "[updater] ERROR: no platforms resolved — refusing to publish empty manifest" >&2
+# Require every platform advertised by the public installers. A partial
+# latest.json leaves install.sh resolving a documented platform to nothing.
+missing_platforms=$(jq -r '
+  ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"]
+  - (.platforms | keys)
+  | join(", ")
+' "$MANIFEST")
+if [ -n "$missing_platforms" ]; then
+  echo "[updater] ERROR: missing required latest.json platform(s): $missing_platforms" >&2
+  echo "[updater] Refusing to publish partial updater manifest." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Linux x86_64 now ships a release asset, and the existing `scripts/validate-release-assets.sh` runs in the release workflow so the documented install path stops silently falling through on Linux.

## Why this matters

- [#1578](https://github.com/tinyhumansai/openhuman/issues/1578) reports the README install command (`curl ... | bash`) fails on Linux x86_64 because `latest.json` only advertises `darwin-aarch64`, `darwin-x86_64`, `windows-x86_64`. The installer correctly detects `linux-x86_64` (`scripts/install.sh:148`) but no matching asset exists.
- `scripts/validate-release-assets.sh` was added in PR #1498 to catch exactly this kind of drift; it just wasn't wired into the release workflow.

## Changes

- `.github/workflows/build-desktop.yml`: Linux builder produces both `.deb` and `appimage`; AppImage updater artifacts are uploaded.
- `.github/workflows/release-production.yml`: new "Validate release assets match latest.json" step invokes `scripts/validate-release-assets.sh`; required-asset list adds `OpenHuman_*_amd64.AppImage`.
- `scripts/release/publish-updater-manifest.sh`: refuses to publish unless every supported platform (including `linux-x86_64`) is present.
- README + GitBook: Linux stable installer support documented as x86_64 AppImage.

## Testing

- `bash -n` syntax checks on the modified shell scripts
- `bash scripts/test_install.sh`
- `bash scripts/install.sh --dry-run --verbose` simulating Linux/x86_64 exits 0
- Synthetic release validation passes when Linux asset present, fails when missing

`pnpm format:check` / `pnpm lint` were not run locally because corepack needed network. None of the changes touch JS/TS source.

Fixes #1578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AppImage bundle format for Linux x64 downloads and releases.

* **Documentation**
  * Clarified platform-specific installer instructions for macOS and Linux x64.
  * Updated supported platforms documentation to specify Linux x64 compatibility.

* **Chores**
  * Enhanced release asset validation and build processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1582)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->