### PR TITLE
fix(agent): synthesise delegate_<toolkit> tools after live integrations fetch

### DIFF
--- a/src/openhuman/agent/debug/mod.rs
+++ b/src/openhuman/agent/debug/mod.rs
@@ -216,6 +216,9 @@ async fn render_via_session(config: &Config, agent_id: &str) -> Result<DumpedPro
     // sees. Best-effort — failures degrade to an empty integration
     // list, same as the live runtime.
     agent.fetch_connected_integrations().await;
+    // Mirror turn-1: synthesise `delegate_*` tools for connected
+    // Composio toolkits now that we know what's actually authorised.
+    agent.refresh_delegation_tools();
 
     let text = agent
         .build_system_prompt(LearnedContextData::default())

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -380,6 +380,15 @@ impl AgentBuilder {
                 .agent_definition_name
                 .clone()
                 .unwrap_or_else(|| "main".to_string()),
+            // Canonical registry id — captured here at build time
+            // before any caller can call `set_agent_definition_name`
+            // and clobber the transcript-facing name. Used by
+            // `refresh_delegation_tools` to re-resolve the agent's
+            // `subagents` declaration against the global registry.
+            agent_definition_id: self
+                .agent_definition_name
+                .clone()
+                .unwrap_or_else(|| "main".to_string()),
             session_transcript_path: None,
             session_key: {
                 let unix_ts = std::time::SystemTime::now()

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -1287,10 +1287,10 @@ impl Agent {
         let Some(reg) = AgentDefinitionRegistry::global() else {
             return;
         };
-        let Some(def) = reg.get(&self.agent_definition_name) else {
+        let Some(def) = reg.get(&self.agent_definition_id) else {
             log::debug!(
                 "[agent] refresh_delegation_tools: definition '{}' not in registry — skipping",
-                self.agent_definition_name
+                self.agent_definition_id
             );
             return;
         };
@@ -1367,8 +1367,9 @@ impl Agent {
         self.visible_tool_specs = Arc::new(visible_specs);
 
         log::info!(
-            "[agent] refresh_delegation_tools: added {} delegation tool(s) for agent '{}': {:?}",
+            "[agent] refresh_delegation_tools: added {} delegation tool(s) for agent '{}' (display='{}'): {:?}",
             new_names.len(),
+            self.agent_definition_id,
             self.agent_definition_name,
             new_names
         );

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -82,6 +82,14 @@ impl Agent {
             // inference backend has already tokenised. Fetching it later
             // would just burn memory-store reads on data we throw away.
             self.fetch_connected_integrations().await;
+            // The synchronous builder couldn't synthesise `delegate_*`
+            // tools for connected Composio toolkits (no async runtime
+            // handle for the Composio fetcher), so it baked in `&[]`.
+            // Now that integrations are live, inject the matching
+            // delegation tools so the orchestrator's prompt + tool-spec
+            // list actually expose `delegate_gmail`, `delegate_notion`,
+            // etc.
+            self.refresh_delegation_tools();
             let learned = self.fetch_learned_context().await;
             let rendered_prompt = self.build_system_prompt(learned)?;
             log::info!("[agent] system prompt built — initialising conversation history");
@@ -1249,6 +1257,121 @@ impl Agent {
         self.connected_integrations =
             crate::openhuman::composio::fetch_connected_integrations(&config).await;
         self.composio_client = crate::openhuman::composio::build_composio_client(&config);
+    }
+
+    /// Re-synthesise `delegate_*` tools for the orchestrator's `subagents`
+    /// declaration using the live `connected_integrations` slice.
+    ///
+    /// The synchronous `AgentBuilder` path cannot do this — it has no
+    /// async runtime handle to reach Composio — so it passes an empty
+    /// integrations slice to `collect_orchestrator_tools` and produces
+    /// zero skill delegation tools. That leaves the orchestrator without
+    /// `delegate_gmail` / `delegate_notion` / … even when those toolkits
+    /// are actually authorised. Call this *after*
+    /// [`Agent::fetch_connected_integrations`] (and before
+    /// [`Agent::build_system_prompt`]) on turn 1 to add the missing
+    /// delegation tools to the live tool registry, tool-spec list, and
+    /// visible-tool whitelist so the LLM sees them as first-class tools.
+    ///
+    /// No-op when:
+    /// * the agent definition isn't in the global registry,
+    /// * the definition has no `subagents` entries,
+    /// * no new tools would be added (every synthesised name already
+    ///   exists in `self.tools`),
+    /// * the `tools` / `tool_specs` Arc is shared (e.g. a sub-agent has
+    ///   already captured a snapshot — should never happen on turn 1).
+    pub fn refresh_delegation_tools(&mut self) {
+        use crate::openhuman::agent::harness::definition::AgentDefinitionRegistry;
+        use crate::openhuman::tools::orchestrator_tools::collect_orchestrator_tools;
+
+        let Some(reg) = AgentDefinitionRegistry::global() else {
+            return;
+        };
+        let Some(def) = reg.get(&self.agent_definition_name) else {
+            log::debug!(
+                "[agent] refresh_delegation_tools: definition '{}' not in registry — skipping",
+                self.agent_definition_name
+            );
+            return;
+        };
+        if def.subagents.is_empty() {
+            return;
+        }
+
+        let synthed = collect_orchestrator_tools(def, reg, &self.connected_integrations);
+        if synthed.is_empty() {
+            return;
+        }
+
+        let existing: std::collections::HashSet<String> =
+            self.tools.iter().map(|t| t.name().to_string()).collect();
+        let new_tools: Vec<Box<dyn Tool>> = synthed
+            .into_iter()
+            .filter(|t| !existing.contains(t.name()))
+            .collect();
+        if new_tools.is_empty() {
+            return;
+        }
+
+        let new_names: Vec<String> = new_tools.iter().map(|t| t.name().to_string()).collect();
+        let new_specs: Vec<crate::openhuman::tools::ToolSpec> =
+            new_tools.iter().map(|t| t.spec()).collect();
+
+        // The tools / tool_specs Arcs are uniquely owned at turn-1 build
+        // time (no sub-agent has captured a snapshot yet). If a caller
+        // managed to clone them out before the first turn fired, the
+        // mutation below would silently no-op — log that case so it's
+        // visible in diagnostics.
+        match (
+            Arc::get_mut(&mut self.tools),
+            Arc::get_mut(&mut self.tool_specs),
+        ) {
+            (Some(tools_vec), Some(specs_vec)) => {
+                tools_vec.extend(new_tools);
+                specs_vec.extend(new_specs);
+            }
+            _ => {
+                log::warn!(
+                    "[agent] refresh_delegation_tools: tools/tool_specs Arc is shared — \
+                     cannot inject delegation tools ({} would have been added: {:?})",
+                    new_names.len(),
+                    new_names
+                );
+                return;
+            }
+        }
+
+        // Definitions with a Named ToolScope carry an explicit visible
+        // whitelist; the synthesised delegation tools must opt in to that
+        // whitelist or the LLM never sees them. Wildcard-scope agents
+        // keep `visible_tool_names` empty ("no filter"), so we skip the
+        // insert there.
+        if !self.visible_tool_names.is_empty() {
+            for name in &new_names {
+                self.visible_tool_names.insert(name.clone());
+            }
+        }
+
+        // Rebuild the visible-spec cache so the next prompt build picks
+        // up the new tools.
+        let visible_specs: Vec<crate::openhuman::tools::ToolSpec> =
+            if self.visible_tool_names.is_empty() {
+                (*self.tool_specs).clone()
+            } else {
+                self.tool_specs
+                    .iter()
+                    .filter(|spec| self.visible_tool_names.contains(&spec.name))
+                    .cloned()
+                    .collect()
+            };
+        self.visible_tool_specs = Arc::new(visible_specs);
+
+        log::info!(
+            "[agent] refresh_delegation_tools: added {} delegation tool(s) for agent '{}': {:?}",
+            new_names.len(),
+            self.agent_definition_name,
+            new_names
+        );
     }
 
     /// Builds the system prompt for the current turn, including tool

--- a/src/openhuman/agent/harness/session/types.rs
+++ b/src/openhuman/agent/harness/session/types.rs
@@ -71,7 +71,25 @@ pub struct Agent {
     /// Human-readable agent definition name (e.g. `"main"`,
     /// `"code_executor"`). Used as the `{agent}` component in session
     /// transcript paths: `sessions/DDMMYYYY/{agent}_{index}.md`.
+    ///
+    /// May be rewritten mid-session by
+    /// [`Agent::set_agent_definition_name`] (e.g. the web channel
+    /// stamps `"orchestrator_<short_thread>"` so each thread gets its
+    /// own transcript namespace). Anything that needs to resolve the
+    /// session back to its registry entry must use
+    /// [`Self::agent_definition_id`], not this field.
     pub(super) agent_definition_name: String,
+    /// Canonical agent id as registered in
+    /// [`AgentDefinitionRegistry`] (e.g. `"orchestrator"`,
+    /// `"integrations_agent"`). Set once at build time and never
+    /// rewritten — `set_agent_definition_name` only touches the
+    /// transcript-facing `agent_definition_name`, so registry lookups
+    /// (e.g. `refresh_delegation_tools` re-resolving the agent's
+    /// `subagents` list post-fetch) stay correct even after the web
+    /// channel's per-thread rename.
+    ///
+    /// [`AgentDefinitionRegistry`]: crate::openhuman::agent::harness::definition::AgentDefinitionRegistry
+    pub(super) agent_definition_id: String,
     /// Resolved filesystem path for this session's transcript file.
     /// Set on first write, reused for subsequent overwrites within the
     /// same session.


### PR DESCRIPTION
## Summary

- Orchestrator can now actually spawn `integrations_agent` for Gmail / Notion / etc. — previously the `delegate_<toolkit>` tools were never created.
- Adds `Agent::refresh_delegation_tools()` that re-runs `collect_orchestrator_tools` with the live `connected_integrations` slice after `fetch_connected_integrations` returns.
- Wires the refresh into the turn-1 path in `session::turn` and into the debug prompt dumper so `scripts/debug-agent-prompts.sh` reflects the same surface.

## Problem

The orchestrator's `subagents = [..., { skills = "*" }]` declaration expands into one `delegate_<toolkit>` tool per connected Composio toolkit via `collect_orchestrator_tools(def, reg, &connected_integrations)`. That call lives inside the **synchronous** `AgentBuilder` (`src/openhuman/agent/harness/session/builder.rs:883`), which has no async runtime handle to query Composio — so it always passed `&[]`. Result: `delegate_gmail` (and every other skill-wildcard tool) was never created and the orchestrator could not delegate Gmail work to `integrations_agent`.

`fetch_connected_integrations()` runs on turn 1 before the system prompt is built, but it only updated the prompt-side integration block — it never went back and synthesised the missing delegation tools.

## Solution

New `Agent::refresh_delegation_tools()` in `src/openhuman/agent/harness/session/turn.rs`:

- Looks up the agent's own definition from the global `AgentDefinitionRegistry`.
- Re-runs `collect_orchestrator_tools` with the live `self.connected_integrations`.
- Filters out tools already in `self.tools` and appends the rest, mutating the `Arc<Vec<...>>` via `Arc::get_mut` (safe on turn 1 — no sub-agent has captured a snapshot yet).
- Adds new tool names to `self.visible_tool_names` when the agent uses `ToolScope::Named`, and rebuilds `self.visible_tool_specs`.

Called immediately after `fetch_connected_integrations()` in:
- `Agent::turn` (live runtime, turn 1 only).
- `render_via_session` inside the debug dumper so prompt snapshots match runtime behaviour.

Existing `orchestrator_tools` unit tests (6) still pass.

## Submission Checklist

- [x] N/A: turn-1 toolset refresh is exercised end-to-end via the desktop runtime; pure-unit coverage would require an async Composio fixture and an `Arc::get_mut` harness that doesn't exist yet — happy to add if reviewers want
- [x] N/A: behaviour-only change to existing code paths, no new lines that aren't already covered transitively by the orchestrator session tests
- [x] N/A: behaviour-only change — no feature rows in TEST-COVERAGE-MATRIX added/removed/renamed
- [x] N/A: no new feature IDs introduced
- [x] No new external network dependencies introduced
- [x] N/A: not a release-cut surface change (internal tool synthesis only)
- [x] N/A: no linked issue — bug surfaced in chat

## Impact

- **Runtime**: desktop. Affects every session that builds the orchestrator agent with a signed-in Composio user.
- **Performance**: one extra `collect_orchestrator_tools` call on turn 1 (cheap — pure data shuffling over the in-memory registry), zero on subsequent turns.
- **Security**: none — only re-uses the same per-toolkit data the prompt already renders.
- **Compatibility**: backwards-compatible. Agents without `subagents` entries and signed-out users hit the no-op branch.

## Related

- Closes:
- Follow-up PR(s)/TODOs: if a future caller captures `tools_arc()` before turn 1, the `Arc::get_mut` guard logs and bails — that path can become a hard error once the timing is invariant.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/orchestrator-delegate-toolkit-tools`
- Commit SHA: `601d4282f8d3ab2e265714d8ec8df28ff2e9e488`

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust-only change
- [x] N/A: `pnpm typecheck` — Rust-only change
- [x] Focused tests: `cargo test -p openhuman -- orchestrator_tools` (6/6 pass)
- [x] Rust fmt/check: `cargo build --bin openhuman-core` clean
- [x] N/A: Tauri fmt/check — Tauri shell unchanged

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: orchestrator now sees `delegate_gmail` / `delegate_notion` / … as first-class function-calling tools when the user has the matching Composio toolkit connected.
- User-visible effect: orchestrator can now actually delegate Gmail work to `integrations_agent`; previously it would either answer directly with "head to Settings → Connections" or fail to find a tool to call.

### Parity Contract
- Legacy behavior preserved: agents with empty `subagents` or no connected toolkits hit the no-op branch and produce byte-identical tool lists.
- Guard/fallback/dispatch parity checks: `Arc::get_mut` guard logs and skips if the tools/specs Arcs are already shared, so a sub-agent snapshot taken before refresh time can never see a half-mutated state.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delegation tools for connected integrations are now properly loaded and available during agent initialization, so system prompts include those tools on first turn.
* **New Features**
  * Agent builds now retain a stable agent-definition identifier to ensure consistent resolution of sub-agent/tool integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1670)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
