### PR TITLE
fix(si_server): skip Sentry for benign "session already active" start_session race (OPENHUMAN-TAURI-5H)

### DIFF
--- a/src/openhuman/screen_intelligence/server.rs
+++ b/src/openhuman/screen_intelligence/server.rs
@@ -156,7 +156,7 @@ impl SiServer {
                 );
             }
             Err(e) => {
-                if is_expected_macos_only_failure(&e) {
+                if is_expected_benign_start_session_failure(&e) {
                     info!("{LOG_PREFIX} failed to start session: {e}");
                 } else {
                     error!("{LOG_PREFIX} failed to start session: {e}");
@@ -363,7 +363,7 @@ pub async fn start_if_enabled(app_config: &Config) {
 
     tokio::spawn(async move {
         if let Err(e) = server.run(&config_for_run).await {
-            if is_expected_macos_only_failure(&e) {
+            if is_expected_benign_start_session_failure(&e) {
                 info!("{LOG_PREFIX} embedded server autostart skipped: {e}");
             } else {
                 error!("{LOG_PREFIX} embedded server exited with error: {e}");
@@ -380,6 +380,32 @@ pub async fn start_if_enabled(app_config: &Config) {
 /// `server.run` future.
 fn is_expected_macos_only_failure(err: &str) -> bool {
     !cfg!(target_os = "macos") && err.contains("macOS-only")
+}
+
+/// True when an engine-side `start_session` error is a benign idempotency
+/// signal — the engine already has a live session, so the embedded server's
+/// own `start_session` call is a duplicate, not a failure. Canonical wire
+/// shape from `engine::start_session`:
+///
+///     "session already active"
+///
+/// Reaches the server when the engine session was created via a different
+/// entry point before the embedded `run()` got there — typically
+/// `screen_intelligence.enable` invoked over RPC, or a prior `run()` cycle
+/// that left the engine session in place across a server restart
+/// (OPENHUMAN-TAURI-5H). The session is *running*, so the right behaviour
+/// is to step aside, not log an error event to Sentry.
+fn is_expected_session_already_active_failure(err: &str) -> bool {
+    err.contains("session already active")
+}
+
+/// Union of the two known-benign `start_session` failure shapes (`macOS-only`
+/// on non-macOS hosts and `session already active`). Use this at every site
+/// that decides between `info!` and `error!` for a `SiServer::run` failure —
+/// keeps the two classifiers in lockstep across `SiServer::run` itself and
+/// `start_if_enabled`'s spawned future.
+fn is_expected_benign_start_session_failure(err: &str) -> bool {
+    is_expected_macos_only_failure(err) || is_expected_session_already_active_failure(err)
 }
 
 /// Run the screen intelligence server standalone (blocking). Intended for CLI usage.
@@ -520,6 +546,51 @@ mod tests {
             assert!(!is_expected_macos_only_failure(macos_marker));
             assert!(!is_expected_macos_only_failure(other_error));
         }
+    }
+
+    #[test]
+    fn is_expected_session_already_active_failure_classifies_known_signal() {
+        // OPENHUMAN-TAURI-5H: the canonical wire shape returned by
+        // `engine::start_session` when the engine already has a live
+        // session. Must classify on every platform — the duplicate is
+        // benign idempotency regardless of host OS.
+        assert!(is_expected_session_already_active_failure(
+            "session already active"
+        ));
+        // Substring match so wrapped / prefixed forms still classify.
+        assert!(is_expected_session_already_active_failure(
+            "screen intelligence: session already active"
+        ));
+        // Unrelated session-domain errors must NOT classify — they're real
+        // failures that should still surface as Sentry events.
+        assert!(!is_expected_session_already_active_failure(
+            "accessibility permission is not granted"
+        ));
+        assert!(!is_expected_session_already_active_failure(
+            "session start failed: io error: broken pipe"
+        ));
+    }
+
+    #[test]
+    fn is_expected_benign_start_session_failure_is_union_of_classifiers() {
+        // The union helper is what every call site (`SiServer::run`,
+        // `start_if_enabled`'s spawned future) consumes. It must return
+        // `true` for either known-benign shape and `false` for genuine
+        // engine failures.
+        assert!(is_expected_benign_start_session_failure(
+            "session already active"
+        ));
+        assert!(!is_expected_benign_start_session_failure(
+            "accessibility permission is not granted"
+        ));
+        assert!(!is_expected_benign_start_session_failure(
+            "screen recording permission is not granted"
+        ));
+
+        #[cfg(not(target_os = "macos"))]
+        assert!(is_expected_benign_start_session_failure(
+            "accessibility automation is macOS-only in V1"
+        ));
     }
 
     #[tokio::test]

--- a/src/openhuman/screen_intelligence/server.rs
+++ b/src/openhuman/screen_intelligence/server.rs
@@ -387,7 +387,9 @@ fn is_expected_macos_only_failure(err: &str) -> bool {
 /// own `start_session` call is a duplicate, not a failure. Canonical wire
 /// shape from `engine::start_session`:
 ///
-///     "session already active"
+/// ```text
+/// "session already active"
+/// ```
 ///
 /// Reaches the server when the engine session was created via a different
 /// entry point before the embedded `run()` got there — typically


### PR DESCRIPTION
## Summary

- Extends the SI server's `start_session` error classifier with a new sibling, `is_expected_session_already_active_failure`, plus a union helper `is_expected_benign_start_session_failure`.
- Both `SiServer::run` (start_session error arm) and `start_if_enabled`'s spawned future now consume the union helper, so duplicate `start_session` calls log at `info!` instead of `error!` — sentry-tracing records at most a breadcrumb.

Fixes OPENHUMAN-TAURI-5H (16 macOS occurrences in 4 days on `openhuman@0.53.22`).

## Why this is benign, not a failure

`engine::start_session` returns `"session already active"` ([`engine.rs:107`](src/openhuman/screen_intelligence/engine.rs#L107)) when the engine already has a live session. This happens at the embedded server entry point when something else got there first:

- `screen_intelligence.enable` invoked over RPC (UI/onboarding flow) before the embedded `run()` reached its own `start_session`, or
- A prior `run()` cycle left the engine session in place across a server restart.

The session is *running*. The embedded server's `start_session` is a duplicate, not a real failure — there's no remediable Sentry signal.

## Why introduce a union helper instead of inlining

The classifier sits at two call sites today (`SiServer::run`, `start_if_enabled`). A union helper keeps the log-level decision in lockstep across both — same pattern as PR #1542 (`is_expected_macos_only_failure`).

## Test plan

- [x] `cargo test --lib openhuman::screen_intelligence::server` — 9 tests pass.
- [x] `is_expected_session_already_active_failure_classifies_known_signal` covers the bare wire shape, a wrapped/prefixed form, and pins unrelated session-domain failures (permission errors, IO errors) so they still surface as Sentry events.
- [x] `is_expected_benign_start_session_failure_is_union_of_classifiers` pins the union helper's contract against both known-benign shapes.
- [x] `cargo check --lib` — no new warnings.
- [x] `cargo fmt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Screen intelligence server now treats duplicate session start attempts (a known benign condition) as non-fatal and logs them at info level instead of failing.
  * Error logging improved to distinguish benign start-session failures from critical errors.

* **Tests**
  * Added unit tests covering duplicate session detection and the combined error-classification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1625)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->