### PR TITLE
feat: hide worker threads from UI and disable spawn (#1624)

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -940,6 +940,10 @@ const Conversations = ({ variant = 'page', composer = 'text' }: ConversationsPro
 
   const filteredThreads = useMemo(() => {
     const base = threads.filter(t => {
+      // Hide worker/subagent threads from the conversation list. They are
+      // currently surfaced inline inside the parent thread via WorkerThreadRefCard.
+      // A dedicated showcase is tracked in tinyhumansai/openhuman#1624.
+      if (t.parentThreadId) return false;
       if (selectedLabel === 'all') return true;
       return t.labels?.includes(selectedLabel);
     });

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -293,16 +293,22 @@ const Conversations = ({ variant = 'page', composer = 'text' }: ConversationsPro
         //   return;
         // }
         const threadStateForSelect = store.getState().thread;
-        if (data.threads.length > 0) {
+        // Worker/subagent threads are hidden from the conversation list
+        // (see tinyhumansai/openhuman#1624). Match the sidebar filter here so
+        // initial/resume selection can't auto-pick a hidden thread and leave
+        // the UI showing a thread that isn't in the list.
+        const visibleThreads = data.threads.filter(t => !t.parentThreadId);
+        if (visibleThreads.length > 0) {
           // Prefer the thread the user was last viewing (persisted across
           // reloads via redux-persist on the `thread` slice). Only fall
           // through to "most recent" if that thread no longer exists
-          // server-side (deleted, purged, or different user).
+          // server-side (deleted, purged, or different user) — or is now
+          // hidden because it's a worker thread.
           const persistedId = threadStateForSelect.selectedThreadId;
           const resumeId =
-            persistedId && data.threads.some(t => t.id === persistedId)
+            persistedId && visibleThreads.some(t => t.id === persistedId)
               ? persistedId
-              : data.threads[0].id;
+              : visibleThreads[0].id;
           dispatch(setSelectedThread(resumeId));
           void dispatch(loadThreadMessages(resumeId));
         } else {

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -167,13 +167,23 @@ impl Tool for SpawnSubagentTool {
             .filter(|s| !s.is_empty());
 
         // Worker-thread spawning is temporarily disabled until a proper UI
-        // showcase lands (see tinyhumansai/openhuman#1624). Force the inline
-        // path regardless of what the model requests.
-        // let dedicated_thread = args
-        //     .get("dedicated_thread")
-        //     .and_then(|v| v.as_bool())
-        //     .unwrap_or(false);
-        let _ = args.get("dedicated_thread");
+        // showcase lands (see tinyhumansai/openhuman#1624). Return an
+        // explicit error when callers request a dedicated thread so the
+        // behaviour is observable rather than silently downgraded.
+        let dedicated_thread_requested = args
+            .get("dedicated_thread")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if dedicated_thread_requested {
+            log::debug!(
+                "[spawn_subagent] dedicated_thread requested but temporarily \
+                 disabled (see tinyhumansai/openhuman#1624); rejecting call"
+            );
+            return Ok(ToolResult::error(
+                "spawn_subagent: `dedicated_thread` is temporarily disabled \
+                 (see tinyhumansai/openhuman#1624); retry without it.",
+            ));
+        }
         let dedicated_thread = false;
 
         // ── Validation ─────────────────────────────────────────────────

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -128,7 +128,7 @@ impl Tool for SpawnSubagentTool {
                 },
                 "dedicated_thread": {
                     "type": "boolean",
-                    "description": "Default `false`. Set `true` ONLY for long, complex sub-tasks where the parent thread should not be flooded with sub-agent output. The sub-agent's prompt and final summary land in a fresh worker-labeled thread the user can open from the thread list, and the parent receives a compact reference (worker thread id + brief summary) instead of the full transcript. Worker threads cannot themselves spawn another worker (sub-agents never see this tool), so this is a one-level-deep escape hatch."
+                    "description": "Temporarily disabled (see tinyhumansai/openhuman#1624). Passing `true` causes this tool to return an explicit error. Omit the field or pass `false` until the worker-thread UI surface lands."
                 }
             }
         })

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -166,10 +166,15 @@ impl Tool for SpawnSubagentTool {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
-        let dedicated_thread = args
-            .get("dedicated_thread")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        // Worker-thread spawning is temporarily disabled until a proper UI
+        // showcase lands (see tinyhumansai/openhuman#1624). Force the inline
+        // path regardless of what the model requests.
+        // let dedicated_thread = args
+        //     .get("dedicated_thread")
+        //     .and_then(|v| v.as_bool())
+        //     .unwrap_or(false);
+        let _ = args.get("dedicated_thread");
+        let dedicated_thread = false;
 
         // ── Validation ─────────────────────────────────────────────────
         if agent_id.is_empty() {

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -29,7 +29,11 @@ use crate::openhuman::agent::harness::definition::{
 };
 use crate::openhuman::context::prompt::ConnectedIntegration;
 
-use super::{ArchetypeDelegationTool, SkillDelegationTool, SpawnWorkerThreadTool, Tool};
+// SpawnWorkerThreadTool import kept commented while the worker-thread spawn is
+// temporarily disabled (see tinyhumansai/openhuman#1624).
+#[allow(unused_imports)]
+use super::SpawnWorkerThreadTool;
+use super::{ArchetypeDelegationTool, SkillDelegationTool, Tool};
 
 /// Synthesise the delegation tool list for an agent based on its
 /// declarative `subagents` field.
@@ -66,9 +70,12 @@ pub fn collect_orchestrator_tools(
     let mut tools: Vec<Box<dyn Tool>> = Vec::new();
 
     // Orchestrator-only tool: spawn_worker_thread.
-    if definition.id == "orchestrator" {
-        tools.push(Box::new(SpawnWorkerThreadTool::new()));
-    }
+    // Temporarily disabled — worker threads do not yet have a proper UI
+    // showcase (see tinyhumansai/openhuman#1624). Re-enable once the
+    // dedicated worker-thread surface lands.
+    // if definition.id == "orchestrator" {
+    //     tools.push(Box::new(SpawnWorkerThreadTool::new()));
+    // }
 
     for entry in &definition.subagents {
         match entry {

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -305,7 +305,9 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "spawn_worker_thread",   // orchestrator-only, prepended in collect_orchestrator_tools
+                // `spawn_worker_thread` is temporarily disabled — see
+                // tinyhumansai/openhuman#1624. Re-add the leading entry when
+                // the registration in `collect_orchestrator_tools` is restored.
                 "research",              // researcher's delegate_name override
                 "delegate_archivist",    // archivist has no delegate_name → default
                 "delegate_gmail",
@@ -336,10 +338,8 @@ mod tests {
         let reg = registry_with_targets();
         let tools = collect_orchestrator_tools(&orch, &reg, &[]);
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
-        assert_eq!(
-            names,
-            vec!["spawn_worker_thread", "research", "delegate_archivist"]
-        );
+        // `spawn_worker_thread` is temporarily disabled — see #1624.
+        assert_eq!(names, vec!["research", "delegate_archivist"]);
     }
 
     /// An AgentId entry that points at an id not present in the registry
@@ -355,7 +355,8 @@ mod tests {
         let reg = registry_with_targets();
         let tools = collect_orchestrator_tools(&orch, &reg, &[]);
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
-        assert_eq!(names, vec!["spawn_worker_thread", "research"]);
+        // `spawn_worker_thread` is temporarily disabled — see #1624.
+        assert_eq!(names, vec!["research"]);
     }
 
     /// An empty `subagents` list should produce zero tools — regular


### PR DESCRIPTION
## Summary

- Filter worker/subagent threads (any thread with `parentThreadId`) out of the main conversation list.
- Stop the orchestrator from registering `spawn_worker_thread` and force `spawn_subagent`'s `dedicated_thread` flag to `false`.
- Stopgap until a proper worker-thread UI showcase lands — tracked in #1624.

## Problem

When the orchestrator spawns a worker/subagent thread (via `spawn_worker_thread` or `spawn_subagent { dedicated_thread: true }`), the worker thread today shows up as a standalone entry in the user's conversation list with no coherent presentation — no clear title, no progress affordance, no done state, no link back to the parent. The inline `WorkerThreadRefCard` inside the parent thread is the only deliberate showcase; the standalone list entry is noise.

## Solution

Three small changes, all pointing at #1624 for the eventual re-enable:

- `app/src/pages/Conversations.tsx`: `filteredThreads` drops threads whose `parentThreadId` is set, so workers never appear in the sidebar.
- `src/openhuman/tools/orchestrator_tools.rs`: the `SpawnWorkerThreadTool::new()` push is commented out, with an `#[allow(unused_imports)]` on the import so the orchestrator no longer advertises `spawn_worker_thread` to the model.
- `src/openhuman/tools/impl/agent/spawn_subagent.rs`: the `dedicated_thread` extraction is commented out and hard-set to `false`, so even if the model requests a dedicated thread the runtime treats it as inline.

`cargo check --manifest-path Cargo.toml` passes cleanly (warnings are pre-existing).

## Submission Checklist

- [x] N/A: behaviour-toggle only — registration & filter changes are guarded by existing tests for the non-worker path; adding tests for the disabled branch would just lock in the temporary stopgap.
- [x] N/A: changed lines are dead-code toggles (commented-out registration, forced `false`) and a one-line filter; not exercisable for meaningful coverage gain.
- [x] N/A: behaviour-only change — no new feature rows.
- [x] N/A: no new feature IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: change is invisible to release-cut surfaces (no UI flows added, just a list filter; smoke checklist untouched).
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Desktop UI: worker threads no longer appear as standalone list entries. `WorkerThreadRefCard` inside parent threads continues to render. Backend: orchestrator no longer exposes `spawn_worker_thread`; `spawn_subagent` always runs inline. No migration. No perf or security implications.

## Related

- Tracks: #1624 (re-enable once a dedicated worker-thread UI surface ships)
- Closes:
- Follow-up PR(s)/TODOs: re-enable `SpawnWorkerThreadTool` registration and `dedicated_thread` flag when #1624 lands

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/hide-worker-threads
- Commit SHA: ccc5887f0e5cfd28853369bd42a2e3f7bad5ff57

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — no JS/CSS format-sensitive lines changed (one-line filter addition with project-style indentation)
- [x] N/A: `pnpm typecheck` — single-property filter; types unchanged
- [x] N/A: focused tests — behaviour toggle only, see Submission Checklist
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml` clean
- [x] N/A: Tauri fmt/check (if changed) — shell unchanged

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: worker/subagent threads no longer surface in the conversation list, and the orchestrator can no longer spawn dedicated worker threads.
- User-visible effect: cleaner sidebar; no more orphan worker entries appearing alongside user-initiated conversations.

### Parity Contract
- Legacy behavior preserved: `WorkerThreadRefCard` inline rendering unchanged; `spawn_subagent` inline path unchanged; non-orchestrator agents unaffected.
- Guard/fallback/dispatch parity checks: `dedicated_thread` arg still consumed (via `args.get`) so existing call sites don't error on unknown-arg validation; orchestrator import kept with `#[allow(unused_imports)]` to ease re-enable.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Worker and subagent threads no longer appear in the main conversation list; only primary conversations are shown for a cleaner view.
  * Resuming a previously selected thread now respects visibility and falls back to the most recent visible conversation or creates a new one if none exist.
  * The option to spawn dedicated worker threads has been temporarily disabled; attempts to use it will return an error and should be retried without the flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1631)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
