### PR TITLE
fix(observability): drop transient backend_api + integrations failures from Sentry

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1250,6 +1250,11 @@ pub fn run() {
                 );
                 return None;
             }
+            if openhuman_core::core::observability::is_transient_backend_api_failure(&event)
+                || openhuman_core::core::observability::is_transient_integrations_failure(&event)
+            {
+                return None;
+            }
             // Strip server_name (hostname) to avoid leaking machine identity.
             event.server_name = None;
             event.user = None;

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -423,16 +423,32 @@ impl BackendOAuthClient {
         }
 
         let response = request.send().await.map_err(|e| {
-            crate::core::observability::report_error(
-                e.to_string().as_str(),
-                "backend_api",
-                "authed_json",
-                &[
-                    ("method", method.as_str()),
-                    ("path", url.path()),
-                    ("failure", "transport"),
-                ],
-            );
+            let error_message = e.to_string();
+            if crate::core::observability::contains_transient_transport_phrase(&error_message) {
+                tracing::warn!(
+                    domain = "backend_api",
+                    operation = "authed_json",
+                    method = method.as_str(),
+                    path = url.path(),
+                    failure = "transport",
+                    error = %error_message,
+                    "[backend_api] transient transport failure on {} {}: {}",
+                    method.as_str(),
+                    url.path(),
+                    error_message,
+                );
+            } else {
+                crate::core::observability::report_error(
+                    error_message.as_str(),
+                    "backend_api",
+                    "authed_json",
+                    &[
+                        ("method", method.as_str()),
+                        ("path", url.path()),
+                        ("failure", "transport"),
+                    ],
+                );
+            }
             anyhow::Error::new(e).context(format!(
                 "backend request {} {}",
                 method.as_str(),
@@ -445,15 +461,19 @@ impl BackendOAuthClient {
         if !status.is_success() {
             let status_code = status.as_u16();
             let status_str = status_code.to_string();
-            // 502/503/504 are transient infrastructure errors (proxy/CDN/backend
+            // These are transient infrastructure errors (proxy/CDN/backend
             // temporarily unavailable). They are not code bugs and callers already
             // implement retry/disable logic, so skip Sentry to avoid noise.
-            let is_transient_infra = matches!(status_code, 502 | 503 | 504);
+            let is_transient_infra =
+                crate::core::observability::is_transient_http_status_code(status_code);
             if is_transient_infra {
                 tracing::warn!(
+                    domain = "backend_api",
+                    operation = "authed_json",
                     method = method.as_str(),
                     path = url.path(),
                     status = status_code,
+                    failure = "non_2xx",
                     "[backend_api] transient {status} on {} {} — not reporting to Sentry",
                     method.as_str(),
                     url.path(),

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -423,7 +423,17 @@ impl BackendOAuthClient {
         }
 
         let response = request.send().await.map_err(|e| {
-            let error_message = e.to_string();
+            // Walk the error source chain so transient markers hidden in nested
+            // causes (reqwest -> hyper -> rustls TLS EOF, etc.) still classify
+            // correctly. The top-level `e.to_string()` often only carries the
+            // outermost wrapper, e.g. "error sending request for url (...)".
+            let mut error_message = e.to_string();
+            let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(&e);
+            while let Some(s) = src {
+                error_message.push_str(" → ");
+                error_message.push_str(&s.to_string());
+                src = s.source();
+            }
             if crate::core::observability::contains_transient_transport_phrase(&error_message) {
                 tracing::warn!(
                     domain = "backend_api",

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -111,6 +111,18 @@ pub async fn rpc_handler(State(state): State<AppState>, Json(req): Json<RpcReque
                 );
             } else if is_session_expired_error(&display_message) {
                 tracing::info!("[rpc] {} -> err ({}ms): {}", method, ms, display_message);
+            } else if crate::core::observability::is_transient_message_failure(&display_message) {
+                // Downstream call (backend_api / integrations / provider) already
+                // demoted the underlying transient failure to a warn. The error
+                // string still propagates up to here; re-reporting at error level
+                // would re-create the very Sentry noise the lower-layer demote
+                // was meant to avoid (#8Z, #93, #8W, #96).
+                tracing::warn!(
+                    method = %method,
+                    elapsed_ms = ms as u64,
+                    "[rpc] transient downstream failure — not reporting to Sentry: {}",
+                    display_message
+                );
             } else {
                 crate::core::observability::report_error_or_expected(
                     display_message.as_str(),

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -117,11 +117,19 @@ pub async fn rpc_handler(State(state): State<AppState>, Json(req): Json<RpcReque
                 // string still propagates up to here; re-reporting at error level
                 // would re-create the very Sentry noise the lower-layer demote
                 // was meant to avoid (#8Z, #93, #8W, #96).
+                //
+                // Redact before logging — `display_message` is upstream-derived
+                // (backend / provider response) and can carry URL fragments,
+                // query params, or pasted-through provider error text that
+                // includes tokens. `sanitize_api_error` runs the same scrub
+                // used in the SessionExpired publish path below.
+                let redacted =
+                    crate::openhuman::providers::ops::sanitize_api_error(&display_message);
                 tracing::warn!(
                     method = %method,
                     elapsed_ms = ms as u64,
-                    "[rpc] transient downstream failure — not reporting to Sentry: {}",
-                    display_message
+                    error = %redacted,
+                    "[rpc] transient downstream failure — not reporting to Sentry (message redacted)"
                 );
             } else {
                 crate::core::observability::report_error_or_expected(

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -33,7 +33,7 @@ pub type Tag<'a> = (&'a str, &'a str);
 /// (`openhuman::providers::ops::should_report_provider_http_failure`) and the
 /// `before_send` filter (`is_transient_provider_http_failure`). Update here
 /// and both sites pick it up — keeps the two layers from drifting.
-pub const TRANSIENT_PROVIDER_HTTP_STATUSES: &[u16] = &[408, 429, 502, 503, 504];
+pub const TRANSIENT_PROVIDER_HTTP_STATUSES: &[u16] = &[408, 429, 502, 503, 504, 520];
 
 /// HTTP status codes that represent transient backend / integration transport
 /// failures rather than application bugs. Keep this as strings because Sentry

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -35,6 +35,23 @@ pub type Tag<'a> = (&'a str, &'a str);
 /// and both sites pick it up — keeps the two layers from drifting.
 pub const TRANSIENT_PROVIDER_HTTP_STATUSES: &[u16] = &[408, 429, 502, 503, 504];
 
+/// HTTP status codes that represent transient backend / integration transport
+/// failures rather than application bugs. Keep this as strings because Sentry
+/// tags are strings, and the before_send classifiers match tag values exactly.
+pub const TRANSIENT_HTTP_STATUSES: &[&str] = &["408", "429", "502", "503", "504", "520"];
+
+/// Transport-layer phrases observed from reqwest / hyper for temporary
+/// upstream interruptions. Keep these specific so rare configuration failures
+/// still reach Sentry.
+pub const TRANSIENT_TRANSPORT_PHRASES: &[&str] = &[
+    "timeout",
+    "operation timed out",
+    "connection forcibly closed",
+    "connection reset",
+    "tls handshake eof",
+    "error sending request",
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpectedErrorKind {
     LocalAiDisabled,

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -365,6 +365,12 @@ pub fn is_transient_backend_api_failure(event: &sentry::protocol::Event<'_>) -> 
     is_transient_domain_failure(event, "backend_api")
 }
 
+/// Transient integrations / Composio failures (timeout, connection reset,
+/// gateway hiccups).
+pub fn is_transient_integrations_failure(event: &sentry::protocol::Event<'_>) -> bool {
+    is_transient_domain_failure(event, "integrations")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -747,6 +753,69 @@ mod tests {
         );
         assert!(
             !is_transient_backend_api_failure(&non_matching_transport),
+            "transport failures without an allowlisted phrase must stay visible"
+        );
+    }
+
+    #[test]
+    fn integrations_filter_drops_transient_statuses() {
+        for status in TRANSIENT_HTTP_STATUSES {
+            let event = event_with_tags(&[
+                ("domain", "integrations"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ]);
+            assert!(
+                is_transient_integrations_failure(&event),
+                "integrations status {status} must be classified as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn integrations_filter_drops_transient_transport_phrases() {
+        for phrase in TRANSIENT_TRANSPORT_PHRASES {
+            let event = event_with_tags_and_message(
+                &[("domain", "integrations"), ("failure", "transport")],
+                &format!("GET /agent-integrations/tools failed: {phrase}"),
+            );
+            assert!(
+                is_transient_integrations_failure(&event),
+                "integrations transport phrase {phrase} must be classified as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn integrations_filter_keeps_non_transient_failures() {
+        for status in ["404", "500"] {
+            let event = event_with_tags(&[
+                ("domain", "integrations"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ]);
+            assert!(
+                !is_transient_integrations_failure(&event),
+                "integrations status {status} must stay visible"
+            );
+        }
+
+        let wrong_domain = event_with_tags(&[
+            ("domain", "composio"),
+            ("failure", "non_2xx"),
+            ("status", "503"),
+        ]);
+        assert!(
+            !is_transient_integrations_failure(&wrong_domain),
+            "domain scoping must keep composio-tagged events visible"
+        );
+
+        let non_matching_transport = event_with_tags_and_message(
+            &[("domain", "integrations"), ("failure", "transport")],
+            "GET /agent-integrations/tools failed: invalid certificate",
+        );
+        assert!(
+            !is_transient_integrations_failure(&non_matching_transport),
             "transport failures without an allowlisted phrase must stay visible"
         );
     }

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -311,6 +311,60 @@ pub fn is_transient_provider_http_failure(event: &sentry::protocol::Event<'_>) -
     TRANSIENT_PROVIDER_HTTP_STATUSES.contains(&status_u16)
 }
 
+pub fn is_transient_http_status(status: &str) -> bool {
+    TRANSIENT_HTTP_STATUSES.contains(&status)
+}
+
+pub fn is_transient_http_status_code(status: u16) -> bool {
+    let status = status.to_string();
+    is_transient_http_status(status.as_str())
+}
+
+pub fn contains_transient_transport_phrase(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    TRANSIENT_TRANSPORT_PHRASES
+        .iter()
+        .any(|phrase| lower.contains(phrase))
+}
+
+fn event_has_transient_transport_phrase(event: &sentry::protocol::Event<'_>) -> bool {
+    event
+        .message
+        .as_deref()
+        .is_some_and(contains_transient_transport_phrase)
+        || event
+            .logentry
+            .as_ref()
+            .is_some_and(|log| contains_transient_transport_phrase(&log.message))
+        || event.exception.values.iter().any(|exception| {
+            exception
+                .value
+                .as_deref()
+                .is_some_and(contains_transient_transport_phrase)
+        })
+}
+
+fn is_transient_domain_failure(event: &sentry::protocol::Event<'_>, domain: &str) -> bool {
+    let tags = &event.tags;
+    if tags.get("domain").map(String::as_str) != Some(domain) {
+        return false;
+    }
+
+    match tags.get("failure").map(String::as_str) {
+        Some("non_2xx") => tags
+            .get("status")
+            .is_some_and(|status| is_transient_http_status(status)),
+        Some("transport") => event_has_transient_transport_phrase(event),
+        _ => false,
+    }
+}
+
+/// Transient backend API failures (gateway hiccups, scheduled downtime).
+/// Match by event tags written by report_error at the authed_json call site.
+pub fn is_transient_backend_api_failure(event: &sentry::protocol::Event<'_>) -> bool {
+    is_transient_domain_failure(event, "backend_api")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -544,6 +598,15 @@ mod tests {
         event
     }
 
+    fn event_with_tags_and_message(
+        pairs: &[(&str, &str)],
+        message: &str,
+    ) -> sentry::protocol::Event<'static> {
+        let mut event = event_with_tags(pairs);
+        event.message = Some(message.to_string());
+        event
+    }
+
     #[test]
     fn transient_filter_drops_429_408_502_503_504() {
         for status in ["429", "408", "502", "503", "504"] {
@@ -622,6 +685,69 @@ mod tests {
         assert!(
             !is_transient_provider_http_failure(&event),
             "non-provider domain must surface even if failure/status tags collide"
+        );
+    }
+
+    #[test]
+    fn backend_api_filter_drops_transient_statuses() {
+        for status in TRANSIENT_HTTP_STATUSES {
+            let event = event_with_tags(&[
+                ("domain", "backend_api"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ]);
+            assert!(
+                is_transient_backend_api_failure(&event),
+                "backend status {status} must be classified as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn backend_api_filter_drops_transient_transport_phrases() {
+        for phrase in TRANSIENT_TRANSPORT_PHRASES {
+            let event = event_with_tags_and_message(
+                &[("domain", "backend_api"), ("failure", "transport")],
+                &format!("GET /teams failed: {phrase}"),
+            );
+            assert!(
+                is_transient_backend_api_failure(&event),
+                "backend transport phrase {phrase} must be classified as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn backend_api_filter_keeps_non_transient_failures() {
+        for status in ["404", "500"] {
+            let event = event_with_tags(&[
+                ("domain", "backend_api"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ]);
+            assert!(
+                !is_transient_backend_api_failure(&event),
+                "backend status {status} must stay visible"
+            );
+        }
+
+        let wrong_domain = event_with_tags(&[
+            ("domain", "scheduler"),
+            ("failure", "non_2xx"),
+            ("status", "503"),
+        ]);
+        assert!(
+            !is_transient_backend_api_failure(&wrong_domain),
+            "domain scoping must keep unrelated transient-shaped events visible"
+        );
+
+        let non_matching_transport = event_with_tags_and_message(
+            &[("domain", "backend_api"), ("failure", "transport")],
+            "GET /teams failed: certificate verify failed",
+        );
+        assert!(
+            !is_transient_backend_api_failure(&non_matching_transport),
+            "transport failures without an allowlisted phrase must stay visible"
         );
     }
 

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -371,6 +371,42 @@ pub fn is_transient_integrations_failure(event: &sentry::protocol::Event<'_>) ->
     is_transient_domain_failure(event, "integrations")
 }
 
+/// String tokens that mark a formatted error message as a transient HTTP
+/// failure. Used at upstream emit sites (`rpc.invoke_method`,
+/// `web_channel.run_chat_task`) where the error has already been stringified
+/// and the original `status` / `failure` tag context is gone.
+///
+/// Each token combines a status code with a non-numeric anchor (parenthesis
+/// or canonical reason phrase) so bare numeric coincidences ("process 502
+/// exited") do not match.
+const TRANSIENT_STATUS_MESSAGE_TOKENS: &[&str] = &[
+    "(408 ",
+    "(429 ",
+    "(502 ",
+    "(503 ",
+    "(504 ",
+    "(520 ",
+    "408 request timeout",
+    "429 too many requests",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+    "520 <unknown status code>",
+];
+
+/// Returns true when a formatted error message describes a transient HTTP
+/// or transport-layer failure that has already been demoted further down the
+/// stack. Use at upstream re-emit sites (`rpc.invoke_method`,
+/// `web_channel.run_chat_task`) where `report_error` is called with the
+/// stringified downstream error and no `failure` / `status` tag context.
+pub fn is_transient_message_failure(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    TRANSIENT_STATUS_MESSAGE_TOKENS
+        .iter()
+        .any(|token| lower.contains(token))
+        || contains_transient_transport_phrase(&lower)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -818,6 +854,55 @@ mod tests {
             !is_transient_integrations_failure(&non_matching_transport),
             "transport failures without an allowlisted phrase must stay visible"
         );
+    }
+
+    #[test]
+    fn message_failure_classifier_matches_canonical_status_phrases() {
+        for msg in [
+            "rpc.invoke_method failed: GET /teams failed (502 Bad Gateway)",
+            "GET /teams/me/usage failed (503 Service Unavailable)",
+            "downstream returned (504 Gateway Timeout): retry budget exhausted",
+            "OpenHuman API error (520 <unknown status code>): cf",
+            "POST /channels/telegram/typing failed (429 Too Many Requests)",
+            "auth connect failed: 503 Service Unavailable",
+        ] {
+            assert!(
+                is_transient_message_failure(msg),
+                "{msg:?} must be classified as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn message_failure_classifier_matches_transport_phrases() {
+        for msg in [
+            "integrations.get failed: composio/tools → operation timed out",
+            "GET https://api.example.com → connection forcibly closed (os 10054)",
+            "POST /v1/foo → tls handshake eof",
+            "error sending request for url (https://api.example.com)",
+        ] {
+            assert!(
+                is_transient_message_failure(msg),
+                "{msg:?} must be classified as transient"
+            );
+        }
+    }
+
+    #[test]
+    fn message_failure_classifier_keeps_unrelated_messages() {
+        for msg in [
+            "rpc.invoke_method failed: schema validation error",
+            "process 502 exited unexpectedly",
+            "GET /teams failed (404 Not Found)",
+            "GET /teams failed (500 Internal Server Error)",
+            "unrelated error with port 5023",
+            "",
+        ] {
+            assert!(
+                !is_transient_message_failure(msg),
+                "{msg:?} must not be classified as transient"
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,11 @@ fn main() {
             if openhuman_core::core::observability::is_transient_provider_http_failure(&event) {
                 return None;
             }
+            if openhuman_core::core::observability::is_transient_backend_api_failure(&event)
+                || openhuman_core::core::observability::is_transient_integrations_failure(&event)
+            {
+                return None;
+            }
             // Strip server_name (hostname) to avoid leaking machine identity
             event.server_name = None;
             // Attach the cached account uid so Sentry can count unique users

--- a/src/openhuman/integrations/client.rs
+++ b/src/openhuman/integrations/client.rs
@@ -121,16 +121,27 @@ impl IntegrationClient {
             let body_text = resp.text().await.unwrap_or_default();
             let detail = extract_error_detail(&body_text, MAX_ERROR_BODY_LEN);
             let status_str = status.as_u16().to_string();
-            crate::core::observability::report_error(
-                format!("Backend returned {status} for POST {url}: {detail}").as_str(),
-                "integrations",
-                "post",
-                &[
-                    ("path", path),
-                    ("status", status_str.as_str()),
-                    ("failure", "non_2xx"),
-                ],
-            );
+            if crate::core::observability::is_transient_http_status_code(status.as_u16()) {
+                tracing::warn!(
+                    domain = "integrations",
+                    operation = "post",
+                    path = path,
+                    status = status_str.as_str(),
+                    failure = "non_2xx",
+                    "[integrations] transient {status} for POST {url}: {detail}",
+                );
+            } else {
+                crate::core::observability::report_error(
+                    format!("Backend returned {status} for POST {url}: {detail}").as_str(),
+                    "integrations",
+                    "post",
+                    &[
+                        ("path", path),
+                        ("status", status_str.as_str()),
+                        ("failure", "non_2xx"),
+                    ],
+                );
+            }
             anyhow::bail!("Backend returned {status} for POST {url}: {detail}");
         }
 
@@ -189,16 +200,27 @@ impl IntegrationClient {
             let body_text = resp.text().await.unwrap_or_default();
             let detail = extract_error_detail(&body_text, MAX_ERROR_BODY_LEN);
             let status_str = status.as_u16().to_string();
-            crate::core::observability::report_error(
-                format!("Backend returned {status} for GET {url}: {detail}").as_str(),
-                "integrations",
-                "get",
-                &[
-                    ("path", path),
-                    ("status", status_str.as_str()),
-                    ("failure", "non_2xx"),
-                ],
-            );
+            if crate::core::observability::is_transient_http_status_code(status.as_u16()) {
+                tracing::warn!(
+                    domain = "integrations",
+                    operation = "get",
+                    path = path,
+                    status = status_str.as_str(),
+                    failure = "non_2xx",
+                    "[integrations] transient {status} for GET {url}: {detail}",
+                );
+            } else {
+                crate::core::observability::report_error(
+                    format!("Backend returned {status} for GET {url}: {detail}").as_str(),
+                    "integrations",
+                    "get",
+                    &[
+                        ("path", path),
+                        ("status", status_str.as_str()),
+                        ("failure", "non_2xx"),
+                    ],
+                );
+            }
             anyhow::bail!("Backend returned {status} for GET {url}: {detail}");
         }
 

--- a/tests/observability_smoke.rs
+++ b/tests/observability_smoke.rs
@@ -1,5 +1,5 @@
-//! Runtime smoke for the Sentry `before_send` filter that drops per-attempt
-//! transient-upstream provider failures (OPENHUMAN-TAURI-2E / 84 / T).
+//! Runtime smoke for the Sentry `before_send` filters that drop per-attempt
+//! transient-upstream provider, backend_api, and integrations failures.
 //!
 //! Unit tests in `src/core/observability.rs` exercise the pure filter
 //! function. This integration test wires the actual `sentry::init` →
@@ -7,7 +7,10 @@
 //! behaves as designed: transient events are dropped, permanent events
 //! and aggregate `all_exhausted` events still surface.
 
-use openhuman_core::core::observability::is_transient_provider_http_failure;
+use openhuman_core::core::observability::{
+    is_transient_backend_api_failure, is_transient_integrations_failure,
+    is_transient_provider_http_failure,
+};
 use sentry::protocol::Event;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -19,6 +22,12 @@ fn event_with_tags(tags: &[(&str, &str)]) -> Event<'static> {
         t.insert((*k).to_string(), (*v).to_string());
     }
     event.tags = t;
+    event
+}
+
+fn event_with_tags_and_message(tags: &[(&str, &str)], message: &str) -> Event<'static> {
+    let mut event = event_with_tags(tags);
+    event.message = Some(message.to_string());
     event
 }
 
@@ -46,7 +55,10 @@ fn count_captured(events: Vec<Event<'static>>) -> usize {
         ),
         // Same filter shape the real binary installs in main.rs.
         before_send: Some(Arc::new(|event| {
-            if is_transient_provider_http_failure(&event) {
+            if is_transient_provider_http_failure(&event)
+                || is_transient_backend_api_failure(&event)
+                || is_transient_integrations_failure(&event)
+            {
                 None
             } else {
                 Some(event)
@@ -66,6 +78,38 @@ fn count_captured(events: Vec<Event<'static>>) -> usize {
         .client()
         .map(|c| c.flush(Some(std::time::Duration::from_secs(2))));
     transport.fetch_and_clear_envelopes().len()
+}
+
+#[test]
+fn drops_backend_api_transient_statuses() {
+    let events = ["408", "429", "502", "503", "504", "520"]
+        .into_iter()
+        .map(|status| {
+            event_with_tags(&[
+                ("domain", "backend_api"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ])
+        })
+        .collect();
+    assert_eq!(
+        count_captured(events),
+        0,
+        "transient backend_api statuses must be filtered in before_send"
+    );
+}
+
+#[test]
+fn drops_integrations_transient_transport_timeout() {
+    let event = event_with_tags_and_message(
+        &[("domain", "integrations"), ("failure", "transport")],
+        "GET /agent-integrations/tools failed: operation timed out",
+    );
+    assert_eq!(
+        count_captured(vec![event]),
+        0,
+        "transient integrations timeouts must be filtered in before_send"
+    );
 }
 
 #[test]
@@ -108,6 +152,20 @@ fn keeps_permanent_failures() {
         count_captured(events),
         5,
         "permanent provider failures must reach Sentry"
+    );
+}
+
+#[test]
+fn keeps_backend_api_404_failure() {
+    let event = event_with_tags(&[
+        ("domain", "backend_api"),
+        ("failure", "non_2xx"),
+        ("status", "404"),
+    ]);
+    assert_eq!(
+        count_captured(vec![event]),
+        1,
+        "non-transient backend_api 404 failures must reach Sentry"
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds shared backend/integrations transient status and transport phrase classifiers in `core::observability`.
- Drops matching `backend_api` and `integrations` Sentry events in both core and Tauri `before_send`.
- Demotes transient `authed_json` and integrations `get`/`post` emit sites to warn-level logs while preserving returned errors.
- Closes the upstream re-emit leak: `rpc.invoke_method` (jsonrpc.rs) and `web_channel.run_chat_task` (web.rs) now demote transient downstream failures via the new `is_transient_message_failure` helper, so the same hiccup no longer captures twice (once at the demoted call site, once at the tag-less re-emit).
- Extends `TRANSIENT_PROVIDER_HTTP_STATUSES` with Cloudflare 520 so `is_transient_provider_http_failure` covers OPENHUMAN-TAURI-49.
- Extends the Sentry `TestTransport` smoke test to prove backend/integrations transient events are filtered and non-transient events still capture.

## Problem

- Backend API and Composio/integrations retries produce per-attempt Sentry noise for 408/429/502/503/504/520 and observed timeout/reset/TLS EOF transport hiccups.
- The same downstream errors propagate up to `rpc.invoke_method` and `web_channel.run_chat_task`, which re-emit `report_error` with `domain="rpc"` / `domain="web_channel"` and no `failure`/`status` tag — so domain-scoped tag classifiers cannot catch them.
- These failures already retry or fail gracefully in callers, so Sentry captures upstream availability noise instead of product bugs.
- 500s, 404s, envelope errors, and non-allowlisted transport failures must stay visible.

## Solution

- Adds `TRANSIENT_HTTP_STATUSES`, `TRANSIENT_TRANSPORT_PHRASES`, `is_transient_backend_api_failure`, and `is_transient_integrations_failure` in `core::observability`.
- Adds `is_transient_message_failure(&str)` for tag-less re-emit sites: matches a tight token list of parenthesised statuses (`(502 `, `(503 `, …) and canonical reason phrases (`502 bad gateway`, `429 too many requests`, …) plus the existing transport phrases. Bare numeric coincidences ("process 502 exited") do NOT match.
- Wraps `rpc.invoke_method` (`src/core/jsonrpc.rs`) and `web_channel.run_chat_task` (`src/openhuman/channels/providers/web.rs`) so transient downstream failures emit `warn!` instead of `report_error`. Returned `Err` and HTTP envelope are unchanged.
- Adds 520 to `TRANSIENT_PROVIDER_HTTP_STATUSES` so the existing `is_transient_provider_http_failure` filter also catches Cloudflare 520 from `llm_provider.api_error` (#49).
- Updates `src/api/rest.rs` and `src/openhuman/integrations/client.rs` to warn instead of calling `report_error` for transient attempts.
- Wires the same classifiers into both `src/main.rs` and `app/src-tauri/src/lib.rs` as defense in depth.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: observability filtering behavior only; no feature-row changes.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: Sentry filtering only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: Sentry issue keys are listed instead of GitHub issue numbers.

## Impact

- Runtime impact is limited to Sentry emission and warn-level diagnostics.
- Backend/integrations/provider calls and rpc/web_channel re-emit paths still return the same `Err` values, so retry/fallback/user-facing behavior is unchanged.
- 500 and 404 failures remain reportable.
- Upstream re-emits (`rpc`, `web_channel`) still log a `warn!` line so transient failures stay visible in local logs and in `target/debug-logs/` even though Sentry no longer captures them.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes OPENHUMAN-TAURI-8Z, OPENHUMAN-TAURI-8X, OPENHUMAN-TAURI-94, OPENHUMAN-TAURI-93, OPENHUMAN-TAURI-92, OPENHUMAN-TAURI-91, OPENHUMAN-TAURI-8W, OPENHUMAN-TAURI-66, OPENHUMAN-TAURI-49, OPENHUMAN-TAURI-K, OPENHUMAN-TAURI-47, OPENHUMAN-TAURI-5R, OPENHUMAN-TAURI-9D, OPENHUMAN-TAURI-5S, OPENHUMAN-TAURI-95, OPENHUMAN-TAURI-96
- Telegram-specific MessageNotFound (OPENHUMAN-TAURI-8S, -8Q, -8P, -8V, -2Y) handled out-of-scope by Jules-N typed-error PR.
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/backend-transient-noise`
- Commit SHA: `8dd38f44` (latest; head of branch after rpc + web_channel + 520 follow-up commits and the CodeRabbit-flagged error-chain walk fix in `src/api/rest.rs`)

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend changes.
- [x] N/A: `pnpm typecheck` — no TypeScript changes.
- [x] Focused tests: `cargo test --lib core::observability::tests` (20 passed, including 3 new `message_failure_classifier_*` cases), `cargo test --test observability_smoke` (7 passed)
- [x] Rust fmt/check (if changed): `cargo fmt --check`, `cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked
- `command:` `cargo clippy --workspace -- -D warnings`
- `error:` fails on existing workspace lint debt unrelated to this PR (78–80 pre-existing clippy errors on `upstream/main`: `useless_vec` in `src/openhuman/tokenjuice/text/process.rs`, `derivable_impls` in `notifications/types.rs`, etc.).
- `impact:` clippy remains blocked at repo level; focused compile and smoke validation for the observability changes pass.

### Behavior Changes
- Intended behavior change: transient backend_api, integrations, provider, rpc, and web_channel failures are no longer sent to Sentry as error events.
- User-visible effect: no user-facing behavior change; requests still fail/retry exactly as before.

### Parity Contract
- Legacy behavior preserved: returned `Err` values and non-transient Sentry reports remain unchanged.
- Guard/fallback/dispatch parity checks: TestTransport smoke verifies transient backend/integrations events drop while backend 404 and provider 500 still capture; new `is_transient_message_failure` unit tests assert 5 negative cases (404, 500, schema errors, bare numbers, empty string) stay reportable.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to distinguish transient (temporary) failures from persistent issues, reducing unnecessary alerts and noise in error tracking when temporary infrastructure problems occur.

* **Tests**
  * Extended test coverage for transient failure detection across API and integration operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1632)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->