### PR TITLE
fix(release): fetch draft release by id so validation stops 404-ing

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -578,9 +578,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare-build.outputs.tag }}
+          RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
         run: |
           set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" > /tmp/openhuman-release.json
+          # Fetch the release by id, not by tag: at this point the release is
+          # still a draft, and `GET /releases/tags/{tag}` returns 404 for
+          # drafts. The id-keyed endpoint works for drafts and published
+          # releases alike.
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > /tmp/openhuman-release.json
           gh release download "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --pattern latest.json \

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ dist-web
 .env.local
 .env.*.local
 
+# pnpm local store (created when --store-dir points into the repo)
+.pnpm-store/
+
+# E2E test artifacts (screenshots, logs, traces — never checked in)
+app/test/e2e/artifacts/
+
 my_docs
 
 # Local prompt dumps written by `scripts/debug-agent-prompts.sh`.


### PR DESCRIPTION
## Summary

- Production release validation step (`Validate release assets match latest.json` in `release-production.yml`) was 404-ing on every run because it called `gh api repos/.../releases/tags/${TAG}` against a release that is still a draft at that point in the workflow.
- The REST endpoint `GET /releases/tags/{tag}` only resolves *published* releases — drafts return 404. Reproduced on v0.53.35 ([job 75761536614](https://github.com/tinyhumansai/openhuman/actions/runs/25790064604/job/75761536614)).
- Switch the fetch to the id-keyed endpoint using the `release_id` already exposed by the `create-release` job, which works for both drafts and published releases.
- Also gitignore `.pnpm-store/` and `app/test/e2e/artifacts/` so they stop showing up in `git status` for local dev.

## Problem

The `publish-release` job runs *before* the draft is flipped to published (it's the job that flips it). Validation inside that job needs to read the release metadata, but does so via the tag-keyed endpoint:

```
gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
# -> gh: Not Found (HTTP 404)
```

This means production release runs have been failing the validation gate even when all assets are present and correct. The `latest.json` download still works because `gh release download --pattern` (a GitHub CLI command, not the raw REST tag endpoint) does resolve drafts by tag.

## Solution

Plumb `needs.create-release.outputs.release_id` (already declared by the `create-release` job) into the validation step as `RELEASE_ID` and hit the id-keyed endpoint:

```
gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"
```

That endpoint returns draft releases too. The `gh release download` line is left alone. The `scripts/validate-release-assets.sh` script consumes the same shape of payload, so no script changes are needed.

A short comment is added explaining *why* the id-keyed endpoint is used so the next person who sees it doesn't reintroduce the tag form.

## Submission Checklist

- [x] N/A: workflow + .gitignore only — no Rust/TS behavior to test.
- [x] N/A: no production code lines changed, only a CI YAML and gitignore patterns; `diff-cover` gate doesn't apply.
- [x] N/A: no feature surface added/removed/renamed.
- [x] N/A: no feature IDs touched.
- [x] N/A: no new network dependencies; same gh API surface, different endpoint shape.
- [x] N/A: not a release-cut UX surface — this *fixes* the release-cut automation.
- [x] N/A: no linked issue; bug observed directly in v0.53.35 production release run.

## Impact

- **Runtime**: none — CI-only change.
- **Release pipeline**: unblocks the production release validation step so future cuts can pass through to the publish step.
- **Security/migration/compat**: none.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/release-validate-draft-404`
- Commit SHA: `a1509675a46a8af281e01f6eda55466d8baa70a5`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (ran via pre-push hook)
- [x] `pnpm typecheck` (ran via pre-push hook)
- [x] N/A: Focused tests — workflow YAML / gitignore only
- [x] N/A: Rust fmt/check — no Rust changes
- [x] N/A: Tauri fmt/check — no Tauri changes

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: release-production.yml validation step uses the release id endpoint instead of the tag endpoint, fixing 404s against draft releases.
- User-visible effect: production releases can now pass the validation gate and proceed to publish.

### Parity Contract
- Legacy behavior preserved: the validator script and `gh release download` call are unchanged; only the source of `release.json` shifts to an endpoint that also covers drafts.
- Guard/fallback/dispatch parity checks: the `create-release` job already publishes `release_id` and is a hard `needs:` dependency of `publish-release`, so the new env var is always defined.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this one
- Resolution: N/A