### PR TITLE
docs: clarify contributor setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **AI-powered assistant for communities — React + Tauri v2 desktop app with a Rust core (JSON-RPC / CLI) and sandboxed QuickJS skills.**
 
-This file orients contributors and coding agents. Authoritative narrative architecture: [`gitbooks/developing/architecture.md`](gitbooks/developing/architecture.md). Frontend layout: [`gitbooks/developing/frontend.md`](gitbooks/developing/frontend.md). Tauri shell: [`gitbooks/developing/tauri-shell.md`](gitbooks/developing/tauri-shell.md).
+This file orients contributors and coding agents. Authoritative narrative architecture: [`gitbooks/developing/architecture.md`](gitbooks/developing/architecture.md). Frontend layout: [`gitbooks/developing/architecture/frontend.md`](gitbooks/developing/architecture/frontend.md). Tauri shell: [`gitbooks/developing/architecture/tauri-shell.md`](gitbooks/developing/architecture/tauri-shell.md).
 
 ---
 
@@ -292,7 +292,7 @@ Bundled prompts live under **`src/openhuman/agent/prompts/`** at the **repositor
 
 Thin desktop host: window management, daemon health bridging, **core process lifecycle** (`core_process`, `CoreProcessHandle`), and **JSON-RPC relay** to the **`openhuman-core`** sidecar (`core_rpc_relay`, `core_rpc`).
 
-Registered IPC commands (see [`gitbooks/developing/tauri-shell.md`](gitbooks/developing/tauri-shell.md)) include **`greet`**, **`write_ai_config_file`**, **`ai_get_config`**, **`ai_refresh_config`**, **`core_rpc_relay`**, **window** commands, and **OpenHuman service / daemon host** helpers (`openhuman_*`).
+Registered IPC commands (see [`gitbooks/developing/architecture/tauri-shell.md`](gitbooks/developing/architecture/tauri-shell.md)) include **`greet`**, **`write_ai_config_file`**, **`ai_get_config`**, **`ai_refresh_config`**, **`core_rpc_relay`**, **window** commands, and **OpenHuman service / daemon host** helpers (`openhuman_*`).
 
 Deep link plugin is registered where supported; behavior is platform-specific (see platform notes below).
 
