### PR TITLE
fix(observability): skip Sentry for transport-level + transient-upstream errors (TAURI-32 / 5Z / 2G)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -40,6 +40,7 @@ pub enum ExpectedErrorKind {
     LocalAiDisabled,
     ApiKeyMissing,
     NetworkUnreachable,
+    TransientUpstreamHttp,
 }
 
 pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
@@ -52,6 +53,9 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     }
     if is_network_unreachable_message(&lower) {
         return Some(ExpectedErrorKind::NetworkUnreachable);
+    }
+    if is_transient_upstream_http_message(&lower) {
+        return Some(ExpectedErrorKind::TransientUpstreamHttp);
     }
     None
 }
@@ -78,6 +82,29 @@ fn is_network_unreachable_message(lower: &str) -> bool {
         || lower.contains("no route to host")
         || lower.contains("tls handshake")
         || lower.contains("certificate verify failed")
+}
+
+/// Detect transient upstream HTTP failures that have bubbled up out of the
+/// provider layer and into higher-level domains (`agent`, `web_channel`, …).
+///
+/// The reliable-provider stack already retries / falls back on
+/// [`TRANSIENT_PROVIDER_HTTP_STATUSES`] (408/429/502/503/504), and the
+/// `before_send` filter drops the per-attempt provider events that carry
+/// `domain=llm_provider`. But the same error is *also* returned via
+/// `Result::Err` and re-reported by callers that wrap the provider — e.g.
+/// `agent.run_single` (OPENHUMAN-TAURI-5Z), `web_channel.run_chat_task`,
+/// scheduler tick handlers — under a different `domain` tag, escaping the
+/// provider-scoped filter and producing one Sentry event per failed turn.
+///
+/// The canonical wire format from `providers::ops::api_error` is:
+/// `"<provider> API error (<status>): <sanitized>"` — e.g.
+/// `"OpenHuman API error (504 Gateway Timeout): error code: 504"`. Pin the
+/// match to that exact `"api error (<status>"` prefix so an unrelated message
+/// that merely mentions "504" (a log line, a doc URL) is not silenced.
+fn is_transient_upstream_http_message(lower: &str) -> bool {
+    TRANSIENT_PROVIDER_HTTP_STATUSES
+        .iter()
+        .any(|code| lower.contains(&format!("api error ({code}")))
 }
 
 /// Capture an error to Sentry with structured tags.
@@ -150,6 +177,14 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 operation = operation,
                 error = %message,
                 "[observability] {domain}.{operation} skipped expected network-unreachable error: {message}"
+            );
+        }
+        ExpectedErrorKind::TransientUpstreamHttp => {
+            tracing::warn!(
+                domain = domain,
+                operation = operation,
+                error = %message,
+                "[observability] {domain}.{operation} skipped transient upstream HTTP error: {message}"
             );
         }
     }
@@ -299,6 +334,70 @@ mod tests {
         );
         assert_eq!(
             expected_error_kind("OpenAI API error (500): internal server error"),
+            None
+        );
+    }
+
+    #[test]
+    fn classifies_transient_upstream_http_errors() {
+        // OPENHUMAN-TAURI-5Z: the canonical shape emitted by
+        // `providers::ops::api_error` and re-raised through `agent.run_single`.
+        assert_eq!(
+            expected_error_kind("OpenHuman API error (504 Gateway Timeout): error code: 504"),
+            Some(ExpectedErrorKind::TransientUpstreamHttp)
+        );
+
+        // Every transient code must classify, whether the status renders as
+        // bare digits or "<digits> <reason>".
+        for raw in [
+            "OpenHuman API error (408): request timeout",
+            "OpenAI API error (429 Too Many Requests): rate limit",
+            "Anthropic API error (502 Bad Gateway): upstream unhealthy",
+            "OpenHuman API error (503): service unavailable",
+            "Provider API error (504): upstream timed out",
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::TransientUpstreamHttp),
+                "should classify as transient upstream HTTP: {raw}"
+            );
+        }
+
+        // Wrapped in an anyhow chain (as it reaches the agent layer) must
+        // still classify — `expected_error_kind` is substring-based.
+        assert_eq!(
+            expected_error_kind(
+                "agent turn failed: OpenHuman API error (504 Gateway Timeout): \
+                 error code: 504"
+            ),
+            Some(ExpectedErrorKind::TransientUpstreamHttp)
+        );
+    }
+
+    #[test]
+    fn does_not_classify_actionable_provider_errors_as_transient_upstream() {
+        // 4xx (other than 408/429) and non-transient 5xx must continue to
+        // reach Sentry — those are real bugs (wrong model name, malformed
+        // request, internal exception) that need to be triaged.
+        for raw in [
+            "OpenAI API error (400): bad request",
+            "OpenAI API error (401): unauthorized",
+            "OpenAI API error (403): forbidden",
+            "OpenAI API error (404): model not found",
+            "OpenAI API error (500): internal server error",
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                None,
+                "must NOT silence actionable provider error: {raw}"
+            );
+        }
+
+        // A free-form message that merely mentions "504" without the
+        // `api error (` prefix must not be classified — pin the match to
+        // the canonical shape from `ops::api_error`.
+        assert_eq!(
+            expected_error_kind("see runbook for 504 handling at https://example.com/504"),
             None
         );
     }

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -39,6 +39,7 @@ pub const TRANSIENT_PROVIDER_HTTP_STATUSES: &[u16] = &[408, 429, 502, 503, 504];
 pub enum ExpectedErrorKind {
     LocalAiDisabled,
     ApiKeyMissing,
+    NetworkUnreachable,
 }
 
 pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
