### PR TITLE
chore: automate contributor reward invites

### DIFF
--- a/.github/workflows/contributor-rewards.yml
+++ b/.github/workflows/contributor-rewards.yml
@@ -21,6 +21,13 @@ jobs:
   reward:
     name: Invite eligible contributor
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true) ||
+      (github.event.action == 'labeled' &&
+        github.event.label.name == 'reward user')
     steps:
       - name: Post reward invite when eligible
         uses: actions/github-script@v8
@@ -214,7 +221,7 @@ jobs:
                 `2. Share this ${target.kind} link so maintainers can verify your GitHub handle: ${target.htmlUrl}`,
                 merchLine,
                 '',
-                `_Reason: ${target.reason}. Automatic rewards are idempotent per GitHub user; maintainer-applied "${triggerLabel}" labels can intentionally start the flow for special cases._`,
+                `*Reason: ${target.reason}. Automatic rewards are idempotent per GitHub user; maintainer-applied "${triggerLabel}" labels can intentionally start the flow for special cases.*`,
               ].join('\n');
             }
 

--- a/.github/workflows/contributor-rewards.yml
+++ b/.github/workflows/contributor-rewards.yml
@@ -1,0 +1,281 @@
+---
+name: Contributor Rewards
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: contributor-rewards-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  reward:
+    name: Invite eligible contributor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post reward invite when eligible
+        uses: actions/github-script@v8
+        env:
+          CONTRIBUTOR_REWARD_TRIGGER_LABEL: reward user
+          CONTRIBUTOR_REWARD_SENT_LABEL: reward sent
+          CONTRIBUTOR_REWARD_DISCORD_URL: ${{ vars.CONTRIBUTOR_REWARD_DISCORD_URL }}
+          CONTRIBUTOR_REWARD_MERCH_URL: ${{ vars.CONTRIBUTOR_REWARD_MERCH_URL }}
+          CONTRIBUTOR_REWARD_MESSAGE: ${{ vars.CONTRIBUTOR_REWARD_MESSAGE }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const triggerLabel = (process.env.CONTRIBUTOR_REWARD_TRIGGER_LABEL || 'reward user').trim();
+            const sentLabel = (process.env.CONTRIBUTOR_REWARD_SENT_LABEL || 'reward sent').trim();
+            const discordUrl =
+              (process.env.CONTRIBUTOR_REWARD_DISCORD_URL || 'https://discord.tinyhumans.ai/').trim();
+            const merchUrl = (process.env.CONTRIBUTOR_REWARD_MERCH_URL || '').trim();
+            const customMessage = (process.env.CONTRIBUTOR_REWARD_MESSAGE || '').trim();
+
+            const normalize = value => String(value || '').trim().toLowerCase();
+            const triggerLabelKey = normalize(triggerLabel);
+
+            function markerFor(login) {
+              return `<!-- openhuman-contributor-reward:user=${normalize(login)} -->`;
+            }
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+                return;
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                core.info(`Created label "${name}".`);
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                core.info(`Label "${name}" already exists.`);
+              }
+            }
+
+            function labeledWithTrigger() {
+              return normalize(context.payload.label?.name) === triggerLabelKey;
+            }
+
+            function actorIsBot(target) {
+              return target.userType === 'Bot' || /\[bot\]$/i.test(target.login);
+            }
+
+            function targetFromEvent() {
+              if (context.eventName === 'workflow_dispatch') {
+                return { bootstrapOnly: true };
+              }
+
+              if (context.eventName === 'pull_request_target') {
+                const pr = context.payload.pull_request;
+                if (!pr) return null;
+
+                if (context.payload.action === 'closed') {
+                  if (!pr.merged) {
+                    core.info(`PR #${pr.number} was closed without merge; skipping reward flow.`);
+                    return null;
+                  }
+
+                  return {
+                    kind: 'pull request',
+                    number: pr.number,
+                    htmlUrl: pr.html_url,
+                    login: pr.user.login,
+                    userType: pr.user.type,
+                    reason: 'first merged pull request',
+                    manualOverride: false,
+                    requireFirstMergedPr: true,
+                  };
+                }
+
+                if (context.payload.action === 'labeled') {
+                  if (!labeledWithTrigger()) {
+                    core.info(`Label "${context.payload.label?.name}" is not "${triggerLabel}"; skipping.`);
+                    return null;
+                  }
+
+                  return {
+                    kind: 'pull request',
+                    number: pr.number,
+                    htmlUrl: pr.html_url,
+                    login: pr.user.login,
+                    userType: pr.user.type,
+                    reason: `maintainer-applied "${triggerLabel}" label on a pull request`,
+                    manualOverride: true,
+                    requireFirstMergedPr: false,
+                  };
+                }
+              }
+
+              if (context.eventName === 'issues') {
+                const issue = context.payload.issue;
+                if (!issue) return null;
+
+                if (issue.pull_request) {
+                  core.info(`Issue event is for PR #${issue.number}; pull_request_target handles PR labels.`);
+                  return null;
+                }
+
+                if (!labeledWithTrigger()) {
+                  core.info(`Label "${context.payload.label?.name}" is not "${triggerLabel}"; skipping.`);
+                  return null;
+                }
+
+                return {
+                  kind: 'issue',
+                  number: issue.number,
+                  htmlUrl: issue.html_url,
+                  login: issue.user.login,
+                  userType: issue.user.type,
+                  reason: `maintainer-applied "${triggerLabel}" label on an issue`,
+                  manualOverride: true,
+                  requireFirstMergedPr: false,
+                };
+              }
+
+              core.info(`Unsupported event "${context.eventName}"; skipping.`);
+              return null;
+            }
+
+            async function isFirstMergedPullRequest(login, currentNumber) {
+              const query = `repo:${owner}/${repo} is:pr is:merged author:${login}`;
+              const response = await github.rest.search.issuesAndPullRequests({
+                q: query,
+                per_page: 100,
+              });
+              const previous = response.data.items.filter(item => item.number !== currentNumber);
+              core.info(
+                `Found ${previous.length} earlier merged PR(s) for ${login} while evaluating #${currentNumber}.`
+              );
+              return previous.length === 0;
+            }
+
+            async function targetAlreadyRewarded(target) {
+              const marker = markerFor(target.login);
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: target.number,
+                per_page: 100,
+              });
+              return comments.some(comment => comment.body?.includes(marker));
+            }
+
+            async function contributorAlreadyRewardedElsewhere(target) {
+              const markerNeedle = `openhuman-contributor-reward:user=${normalize(target.login)}`;
+              const query = `repo:${owner}/${repo} "${markerNeedle}" in:comments`;
+              const response = await github.rest.search.issuesAndPullRequests({
+                q: query,
+                per_page: 10,
+              });
+              return response.data.items.some(item => item.number !== target.number);
+            }
+
+            function renderCustomMessage(target) {
+              const replacements = {
+                '{user}': `@${target.login}`,
+                '{login}': target.login,
+                '{discord_url}': discordUrl,
+                '{merch_url}': merchUrl,
+                '{reason}': target.reason,
+                '{target_url}': target.htmlUrl,
+              };
+
+              let body = customMessage;
+              for (const [token, value] of Object.entries(replacements)) {
+                body = body.split(token).join(value);
+              }
+              return `${markerFor(target.login)}\n${body}`;
+            }
+
+            function renderDefaultMessage(target) {
+              const merchLine = merchUrl
+                ? `3. Claim merch: ${merchUrl}`
+                : '3. For merch, ask a maintainer in Discord. Keep shipping details out of GitHub comments.';
+
+              return [
+                markerFor(target.login),
+                `Thanks @${target.login} for contributing to OpenHuman.`,
+                '',
+                'You are eligible for the contributor reward flow:',
+                '',
+                `1. Join the OpenHuman Discord: ${discordUrl}`,
+                `2. Share this ${target.kind} link so maintainers can verify your GitHub handle: ${target.htmlUrl}`,
+                merchLine,
+                '',
+                `_Reason: ${target.reason}. Automatic rewards are idempotent per GitHub user; maintainer-applied "${triggerLabel}" labels can intentionally start the flow for special cases._`,
+              ].join('\n');
+            }
+
+            const target = targetFromEvent();
+
+            await ensureLabel(triggerLabel, 'fbca04', 'Maintainer-triggered contributor reward invite');
+            await ensureLabel(sentLabel, '0e8a16', 'Contributor reward invite has been posted');
+
+            if (!target) {
+              await core.summary.addHeading('Contributor Rewards').addRaw('No eligible target for this event.').write();
+              return;
+            }
+
+            if (target.bootstrapOnly) {
+              await core.summary
+                .addHeading('Contributor Rewards')
+                .addRaw(`Labels "${triggerLabel}" and "${sentLabel}" are ready.`)
+                .write();
+              return;
+            }
+
+            if (actorIsBot(target)) {
+              core.info(`Skipping bot account ${target.login}.`);
+              return;
+            }
+
+            if (target.requireFirstMergedPr) {
+              const firstMergedPr = await isFirstMergedPullRequest(target.login, target.number);
+              if (!firstMergedPr) {
+                core.info(`${target.login} already has a merged PR; skipping automatic reward.`);
+                return;
+              }
+            }
+
+            if (await targetAlreadyRewarded(target)) {
+              core.info(`#${target.number} already has a reward marker for ${target.login}; skipping.`);
+              return;
+            }
+
+            if (!target.manualOverride && (await contributorAlreadyRewardedElsewhere(target))) {
+              core.info(`${target.login} already has a reward marker elsewhere; skipping automatic reward.`);
+              return;
+            }
+
+            const body = customMessage ? renderCustomMessage(target) : renderDefaultMessage(target);
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: target.number,
+              body,
+            });
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: target.number,
+              labels: [sentLabel],
+            });
+
+            core.info(`Posted contributor reward invite for ${target.login} on #${target.number}.`);
+            await core.summary
+              .addHeading('Contributor Rewards')
+              .addRaw(`Posted reward invite for @${target.login} on ${target.htmlUrl}.`)
+              .write();

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,13 @@ git checkout -b docs/your-change
 
 If you are contributing through a coding agent or remote environment, include the metadata required by the PR template and the Codex PR checklist.
 
