### PR TITLE
fix(windows): retry-with-backoff for transient FS errors on auth-profiles.lock + .openhuman wipe (#9E, #9C, #4Y, #61, #5Q, #9F, #4M)

### DIFF
--- a/.github/workflows/contributor-rewards.yml
+++ b/.github/workflows/contributor-rewards.yml
@@ -1,0 +1,288 @@
+---
+name: Contributor Rewards
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: contributor-rewards-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  reward:
+    name: Invite eligible contributor
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true) ||
+      (github.event.action == 'labeled' &&
+        github.event.label.name == 'reward user')
+    steps:
+      - name: Post reward invite when eligible
+        uses: actions/github-script@v8
+        env:
+          CONTRIBUTOR_REWARD_TRIGGER_LABEL: reward user
+          CONTRIBUTOR_REWARD_SENT_LABEL: reward sent
+          CONTRIBUTOR_REWARD_DISCORD_URL: ${{ vars.CONTRIBUTOR_REWARD_DISCORD_URL }}
+          CONTRIBUTOR_REWARD_MERCH_URL: ${{ vars.CONTRIBUTOR_REWARD_MERCH_URL }}
+          CONTRIBUTOR_REWARD_MESSAGE: ${{ vars.CONTRIBUTOR_REWARD_MESSAGE }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const triggerLabel = (process.env.CONTRIBUTOR_REWARD_TRIGGER_LABEL || 'reward user').trim();
+            const sentLabel = (process.env.CONTRIBUTOR_REWARD_SENT_LABEL || 'reward sent').trim();
+            const discordUrl =
+              (process.env.CONTRIBUTOR_REWARD_DISCORD_URL || 'https://discord.tinyhumans.ai/').trim();
+            const merchUrl = (process.env.CONTRIBUTOR_REWARD_MERCH_URL || '').trim();
+            const customMessage = (process.env.CONTRIBUTOR_REWARD_MESSAGE || '').trim();
+
+            const normalize = value => String(value || '').trim().toLowerCase();
+            const triggerLabelKey = normalize(triggerLabel);
+
+            function markerFor(login) {
+              return `<!-- openhuman-contributor-reward:user=${normalize(login)} -->`;
+            }
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+                return;
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                core.info(`Created label "${name}".`);
+              } catch (error) {
+                if (error.status !== 422) throw error;
+                core.info(`Label "${name}" already exists.`);
+              }
+            }
+
+            function labeledWithTrigger() {
+              return normalize(context.payload.label?.name) === triggerLabelKey;
+            }
+
+            function actorIsBot(target) {
+              return target.userType === 'Bot' || /\[bot\]$/i.test(target.login);
+            }
+
+            function targetFromEvent() {
+              if (context.eventName === 'workflow_dispatch') {
+                return { bootstrapOnly: true };
+              }
+
+              if (context.eventName === 'pull_request_target') {
+                const pr = context.payload.pull_request;
+                if (!pr) return null;
+
+                if (context.payload.action === 'closed') {
+                  if (!pr.merged) {
+                    core.info(`PR #${pr.number} was closed without merge; skipping reward flow.`);
+                    return null;
+                  }
+
+                  return {
+                    kind: 'pull request',
+                    number: pr.number,
+                    htmlUrl: pr.html_url,
+                    login: pr.user.login,
+                    userType: pr.user.type,
+                    reason: 'first merged pull request',
+                    manualOverride: false,
+                    requireFirstMergedPr: true,
+                  };
+                }
+
+                if (context.payload.action === 'labeled') {
+                  if (!labeledWithTrigger()) {
+                    core.info(`Label "${context.payload.label?.name}" is not "${triggerLabel}"; skipping.`);
+                    return null;
+                  }
+
+                  return {
+                    kind: 'pull request',
+                    number: pr.number,
+                    htmlUrl: pr.html_url,
+                    login: pr.user.login,
+                    userType: pr.user.type,
+                    reason: `maintainer-applied "${triggerLabel}" label on a pull request`,
+                    manualOverride: true,
+                    requireFirstMergedPr: false,
+                  };
+                }
+              }
+
+              if (context.eventName === 'issues') {
+                const issue = context.payload.issue;
+                if (!issue) return null;
+
+                if (issue.pull_request) {
+                  core.info(`Issue event is for PR #${issue.number}; pull_request_target handles PR labels.`);
+                  return null;
+                }
+
+                if (!labeledWithTrigger()) {
+                  core.info(`Label "${context.payload.label?.name}" is not "${triggerLabel}"; skipping.`);
+                  return null;
+                }
+
+                return {
+                  kind: 'issue',
+                  number: issue.number,
+                  htmlUrl: issue.html_url,
+                  login: issue.user.login,
+                  userType: issue.user.type,
+                  reason: `maintainer-applied "${triggerLabel}" label on an issue`,
+                  manualOverride: true,
+                  requireFirstMergedPr: false,
+                };
+              }
+
+              core.info(`Unsupported event "${context.eventName}"; skipping.`);
+              return null;
+            }
+
+            async function isFirstMergedPullRequest(login, currentNumber) {
+              const query = `repo:${owner}/${repo} is:pr is:merged author:${login}`;
+              const response = await github.rest.search.issuesAndPullRequests({
+                q: query,
+                per_page: 100,
+              });
+              const previous = response.data.items.filter(item => item.number !== currentNumber);
+              core.info(
+                `Found ${previous.length} earlier merged PR(s) for ${login} while evaluating #${currentNumber}.`
+              );
+              return previous.length === 0;
+            }
+
+            async function targetAlreadyRewarded(target) {
+              const marker = markerFor(target.login);
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: target.number,
+                per_page: 100,
+              });
+              return comments.some(comment => comment.body?.includes(marker));
+            }
+
+            async function contributorAlreadyRewardedElsewhere(target) {
+              const markerNeedle = `openhuman-contributor-reward:user=${normalize(target.login)}`;
+              const query = `repo:${owner}/${repo} "${markerNeedle}" in:comments`;
+              const response = await github.rest.search.issuesAndPullRequests({
+                q: query,
+                per_page: 10,
+              });
+              return response.data.items.some(item => item.number !== target.number);
+            }
+
+            function renderCustomMessage(target) {
+              const replacements = {
+                '{user}': `@${target.login}`,
+                '{login}': target.login,
+                '{discord_url}': discordUrl,
+                '{merch_url}': merchUrl,
+                '{reason}': target.reason,
+                '{target_url}': target.htmlUrl,
+              };
+
+              let body = customMessage;
+              for (const [token, value] of Object.entries(replacements)) {
+                body = body.split(token).join(value);
+              }
+              return `${markerFor(target.login)}\n${body}`;
+            }
+
+            function renderDefaultMessage(target) {
+              const merchLine = merchUrl
+                ? `3. Claim merch: ${merchUrl}`
+                : '3. For merch, ask a maintainer in Discord. Keep shipping details out of GitHub comments.';
+
+              return [
+                markerFor(target.login),
+                `Thanks @${target.login} for contributing to OpenHuman.`,
+                '',
+                'You are eligible for the contributor reward flow:',
+                '',
+                `1. Join the OpenHuman Discord: ${discordUrl}`,
+                `2. Share this ${target.kind} link so maintainers can verify your GitHub handle: ${target.htmlUrl}`,
+                merchLine,
+                '',
+                `*Reason: ${target.reason}. Automatic rewards are idempotent per GitHub user; maintainer-applied "${triggerLabel}" labels can intentionally start the flow for special cases.*`,
+              ].join('\n');
+            }
+
+            const target = targetFromEvent();
+
+            await ensureLabel(triggerLabel, 'fbca04', 'Maintainer-triggered contributor reward invite');
+            await ensureLabel(sentLabel, '0e8a16', 'Contributor reward invite has been posted');
+
+            if (!target) {
+              await core.summary.addHeading('Contributor Rewards').addRaw('No eligible target for this event.').write();
+              return;
+            }
+
+            if (target.bootstrapOnly) {
+              await core.summary
+                .addHeading('Contributor Rewards')
+                .addRaw(`Labels "${triggerLabel}" and "${sentLabel}" are ready.`)
+                .write();
+              return;
+            }
+
+            if (actorIsBot(target)) {
+              core.info(`Skipping bot account ${target.login}.`);
+              return;
+            }
+
+            if (target.requireFirstMergedPr) {
+              const firstMergedPr = await isFirstMergedPullRequest(target.login, target.number);
+              if (!firstMergedPr) {
+                core.info(`${target.login} already has a merged PR; skipping automatic reward.`);
+                return;
+              }
+            }
+
+            if (await targetAlreadyRewarded(target)) {
+              core.info(`#${target.number} already has a reward marker for ${target.login}; skipping.`);
+              return;
+            }
+
+            if (!target.manualOverride && (await contributorAlreadyRewardedElsewhere(target))) {
+              core.info(`${target.login} already has a reward marker elsewhere; skipping automatic reward.`);
+              return;
+            }
+
+            const body = customMessage ? renderCustomMessage(target) : renderDefaultMessage(target);
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: target.number,
+              body,
+            });
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: target.number,
+              labels: [sentLabel],
+            });
+
+            core.info(`Posted contributor reward invite for ${target.login} on #${target.number}.`);
+            await core.summary
+              .addHeading('Contributor Rewards')
+              .addRaw(`Posted reward invite for @${target.login} on ${target.htmlUrl}.`)
+              .write();

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,6 +297,13 @@ git checkout -b docs/your-change
 
 If you are contributing through a coding agent or remote environment, include the metadata required by the PR template and the Codex PR checklist.
 
+### Contributor rewards
+
+Maintainers can reward eligible contributors through the automated workflow in
+[`docs/CONTRIBUTOR-REWARDS.md`](docs/CONTRIBUTOR-REWARDS.md). First merged pull
+requests are handled automatically, and maintainers can apply the `reward user`
+label to manually start the same Discord and merch invite flow.
+
 ## Project Conventions
 
 - Use Redux and existing app state patterns instead of adding new ad hoc browser storage.

--- a/app/src/utils/__tests__/toolTimelineFormatting.test.ts
+++ b/app/src/utils/__tests__/toolTimelineFormatting.test.ts
@@ -57,6 +57,45 @@ describe('formatTimelineEntry', () => {
     });
   });
 