@@ -49,7 +50,34 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if lower.contains("api key not set") || lower.contains("missing api key") {
         return Some(ExpectedErrorKind::ApiKeyMissing);
     }
+    if is_network_unreachable_message(&lower) {
+        return Some(ExpectedErrorKind::NetworkUnreachable);
+    }
     None
+}
+
+/// Detect transport-level connection failures that fire before any HTTP status
+/// is observed — DNS resolution failures, TCP connect refused/reset, TLS
+/// handshake failures, or ISP/firewall blocks. The canonical shape is
+/// reqwest's `"error sending request for url (…)"`, which surfaces from any
+/// HTTP call site (provider chat, embeddings, backend RPC) when the request
+/// can't reach the server at all.
+///
+/// These are user-environment problems — VPN drop, captive portal, ISP-level
+/// block (OPENHUMAN-TAURI-32: user in RU couldn't reach `api.tinyhumans.ai`),
+/// firewall — that no amount of retry / fallback on our side can resolve.
+/// Sentry has no signal to act on (no status, no trace, no payload), so each
+/// occurrence is pure noise. Classify them as expected so the report site
+/// logs a breadcrumb rather than spawning an error event.
+fn is_network_unreachable_message(lower: &str) -> bool {
+    lower.contains("error sending request for url")
+        || lower.contains("dns error")
+        || lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("network is unreachable")
+        || lower.contains("no route to host")
+        || lower.contains("tls handshake")
+        || lower.contains("certificate verify failed")
 }
 
 /// Capture an error to Sentry with structured tags.
@@ -114,6 +142,14 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 operation = operation,
                 error = %message,
                 "[observability] {domain}.{operation} skipped expected API-key configuration error: {message}"
+            );
+        }
+        ExpectedErrorKind::NetworkUnreachable => {
+            tracing::warn!(
+                domain = domain,
+                operation = operation,
+                error = %message,
+                "[observability] {domain}.{operation} skipped expected network-unreachable error: {message}"
             );
         }
     }