+### Contributor rewards
+
+Maintainers can reward eligible contributors through the automated workflow in
+[`docs/CONTRIBUTOR-REWARDS.md`](docs/CONTRIBUTOR-REWARDS.md). First merged pull
+requests are handled automatically, and maintainers can apply the `reward user`
+label to manually start the same Discord and merch invite flow.
+
 ## Project Conventions
 
 - Use Redux and existing app state patterns instead of adding new ad hoc browser storage.

--- a/docs/CONTRIBUTOR-REWARDS.md
+++ b/docs/CONTRIBUTOR-REWARDS.md
@@ -1,0 +1,82 @@
+# Contributor Rewards Automation
+
+OpenHuman uses `.github/workflows/contributor-rewards.yml` to invite eligible
+contributors into the Discord and merch reward flow.
+
+## Triggers
+
+The workflow runs when:
+
+- a pull request is merged and the PR author has no earlier merged PR in this
+  repository;
+- a maintainer applies the `reward user` label to a pull request;
+- a maintainer applies the `reward user` label to an issue;
+- a maintainer runs the workflow manually to bootstrap the labels.
+
+The workflow creates these labels if they do not already exist:
+
+- `reward user` - maintainer-triggered reward invite;
+- `reward sent` - audit label added after the invite comment is posted.
+
+## Idempotency
+
+Each reward comment includes a hidden marker scoped to the GitHub login:
+
+```html
+<!-- openhuman-contributor-reward:user=<login> -->
+```
+
+Automatic first-merged-PR rewards are skipped when the same login already has a
+reward marker elsewhere in the repository. Maintainers can intentionally start
+the flow again by applying `reward user`, but the workflow still skips a target
+issue or PR that already contains the same marker.
+
+Bot accounts are skipped.
+
+## Configuration
+
+Configure these repository variables under
+**Settings -> Secrets and variables -> Actions -> Variables**:
+
+| Variable                         | Required | Purpose                                                                  |
+| -------------------------------- | -------- | ------------------------------------------------------------------------ |
+| `CONTRIBUTOR_REWARD_DISCORD_URL` | No       | Public Discord invite URL. Defaults to `https://discord.tinyhumans.ai/`. |
+| `CONTRIBUTOR_REWARD_MERCH_URL`   | No       | Public merch claim or redemption URL included in the comment.            |
+| `CONTRIBUTOR_REWARD_MESSAGE`     | No       | Full custom comment body. Supports tokens listed below.                  |
+
+`CONTRIBUTOR_REWARD_MESSAGE` can use these tokens:
+
+- `{user}` - GitHub mention, for example `@octocat`;
+- `{login}` - raw GitHub login;
+- `{discord_url}` - configured Discord URL;
+- `{merch_url}` - configured merch URL or an empty string;
+- `{reason}` - trigger reason;
+- `{target_url}` - issue or PR URL.
+
+Do not put private Discord invite mechanics, shipping forms, access tokens, or
+other secrets in repository variables used by this workflow. Anything rendered
+by the workflow is posted as a public GitHub comment.
+
+## Security Model
+
+The workflow uses `pull_request_target` so it can comment on pull requests from
+forks. It must not check out or execute pull request code. The current workflow
+only reads the GitHub event payload and calls GitHub APIs through
+`actions/github-script`.
+
+Required permissions are limited to:
+
+- `contents: read`;
+- `issues: write`;
+- `pull-requests: read`.
+
+## Manual Operation
+
+To reward a contributor manually:
+
+1. Open the issue or pull request.
+2. Apply the `reward user` label.
+3. Wait for the workflow to post the reward comment and add `reward sent`.
+
+If the labels do not exist yet, run **Actions -> Contributor Rewards -> Run
+workflow** once on `main`.


