### PR TITLE
fix(api): safely join api_url + path so misconfigured base can't corrupt routes

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -156,9 +156,18 @@ mod tests {
 
     #[test]
     fn api_url_empty_path_returns_normalized_base() {
-        assert_eq!(api_url("https://api.tinyhumans.ai", ""), "https://api.tinyhumans.ai");
-        assert_eq!(api_url("https://api.tinyhumans.ai/", ""), "https://api.tinyhumans.ai");
-        assert_eq!(api_url("  https://api.tinyhumans.ai/  ", ""), "https://api.tinyhumans.ai");
+        assert_eq!(
+            api_url("https://api.tinyhumans.ai", ""),
+            "https://api.tinyhumans.ai"
+        );
+        assert_eq!(
+            api_url("https://api.tinyhumans.ai/", ""),
+            "https://api.tinyhumans.ai"
+        );
+        assert_eq!(
+            api_url("  https://api.tinyhumans.ai/  ", ""),
+            "https://api.tinyhumans.ai"
+        );
     }
 
     #[test]
@@ -177,11 +186,17 @@ mod tests {
     #[test]
     fn api_url_clean_base_joins_cleanly() {
         assert_eq!(
-            api_url("https://api.tinyhumans.ai", "/agent-integrations/composio/toolkits"),
+            api_url(
+                "https://api.tinyhumans.ai",
+                "/agent-integrations/composio/toolkits"
+            ),
             "https://api.tinyhumans.ai/agent-integrations/composio/toolkits"
         );
         assert_eq!(
-            api_url("https://api.tinyhumans.ai/", "/agent-integrations/composio/toolkits"),
+            api_url(
+                "https://api.tinyhumans.ai/",
+                "/agent-integrations/composio/toolkits"
+            ),
             "https://api.tinyhumans.ai/agent-integrations/composio/toolkits"
         );
     }
@@ -189,7 +204,10 @@ mod tests {
     #[test]
     fn api_url_preserves_query_string_on_path() {
         assert_eq!(
-            api_url("https://api.tinyhumans.ai", "/agent-integrations/composio/tools?toolkits=gmail"),
+            api_url(
+                "https://api.tinyhumans.ai",
+                "/agent-integrations/composio/tools?toolkits=gmail"
+            ),
             "https://api.tinyhumans.ai/agent-integrations/composio/tools?toolkits=gmail"
         );
     }

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -32,6 +32,43 @@ pub fn normalize_api_base_url(url: &str) -> String {
     url.trim().trim_end_matches('/').to_string()
 }
 
+/// Safely join an API base URL with a path.
+///
+/// Behaviour:
+/// - Empty `path` → normalized `base` (no trailing slash).
+/// - `path` starting with `/` → replaces any path on `base` (RFC 3986
+///   absolute-path reference). This is the case that protects us from a
+///   misconfigured `api_url` like `https://api.tinyhumans.ai/openai/v1/chat/completions`
+///   silently corrupting every `/agent-integrations/...` call.
+/// - If `base` fails to parse as a URL, falls back to slash-safe concat
+///   so callers always get a usable string.
+///
+/// Paths SHOULD start with `/`. Relative paths (no leading slash) are
+/// resolved against the base path per RFC 3986, which means the base's
+/// last path segment is dropped — almost never what you want for an API.
+pub fn api_url(base: &str, path: &str) -> String {
+    let base_trimmed = base.trim();
+    if path.is_empty() {
+        return normalize_api_base_url(base_trimmed);
+    }
+    match url::Url::parse(base_trimmed) {
+        Ok(parsed) => match parsed.join(path) {
+            Ok(joined) => joined.to_string().trim_end_matches('/').to_string(),
+            Err(_) => fallback_concat(base_trimmed, path),
+        },
+        Err(_) => fallback_concat(base_trimmed, path),
+    }
+}
+
+fn fallback_concat(base: &str, path: &str) -> String {
+    let base = base.trim_end_matches('/');
+    if path.starts_with('/') {
+        format!("{base}{path}")
+    } else {
+        format!("{base}/{path}")
+    }
+}
+
 /// Resolve API base URL from the environment.
 ///
 /// Each key is checked independently so that an empty `BACKEND_URL` does not
@@ -116,6 +153,52 @@ mod tests {
     // Serialise all env-mutating tests to prevent flaky failures under
     // parallel test execution (std::env is process-global).
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn api_url_empty_path_returns_normalized_base() {
+        assert_eq!(api_url("https://api.tinyhumans.ai", ""), "https://api.tinyhumans.ai");
+        assert_eq!(api_url("https://api.tinyhumans.ai/", ""), "https://api.tinyhumans.ai");
+        assert_eq!(api_url("  https://api.tinyhumans.ai/  ", ""), "https://api.tinyhumans.ai");
+    }
+
+    #[test]
+    fn api_url_absolute_path_replaces_base_path() {
+        // This is the regression: api_url misconfigured with a path baked in
+        // must not corrupt /agent-integrations/* calls.
+        assert_eq!(
+            api_url(
+                "https://api.tinyhumans.ai/openai/v1/chat/completions",
+                "/agent-integrations/composio/toolkits"
+            ),
+            "https://api.tinyhumans.ai/agent-integrations/composio/toolkits"
+        );
+    }
+
+    #[test]
+    fn api_url_clean_base_joins_cleanly() {
+        assert_eq!(
+            api_url("https://api.tinyhumans.ai", "/agent-integrations/composio/toolkits"),
+            "https://api.tinyhumans.ai/agent-integrations/composio/toolkits"
+        );
+        assert_eq!(
+            api_url("https://api.tinyhumans.ai/", "/agent-integrations/composio/toolkits"),
+            "https://api.tinyhumans.ai/agent-integrations/composio/toolkits"
+        );
+    }
+
+    #[test]
+    fn api_url_preserves_query_string_on_path() {
+        assert_eq!(
+            api_url("https://api.tinyhumans.ai", "/agent-integrations/composio/tools?toolkits=gmail"),
+            "https://api.tinyhumans.ai/agent-integrations/composio/tools?toolkits=gmail"
+        );
+    }
+
+    #[test]
+    fn api_url_unparseable_base_falls_back_to_concat() {
+        assert_eq!(api_url("not a url", "/x"), "not a url/x");
+        assert_eq!(api_url("not a url/", "/x"), "not a url/x");
+    }
 
     #[test]
     fn staging_app_env_uses_staging_default_api() {

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -314,7 +314,7 @@ impl ComposioClient {
             error: Option<String>,
         }
 
-        let url = format!("{}{}", self.inner.backend_url, path);
+        let url = crate::api::config::api_url(&self.inner.backend_url, path);
         tracing::debug!("[composio] DELETE {}", url);
 
         // Build a fresh lightweight reqwest client for this DELETE.

--- a/src/openhuman/integrations/client.rs
+++ b/src/openhuman/integrations/client.rs
@@ -78,7 +78,7 @@ impl IntegrationClient {
         path: &str,
         body: &serde_json::Value,
     ) -> anyhow::Result<T> {
-        let url = format!("{}{}", self.backend_url, path);
+        let url = crate::api::config::api_url(&self.backend_url, path);
         tracing::debug!("[integrations] POST {}", url);
 
         let resp = self
@@ -148,7 +148,7 @@ impl IntegrationClient {
 
     /// GET from a backend endpoint and parse the response `data` field.
     pub async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> anyhow::Result<T> {
-        let url = format!("{}{}", self.backend_url, path);
+        let url = crate::api::config::api_url(&self.backend_url, path);
         tracing::debug!("[integrations] GET {}", url);
 
         let resp = self


### PR DESCRIPTION
## Summary

- A misconfigured `api_url` (e.g. a user pasted the LLM endpoint `https://api.tinyhumans.ai/openai/v1/chat/completions` into the base URL setting) silently corrupted every `/agent-integrations/...` call because the HTTP clients just `format!("{base}{path}")`-concatenated.
- Result was URLs like `…/openai/v1/chat/completions/agent-integrations/composio/toolkits` that 404 — breaking Composio connections (\"stale\") and toolkit loading for affected users.
- Add `api::config::api_url(base, path)` that uses `url::Url::join` so an absolute-path reference replaces any path baked into the base (RFC 3986), and replace the three concat call sites.

## Problem

The `Config.api_url` field is the single base for both LLM-proxy calls and `/agent-integrations/*` calls. When a user puts a path-bearing URL in that field, the integrations client compounds the path. Every Composio call (`list_toolkits`, `list_tools`, `list_connections`, `authorize`, `triggers`, …) and every shared integrations `get`/`post` is affected. The user-visible symptom is \"Connections are showing stale status\" plus 404s from `list_toolkits`.

## Solution

- New helper `pub fn api_url(base: &str, path: &str) -> String` in `src/api/config.rs`.
  - Empty `path` → normalized base (no trailing slash).
  - Non-empty `path` → `url::Url::parse(base)?.join(path)?`. For an absolute-path reference (`/agent-integrations/...`) this replaces the base's path per RFC 3986, neutralising the misconfigured-base case.
  - Unparseable base → slash-safe `fallback_concat` so callers always get a usable string.
- Replaced the three call sites: `src/openhuman/integrations/client.rs` (POST + GET) and `src/openhuman/composio/client.rs` (DELETE).
- Tradeoff: `Url::join` would drop the base's last path segment if path is *relative* — documented in the helper's docstring. All our API paths start with `/`, so this is safe.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: pure bugfix in a code-path with existing tests; diff coverage is satisfied by the 5 new unit tests for `api_url` itself, which are the changed lines.
- [x] N/A: behaviour-only change — no feature added/removed/renamed in the matrix.
- [x] N/A: no matrix feature IDs touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut surfaces.
- [x] N/A: no linked issue — surfaced directly in chat from a user repro.

## Impact

- Runtime/platform: desktop (all OSes via the shared core). No mobile/web/CLI change beyond the fact that the core CLI also uses the same client.
- Performance: one `Url::parse` per request; negligible.
- Security: slightly *safer* — a path baked into a misconfigured base no longer carries through to every backend call. No auth/secrets change.
- Migration/compat: backward-compatible. Existing valid bases (`https://api.tinyhumans.ai`, with or without trailing slash) produce identical output to the old `format!` path.

## Related

- Closes:
- Follow-up PR(s)/TODOs: optionally reject/strip a path on `api_url` at config load to warn the user proactively; not done here to keep the diff minimal.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/api-url-safe-join
- Commit SHA: 7e5108d3e5e3d2eb10c7800ef734f92b41db15be

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] N/A: no `app/` TypeScript changes in this PR.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib api::config::` (11/11 pass, including 5 new `api_url_*` tests)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean
- [x] N/A: Tauri shell unchanged.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: URL construction in the integrations + composio HTTP clients goes through a safe joiner that uses RFC 3986 resolution instead of string concat.
- User-visible effect: users with a path-bearing `api_url` (e.g. pasted an LLM endpoint URL) no longer see `/agent-integrations/*` 404s. Composio connections stop showing \"stale\" for that misconfiguration.

### Parity Contract
- Legacy behavior preserved: when `api_url` is the correct origin (e.g. `https://api.tinyhumans.ai`), the joined URL is byte-identical to what the previous `format!` produced.
- Guard/fallback/dispatch parity checks: unparseable base falls back to slash-safe concat (covered by `api_url_unparseable_base_falls_back_to_concat`).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A