### PR TITLE
fix(whatsapp_data): preserve anyhow cause chain in RPC error envelopes (OPENHUMAN-TAURI-6B)

### DIFF
--- a/src/openhuman/whatsapp_data/rpc.rs
+++ b/src/openhuman/whatsapp_data/rpc.rs
@@ -40,8 +40,15 @@ pub async fn whatsapp_data_ingest(req: IngestRequest) -> Result<RpcOutcome<Inges
     );
     let store = require_store()?;
     let result = ops::ingest(&store, req).map_err(|e| {
-        log::warn!("[whatsapp_data][rpc] ingest error: {e}");
-        format!("[whatsapp_data] ingest failed: {e}")
+        // {e:#} renders the full anyhow chain — store::upsert_chats wraps
+        // the rusqlite error with `.with_context("upsert wa_chat <jid>")`,
+        // so plain Display ({e}) only emits the outer context and drops
+        // the underlying SQLite cause (database locked, schema mismatch,
+        // FK violation, …) before it reaches Sentry. See OPENHUMAN-TAURI-6B
+        // / TAURI-B2 for the canonical instance where this masked the
+        // real failure.
+        log::warn!("[whatsapp_data][rpc] ingest error: {e:#}");
+        format!("[whatsapp_data] ingest failed: {e:#}")
     })?;
     log::debug!(
         "[whatsapp_data][rpc] ingest ok chats={} messages={} pruned={}",
@@ -67,8 +74,8 @@ pub async fn whatsapp_data_list_chats(
     );
     let store = require_store()?;
     let chats = ops::list_chats(&store, req).map_err(|e| {
-        log::warn!("[whatsapp_data][rpc] list_chats error: {e}");
-        format!("[whatsapp_data] list_chats failed: {e}")
+        log::warn!("[whatsapp_data][rpc] list_chats error: {e:#}");
+        format!("[whatsapp_data] list_chats failed: {e:#}")
     })?;
     log::debug!("[whatsapp_data][rpc] list_chats ok count={}", chats.len());
     Ok(RpcOutcome::single_log(
@@ -87,8 +94,8 @@ pub async fn whatsapp_data_list_messages(
     );
     let store = require_store()?;
     let msgs = ops::list_messages(&store, req).map_err(|e| {
-        log::warn!("[whatsapp_data][rpc] list_messages error: {e}");
-        format!("[whatsapp_data] list_messages failed: {e}")
+        log::warn!("[whatsapp_data][rpc] list_messages error: {e:#}");
+        format!("[whatsapp_data] list_messages failed: {e:#}")
     })?;
     log::debug!("[whatsapp_data][rpc] list_messages ok count={}", msgs.len());
     Ok(RpcOutcome::single_log(
@@ -108,8 +115,8 @@ pub async fn whatsapp_data_search_messages(
     );
     let store = require_store()?;
     let results = ops::search_messages(&store, req).map_err(|e| {
-        log::warn!("[whatsapp_data][rpc] search_messages error: {e}");
-        format!("[whatsapp_data] search_messages failed: {e}")
+        log::warn!("[whatsapp_data][rpc] search_messages error: {e:#}");
+        format!("[whatsapp_data] search_messages failed: {e:#}")
     })?;
     log::debug!(
         "[whatsapp_data][rpc] search_messages ok count={}",


### PR DESCRIPTION
## Summary

- Switches the four `whatsapp_data` RPC handlers (`whatsapp_data_ingest`, `…_list_chats`, `…_list_messages`, `…_search_messages`) from plain `{e}` to alternate `{e:#}` Display rendering in their `map_err` envelopes.
- Same anyhow-chain-rendering fix called out in the `report_error` doc-string in `core/observability.rs` (referencing OPENHUMAN-TAURI-B2 — _\"Without this, anyhow's default `to_string()` only emits the outermost context and the underlying cause is dropped — making the captured Sentry event undiagnosable.\"_).

This is **not** a Sentry-skip — it's the inverse. The current Sentry events are too vague to act on; the fix makes them actionable so we can diagnose and fix the actual root cause.

Fixes OPENHUMAN-TAURI-6B (12 occurrences in 3 days, Linux user on `openhuman@0.53.22`).

## Why the chain matters here

[`store::upsert_chats`](src/openhuman/whatsapp_data/store.rs#L115) wraps every rusqlite error with `.with_context(|| format!(\"upsert wa_chat {chat_id}\"))`. The anyhow chain at the failure site is:

- **outer**: `\"upsert wa_chat 919xxxxxxxxxx@s.whatsapp.net\"`
- **cause**: `rusqlite::Error` — could be `SQLITE_BUSY`, schema mismatch, FK violation, disk-full, …

`format!(\"... {e}\")` renders only the outer label. The 12 Sentry events all read `\"[whatsapp_data] ingest failed: upsert wa_chat <jid>\"` with **no underlying cause** — we can't tell which SQLite condition is firing on Linux ingest.

`{e:#}` (anyhow's alternate format) joins the outer context plus every wrapped cause with `\": \"`, so the next Sentry event surfaces the rusqlite detail we need to actually fix the underlying issue.

## Why update all four handlers, not just `ingest`

Only `ingest` has Sentry occurrences today, but the other three use the identical pattern and would mask the same class of bug on any future failure. Single sibling pass keeps the file consistent and forecloses the next \"vague \\$method failed: \\$context\" Sentry issue from `whatsapp_data`.

## Test plan

- [x] `cargo check --lib` — no new warnings.
- [x] `cargo fmt`.
- [x] No new tests: the `{e:#}` rendering contract is already covered by `core::observability::tests::anyhow_chain_is_rendered_in_full`. A behavioural test here would require a running global store + synthetic SQLite failure injection — disproportionate for a four-site format-specifier fix.

## Follow-up

Once a fresh Sentry event lands on `main` post-merge, the actual rusqlite cause will be visible and a targeted follow-up PR can fix the underlying SQLite condition (likely lock contention given the 23-second `elapsed_ms` on the reported event, but the chain will tell us for sure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error message formatting and logging for WhatsApp data operations (ingest, chat listing, message listing, and search). Improved error reporting provides better visibility into underlying system issues for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1639)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->