### PR TITLE
test: wait for local model usage flags to load

### DIFF
--- a/app/src/components/settings/panels/__tests__/LocalModelPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/LocalModelPanel.test.tsx
@@ -208,7 +208,9 @@ describe('LocalModelPanel — usage flags', () => {
     const embeddingsLabel = await screen.findByText('Embeddings');
     const checkbox = embeddingsLabel.closest('label')?.querySelector('input[type="checkbox"]');
     expect(checkbox).toBeTruthy();
-    expect(checkbox as HTMLInputElement).not.toBeDisabled();
+    await waitFor(() => {
+      expect(checkbox as HTMLInputElement).not.toBeDisabled();
+    });
     fireEvent.click(checkbox as HTMLInputElement);
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Wait for the async local AI usage config load before asserting the sub-flag checkbox is enabled.
- This removes an order-dependent failure in the full Vitest suite while keeping the focused LocalModelPanel coverage intact.

## Why
During beta-test preflight on `origin/main`, `pnpm test` failed consistently in the full suite:

```
LocalModelPanel — usage flags > persists a sub-flag toggle once master is enabled
Error: expect(element).not.toBeDisabled()
```

The focused test file passed by itself, which points to timing/order sensitivity rather than a product logic regression. The component intentionally loads usage flags asynchronously through the zero-delay initial load, so the assertion should wait for the loaded state.

## Verification
- `pnpm exec vitest run --config test/vitest.config.ts src/components/settings/panels/__tests__/LocalModelPanel.test.tsx --reporter=default`
- `pnpm test`
- `pnpm format:check`
- `pnpm lint` (passes with existing warnings)
- `pnpm compile`
- pre-push hook: `format:check`, `lint`, `compile`, `rust:check`, `lint:commands-tokens`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes to document. This pull request contains only internal test improvements with no impact on end-user functionality or features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1643)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->