### PR DESCRIPTION
## Summary

- Adds a `Contributor Rewards` GitHub Actions workflow for first-time merged PR rewards and maintainer-triggered reward invites.
- Creates and uses `reward user` / `reward sent` labels with idempotent comment markers to avoid duplicate invites.
- Documents maintainer setup, security constraints, custom message variables, and manual operation in `docs/CONTRIBUTOR-REWARDS.md`.
- Links the contributor guide to the reward workflow documentation.
- Addresses CodeRabbit follow-up feedback by short-circuiting non-reward label events and using safer Markdown italics.

## Problem

- Closes #1577.
- Maintainers need a repeatable way to invite first-time contributors and manually reward labeled issues/PRs without hand-tracking prior rewards.
- Because the workflow runs on `pull_request_target`, it must avoid checking out or executing contributor code.

## Solution

- Handles merged PRs automatically when the author has no earlier merged PR in the repository.
- Handles manual rewards when maintainers apply the `reward user` label to a PR or issue.
- Posts a public reward comment with a hidden per-user marker, then labels the target `reward sent`.
- Keeps the workflow limited to GitHub payload/API operations; it does not checkout code or run PR contents.
- Supports repo variables for Discord URL, merch URL, and a custom public message template.
- Adds a job-level guard so label events only start a runner for the default reward label.

