### PR TITLE
feat(tauri): hide main window to tray on Windows close

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2092,6 +2092,20 @@ pub fn run() {
                     let _ = window.hide();
                 }
             }
+            #[cfg(target_os = "windows")]
+            RunEvent::WindowEvent {
+                label,
+                event: WindowEvent::CloseRequested { api, .. },
+                ..
+            } if label == "main" => {
+                log::info!(
+                    "[window] close requested on main window — hiding to tray instead of destroying"
+                );
+                api.prevent_close();
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+            }
             #[cfg(target_os = "macos")]
             RunEvent::Reopen { .. } => {
                 log::info!("[window] reopen event — showing main window");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ mod webview_apis;
 mod whatsapp_scanner;
 mod window_state;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri::WindowEvent;
 #[cfg(not(target_os = "linux"))]
 use tauri::{


### PR DESCRIPTION
## Summary

Closing the main window on Windows now hides it to the system tray instead of exiting, mirroring the existing macOS behavior. The tray left-click and `tray_quit` menu item already restore and exit the app respectively, so no other wiring is needed.

## Implementation

`app/src-tauri/src/lib.rs:2095` — added a `#[cfg(target_os = "windows")]` arm to the `WindowEvent::CloseRequested` match, right next to the existing macOS arm at `:2082`. The Windows arm calls `api.prevent_close()` then `window.hide()`, same shape as the macOS arm.

No settings toggle in this PR — the issue says "could also be good", not required. Happy to add a follow-up if you want the toggle.

## Testing

- `cargo fmt --check` passes
- Local `cargo check` skipped because the workspace is missing `app/src-tauri/vendor/tauri-cef/` (shallow clone)
- Manual verification on Windows hardware would help confirm behavior; I don't have a Windows machine handy

Fixes #1503


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows close behavior: closing the main window now hides/minimizes it to the background/tray instead of terminating the app, preventing accidental exits.

* **New Features**
  * Mascot native window support enabled on Windows (previously macOS-only).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1583)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->