### PR TITLE
fix(auth): offer "clear app data" recovery when login decryption fails

### DIFF
--- a/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
+++ b/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
@@ -35,7 +35,11 @@ describe('OAuthProviderButton', () => {
     vi.mocked(getBackendUrl).mockResolvedValue('https://backend.test');
     vi.mocked(openUrl).mockResolvedValue(undefined);
     vi.mocked(isTauri).mockReturnValue(true);
-    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(getDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
   });
 
   afterEach(() => {
@@ -82,7 +86,11 @@ describe('OAuthProviderButton', () => {
   });
 
   it('does NOT reset isLoading on focus when a deep-link auth round-trip is processing', async () => {
-    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(getDeepLinkAuthState).mockReturnValue({
+      isProcessing: true,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
 
     render(<OAuthProviderButton provider={stubProvider} />);
 

--- a/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
+++ b/app/src/components/oauth/__tests__/OAuthProviderButton.test.tsx
@@ -35,7 +35,7 @@ describe('OAuthProviderButton', () => {
     vi.mocked(getBackendUrl).mockResolvedValue('https://backend.test');
     vi.mocked(openUrl).mockResolvedValue(undefined);
     vi.mocked(isTauri).mockReturnValue(true);
-    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
   });
 
   afterEach(() => {
@@ -82,7 +82,7 @@ describe('OAuthProviderButton', () => {
   });
 
   it('does NOT reset isLoading on focus when a deep-link auth round-trip is processing', async () => {
-    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null });
+    vi.mocked(getDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
 
     render(<OAuthProviderButton provider={stubProvider} />);
 

--- a/app/src/components/settings/SettingsHome.tsx
+++ b/app/src/components/settings/SettingsHome.tsx
@@ -2,14 +2,9 @@ import { ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useCoreState } from '../../providers/CoreStateProvider';
-import { persistor } from '../../store';
+import { clearAllAppData } from '../../utils/clearAllAppData';
 import { BILLING_DASHBOARD_URL } from '../../utils/links';
 import { openUrl } from '../../utils/openUrl';
-import {
-  resetOpenHumanDataAndRestartCore,
-  restartApp,
-  scheduleCefProfilePurge,
-} from '../../utils/tauriCommands';
 import { resetWalkthrough } from '../walkthrough/AppWalkthrough';
 import SettingsHeader from './components/SettingsHeader';
 import SettingsMenuItem from './components/SettingsMenuItem';
@@ -55,60 +50,12 @@ const SettingsHome = () => {
     }
   };
 
-  const clearAllAppData = async () => {
-    const currentUserId = snapshot.auth.userId ?? snapshot.currentUser?._id ?? null;
-
-    // Queue the current user-scoped CEF profile for deletion on next launch.
-    // The active CEF browser process may still hold SQLite/cache file handles,
-    // so we delete after the shell restarts rather than relying on in-process
-    // removal to succeed everywhere.
-    try {
-      await scheduleCefProfilePurge(currentUserId);
-    } catch (err) {
-      console.warn('[Settings] Failed to queue CEF profile purge:', err);
-    }
-
-    // 1. Logout — clear session in core (auth_clear_session). Best-effort:
-    //    if the core process is wedged we still want to wipe local data.
-    try {
-      await clearSession();
-    } catch (err) {
-      console.warn('[Settings] Rust logout failed during clearAllAppData:', err);
-    }
-
-    // 2. Delete workspace folder + restart core. The core RPC removes both
-    //    the active openhuman_dir and the default ~/.openhuman, then we
-    //    restart the sidecar so it boots from a clean slate.
-    try {
-      await resetOpenHumanDataAndRestartCore();
-    } catch (err) {
-      console.warn('[Settings] Failed to reset OpenHuman data dir and restart core:', err);
-      throw err;
-    }
-
-    // 3. Purge redux-persist storage + browser storage. `persistor.purge()`
-    //    wipes the persisted backend; localStorage/sessionStorage clears
-    //    everything else (auth flags, theme, etc.).
-    try {
-      await persistor.purge();
-    } catch (err) {
-      console.warn('[Settings] persistor.purge failed:', err);
-      setError('Failed to clear persisted app state. Please try again.');
-      return;
-    }
-    window.localStorage.clear();
-    window.sessionStorage.clear();
-
-    // 4. Full app restart so the CEF runtime reboots into the fresh
-    //    pre-login profile instead of keeping the old browser process alive.
-    await restartApp();
-  };
-
   const handleLogoutAndClearData = async () => {
     try {
       setIsLoading(true);
       setError(null);
-      await clearAllAppData(); // This will redirect to login
+      const currentUserId = snapshot.auth.userId ?? snapshot.currentUser?._id ?? null;
+      await clearAllAppData({ clearSession, userId: currentUserId }); // restarts the app
     } catch (_error) {
       setError('Failed to clear data and logout. Please try again.');
     } finally {

--- a/app/src/components/settings/__tests__/SettingsHome.test.tsx
+++ b/app/src/components/settings/__tests__/SettingsHome.test.tsx
@@ -40,7 +40,9 @@ vi.mock('../../../utils/tauriCommands', () => ({
   scheduleCefProfilePurge: vi.fn().mockResolvedValue(undefined),
 }));
 
-const mockClearAllAppData = vi.fn().mockResolvedValue(undefined);
+const { mockClearAllAppData } = vi.hoisted(() => ({
+  mockClearAllAppData: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('../../../utils/clearAllAppData', () => ({
   clearAllAppData: (...args: unknown[]) => mockClearAllAppData(...args),
 }));

--- a/app/src/components/settings/__tests__/SettingsHome.test.tsx
+++ b/app/src/components/settings/__tests__/SettingsHome.test.tsx
@@ -40,6 +40,11 @@ vi.mock('../../../utils/tauriCommands', () => ({
   scheduleCefProfilePurge: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockClearAllAppData = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../../utils/clearAllAppData', () => ({
+  clearAllAppData: (...args: unknown[]) => mockClearAllAppData(...args),
+}));
+
 vi.mock('../../walkthrough/AppWalkthrough', () => ({ resetWalkthrough: vi.fn() }));
 
 // --- helpers ---
@@ -243,6 +248,28 @@ describe('SettingsHome', () => {
 
       await user.click(screen.getByText('Developer Options').closest('button')!);
       expect(mockNavigateToSettings).toHaveBeenCalledWith('developer-options');
+    });
+  });
+
+  describe('Clear App Data flow', () => {
+    beforeEach(() => {
+      mockClearAllAppData.mockReset().mockResolvedValue(undefined);
+    });
+
+    it('passes the current snapshot user id + clearSession to clearAllAppData', async () => {
+      const user = userEvent.setup();
+      renderSettingsHome();
+
+      await user.click(screen.getByText('Clear App Data').closest('button')!);
+      // Confirm in the modal
+      const confirmButtons = screen.getAllByRole('button', { name: /Clear App Data/i });
+      // The last one is the modal confirm button (first is the menu item we just clicked).
+      await user.click(confirmButtons[confirmButtons.length - 1]);
+
+      expect(mockClearAllAppData).toHaveBeenCalledTimes(1);
+      const args = mockClearAllAppData.mock.calls[0][0];
+      expect(args).toMatchObject({ userId: null });
+      expect(typeof args.clearSession).toBe('function');
     });
   });
 });

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -6,6 +6,7 @@ import RotatingTetrahedronCanvas from '../components/RotatingTetrahedronCanvas';
 import { clearBackendUrlCache } from '../services/backendUrl';
 import { clearCoreRpcUrlCache, testCoreRpcConnection } from '../services/coreRpcClient';
 import { useDeepLinkAuthState } from '../store/deepLinkAuthState';
+import { clearAllAppData } from '../utils/clearAllAppData';
 import {
   clearStoredRpcUrl,
   getDefaultRpcUrl,
@@ -16,13 +17,29 @@ import {
 } from '../utils/configPersistence';
 
 const Welcome = () => {
-  const { isProcessing, errorMessage } = useDeepLinkAuthState();
+  const { isProcessing, errorMessage, requiresAppDataReset } = useDeepLinkAuthState();
 
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [rpcUrl, setRpcUrl] = useState(getStoredRpcUrl());
   const [rpcUrlError, setRpcUrlError] = useState<string | null>(null);
   const [isTestingConnection, setIsTestingConnection] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [isClearingAppData, setIsClearingAppData] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
+
+  const handleClearAppData = async () => {
+    setIsClearingAppData(true);
+    setResetError(null);
+    try {
+      // No live session at the Welcome screen — skip the core-side
+      // `clearSession` step, just wipe local data and restart.
+      await clearAllAppData();
+    } catch (err) {
+      console.error('[Welcome] clearAllAppData failed:', err);
+      setResetError('Could not clear app data. Please quit and reopen OpenHuman, then try again.');
+      setIsClearingAppData(false);
+    }
+  };
 
   const handleRpcUrlChange = (value: string) => {
     setRpcUrl(value);
@@ -175,7 +192,32 @@ const Welcome = () => {
             <div
               role="alert"
               className="mb-5 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-              {errorMessage}
+              <p>{errorMessage}</p>
+              {requiresAppDataReset ? (
+                <div className="mt-3 space-y-2">
+                  <button
+                    type="button"
+                    onClick={handleClearAppData}
+                    disabled={isClearingAppData}
+                    className="w-full rounded-lg bg-red-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60">
+                    {isClearingAppData ? (
+                      <span className="flex items-center justify-center gap-2">
+                        <span className="h-3 w-3 animate-spin rounded-full border border-white border-t-transparent" />
+                        Clearing app data...
+                      </span>
+                    ) : (
+                      'Clear app data & restart'
+                    )}
+                  </button>
+                  <p className="text-[11px] leading-4 text-red-600/80">
+                    This wipes locally stored secrets and accounts on this device. Your cloud
+                    account is unaffected — you can sign in again right after.
+                  </p>
+                  {resetError ? (
+                    <p className="text-[11px] leading-4 font-medium text-red-700">{resetError}</p>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/app/src/pages/Welcome.tsx
+++ b/app/src/pages/Welcome.tsx
@@ -1,3 +1,4 @@
+import createDebug from 'debug';
 import { useState } from 'react';
 
 import OAuthProviderButton from '../components/oauth/OAuthProviderButton';
@@ -15,6 +16,8 @@ import {
   normalizeRpcUrl,
   storeRpcUrl,
 } from '../utils/configPersistence';
+
+const log = createDebug('app:welcome');
 
 const Welcome = () => {
   const { isProcessing, errorMessage, requiresAppDataReset } = useDeepLinkAuthState();
@@ -35,7 +38,8 @@ const Welcome = () => {
       // `clearSession` step, just wipe local data and restart.
       await clearAllAppData();
     } catch (err) {
-      console.error('[Welcome] clearAllAppData failed:', err);
+      const message = err instanceof Error ? err.message : String(err);
+      log('clearAllAppData failed: %s', message);
       setResetError('Could not clear app data. Please quit and reopen OpenHuman, then try again.');
       setIsClearingAppData(false);
     }

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -52,7 +52,9 @@ vi.mock('../../components/oauth/providerConfigs', () => ({
 
 vi.mock('../../store/deepLinkAuthState', () => ({ useDeepLinkAuthState: vi.fn() }));
 
-const mockClearAllAppData = vi.fn().mockResolvedValue(undefined);
+const { mockClearAllAppData } = vi.hoisted(() => ({
+  mockClearAllAppData: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('../../utils/clearAllAppData', () => ({
   clearAllAppData: (...args: unknown[]) => mockClearAllAppData(...args),
 }));

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -174,9 +174,7 @@ describe('Welcome — decryption-failure recovery action', () => {
   it('renders the "Clear app data & restart" button when reset is required', () => {
     render(<Welcome />);
 
-    expect(
-      screen.getByRole('button', { name: /Clear app data & restart/ })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Clear app data & restart/ })).toBeInTheDocument();
     expect(screen.getByText(/cloud account is unaffected/i)).toBeInTheDocument();
   });
 

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -52,6 +52,11 @@ vi.mock('../../components/oauth/providerConfigs', () => ({
 
 vi.mock('../../store/deepLinkAuthState', () => ({ useDeepLinkAuthState: vi.fn() }));
 
+const mockClearAllAppData = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../utils/clearAllAppData', () => ({
+  clearAllAppData: (...args: unknown[]) => mockClearAllAppData(...args),
+}));
+
 vi.mock('../../services/coreRpcClient', () => ({
   clearCoreRpcUrlCache: vi.fn(),
   testCoreRpcConnection: vi.fn(),
@@ -150,6 +155,52 @@ describe('Welcome auth entrypoint', () => {
     render(<Welcome />);
 
     expect(screen.getByRole('alert')).toHaveTextContent('OAuth failed');
+    expect(
+      screen.queryByRole('button', { name: /Clear app data & restart/ })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('Welcome — decryption-failure recovery action', () => {
+  beforeEach(() => {
+    mockClearAllAppData.mockReset().mockResolvedValue(undefined);
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: "Sign-in failed because OpenHuman couldn't decrypt locally stored data.",
+      requiresAppDataReset: true,
+    });
+  });
+
+  it('renders the "Clear app data & restart" button when reset is required', () => {
+    render(<Welcome />);
+
+    expect(
+      screen.getByRole('button', { name: /Clear app data & restart/ })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/cloud account is unaffected/i)).toBeInTheDocument();
+  });
+
+  it('invokes clearAllAppData on click', async () => {
+    render(<Welcome />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear app data & restart/ }));
+
+    await waitFor(() => expect(mockClearAllAppData).toHaveBeenCalledTimes(1));
+    // Pre-login path: no clearSession callback is passed.
+    expect(mockClearAllAppData).toHaveBeenCalledWith();
+  });
+
+  it('surfaces an inline error if clearAllAppData rejects', async () => {
+    mockClearAllAppData.mockRejectedValueOnce(new Error('reset blew up'));
+
+    render(<Welcome />);
+    fireEvent.click(screen.getByRole('button', { name: /Clear app data & restart/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not clear app data/)).toBeInTheDocument();
+    });
+    // Button re-enabled so the user can retry.
+    expect(screen.getByRole('button', { name: /Clear app data & restart/ })).not.toBeDisabled();
   });
 });
 

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -90,7 +90,7 @@ describe('Welcome auth entrypoint', () => {
   beforeEach(() => {
     oauthButtonSpy.mockReset();
     oauthOverrideSpy.mockReset();
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -125,7 +125,7 @@ describe('Welcome auth entrypoint', () => {
   });
 
   it('shows the deep-link processing state when auth is already in progress', () => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
 
     render(<Welcome />);
 
@@ -136,6 +136,7 @@ describe('Welcome auth entrypoint', () => {
     vi.mocked(useDeepLinkAuthState).mockReturnValue({
       isProcessing: false,
       errorMessage: 'OAuth failed',
+      requiresAppDataReset: false,
     });
 
     render(<Welcome />);
@@ -146,7 +147,7 @@ describe('Welcome auth entrypoint', () => {
 
 describe('Welcome — RPC URL advanced panel', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -216,7 +217,7 @@ describe('Welcome — RPC URL advanced panel', () => {
 
 describe('Welcome — Save button', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -294,7 +295,7 @@ describe('Welcome — Save button', () => {
 
 describe('Welcome — Test Connection button', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -419,7 +420,7 @@ describe('Welcome — Test Connection button', () => {
 
 describe('Welcome — Reset to Default button', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -475,7 +476,7 @@ describe('Welcome — Reset to Default button', () => {
 
 describe('Welcome — URL input behaviour', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -526,7 +527,7 @@ describe('Welcome — URL input behaviour', () => {
 
 describe('Welcome — OAuth buttons presence', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
   });
 
   it('renders all providers with showOnWelcome=true', () => {
@@ -544,7 +545,7 @@ describe('Welcome — OAuth buttons presence', () => {
   });
 
   it('hides OAuth buttons while auth is processing', () => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
     render(<Welcome />);
 
     expect(screen.queryByRole('button', { name: 'google' })).not.toBeInTheDocument();

--- a/app/src/pages/__tests__/Welcome.test.tsx
+++ b/app/src/pages/__tests__/Welcome.test.tsx
@@ -90,7 +90,11 @@ describe('Welcome auth entrypoint', () => {
   beforeEach(() => {
     oauthButtonSpy.mockReset();
     oauthOverrideSpy.mockReset();
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -125,7 +129,11 @@ describe('Welcome auth entrypoint', () => {
   });
 
   it('shows the deep-link processing state when auth is already in progress', () => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: true,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
 
     render(<Welcome />);
 
@@ -147,7 +155,11 @@ describe('Welcome auth entrypoint', () => {
 
 describe('Welcome — RPC URL advanced panel', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -217,7 +229,11 @@ describe('Welcome — RPC URL advanced panel', () => {
 
 describe('Welcome — Save button', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -295,7 +311,11 @@ describe('Welcome — Save button', () => {
 
 describe('Welcome — Test Connection button', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -420,7 +440,11 @@ describe('Welcome — Test Connection button', () => {
 
 describe('Welcome — Reset to Default button', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -476,7 +500,11 @@ describe('Welcome — Reset to Default button', () => {
 
 describe('Welcome — URL input behaviour', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     vi.mocked(clearCoreRpcUrlCache).mockReset();
     vi.mocked(clearBackendUrlCache).mockReset();
     vi.mocked(storeRpcUrl).mockReset();
@@ -527,7 +555,11 @@ describe('Welcome — URL input behaviour', () => {
 
 describe('Welcome — OAuth buttons presence', () => {
   beforeEach(() => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
   });
 
   it('renders all providers with showOnWelcome=true', () => {
@@ -545,7 +577,11 @@ describe('Welcome — OAuth buttons presence', () => {
   });
 
   it('hides OAuth buttons while auth is processing', () => {
-    vi.mocked(useDeepLinkAuthState).mockReturnValue({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
+    vi.mocked(useDeepLinkAuthState).mockReturnValue({
+      isProcessing: true,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
     render(<Welcome />);
 
     expect(screen.queryByRole('button', { name: 'google' })).not.toBeInTheDocument();

--- a/app/src/store/__tests__/deepLinkAuthState.test.ts
+++ b/app/src/store/__tests__/deepLinkAuthState.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 describe('deepLinkAuthState transitions', () => {
   it('starts idle with no error message', () => {
     completeDeepLinkAuthProcessing();
-    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: null });
+    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
   });
 
   it('beginDeepLinkAuthProcessing flips isProcessing true and clears prior error', () => {
@@ -29,19 +29,36 @@ describe('deepLinkAuthState transitions', () => {
     expect(getDeepLinkAuthState().errorMessage).toBe('prior failure');
 
     beginDeepLinkAuthProcessing();
-    expect(getDeepLinkAuthState()).toEqual({ isProcessing: true, errorMessage: null });
+    expect(getDeepLinkAuthState()).toEqual({
+      isProcessing: true,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
   });
 
   it('completeDeepLinkAuthProcessing returns to idle', () => {
     beginDeepLinkAuthProcessing();
     completeDeepLinkAuthProcessing();
-    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: null });
+    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
   });
 
   it('failDeepLinkAuthProcessing surfaces message and resets processing flag', () => {
     beginDeepLinkAuthProcessing();
     failDeepLinkAuthProcessing('token expired');
-    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: 'token expired' });
+    expect(getDeepLinkAuthState()).toEqual({
+      isProcessing: false,
+      errorMessage: 'token expired',
+      requiresAppDataReset: false,
+    });
+  });
+
+  it('failDeepLinkAuthProcessing carries through the requiresAppDataReset hint', () => {
+    failDeepLinkAuthProcessing('cannot decrypt', { requiresAppDataReset: true });
+    expect(getDeepLinkAuthState()).toEqual({
+      isProcessing: false,
+      errorMessage: 'cannot decrypt',
+      requiresAppDataReset: true,
+    });
   });
 });
 
@@ -92,16 +109,24 @@ describe('useDeepLinkAuthState hook', () => {
   it('re-renders when state changes', () => {
     completeDeepLinkAuthProcessing();
     const { result } = renderHook(() => useDeepLinkAuthState());
-    expect(result.current).toEqual({ isProcessing: false, errorMessage: null });
+    expect(result.current).toEqual({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
 
     act(() => {
       beginDeepLinkAuthProcessing();
     });
-    expect(result.current).toEqual({ isProcessing: true, errorMessage: null });
+    expect(result.current).toEqual({
+      isProcessing: true,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
 
     act(() => {
       failDeepLinkAuthProcessing('denied');
     });
-    expect(result.current).toEqual({ isProcessing: false, errorMessage: 'denied' });
+    expect(result.current).toEqual({
+      isProcessing: false,
+      errorMessage: 'denied',
+      requiresAppDataReset: false,
+    });
   });
 });

--- a/app/src/store/__tests__/deepLinkAuthState.test.ts
+++ b/app/src/store/__tests__/deepLinkAuthState.test.ts
@@ -21,7 +21,11 @@ afterEach(() => {
 describe('deepLinkAuthState transitions', () => {
   it('starts idle with no error message', () => {
     completeDeepLinkAuthProcessing();
-    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    expect(getDeepLinkAuthState()).toEqual({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
   });
 
   it('beginDeepLinkAuthProcessing flips isProcessing true and clears prior error', () => {
@@ -39,7 +43,11 @@ describe('deepLinkAuthState transitions', () => {
   it('completeDeepLinkAuthProcessing returns to idle', () => {
     beginDeepLinkAuthProcessing();
     completeDeepLinkAuthProcessing();
-    expect(getDeepLinkAuthState()).toEqual({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    expect(getDeepLinkAuthState()).toEqual({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
   });
 
   it('failDeepLinkAuthProcessing surfaces message and resets processing flag', () => {
@@ -109,7 +117,11 @@ describe('useDeepLinkAuthState hook', () => {
   it('re-renders when state changes', () => {
     completeDeepLinkAuthProcessing();
     const { result } = renderHook(() => useDeepLinkAuthState());
-    expect(result.current).toEqual({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
+    expect(result.current).toEqual({
+      isProcessing: false,
+      errorMessage: null,
+      requiresAppDataReset: false,
+    });
 
     act(() => {
       beginDeepLinkAuthProcessing();

--- a/app/src/store/deepLinkAuthState.ts
+++ b/app/src/store/deepLinkAuthState.ts
@@ -3,9 +3,19 @@ import { useSyncExternalStore } from 'react';
 export interface DeepLinkAuthState {
   isProcessing: boolean;
   errorMessage: string | null;
+  // Set when sign-in fails because the local core could not decrypt persisted
+  // secrets — typically the encryption key on disk no longer matches the
+  // ciphertext (key rotated, profile copied between machines, tampered/corrupt
+  // storage). The only safe recovery is wiping local app data so the next
+  // login starts from a clean slate.
+  requiresAppDataReset: boolean;
 }
 
-const initialState: DeepLinkAuthState = { isProcessing: false, errorMessage: null };
+const initialState: DeepLinkAuthState = {
+  isProcessing: false,
+  errorMessage: null,
+  requiresAppDataReset: false,
+};
 
 let deepLinkAuthState: DeepLinkAuthState = initialState;
 const listeners = new Set<() => void>();
@@ -31,15 +41,30 @@ export const subscribeDeepLinkAuthState = (listener: () => void): (() => void) =
 };
 
 export const beginDeepLinkAuthProcessing = (): void => {
-  setDeepLinkAuthState({ isProcessing: true, errorMessage: null });
+  setDeepLinkAuthState({
+    isProcessing: true,
+    errorMessage: null,
+    requiresAppDataReset: false,
+  });
 };
 
 export const completeDeepLinkAuthProcessing = (): void => {
-  setDeepLinkAuthState({ isProcessing: false, errorMessage: null });
+  setDeepLinkAuthState({
+    isProcessing: false,
+    errorMessage: null,
+    requiresAppDataReset: false,
+  });
 };
 
-export const failDeepLinkAuthProcessing = (message: string): void => {
-  setDeepLinkAuthState({ isProcessing: false, errorMessage: message });
+export const failDeepLinkAuthProcessing = (
+  message: string,
+  options: { requiresAppDataReset?: boolean } = {}
+): void => {
+  setDeepLinkAuthState({
+    isProcessing: false,
+    errorMessage: message,
+    requiresAppDataReset: Boolean(options.requiresAppDataReset),
+  });
 };
 
 export const useDeepLinkAuthState = (): DeepLinkAuthState =>

--- a/app/src/store/deepLinkAuthState.ts
+++ b/app/src/store/deepLinkAuthState.ts
@@ -41,19 +41,11 @@ export const subscribeDeepLinkAuthState = (listener: () => void): (() => void) =
 };
 
 export const beginDeepLinkAuthProcessing = (): void => {
-  setDeepLinkAuthState({
-    isProcessing: true,
-    errorMessage: null,
-    requiresAppDataReset: false,
-  });
+  setDeepLinkAuthState({ isProcessing: true, errorMessage: null, requiresAppDataReset: false });
 };
 
 export const completeDeepLinkAuthProcessing = (): void => {
-  setDeepLinkAuthState({
-    isProcessing: false,
-    errorMessage: null,
-    requiresAppDataReset: false,
-  });
+  setDeepLinkAuthState({ isProcessing: false, errorMessage: null, requiresAppDataReset: false });
 };
 
 export const failDeepLinkAuthProcessing = (

--- a/app/src/utils/__tests__/clearAllAppData.test.ts
+++ b/app/src/utils/__tests__/clearAllAppData.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAllAppData } from '../clearAllAppData';
+
+const { mockPurge, mockReset, mockRestart, mockPurgeCef } = vi.hoisted(() => ({
+  mockPurge: vi.fn().mockResolvedValue(undefined),
+  mockReset: vi.fn().mockResolvedValue(undefined),
+  mockRestart: vi.fn().mockResolvedValue(undefined),
+  mockPurgeCef: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../store', () => ({ persistor: { purge: mockPurge } }));
+
+vi.mock('../tauriCommands', () => ({
+  resetOpenHumanDataAndRestartCore: mockReset,
+  restartApp: mockRestart,
+  scheduleCefProfilePurge: mockPurgeCef,
+}));
+
+describe('clearAllAppData', () => {
+  beforeEach(() => {
+    mockPurge.mockReset().mockResolvedValue(undefined);
+    mockReset.mockReset().mockResolvedValue(undefined);
+    mockRestart.mockReset().mockResolvedValue(undefined);
+    mockPurgeCef.mockReset().mockResolvedValue(undefined);
+    window.localStorage.setItem('persisted', '1');
+    window.sessionStorage.setItem('session-persisted', '1');
+  });
+
+  it('runs the full wipe sequence and restarts the app', async () => {
+    const clearSession = vi.fn().mockResolvedValue(undefined);
+
+    await clearAllAppData({ clearSession, userId: 'user-1' });
+
+    expect(mockPurgeCef).toHaveBeenCalledWith('user-1');
+    expect(clearSession).toHaveBeenCalledTimes(1);
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockPurge).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem('persisted')).toBeNull();
+    expect(window.sessionStorage.getItem('session-persisted')).toBeNull();
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to a null user scope when no userId is provided', async () => {
+    await clearAllAppData();
+
+    expect(mockPurgeCef).toHaveBeenCalledWith(null);
+    // No clearSession was provided — call sequence still completes.
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues if scheduleCefProfilePurge fails (best-effort)', async () => {
+    mockPurgeCef.mockRejectedValueOnce(new Error('cef-purge boom'));
+
+    await expect(clearAllAppData()).resolves.toBeUndefined();
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues if clearSession fails (best-effort)', async () => {
+    const clearSession = vi.fn().mockRejectedValue(new Error('logout boom'));
+
+    await expect(clearAllAppData({ clearSession })).resolves.toBeUndefined();
+
+    expect(clearSession).toHaveBeenCalledTimes(1);
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when resetOpenHumanDataAndRestartCore fails (unrecoverable)', async () => {
+    mockReset.mockRejectedValueOnce(new Error('core reset boom'));
+
+    await expect(clearAllAppData()).rejects.toThrow('core reset boom');
+
+    expect(mockPurge).not.toHaveBeenCalled();
+    expect(mockRestart).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -5,7 +5,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   completeDeepLinkAuthProcessing,
   getDeepLinkAuthState,
+  subscribeDeepLinkAuthState,
 } from '../../store/deepLinkAuthState';
+
+const waitForAuthSettled = (): Promise<void> =>
+  new Promise(resolve => {
+    if (!getDeepLinkAuthState().isProcessing) {
+      resolve();
+      return;
+    }
+    const unsubscribe = subscribeDeepLinkAuthState(() => {
+      if (!getDeepLinkAuthState().isProcessing) {
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
 import { setupDesktopDeepLinkListener } from '../desktopDeepLinkListener';
 import { storeSession } from '../tauriCommands';
 
@@ -81,7 +96,7 @@ describe('desktopDeepLinkListener', () => {
 
     await setupDesktopDeepLinkListener();
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await waitForAuthSettled();
 
     const state = getDeepLinkAuthState();
     expect(state.requiresAppDataReset).toBe(true);
@@ -95,7 +110,7 @@ describe('desktopDeepLinkListener', () => {
     vi.mocked(getCurrent).mockResolvedValue(['openhuman://auth?token=abc&key=auth']);
 
     await setupDesktopDeepLinkListener();
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await waitForAuthSettled();
 
     const state = getDeepLinkAuthState();
     expect(state.requiresAppDataReset).toBe(false);

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -7,6 +7,8 @@ import {
   getDeepLinkAuthState,
   subscribeDeepLinkAuthState,
 } from '../../store/deepLinkAuthState';
+import { setupDesktopDeepLinkListener } from '../desktopDeepLinkListener';
+import { storeSession } from '../tauriCommands';
 
 const waitForAuthSettled = (): Promise<void> =>
   new Promise(resolve => {
@@ -21,8 +23,6 @@ const waitForAuthSettled = (): Promise<void> =>
       }
     });
   });
-import { setupDesktopDeepLinkListener } from '../desktopDeepLinkListener';
-import { storeSession } from '../tauriCommands';
 
 vi.mock('../../lib/coreState/store', () => ({
   getCoreStateSnapshot: () => ({ isBootstrapping: false, snapshot: { sessionToken: null } }),

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -6,7 +6,13 @@ import {
   completeDeepLinkAuthProcessing,
   getDeepLinkAuthState,
 } from '../../store/deepLinkAuthState';
+import { storeSession } from '../tauriCommands';
 import { setupDesktopDeepLinkListener } from '../desktopDeepLinkListener';
+
+vi.mock('../../lib/coreState/store', () => ({
+  getCoreStateSnapshot: () => ({ isBootstrapping: false, snapshot: { sessionToken: null } }),
+  patchCoreStateSnapshot: vi.fn(),
+}));
 
 const windowControls = vi.hoisted(() => ({
   show: vi.fn().mockResolvedValue(undefined),
@@ -64,6 +70,36 @@ describe('desktopDeepLinkListener', () => {
       })
     );
     expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('token%3Dsecret');
+  });
+
+  it('flags requiresAppDataReset when auth fails with a decryption error', async () => {
+    vi.mocked(storeSession).mockRejectedValueOnce(
+      new Error('Decryption failed — wrong key or tampered data')
+    );
+
+    vi.mocked(getCurrent).mockResolvedValue(['openhuman://auth?token=abc&key=auth']);
+
+    await setupDesktopDeepLinkListener();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const state = getDeepLinkAuthState();
+    expect(state.requiresAppDataReset).toBe(true);
+    expect(state.errorMessage).toMatch(/Clear app data to start fresh/);
+    expect(state.isProcessing).toBe(false);
+  });
+
+  it('keeps requiresAppDataReset false for non-decryption auth failures', async () => {
+    vi.mocked(storeSession).mockRejectedValueOnce(new Error('network down'));
+
+    vi.mocked(getCurrent).mockResolvedValue(['openhuman://auth?token=abc&key=auth']);
+
+    await setupDesktopDeepLinkListener();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const state = getDeepLinkAuthState();
+    expect(state.requiresAppDataReset).toBe(false);
+    expect(state.errorMessage).toBe('Sign-in failed. Please try again.');
   });
 
   it('sanitizes provider and error code values from OAuth error deep links', async () => {

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -46,6 +46,7 @@ describe('desktopDeepLinkListener', () => {
       isProcessing: false,
       errorMessage:
         'Twitter/X sign-in failed before OpenHuman received authorization. Check the Twitter Developer Portal app settings: OAuth 2.0 must be enabled, callback URL must match the backend redirect URL exactly, and the client ID, client secret, and requested scopes must match the OpenHuman backend configuration.',
+      requiresAppDataReset: false,
     });
     expect(oauthErrorEvents).toHaveLength(1);
     expect(oauthErrorEvents[0].detail).toEqual({

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -6,8 +6,8 @@ import {
   completeDeepLinkAuthProcessing,
   getDeepLinkAuthState,
 } from '../../store/deepLinkAuthState';
-import { storeSession } from '../tauriCommands';
 import { setupDesktopDeepLinkListener } from '../desktopDeepLinkListener';
+import { storeSession } from '../tauriCommands';
 
 vi.mock('../../lib/coreState/store', () => ({
   getCoreStateSnapshot: () => ({ isBootstrapping: false, snapshot: { sessionToken: null } }),

--- a/app/src/utils/clearAllAppData.ts
+++ b/app/src/utils/clearAllAppData.ts
@@ -1,0 +1,70 @@
+import { persistor } from '../store';
+import {
+  resetOpenHumanDataAndRestartCore,
+  restartApp,
+  scheduleCefProfilePurge,
+} from './tauriCommands';
+
+export interface ClearAllAppDataOptions {
+  // Optional core-side session clear (e.g. `auth_clear_session`). Best-effort —
+  // skipped silently if the caller cannot/does not provide it (e.g. pre-login
+  // recovery from a corrupt key file, where there is no live session).
+  clearSession?: () => Promise<unknown>;
+  // User scope passed to the CEF profile purge so per-user browser data is
+  // queued for deletion on the next launch. `null` purges the unauthenticated
+  // default profile.
+  userId?: string | null;
+}
+
+/**
+ * Sign out + wipe every local data store and restart the app:
+ *
+ *  1. Queue the CEF profile directory for deletion on next launch.
+ *  2. Best-effort `clearSession` to drop the core's auth state.
+ *  3. Reset the openhuman workspace dir + restart the core sidecar.
+ *  4. Purge redux-persist + window storage.
+ *  5. Restart the desktop shell so CEF reboots into the fresh profile.
+ *
+ * Used by Settings (Danger Zone) and the Welcome screen's decryption-recovery
+ * action. Throws on the first step that can't be recovered from — callers are
+ * expected to surface that to the user.
+ */
+export const clearAllAppData = async ({
+  clearSession,
+  userId = null,
+}: ClearAllAppDataOptions = {}): Promise<void> => {
+  // 1. Queue the active user-scoped CEF profile for deletion on next launch.
+  //    The CEF process may still hold SQLite/cache handles, so we delete
+  //    after the shell restarts.
+  try {
+    await scheduleCefProfilePurge(userId);
+  } catch (err) {
+    console.warn('[clearAllAppData] Failed to queue CEF profile purge:', err);
+  }
+
+  // 2. Best-effort core-side session clear. If the core is wedged or there is
+  //    no session yet (pre-login recovery), keep going — we still want to wipe
+  //    local data.
+  if (clearSession) {
+    try {
+      await clearSession();
+    } catch (err) {
+      console.warn('[clearAllAppData] core session clear failed:', err);
+    }
+  }
+
+  // 3. Delete workspace folder + restart core. The core RPC removes both the
+  //    active openhuman_dir and the default `~/.openhuman`, then we restart
+  //    the sidecar so it boots from a clean slate.
+  await resetOpenHumanDataAndRestartCore();
+
+  // 4. Purge redux-persist + browser storage. `persistor.purge()` wipes the
+  //    persisted backend; localStorage/sessionStorage clear everything else
+  //    (auth flags, theme, etc.).
+  await persistor.purge();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+
+  // 5. Full app restart so CEF reboots into the fresh pre-login profile.
+  await restartApp();
+};

--- a/app/src/utils/desktopDeepLinkListener.ts
+++ b/app/src/utils/desktopDeepLinkListener.ts
@@ -118,8 +118,27 @@ const handleAuthDeepLink = async (parsed: URL) => {
     completeDeepLinkAuthProcessing();
   } catch (error) {
     console.error('[DeepLink][auth] failed to complete login:', error);
-    failDeepLinkAuthProcessing('Sign-in failed. Please try again.');
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    if (isDecryptionFailure(rawMessage)) {
+      failDeepLinkAuthProcessing(
+        "Sign-in failed because OpenHuman couldn't decrypt locally stored data. " +
+          'This usually means the encryption key on this device no longer matches ' +
+          'your stored secrets. Clear app data to start fresh.',
+        { requiresAppDataReset: true }
+      );
+    } else {
+      failDeepLinkAuthProcessing('Sign-in failed. Please try again.');
+    }
   }
+};
+
+const isDecryptionFailure = (message: string): boolean => {
+  const lowered = message.toLowerCase();
+  return (
+    lowered.includes('decryption failed') ||
+    lowered.includes('wrong key or tampered data') ||
+    lowered.includes('corrupt data')
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

- Detect "Decryption failed" errors during the OAuth deep-link sign-in flow and surface a one-click **Clear app data & restart** recovery directly in the Welcome screen.
- Extract the existing Settings → Danger Zone clear-data sequence (CEF profile purge → core workspace reset → redux-persist + window storage wipe → app restart) into a shared `clearAllAppData()` util used by both call sites.
- Plumb a `requiresAppDataReset` flag through `DeepLinkAuthState` so the Welcome screen only shows the destructive action when it's actually applicable.

## Problem

When the local core sidecar can't decrypt secrets at sign-in (e.g. encryption key rotated, profile copied between machines, tampered/corrupt storage), the deep-link auth handler used to swallow the underlying `Decryption failed — wrong key or tampered data` error and surface a generic "Sign-in failed. Please try again." with no path forward. The Settings → "Clear App Data" escape hatch is unreachable while logged out, so users were effectively stuck on the Welcome screen.

## Solution

- `desktopDeepLinkListener.ts` inspects the caught error from `handleAuthDeepLink` for `decryption failed` / `wrong key or tampered data` / `corrupt data` substrings. On match, it flips the new `requiresAppDataReset` flag on `DeepLinkAuthState` and shows a more useful message ("Clear app data to start fresh" + reassurance the cloud account is untouched).
- `Welcome.tsx` reads the flag and renders a red "Clear app data & restart" button inside the existing error block, with an in-flight spinner and inline failure surface.
- Extracted `app/src/utils/clearAllAppData.ts` (CEF profile purge → optional core `clearSession` → workspace reset/core restart → redux-persist + window storage wipe → app restart). Welcome calls it without `clearSession` (no live session pre-login); `SettingsHome.tsx` calls it with the current user's session clear callback. Both call sites stay in sync.
- Tests cover the new option flag in `deepLinkAuthState`, the existing snapshot tests, and the listener's error-classification path.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — no new/removed/renamed feature rows in the coverage matrix
- [x] N/A: no feature IDs from the matrix apply to this UX-recovery change
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut surfaces (deep-link auth error path only, manual smoke unchanged)
- [x] N/A: no linked issue

## Impact

- **Desktop only.** The deep-link auth path and `clearAllAppData` are Tauri-specific; web/CLI surfaces are untouched.
- **No migration required.** The new `requiresAppDataReset` field defaults to `false` and is recomputed on every transition.
- **User-visible behavior:** when (and only when) sign-in fails because of a local decryption error, a destructive recovery action appears on the Welcome screen. Cloud account / server-side data is unaffected.
- **Security:** the recovery wipes local secrets and the CEF profile; matches the Settings → Danger Zone behavior bit-for-bit (same util).

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/login-decryption-recovery
- Commit SHA: 1b7a086b

### Validation Run
- [x] \`pnpm --filter openhuman-app format:check\`
- [x] \`pnpm typecheck\`
- [x] Focused tests: \`pnpm debug unit deepLinkAuthState desktopDeepLinkListener SettingsHome OAuthProviderButton Welcome\` — 83 passed
- [x] N/A: Rust fmt/check (if changed): no Rust changes
- [x] N/A: Tauri fmt/check (if changed): no Tauri shell changes

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended behavior change: surface a "Clear app data & restart" button on the Welcome screen when login fails due to a decryption error.
- User-visible effect: previously stuck users now have an in-product recovery path; happy-path sign-in is unchanged.

### Parity Contract
- Legacy behavior preserved: non-decryption deep-link auth failures still render the existing generic "Sign-in failed. Please try again." message with no recovery button.
- Guard/fallback/dispatch parity checks: \`requiresAppDataReset\` defaults to \`false\` on every transition (\`begin\`/\`complete\`), so stale state can't leave the button visible after a successful retry.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized “Clear app data & restart” flow added to Settings and Welcome with confirmation, loading state, and error feedback.

* **Bug Fixes**
  * Better detection of local decryption/key-mismatch failures and now surface a targeted recovery option to wipe local data and restart.

* **Tests**
  * Expanded test coverage for the reset hint, auth-state transitions, and the clear-app-data workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1652)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->