+  it('formats delegate_to_integrations_agent with a known toolkit arg', () => {
+    expect(
+      formatTimelineEntry(
+        entry({
+          name: 'delegate_to_integrations_agent',
+          argsBuffer: JSON.stringify({
+            toolkit: 'gmail',
+            prompt: 'Find the latest invoice from Stripe.',
+          }),
+        })
+      )
+    ).toEqual({
+      title: 'Making requests to your Gmail account',
+      detail: 'Find the latest invoice from Stripe.',
+    });
+  });
+
+  it('formats delegate_to_integrations_agent with an unknown toolkit arg', () => {
+    expect(
+      formatTimelineEntry(
+        entry({
+          name: 'delegate_to_integrations_agent',
+          argsBuffer: JSON.stringify({ toolkit: 'slack_bot', prompt: 'post update' }),
+        })
+      )
+    ).toEqual({ title: 'Checking your Slack Bot', detail: 'post update' });
+  });
+
+  it('formats delegate_to_integrations_agent without a toolkit arg as a generic connected-app label', () => {
+    expect(
+      formatTimelineEntry(
+        entry({
+          name: 'delegate_to_integrations_agent',
+          argsBuffer: JSON.stringify({ prompt: 'do something useful' }),
+        })
+      )
+    ).toEqual({ title: 'Checking your connected app', detail: 'do something useful' });
+  });
+
   it('formats delegate_tools_agent with toolkit context from args', () => {
     expect(
       formatTimelineEntry(

--- a/app/src/utils/toolTimelineFormatting.ts
+++ b/app/src/utils/toolTimelineFormatting.ts
@@ -55,10 +55,29 @@ export function formatTimelineEntry(entry: ToolTimelineEntry): { title: string; 
       inferIntegrationName(parsedArgs?.toolkit) ??
       inferIntegrationNameFromPrompt(parsedArgs?.prompt) ??
       inferIntegrationName(entry.name);
-    return {
-      title: provider ? integrationActivityTitle(provider) : humanizeIdentifier(entry.name),
-      detail: entry.detail ?? parsedArgs?.prompt,
-    };
+
+    // The collapsed `delegate_to_integrations_agent` tool has no toolkit
+    // baked into its name; if we couldn't infer a provider from args or
+    // prompt, surface a generic connected-app label (matches the
+    // `spawn_subagent → integrations_agent` fallback above) instead of
+    // humanising the tool name into "To Integrations Agent". Unknown
+    // toolkit slugs from args fall back to a humanised toolkit label so
+    // composio integrations outside KNOWN_TOOLKIT_RE still render
+    // meaningfully (e.g. `slack_bot` → "Slack Bot") rather than the
+    // generic copy.
+    let title: string;
+    if (provider) {
+      title = integrationActivityTitle(provider);
+    } else if (entry.name === 'delegate_to_integrations_agent') {
+      const rawToolkit = parsedArgs?.toolkit?.trim();
+      title = rawToolkit
+        ? integrationActivityTitle(humanizeIdentifier(rawToolkit))
+        : 'Checking your connected app';
+    } else {
+      title = humanizeIdentifier(entry.name);
+    }
+
+    return { title, detail: entry.detail ?? parsedArgs?.prompt };
   }
 
   return {

--- a/docs/CONTRIBUTOR-REWARDS.md
+++ b/docs/CONTRIBUTOR-REWARDS.md
@@ -1,0 +1,82 @@
+# Contributor Rewards Automation
+
+OpenHuman uses `.github/workflows/contributor-rewards.yml` to invite eligible
+contributors into the Discord and merch reward flow.
+
+## Triggers
+
+The workflow runs when:
+
+- a pull request is merged and the PR author has no earlier merged PR in this
+  repository;
+- a maintainer applies the `reward user` label to a pull request;
+- a maintainer applies the `reward user` label to an issue;
+- a maintainer runs the workflow manually to bootstrap the labels.
+
+The workflow creates these labels if they do not already exist:
+
+- `reward user` - maintainer-triggered reward invite;
+- `reward sent` - audit label added after the invite comment is posted.
+
+## Idempotency
+
+Each reward comment includes a hidden marker scoped to the GitHub login:
+
+```html
+<!-- openhuman-contributor-reward:user=<login> -->
+```
+
+Automatic first-merged-PR rewards are skipped when the same login already has a
+reward marker elsewhere in the repository. Maintainers can intentionally start
+the flow again by applying `reward user`, but the workflow still skips a target
+issue or PR that already contains the same marker.
+
+Bot accounts are skipped.
+
+## Configuration
+
+Configure these repository variables under
+**Settings -> Secrets and variables -> Actions -> Variables**:
+
+| Variable                         | Required | Purpose                                                                  |
+| -------------------------------- | -------- | ------------------------------------------------------------------------ |
+| `CONTRIBUTOR_REWARD_DISCORD_URL` | No       | Public Discord invite URL. Defaults to `https://discord.tinyhumans.ai/`. |
+| `CONTRIBUTOR_REWARD_MERCH_URL`   | No       | Public merch claim or redemption URL included in the comment.            |
+| `CONTRIBUTOR_REWARD_MESSAGE`     | No       | Full custom comment body. Supports tokens listed below.                  |
+
+`CONTRIBUTOR_REWARD_MESSAGE` can use these tokens:
+
+- `{user}` - GitHub mention, for example `@octocat`;
+- `{login}` - raw GitHub login;
+- `{discord_url}` - configured Discord URL;
+- `{merch_url}` - configured merch URL or an empty string;
+- `{reason}` - trigger reason;
+- `{target_url}` - issue or PR URL.
+
+Do not put private Discord invite mechanics, shipping forms, access tokens, or
+other secrets in repository variables used by this workflow. Anything rendered
+by the workflow is posted as a public GitHub comment.
+
+## Security Model
+
+The workflow uses `pull_request_target` so it can comment on pull requests from
+forks. It must not check out or execute pull request code. The current workflow
+only reads the GitHub event payload and calls GitHub APIs through
+`actions/github-script`.
+
+Required permissions are limited to:
+
+- `contents: read`;
+- `issues: write`;
+- `pull-requests: read`.
+
+## Manual Operation
+
+To reward a contributor manually:
+
+1. Open the issue or pull request.
+2. Apply the `reward user` label.
+3. Wait for the workflow to post the reward comment and add `reward sent`.
+
+If the labels do not exist yet, run **Actions -> Contributor Rewards -> Run
+workflow** once on `main`.

--- a/src/openhuman/agent/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent/agents/orchestrator/prompt.md
@@ -21,7 +21,7 @@ Follow this sequence for every user message:
    - Yes: use direct tools first (`current_time`, `cron_*`, `memory_*`, `composio_list_connections`, etc.).
    - No: continue.
 3. **Does this need specialised execution?**
-   - If external SaaS integration work is required, use `delegate_{toolkit}` (e.g. `delegate_gmail`, `delegate_notion`).
+   - If external SaaS integration work is required, use `delegate_to_integrations_agent` with `toolkit` set to the relevant slug (see the **Connected Integrations** section for the current list).
    - If code writing/execution/debugging is required, use `delegate_run_code`.
    - If web/doc crawling is required, use `delegate_researcher`.
    - If complex multi-step decomposition is required, use `delegate_plan`.
@@ -29,9 +29,7 @@ Follow this sequence for every user message:
    - If memory archiving or distillation is required, use `delegate_archivist`.
 4. **After delegation**, summarise results clearly and concisely.
 
-Default bias: **do not spawn a sub-agent when a direct response or direct tool call is sufficient**.
-
-When delegating: use `delegate_researcher` for web/doc lookups, `delegate_run_code` for coding, `delegate_plan` for complex decomposition, `delegate_critic` for reviews, `delegate_archivist` for memory writes, `delegate_{toolkit}` for external integrations. Use `spawn_worker_thread` for long tasks that need their own thread.
+Default bias: **do not spawn a sub-agent when a direct response or direct tool call is sufficient**. Use `spawn_worker_thread` for long tasks that need their own thread.
 
 ## Rules
 
@@ -59,7 +57,7 @@ multi-file refactors, or batch integration work. It creates a persisted **worker
 thread the user can open from the thread list, and returns a compact `[worker_thread_ref]`
 (thread id + brief summary) to the parent instead of the full transcript.
 
-For routine delegation use the matching `delegate_*` tool and surface the result inline.
+For routine delegation use the matching specialist `delegate_*` tool (or `delegate_to_integrations_agent` for external services) and surface the result inline.
 
 Worker threads are one level deep by design: a sub-agent spawned via `spawn_worker_thread`
 cannot itself call `spawn_worker_thread`, so workers never nest.

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -3,9 +3,10 @@
 //! The orchestrator follows a direct-first policy: respond directly or use
 //! cheap direct tools whenever possible, and delegate only for specialised
 //! execution. It never executes Composio actions itself; the integration
-//! block points to `delegate_{toolkit}` tools (synthesised by
-//! `orchestrator_tools::collect_orchestrator_tools`) for true
-//! external-service operations. That prose lives here (not in the shared
+//! block points to the single collapsed `delegate_to_integrations_agent`
+//! tool (synthesised by `orchestrator_tools::collect_orchestrator_tools`,
+//! #1335) for true external-service operations, with the toolkit slug
+//! passed as an argument. That prose lives here (not in the shared
 //! prompts module) so the skill-executor voice stays in
 //! `integrations_agent/prompt.rs` and nobody has to branch on `agent_id`
 //! in a shared section impl.
@@ -90,15 +91,16 @@ fn render_delegation_guide(integrations: &[ConnectedIntegration]) -> String {
     }
     let mut out = String::from(
         "## Connected Integrations\n\n\
-         Delegate tasks for these services using the matching `delegate_{toolkit}` tool:\n\n",
+         Delegate tasks for these services with `delegate_to_integrations_agent`, passing the toolkit slug as `toolkit`:\n\n",
     );
     for ci in connected {
         // Use the same slug canonicalisation as `collect_orchestrator_tools`
-        // so the tool name in the prompt always matches the synthesised tool.
+        // so the `toolkit` arg the orchestrator emits always matches the
+        // enum the synthesised tool accepts.
         let slug = sanitise_slug(&ci.toolkit);
         let _ = writeln!(
             out,
-            "- **{}** (delegate via `delegate_{}`): {}",
+            "- **{}** (`toolkit: \"{}\"`): {}",
             ci.toolkit, slug, ci.description
         );
     }
@@ -161,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn build_emits_delegation_guide_with_spawn_snippet() {
+    fn build_emits_delegation_guide_with_collapsed_tool() {
         let integrations = vec![ConnectedIntegration {
             toolkit: "gmail".into(),
             description: "Email access.".into(),
@@ -170,7 +172,10 @@ mod tests {
         }];
         let body = build(&ctx_with(&integrations)).unwrap();
         assert!(body.contains("## Connected Integrations"));
-        assert!(body.contains("delegate_gmail"));
+        assert!(body.contains("delegate_to_integrations_agent"));
+        assert!(body.contains("toolkit: \"gmail\""));
+        // Must NOT contain the old per-toolkit fan-out tool names.
+        assert!(!body.contains("delegate_gmail"));
         // Must NOT contain the old verbose spawn_subagent snippet.
         assert!(!body.contains("spawn_subagent(agent_id=\"integrations_agent\""));
         // Delegator voice must NOT use the skill-executor wording.
@@ -178,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn delegation_guide_uses_compact_delegate_format() {
+    fn delegation_guide_uses_compact_collapsed_format() {
         let integrations = vec![ConnectedIntegration {
             toolkit: "gmail".into(),
             description: "Email access.".into(),
@@ -187,15 +192,16 @@ mod tests {
         }];
         let body = build(&ctx_with(&integrations)).unwrap();
         assert!(body.contains("## Connected Integrations"));
-        assert!(body.contains("delegate_gmail"));
-        // Must NOT contain the old verbose spawn_subagent snippet.
+        assert!(body.contains("delegate_to_integrations_agent"));
+        // Old verbose / per-toolkit forms must be gone.
+        assert!(!body.contains("delegate_gmail"));
         assert!(!body.contains("spawn_subagent(agent_id=\"integrations_agent\""));
     }
 
     #[test]
     fn build_hides_unconnected_integrations() {
         // Only connected toolkits make it into the Delegation Guide
-        // — unconnected entries would just trigger a spawn_subagent
+        // — unconnected entries would just trigger a downstream
         // pre-flight rejection, so keeping them out keeps the prompt
         // focused on what the orchestrator can actually delegate.
         let integrations = vec![

--- a/src/openhuman/agent/harness/definition.rs
+++ b/src/openhuman/agent/harness/definition.rs
@@ -157,10 +157,11 @@ pub struct AgentDefinition {
     ///   agent's `delegate_name` override) and whose description is the
     ///   target agent's [`AgentDefinition::when_to_use`].
     ///
-    /// * [`SubagentEntry::Skills`] — one [`SkillDelegationTool`] per
-    ///   connected Composio toolkit, each named `delegate_{toolkit}`,
-    ///   all routing to the generic `integrations_agent` with an appropriate
-    ///   `skill_filter` pre-populated.
+    /// * [`SubagentEntry::Skills`] — a single collapsed
+    ///   [`SkillDelegationTool`] named `delegate_to_integrations_agent`
+    ///   that takes the toolkit slug as an argument and routes to the
+    ///   generic `integrations_agent` with the corresponding
+    ///   `skill_filter` pre-populated (#1335).
     ///
     /// `subagents` is intentionally separate from [`AgentDefinition::tools`]
     /// so that reading a TOML makes the distinction obvious: `tools` is
@@ -207,9 +208,11 @@ pub struct AgentDefinition {
 pub enum SubagentEntry {
     /// Delegate to a specific built-in or custom agent by id.
     AgentId(String),
-    /// Expand at build time to one `delegate_{toolkit}` tool per
-    /// connected Composio toolkit, each routing to the generic
-    /// `integrations_agent` with `skill_filter` pre-set.
+    /// Expand at build time to a single collapsed
+    /// `delegate_to_integrations_agent` tool whose `toolkit` argument
+    /// selects which connected Composio toolkit to route to, with
+    /// `skill_filter` pre-set on the underlying `integrations_agent`
+    /// dispatch (#1335).
     Skills(SkillsWildcard),
 }
 

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -869,8 +869,10 @@ impl Agent {
         //
         // For an agent with `subagents = [...]` in its TOML (today:
         // orchestrator), `collect_orchestrator_tools` synthesises one
-        // `ArchetypeDelegationTool` per named sub-agent plus one
-        // `SkillDelegationTool` per connected Composio toolkit.
+        // `ArchetypeDelegationTool` per named sub-agent plus a single
+        // collapsed `SkillDelegationTool`
+        // (`delegate_to_integrations_agent`) whose `toolkit` argument
+        // selects among the connected Composio toolkits (#1335).
         //
         // For an agent without `subagents` (today: welcome, critic,
         // archivist, etc.), no delegation tools are synthesised — the

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -87,10 +87,11 @@ pub(crate) async fn agent_turn(
 ///
 /// * `extra_tools` — per-turn synthesised tools to splice alongside the
 ///   persistent `tools_registry`. The agent-dispatch path uses this to
-///   surface delegation tools (`research`, `delegate_gmail`, …) that
-///   are synthesised fresh per turn from the active agent's
-///   `subagents` field and the current Composio integration list, and
-///   therefore are not registered in the global startup-time registry.
+///   surface delegation tools (`research`, `plan`,
+///   `delegate_to_integrations_agent`, …) that are synthesised fresh
+///   per turn from the active agent's `subagents` field and the
+///   current Composio integration list, and therefore are not
+///   registered in the global startup-time registry.
 ///
 /// The combined tool list seen by the LLM this turn is
 /// `tools_registry.iter().chain(extra_tools.iter())`, further narrowed

--- a/src/openhuman/channels/runtime/dispatch.rs
+++ b/src/openhuman/channels/runtime/dispatch.rs
@@ -499,7 +499,8 @@ async fn resolve_target_agent(channel: &str) -> AgentScoping {
 /// * every tool name in the agent's `[tools] named = [...]` list
 ///   (when the scope is [`ToolScope::Named`]); and
 /// * every name produced by the per-turn synthesised delegation tools
-///   in `extra_tools` (e.g. `research`, `delegate_gmail`).
+///   in `extra_tools` (e.g. `research`, `plan`,
+///   `delegate_to_integrations_agent`).
 ///
 /// When the agent's tool scope is [`ToolScope::Wildcard`] **and** there
 /// are no `extra_tools`, returns `None` to preserve the legacy
@@ -632,9 +633,11 @@ mod scoping_tests {
 
     /// `ToolScope::Named` with extras returns the union of the TOML
     /// named list and the extras' names. This is the orchestrator's
-    /// path: 4 direct tools from the TOML + N synthesised delegation
-    /// tools (`research`, `plan`, `delegate_gmail`, …) → all of them
-    /// visible to the orchestrator's LLM.
+    /// path: direct tools from the TOML + the synthesised delegation
+    /// tools (`research`, `plan`, `delegate_to_integrations_agent`)
+    /// → all of them visible to the orchestrator's LLM. The stub
+    /// names in this test are arbitrary; they exercise the union
+    /// logic, not the real synthesiser.
     #[test]
     fn named_scope_with_extras_returns_union() {
         let def = def_with_scope(ToolScope::Named(vec![

--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -468,27 +468,41 @@ impl AuthProfilesStore {
 
         let mut waited = 0_u64;
         loop {
-            match OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(&self.lock_path)
-            {
+            let open_result = crate::openhuman::util::retry_with_backoff(
+                "create auth profile lock",
+                6,
+                100,
+                || {
+                    OpenOptions::new()
+                        .create_new(true)
+                        .write(true)
+                        .open(&self.lock_path)
+                        .context("open lock file")
+                },
+            );
+
+            match open_result {
                 Ok(mut file) => {
                     let _ = writeln!(file, "pid={}", std::process::id());
                     return Ok(AuthProfileLockGuard {
                         lock_path: self.lock_path.clone(),
                     });
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if waited >= LOCK_TIMEOUT_MS {
-                        anyhow::bail!("Timed out waiting for auth profile lock");
-                    }
-                    thread::sleep(Duration::from_millis(LOCK_WAIT_MS));
-                    waited = waited.saturating_add(LOCK_WAIT_MS);
-                }
                 Err(e) => {
-                    return Err(e)
-                        .with_context(|| "Failed to create auth profile lock".to_string());
+                    let is_already_exists = e
+                        .chain()
+                        .find_map(|e| e.downcast_ref::<std::io::Error>())
+                        .map_or(false, |ioe| ioe.kind() == std::io::ErrorKind::AlreadyExists);
+
+                    if is_already_exists {
+                        if waited >= LOCK_TIMEOUT_MS {
+                            anyhow::bail!("Timed out waiting for auth profile lock");
+                        }
+                        thread::sleep(Duration::from_millis(LOCK_WAIT_MS));
+                        waited = waited.saturating_add(LOCK_WAIT_MS);
+                    } else {
+                        return Err(e).context("Failed to create auth profile lock");
+                    }
                 }
             }
         }

--- a/src/openhuman/memory/tree/read_rpc.rs
+++ b/src/openhuman/memory/tree/read_rpc.rs
@@ -1356,7 +1356,7 @@ pub async fn wipe_all_rpc(config: &Config) -> Result<RpcOutcome<WipeAllResponse>
 
     let resp = WipeAllResponse {
         rows_deleted,
-        dirs_removed: dirs_removed.clone(),
+        dirs_removed,
         sync_state_cleared,
     };
 
@@ -1416,17 +1416,19 @@ pub struct ResetTreeResponse {
 /// inert fallback to a real Ollama model) and want to re-summarise
 /// existing data without paying the upstream sync cost again.
 ///
-/// Three steps, each in its own SQL pass:
+/// Three steps, executed in this order:
 ///   1. Truncate `mem_tree_summaries`, `mem_tree_trees`,
 ///      `mem_tree_buffers`, `mem_tree_jobs`. The tree schema is
 ///      derived state — chunks are the source of truth.
-///   2. Remove `<content_root>/wiki/summaries/` on disk so stale
-///      `.md` files don't drift from the SQL truth.
-///   3. Reset every chunk's `lifecycle_status` to
+///   2. Reset every chunk's `lifecycle_status` to
 ///      `'pending_extraction'` and enqueue an `extract_chunk` job
 ///      keyed on the chunk id. The async worker picks each up and
 ///      re-runs entity extract → score → embed → append-to-buffer.
 ///      Seals happen automatically as L0 buffers cross the gate.
+///   3. Remove `<content_root>/wiki/summaries/` on disk so stale
+///      `.md` files don't drift from the SQL truth. Done last (and
+///      outside `spawn_blocking`) so the on-disk removal can use
+///      async retry without blocking the worker thread.
 pub async fn reset_tree_rpc(config: &Config) -> Result<RpcOutcome<ResetTreeResponse>, String> {
     use crate::openhuman::memory::tree::jobs::store as jobs_store;
     use crate::openhuman::memory::tree::jobs::types::{ExtractChunkPayload, NewJob};
@@ -1455,7 +1457,7 @@ pub async fn reset_tree_rpc(config: &Config) -> Result<RpcOutcome<ResetTreeRespo
                 Ok(total)
             })?;
 
-            // Step 3 — flip every chunk back to `pending_extraction` and
+            // Step 2 — flip every chunk back to `pending_extraction` and
             // enqueue an `extract_chunk` job per id.
             let (chunks_requeued, jobs_enqueued) =
                 with_connection(&cfg, |conn| -> anyhow::Result<(u64, u64)> {
@@ -1496,7 +1498,7 @@ pub async fn reset_tree_rpc(config: &Config) -> Result<RpcOutcome<ResetTreeRespo
         .map_err(|e| format!("reset_tree join error: {e}"))?
         .map_err(|e| format!("reset_tree: {e:#}"))?;
 
-    // Step 2 — wipe the on-disk wiki/summaries tree.
+    // Step 3 — wipe the on-disk wiki/summaries tree.
     // Use async retry to avoid blocking the executor during Windows sharing violations.
     let summaries_dir = config
         .memory_tree_content_root()

--- a/src/openhuman/memory/tree/read_rpc.rs
+++ b/src/openhuman/memory/tree/read_rpc.rs
@@ -1254,7 +1254,7 @@ pub struct WipeAllResponse {
 /// can re-sync from scratch without leaving the app.
 pub async fn wipe_all_rpc(config: &Config) -> Result<RpcOutcome<WipeAllResponse>, String> {
     let cfg = config.clone();
-    let resp = tokio::task::spawn_blocking(move || -> Result<WipeAllResponse> {
+    let (rows_deleted, sync_state_cleared) = tokio::task::spawn_blocking(move || -> Result<(u64, u64)> {
         // Tables to truncate. Order matters: `mem_tree_summaries` and
         // `mem_tree_buffers` both have `FOREIGN KEY (tree_id) REFERENCES
         // mem_tree_trees(id)` with `PRAGMA foreign_keys = ON`, so trees
@@ -1283,45 +1283,11 @@ pub async fn wipe_all_rpc(config: &Config) -> Result<RpcOutcome<WipeAllResponse>
             Ok(total)
         })?;
 
-        // Filesystem cleanup. Each directory is best-effort: if one
-        // fails (permission denied, path doesn't exist) we keep going
-        // and report what we managed to remove. `email/` and the
-        // legacy bare `summaries/` are listed for back-compat —
-        // workspaces ingested before the raw-archive + wiki/ moves
-        // still have files there. Fresh installs only ever populate
-        // `raw/`, `wiki/`, `chat/`, and `document/`.
-        const DIRS: &[&str] = &["raw", "wiki", "chat", "document", "email", "summaries"];
-        let content_root = cfg.memory_tree_content_root();
-        let mut dirs_removed: Vec<String> = Vec::new();
-        for dir in DIRS {
-            let path = content_root.join(dir);
-            match std::fs::remove_dir_all(&path) {
-                Ok(()) => dirs_removed.push((*dir).to_string()),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    // Logical name (raw / wiki / chat / ...) is enough
-                    // signal — the absolute path embeds the user's
-                    // home directory.
-                    log::warn!(
-                        "[memory_tree::read::wipe] failed to remove dir={} err={e}",
-                        dir
-                    );
-                }
-            }
-        }
-
         // Composio sync-state lives in the unified memory store
         // (`<workspace>/memory/memory.db`). Open it directly and
         // delete every key in the `composio-sync-state` namespace —
         // this clears each provider's `cursor` + `synced_ids` set so
         // the next sync re-fetches from the beginning.
-        //
-        // We do **not** swallow clear failures into `0`: callers (and
-        // the frontend `sync_state_cleared` contract) need to
-        // distinguish "nothing to clear" from "failed to clear, so
-        // the next sync may still be incremental." A missing DB is
-        // legitimately "nothing to clear"; a SQLite error is a
-        // failed wipe and propagates.
         let sync_state_cleared: u64 = {
             let unified_db = cfg.workspace_dir.join("memory").join("memory.db");
             if !unified_db.exists() {
@@ -1335,15 +1301,64 @@ pub async fn wipe_all_rpc(config: &Config) -> Result<RpcOutcome<WipeAllResponse>
             }
         };
 
-        Ok(WipeAllResponse {
-            rows_deleted,
-            dirs_removed,
-            sync_state_cleared,
-        })
+        Ok((rows_deleted, sync_state_cleared))
     })
     .await
     .map_err(|e| format!("wipe_all join error: {e}"))?
     .map_err(|e| format!("wipe_all: {e:#}"))?;
+
+    // Filesystem cleanup. Each directory is best-effort: if one
+    // fails (permission denied, path doesn't exist) we keep going
+    // and report what we managed to remove. `email/` and the
+    // legacy bare `summaries/` are listed for back-compat —
+    // workspaces ingested before the raw-archive + wiki/ moves
+    // still have files there. Fresh installs only ever populate
+    // `raw/`, `wiki/`, `chat/`, and `document/`.
+    //
+    // Use async retry to avoid blocking the executor during Windows sharing violations.
+    const DIRS: &[&str] = &["raw", "wiki", "chat", "document", "email", "summaries"];
+    let content_root = config.memory_tree_content_root();
+    let mut dirs_removed: Vec<String> = Vec::new();
+    for dir in DIRS {
+        let path = content_root.join(dir);
+        let remove_result = crate::openhuman::util::retry_with_backoff_async(
+            &format!("remove dir {}", dir),
+            6,
+            200,
+            || async {
+                tokio::fs::remove_dir_all(&path)
+                    .await
+                    .context("remove_dir_all")
+            },
+        )
+        .await;
+
+        match remove_result {
+            Ok(()) => dirs_removed.push((*dir).to_string()),
+            Err(e) => {
+                let is_not_found = e
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<std::io::Error>())
+                    .map_or(false, |ioe| ioe.kind() == std::io::ErrorKind::NotFound);
+                if !is_not_found {
+                    // Logical name (raw / wiki / chat / ...) is enough
+                    // signal — the absolute path embeds the user's
+                    // home directory.
+                    log::warn!(
+                        "[memory_tree::read::wipe] failed to remove dir={} err={:#}",
+                        dir,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    let resp = WipeAllResponse {
+        rows_deleted,
+        dirs_removed: dirs_removed.clone(),
+        sync_state_cleared,
+    };
 
     let log = format!(
         "memory_tree::read: wipe_all rows={} dirs={:?} sync_state={}",
@@ -1417,109 +1432,112 @@ pub async fn reset_tree_rpc(config: &Config) -> Result<RpcOutcome<ResetTreeRespo
     use crate::openhuman::memory::tree::jobs::types::{ExtractChunkPayload, NewJob};
 
     let cfg = config.clone();
-    let resp = tokio::task::spawn_blocking(move || -> Result<ResetTreeResponse> {
-        // Step 1 — truncate tree state in one transaction. Chunks
-        // (`mem_tree_chunks`), the entity index, score rows, and the
-        // sync-state KV all stay intact.
-        //
-        // Order matters: `mem_tree_summaries` and `mem_tree_buffers`
-        // both have `FOREIGN KEY (tree_id) REFERENCES mem_tree_trees(id)`,
-        // and `PRAGMA foreign_keys = ON` is set. Trees must come last
-        // or SQLite throws "FOREIGN KEY constraint failed". `mem_tree_jobs`
-        // has no FK so its position is free.
-        // `mem_tree_entity_index` holds both leaf (chunk) and summary
-        // entity rows. Clearing it on reset prevents `top_entities`
-        // from counting orphan rows pointing at deleted summaries;
-        // the leaf rows get rebuilt naturally when the requeued
-        // `extract_chunk` jobs run for every chunk.
-        const TREE_TABLES: &[&str] = &[
-            "mem_tree_summaries",
-            "mem_tree_buffers",
-            "mem_tree_jobs",
-            "mem_tree_entity_index",
-            "mem_tree_trees",
-        ];
-        let tree_rows_deleted: u64 = with_connection(&cfg, |conn| {
-            let tx = conn.unchecked_transaction()?;
-            let mut total: u64 = 0;
-            for table in TREE_TABLES {
-                let n = tx
-                    .execute(&format!("DELETE FROM {table}"), [])
-                    .with_context(|| format!("delete from {table}"))?;
-                total += n as u64;
-            }
-            tx.commit()?;
-            Ok(total)
-        })?;
-
-        // Step 2 — wipe the on-disk wiki/summaries tree. Best-effort:
-        // a missing folder is fine (fresh workspace). Other errors
-        // log + carry on — the SQL truth is what the rebuild relies on.
-        let summaries_dir = cfg
-            .memory_tree_content_root()
-            .join("wiki")
-            .join("summaries");
-        match std::fs::remove_dir_all(&summaries_dir) {
-            Ok(()) => log::debug!("[memory_tree::read::reset_tree] removed wiki/summaries"),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                log::warn!("[memory_tree::read::reset_tree] failed to remove wiki/summaries: {e}")
-            }
-        }
-
-        // Step 3 — flip every chunk back to `pending_extraction` and
-        // enqueue an `extract_chunk` job per id. Done in a single
-        // transaction so partial state is impossible: either the
-        // whole queue is in flight or nothing is. We use a chunked
-        // SELECT so very large workspaces don't materialise the
-        // entire id list in memory.
-        let (chunks_requeued, jobs_enqueued) =
-            with_connection(&cfg, |conn| -> anyhow::Result<(u64, u64)> {
+    let (tree_rows_deleted, chunks_requeued, jobs_enqueued) =
+        tokio::task::spawn_blocking(move || -> Result<(u64, u64, u64)> {
+            // Step 1 — truncate tree state in one transaction.
+            const TREE_TABLES: &[&str] = &[
+                "mem_tree_summaries",
+                "mem_tree_buffers",
+                "mem_tree_jobs",
+                "mem_tree_entity_index",
+                "mem_tree_trees",
+            ];
+            let tree_rows_deleted: u64 = with_connection(&cfg, |conn| {
                 let tx = conn.unchecked_transaction()?;
-                let chunks_requeued = tx.execute(
-                    "UPDATE mem_tree_chunks SET lifecycle_status = 'pending_extraction'",
-                    [],
-                )? as u64;
-                let chunk_ids: Vec<String> = {
-                    let mut stmt = tx.prepare("SELECT id FROM mem_tree_chunks")?;
-                    let rows = stmt
-                        .query_map([], |r| r.get::<_, String>(0))?
-                        .collect::<rusqlite::Result<Vec<_>>>()
-                        .context("collect chunk ids")?;
-                    rows
-                };
-                let mut jobs_enqueued: u64 = 0;
-                for id in &chunk_ids {
-                    let payload = ExtractChunkPayload {
-                        chunk_id: id.clone(),
-                    };
-                    let job =
-                        NewJob::extract_chunk(&payload).context("build extract_chunk NewJob")?;
-                    if jobs_store::enqueue_tx(&tx, &job)
-                        .context("enqueue extract_chunk")?
-                        .is_some()
-                    {
-                        jobs_enqueued += 1;
-                    }
+                let mut total: u64 = 0;
+                for table in TREE_TABLES {
+                    let n = tx
+                        .execute(&format!("DELETE FROM {table}"), [])
+                        .with_context(|| format!("delete from {table}"))?;
+                    total += n as u64;
                 }
                 tx.commit()?;
-                Ok((chunks_requeued, jobs_enqueued))
+                Ok(total)
             })?;
 
-        // Wake the worker pool so the freshly-enqueued jobs start
-        // running immediately rather than waiting for the next
-        // periodic poll.
-        crate::openhuman::memory::tree::jobs::wake_workers();
+            // Step 3 — flip every chunk back to `pending_extraction` and
+            // enqueue an `extract_chunk` job per id.
+            let (chunks_requeued, jobs_enqueued) =
+                with_connection(&cfg, |conn| -> anyhow::Result<(u64, u64)> {
+                    let tx = conn.unchecked_transaction()?;
+                    let chunks_requeued = tx.execute(
+                        "UPDATE mem_tree_chunks SET lifecycle_status = 'pending_extraction'",
+                        [],
+                    )? as u64;
+                    let chunk_ids: Vec<String> = {
+                        let mut stmt = tx.prepare("SELECT id FROM mem_tree_chunks")?;
+                        let rows = stmt
+                            .query_map([], |r| r.get::<_, String>(0))?
+                            .collect::<rusqlite::Result<Vec<_>>>()
+                            .context("collect chunk ids")?;
+                        rows
+                    };
+                    let mut jobs_enqueued: u64 = 0;
+                    for id in &chunk_ids {
+                        let payload = ExtractChunkPayload {
+                            chunk_id: id.clone(),
+                        };
+                        let job = NewJob::extract_chunk(&payload)
+                            .context("build extract_chunk NewJob")?;
+                        if jobs_store::enqueue_tx(&tx, &job)
+                            .context("enqueue extract_chunk")?
+                            .is_some()
+                        {
+                            jobs_enqueued += 1;
+                        }
+                    }
+                    tx.commit()?;
+                    Ok((chunks_requeued, jobs_enqueued))
+                })?;
 
-        Ok(ResetTreeResponse {
-            tree_rows_deleted,
-            chunks_requeued,
-            jobs_enqueued,
+            Ok((tree_rows_deleted, chunks_requeued, jobs_enqueued))
         })
-    })
-    .await
-    .map_err(|e| format!("reset_tree join error: {e}"))?
-    .map_err(|e| format!("reset_tree: {e:#}"))?;
+        .await
+        .map_err(|e| format!("reset_tree join error: {e}"))?
+        .map_err(|e| format!("reset_tree: {e:#}"))?;
+
+    // Step 2 — wipe the on-disk wiki/summaries tree.
+    // Use async retry to avoid blocking the executor during Windows sharing violations.
+    let summaries_dir = config
+        .memory_tree_content_root()
+        .join("wiki")
+        .join("summaries");
+    let remove_result = crate::openhuman::util::retry_with_backoff_async(
+        "remove wiki/summaries",
+        6,
+        200,
+        || async {
+            tokio::fs::remove_dir_all(&summaries_dir)
+                .await
+                .context("remove_dir_all")
+        },
+    )
+    .await;
+
+    match remove_result {
+        Ok(()) => log::debug!("[memory_tree::read::reset_tree] removed wiki/summaries"),
+        Err(e) => {
+            let is_not_found = e
+                .chain()
+                .find_map(|e| e.downcast_ref::<std::io::Error>())
+                .map_or(false, |ioe| ioe.kind() == std::io::ErrorKind::NotFound);
+            if !is_not_found {
+                log::warn!(
+                    "[memory_tree::read::reset_tree] failed to remove wiki/summaries: {:#}",
+                    e
+                )
+            }
+        }
+    }
+
+    // Wake the worker pool so the freshly-enqueued jobs start running.
+    crate::openhuman::memory::tree::jobs::wake_workers();
+
+    let resp = ResetTreeResponse {
+        tree_rows_deleted,
+        chunks_requeued,
+        jobs_enqueued,
+    };
 
     let log = format!(
         "memory_tree::read: reset_tree tree_rows={} chunks={} jobs={}",

--- a/src/openhuman/tools/impl/agent/dispatch.rs
+++ b/src/openhuman/tools/impl/agent/dispatch.rs
@@ -54,9 +54,10 @@ pub(crate) async fn dispatch_subagent(
     );
 
     // Propagate the per-call toolkit scope into the subagent runner so
-    // that `SkillDelegationTool`s can narrow `integrations_agent` to a single
-    // Composio toolkit (e.g. `delegate_gmail` → integrations_agent +
-    // toolkit="gmail"). Earlier code plumbed this through
+    // that the collapsed `SkillDelegationTool` can narrow
+    // `integrations_agent` to a single Composio toolkit (e.g.
+    // `delegate_to_integrations_agent { toolkit: "gmail" }` →
+    // integrations_agent + toolkit="gmail"). Earlier code plumbed this through
     // `skill_filter_override` (which matches `{skill}__` QuickJS-style
     // names), but Composio actions are named `GMAIL_*` / `NOTION_*` —
     // so the filter excluded every Composio tool instead of narrowing

--- a/src/openhuman/tools/impl/agent/skill_delegation.rs
+++ b/src/openhuman/tools/impl/agent/skill_delegation.rs
@@ -1,12 +1,83 @@
+//! Single collapsed delegation tool for Composio-backed integrations
+//! (#1335).
+//!
+//! Replaces the previous per-toolkit fan-out where the orchestrator's
+//! function-calling schema gained a new `delegate_<toolkit>` entry for
+//! every connected integration. Every one of those tools dispatched to
+//! the same `integrations_agent` with a different `skill_filter`, so
+//! exposing them separately bloated the orchestrator's tool list
+//! linearly with no behavioural benefit.
+//!
+//! The collapsed tool keeps the routing handle the orchestrator needs
+//! ("send this to integrations, scoped to toolkit X") while making the
+//! orchestrator's schema cost constant in the integration dimension.
+//!
+//! The list of connected toolkits is rendered inline in the tool
+//! description so the orchestrator still discovers which integrations
+//! are available without each one being its own schema entry.
+
 use async_trait::async_trait;
 use serde_json::json;
 
+use crate::openhuman::tools::orchestrator_tools::sanitise_slug;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCategory, ToolResult};
 
+/// Canonical tool name surfaced to the orchestrator LLM.
+pub const INTEGRATIONS_DELEGATE_TOOL_NAME: &str = "delegate_to_integrations_agent";
+
+/// Single collapsed delegation tool for all connected Composio toolkits.
+///
+/// Carries the slugs + one-line descriptions of every connected toolkit
+/// so the tool's `description()` (which is what the orchestrator's LLM
+/// sees) enumerates the routing choices without needing N tools to
+/// represent them.
 pub struct SkillDelegationTool {
     pub tool_name: String,
-    pub skill_id: String,
+    /// `(slug, description)` for every currently-connected toolkit.
+    /// `slug` is already `sanitise_slug`'d so it can be matched against
+    /// the LLM-provided `toolkit` argument with a plain `==`.
+    pub connected_toolkits: Vec<(String, String)>,
     pub tool_description: String,
+}
+
+impl SkillDelegationTool {
+    /// Build the canonical collapsed tool from the connected-toolkit
+    /// list. Returns `None` when there are zero connected toolkits —
+    /// callers in `collect_orchestrator_tools` interpret that as "don't
+    /// expose any integrations delegation surface at all", which is the
+    /// right thing to do because the orchestrator can't usefully route
+    /// to an empty set.
+    pub fn for_connected(connected: Vec<(String, String)>) -> Option<Self> {
+        if connected.is_empty() {
+            return None;
+        }
+        let description = build_description(&connected);
+        Some(Self {
+            tool_name: INTEGRATIONS_DELEGATE_TOOL_NAME.to_string(),
+            connected_toolkits: connected,
+            tool_description: description,
+        })
+    }
+}
+
+fn build_description(connected: &[(String, String)]) -> String {
+    let mut buf = String::from(
+        "Use only when direct response/direct tools are insufficient and the task truly \
+         requires external integration actions. Routes the work to the integrations_agent \
+         with the named toolkit pre-selected. Required argument `toolkit` must be one of \
+         the currently-connected slugs below; pass the user's task verbatim as `prompt`. \
+         Connected toolkits:",
+    );
+    for (slug, desc) in connected {
+        buf.push_str("\n - ");
+        buf.push_str(slug);
+        let trimmed = desc.trim();
+        if !trimmed.is_empty() {
+            buf.push_str(": ");
+            buf.push_str(trimmed);
+        }
+    }
+    buf
 }
 
 #[async_trait]
@@ -20,10 +91,21 @@ impl Tool for SkillDelegationTool {
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
+        let slugs: Vec<&str> = self
+            .connected_toolkits
+            .iter()
+            .map(|(slug, _)| slug.as_str())
+            .collect();
         json!({
             "type": "object",
-            "required": ["prompt"],
+            "required": ["toolkit", "prompt"],
             "properties": {
+                "toolkit": {
+                    "type": "string",
+                    "enum": slugs,
+                    "description": "Composio toolkit slug to route to (e.g. `gmail`, `notion`). \
+                                    Must match one of the connected toolkits enumerated in this tool's description."
+                },
                 "prompt": {
                     "type": "string",
                     "description": "Clear instruction for what to do. Include all relevant context — the sub-agent has no memory of your conversation."
@@ -41,26 +123,225 @@ impl Tool for SkillDelegationTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let raw_toolkit = args
+            .get("toolkit")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        log::debug!(
+            "[skill-delegation] execute start tool='{}' raw_toolkit={:?} prompt_chars={}",
+            self.tool_name,
+            raw_toolkit,
+            args.get("prompt")
+                .and_then(|v| v.as_str())
+                .map(|s| s.chars().count())
+                .unwrap_or(0)
+        );
+        if raw_toolkit.is_empty() {
+            log::debug!(
+                "[skill-delegation] reject: missing `toolkit` argument for tool='{}'",
+                self.tool_name
+            );
+            return Ok(ToolResult::error(format!(
+                "{}: `toolkit` is required and must match a connected integration slug",
+                self.tool_name
+            )));
+        }
+        let slug = sanitise_slug(&raw_toolkit);
+        let known = self
+            .connected_toolkits
+            .iter()
+            .any(|(known_slug, _)| known_slug == &slug);
+        if !known {
+            let allowed: Vec<&str> = self
+                .connected_toolkits
+                .iter()
+                .map(|(slug, _)| slug.as_str())
+                .collect();
+            log::debug!(
+                "[skill-delegation] reject: toolkit '{}' (sanitised='{}') not in connected set {:?}",
+                raw_toolkit,
+                slug,
+                allowed
+            );
+            return Ok(ToolResult::error(format!(
+                "{}: toolkit `{raw_toolkit}` is not connected — allowed: [{}]",
+                self.tool_name,
+                allowed.join(", ")
+            )));
+        }
+
         let prompt = args
             .get("prompt")
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .trim()
             .to_string();
-
         if prompt.is_empty() {
+            log::debug!(
+                "[skill-delegation] reject: empty `prompt` for tool='{}' toolkit='{}'",
+                self.tool_name,
+                slug
+            );
             return Ok(ToolResult::error(format!(
                 "{}: `prompt` is required",
                 self.tool_name
             )));
         }
 
-        super::dispatch_subagent(
-            "integrations_agent",
-            &self.tool_name,
-            &prompt,
-            Some(&self.skill_id),
-        )
-        .await
+        log::debug!(
+            "[skill-delegation] dispatching toolkit='{}' to integrations_agent (prompt_chars={})",
+            slug,
+            prompt.chars().count()
+        );
+        super::dispatch_subagent("integrations_agent", &self.tool_name, &prompt, Some(&slug)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_connected_returns_none_when_no_toolkits() {
+        assert!(SkillDelegationTool::for_connected(vec![]).is_none());
+    }
+
+    #[test]
+    fn for_connected_uses_canonical_tool_name() {
+        let tool = SkillDelegationTool::for_connected(vec![(
+            "gmail".to_string(),
+            "Email access.".to_string(),
+        )])
+        .unwrap();
+        assert_eq!(tool.name(), INTEGRATIONS_DELEGATE_TOOL_NAME);
+        assert_eq!(tool.name(), "delegate_to_integrations_agent");
+    }
+
+    #[test]
+    fn description_enumerates_connected_toolkits() {
+        let tool = SkillDelegationTool::for_connected(vec![
+            ("gmail".to_string(), "Email access.".to_string()),
+            ("notion".to_string(), "Pages and databases.".to_string()),
+        ])
+        .unwrap();
+        let desc = tool.description();
+        assert!(desc.contains("gmail"));
+        assert!(desc.contains("notion"));
+        assert!(desc.contains("Email access."));
+        assert!(desc.contains("Pages and databases."));
+    }
+
+    #[test]
+    fn parameters_schema_enforces_toolkit_enum_against_connected_slugs() {
+        let tool = SkillDelegationTool::for_connected(vec![
+            ("gmail".to_string(), "Email.".to_string()),
+            ("notion".to_string(), "Docs.".to_string()),
+        ])
+        .unwrap();
+        let schema = tool.parameters_schema();
+        let enum_vals = schema["properties"]["toolkit"]["enum"]
+            .as_array()
+            .expect("toolkit enum is an array");
+        let collected: Vec<&str> = enum_vals.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(collected, vec!["gmail", "notion"]);
+
+        let required = schema["required"].as_array().expect("required is an array");
+        let required: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required.contains(&"toolkit"));
+        assert!(required.contains(&"prompt"));
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_missing_toolkit_argument() {
+        let tool =
+            SkillDelegationTool::for_connected(vec![("gmail".to_string(), "Email.".to_string())])
+                .unwrap();
+        let result = tool.execute(json!({"prompt": "x"})).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("toolkit"));
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_unknown_toolkit_with_allowed_list() {
+        let tool = SkillDelegationTool::for_connected(vec![
+            ("gmail".to_string(), "Email.".to_string()),
+            ("notion".to_string(), "Docs.".to_string()),
+        ])
+        .unwrap();
+        let result = tool
+            .execute(json!({"toolkit": "slack", "prompt": "hi"}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        let body = result.output();
+        assert!(body.contains("slack"));
+        assert!(body.contains("gmail"));
+        assert!(body.contains("notion"));
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_empty_prompt() {
+        let tool =
+            SkillDelegationTool::for_connected(vec![("gmail".to_string(), "Email.".to_string())])
+                .unwrap();
+        let result = tool
+            .execute(json!({"toolkit": "gmail", "prompt": "   "}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("prompt"));
+    }
+
+    #[tokio::test]
+    async fn execute_normalises_toolkit_input_before_matching() {
+        // Mixed-case + odd-character user input must collapse onto the
+        // canonical slug before the connectedness check fires.
+        let tool = SkillDelegationTool::for_connected(vec![(
+            "google_calendar".to_string(),
+            "Calendar.".to_string(),
+        )])
+        .unwrap();
+        // "GMail" sanitises to `gmail` — NOT in the connected set, so it
+        // must be rejected with the unknown-toolkit message that
+        // enumerates the allowed slugs.
+        let bad = tool
+            .execute(json!({"toolkit": "GMail", "prompt": "x"}))
+            .await
+            .unwrap();
+        assert!(bad.is_error);
+        let bad_body = bad.output();
+        assert!(
+            bad_body.contains("not connected"),
+            "expected unknown-toolkit error path, got: {bad_body}"
+        );
+        assert!(bad_body.contains("google_calendar"));
+
+        // "Google-Calendar" sanitises to `google_calendar`, which IS in
+        // the connected set, so the toolkit gate must let it through.
+        // Dispatch will then fail because no agent registry is wired up
+        // in this unit-test process — but the error must NOT be the
+        // unknown-toolkit branch, because that branch was supposed to
+        // be bypassed by the slug normalisation.
+        let ok = tool
+            .execute(json!({"toolkit": "Google-Calendar", "prompt": "do thing"}))
+            .await;
+        match ok {
+            Ok(result) => {
+                let body = result.output();
+                assert!(
+                    !body.contains("not connected"),
+                    "normalised slug should pass the toolkit gate, got: {body}"
+                );
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(
+                    !msg.contains("not connected"),
+                    "normalised slug should pass the toolkit gate, got: {msg}"
+                );
+            }
+        }
     }
 }

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -3,10 +3,16 @@
 //! The orchestrator agent is direct-first and only delegates specialised
 //! work. Rather than exposing a single generic
 //! `spawn_subagent(agent_id, prompt)` mega-tool, we synthesise one named
-//! tool per entry in the orchestrator's `subagents = [...]` TOML field,
-//! so the LLM's function-calling schema contains discoverable, well-named
-//! tools like `research`, `plan`, `run_code`, `delegate_gmail`,
-//! `delegate_github`, etc.
+//! tool per [`SubagentEntry::AgentId`] in the orchestrator's
+//! `subagents = [...]` TOML field, so the LLM's function-calling schema
+//! contains discoverable, well-named tools like `research`, `plan`,
+//! `run_code`, etc.
+//!
+//! For [`SubagentEntry::Skills`] wildcard expansions (#1335) we synthesise
+//! a single collapsed `delegate_to_integrations_agent` tool that takes the
+//! toolkit slug as an argument — keeping the orchestrator's schema cost
+//! constant in the integration dimension instead of scaling with the
+//! number of connected toolkits.
 //!
 //! Each synthesised tool's description is pulled live from the target
 //! agent's [`AgentDefinition::when_to_use`] (for
@@ -45,18 +51,23 @@ use super::{ArchetypeDelegationTool, SkillDelegationTool, Tool};
 /// `when_to_use` — so editing an agent's TOML description immediately
 /// updates the tool schema the orchestrator LLM sees, with zero drift.
 ///
-/// Each [`SubagentEntry::Skills`] wildcard expands to one
-/// [`SkillDelegationTool`] per connected Composio integration in
-/// `connected_integrations`. The synthesised tool routes to the generic
-/// `integrations_agent` with `skill_filter = Some("{toolkit_slug}")` pre-set.
+/// Each [`SubagentEntry::Skills`] wildcard expands to a single
+/// collapsed [`SkillDelegationTool`] named
+/// `delegate_to_integrations_agent` whose `toolkit` argument selects
+/// among the slugs of every connected Composio integration in
+/// `connected_integrations`. The tool routes to the generic
+/// `integrations_agent` with the chosen toolkit's slug passed as
+/// `skill_filter`. The collapsed form keeps the orchestrator's
+/// function-calling schema constant in the integration dimension
+/// (#1335).
 ///
 /// Entries that reference unknown agent ids (not in the registry) are
 /// logged at `warn` and skipped — the orchestrator still builds, just
 /// without the broken delegation. Entries that reference Skills wildcards
 /// with an empty `connected_integrations` slice produce zero tools, which
 /// is the correct behaviour when the user has not yet connected any
-/// integrations (the LLM should not see phantom `delegate_gmail` tools
-/// for unconnected toolkits).
+/// integrations (the LLM should not see a `delegate_to_integrations_agent`
+/// tool with an empty enum).
 ///
 /// Returns an empty Vec when `definition.subagents` is empty — callers
 /// (notably the builder) handle this by not extending the visible-tool
@@ -130,11 +141,27 @@ pub fn collect_orchestrator_tools(
                     );
                     continue;
                 }
+                // Collapsed delegation tool (#1335). Previously this loop
+                // emitted one `delegate_<toolkit>` tool per connected
+                // integration. Every one of those tools dispatched to the
+                // same `integrations_agent` with a different `skill_filter`,
+                // so the fan-out cost the orchestrator schema bytes without
+                // buying any new routing capability. We now emit at most
+                // one `delegate_to_integrations_agent` tool that takes the
+                // toolkit slug as an argument; the description enumerates
+                // the connected toolkits so the orchestrator still
+                // discovers which integrations are routable.
+                // `sanitise_slug` is lossy — `Slack.Bot` and `Slack-Bot`
+                // both collapse to `slack_bot`. Once the raw id is
+                // discarded, one upstream integration would silently
+                // shadow the other. Detect the collision here, drop
+                // every duplicate after the first, and warn so routing
+                // stays unambiguous (the first arrival keeps the slug;
+                // later arrivals are unreachable through this enum and
+                // safer to omit than silently re-target).
+                let mut connected: Vec<(String, String)> = Vec::new();
+                let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
                 for integration in connected_integrations {
-                    // Only emit a delegate_* tool for integrations that are
-                    // actually connected — exposing unconnected entries would
-                    // let the orchestrator call a tool whose pre-flight
-                    // will immediately reject with "not connected".
                     if !integration.connected {
                         log::debug!(
                             "[orchestrator_tools] skipping unconnected integration: {}",
@@ -142,38 +169,50 @@ pub fn collect_orchestrator_tools(
                         );
                         continue;
                     }
-                    // Slug the toolkit name into a tool-name-safe form.
-                    // Composio toolkit slugs are already lowercase / dash-
-                    // separated (e.g. "gmail", "google_calendar"), but
-                    // we guard against surprises so a quirky slug can
-                    // never produce an invalid function-calling schema.
+                    // Slug the toolkit name into a tool-name-safe
+                    // (and argument-safe) form so the LLM-facing
+                    // enum stays predictable across odd toolkit
+                    // names (dashes, dots, spaces, mixed case).
                     let slug = sanitise_slug(&integration.toolkit);
-                    let tool_name = format!("delegate_{}", slug);
-                    // Prefer the toolkit's own one-line description when
-                    // available; fall back to a generic template so the
-                    // LLM still gets a meaningful tool description even
-                    // on brand-new or poorly-populated toolkits.
+                    if !seen.insert(slug.clone()) {
+                        log::warn!(
+                            "[orchestrator_tools] duplicate sanitised slug '{slug}' from raw \
+                             toolkit '{raw}' — dropping to keep collapsed delegation routing \
+                             unambiguous",
+                            raw = integration.toolkit
+                        );
+                        continue;
+                    }
+                    // Empty integration descriptions otherwise render as a
+                    // bare ` - slug` line in the collapsed tool description,
+                    // which gives the orchestrator LLM no hint about what
+                    // the toolkit actually does. Fall back to the
+                    // generic per-toolkit phrasing the old fan-out path
+                    // used so brand-new or under-populated toolkits stay
+                    // informative.
                     let description = if integration.description.trim().is_empty() {
                         format!(
-                            "Use only when direct response/direct tools are insufficient and the task truly requires external integration actions. Delegate to the integrations_agent with the `{}` integration pre-selected.",
+                            "External integration via {} — see the toolkit docs for available actions.",
                             integration.toolkit
                         )
                     } else {
-                        format!(
-                            "Use only when direct response/direct tools are insufficient and the task truly requires external integration actions. Delegate to the integrations_agent using `{}`. {}",
-                            integration.toolkit, integration.description
-                        )
+                        integration.description.clone()
                     };
-                    log::debug!(
-                        "[orchestrator_tools] registering skill delegation tool: {} -> integrations_agent (skill_filter={})",
-                        tool_name,
-                        slug
-                    );
-                    tools.push(Box::new(SkillDelegationTool {
-                        tool_name,
-                        skill_id: slug,
-                        tool_description: description,
-                    }));
+                    connected.push((slug, description));
+                }
+                match SkillDelegationTool::for_connected(connected) {
+                    Some(tool) => {
+                        log::debug!(
+                            "[orchestrator_tools] registering collapsed integrations delegation tool ({} toolkits)",
+                            tool.connected_toolkits.len()
+                        );
+                        tools.push(Box::new(tool));
+                    }
+                    None => {
+                        log::debug!(
+                            "[orchestrator_tools] no connected integrations — collapsed delegation tool omitted"
+                        );
+                    }
                 }
             }
         }
@@ -287,10 +326,10 @@ mod tests {
     /// Baseline: an orchestrator with 2 AgentId entries + a Skills
     /// wildcard, against a registry that knows both targets and a
     /// connected_integrations list with three toolkits, should produce
-    /// 2 + 3 = 5 delegation tools, each with the expected name and
-    /// description source.
+    /// 2 archetype tools + 1 collapsed integrations delegation tool
+    /// (#1335) — independent of how many integrations are connected.
     #[test]
-    fn collects_agentid_entries_and_expands_skills_wildcard() {
+    fn collects_agentid_entries_and_collapses_skills_wildcard() {
         let orch = sample_orchestrator();
         let reg = registry_with_targets();
         let integrations = vec![
@@ -305,35 +344,62 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                // `spawn_worker_thread` is temporarily disabled — see
-                // tinyhumansai/openhuman#1624. Re-add the leading entry when
-                // the registration in `collect_orchestrator_tools` is restored.
-                "research",              // researcher's delegate_name override
-                "delegate_archivist",    // archivist has no delegate_name → default
-                "delegate_gmail",
-                "delegate_github",
-                "delegate_notion",
+                // `spawn_worker_thread` is temporarily disabled upstream —
+                // see tinyhumansai/openhuman#1624. Re-add the leading entry
+                // when the registration in `collect_orchestrator_tools` is
+                // restored.
+                "research",           // researcher's delegate_name override
+                "delegate_archivist", // archivist has no delegate_name → default
+                "delegate_to_integrations_agent",
             ],
-            "tool names should come from delegate_name overrides, id fallbacks, and sanitised toolkit slugs"
+            "skills wildcard must collapse to a single delegate_to_integrations_agent tool"
         );
 
-        // Descriptions should come from when_to_use for archetype tools,
-        // and from a templated string mentioning the toolkit display name
-        // for skill tools.
+        // Archetype tool descriptions come from `when_to_use`.
         let research_tool = tools.iter().find(|t| t.name() == "research").unwrap();
         assert!(research_tool.description().contains("crawler"));
 
-        let gmail_tool = tools.iter().find(|t| t.name() == "delegate_gmail").unwrap();
-        assert!(gmail_tool.description().contains("gmail"));
-        assert!(gmail_tool.description().contains("email"));
+        // The collapsed delegation tool enumerates every connected toolkit
+        // in its description so the orchestrator still discovers what's
+        // routable.
+        let delegate_tool = tools
+            .iter()
+            .find(|t| t.name() == "delegate_to_integrations_agent")
+            .unwrap();
+        let desc = delegate_tool.description();
+        assert!(desc.contains("gmail"));
+        assert!(desc.contains("github"));
+        assert!(desc.contains("notion"));
+    }
+
+    /// The collapsed delegation tool's count is constant in the
+    /// integration dimension (#1335 primary acceptance criterion).
+    #[test]
+    fn collapsed_delegation_tool_count_is_constant_across_integration_counts() {
+        let orch = sample_orchestrator();
+        let reg = registry_with_targets();
+
+        for n in [1usize, 3, 7, 20] {
+            let integrations: Vec<_> = (0..n)
+                .map(|i| integration(&format!("tool{i}"), &format!("Toolkit number {i}.")))
+                .collect();
+            let tools = collect_orchestrator_tools(&orch, &reg, &integrations);
+            let delegation_count = tools
+                .iter()
+                .filter(|t| t.name() == "delegate_to_integrations_agent")
+                .count();
+            assert_eq!(
+                delegation_count, 1,
+                "expected exactly one collapsed delegation tool for {n} integrations"
+            );
+        }
     }
 
     /// An orchestrator with a Skills wildcard but no connected
-    /// integrations should produce zero skill delegation tools — the LLM
-    /// must not be shown phantom `delegate_*` tools for toolkits that
-    /// aren't authorised.
+    /// integrations should produce zero integrations delegation tools —
+    /// the LLM must not be shown a routing handle for an empty set.
     #[test]
-    fn skills_wildcard_with_no_integrations_produces_no_tools() {
+    fn skills_wildcard_with_no_integrations_produces_no_delegation_tool() {
         let orch = sample_orchestrator();
         let reg = registry_with_targets();
         let tools = collect_orchestrator_tools(&orch, &reg, &[]);
@@ -381,12 +447,12 @@ mod tests {
         assert_eq!(sanitise_slug("weird name!"), "weird_name_");
     }
 
-    /// Unconnected integrations must be silently skipped — exposing a
-    /// `delegate_*` tool for a toolkit whose OAuth token is absent would
-    /// let the orchestrator call a tool whose pre-flight check immediately
-    /// rejects with "not connected".
+    /// Unconnected integrations must be silently dropped from the
+    /// collapsed delegation tool's enum. Otherwise the orchestrator
+    /// could supply `toolkit = "<unconnected>"` and trigger a pre-flight
+    /// rejection downstream that says "not connected".
     #[test]
-    fn unconnected_integrations_are_skipped() {
+    fn unconnected_integrations_are_omitted_from_collapsed_tool() {
         let orch = sample_orchestrator();
         let reg = registry_with_targets();
         let integrations = vec![
@@ -395,23 +461,124 @@ mod tests {
                 toolkit: "github".into(),
                 description: "GitHub access.".into(),
                 tools: vec![],
-                connected: false, // not connected — must not produce a tool
+                connected: false, // not connected — must not appear in the enum
             },
             integration("notion", "Read and write pages."),
         ];
         let tools = collect_orchestrator_tools(&orch, &reg, &integrations);
-        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        let delegate_tool = tools
+            .iter()
+            .find(|t| t.name() == "delegate_to_integrations_agent")
+            .expect(
+                "collapsed delegation tool must exist when at least one integration is connected",
+            );
+        let desc = delegate_tool.description();
+        assert!(desc.contains("gmail"));
+        assert!(desc.contains("notion"));
         assert!(
-            names.contains(&"delegate_gmail"),
-            "connected gmail must produce a tool"
+            !desc.contains("github"),
+            "unconnected github must not leak into the delegation tool description"
         );
+
+        let schema = delegate_tool.parameters_schema();
+        let enum_vals = schema["properties"]["toolkit"]["enum"]
+            .as_array()
+            .expect("toolkit enum must be present");
+        let slugs: Vec<&str> = enum_vals.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(slugs, vec!["gmail", "notion"]);
+    }
+
+    /// Quirky toolkit slugs (dashes, mixed case) must be canonicalised
+    /// before they land in the collapsed tool's enum so the
+    /// LLM-provided argument can be matched with `==` rather than a
+    /// fuzzy comparison.
+    #[test]
+    fn collapsed_tool_enum_uses_sanitised_slugs() {
+        let mut orch = def("orchestrator", "t", None);
+        orch.subagents = vec![SubagentEntry::Skills(SkillsWildcard { skills: "*".into() })];
+        let reg = registry_with_targets();
+        let integrations = vec![
+            integration("Google-Calendar", "Calendar."),
+            integration("Slack.Bot", "Chat."),
+        ];
+        let tools = collect_orchestrator_tools(&orch, &reg, &integrations);
+        let delegate_tool = tools
+            .iter()
+            .find(|t| t.name() == "delegate_to_integrations_agent")
+            .expect("collapsed tool present");
+        let schema = delegate_tool.parameters_schema();
+        let enum_vals = schema["properties"]["toolkit"]["enum"].as_array().unwrap();
+        let slugs: Vec<&str> = enum_vals.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(slugs, vec!["google_calendar", "slack_bot"]);
+    }
+
+    /// Two upstream toolkits whose names sanitise to the same slug
+    /// must not silently both land in the collapsed enum — the second
+    /// arrival is dropped (with a warn log) so the orchestrator's
+    /// routing handle stays unambiguous. Without this guard,
+    /// `Slack.Bot` and `Slack-Bot` would both render as `slack_bot`
+    /// in the enum and the orchestrator could no longer distinguish
+    /// them.
+    /// An integration with an empty description must not render as a
+    /// bare ` - slug` line in the collapsed tool description — the
+    /// orchestrator LLM would have no signal about what the toolkit
+    /// does. The synthesiser falls back to a generic descriptive
+    /// phrase keyed on the raw toolkit name.
+    #[test]
+    fn empty_integration_description_falls_back_to_generic_label() {
+        let mut orch = def("orchestrator", "t", None);
+        orch.subagents = vec![SubagentEntry::Skills(SkillsWildcard { skills: "*".into() })];
+        let reg = registry_with_targets();
+        let integrations = vec![
+            ConnectedIntegration {
+                toolkit: "Brand.New".into(),
+                description: "   ".into(),
+                tools: vec![],
+                connected: true,
+            },
+            integration("gmail", "Email."),
+        ];
+        let tools = collect_orchestrator_tools(&orch, &reg, &integrations);
+        let delegate_tool = tools
+            .iter()
+            .find(|t| t.name() == "delegate_to_integrations_agent")
+            .expect("collapsed tool present");
+        let desc = delegate_tool.description();
         assert!(
-            !names.contains(&"delegate_github"),
-            "unconnected github must NOT produce a tool"
+            desc.contains("External integration via Brand.New"),
+            "expected fallback phrasing, got: {desc}"
         );
-        assert!(
-            names.contains(&"delegate_notion"),
-            "connected notion must produce a tool"
+        assert!(desc.contains("Email."));
+    }
+
+    #[test]
+    fn duplicate_sanitised_slug_drops_later_collisions() {
+        let mut orch = def("orchestrator", "t", None);
+        orch.subagents = vec![SubagentEntry::Skills(SkillsWildcard { skills: "*".into() })];
+        let reg = registry_with_targets();
+        let integrations = vec![
+            integration("Slack.Bot", "First slack."),
+            integration("Slack-Bot", "Second slack — must be dropped."),
+            integration("Notion", "Pages."),
+        ];
+        let tools = collect_orchestrator_tools(&orch, &reg, &integrations);
+        let delegate_tool = tools
+            .iter()
+            .find(|t| t.name() == "delegate_to_integrations_agent")
+            .expect("collapsed tool present");
+        let schema = delegate_tool.parameters_schema();
+        let enum_vals = schema["properties"]["toolkit"]["enum"].as_array().unwrap();
+        let slugs: Vec<&str> = enum_vals.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(
+            slugs,
+            vec!["slack_bot", "notion"],
+            "second slack_bot collision must be dropped, not silently shadowed"
         );
+        // The dropped description must not appear in the tool description
+        // either — otherwise the orchestrator would think there's a route
+        // it can't actually distinguish.
+        let desc = delegate_tool.description();
+        assert!(desc.contains("First slack."));
+        assert!(!desc.contains("Second slack"));
     }
 }

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn test_truncate_cjk_characters() {
         // CJK characters (Chinese - each is 3 bytes)
-        let s = "这是一个测试消息用来触发崩溃的中文"; // 21 characters
+        let s = "这是一个测试消息用来触发崩溃 of the 中文"; // 21 characters
         let result = truncate_with_ellipsis(s, 16);
         assert!(result.ends_with("..."));
         assert!(result.is_char_boundary(result.len() - 1));
@@ -221,4 +221,237 @@ mod tests {
         assert_eq!(truncate_with_suffix(s, 5, "!!!"), "Hello!!!");
         assert_eq!(truncate_with_suffix(s, 20, "!!!"), "Hello World");
     }
+
+    #[test]
+    fn test_retry_with_backoff_success_immediate() {
+        let mut calls = 0;
+        let result = retry_with_backoff("test", 3, 1, || {
+            calls += 1;
+            Ok::<_, anyhow::Error>(42)
+        });
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn test_retry_with_backoff_success_after_retries() {
+        let mut calls = 0;
+        let result = retry_with_backoff("test", 3, 1, || {
+            calls += 1;
+            if calls < 3 {
+                anyhow::bail!("__TEST_TRANSIENT__ error {}", calls);
+            }
+            Ok(42)
+        });
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls, 3);
+    }
+
+    #[tokio::test]
+    async fn test_retry_with_backoff_async_success_after_retries() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_with_backoff_async("test_async", 3, 1, || async {
+            let c = calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if c < 3 {
+                anyhow::bail!("__TEST_TRANSIENT__ error {}", c);
+            }
+            Ok(42)
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn test_retry_with_backoff_failure_after_all_attempts() {
+        let mut calls = 0;
+        let result = retry_with_backoff("test", 3, 1, || {
+            calls += 1;
+            anyhow::bail!("__TEST_TRANSIENT__ error {}", calls);
+            #[allow(unreachable_code)]
+            Ok::<i32, anyhow::Error>(0)
+        });
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("test failed after 3 attempts"));
+        assert_eq!(calls, 3);
+    }
+
+    #[test]
+    fn test_retry_with_backoff_bail_on_non_transient() {
+        let mut calls = 0;
+        let result = retry_with_backoff("test", 3, 1, || {
+            calls += 1;
+            anyhow::bail!("permanent error");
+            #[allow(unreachable_code)]
+            Ok::<i32, anyhow::Error>(0)
+        });
+        let err = result.unwrap_err();
+        assert_eq!(err.to_string(), "permanent error");
+        assert_eq!(calls, 1);
+    }
+}
+
+/// Helper to retry a filesystem operation with exponential backoff.
+///
+/// Particularly useful on Windows where mandatory file locking often causes
+/// transient `ERROR_SHARING_VIOLATION` (32) or `ERROR_ACCESS_DENIED` (5)
+/// when multiple processes (or a stale handle) touch the same tree.
+///
+/// Sleep `base_ms * 2^i` between attempts. Logs at `warn!` on retry and
+/// `info!` on success-after-retry.
+///
+/// **Note**: This is the synchronous version using `std::thread::sleep`.
+/// Use `retry_with_backoff_async` in asynchronous contexts to avoid blocking
+/// the executor.
+pub fn retry_with_backoff<T, F>(
+    op_name: &str,
+    attempts: u32,
+    base_ms: u64,
+    mut f: F,
+) -> anyhow::Result<T>
+where
+    F: FnMut() -> anyhow::Result<T>,
+{
+    let mut last_err: Option<anyhow::Error> = None;
+
+    for i in 0..attempts {
+        match f() {
+            Ok(val) => {
+                if i > 0 {
+                    tracing::info!(
+                        op = op_name,
+                        retries = i,
+                        "[util] {} succeeded after {} retries",
+                        op_name,
+                        i
+                    );
+                }
+                return Ok(val);
+            }
+            Err(e) => {
+                if !is_transient_fs_error(&e) {
+                    return Err(e);
+                }
+
+                if i == attempts - 1 {
+                    last_err = Some(e);
+                    break;
+                }
+
+                let sleep_ms = base_ms * 2u64.pow(i);
+                tracing::warn!(
+                    op = op_name,
+                    attempt = i + 1,
+                    max_attempts = attempts,
+                    error = %e,
+                    retry_in_ms = sleep_ms,
+                    "[util] {} failed (attempt {}/{}): {}. Retrying in {}ms...",
+                    op_name,
+                    i + 1,
+                    attempts,
+                    e,
+                    sleep_ms
+                );
+
+                std::thread::sleep(std::time::Duration::from_millis(sleep_ms));
+            }
+        }
+    }
+
+    Err(last_err
+        .expect("attempts > 0")
+        .context(format!("{} failed after {} attempts", op_name, attempts)))
+}
+
+/// Asynchronous version of `retry_with_backoff` using `tokio::time::sleep`.
+pub async fn retry_with_backoff_async<T, F, Fut>(
+    op_name: &str,
+    attempts: u32,
+    base_ms: u64,
+    mut f: F,
+) -> anyhow::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let mut last_err: Option<anyhow::Error> = None;
+
+    for i in 0..attempts {
+        match f().await {
+            Ok(val) => {
+                if i > 0 {
+                    tracing::info!(
+                        op = op_name,
+                        retries = i,
+                        "[util] {} succeeded after {} retries",
+                        op_name,
+                        i
+                    );
+                }
+                return Ok(val);
+            }
+            Err(e) => {
+                if !is_transient_fs_error(&e) {
+                    return Err(e);
+                }
+
+                if i == attempts - 1 {
+                    last_err = Some(e);
+                    break;
+                }
+
+                let sleep_ms = base_ms * 2u64.pow(i);
+                tracing::warn!(
+                    op = op_name,
+                    attempt = i + 1,
+                    max_attempts = attempts,
+                    error = %e,
+                    retry_in_ms = sleep_ms,
+                    "[util] {} failed (attempt {}/{}): {}. Retrying in {}ms...",
+                    op_name,
+                    i + 1,
+                    attempts,
+                    e,
+                    sleep_ms
+                );
+
+                tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
+            }
+        }
+    }
+
+    Err(last_err
+        .expect("attempts > 0")
+        .context(format!("{} failed after {} attempts", op_name, attempts)))
+}
+
+/// Returns true if the error is a transient filesystem error that should be retried,
+/// particularly on Windows where file locking is mandatory.
+pub fn is_transient_fs_error(err: &anyhow::Error) -> bool {
+    // In tests, allow a specific error message to be treated as transient
+    // so we can verify the retry logic on all platforms.
+    if cfg!(test) && err.to_string().contains("__TEST_TRANSIENT__") {
+        return true;
+    }
+
+    let io_err = err.chain().find_map(|e| e.downcast_ref::<std::io::Error>());
+
+    if let Some(io_err) = io_err {
+        #[cfg(windows)]
+        {
+            if let Some(code) = io_err.raw_os_error() {
+                // 5: ERROR_ACCESS_DENIED
+                // 32: ERROR_SHARING_VIOLATION
+                // 33: ERROR_LOCK_VIOLATION
+                // 1224: ERROR_USER_MAPPED_FILE
+                return code == 5 || code == 32 || code == 33 || code == 1224;
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = io_err;
+        }
+    }
+    false
 }

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -291,6 +291,22 @@ mod tests {
         assert_eq!(calls, 1);
     }
 
+    #[tokio::test]
+    async fn test_retry_with_backoff_async_bail_on_non_transient() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_with_backoff_async("test_async_bail", 3, 1, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("permanent error");
+            #[allow(unreachable_code)]
+            Ok::<i32, anyhow::Error>(0)
+        })
+        .await;
+        let err = result.unwrap_err();
+        assert_eq!(err.to_string(), "permanent error");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
     #[test]
     fn test_retry_with_backoff_rejects_zero_attempts() {
         let mut calls = 0;
@@ -359,13 +375,7 @@ where
         match f() {
             Ok(val) => {
                 if i > 0 {
-                    tracing::info!(
-                        op = op_name,
-                        retries = i,
-                        "[util] {} succeeded after {} retries",
-                        op_name,
-                        i
-                    );
+                    tracing::info!(op = op_name, retries = i, "[util] succeeded after retries");
                 }
                 return Ok(val);
             }
@@ -386,12 +396,7 @@ where
                     max_attempts = attempts,
                     error = %e,
                     retry_in_ms = sleep_ms,
-                    "[util] {} failed (attempt {}/{}): {}. Retrying in {}ms...",
-                    op_name,
-                    i + 1,
-                    attempts,
-                    e,
-                    sleep_ms
+                    "[util] transient fs retry"
                 );
 
                 std::thread::sleep(std::time::Duration::from_millis(sleep_ms));
@@ -423,13 +428,7 @@ where
         match f().await {
             Ok(val) => {
                 if i > 0 {
-                    tracing::info!(
-                        op = op_name,
-                        retries = i,
-                        "[util] {} succeeded after {} retries",
-                        op_name,
-                        i
-                    );
+                    tracing::info!(op = op_name, retries = i, "[util] succeeded after retries");
                 }
                 return Ok(val);
             }
@@ -450,12 +449,7 @@ where
                     max_attempts = attempts,
                     error = %e,
                     retry_in_ms = sleep_ms,
-                    "[util] {} failed (attempt {}/{}): {}. Retrying in {}ms...",
-                    op_name,
-                    i + 1,
-                    attempts,
-                    e,
-                    sleep_ms
+                    "[util] transient fs retry"
                 );
 
                 tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -290,6 +290,44 @@ mod tests {
         assert_eq!(err.to_string(), "permanent error");
         assert_eq!(calls, 1);
     }
+
+    #[test]
+    fn test_retry_with_backoff_rejects_zero_attempts() {
+        let mut calls = 0;
+        let result = retry_with_backoff("zero_sync", 0, 1, || {
+            calls += 1;
+            Ok::<i32, anyhow::Error>(42)
+        });
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("requires attempts > 0"),
+            "unexpected error message: {}",
+            err
+        );
+        assert_eq!(calls, 0, "closure must not run when attempts == 0");
+    }
+
+    #[tokio::test]
+    async fn test_retry_with_backoff_async_rejects_zero_attempts() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = AtomicU32::new(0);
+        let result = retry_with_backoff_async("zero_async", 0, 1, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok::<i32, anyhow::Error>(42)
+        })
+        .await;
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("requires attempts > 0"),
+            "unexpected error message: {}",
+            err
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "closure must not run when attempts == 0"
+        );
+    }
 }
 
 /// Helper to retry a filesystem operation with exponential backoff.
@@ -313,6 +351,8 @@ pub fn retry_with_backoff<T, F>(
 where
     F: FnMut() -> anyhow::Result<T>,
 {
+    anyhow::ensure!(attempts > 0, "{} requires attempts > 0", op_name);
+
     let mut last_err: Option<anyhow::Error> = None;
 
     for i in 0..attempts {
@@ -375,6 +415,8 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<T>>,
 {
+    anyhow::ensure!(attempts > 0, "{} requires attempts > 0", op_name);
+
     let mut last_err: Option<anyhow::Error> = None;
 
     for i in 0..attempts {


### PR DESCRIPTION
## Summary

- New shared helpers `retry_with_backoff` / `retry_with_backoff_async` in `src/openhuman/util.rs` that retry on Windows transient FS error codes (5, 32, 33, 1224).
- `AuthProfilesStore::acquire_lock` now retries lock creation 6× with exponential backoff (100ms base).
- `memory::tree::wipe_all_rpc` + `reset_tree_rpc` now retry `.openhuman` tree removal 6× with 200ms base.
- Final-failure path still calls `report_error` — only the transient-retry phase is quieted.

## Problem

- Seven Sentry issues on Windows clients fired from one of two transient-handle races:
  - `Failed to create auth profile lock at C:\Users\…\auth-profiles.lock` (OPENHUMAN-TAURI-9E ×1, -9C ×1, -4Y ×1, -61 ×1; read-path -5Q ×1) — CEF subprocess / AV scanner holds a handle on the parent dir for a sub-second window when openhuman tries to create the lock file. Windows file locking is mandatory, so `create_new` fails with `ERROR_SHARING_VIOLATION` (32) or `ERROR_ACCESS_DENIED` (5) instead of blocking.
  - `Failed to remove C:\Users\…\.openhuman: The process cannot access the file because it is being used by another process. (os error 32)` (OPENHUMAN-TAURI-9F ×1, -4M ×1) — same shape on tree-wipe; CEF profile / Ollama binary handle releases within seconds.
- Hard-failing on the first attempt produced Sentry noise on every cold-start race; the operations succeed deterministically on retry.

## Solution

- `src/openhuman/util.rs`: new `retry_with_backoff` (sync, `std::thread::sleep`) and `retry_with_backoff_async` (tokio). Both honor a shared `is_transient_fs_error` classifier that matches Windows `os_error` codes 5, 32, 33, 1224. On non-Windows, transient classification returns false (POSIX `EACCES` is not transient — surface immediately).
- `src/openhuman/credentials/profiles.rs`: `acquire_lock` wraps `OpenOptions::create_new` with `retry_with_backoff("create auth profile lock", 6, 100, …)`. The existing `AlreadyExists` busy-wait loop is preserved — that's the legitimate "another openhuman PID is signing in" case. Only the *unexpected* error path retries.
- `src/openhuman/memory/tree/read_rpc.rs`: `wipe_all_rpc` + `reset_tree_rpc` separate the SQLite truncation (still `spawn_blocking`) from the filesystem cleanup (now `tokio::fs` wrapped in `retry_with_backoff_async`). Avoids blocking the executor while retries are sleeping.
- Logging: mid-retry `tracing::warn!` with structured tags (`op`, `attempt`, `retry_in_ms`, `error`) keeps the diagnostic locally visible; final-failure surfaces unwrapped so `report_error` still emits the Sentry event when retries are exhausted. First-attempt success is silent.
- Tests: 5 new unit tests in `src/openhuman/util.rs` — immediate success, success-after-retries (sync + async), failure-after-all-attempts, non-transient bails immediately. Cross-platform tests use a `__TEST_TRANSIENT__` error-message marker so the retry logic exercises on POSIX CI.

## Submission Checklist

- [x] Tests added or updated — 5 unit tests in `src/openhuman/util.rs` covering happy path + failure modes + non-transient short-circuit.
- N/A: Diff coverage ≥ 80% — touched lines are mostly retry plumbing; helpers exercised by the new unit tests; call sites are integration paths covered by their existing tests (`cargo test --lib openhuman::credentials` passes 112/0).
- N/A: Coverage matrix updated — behaviour-only retry layer, no new feature row.
- N/A: All affected feature IDs from the matrix — see above.
- [x] No new external network dependencies introduced.
- N/A: Manual smoke checklist — does not touch release-cut surfaces.
- [x] Linked issues closed via `Closes` in `## Related`.

## Impact

- Stops ~7 events / 3d on the Windows auth-lock and tree-wipe paths.
- Eliminates a class of cold-start failures users hit on Windows when AV scanners / CEF subprocesses hold transient handles. The retry loop is bounded (worst-case ~3-12 seconds before surfacing the real failure), so there's no risk of indefinite hang.
- No POSIX behavior change — `is_transient_fs_error` returns false on non-Windows and the retry short-circuits.

## Related

- Closes OPENHUMAN-TAURI-9E
- Closes OPENHUMAN-TAURI-9C
- Closes OPENHUMAN-TAURI-4Y
- Closes OPENHUMAN-TAURI-61
- Closes OPENHUMAN-TAURI-5Q
- Closes OPENHUMAN-TAURI-9F
- Closes OPENHUMAN-TAURI-4M

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

- Authored by: Google Jules (cloud agent, session `2289277133504848069`)
- Jules session status flipped to `Failed` at the publish stage, but the produced patch was complete and clean. Pulled via `jules remote pull --session`, applied to a fresh branch off `upstream/main` with a single conflict in `src/openhuman/util.rs` (resolved by keeping HEAD's existing truncate tests + appending Jules's new retry tests).
- Cherry-pick + conflict-resolve + 3-commit split done orchestrator-side by Claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock-file acquisition with targeted retries for transient errors.
  * Enhanced wipe/reset workflows to tolerate "not found" and transient filesystem failures.

* **Refactor**
  * Moved on-disk cleanup out of blocking tasks into non-blocking async operations to reduce executor blocking and streamline response assembly.

* **Chores / Tests**
  * Added robust retry utilities and unit tests for retry success, eventual failure, and non-retryable errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1641)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->