@@ -216,6 +252,53 @@ mod tests {
         );
         assert_eq!(
             expected_error_kind("ollama embed failed with status 500"),
+            None
+        );
+    }
+
+    #[test]
+    fn classifies_network_unreachable_errors() {
+        // OPENHUMAN-TAURI-32: reqwest's transport-level error wrapped by the
+        // web_channel error site. The classifier must catch it even when
+        // embedded in caller context, since `report_error_or_expected` runs
+        // `expected_error_kind` on the full anyhow chain.
+        assert_eq!(
+            expected_error_kind(
+                "run_chat_task failed client_id=abc thread_id=t1 request_id=r1 \
+                 error=error sending request for url (https://api.tinyhumans.ai/openai/v1/chat/completions)"
+            ),
+            Some(ExpectedErrorKind::NetworkUnreachable)
+        );
+        for raw in [
+            "error sending request for url (https://api.example.com/x)",
+            "provider failed: dns error: failed to lookup address information",
+            "tcp connect: connection refused (os error 61)",
+            "stream closed: connection reset by peer",
+            "network is unreachable (os error 51)",
+            "no route to host",
+            "tls handshake eof",
+            "certificate verify failed: unable to get local issuer certificate",
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::NetworkUnreachable),
+                "should classify as network-unreachable: {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_provider_errors_as_network() {
+        // Status-bearing provider failures (404, 500, …) are surfaced via
+        // their HTTP status path and must NOT be silenced by the
+        // network-unreachable classifier — the body text doesn't hit any of
+        // the transport-level markers.
+        assert_eq!(
+            expected_error_kind("OpenAI API error (404): model gpt-x not found"),
+            None
+        );
+        assert_eq!(
+            expected_error_kind("OpenAI API error (500): internal server error"),
             None
         );
     }

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -502,7 +502,16 @@ impl Agent {
             }
             Err(err) => {
                 let sanitized_message = Self::sanitize_event_error_message(&err);
-                crate::core::observability::report_error(
+                // OPENHUMAN-TAURI-5Z: upstream transient HTTP failures
+                // (408/429/502/503/504) are already retried + filtered at the
+                // provider layer. When retries exhaust they bubble up here via
+                // `Result::Err`, and re-reporting under `domain=agent` escapes
+                // the `domain=llm_provider` filter — one Sentry event per
+                // failed turn for a transient infrastructure blip. Route
+                // through `report_error_or_expected` so the classifier demotes
+                // those (and other expected user-state errors) to a warn-level
+                // breadcrumb while preserving the AgentError publish + return.
+                crate::core::observability::report_error_or_expected(
                     &err,
                     "agent",
                     "run_single",

--- a/src/openhuman/channels/providers/web.rs
+++ b/src/openhuman/channels/providers/web.rs
@@ -337,7 +337,14 @@ pub async fn start_chat(
                     client_id_task, thread_id_task, request_id_task, err
                 );
                 let (classified_type, classified_message) = classify_inference_error(&err);
-                crate::core::observability::report_error(
+                // Route through `report_error_or_expected` so transport-level
+                // connection failures (DNS/TCP/TLS handshake, ISP blocks —
+                // see OPENHUMAN-TAURI-32 for a RU user who couldn't reach
+                // `api.tinyhumans.ai` at all) get logged as warn-level
+                // breadcrumbs instead of error events. Sentry has no signal
+                // to act on these — no status, no trace, no payload — and
+                // every retry exhaustion produces another noisy event.
+                crate::core::observability::report_error_or_expected(
                     detailed.as_str(),
                     "web_channel",
                     "run_chat_task",

--- a/src/openhuman/integrations/client.rs
+++ b/src/openhuman/integrations/client.rs
@@ -101,7 +101,13 @@ impl IntegrationClient {
                     chain.push_str(&s.to_string());
                     src = s.source();
                 }
-                crate::core::observability::report_error(
+                // Use `report_error_or_expected` so transport-level shapes
+                // ("error sending request for url", "tls handshake eof",
+                // "connection refused/reset", …) are classified as
+                // `NetworkUnreachable` and skip Sentry — user-environment
+                // problems (VPN drop, captive portal, ISP block, TLS MITM)
+                // that no retry on our side can resolve (OPENHUMAN-TAURI-2G).
+                crate::core::observability::report_error_or_expected(
                     chain.as_str(),
                     "integrations",
                     "post",
@@ -165,7 +171,11 @@ impl IntegrationClient {
                     chain.push_str(&s.to_string());
                     src = s.source();
                 }
-                crate::core::observability::report_error(
+                // Mirrors the post() transport site — classify reqwest
+                // transport-level failures as NetworkUnreachable so they
+                // skip Sentry. OPENHUMAN-TAURI-2G: TLS handshake EOF
+                // against api.tinyhumans.ai from a SG user.
+                crate::core::observability::report_error_or_expected(
                     chain.as_str(),
                     "integrations",
                     "get",


### PR DESCRIPTION
## Summary

Consolidates three transport-level Sentry-noise fixes (previously split across #1594 + #1601) into a single PR. All three share the same classifier (`ExpectedErrorKind::NetworkUnreachable` / `TransientUpstreamHttp` in `src/core/observability.rs`) and the same call-site pattern (swap `report_error` → `report_error_or_expected` so the classifier picks up the error chain). One review, one merge — no duplicated classifier commits across branches.

### Covers

- **OPENHUMAN-TAURI-32** — `web_channel.run_chat_task` (reqwest transport errors: DNS / TCP / TLS / cert / ISP-block shapes, observed from RU user where `api.tinyhumans.ai` was unreachable). Adds the `NetworkUnreachable` variant + `is_network_unreachable_message` matching 8 transport shapes.
- **OPENHUMAN-TAURI-5Z** — `agent.run_single` aggregate path. Adds the `TransientUpstreamHttp` variant + `is_transient_upstream_http_message` pinned to the `"<provider> API error (<status>"` wire format with `TRANSIENT_PROVIDER_HTTP_STATUSES` (408/429/502/503/504), so it catches per-turn 5xx/429/timeout that has escaped the provider-scoped `before_send` filter under a different `domain` tag.
- **OPENHUMAN-TAURI-2G** — `IntegrationClient::post` and `IntegrationClient::get` (17 events from a SG user, all `tls handshake eof`). Same classifier picks them up.

## Problem

Transport-level reqwest failures fire before any HTTP status is observed. There is no status, no trace, no payload — nothing Sentry can group, facet, or action on. The reliable-provider layer already retries with backoff/fallback; when those exhaust, downstream call sites (`web_channel`, `agent.run_single`, `integrations.{get,post}`) re-emit `report_error` on top of the aggregate event. One user with a flaky connection (VPN drop, captive portal, ISP MITM, transient handshake reset) produces a sustained stream of identical "events" that are pure environmental noise.

The same noise pattern hits the agent layer when transient upstream HTTP statuses (408/429/502/503/504) escape the provider-scoped `before_send` filter under a `domain=agent` tag — handled here by the second classifier variant.

## Solution

`src/core/observability.rs`:
- Add `ExpectedErrorKind::NetworkUnreachable` and `is_network_unreachable_message` matching 8 transport-level shapes (`error sending request for url`, `dns error`, `connection refused`, `connection reset`, `network is unreachable`, `no route to host`, `tls handshake`, `certificate verify failed`).
- Add `ExpectedErrorKind::TransientUpstreamHttp` and `is_transient_upstream_http_message` pinned to the `"<provider> API error (<status>"` wire format from `providers::ops::api_error` for `TRANSIENT_PROVIDER_HTTP_STATUSES` (408/429/502/503/504) — anchored to the `"api error ("` prefix so a free-form mention of "504" elsewhere isn't silenced.
- `report_expected_message` handles both new variants with `tracing::warn!`, so `sentry-tracing` emits a breadcrumb instead of an error event.

`src/openhuman/channels/providers/web.rs`:
- Switch the `run_chat_task` failure site from `report_error` → `report_error_or_expected` so it routes through the classifier.
- The user-facing `chat_error` event is unchanged — still goes through `classify_inference_error`, still emits the sanitized generic message via the existing socket bridge.

`src/openhuman/agent/harness/session/runtime.rs`:
- Switch `Agent::run_single` from `report_error` → `report_error_or_expected`. `Result::Err` return and `DomainEvent::AgentError` publish are unchanged — only the Sentry event is suppressed.

`src/openhuman/integrations/client.rs`:
- Switch `IntegrationClient::post` and `IntegrationClient::get` transport-failure sites from `report_error` → `report_error_or_expected`. Non-2xx and envelope-error paths are unchanged — those are actionable backend failures and should continue to surface.

Status-bearing failures (404 / 500 / etc.) outside the curated transient set are untouched by the new classifier and still surface via their existing paths.

## Submission Checklist

- [x] Tests added or updated — three new unit tests in `core/observability.rs`: `classifies_network_unreachable_errors` (8 transport-level patterns including the literal OPENHUMAN-TAURI-32 / TAURI-2G message bodies), `classifies_transient_upstream_http_errors` (the 5 transient codes against the canonical `"API error (<status>"` wire format), and two regression guards: `does_not_classify_unrelated_provider_errors_as_network` and `does_not_classify_actionable_provider_errors_as_transient_upstream` (locks 404 / 500 outside both classifiers). Existing `start_chat_emits_sanitized_chat_error_on_inference_failure` already drives the new code path end-to-end with the exact `"error sending request for url (…)"` payload and stays green.
- [x] **Diff coverage ≥ 80%** — N/A locally; will run via CI. All new lines in `observability.rs` are covered by the new tests; the one-line call-site swaps in `web.rs`, `runtime.rs`, and `client.rs` are exercised by existing forced-error tests in those modules.
- [x] Coverage matrix updated — N/A: behaviour-only change (Sentry classification, no new user-visible feature row).
- [x] All affected feature IDs listed under `## Related` — see below.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — N/A: change is on the error-reporting side, not a release-cut surface.
- [x] Linked issue — see `## Related`.

## Impact

- **Runtime:** desktop only (web channel, agent harness, and integrations client all run in the core sidecar).
- **Security:** no change. Error text was already redacted via `sanitize_api_error` upstream; this PR only changes the log level / Sentry routing, not the message content.
- **Performance:** negligible — one extra `to_ascii_lowercase` + `contains` lookup per error site that calls `report_error_or_expected`.
- **Migration / compatibility:** none. Existing callers of `report_error` are unaffected.

## Related

- Closes OPENHUMAN-TAURI-32
- Closes OPENHUMAN-TAURI-5Z
- Closes OPENHUMAN-TAURI-2G
- Supersedes #1594 (the network-unreachable classifier + agent runtime switch, now folded in here)
- Prior art: #1575 (param-validation), #1530 (budget-exceeded), #1529 (transient upstream HTTP at provider layer)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issues
- OPENHUMAN-TAURI-32 — https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-32
- OPENHUMAN-TAURI-5Z — https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-5Z
- OPENHUMAN-TAURI-2G — https://tinyhumans.sentry.io/issues/OPENHUMAN-TAURI-2G

### Commit & Branch
- Branch: `fix/integrations-transport-sentry-2g` (based on `origin/main`)
- Commits: `25b1a998` (NetworkUnreachable + web channel) · `c41f8416` (integrations client) · `202a82e3` (TransientUpstreamHttp + agent runtime — cherry-pick from #1594)

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change.
- [x] `pnpm typecheck` — N/A: Rust-only change.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib core::observability::` (15/15 pass on the combined branch).
- [x] Rust fmt/check: `cargo check --manifest-path Cargo.toml` (clean, only pre-existing dead-code warnings).
- [x] Tauri fmt/check: N/A — no `app/src-tauri/` changes.

### Validation Blocked
- `command:` `pnpm pre-push` (lint:commands-tokens / `react-hooks/set-state-in-effect`)
- `error:` regex/lint hits on `src/components/commands/` Tailwind tokens and pre-existing React-hooks warnings in `BootCheckGate.tsx`, `RotatingTetrahedronCanvas.tsx`, `CommandProvider.tsx`, `TriggerToggles.tsx`, `MemoryNavigator.tsx` — unrelated to this PR's Rust-only diff.
- `impact:` Pushed with `--no-verify` per CLAUDE.md guidance for hook failures unrelated to the changes.

### Known CI Failures (pre-existing on `main`)
- `Rust Core Tests + Quality` and `Rust Core Coverage (cargo-llvm-cov)` will be red on this PR with the **same 38 test failures** that also fail on `main` (e.g. main run `25785337660` on commit `de33b129`). Failing tests are concentrated in `openhuman::config::ops::*`, `openhuman::credentials::cli::*`, `openhuman::local_ai::schemas::*`, `openhuman::subconscious::executor::*`, `openhuman::threads::ops::*`, `openhuman::update::ops::*`, plus `core::jsonrpc::tests::thread_not_found_rpc_error_does_not_report_to_sentry` — all infrastructure flakiness from shared global state (`TEST_ENV_LOCK`, sentry hub, tracing subscriber). All 38 pass locally in isolation; specifically `core::jsonrpc::tests::thread_not_found_rpc_error_does_not_report_to_sentry` passes and proves "unrelated RPC errors still reach Sentry" — i.e. the combined classifier does not over-match.

### Behavior Changes
- Intended behavior change: transport-level connection failures and transient upstream HTTP failures (408/429/502/503/504) from `web_channel.run_chat_task`, `agent.run_single`, and `IntegrationClient::{get,post}` no longer create Sentry error events; they emit a `warn`-level breadcrumb instead.
- User-visible effect: none. The on-screen `chat_error` message and integration error surfaces are unchanged.

### Parity Contract
- Legacy behavior preserved: `report_error` continues to emit error events at all other call sites; only `report_error_or_expected` gates on the classifier, and only the new `NetworkUnreachable` / `TransientUpstreamHttp` shapes are added — existing `LocalAiDisabled` / `ApiKeyMissing` behavior is unchanged.
- Guard/fallback/dispatch parity checks: `does_not_classify_unrelated_provider_errors_as_network` and `does_not_classify_actionable_provider_errors_as_transient_upstream` lock 404 / 500 outside the new classifiers.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): #1594 (`fix/observability-network-unreachable-sentry`) — same classifier + web channel + agent runtime changes.
- Canonical PR: this one.
- Resolution: closing #1594 as superseded; its agent-runtime commit (`a21dd58a`) is cherry-picked into this branch as `202a82e3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of transport-level network failures (DNS/TCP/TLS/connectivity) so they’re classified as expected and logged as warnings instead of triggering error events.
  * Updated chat, integration client, and agent runtime reporting to use the new expected-vs-unexpected handling, reducing noisy alerts.

* **Tests**
  * Added unit tests covering multiple network-failure message variants and verifying provider errors remain correctly classified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1601)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
