### PR TITLE
fix(chat): stop duplicating assistant replies on multi-segment turns

### DIFF
--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -120,6 +120,13 @@ function deleteSegmentDelivery(deliveries: Map<string, SegmentDelivery>, key: st
   deliveries.delete(key);
 }
 
+// Delivery is complete iff every expected segment_index arrived. Do NOT also
+// compare reconstructed segments against event.full_response — the server
+// trims each segment and normalises joiners during segmentation
+// (presentation.rs::segment_for_delivery), while full_response keeps the raw
+// LLM text. A byte-equality check therefore fails on virtually every
+// multi-segment turn and triggers the reconciliation path, producing a
+// duplicate assistant message.
 function hasCompleteSegmentDelivery(
   event: ChatDoneEvent,
   delivery: SegmentDelivery | undefined
@@ -127,14 +134,10 @@ function hasCompleteSegmentDelivery(
   const expected = event.segment_total ?? 0;
   if (expected <= 0 || !delivery) return false;
   if (delivery.segments.size < expected) return false;
-
-  let reconstructed = '';
   for (let i = 0; i < expected; i += 1) {
-    const segment = delivery.segments.get(i);
-    if (segment === undefined) return false;
-    reconstructed += segment;
+    if (!delivery.segments.has(i)) return false;
   }
-  return reconstructed === event.full_response;
+  return true;
 }
 
 function chatDoneExtraMetadata(event: ChatDoneEvent): Record<string, unknown> | undefined {

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -324,21 +324,26 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       expect(threadApi.appendMessage).toHaveBeenCalledTimes(2);
     });
 
