### PR TITLE
feat(settings): add mascot color customization (closes #1651)

### DIFF
--- a/app/src/components/settings/SettingsHome.tsx
+++ b/app/src/components/settings/SettingsHome.tsx
@@ -99,6 +99,22 @@ const SettingsHome = () => {
           ),
           onClick: () => navigateToSettings('notifications'),
         },
+        {
+          id: 'mascot',
+          title: 'Mascot',
+          description: 'Pick the mascot color used across the app',
+          icon: (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 21a9 9 0 100-18 9 9 0 000 18zM9 10h.01M15 10h.01M9.5 15c.83.67 1.67 1 2.5 1s1.67-.33 2.5-1"
+              />
+            </svg>
+          ),
+          onClick: () => navigateToSettings('mascot'),
+        },
       ],
     },
     {

--- a/app/src/components/settings/hooks/useSettingsNavigation.ts
+++ b/app/src/components/settings/hooks/useSettingsNavigation.ts
@@ -32,6 +32,7 @@ export type SettingsRoute =
   | 'local-model-debug'
   | 'notifications'
   | 'notification-routing'
+  | 'mascot'
   | 'intelligence'
   | 'webhooks-triggers'
   | 'composio-triggers';
@@ -109,6 +110,7 @@ export const useSettingsNavigation = (): SettingsNavigationHook => {
     // shorter `notifications` prefix.
     if (path.includes('/settings/notification-routing')) return 'notification-routing';
     if (path.includes('/settings/notifications')) return 'notifications';
+    if (path.includes('/settings/mascot')) return 'mascot';
     return 'home';
   };
 
@@ -226,6 +228,10 @@ export const useSettingsNavigation = (): SettingsNavigationHook => {
 
       // Notifications panel sits at the top level of Settings.
       case 'notifications':
+        return [settingsCrumb];
+
+      // Mascot appearance panel sits at the top level of Settings.
+      case 'mascot':
         return [settingsCrumb];
 
       case 'home':

--- a/app/src/components/settings/panels/MascotPanel.tsx
+++ b/app/src/components/settings/panels/MascotPanel.tsx
@@ -1,0 +1,110 @@
+import { getMascotPalette, type MascotColor } from '../../../features/human/Mascot/mascotPalette';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import {
+  DEFAULT_MASCOT_COLOR,
+  selectMascotColor,
+  setMascotColor,
+  SUPPORTED_MASCOT_COLORS,
+} from '../../../store/mascotSlice';
+import SettingsHeader from '../components/SettingsHeader';
+import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
+
+interface ColorOption {
+  id: MascotColor;
+  label: string;
+}
+
+const COLOR_OPTIONS: ColorOption[] = [
+  { id: 'yellow', label: 'Yellow' },
+  { id: 'burgundy', label: 'Burgundy' },
+  { id: 'black', label: 'Black' },
+  { id: 'navy', label: 'Navy' },
+  { id: 'green', label: 'Green' },
+];
+
+const MascotPanel = () => {
+  const { navigateBack, breadcrumbs } = useSettingsNavigation();
+  const dispatch = useAppDispatch();
+  const storedColor = useAppSelector(selectMascotColor);
+
+  // Filter the menu to colors the asset pipeline currently supports — guards
+  // against an older persisted value pointing at a variant a future build
+  // removed. The selected swatch still highlights iff the stored color is
+  // present; otherwise we silently fall back to the default for the preview.
+  const available = COLOR_OPTIONS.filter(opt =>
+    (SUPPORTED_MASCOT_COLORS as readonly string[]).includes(opt.id)
+  );
+  const activeColor: MascotColor = (SUPPORTED_MASCOT_COLORS as readonly string[]).includes(
+    storedColor
+  )
+    ? storedColor
+    : DEFAULT_MASCOT_COLOR;
+
+  const handleSelect = (color: MascotColor) => {
+    if (color === storedColor) return;
+    dispatch(setMascotColor(color));
+  };
+
+  return (
+    <div>
+      <SettingsHeader
+        title="Mascot"
+        showBackButton={true}
+        onBack={navigateBack}
+        breadcrumbs={breadcrumbs}
+      />
+
+      <div className="p-4 space-y-4">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-stone-400 mb-2 px-1">
+            Color
+          </h3>
+          <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
+            {available.length === 0 ? (
+              <p className="p-4 text-sm text-stone-500">
+                No mascot color variants are available in this build.
+              </p>
+            ) : (
+              <div
+                className="grid grid-cols-5 gap-3 p-4"
+                role="radiogroup"
+                aria-label="Mascot color">
+                {available.map(opt => {
+                  const palette = getMascotPalette(opt.id);
+                  const selected = opt.id === activeColor;
+                  return (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      aria-label={opt.label}
+                      onClick={() => handleSelect(opt.id)}
+                      data-testid={`mascot-color-${opt.id}`}
+                      className={`flex flex-col items-center gap-2 rounded-lg p-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
+                        selected ? 'bg-stone-100' : 'hover:bg-stone-50'
+                      }`}>
+                      <span
+                        className={`w-10 h-10 rounded-full border-2 transition-shadow ${
+                          selected ? 'border-primary-500 shadow-soft' : 'border-stone-200'
+                        }`}
+                        style={{ backgroundColor: palette.bodyFill }}
+                      />
+                      <span className="text-xs text-stone-700">{opt.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-stone-500 leading-relaxed px-1 mt-2">
+            The selected color is applied everywhere the mascot appears and is remembered across
+            restarts.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MascotPanel;

--- a/app/src/components/settings/panels/__tests__/MascotPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/MascotPanel.test.tsx
@@ -1,0 +1,79 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import mascotReducer, { setMascotColor } from '../../../../store/mascotSlice';
+import MascotPanel from '../MascotPanel';
+
+const { mockNavigateBack } = vi.hoisted(() => ({ mockNavigateBack: vi.fn() }));
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack: mockNavigateBack,
+    breadcrumbs: [{ label: 'Settings' }],
+  }),
+}));
+
+function buildStore() {
+  return configureStore({ reducer: { mascot: mascotReducer } });
+}
+
+function renderPanel(store = buildStore()) {
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <MascotPanel />
+        </MemoryRouter>
+      </Provider>
+    ),
+  };
+}
+
+describe('MascotPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a radio swatch for each supported color', () => {
+    renderPanel();
+    expect(screen.getByRole('radiogroup', { name: 'Mascot color' })).toBeInTheDocument();
+    for (const label of ['Yellow', 'Burgundy', 'Black', 'Navy', 'Green']) {
+      expect(screen.getByRole('radio', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('marks the currently selected color as aria-checked', () => {
+    const store = buildStore();
+    store.dispatch(setMascotColor('navy'));
+    renderPanel(store);
+    expect(screen.getByRole('radio', { name: 'Navy' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'Yellow' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('dispatches setMascotColor when a swatch is clicked', () => {
+    const { store } = renderPanel();
+    fireEvent.click(screen.getByRole('radio', { name: 'Burgundy' }));
+    expect(store.getState().mascot.color).toBe('burgundy');
+  });
+
+  it('is a no-op when clicking the already-selected color', () => {
+    const store = buildStore();
+    store.dispatch(setMascotColor('green'));
+    const dispatchSpy = vi.spyOn(store, 'dispatch');
+    renderPanel(store);
+    fireEvent.click(screen.getByRole('radio', { name: 'Green' }));
+    // No additional dispatches beyond what React-Redux did to subscribe.
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(store.getState().mascot.color).toBe('green');
+  });
+
+  it('invokes navigateBack from the header back button', () => {
+    renderPanel();
+    fireEvent.click(screen.getByLabelText('Go back'));
+    expect(mockNavigateBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/features/human/HumanPage.tsx
+++ b/app/src/features/human/HumanPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import Conversations from '../../pages/Conversations';
+import { useAppSelector } from '../../store/hooks';
+import { selectMascotColor } from '../../store/mascotSlice';
 import { YellowMascot } from './Mascot';
 import { useHumanMascot } from './useHumanMascot';
 
@@ -18,6 +20,7 @@ const HumanPage = () => {
 
   // Visemes are intentionally unused — the YellowMascot has its own talking lipsync.
   const { face } = useHumanMascot({ speakReplies });
+  const mascotColor = useAppSelector(selectMascotColor);
 
   // Sidebar reserves ~436px (420px panel + 16px gutter) on the right; the
   // mascot stage takes the remaining width so the two never overlap.
@@ -33,7 +36,7 @@ const HumanPage = () => {
       {/* Mascot stage — fills the area to the left of the reserved sidebar column. */}
       <div className="absolute inset-y-0 left-0 right-[436px] flex items-center justify-center">
         <div className="relative w-[min(80vh,90%)] aspect-square">
-          <YellowMascot face={face} />
+          <YellowMascot face={face} mascotColor={mascotColor} />
         </div>
       </div>
 

--- a/app/src/features/human/Mascot/index.ts
+++ b/app/src/features/human/Mascot/index.ts
@@ -4,3 +4,5 @@ export { YellowMascot } from './YellowMascot';
 export type { YellowMascotProps } from './YellowMascot';
 export { lerpViseme, VISEMES, visemePath } from './visemes';
 export type { VisemeId, VisemeShape } from './visemes';
+export { getMascotPalette } from './mascotPalette';
+export type { MascotColor, MascotPalette } from './mascotPalette';

--- a/app/src/features/meet/MascotFrameProducer.tsx
+++ b/app/src/features/meet/MascotFrameProducer.tsx
@@ -1,6 +1,8 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { type FC, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useAppSelector } from '../../store/hooks';
+import { selectMascotColor } from '../../store/mascotSlice';
 import {
   type FrameConfig,
   FrameConfigContext,
@@ -114,6 +116,7 @@ export const MascotFrameProducer: FC = () => {
 
 const ProducerSession: FC<{ session: BusSession }> = ({ session }) => {
   const hostRef = useRef<HTMLDivElement>(null);
+  const mascotColor = useAppSelector(selectMascotColor);
   const wsRef = useRef<WebSocket | null>(null);
   const wsReadyRef = useRef(false);
   const stoppedRef = useRef(false);
@@ -378,7 +381,7 @@ const ProducerSession: FC<{ session: BusSession }> = ({ session }) => {
               loadingColor="#ffffff"
               greeting={false}
               sleeping={false}
-              mascotColor="yellow"
+              mascotColor={mascotColor}
               arm="wave"
               talking={false}
               thinking={false}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -14,6 +14,7 @@ import CronJobsPanel from '../components/settings/panels/CronJobsPanel';
 import DeveloperOptionsPanel from '../components/settings/panels/DeveloperOptionsPanel';
 import LocalModelDebugPanel from '../components/settings/panels/LocalModelDebugPanel';
 import LocalModelPanel from '../components/settings/panels/LocalModelPanel';
+import MascotPanel from '../components/settings/panels/MascotPanel';
 import MemoryDataPanel from '../components/settings/panels/MemoryDataPanel';
 import MemoryDebugPanel from '../components/settings/panels/MemoryDebugPanel';
 import MessagingPanel from '../components/settings/panels/MessagingPanel';
@@ -293,6 +294,7 @@ const Settings = () => {
         <Route path="voice" element={wrapSettingsPage(<VoicePanel />)} />
         <Route path="messaging" element={wrapSettingsPage(<MessagingPanel />)} />
         <Route path="notifications" element={wrapSettingsPage(<NotificationsPanel />)} />
+        <Route path="mascot" element={wrapSettingsPage(<MascotPanel />)} />
         <Route path="tools" element={wrapSettingsPage(<ToolsPanel />)} />
         {/* AI & Models leaf panels */}
         <Route path="local-model" element={wrapSettingsPage(<LocalModelPanel />)} />

--- a/app/src/store/__tests__/mascotSlice.test.ts
+++ b/app/src/store/__tests__/mascotSlice.test.ts
@@ -1,0 +1,74 @@
+import { REHYDRATE } from 'redux-persist';
+import { describe, expect, it } from 'vitest';
+
+import reducer, {
+  DEFAULT_MASCOT_COLOR,
+  selectMascotColor,
+  setMascotColor,
+  SUPPORTED_MASCOT_COLORS,
+} from '../mascotSlice';
+import { resetUserScopedState } from '../resetActions';
+
+describe('mascotSlice', () => {
+  it('starts with the default mascot color', () => {
+    const state = reducer(undefined, { type: '@@INIT' });
+    expect(state.color).toBe(DEFAULT_MASCOT_COLOR);
+  });
+
+  it('setMascotColor updates the color for supported variants', () => {
+    let state = reducer(undefined, setMascotColor('navy'));
+    expect(state.color).toBe('navy');
+    state = reducer(state, setMascotColor('burgundy'));
+    expect(state.color).toBe('burgundy');
+  });
+
+  it('setMascotColor ignores unknown variants', () => {
+    const before = reducer(undefined, setMascotColor('green'));
+    // Cast: simulate a stale call (e.g. an older build dispatching a removed
+    // variant) without weakening the public action signature.
+    const after = reducer(before, setMascotColor('pink' as unknown as 'green'));
+    expect(after.color).toBe('green');
+  });
+
+  it('resetUserScopedState resets back to default', () => {
+    const dirty = reducer(undefined, setMascotColor('green'));
+    const reset = reducer(dirty, resetUserScopedState());
+    expect(reset.color).toBe(DEFAULT_MASCOT_COLOR);
+  });
+
+  it('selectMascotColor reads the current color', () => {
+    const state = reducer(undefined, setMascotColor('black'));
+    expect(selectMascotColor({ mascot: state })).toBe('black');
+  });
+
+  it('exposes all five supported colors', () => {
+    expect(new Set(SUPPORTED_MASCOT_COLORS)).toEqual(
+      new Set(['yellow', 'burgundy', 'black', 'navy', 'green'])
+    );
+  });
+
+  describe('REHYDRATE', () => {
+    const rehydrate = (key: string, payload?: unknown) => ({ type: REHYDRATE, key, payload });
+
+    it('ignores REHYDRATE for a different persist key', () => {
+      const initial = reducer(undefined, setMascotColor('green'));
+      const state = reducer(initial, rehydrate('other', { color: 'navy' }));
+      expect(state.color).toBe('green');
+    });
+
+    it('restores a valid persisted color for the mascot key', () => {
+      const state = reducer(undefined, rehydrate('mascot', { color: 'burgundy' }));
+      expect(state.color).toBe('burgundy');
+    });
+
+    it('falls back to the default when the persisted color is unknown', () => {
+      const state = reducer(undefined, rehydrate('mascot', { color: 'fuchsia' }));
+      expect(state.color).toBe(DEFAULT_MASCOT_COLOR);
+    });
+
+    it('falls back to the default when no payload is present', () => {
+      const state = reducer(undefined, rehydrate('mascot'));
+      expect(state.color).toBe(DEFAULT_MASCOT_COLOR);
+    });
+  });
+});

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -16,6 +16,7 @@ import accountsReducer from './accountsSlice';
 import channelConnectionsReducer from './channelConnectionsSlice';
 import chatRuntimeReducer from './chatRuntimeSlice';
 import coreModeReducer from './coreModeSlice';
+import mascotReducer from './mascotSlice';
 import notificationReducer from './notificationSlice';
 import providerSurfacesReducer from './providerSurfaceSlice';
 import socketReducer from './socketSlice';
@@ -104,6 +105,11 @@ const persistedNotificationReducer = persistReducer(notificationPersistConfig, n
 const threadPersistConfig = { key: 'thread', storage, whitelist: ['selectedThreadId'] };
 const persistedThreadReducer = persistReducer(threadPersistConfig, threadReducer);
 
+// Mascot appearance — color preference is per-user so it travels with the
+// account on logout/login rather than leaking across users.
+const mascotPersistConfig = { key: 'mascot', storage, whitelist: ['color'] };
+const persistedMascotReducer = persistReducer(mascotPersistConfig, mascotReducer);
+
 export const store = configureStore({
   reducer: {
     socket: socketReducer,
@@ -114,6 +120,7 @@ export const store = configureStore({
     notifications: persistedNotificationReducer,
     providerSurfaces: providerSurfacesReducer,
     coreMode: persistedCoreModeReducer,
+    mascot: persistedMascotReducer,
   },
   middleware: getDefaultMiddleware => {
     const middleware = getDefaultMiddleware({

--- a/app/src/store/mascotSlice.ts
+++ b/app/src/store/mascotSlice.ts
@@ -1,0 +1,62 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { REHYDRATE } from 'redux-persist';
+
+import type { MascotColor } from '../features/human/Mascot/mascotPalette';
+import { resetUserScopedState } from './resetActions';
+
+export const SUPPORTED_MASCOT_COLORS: readonly MascotColor[] = [
+  'yellow',
+  'burgundy',
+  'black',
+  'navy',
+  'green',
+];
+
+export const DEFAULT_MASCOT_COLOR: MascotColor = 'yellow';
+
+export interface MascotState {
+  color: MascotColor;
+}
+
+const initialState: MascotState = { color: DEFAULT_MASCOT_COLOR };
+
+function isMascotColor(value: unknown): value is MascotColor {
+  return (
+    typeof value === 'string' && (SUPPORTED_MASCOT_COLORS as readonly string[]).includes(value)
+  );
+}
+
+const mascotSlice = createSlice({
+  name: 'mascot',
+  initialState,
+  reducers: {
+    setMascotColor(state, action: PayloadAction<MascotColor>) {
+      if (isMascotColor(action.payload)) {
+        state.color = action.payload;
+      }
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(resetUserScopedState, () => initialState);
+    // Guard against unknown/missing color values surviving a rehydrate (e.g.
+    // a future build removed a variant that was previously persisted).
+    builder.addCase(REHYDRATE, (state, action) => {
+      const rehydrateAction = action as {
+        type: typeof REHYDRATE;
+        key: string;
+        payload?: { color?: unknown };
+      };
+      if (rehydrateAction.key !== 'mascot') return;
+      const restored = rehydrateAction.payload?.color;
+      state.color = isMascotColor(restored) ? restored : DEFAULT_MASCOT_COLOR;
+    });
+  },
+});
+
+export const { setMascotColor } = mascotSlice.actions;
+
+export const selectMascotColor = (state: { mascot: MascotState }): MascotColor =>
+  state.mascot.color;
+
+export { mascotSlice };
+export default mascotSlice.reducer;


### PR DESCRIPTION
## Summary

- Adds a "Mascot" entry under Settings → General with five preset color swatches (yellow / burgundy / black / navy / green).
- New `mascotSlice` persists the chosen color through `userScopedStorage` (per-user, survives restarts) and falls back to the default on rehydrate when the persisted value is missing or unknown.
- `HumanPage` and the Meet camera frame producer both read the color from Redux so the mascot stays consistent wherever it renders.
- Existing users keep their current mascot color (yellow) until they change it.

## Problem

Closes #1651. The app shipped multiple mascot color variants (already wired through `mascotPalette.ts`) but no product UI for users to pick one — making the experience feel fixed and impersonal. There was also no settings surface or persistence path that future customization work (accessories, style packs, etc.) could build on.

## Solution

- New `app/src/store/mascotSlice.ts` with a `MascotColor` selector, `setMascotColor` action, validation guard, and `REHYDRATE` handling that defaults unknown variants back to yellow.
- Wired into the persisted store via `userScopedStorage` (whitelist: `color`), keyed as `mascot` so each user's preference is namespaced.
- New `MascotPanel` with a 5-swatch radiogroup, accessible roles/labels, and a graceful empty-state for builds with no available variants. Reachable from Settings home (General → Mascot) and the new `/settings/mascot` route.
- `HumanPage` and `MascotFrameProducer` now derive `mascotColor` from `selectMascotColor` instead of hardcoding `'yellow'`. The native macOS mascot NSPanel webview (`MascotWindowApp`) is intentionally untouched — it runs outside the Redux store and is a separate follow-up.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — slice covers setter validation, REHYDRATE key filtering, unknown-payload fallback, and reset; panel covers swatch rendering, selection state, dispatch, no-op-on-same, and back navigation.
- [x] **Diff coverage ≥ 80%** — new code is exercised by `mascotSlice.test.ts` and `MascotPanel.test.tsx`; integration sites (HumanPage / MascotFrameProducer) are one-line selector reads.
- [x] N/A: behaviour-only change with no matching feature row in `docs/TEST-COVERAGE-MATRIX.md` — coverage matrix update deferred to a follow-up that bundles broader settings rows. (Coverage matrix updated)
- [x] No new external network dependencies introduced.
- [x] N/A: settings-only UI behind an existing route, not a release-cut surface. (Manual smoke checklist updated if this touches release-cut surfaces)
- [x] Linked issue closed via `Closes #1651` in the `## Related` section.

## Impact

- **Desktop only** — matches the shipped product scope.
- **No core/RPC changes** — persistence rides the existing `userScopedStorage` redux-persist path, so logout/login carries the preference per the same rules as notifications/threads/etc.
- **No migration needed** — existing users land on the `yellow` default until they change it; unknown persisted values are coerced back to the default.

## Related

- Closes: #1651
- Follow-up PR(s)/TODOs: thread the chosen color into the native macOS mascot NSPanel (`MascotWindowApp`) and extend customization beyond color (accessories, expressions, style packs).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A (GitHub issue #1651)
- URL: https://github.com/tinyhumansai/openhuman/issues/1651

### Commit & Branch
- Branch: issue/1651-allow-users-to-customize-their-mascot-co
- Commit SHA: 7a286973646112db41d9cca93a7b8406461312df

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (ran `pnpm format` which is a superset; output clean)
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm vitest run --config test/vitest.config.ts src/store/__tests__/mascotSlice.test.ts src/components/settings/panels/__tests__/MascotPanel.test.tsx` (15/15 passed)
- [x] N/A: no Rust changes in this PR. (Rust fmt/check)
- [x] N/A: no Tauri changes in this PR. (Tauri fmt/check)

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: Users can pick a mascot color in Settings; selection persists per-user across restarts and is applied wherever the mascot renders in-app.
- User-visible effect: New "Mascot" row in Settings → General; new `/settings/mascot` panel with five color swatches; selecting one updates the mascot immediately on HumanPage and in the Meet camera frame.

### Parity Contract
- Legacy behavior preserved: Default remains yellow; mascot color prop on `<YellowMascot>` is unchanged (already accepted `mascotColor`).
- Guard/fallback/dispatch parity checks: Unknown persisted colors are coerced back to the default on REHYDRATE, and `setMascotColor` ignores unknown variants — so older persisted state never crashes a future build that dropped a variant.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None known.
- Canonical PR: This PR.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mascot color customization to Settings
  * Users can select from available mascot color options in a dedicated panel
  * Selected mascot color persists across sessions
  * Mascot displays with the chosen color throughout the app

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1667)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
