### PR TITLE
fix(onboarding): disable unreliable Apify LinkedIn scrape during profile build

### DIFF
--- a/app/src/pages/onboarding/steps/ContextGatheringStep.tsx
+++ b/app/src/pages/onboarding/steps/ContextGatheringStep.tsx
@@ -5,9 +5,8 @@
  *
  *   1. Composio Gmail search (`tools_composio_execute` -> `GMAIL_FETCH_EMAILS`)
  *      to find a LinkedIn profile URL in the user's recent mail.
- *   2. Apify LinkedIn scrape (`tools_apify_linkedin_scrape`) to pull a
- *      structured public profile snapshot and render it as markdown.
- *   3. Persist the assembled markdown via `learning_save_profile` with
+ *   2. Apify LinkedIn scrape — disabled (unreliable); stage is skipped.
+ *   3. Persist a URL-only markdown via `learning_save_profile` with
  *      `summarize=true` so the core LLM compresses it into PROFILE.md.
  *
  * External calls still go through core (auth, proxy, billing). Only the
@@ -138,16 +137,6 @@ async function findLinkedInUrlViaComposio(): Promise<string | null> {
   return null;
 }
 
-async function apifyScrapeLinkedIn(profileUrl: string): Promise<string> {
-  console.debug('[onboarding:context] apify_linkedin_scrape', { profileUrl });
-  const raw = await callCoreRpc<unknown>({
-    method: 'openhuman.tools_apify_linkedin_scrape',
-    params: { profile_url: profileUrl },
-  });
-  const result = unwrapCliEnvelope<{ data: unknown; markdown: string }>(raw);
-  return result.markdown ?? '';
-}
-
 async function saveProfile(markdown: string): Promise<void> {
   await callCoreRpc<unknown>({
     method: 'openhuman.learning_save_profile',
@@ -224,27 +213,10 @@ const ContextGatheringStep = ({
       return;
     }
 
-    // Stage 2 — Apify LinkedIn scrape
-    const scrapeStartedAt = stageNow();
-    setStage('linkedin-scrape', 'active');
-    let scrapedMarkdown = '';
-    try {
-      scrapedMarkdown = await apifyScrapeLinkedIn(profileUrl);
-      setStage(
-        'linkedin-scrape',
-        scrapedMarkdown.trim() ? 'done' : 'skipped',
-        durationMs(scrapeStartedAt),
-        scrapedMarkdown.trim() ? undefined : 'empty_markdown'
-      );
-    } catch (e) {
-      const reason = errorReason(e);
-      console.warn('[onboarding:context] apify_linkedin_scrape stage failed', {
-        durationMs: durationMs(scrapeStartedAt),
-        reason,
-      });
-      setStage('linkedin-scrape', 'error', durationMs(scrapeStartedAt), reason);
-      // Continue — save_profile can still write a URL-only file.
-    }
+    // Stage 2 — Apify LinkedIn scrape (disabled: unreliable, skipped during
+    // profile build). PROFILE.md is built URL-only from stage 3.
+    setStage('linkedin-scrape', 'skipped', 0, 'apify_disabled');
+    const scrapedMarkdown = '';
 
     // Stage 3 — summarize + persist via core LLM compressor
     const profileStartedAt = stageNow();

--- a/app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx
@@ -57,7 +57,7 @@ describe('ContextGatheringStep', () => {
     });
   });
 
-  it('runs the full Gmail -> Apify scrape -> save pipeline and auto-navigates', async () => {
+  it('runs Gmail -> save pipeline with Apify disabled and auto-navigates', async () => {
     const onNext = vi.fn().mockResolvedValue(undefined);
     callCoreRpc.mockImplementation(async (req: { method: string; params: unknown }) => {
       if (req.method === 'openhuman.tools_composio_execute') {
@@ -68,12 +68,6 @@ describe('ContextGatheringStep', () => {
               { messageText: 'Visit https://www.linkedin.com/comm/in/jane-doe?foo=bar to view.' },
             ],
           },
-        };
-      }
-      if (req.method === 'openhuman.tools_apify_linkedin_scrape') {
-        return {
-          data: { name: 'Jane Doe', headline: 'Founder at Acme' },
-          markdown: '# Jane Doe\n\nFounder at Acme. Based in Berlin.',
         };
       }
       if (req.method === 'openhuman.learning_save_profile') {
@@ -89,24 +83,15 @@ describe('ContextGatheringStep', () => {
     await waitFor(() => expect(onNext).toHaveBeenCalled(), { timeout: 5000 });
 
     const calls = callCoreRpc.mock.calls.map((c: Array<{ method: string }>) => c[0].method);
-    expect(calls).toEqual([
-      'openhuman.tools_composio_execute',
-      'openhuman.tools_apify_linkedin_scrape',
-      'openhuman.learning_save_profile',
-    ]);
-
-    const scrapeCall = callCoreRpc.mock.calls.find(
-      (c: Array<{ method: string }>) => c[0].method === 'openhuman.tools_apify_linkedin_scrape'
-    );
-    expect((scrapeCall![0].params as { profile_url: string }).profile_url).toBe(
-      'https://www.linkedin.com/in/jane-doe'
-    );
+    expect(calls).toEqual(['openhuman.tools_composio_execute', 'openhuman.learning_save_profile']);
+    // Apify scrape must not be called — it is disabled during profile build.
+    expect(calls).not.toContain('openhuman.tools_apify_linkedin_scrape');
 
     const saveCall = callCoreRpc.mock.calls.find(
       (c: Array<{ method: string }>) => c[0].method === 'openhuman.learning_save_profile'
     );
     expect(saveCall![0].params.summarize).toBe(true);
-    expect(saveCall![0].params.markdown).toContain('Founder at Acme');
+    expect(saveCall![0].params.markdown).toContain('https://www.linkedin.com/in/jane-doe');
   });
 
   it('skips downstream stages when Gmail finds no LinkedIn URL and auto-navigates', async () => {
@@ -187,7 +172,6 @@ describe('ContextGatheringStep', () => {
     });
 
     it('pipeline saves profile even after user continues and component unmounts', async () => {
-      let resolveScrape!: (v: unknown) => void;
       let resolveSave!: (v: unknown) => void;
 
       callCoreRpc.mockImplementation(async (req: { method: string }) => {
@@ -196,11 +180,6 @@ describe('ContextGatheringStep', () => {
             successful: true,
             data: { messages: [{ messageText: 'https://www.linkedin.com/in/test-user' }] },
           };
-        }
-        if (req.method === 'openhuman.tools_apify_linkedin_scrape') {
-          return new Promise(res => {
-            resolveScrape = res;
-          });
         }
         if (req.method === 'openhuman.learning_save_profile') {
           return new Promise(res => {
@@ -215,24 +194,18 @@ describe('ContextGatheringStep', () => {
         <ContextGatheringStep connectedSources={['composio:gmail']} onNext={onNext} />
       );
 
-      // Wait for Gmail stage to complete and scrape to start
+      // Wait for Gmail stage to complete and save_profile to start
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();
       });
 
-      // User continues while the scrape is still running, then the route unmounts.
+      // User continues while save_profile is still running, then the route unmounts.
       fireEvent.click(screen.getByRole('button', { name: /continue to chat/i }));
       expect(onNext).toHaveBeenCalled();
       unmount();
 
       // Resolve remaining pipeline stages after unmount
-      await act(async () => {
-        resolveScrape({ data: {}, markdown: '# Test User' });
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
       await act(async () => {
         resolveSave({ path: '/tmp/PROFILE.md', bytes: 128 });
         await Promise.resolve();
@@ -243,6 +216,11 @@ describe('ContextGatheringStep', () => {
         (c: Array<{ method: string }>) => c[0].method === 'openhuman.learning_save_profile'
       );
       expect(saveCalls.length).toBe(1);
+      // Apify must never have been invoked.
+      const apifyCalls = callCoreRpc.mock.calls.filter(
+        (c: Array<{ method: string }>) => c[0].method === 'openhuman.tools_apify_linkedin_scrape'
+      );
+      expect(apifyCalls.length).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- Skips the `linkedin-scrape` stage in `ContextGatheringStep` because the Apify `dev_fusion/linkedin-profile-scraper` actor has been unreliable (frequent empty / malformed payloads).
- Onboarding now builds `PROFILE.md` URL-only — the Gmail-discovered LinkedIn URL is passed straight through `learning_save_profile` (`summarize=true`) for the core LLM compressor.
- Removes the unused `apifyScrapeLinkedIn` helper and updates unit tests + the file header docstring.

## Problem

The Apify LinkedIn scraping stage during onboarding profile-building has been unreliable: it often returns empty or malformed data, surfaces noisy errors to new users, and burns Apify quota for output we can't trust. The downstream save-profile stage already handles the no-scrape case by writing a URL-only `PROFILE.md` stub, so the scrape stage is the weakest link rather than the load-bearing one.

## Solution

- In `app/src/pages/onboarding/steps/ContextGatheringStep.tsx`, replace the scrape stage with a synchronous `setStage('linkedin-scrape', 'skipped', 0, 'apify_disabled')` and drop the `apifyScrapeLinkedIn` helper. `scrapedMarkdown` stays empty so the existing `build-profile` stage falls through to its URL-only path.
- Update the file header docstring to reflect the new two-RPC pipeline.
- The core RPC `openhuman.tools_apify_linkedin_scrape` is untouched and remains available to other callers.
- Updated unit tests assert: (a) Apify RPC is never invoked, (b) pipeline is Gmail → save_profile only, (c) saved markdown contains the LinkedIn URL, (d) the unmount-mid-pipeline test now blocks on save_profile instead of scrape.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change
- [x] N/A: no matrix-tracked feature IDs added or removed by this change
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: onboarding scrape stage is not part of release-cut smoke surfaces
- [x] N/A: no linked issue — direct fix for unreliable upstream actor

## Impact

- **Desktop only** (onboarding flow). No CLI / core RPC surface change.
- **User-visible**: onboarding finishes faster and stops surfacing Apify failures; `PROFILE.md` is now URL-only when Gmail provides a LinkedIn URL. Other LinkedIn enrichment paths (callers of `openhuman.tools_apify_linkedin_scrape` and `run_linkedin_enrichment`) still scrape as before.
- **Performance**: removes one external HTTP call from the onboarding critical path.
- **Compatibility**: no schema/RPC breaking changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs: re-enable scrape stage if/when we switch off Apify to a more reliable LinkedIn data source.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/onboarding-disable-apify-scrape
- Commit SHA: 9aa3192d5ee4f8888408eabf2bd254b3d9820f0f

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (Prettier auto-fixed test formatting; re-pushed)
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit ContextGatheringStep` → 10/10 passing
- [x] N/A: no Rust core changes
- [x] N/A: no Tauri shell changes

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: Onboarding no longer calls Apify LinkedIn scraper.
- User-visible effect: Faster onboarding finish and no more Apify-related "Almost there" error screens; `PROFILE.md` written URL-only when a LinkedIn URL is discovered via Gmail.

### Parity Contract
- Legacy behavior preserved: Gmail discovery and `learning_save_profile` stages unchanged; core `tools_apify_linkedin_scrape` RPC unchanged.
- Guard/fallback/dispatch parity checks: existing no-Gmail / no-URL / save-error branches still exercised by the test suite.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the onboarding data-gathering pipeline by disabling LinkedIn scraping integration. The process now uses only Gmail-derived LinkedIn information during profile setup, with placeholder messaging when scraping data is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1627)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