-    it('reconciles when segments are present but not in full_response order', async () => {
+    it('does not reconcile when all segments arrived even if full_response differs (trim/joiner)', async () => {
+      // Regression: the server's segmenter trims each segment and joins with
+      // "\n\n", while chat_done.full_response is the raw LLM text. A strict
+      // byte-equality check used to fire reconciliation on every multi-segment
+      // turn — once we have all expected segment_index values, delivery is
+      // complete regardless of full_response content.
       const listeners = renderProvider();
 
       act(() => {
         listeners.onSegment?.({
-          thread_id: 't-out-of-order',
-          request_id: 'r-out-of-order',
-          full_response: 'Alpha',
+          thread_id: 't-trim',
+          request_id: 'r-trim',
+          full_response: 'Hello.',
           segment_index: 0,
           segment_total: 2,
         });
         listeners.onSegment?.({
-          thread_id: 't-out-of-order',
-          request_id: 'r-out-of-order',
-          full_response: 'Beta',
+          thread_id: 't-trim',
+          request_id: 'r-trim',
+          full_response: 'World.',
           segment_index: 1,
           segment_total: 2,
         });
@@ -348,9 +353,44 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
 
       act(() => {
         listeners.onDone?.({
-          thread_id: 't-out-of-order',
-          request_id: 'r-out-of-order',
-          full_response: 'BetaAlpha',
+          thread_id: 't-trim',
+          request_id: 'r-trim',
+          // Raw LLM output: leading/trailing whitespace + paragraph break.
+          // segments.join('') === 'Hello.World.' !== full_response, but
+          // delivery is still complete.
+          full_response: '\nHello.\n\nWorld.\n',
+          rounds_used: 1,
+          total_input_tokens: 10,
+          total_output_tokens: 20,
+          segment_total: 2,
+        });
+      });
+
+      await waitFor(() => expect(mockRefetchSnapshot).toHaveBeenCalledTimes(1));
+      expect(threadApi.appendMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('reconciles when a segment is missing', async () => {
+      const listeners = renderProvider();
+
+      act(() => {
+        listeners.onSegment?.({
+          thread_id: 't-missing',
+          request_id: 'r-missing',
+          full_response: 'Part one.',
+          segment_index: 0,
+          segment_total: 2,
+        });
+        // segment_index 1 never arrives.
+      });
+
+      await waitFor(() => expect(threadApi.appendMessage).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        listeners.onDone?.({
+          thread_id: 't-missing',
+          request_id: 'r-missing',
+          full_response: 'Part one.\n\nPart two.',
           rounds_used: 1,
           total_input_tokens: 10,
           total_output_tokens: 20,
@@ -360,11 +400,11 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
 
       await waitFor(() =>
         expect(threadApi.appendMessage).toHaveBeenCalledWith(
-          't-out-of-order',
-          expect.objectContaining({ content: 'BetaAlpha', sender: 'agent' })
+          't-missing',
+          expect.objectContaining({ content: 'Part one.\n\nPart two.', sender: 'agent' })
         )
       );
-      expect(threadApi.appendMessage).toHaveBeenCalledTimes(3);
+      expect(threadApi.appendMessage).toHaveBeenCalledTimes(2);
     });
 
     it('expires stale segment delivery state before chat_done reconciliation', async () => {


### PR DESCRIPTION
## Summary

- Stop duplicating every multi-paragraph assistant reply in the chat UI.
- Replace a content-equality check in segment reconciliation with a count + index-presence check.
- Update the "out-of-order full_response" unit test (which had asserted the buggy behaviour) and add a regression test for a genuinely missing segment.

## Problem

When the server splits a long assistant reply into multiple bubbles via `presentation.rs::segment_for_delivery`, the client receives N `chat_segment` events followed by a `chat_done`. Each segment is persisted as its own message in `onSegment`. `onDone` then runs a "did all segments arrive?" check and, if not, falls back to appending `chat_done.full_response` as one more message.

That fallback check used:

```ts
return reconstructed === event.full_response;
```

where `reconstructed` is the received segments joined with no separator. The server-side segmenter `.trim()`s each segment and joins paragraphs with a normalised `\n\n`, while `chat_done.full_response` ships the raw LLM text (leading/trailing whitespace, original separators). The strings basically never matched — so the fallback fired on **every** multi-segment turn and produced N segment bubbles + one duplicate full-text bubble. The duplicates were persisted to the backend via `threadApi.appendMessage`, so they stick around in thread history on reload.

The bug only fires when segmentation kicks in (response ≥ 80 chars, no code fences, not predominantly list/table content), so short replies and structured responses were unaffected — easy to miss in unit tests that used clean concatenable inputs.

## Solution

Trust the count, not the content. Delivery is complete iff every expected `segment_index` arrived:

- `delivery.segments.size === segment_total`
- every index in `[0, segment_total)` is present in the Map

Per-segment dedup already runs at the cache key `segment:${thread}:${request}:${segment_index}`, so the Map can only reach size `segment_total` when all distinct indices have been seen exactly once. The content-equality check added nothing except a guaranteed false-negative because of the lossy server-side normalisation.

Reconciliation still fires when a `segment_index` is genuinely missing (socket drop / partial delivery), which is the case it was designed for — covered by a new test.

Added a leading comment to `hasCompleteSegmentDelivery` explaining why the equality check was removed, so it doesn't get reintroduced.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] N/A: behaviour-only change — no new/removed/renamed feature rows for [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)
- [ ] N/A: behaviour-only change, no matrix feature IDs affected
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] N/A: touches chat-runtime client glue, no new surface in [`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md) — existing "send a chat message" smoke covers it
- [ ] N/A: no linked issue (regression caught during live triage)

## Impact

- **Desktop**: every multi-paragraph assistant reply previously produced one redundant bubble persisted to backend; now produces exactly N segment bubbles.
- **No protocol change** — purely a client-side check tightening.
- **No migration**: existing duplicate messages already persisted in user threads stay until manually deleted; future turns are clean.
- Performance: one fewer `appendMessage` RPC + one fewer Redux dispatch per affected turn.
- Backwards compatibility: the genuine "segment dropped on the wire" recovery path still works (covered by new test).

## Related

- Closes: _no GitHub issue — regression found during live debugging session_
- Follow-up PR(s)/TODOs: `scripts/run-dev-win.sh` has two unrelated Windows build-tooling bugs (greedy-regex SDK detection, leaked `VSINSTALLDIR` causing `Generator Ninja does not support instance specification` on fresh worktrees) — separate PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `debug/double-messages-chat`
- Commit SHA: `37b9cd4667c98046ddb80cd95756f141f87ab243`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm --filter openhuman-app test:unit src/providers/__tests__/ChatRuntimeProvider.test.tsx` — 22/22 passed
- [ ] N/A: no Rust changes
- [ ] N/A: no Tauri shell changes

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: multi-segment assistant replies no longer produce a duplicate full-response bubble.
- User-visible effect: in the chat list, an assistant reply that previously rendered as e.g. 2 segment bubbles followed by a 3rd duplicate-content bubble now renders as exactly 2 bubbles.

### Parity Contract
- Legacy behavior preserved: the genuine missing-segment recovery path (when a `segment_index` never arrives) is unchanged — `onDone` still appends `full_response` in that case. Covered by the new `'reconciles when a segment is missing'` test.
- Guard/fallback/dispatch parity checks: `!event.segment_total` branch (single-bubble path) untouched; `onSegment` per-segment dedup untouched; segment-delivery TTL/eviction untouched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat streaming completion detection to prevent unnecessary reconciliation when segment delivery is complete, even if response formatting differs.

* **Tests**
  * Updated test coverage for streaming chat scenarios, including regression tests for segment delivery verification and reconciliation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1648)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->