### PR TITLE
fix(appimage): resolve libcef.so for lib4bin so Linux bundle stops aborting

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -408,6 +408,32 @@ jobs:
           # Inline NODE_OPTIONS so it reaches the vite child spawned by
           # beforeBuildCommand. Step-level env was observed not to propagate
           # on macos-arm64 runners, causing OOM at node's ~2GB auto default.
+          #
+          # Linux AppImage bundler note: the vendored tauri-cef bundler
+          # invokes `quick-sharun.sh`, which runs `lib4bin` → `ldd` on the
+          # staged OpenHuman binary. CEF (libcef.so) is downloaded into
+          # `~/.cache/tauri-cef/<version>/<os-arch>/` at cargo-build time and
+          # copied into the AppDir at usr/lib/libcef.so, but the binary's
+          # RUNPATH does not include either location, so plain `ldd` reports
+          # `libcef.so => not found` and lib4bin aborts with the generic
+          # "is missing libraries! Aborting..." banner. To get past it we:
+          #   1. Run `cargo tauri build --no-bundle` first so the cef-dll-sys
+          #      build script downloads libcef.so into the cache dir.
+          #   2. Re-invoke `cargo tauri build` (incremental — cargo skips the
+          #      already-compiled artifacts) with that cache dir on
+          #      LD_LIBRARY_PATH so the bundler's ldd call resolves libcef.so.
+          # macOS / Windows take the original single-call path.
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            echo "[appimage-fix] linux split build: compile first to fetch CEF"
+            NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build --no-bundle $PROFILE_FLAG -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
+            CEF_LIB_DIR="$(find "$HOME/.cache/tauri-cef" -name libcef.so -printf '%h\n' 2>/dev/null | head -1)"
+            if [ -z "$CEF_LIB_DIR" ]; then
+              echo "::error::libcef.so not found under ~/.cache/tauri-cef after --no-bundle compile; cannot satisfy lib4bin ldd resolution." >&2
+              exit 1
+            fi
+            echo "[appimage-fix] prepending CEF lib dir to LD_LIBRARY_PATH: $CEF_LIB_DIR"
+            export LD_LIBRARY_PATH="$CEF_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          fi
           NODE_OPTIONS="--max-old-space-size=8192" cargo tauri build $PROFILE_FLAG -c "$TAURI_CONFIG_OVERRIDE" $MATRIX_ARGS
 
       # Diagnostic for the recurring quick-sharun "is missing libraries!


### PR DESCRIPTION
## Summary

Linux staging build keeps aborting at the AppImage bundler with quick-sharun's generic banner:

    OpenHuman is missing libraries! Aborting...

The post-build ldd diagnostic added in #1591 ran on the latest failing job (https://github.com/tinyhumansai/openhuman/actions/runs/25785303625/job/75737262316) and narrowed the culprit to a single unresolved symbol:

    libcef.so => not found

## Why this happens

The vendored tauri-cef bundler (\`app/src-tauri/vendor/tauri-cef/.../sharun_cef.rs\`) copies \`libcef.so\` into the staged AppDir at \`usr/lib/libcef.so\` and downloads the CEF distribution into \`~/.cache/tauri-cef/<version>/<os-arch>/\` at build time. But the OpenHuman binary's \`DT_RUNPATH\` does **not** point at either location, so when \`lib4bin\` runs \`ldd\` against the staged binary to discover transitive libraries, \`libcef.so\` is unresolved on the loader's default search path. lib4bin then aborts before it has a chance to copy CEF into the sharun bundle — which is why the banner says "missing libraries" even though \`libcef.so\` is physically present in the AppDir.

## Fix

Linux-only change to the \`Build and package Tauri app\` step:

1. Run \`cargo tauri build --no-bundle\` first so the cef-dll-sys build script populates \`~/.cache/tauri-cef/\`.
2. \`find\` the CEF lib dir and prepend it to \`LD_LIBRARY_PATH\`.
3. Re-invoke \`cargo tauri build\` (incremental — cargo's target dir is warm, no recompile) so the bundler's \`ldd\` resolves \`libcef.so\`.

macOS and Windows matrix entries keep the original single-call path.

Failing job for reference: https://github.com/tinyhumansai/openhuman/actions/runs/25785303625/job/75737262316

## Test plan

- [ ] Re-run \`release-staging.yml\` against this branch; Linux matrix entry produces both \`.deb\` and \`.AppImage\` artifacts
- [ ] macOS + Windows matrix entries are unaffected (their build command is untouched)
- [ ] The post-build ldd diagnostic from #1591 either reports \`(all resolved)\` or, if a different lib regresses, names it so we can iterate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Linux AppImage build process to ensure proper dependency resolution during compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1602)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->