@@ -455,7 +455,7 @@ let resp: BillingChargeResponse = request_native_global(
 
 ## App theme & design system
 
-**Design intent**: Premium, calm visual language — ocean primary (`#4A83DD`), sage / amber / coral semantic colors, Inter + Cabinet Grotesk + JetBrains Mono, Tailwind with custom radii/spacing/shadows. Details: [`gitbooks/resources/design-language.md`](gitbooks/resources/design-language.md).
+**Design intent**: Premium, calm visual language — ocean primary (`#4A83DD`), sage / amber / coral semantic colors, Inter + Cabinet Grotesk + JetBrains Mono, Tailwind with custom radii/spacing/shadows. Implementation tokens live in [`app/tailwind.config.js`](app/tailwind.config.js).
 
 ## Desktop shell (Tauri) vs application code
 
@@ -522,7 +522,7 @@ Follow this order so behavior is **specified**, **proven in Rust**, **proven ove
 
 ## Platform notes
 
-- **macOS deep links**: Often require a built **`.app`** bundle; not only `tauri dev`. See [`docs/telegram-login-desktop.md`](docs/telegram-login-desktop.md) if applicable.
+- **macOS deep links**: Often require a built **`.app`** bundle; not only `tauri dev`.
 - **`window.__TAURI__`**: Not assumed at module load; guard Tauri usage accordingly.
 - **Core sidecar**: Must be staged/built so `core_rpc` can reach the `openhuman-core` binary (see `scripts/stage-core-sidecar.mjs`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **AI assistant for communities — React + Tauri v2 desktop app with a Rust core (JSON-RPC / CLI).**
 
-Narrative architecture: [`gitbooks/developing/architecture.md`](gitbooks/developing/architecture.md). Frontend: [`gitbooks/developing/frontend.md`](gitbooks/developing/frontend.md). Tauri shell: [`gitbooks/developing/tauri-shell.md`](gitbooks/developing/tauri-shell.md). Coding-harness tool surface: [`gitbooks/developing/coding-harness.md`](gitbooks/developing/coding-harness.md).
+Narrative architecture: [`gitbooks/developing/architecture.md`](gitbooks/developing/architecture.md). Frontend: [`gitbooks/developing/architecture/frontend.md`](gitbooks/developing/architecture/frontend.md). Tauri shell: [`gitbooks/developing/architecture/tauri-shell.md`](gitbooks/developing/architecture/tauri-shell.md). Agent-harness tool surface: [`gitbooks/developing/architecture/agent-harness.md`](gitbooks/developing/architecture/agent-harness.md).
 
 ---
 
@@ -165,7 +165,7 @@ bash scripts/test-rust-with-mock.sh --test json_rpc_e2e
 
 Thin desktop host: window management, daemon health, **core process lifecycle** (`core_process`, `CoreProcessHandle`), **JSON-RPC relay** (`core_rpc_relay`, `core_rpc`).
 
-Registered IPC (see [`gitbooks/developing/tauri-shell.md`](gitbooks/developing/tauri-shell.md)): `greet`, `write_ai_config_file`, `ai_get_config`, `ai_refresh_config`, `core_rpc_relay`, window commands, `openhuman_*` daemon helpers.
+Registered IPC (see [`gitbooks/developing/architecture/tauri-shell.md`](gitbooks/developing/architecture/tauri-shell.md)): `greet`, `write_ai_config_file`, `ai_get_config`, `ai_refresh_config`, `core_rpc_relay`, window commands, `openhuman_*` daemon helpers.
 
 ### CEF child webviews — no new JS injection
 
@@ -233,7 +233,7 @@ Each domain owns a `bus.rs` with its `EventHandler` impls — e.g. `cron/bus.rs`
 
 ## Design
 
-Premium, calm visual language — ocean primary `#4A83DD`, sage / amber / coral semantics, Inter + Cabinet Grotesk + JetBrains Mono, Tailwind with custom radii/spacing/shadows. See [`gitbooks/resources/design-language.md`](gitbooks/resources/design-language.md).
+Premium, calm visual language — ocean primary `#4A83DD`, sage / amber / coral semantics, Inter + Cabinet Grotesk + JetBrains Mono, Tailwind with custom radii/spacing/shadows. Implementation tokens live in [`app/tailwind.config.js`](app/tailwind.config.js).
 
 ## Shell vs app code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 | Node.js | `>=24.0.0` from [`app/package.json`](app/package.json) | Install the current Node 24 release or newer. |
 | pnpm | `pnpm@10.10.0` from [`package.json`](package.json) | The repo enforces pnpm via the root `packageManager` field. |
 | Rust | `1.93.0` from [`rust-toolchain.toml`](rust-toolchain.toml) | Install with `rustup`; `rustfmt` and `clippy` are required components. |
+| CMake | Current stable | Required by native Rust dependencies such as Whisper bindings. |
 | Tauri vendored sources | Git submodules under `app/src-tauri/vendor/` | Required for the CEF-aware Tauri CLI and notification plugin patches. |
 | macOS tools | Xcode Command Line Tools | Needed for local desktop builds on macOS. |
 | Linux desktop packages | System GTK/WebKit/AppIndicator build deps | Install the package set Tauri requires for your distro before attempting desktop builds. |
@@ -46,6 +47,14 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 - **Desktop development** needs the vendored Tauri/CEF setup. The preferred entrypoint is `pnpm --filter openhuman-app dev:app`, which ensures the vendored Tauri CLI is installed and configures `CEF_PATH`.
 - **Linux desktop builds** require extra system packages beyond Node/Rust. Follow the distro-specific Tauri dependency list before running desktop commands, then use the OpenHuman scripts below. For deeper platform troubleshooting, see [`gitbooks/developing/getting-set-up.md`](gitbooks/developing/getting-set-up.md).
 - **Skills development** happens in the separate [`tinyhumansai/openhuman-skills`](https://github.com/tinyhumansai/openhuman-skills) repository. This repo consumes built skill bundles from GitHub or a local override path; it does not vendor the skills source as a submodule.
+
+Example macOS bootstrap with Homebrew:
+
+```bash
+brew install node@24 pnpm rustup-init cmake
+rustup toolchain install 1.93.0 --profile minimal
+rustup component add rustfmt clippy --toolchain 1.93.0
+```
 
 ### 2. Clone and install
 
@@ -161,8 +170,8 @@ Useful local paths during development:
 Most contributor-visible configuration and state flows are documented in:
 
 - [`gitbooks/developing/getting-set-up.md`](gitbooks/developing/getting-set-up.md)
-- [`gitbooks/developing/frontend.md`](gitbooks/developing/frontend.md)
-- [`gitbooks/developing/tauri-shell.md`](gitbooks/developing/tauri-shell.md)
+- [`gitbooks/developing/architecture/frontend.md`](gitbooks/developing/architecture/frontend.md)
+- [`gitbooks/developing/architecture/tauri-shell.md`](gitbooks/developing/architecture/tauri-shell.md)
 
 ## Project Layout
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@ OpenHuman is an open-source agentic assistant designed to integrate with you in 
 
 - **[Messaging channels](https://tinyhumans.gitbook.io/openhuman/features/integrations#messaging-channels)** and **[privacy & security](https://tinyhumans.gitbook.io/openhuman/features/privacy-and-security)**: inbound/outbound across the channels you already use, with workflow data that stays on device, encrypted locally, treated as yours.
 
-For contributors: Read the [Architecture](https://tinyhumans.gitbook.io/openhuman/developing/architecture) · [Getting Set Up](https://tinyhumans.gitbook.io/openhuman/developing/getting-set-up) · [Cloud Deploy](https://tinyhumans.gitbook.io/openhuman/developing/cloud-deploy) · [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+## Contributing from source
+
+New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands. The short path is:
+
+1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, and the platform desktop build prerequisites.
+2. Fork and clone the repo, then run `git submodule update --init --recursive` before `pnpm install` so the vendored Tauri/CEF sources are present.
+3. Use `pnpm dev` for web-only UI work, `pnpm --filter openhuman-app dev:app` for the desktop shell, and focused checks such as `pnpm typecheck`, `pnpm format:check`, and `cargo check -p openhuman --lib` before opening a PR.
+
+Deeper docs: [Architecture](https://tinyhumans.gitbook.io/openhuman/developing/architecture) · [Getting Set Up](https://tinyhumans.gitbook.io/openhuman/developing/getting-set-up) · [Cloud Deploy](./gitbooks/features/cloud-deploy.md).
 
 ## Context in minutes, not weeks
 

--- a/gitbooks/developing/README.md
+++ b/gitbooks/developing/README.md
@@ -56,7 +56,7 @@ PRs must clear the **≥ 80% coverage on changed lines** gate. Add tests for new
 
 ## Going deeper
 
-* [**Coding Harness**](/broken/pages/RRYmjibvEbtqRSPntgPX). The agent's code-focused tool surface and how to extend it.
+* [**Agent Harness**](architecture/agent-harness.md). The agent's code-focused tool surface and how to extend it.
 * [**Chromium Embedded Framework**](cef.md). How embedded provider webviews work, why they don't run injected JS, and what the per-provider scanners do instead.
 
 For features still being built, the [Subconscious Loop](../features/subconscious.md) page covers the background task evaluation system end-to-end.

--- a/gitbooks/developing/getting-set-up.md
+++ b/gitbooks/developing/getting-set-up.md
@@ -17,8 +17,20 @@ This guide covers two paths:
 ## Prerequisites
 
 - `git`
-- `node` + `pnpm` (see `pnpm-workspace.yaml`)
-- Rust toolchain (see `rust-toolchain.toml`)
+- Node.js 24 or newer (see `app/package.json`)
+- `pnpm@10.10.0` (see the root `package.json` `packageManager` field)
+- Rust 1.93.0 through `rustup` with `rustfmt` and `clippy` (see `rust-toolchain.toml`)
+- CMake, required by native Rust dependencies
+- Git submodules under `app/src-tauri/vendor/`, required for the vendored CEF-aware Tauri CLI
+- Platform desktop build tools: Xcode Command Line Tools on macOS, or the Tauri GTK/WebKit/AppIndicator package set on Linux
+
+macOS Homebrew quick start:
+
+```bash
+brew install node@24 pnpm rustup-init cmake
+rustup toolchain install 1.93.0 --profile minimal
+rustup component add rustfmt clippy --toolchain 1.93.0
+```
 
 ## Build from source (local compile)
 
@@ -29,24 +41,31 @@ Run from the repository root:
 git clone https://github.com/tinyhumansai/openhuman.git
 cd openhuman
 
-# 2) Install JS deps (workspace)
+# 2) Fetch vendored Tauri/CEF sources
+git submodule update --init --recursive
+
+# 3) Install JS deps (workspace)
 pnpm install
 
-# 3) Build Rust core binary
+# 4) Build Rust core binary
 cargo build --manifest-path Cargo.toml --bin openhuman-core
 
-# 4) Stage core sidecar for the desktop app
+# 5) Run the desktop staging hook (currently a no-op; kept for script compatibility)
 cd app
 pnpm core:stage
 
-# 5) Build desktop app artifacts
+# 6) Build desktop app artifacts
 pnpm build
 ```
 
 For local development instead of production build:
 
 ```bash
+# Web-only UI development
 pnpm dev
+
+# Desktop app development with the vendored Tauri/CEF CLI
+pnpm --filter openhuman-app dev:app
 ```
 
 ## Install latest stable release (macOS/Linux x64)

--- a/gitbooks/developing/getting-set-up.md
+++ b/gitbooks/developing/getting-set-up.md
@@ -61,10 +61,11 @@ pnpm build
 For local development instead of production build:
 
 ```bash
-# Web-only UI development
+# Web-only UI development: run inside app/ after the `cd app` step above
 pnpm dev
 
-# Desktop app development with the vendored Tauri/CEF CLI
+# Desktop app development with the vendored Tauri/CEF CLI: run from the workspace root
+cd ..
 pnpm --filter openhuman-app dev:app
 ```
 


### PR DESCRIPTION
## Summary

- Adds a README contributor-from-source quick start for first-time setup.
- Documents required Node, pnpm, Rust, CMake, submodule, and platform build prerequisites in contributor docs.
- Adds a macOS Homebrew bootstrap example and clearer source-build steps.
- Fixes stale contributor/agent documentation links to the current architecture pages.

## Problem

Issue #1600 notes that first-time contributor setup docs are too sparse. The current docs did not call out CMake, submodules, the pinned toolchain versions, or the preferred desktop dev command clearly enough, and several internal contributor links pointed at moved or missing pages.

## Solution

- Clarified the source setup path in `README.md`, `CONTRIBUTING.md`, and `gitbooks/developing/getting-set-up.md`.
- Added CMake and vendored Tauri/CEF submodules to the prerequisites so native Rust and desktop builds do not fail unexpectedly.
- Updated moved links from `gitbooks/developing/{frontend,tauri-shell}.md` to `gitbooks/developing/architecture/{frontend,tauri-shell}.md` and replaced a broken GitBook placeholder link with the agent harness page.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — N/A: documentation-only contributor setup/link update.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. — N/A: documentation-only change with no executable coverage surface.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — N/A: no feature row changed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no affected feature IDs.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: contributor docs only, not a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: none; documentation only.
- Security/performance/migration impact: none.
- Contributor impact: clearer local setup path and fewer broken links for new contributors and coding agents.

## Related

- Closes #1600
- Follow-up PR(s)/TODOs: #1595 UTF-8 body preview panic fix will be handled separately.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A — GitHub issue only.
- URL: N/A — GitHub issue only.

### Commit & Branch
- Branch: docs/contributor-setup-env
- Commit SHA: fb23a80e1e01522d192f0ea4230d240f7379180d

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `python3` local markdown link checker over README/CONTRIBUTING/AGENTS/CLAUDE and `gitbooks/developing/**/*.md` (`TOTAL_MISSING=0`)
- [x] Rust fmt/check (if changed): `pnpm --filter openhuman-app format:check` includes `cargo fmt --manifest-path ../Cargo.toml --all --check`; no Rust code changed.
- [x] Tauri fmt/check (if changed): `pnpm --filter openhuman-app format:check` includes `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check`; no Tauri code changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: No runtime behavior change; docs only.
- User-visible effect: New contributors see clearer setup and link guidance.

### Parity Contract
- Legacy behavior preserved: N/A — docs only.
- Guard/fallback/dispatch parity checks: N/A — docs only.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor docs to point to the revised architecture and agent-harness/tauri-shell locations
  * Pointed design token guidance to the in-repo Tailwind config
  * Clarified prerequisites and pinned versions (Node 24+, pnpm 10.10.0, Rust 1.93.0); added CMake requirement
  * Added macOS Homebrew bootstrap examples and expanded local build/dev setup with explicit submodule, build, and run steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1618)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->