### PR TITLE
fix(team): preserve anyhow cause chain in backend RPC error envelopes (OPENHUMAN-TAURI-AD)

### DIFF
--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -63,11 +63,22 @@ async fn get_authed_value(
 ) -> Result<Value, String> {
     let token = require_token(config)?;
     let api_url = effective_api_url(&config.api_url);
-    let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
+    let client = BackendOAuthClient::new(&api_url).map_err(|e| format!("{e:#}"))?;
+    // `{e:#}` renders the full anyhow chain. `authed_json` wraps the
+    // underlying reqwest error with `.context(format!("backend request {} {}", …))`
+    // (`api/rest.rs::authed_json`), so plain `e.to_string()` only emits
+    // the outer "backend request GET /teams" label and drops the cause
+    // (connect timeout, DNS failure, TLS handshake, non-2xx status, …)
+    // before the JSON-RPC layer reports it to Sentry. OPENHUMAN-TAURI-AD
+    // is the canonical instance: 2 events on `0.53.35` from a Russia
+    // user, all with the truncated label and elapsed_ms=49 — far too
+    // short for a real timeout, so the underlying cause is the only
+    // signal worth surfacing. Same failure mode the `report_error`
+    // doc-string in `core/observability.rs` calls out (TAURI-B2).
     client
         .authed_json(&token, method, path, body)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| format!("{e:#}"))
 }
 
 pub async fn get_usage(config: &Config) -> Result<RpcOutcome<Value>, String> {


### PR DESCRIPTION
## Summary

- Switches both `map_err` sites in [`team::ops::get_authed_value`](src/openhuman/team/ops.rs) from plain `e.to_string()` to `format!(\"{e:#}\")`.
- Same anyhow-chain-rendering fix as PR #1639 (whatsapp_data) — the `report_error` doc-string in `core/observability.rs` calls out this exact failure mode (referencing OPENHUMAN-TAURI-B2): _\"Without this, anyhow's default `to_string()` only emits the outermost context and the underlying cause is dropped — making the captured Sentry event undiagnosable.\"_

This is **not** a Sentry-skip — it's the inverse. The current Sentry events are too vague to act on; the fix makes them actionable so we can diagnose the actual root cause.

Fixes OPENHUMAN-TAURI-AD (2 occurrences on `openhuman@0.53.35`, Windows user in St. Petersburg, Russia).

## Why the chain matters here

[`api::rest::authed_json`](src/api/rest.rs#L436-L441) wraps the underlying reqwest error with `.context(format!(\"backend request {} {}\", method, path))`. The anyhow chain at the failure site is:

- **outer**: `\"backend request GET /teams\"`
- **cause**: `reqwest::Error` — could be connect timeout, DNS failure, TLS handshake error, immediate connection refused, non-2xx HTTP status, …

`e.to_string()` renders only the outer label. The Sentry events all read `\"backend request GET /teams\"` with **no underlying cause** — and `elapsed_ms=49` is way too short for a real network timeout, so the true cause (immediate refusal? token rejected mid-request? URL parse error?) is the only signal worth surfacing.

`{e:#}` (anyhow's alternate format) joins the outer context plus every wrapped cause with `\": \"`, so the next event will tell us *why* the request failed and we can fix the underlying condition.

## Why fix once in `get_authed_value`

Every team RPC (`list_teams`, `get_team`, `list_members`, `get_usage`, `create_team`, `update_team`, `delete_team`, `switch_team`, `leave_team`, `join_team`) routes through this one helper, so a single change covers the whole domain — no per-handler fanout needed.

## Test plan

- [x] `cargo check --lib` — no new warnings.
- [x] `cargo fmt`.
- [x] No new tests: the `{e:#}` rendering contract is already covered by `core::observability::tests::anyhow_chain_is_rendered_in_full`. Behavioural coverage here would require a synthetic reqwest failure fixture — disproportionate for a single-helper format-specifier fix.

## Follow-up

Once this ships and the next Sentry event lands with the cause chain visible, a targeted follow-up PR can address the underlying condition. The 49ms elapsed time argues against \"network unreachable\" (PR #1601 would silence those once their full message includes `\"error sending request for url\"` via this chain) — more likely an immediate transport refusal or auth boundary, both of which warrant their own handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message formatting to display complete error context chains, providing more detailed information for diagnosing issues.

* **Documentation**
  * Added inline comments documenting how error messages are surfaced in the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1647)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->