### PR TITLE
fix: cache device profile detection

### DIFF
--- a/src/openhuman/local_ai/device.rs
+++ b/src/openhuman/local_ai/device.rs
@@ -25,8 +25,10 @@ impl DeviceProfile {
     }
 }
 
-/// Probe the current machine and return a [`DeviceProfile`].
+/// Return the detected [`DeviceProfile`] for the current machine.
 ///
+/// The profile is probed once on first call and cached for the process lifetime.
+/// Hardware changes during runtime are detected after the app restarts.
 /// GPU detection is best-effort: Apple Silicon is assumed to have a GPU (Metal);
 /// on other platforms we report "unknown" unless more specific probing is added later.
 pub fn detect_device_profile() -> DeviceProfile {

--- a/src/openhuman/local_ai/device.rs
+++ b/src/openhuman/local_ai/device.rs
@@ -1,7 +1,10 @@
 //! Device profile detection for guided model selection.
 
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 use sysinfo::System;
+
+static DEVICE_PROFILE_CACHE: OnceLock<DeviceProfile> = OnceLock::new();
 
 /// Summary of local hardware relevant for model tier selection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -27,6 +30,12 @@ impl DeviceProfile {
 /// GPU detection is best-effort: Apple Silicon is assumed to have a GPU (Metal);
 /// on other platforms we report "unknown" unless more specific probing is added later.
 pub fn detect_device_profile() -> DeviceProfile {
+    DEVICE_PROFILE_CACHE
+        .get_or_init(detect_device_profile_uncached)
+        .clone()
+}
+
+fn detect_device_profile_uncached() -> DeviceProfile {
     let mut sys = System::new_all();
     sys.refresh_all();
 


### PR DESCRIPTION
## Summary
- Cache the detected device profile for the lifetime of the app process.
- Avoid repeatedly probing hardware during local AI device/status polling.
- Keep the existing Windows `CREATE_NO_WINDOW` handling for the `nvidia-smi` probe.

## Why
On Windows, repeated GPU detection can invoke `nvidia-smi` often enough to cause visible console flashing. The device profile is effectively static during a desktop app session, so caching it avoids repeated subprocess probes without changing model recommendation behavior for normal use.

The only tradeoff is that hardware changes made while the app is already running are picked up after restart, which matches typical expectations for a hardware capability profile.

## Testing
- `cargo fmt --check`
- Verified in a Windows dev checkout that the repeated `nvidia-smi` console flashing stops after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Device profile detection now caches results for the process lifetime, reducing repeated hardware probing and improving performance.
* **Documentation**
  * Docs updated to clarify that device profiling runs once per process and subsequent calls use the cached profile.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1585)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->