### PR TITLE
fix(staging-build): unblock Windows compile + diagnose Linux AppImage bundler

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -159,22 +159,10 @@ jobs:
             libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
             libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
             libgbm1 libpango-1.0-0 libcairo2 libatspi2.0-0 libxshmfence1 libu2f-udev
-      - name: Dump missing shared libs (debug)
-        if: matrix.settings.platform == 'ubuntu-22.04'
-        shell: bash
-        env:
-          PROFILE: ${{ inputs.build_profile }}
-          MATRIX_TARGET: ${{ matrix.settings.target }}
-        run: |
-          set +e
-          for BIN in \
-            "app/src-tauri/target/${MATRIX_TARGET}/${PROFILE}/OpenHuman" \
-            "target/${MATRIX_TARGET}/${PROFILE}/OpenHuman"; do
-            if [ -x "$BIN" ]; then
-              echo "ldd $BIN"
-              ldd "$BIN" | grep 'not found' || echo "  all resolved"
-            fi
-          done
+      # NOTE: The post-build dump lives further down (after `cargo tauri build`)
+      # so the binary actually exists when ldd runs. Running it here pre-build
+      # silently no-op'd and gave us no signal during the
+      # quick-sharun "missing libraries" failures.
 
       # Skip first 7 lines of Cargo.lock (workspace package version bumps) so the key tracks dependency changes only
       - name: Cargo.lock fingerprint (deps only)
@@ -421,6 +409,33 @@ jobs:
           # beforeBuildCommand. Step-level env was observed not to propagate
           # on macos-arm64 runners, causing OOM at node's ~2GB auto default.
           NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build $PROFILE_FLAG -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
+
+      # Diagnostic for the recurring quick-sharun "is missing libraries!
+      # Aborting..." error on the AppImage bundler — the upstream script
+      # only prints a generic banner and swallows lib4bin's actual output,
+      # so we have no visibility into which .so is unresolved. `if: always()`
+      # ensures this still runs when `cargo tauri build` failed at bundling
+      # (the binary itself is produced before bundling starts).
+      - name: Dump linked libraries of built binary (ubuntu debug)
+        if: always() && matrix.settings.platform == 'ubuntu-22.04'
+        shell: bash
+        env:
+          PROFILE: ${{ inputs.build_profile }}
+          MATRIX_TARGET: ${{ matrix.settings.target }}
+        run: |
+          set +e
+          for BIN in \
+            "app/src-tauri/target/${MATRIX_TARGET}/${PROFILE}/OpenHuman" \
+            "app/src-tauri/target/${MATRIX_TARGET}/${PROFILE}/bundle/appimage_deb/data/usr/bin/OpenHuman" \
+            "target/${MATRIX_TARGET}/${PROFILE}/OpenHuman"; do
+            if [ -x "$BIN" ]; then
+              echo "==> ldd $BIN"
+              ldd "$BIN" || true
+              echo "==> unresolved:"
+              ldd "$BIN" | grep 'not found' || echo "  (all resolved)"
+              echo
+            fi
+          done
 
       # Regression guard for #1403: if @sentry/vite-plugin silently no-op'd
       # (e.g. SENTRY_AUTH_TOKEN missing, or the `sourcemaps.assets` glob

--- a/src/openhuman/local_ai/install.rs
+++ b/src/openhuman/local_ai/install.rs
@@ -23,7 +23,8 @@ pub(crate) fn is_ollama_installer_running() -> bool {
     // CPU/memory/disk/network. refresh_all() adds dozens of milliseconds of
     // blocking I/O on a loaded Windows machine and this function runs on the
     // async executor inside download_and_install_ollama.
-    sys.refresh_processes(ProcessesToUpdate::All);
+    // sysinfo 0.33 added a second `remove_dead_processes` parameter.
+    sys.refresh_processes(ProcessesToUpdate::All, true);
     sys.processes().values().any(|p| {
         p.name()
             .to_string_lossy()


### PR DESCRIPTION
## Summary

The staging build matrix has been failing on Windows and Linux since the v0.53.32 tag — two unrelated regressions:

- **Windows**: `cargo update` in #1581 bumped `sysinfo` past the 0.32→0.33 API break. The Windows-only Ollama-installer detection path added in #1569 (`src/openhuman/local_ai/install.rs`) still calls the old 1-arg `System::refresh_processes(ProcessesToUpdate::All)`; 0.33 added a second `remove_dead_processes: bool` parameter, so the lib no longer compiles on the windows matrix entry. Pass `true` (the upstream default for "remove dead processes" semantics).
- **Linux**: #1582 flipped on \`--bundles deb appimage\` for the Linux matrix entry for the first time. AppImage bundling via `quick-sharun.sh` (downloaded fresh from `pkgforge-dev/Anylinux-AppImages`) fails with the generic banner \`OpenHuman is missing libraries! Aborting...\` which **does not** name the missing `.so`. The pre-existing "Dump missing shared libs" debug step ran *before* `cargo tauri build`, so the binary didn't exist yet and the step silently no-op'd.

  This PR moves and broadens the ldd dump so it runs **after** the build (with `if: always()`, including on bundle failure), scans both `target/.../OpenHuman` and the staged `bundle/appimage_deb/data/usr/bin/OpenHuman`, and prints full `ldd` output plus the "not found" subset. The next failing run will name the unresolved library so we can patch the apt install list (or pin the upstream script). The Windows fix above should make this run reach the bundling step.

Failing runs:
- https://github.com/tinyhumansai/openhuman/actions/runs/25779462318/job/75718841292 (windows)
- https://github.com/tinyhumansai/openhuman/actions/runs/25779462318/job/75718841277 (ubuntu)

## Test plan

- [ ] Re-run \`release-staging.yml\` against this branch; windows matrix entry compiles and bundles
- [ ] Ubuntu matrix entry still fails at the AppImage step, but the new \`Dump linked libraries of built binary\` step prints unresolved \`.so\` names so we know what apt package to add as a follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build diagnostics on Ubuntu to better identify library dependencies after compilation.
  * Enhanced process detection mechanism on Windows systems for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1591)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->