## Submission Checklist

- [x] N/A: GitHub Actions/docs change; validated with actionlint and script syntax compile instead of app unit tests.
- [x] N/A: No app/Rust code changed, so Vitest/cargo coverage does not apply.
- [x] N/A: No feature rows added/removed/renamed in the coverage matrix.
- [x] N/A: No affected feature IDs from `docs/TEST-COVERAGE-MATRIX.md`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Does not touch release-cut surfaces.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: GitHub Actions only.
- Security: workflow uses `pull_request_target` but does not checkout or execute PR code; it only reads event payload data and GitHub APIs.
- Maintainer setup: optional repository variables can customize the public reward message and links.
- Compatibility: existing contribution flow remains unchanged unless the workflow triggers on a merged first PR or `reward user` label.

## Related

- Closes #1577
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `chore/contributor-reward-invites`
- Commit SHA: `81a5bb0b`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` — N/A: no app/TS source changed.
- [x] Focused tests:
  - `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/contributor-rewards.yml`
  - `node` syntax compile of the `actions/github-script` block
  - `pnpm --dir app exec prettier --check ../.github/workflows/contributor-rewards.yml ../docs/CONTRIBUTOR-REWARDS.md`
  - `git diff --check`
  - `cargo test -p openhuman core::jsonrpc::tests::thread_not_found_rpc_error_does_not_report_to_sentry -- --exact --nocapture`
- [x] Rust fmt/check (if changed): N/A, no Rust source changes; `pnpm --filter openhuman-app format:check` ran Rust fmt checks.
- [x] Tauri fmt/check (if changed): N/A, no Tauri source changes; `pnpm --filter openhuman-app format:check` ran Tauri fmt checks.

### Validation Blocked
- `command:` `cargo test -p openhuman --lib`
- `error:` Full Rust lib test currently fails with global test-state poisoning (`PoisonError`) and unrelated local-ai assertions; the focused Sentry regression test passes when run directly.
- `impact:` This PR only changes workflow/docs. The same Rust Core Tests + Quality failure is present on `main` for run `25778625881`, so it appears unrelated to this PR.

### Behavior Changes
- Intended behavior change: first-time merged PR authors and manually labeled reward targets receive a maintainer-configurable reward invite comment.
- User-visible effect: eligible contributors see a GitHub comment with the Discord/reward instructions; targets receive a `reward sent` label.

### Parity Contract
- Legacy behavior preserved: existing contribution, build, and app runtime behavior is unchanged.
- Guard/fallback/dispatch parity checks: duplicate markers prevent repeat comments; bot authors are skipped; manual label rewards work for both issues and PRs.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found in open PR search for #1577 / reward invite terms before opening.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated contributor rewards flow that posts reward invitations for merged PRs and labeled issues.
  * First-time contributors are auto-eligible; maintainers can manually trigger invites via a label.
  * Workflow ensures reward labels exist, skips bot accounts, and avoids duplicate invites.

* **Documentation**
  * Added contributor rewards documentation and updated contributing guide describing the process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1589)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->