### PR TITLE
feat(composio): BYO Composio API key (opt-in direct client)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,3 +192,12 @@ RUST_BACKTRACE=1
 # OPENHUMAN_SERVICE_MOCK=0
 # [optional] Path to mock state file
 # OPENHUMAN_SERVICE_MOCK_STATE_FILE=
+
+# ---------------------------------------------------------------------------
+# [composio] BYO (Bring Your Own) Composio API key.
+# When set, the core bypasses the openhuman backend proxy and calls
+# api.composio.dev directly. Tool calls work; triggers (webhooks) do
+# not — they require the hosted backend's HMAC-verified webhook
+# endpoint. See `src/openhuman/composio/direct.rs` and the
+# "Composio API Key (BYO)" settings panel.
+# COMPOSIO_API_KEY=

--- a/app/src/components/settings/hooks/useSettingsNavigation.ts
+++ b/app/src/components/settings/hooks/useSettingsNavigation.ts
@@ -34,7 +34,8 @@ export type SettingsRoute =
   | 'notification-routing'
   | 'intelligence'
   | 'webhooks-triggers'
-  | 'composio-triggers';
+  | 'composio-triggers'
+  | 'composio-byo';
 
 export interface BreadcrumbItem {
   label: string;
@@ -100,6 +101,7 @@ export const useSettingsNavigation = (): SettingsNavigationHook => {
     if (path.includes('/settings/memory-debug')) return 'memory-debug';
     if (path.includes('/settings/webhooks-debug')) return 'webhooks-debug';
     if (path.includes('/settings/webhooks-triggers')) return 'webhooks-triggers';
+    if (path.includes('/settings/composio-byo')) return 'composio-byo';
     if (path.includes('/settings/composio-triggers')) return 'composio-triggers';
     if (path.includes('/settings/intelligence')) return 'intelligence';
     if (path.includes('/settings/recovery-phrase')) return 'recovery-phrase';
@@ -217,6 +219,7 @@ export const useSettingsNavigation = (): SettingsNavigationHook => {
       case 'intelligence':
       case 'webhooks-triggers':
       case 'composio-triggers':
+      case 'composio-byo':
       case 'notification-routing':
         return [settingsCrumb, developerCrumb];
 

--- a/app/src/components/settings/panels/ComposioByoPanel.tsx
+++ b/app/src/components/settings/panels/ComposioByoPanel.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  openhumanGetComposioByoStatus,
+  openhumanUpdateComposioByoSettings,
+} from '../../../utils/tauriCommands';
+import type { ComposioByoStatus } from '../../../utils/tauriCommands/config';
+import SettingsHeader from '../components/SettingsHeader';
+import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
+
+/**
+ * BYO Composio Settings.
+ *
+ * Lets the user paste their own Composio API key. When set, the Rust
+ * core bypasses the openhuman backend proxy and talks to
+ * `api.composio.dev` directly. Triggers (webhooks) are unsupported in
+ * BYO mode — the panel surfaces that limitation explicitly so the user
+ * isn't surprised.
+ *
+ * Implementation note: the masked key (`sk_••••••abcd`) is the only
+ * preview the core sends back. The full key is never echoed to the
+ * renderer once saved — re-entering replaces it.
+ */
+const ComposioByoPanel = () => {
+  const { navigateBack, breadcrumbs } = useSettingsNavigation();
+
+  const [status, setStatus] = useState<ComposioByoStatus | null>(null);
+  const [keyInput, setKeyInput] = useState('');
+  const [revealInput, setRevealInput] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'cleared' | 'error'>('idle');
+  const saveStatusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = async () => {
+    try {
+      const res = await openhumanGetComposioByoStatus();
+      if (res.result) {
+        setStatus(res.result);
+      }
+    } catch (err) {
+      console.warn('[ComposioByoPanel] failed to load status:', err);
+    }
+  };
+
+  useEffect(() => {
+    let isMounted = true;
+    refresh()
+      .catch(err => {
+        if (!isMounted) return;
+        console.warn('[ComposioByoPanel] initial load failed:', err);
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+      if (saveStatusTimer.current !== null) {
+        clearTimeout(saveStatusTimer.current);
+      }
+    };
+  }, []);
+
+  const flashStatus = (next: 'saved' | 'cleared' | 'error') => {
+    setSaveStatus(next);
+    if (saveStatusTimer.current !== null) clearTimeout(saveStatusTimer.current);
+    saveStatusTimer.current = setTimeout(() => setSaveStatus('idle'), 3000);
+  };
+
+  const handleSave = async () => {
+    const trimmed = keyInput.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    try {
+      await openhumanUpdateComposioByoSettings({ byo_api_key: trimmed });
+      setKeyInput('');
+      await refresh();
+      flashStatus('saved');
+    } catch (err) {
+      console.warn('[ComposioByoPanel] failed to save BYO key:', err);
+      flashStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    setSaving(true);
+    try {
+      await openhumanUpdateComposioByoSettings({ byo_api_key: null });
+      setKeyInput('');
+      await refresh();
+      flashStatus('cleared');
+    } catch (err) {
+      console.warn('[ComposioByoPanel] failed to clear BYO key:', err);
+      flashStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div>
+        <SettingsHeader
+          title="Composio API Key"
+          showBackButton
+          onBack={navigateBack}
+          breadcrumbs={breadcrumbs}
+        />
+        <div className="p-4">
+          <p className="text-sm text-stone-500">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isByoActive = status?.active === true;
+
+  return (
+    <div>
+      <SettingsHeader
+        title="Composio API Key"
+        showBackButton
+        onBack={navigateBack}
+        breadcrumbs={breadcrumbs}
+      />
+
+      <div className="p-4 space-y-5">
+        <p className="text-sm text-stone-500">
+          By default OpenHuman talks to Composio through the hosted openhuman backend. If you want
+          to manage your own toolkit allowlist, billing, and security boundaries, you can supply
+          your own Composio API key here — the core will then call{' '}
+          <span className="font-mono">api.composio.dev</span> directly with your key, and the hosted
+          backend never sees your tool calls.
+        </p>
+
+        {/* Status card */}
+        <div
+          className={`rounded-2xl border p-4 ${
+            isByoActive ? 'border-primary-200 bg-primary-50/60' : 'border-stone-200 bg-stone-50/60'
+          }`}>
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-stone-900">
+              {isByoActive ? 'Using your Composio key' : 'Using hosted openhuman backend'}
+            </span>
+            <span
+              className={`text-xs font-mono px-2 py-0.5 rounded ${
+                isByoActive ? 'bg-primary-100 text-primary-800' : 'bg-stone-200 text-stone-700'
+              }`}
+              aria-label={`Current backend: ${status?.backend ?? 'proxy'}`}>
+              {status?.backend ?? 'proxy'}
+            </span>
+          </div>
+          {isByoActive && status?.masked_key ? (
+            <p className="mt-1 text-xs text-stone-500">
+              Active key: <span className="font-mono">{status.masked_key}</span>
+            </p>
+          ) : (
+            <p className="mt-1 text-xs text-stone-500">
+              No BYO key configured. Paste a key below to switch.
+            </p>
+          )}
+        </div>
+
+        {/* BYO unsupported features */}
+        <div className="rounded-2xl border border-amber-200 bg-amber-50/60 p-4">
+          <p className="text-sm font-medium text-amber-900">
+            What BYO mode supports — and what it doesn’t
+          </p>
+          <ul className="mt-2 space-y-1 text-xs text-amber-900/90 list-disc pl-5">
+            <li>Listing toolkits, connections, tools, and executing tool calls — supported.</li>
+            <li>
+              Composio <em>triggers</em> (webhook-driven events) — <strong>not supported</strong>.
+              Triggers need an internet-reachable webhook endpoint; the hosted backend provides
+              that. To use triggers, clear your BYO key and switch back to the hosted backend.
+            </li>
+            <li>
+              New OAuth handoff (<span className="font-mono">authorize</span>) — connect accounts in
+              your Composio dashboard, then they’ll appear here.
+            </li>
+          </ul>
+        </div>
+
+        {/* Key input */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-stone-800" htmlFor="composio-byo-key">
+            {isByoActive ? 'Replace your Composio API key' : 'Composio API key'}
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="composio-byo-key"
+              type={revealInput ? 'text' : 'password'}
+              value={keyInput}
+              onChange={e => setKeyInput(e.target.value)}
+              placeholder="sk_live_…"
+              autoComplete="off"
+              spellCheck={false}
+              className="flex-1 rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm font-mono text-stone-900 placeholder-stone-400 focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-400"
+            />
+            <button
+              type="button"
+              onClick={() => setRevealInput(v => !v)}
+              className="px-3 rounded-xl border border-stone-200 bg-white text-xs text-stone-700 hover:bg-stone-50"
+              aria-pressed={revealInput}>
+              {revealInput ? 'Hide' : 'Show'}
+            </button>
+          </div>
+          <p className="text-xs text-stone-500">
+            Stored locally in your config.toml. Never sent to the openhuman backend.
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || keyInput.trim().length === 0}
+            className="flex-1 py-2 rounded-xl bg-primary-600 text-white text-sm font-medium hover:bg-primary-500 transition-colors disabled:opacity-50">
+            {saving ? 'Saving…' : isByoActive ? 'Replace key' : 'Save key'}
+          </button>
+          {isByoActive && (
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={saving}
+              className="py-2 px-4 rounded-xl border border-coral-200 bg-coral-50 text-coral-800 text-sm font-medium hover:bg-coral-100 transition-colors disabled:opacity-50">
+              Clear & use hosted backend
+            </button>
+          )}
+        </div>
+
+        {saveStatus === 'saved' && (
+          <p className="text-xs text-center text-green-600">
+            BYO key saved. Core is now in direct mode.
+          </p>
+        )}
+        {saveStatus === 'cleared' && (
+          <p className="text-xs text-center text-stone-600">
+            BYO key cleared. Reverted to hosted backend.
+          </p>
+        )}
+        {saveStatus === 'error' && (
+          <p className="text-xs text-center text-red-500">Failed to update. Try again.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ComposioByoPanel;

--- a/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
+++ b/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
@@ -190,6 +190,23 @@ const developerItems = [
     ),
   },
   {
+    id: 'composio-byo',
+    title: 'Composio API Key (BYO)',
+    description:
+      'Use your own Composio API key. Bypasses the hosted backend for tool calls; triggers stay on the hosted backend.',
+    route: 'composio-byo',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+        />
+      </svg>
+    ),
+  },
+  {
     id: 'composio-triggers',
     title: 'Integration Triggers',
     description: 'Configure AI triage settings for Composio integration triggers',

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import AutocompleteDebugPanel from '../components/settings/panels/AutocompleteDe
 import AutocompletePanel from '../components/settings/panels/AutocompletePanel';
 import BackendProviderPanel from '../components/settings/panels/BackendProviderPanel';
 import BillingPanel from '../components/settings/panels/BillingPanel';
+import ComposioByoPanel from '../components/settings/panels/ComposioByoPanel';
 import ComposioTriagePanel from '../components/settings/panels/ComposioTriagePanel';
 import ConnectionsPanel from '../components/settings/panels/ConnectionsPanel';
 import CronJobsPanel from '../components/settings/panels/CronJobsPanel';
@@ -319,6 +320,7 @@ const Settings = () => {
         <Route path="intelligence" element={<Intelligence />} />
         <Route path="webhooks-triggers" element={<Webhooks />} />
         <Route path="composio-triggers" element={wrapSettingsPage(<ComposioTriagePanel />)} />
+        <Route path="composio-byo" element={wrapSettingsPage(<ComposioByoPanel />)} />
         {/* About / updates */}
         <Route path="about" element={wrapSettingsPage(<AboutPanel />)} />
         {/* Fallback */}

--- a/app/src/services/rpcMethods.ts
+++ b/app/src/services/rpcMethods.ts
@@ -1,11 +1,13 @@
 export const CORE_RPC_METHODS = {
   configGet: 'openhuman.config_get',
   configGetAnalyticsSettings: 'openhuman.config_get_analytics_settings',
+  configGetComposioByoStatus: 'openhuman.config_get_composio_byo_status',
   configGetComposioTriggerSettings: 'openhuman.config_get_composio_trigger_settings',
   configGetRuntimeFlags: 'openhuman.config_get_runtime_flags',
   configSetBrowserAllowAll: 'openhuman.config_set_browser_allow_all',
   configUpdateAnalyticsSettings: 'openhuman.config_update_analytics_settings',
   configUpdateBrowserSettings: 'openhuman.config_update_browser_settings',
+  configUpdateComposioByoSettings: 'openhuman.config_update_composio_byo_settings',
   configUpdateComposioTriggerSettings: 'openhuman.config_update_composio_trigger_settings',
   configUpdateLocalAiSettings: 'openhuman.config_update_local_ai_settings',
   configUpdateMemorySettings: 'openhuman.config_update_memory_settings',

--- a/app/src/utils/tauriCommands/config.ts
+++ b/app/src/utils/tauriCommands/config.ts
@@ -293,6 +293,47 @@ export async function openhumanGetComposioTriggerSettings(): Promise<
   });
 }
 
+// ── Composio BYO (Bring Your Own API key) ──────────────────────────
+
+export interface ComposioByoStatus {
+  /** True when a non-empty BYO key is configured. */
+  active: boolean;
+  /** Masked preview of the key (e.g. `sk_••••••abcd`), or `null` when unset. */
+  masked_key: string | null;
+  /** Which transport the core will use: `"direct"` (BYO) or `"proxy"` (hosted backend). */
+  backend: 'direct' | 'proxy';
+}
+
+export interface ComposioByoSettingsUpdate {
+  /**
+   * Omit to leave unchanged. Pass `null` or `""` to clear. Pass a
+   * non-empty string to set the key. The core trims whitespace; any
+   * whitespace-only value is treated as a clear.
+   */
+  byo_api_key?: string | null;
+}
+
+export async function openhumanGetComposioByoStatus(): Promise<CommandResponse<ComposioByoStatus>> {
+  if (!isTauri()) {
+    throw new Error('Not running in Tauri');
+  }
+  return await callCoreRpc<CommandResponse<ComposioByoStatus>>({
+    method: 'openhuman.config_get_composio_byo_status',
+  });
+}
+
+export async function openhumanUpdateComposioByoSettings(
+  update: ComposioByoSettingsUpdate
+): Promise<CommandResponse<ConfigSnapshot>> {
+  if (!isTauri()) {
+    throw new Error('Not running in Tauri');
+  }
+  return await callCoreRpc<CommandResponse<ConfigSnapshot>>({
+    method: 'openhuman.config_update_composio_byo_settings',
+    params: update,
+  });
+}
+
 export async function openhumanGetRuntimeFlags(): Promise<CommandResponse<RuntimeFlags>> {
   if (!isTauri()) {
     throw new Error('Not running in Tauri');

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -1,13 +1,27 @@
-//! Thin HTTP wrapper over the openhuman backend's
-//! `/agent-integrations/composio/*` routes.
+//! Composio HTTP client.
 //!
-//! All calls go through the shared
-//! [`crate::openhuman::integrations::IntegrationClient`] so they inherit
-//! the same Bearer JWT auth, timeout, envelope parsing, and proxy behavior
-//! as the other backend-proxied integrations.
+//! Routes every call through one of two backends:
 //!
-//! Logging uses the `[composio]` grep-prefix so all sidecar output for
-//! this domain can be filtered in one shot.
+//! - **Proxy** (default) — talks to the openhuman backend's
+//!   `/agent-integrations/composio/*` endpoints. The backend owns the
+//!   shared Composio API key, the toolkit allowlist, billing/margin,
+//!   HMAC webhook verification, and Socket.IO trigger fan-out. This is
+//!   the original behaviour and still kicks in for any user who has
+//!   not set `config.composio.byo_api_key`.
+//!
+//! - **Direct** ("BYO" — Bring Your Own key) — talks to
+//!   `https://backend.composio.dev/api/v3/*` directly using the user's
+//!   own Composio API key. See [`super::direct`] for the supported
+//!   surface and the BYO-unsupported error contract.
+//!
+//! Public method signatures are stable across both backends so the
+//! domain modules ([`super::ops`], [`super::tools`], [`super::schemas`])
+//! do not need to know which backend is active.
+//!
+//! Logging uses the `[composio]` grep-prefix on the entry side and the
+//! `[composio:direct]` / `[composio:proxy]` prefixes inside the
+//! per-backend implementations so the sidecar logs can be filtered
+//! either at the domain level or per backend.
 
 use std::sync::Arc;
 
@@ -16,6 +30,7 @@ use serde_json::json;
 
 use crate::openhuman::integrations::IntegrationClient;
 
+use super::direct::DirectComposioClient;
 use super::types::{
     ComposioActiveTriggersResponse, ComposioAuthorizeResponse, ComposioAvailableTriggersResponse,
     ComposioConnectionsResponse, ComposioCreateTriggerResponse, ComposioDeleteResponse,
@@ -23,53 +38,95 @@ use super::types::{
     ComposioGithubReposResponse, ComposioToolkitsResponse, ComposioToolsResponse,
 };
 
-/// High-level client for all backend-proxied Composio operations.
+/// Internal dispatch enum. Held inside `ComposioClient`, never exposed
+/// directly — public method signatures stay stable for all callers.
+#[derive(Clone)]
+enum ComposioBackend {
+    Proxy(Arc<IntegrationClient>),
+    Direct(DirectComposioClient),
+}
+
+/// High-level Composio client. Cheap to clone — both variants share
+/// their connection pool via `Arc`.
 #[derive(Clone)]
 pub struct ComposioClient {
-    inner: Arc<IntegrationClient>,
+    backend: ComposioBackend,
 }
 
 impl ComposioClient {
+    /// Build a proxy-backed client (the historical constructor).
+    /// Equivalent to the previous behaviour: every call hits the
+    /// openhuman backend's `/agent-integrations/composio/*` routes.
     pub fn new(inner: Arc<IntegrationClient>) -> Self {
-        Self { inner }
+        Self {
+            backend: ComposioBackend::Proxy(inner),
+        }
     }
 
-    /// Access the underlying integration client (useful for tests or for
-    /// callers that need to reuse the same reqwest pool for bespoke calls).
+    /// Build a BYO direct-backed client.
+    pub fn direct(direct: DirectComposioClient) -> Self {
+        Self {
+            backend: ComposioBackend::Direct(direct),
+        }
+    }
+
+    /// True when this client is talking to Composio directly using the
+    /// user's BYO API key (as opposed to the openhuman backend proxy).
+    pub fn is_byo(&self) -> bool {
+        matches!(self.backend, ComposioBackend::Direct(_))
+    }
+
+    /// Stable, human-readable backend label for diagnostics.
+    pub fn backend_label(&self) -> &'static str {
+        match self.backend {
+            ComposioBackend::Proxy(_) => "proxy",
+            ComposioBackend::Direct(_) => "direct",
+        }
+    }
+
+    /// Access the underlying proxy integration client. Panics in
+    /// BYO/Direct mode — callers that need raw access (tests, the
+    /// legacy `raw_delete` path) only run on the proxy variant.
     pub fn inner(&self) -> &Arc<IntegrationClient> {
-        &self.inner
+        match &self.backend {
+            ComposioBackend::Proxy(c) => c,
+            ComposioBackend::Direct(_) => {
+                panic!("ComposioClient::inner() called on a BYO/Direct-mode client")
+            }
+        }
     }
 
     // ── Toolkits ────────────────────────────────────────────────────
 
-    /// `GET /agent-integrations/composio/toolkits` — server-enforced
-    /// allowlist of toolkits that composio calls may target.
     pub async fn list_toolkits(&self) -> Result<ComposioToolkitsResponse> {
-        tracing::debug!("[composio] list_toolkits");
-        self.inner
-            .get::<ComposioToolkitsResponse>("/agent-integrations/composio/toolkits")
-            .await
+        tracing::debug!(backend = self.backend_label(), "[composio] list_toolkits");
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                inner
+                    .get::<ComposioToolkitsResponse>("/agent-integrations/composio/toolkits")
+                    .await
+            }
+            ComposioBackend::Direct(d) => d.list_toolkits().await,
+        }
     }
 
     // ── Connections ─────────────────────────────────────────────────
 
-    /// `GET /agent-integrations/composio/connections` — active connected
-    /// accounts for the authenticated user, filtered to the allowlist.
     pub async fn list_connections(&self) -> Result<ComposioConnectionsResponse> {
-        tracing::debug!("[composio] list_connections");
-        self.inner
-            .get::<ComposioConnectionsResponse>("/agent-integrations/composio/connections")
-            .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            "[composio] list_connections"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                inner
+                    .get::<ComposioConnectionsResponse>("/agent-integrations/composio/connections")
+                    .await
+            }
+            ComposioBackend::Direct(d) => d.list_connections().await,
+        }
     }
 
-    /// `POST /agent-integrations/composio/authorize` — begin an OAuth
-    /// handoff for `toolkit` and return the hosted `connectUrl` the user
-    /// must open in a browser.
-    ///
-    /// `extra_params` is an optional JSON object whose key/value pairs are
-    /// merged into the request body. Some toolkits (e.g. `whatsapp`) require
-    /// additional fields (e.g. `waba_id`) that Composio will reject the
-    /// authorization without.
     pub async fn authorize(
         &self,
         toolkit: &str,
@@ -79,75 +136,97 @@ impl ComposioClient {
         if toolkit.is_empty() {
             anyhow::bail!("composio.authorize: toolkit must not be empty");
         }
-        tracing::debug!(toolkit = %toolkit, has_extra_params = extra_params.is_some(), "[composio] authorize");
-        let mut body = serde_json::json!({ "toolkit": toolkit });
-        if let Some(extra) = extra_params {
+        // Input validation for `extra_params` must run on both backends
+        // — the proxy path enforces it server-side too, but failing fast
+        // here gives identical error messages regardless of backend.
+        if let Some(ref extra) = extra_params {
             const RESERVED: &[&str] = &["toolkit", "toolkit_version", "auth", "client_id"];
             let extra_obj = extra.as_object().ok_or_else(|| {
                 anyhow::anyhow!("composio.authorize: extra_params must be a JSON object")
             })?;
-            let obj = body.as_object_mut().ok_or_else(|| {
-                anyhow::anyhow!("composio.authorize: internal payload must be an object")
-            })?;
-            for (k, v) in extra_obj {
+            for k in extra_obj.keys() {
                 if RESERVED.contains(&k.as_str()) {
                     anyhow::bail!(
                         "composio.authorize: extra_params cannot override reserved key '{k}'"
                     );
                 }
-                obj.insert(k.clone(), v.clone());
             }
         }
-        self.inner
-            .post::<ComposioAuthorizeResponse>("/agent-integrations/composio/authorize", &body)
-            .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            toolkit = %toolkit,
+            has_extra_params = extra_params.is_some(),
+            "[composio] authorize"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let mut body = json!({ "toolkit": toolkit });
+                if let Some(extra) = extra_params {
+                    let extra_obj = extra.as_object().expect("validated above");
+                    let obj = body.as_object_mut().expect("body is object");
+                    for (k, v) in extra_obj {
+                        obj.insert(k.clone(), v.clone());
+                    }
+                }
+                inner
+                    .post::<ComposioAuthorizeResponse>(
+                        "/agent-integrations/composio/authorize",
+                        &body,
+                    )
+                    .await
+            }
+            ComposioBackend::Direct(d) => d.authorize().await,
+        }
     }
 
-    /// `DELETE /agent-integrations/composio/connections/{id}`.
-    ///
-    /// The backend verifies that the caller owns the connection before
-    /// deleting it. We call this via `POST` with a synthetic `_method`
-    /// body because [`IntegrationClient`] does not currently expose a
-    /// generic `delete()` — the backend accepts the method override.
     pub async fn delete_connection(&self, connection_id: &str) -> Result<ComposioDeleteResponse> {
         let connection_id = connection_id.trim();
         if connection_id.is_empty() {
             anyhow::bail!("composio.delete_connection: connectionId must not be empty");
         }
-        tracing::debug!(connection_id = %connection_id, "[composio] delete_connection");
-        // Fall through to the reusable raw HTTP delete helper below.
-        self.raw_delete::<ComposioDeleteResponse>(&format!(
-            "/agent-integrations/composio/connections/{connection_id}"
-        ))
-        .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            connection_id = %connection_id,
+            "[composio] delete_connection"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                raw_delete::<ComposioDeleteResponse>(
+                    inner,
+                    &format!("/agent-integrations/composio/connections/{connection_id}"),
+                )
+                .await
+            }
+            ComposioBackend::Direct(d) => d.delete_connection(connection_id).await,
+        }
     }
 
     // ── Tools ───────────────────────────────────────────────────────
 
-    /// `GET /agent-integrations/composio/tools?toolkits=<csv>` — fetch
-    /// OpenAI function-calling schemas. Omit `toolkits` to get every
-    /// enabled toolkit's tools.
     pub async fn list_tools(&self, toolkits: Option<&[String]>) -> Result<ComposioToolsResponse> {
-        let path = match toolkits {
-            Some(list) if !list.is_empty() => {
-                let joined = list
-                    .iter()
-                    .map(|t| t.trim())
-                    .filter(|t| !t.is_empty())
-                    .collect::<Vec<_>>()
-                    .join(",");
-                format!("/agent-integrations/composio/tools?toolkits={joined}")
+        tracing::debug!(backend = self.backend_label(), "[composio] list_tools");
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let path = match toolkits {
+                    Some(list) if !list.is_empty() => {
+                        let joined = list
+                            .iter()
+                            .map(|t| t.trim())
+                            .filter(|t| !t.is_empty())
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        format!("/agent-integrations/composio/tools?toolkits={joined}")
+                    }
+                    _ => "/agent-integrations/composio/tools".to_string(),
+                };
+                inner.get::<ComposioToolsResponse>(&path).await
             }
-            _ => "/agent-integrations/composio/tools".to_string(),
-        };
-        tracing::debug!(path = %path, "[composio] list_tools");
-        self.inner.get::<ComposioToolsResponse>(&path).await
+            ComposioBackend::Direct(d) => d.list_tools(toolkits).await,
+        }
     }
 
     // ── Execute ─────────────────────────────────────────────────────
 
-    /// `POST /agent-integrations/composio/execute` — run a Composio
-    /// action and return the provider result + cost.
     pub async fn execute_tool(
         &self,
         tool: &str,
@@ -157,30 +236,51 @@ impl ComposioClient {
         if tool.is_empty() {
             anyhow::bail!("composio.execute_tool: tool slug must not be empty");
         }
-        let arguments = arguments.unwrap_or(serde_json::Value::Object(Default::default()));
-        tracing::debug!(tool = %tool, "[composio] execute_tool");
-        let body = json!({ "tool": tool, "arguments": arguments });
-        self.inner
-            .post::<ComposioExecuteResponse>("/agent-integrations/composio/execute", &body)
-            .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            tool = %tool,
+            "[composio] execute_tool"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let arguments = arguments.unwrap_or(serde_json::Value::Object(Default::default()));
+                let body = json!({ "tool": tool, "arguments": arguments });
+                inner
+                    .post::<ComposioExecuteResponse>("/agent-integrations/composio/execute", &body)
+                    .await
+            }
+            ComposioBackend::Direct(d) => d.execute_tool(tool, arguments).await,
+        }
     }
 
-    /// `GET /agent-integrations/composio/github/repos` — list repositories
-    /// available via the user's authorized GitHub connected account.
     pub async fn list_github_repos(
         &self,
         connection_id: Option<&str>,
     ) -> Result<ComposioGithubReposResponse> {
-        let path = match connection_id.map(str::trim).filter(|id| !id.is_empty()) {
-            Some(id) => format!("/agent-integrations/composio/github/repos?connectionId={id}"),
-            None => "/agent-integrations/composio/github/repos".to_string(),
-        };
-        tracing::debug!(path = %path, "[composio] list_github_repos");
-        self.inner.get::<ComposioGithubReposResponse>(&path).await
+        tracing::debug!(
+            backend = self.backend_label(),
+            "[composio] list_github_repos"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let path = match connection_id.map(str::trim).filter(|id| !id.is_empty()) {
+                    Some(id) => {
+                        format!("/agent-integrations/composio/github/repos?connectionId={id}")
+                    }
+                    None => "/agent-integrations/composio/github/repos".to_string(),
+                };
+                inner.get::<ComposioGithubReposResponse>(&path).await
+            }
+            ComposioBackend::Direct(d) => d.list_github_repos().await,
+        }
     }
 
-    /// `POST /agent-integrations/composio/triggers` — create a trigger
-    /// instance for the authenticated user.
+    // ── Triggers ────────────────────────────────────────────────────
+    //
+    // All trigger methods are BYO-unsupported (see `direct.rs`). They
+    // still validate inputs identically on both backends so the error
+    // surface is consistent.
+
     pub async fn create_trigger(
         &self,
         slug: &str,
@@ -191,24 +291,33 @@ impl ComposioClient {
         if slug.is_empty() {
             anyhow::bail!("composio.create_trigger: slug must not be empty");
         }
-        let mut body = json!({ "slug": slug });
-        if let Some(connection_id) = connection_id.map(str::trim).filter(|id| !id.is_empty()) {
-            body["connectionId"] = json!(connection_id);
+        tracing::debug!(
+            backend = self.backend_label(),
+            slug = %slug,
+            "[composio] create_trigger"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let mut body = json!({ "slug": slug });
+                if let Some(connection_id) =
+                    connection_id.map(str::trim).filter(|id| !id.is_empty())
+                {
+                    body["connectionId"] = json!(connection_id);
+                }
+                if let Some(config) = trigger_config {
+                    body["triggerConfig"] = config;
+                }
+                inner
+                    .post::<ComposioCreateTriggerResponse>(
+                        "/agent-integrations/composio/triggers",
+                        &body,
+                    )
+                    .await
+            }
+            ComposioBackend::Direct(d) => d.create_trigger().await,
         }
-        if let Some(config) = trigger_config {
-            body["triggerConfig"] = config;
-        }
-        tracing::debug!(slug = %slug, "[composio] create_trigger");
-        self.inner
-            .post::<ComposioCreateTriggerResponse>("/agent-integrations/composio/triggers", &body)
-            .await
     }
 
-    // ── Trigger management (PR #671) ────────────────────────────────
-
-    /// `GET /agent-integrations/composio/triggers/available` — catalog of
-    /// triggers the user could enable for a toolkit. For GitHub the
-    /// backend fans out into per-repo entries scoped by `connection_id`.
     pub async fn list_available_triggers(
         &self,
         toolkit: &str,
@@ -218,43 +327,52 @@ impl ComposioClient {
         if toolkit.is_empty() {
             anyhow::bail!("composio.list_available_triggers: toolkit must not be empty");
         }
-        let toolkit_q = urlencoding::encode(toolkit);
-        let path = match connection_id.map(str::trim).filter(|id| !id.is_empty()) {
-            Some(id) => format!(
-                "/agent-integrations/composio/triggers/available?toolkit={toolkit_q}&connectionId={}",
-                urlencoding::encode(id)
-            ),
-            None => format!(
-                "/agent-integrations/composio/triggers/available?toolkit={toolkit_q}"
-            ),
-        };
-        tracing::debug!(path = %path, "[composio] list_available_triggers");
-        self.inner
-            .get::<ComposioAvailableTriggersResponse>(&path)
-            .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            toolkit = %toolkit,
+            "[composio] list_available_triggers"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let toolkit_q = urlencoding::encode(toolkit);
+                let path = match connection_id.map(str::trim).filter(|id| !id.is_empty()) {
+                    Some(id) => format!(
+                        "/agent-integrations/composio/triggers/available?toolkit={toolkit_q}&connectionId={}",
+                        urlencoding::encode(id)
+                    ),
+                    None => format!(
+                        "/agent-integrations/composio/triggers/available?toolkit={toolkit_q}"
+                    ),
+                };
+                inner.get::<ComposioAvailableTriggersResponse>(&path).await
+            }
+            ComposioBackend::Direct(d) => d.list_available_triggers().await,
+        }
     }
 
-    /// `GET /agent-integrations/composio/triggers` — currently enabled
-    /// triggers for the user, optionally filtered to a toolkit.
     pub async fn list_active_triggers(
         &self,
         toolkit: Option<&str>,
     ) -> Result<ComposioActiveTriggersResponse> {
-        let path = match toolkit.map(str::trim).filter(|t| !t.is_empty()) {
-            Some(t) => format!(
-                "/agent-integrations/composio/triggers?toolkit={}",
-                urlencoding::encode(t)
-            ),
-            None => "/agent-integrations/composio/triggers".to_string(),
-        };
-        tracing::debug!(path = %path, "[composio] list_active_triggers");
-        self.inner
-            .get::<ComposioActiveTriggersResponse>(&path)
-            .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            "[composio] list_active_triggers"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let path = match toolkit.map(str::trim).filter(|t| !t.is_empty()) {
+                    Some(t) => format!(
+                        "/agent-integrations/composio/triggers?toolkit={}",
+                        urlencoding::encode(t)
+                    ),
+                    None => "/agent-integrations/composio/triggers".to_string(),
+                };
+                inner.get::<ComposioActiveTriggersResponse>(&path).await
+            }
+            ComposioBackend::Direct(d) => d.list_active_triggers().await,
+        }
     }
 
-    /// `POST /agent-integrations/composio/triggers` — enable a single
-    /// trigger on a connection the caller owns.
     pub async fn enable_trigger(
         &self,
         connection_id: &str,
@@ -269,17 +387,29 @@ impl ComposioClient {
         if slug.is_empty() {
             anyhow::bail!("composio.enable_trigger: slug must not be empty");
         }
-        let mut body = json!({ "connectionId": connection_id, "slug": slug });
-        if let Some(config) = trigger_config {
-            body["triggerConfig"] = config;
+        tracing::debug!(
+            backend = self.backend_label(),
+            slug = %slug,
+            connection_id = %connection_id,
+            "[composio] enable_trigger"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                let mut body = json!({ "connectionId": connection_id, "slug": slug });
+                if let Some(config) = trigger_config {
+                    body["triggerConfig"] = config;
+                }
+                inner
+                    .post::<ComposioEnableTriggerResponse>(
+                        "/agent-integrations/composio/triggers",
+                        &body,
+                    )
+                    .await
+            }
+            ComposioBackend::Direct(d) => d.enable_trigger().await,
         }
-        tracing::debug!(slug = %slug, connection_id = %connection_id, "[composio] enable_trigger");
-        self.inner
-            .post::<ComposioEnableTriggerResponse>("/agent-integrations/composio/triggers", &body)
-            .await
     }
 
-    /// `DELETE /agent-integrations/composio/triggers/:triggerId`.
     pub async fn disable_trigger(
         &self,
         trigger_id: &str,
@@ -288,117 +418,138 @@ impl ComposioClient {
         if trigger_id.is_empty() {
             anyhow::bail!("composio.disable_trigger: triggerId must not be empty");
         }
-        tracing::debug!(trigger_id = %trigger_id, "[composio] disable_trigger");
-        self.raw_delete::<ComposioDisableTriggerResponse>(&format!(
-            "/agent-integrations/composio/triggers/{}",
-            urlencoding::encode(trigger_id)
-        ))
-        .await
+        tracing::debug!(
+            backend = self.backend_label(),
+            trigger_id = %trigger_id,
+            "[composio] disable_trigger"
+        );
+        match &self.backend {
+            ComposioBackend::Proxy(inner) => {
+                raw_delete::<ComposioDisableTriggerResponse>(
+                    inner,
+                    &format!(
+                        "/agent-integrations/composio/triggers/{}",
+                        urlencoding::encode(trigger_id)
+                    ),
+                )
+                .await
+            }
+            ComposioBackend::Direct(d) => d.disable_trigger().await,
+        }
+    }
+}
+
+// ── Raw DELETE (proxy backend only) ─────────────────────────────────
+
+/// Perform an HTTP DELETE through the backend proxy and parse the
+/// standard backend envelope. [`IntegrationClient`] only exposes
+/// `get` / `post`, so the proxy DELETE path re-implements envelope
+/// handling here.
+async fn raw_delete<T: serde::de::DeserializeOwned>(
+    inner: &Arc<IntegrationClient>,
+    path: &str,
+) -> Result<T> {
+    #[derive(serde::Deserialize)]
+    struct Envelope<T> {
+        #[serde(default)]
+        success: bool,
+        data: Option<T>,
+        #[serde(default)]
+        error: Option<String>,
     }
 
-    // ── Raw DELETE ──────────────────────────────────────────────────
+    let url = format!("{}{}", inner.backend_url, path);
+    tracing::debug!("[composio] DELETE {}", url);
 
-    /// Perform an HTTP DELETE and parse the standard backend envelope.
-    ///
-    /// [`IntegrationClient`] only exposes `get` / `post` today, and the
-    /// composio route actually requires a DELETE. We re-implement the
-    /// envelope handling here so we don't have to widen the shared
-    /// client's public surface just for one caller.
-    async fn raw_delete<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        #[derive(serde::Deserialize)]
-        struct Envelope<T> {
-            #[serde(default)]
-            success: bool,
-            data: Option<T>,
-            #[serde(default)]
-            error: Option<String>,
-        }
+    let http_client = reqwest::Client::builder()
+        .use_rustls_tls()
+        .http1_only()
+        .timeout(std::time::Duration::from_secs(60))
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .build()?;
 
-        let url = format!("{}{}", self.inner.backend_url, path);
-        tracing::debug!("[composio] DELETE {}", url);
+    let resp = http_client
+        .delete(&url)
+        .header("Authorization", format!("Bearer {}", inner.auth_token))
+        .send()
+        .await?;
 
-        // Build a fresh lightweight reqwest client for this DELETE.
-        // Note: this allocates a *new* connection pool — it does NOT
-        // reuse the pool inside `self.inner`. To reuse the shared pool
-        // we'd need to clone or expose the existing `reqwest::Client`
-        // from `IntegrationClient`, which we intentionally avoid so the
-        // public surface of that type doesn't widen for one caller.
-        //
-        // Mirror the TLS settings of the shared client
-        // (`use_rustls_tls + http1_only`) so this path has the same
-        // connection behaviour as the other backend calls.
-        let http_client = reqwest::Client::builder()
-            .use_rustls_tls()
-            .http1_only()
-            .timeout(std::time::Duration::from_secs(60))
-            .connect_timeout(std::time::Duration::from_secs(15))
-            .build()?;
-
-        let resp = http_client
-            .delete(&url)
-            .header("Authorization", format!("Bearer {}", self.inner.auth_token))
-            .send()
-            .await?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body_text = resp.text().await.unwrap_or_default();
-            let detail = crate::openhuman::integrations::client::extract_error_detail(
-                &body_text,
-                crate::openhuman::integrations::client::MAX_ERROR_BODY_LEN,
-            );
-            // Use the same UTF-8-safe truncation for the debug-log preview
-            // — direct byte-slicing (`&body_text[..len.min(300)]`) panics
-            // when the cutoff lands inside a multibyte codepoint.
-            let logged_body =
-                crate::openhuman::integrations::client::extract_error_detail(&body_text, 300);
-            tracing::debug!(
-                "[composio] DELETE {} → {} body={}",
-                url,
-                status,
-                logged_body
-            );
-            let status_str = status.as_u16().to_string();
-            crate::core::observability::report_error(
-                format!("Backend returned {status} for DELETE {url}: {detail}").as_str(),
-                "composio",
-                "delete",
-                &[
-                    ("path", path),
-                    ("status", status_str.as_str()),
-                    ("failure", "non_2xx"),
-                ],
-            );
-            anyhow::bail!("Backend returned {status} for DELETE {url}: {detail}");
-        }
-
-        let envelope: Envelope<T> = resp.json().await?;
-        if !envelope.success {
-            let msg = envelope
-                .error
-                .unwrap_or_else(|| "unknown backend error".into());
-            crate::core::observability::report_error(
-                msg.as_str(),
-                "composio",
-                "delete",
-                &[("path", path), ("failure", "envelope_error")],
-            );
-            anyhow::bail!("Backend error for DELETE {}: {}", url, msg);
-        }
-        envelope.data.ok_or_else(|| {
-            anyhow::anyhow!("Backend returned success but no data for DELETE {}", url)
-        })
+    let status = resp.status();
+    if !status.is_success() {
+        let body_text = resp.text().await.unwrap_or_default();
+        let detail = crate::openhuman::integrations::client::extract_error_detail(
+            &body_text,
+            crate::openhuman::integrations::client::MAX_ERROR_BODY_LEN,
+        );
+        let logged_body =
+            crate::openhuman::integrations::client::extract_error_detail(&body_text, 300);
+        tracing::debug!(
+            "[composio] DELETE {} → {} body={}",
+            url,
+            status,
+            logged_body
+        );
+        let status_str = status.as_u16().to_string();
+        crate::core::observability::report_error(
+            format!("Backend returned {status} for DELETE {url}: {detail}").as_str(),
+            "composio",
+            "delete",
+            &[
+                ("path", path),
+                ("status", status_str.as_str()),
+                ("failure", "non_2xx"),
+            ],
+        );
+        anyhow::bail!("Backend returned {status} for DELETE {url}: {detail}");
     }
+
+    let envelope: Envelope<T> = resp.json().await?;
+    if !envelope.success {
+        let msg = envelope
+            .error
+            .unwrap_or_else(|| "unknown backend error".into());
+        crate::core::observability::report_error(
+            msg.as_str(),
+            "composio",
+            "delete",
+            &[("path", path), ("failure", "envelope_error")],
+        );
+        anyhow::bail!("Backend error for DELETE {}: {}", url, msg);
+    }
+    envelope
+        .data
+        .ok_or_else(|| anyhow::anyhow!("Backend returned success but no data for DELETE {}", url))
 }
 
 /// Build a [`ComposioClient`] from the root config.
 ///
-/// Composio is **always enabled** — there are no configuration flags
-/// gating it. The backend URL and auth token come from the shared
-/// core defaults (`config.api_url` plus the app-session JWT) via
-/// [`crate::openhuman::integrations::build_client`]. The only reason
-/// this returns `None` is that the user isn't signed in yet.
+/// Routing:
+///
+/// 1. If `config.composio.byo_api_key` is set (non-empty), return a
+///    BYO/Direct client that talks to `api.composio.dev` using that
+///    key. Does **not** require the user to be signed in to the
+///    openhuman backend.
+/// 2. Otherwise fall back to the original proxy-backed client built
+///    through [`crate::openhuman::integrations::build_client`]. Returns
+///    `None` only when the user has no app-session JWT (i.e. not
+///    signed in).
 pub fn build_composio_client(config: &crate::openhuman::config::Config) -> Option<ComposioClient> {
+    if let Some(api_key) = config.composio.byo_api_key_trimmed() {
+        match super::direct::DirectComposioClient::new(
+            api_key.to_string(),
+            config.composio.entity_id.clone(),
+        ) {
+            Ok(direct) => {
+                tracing::info!("[composio] using BYO Direct client (composio.byo_api_key set)");
+                return Some(ComposioClient::direct(direct));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[composio] failed to build BYO Direct client: {e} — falling back to proxy"
+                );
+            }
+        }
+    }
     let inner = crate::openhuman::integrations::build_client(config)?;
     Some(ComposioClient::new(inner))
 }

--- a/src/openhuman/composio/client_tests.rs
+++ b/src/openhuman/composio/client_tests.rs
@@ -580,3 +580,81 @@ async fn delete_connection_surfaces_envelope_error_detail() {
     );
     assert!(msg.contains("400"), "expected status 400, got: {msg}");
 }
+
+// ── BYO routing ────────────────────────────────────────────────
+//
+// When `config.composio.byo_api_key` is set, `build_composio_client`
+// must return a Direct-backed client regardless of whether the user
+// is signed in. These tests cover the routing contract that
+// `ComposioClient::is_byo()` exposes.
+
+#[test]
+fn build_composio_client_picks_byo_when_key_set() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::default();
+    config.config_path = tmp.path().join("config.toml");
+    config.composio.byo_api_key = Some("sk_test_abc123xyz".into());
+    let client = build_composio_client(&config).expect("BYO client builds without auth token");
+    assert!(client.is_byo(), "expected BYO/Direct backend");
+    assert_eq!(client.backend_label(), "direct");
+}
+
+#[test]
+fn build_composio_client_ignores_whitespace_only_byo_key() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::default();
+    config.config_path = tmp.path().join("config.toml");
+    config.composio.byo_api_key = Some("   ".into());
+    // No auth token + whitespace-only BYO key → falls back to proxy
+    // path, which fails because no session token is stored.
+    assert!(
+        build_composio_client(&config).is_none(),
+        "whitespace-only BYO key should not switch backends"
+    );
+}
+
+#[tokio::test]
+async fn byo_client_trigger_methods_return_byo_unsupported() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::default();
+    config.config_path = tmp.path().join("config.toml");
+    config.composio.byo_api_key = Some("sk_test_key".into());
+    let client = build_composio_client(&config).expect("BYO client");
+
+    let err = client
+        .create_trigger("GMAIL_NEW", None, None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .starts_with(crate::openhuman::composio::BYO_UNSUPPORTED_PREFIX),
+        "trigger error should carry BYO sentinel, got: {err}"
+    );
+
+    let err = client
+        .enable_trigger("conn", "slug", None)
+        .await
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .starts_with(crate::openhuman::composio::BYO_UNSUPPORTED_PREFIX));
+
+    let err = client.disable_trigger("trig").await.unwrap_err();
+    assert!(err
+        .to_string()
+        .starts_with(crate::openhuman::composio::BYO_UNSUPPORTED_PREFIX));
+}
+
+#[tokio::test]
+async fn byo_client_list_active_triggers_returns_empty_not_error() {
+    // UI surfaces call list_active_triggers on every poll; we want
+    // BYO mode to return an empty list rather than failing.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config = Config::default();
+    config.config_path = tmp.path().join("config.toml");
+    config.composio.byo_api_key = Some("sk_test_key".into());
+    let client = build_composio_client(&config).expect("BYO client");
+
+    let resp = client.list_active_triggers(None).await.unwrap();
+    assert!(resp.triggers.is_empty());
+}

--- a/src/openhuman/composio/direct.rs
+++ b/src/openhuman/composio/direct.rs
@@ -1,0 +1,559 @@
+//! Direct Composio REST API client used in BYO (Bring Your Own
+//! API key) mode.
+//!
+//! When `config.composio.byo_api_key` is set, the core stops talking to
+//! the openhuman backend's `/agent-integrations/composio/*` proxy and
+//! instead hits Composio's public REST API at
+//! `https://backend.composio.dev/api/v3/*` directly using the user's
+//! API key (`X-API-Key` header).
+//!
+//! ## What is supported
+//!
+//! - **Toolkits / tools / connections / execute** — read-only catalog
+//!   and tool execution work end-to-end with the user's own key.
+//!
+//! ## What is NOT supported in BYO mode
+//!
+//! - **Triggers** — Composio delivers triggers via HMAC-verified
+//!   webhooks that must terminate at a publicly reachable URL. The
+//!   openhuman backend owns that endpoint and fans events out over
+//!   Socket.IO to user sessions. A desktop app cannot receive inbound
+//!   HTTP, so trigger creation / listing / disable all return
+//!   [`ByoUnsupportedError`].
+//! - **OAuth `authorize` handoff** — Composio's hosted OAuth needs an
+//!   `auth_config_id` pre-provisioned in the user's Composio dashboard
+//!   plus a redirect URL the user controls. BYO users connect accounts
+//!   in their Composio dashboard; the core only executes against
+//!   already-connected accounts.
+//! - **GitHub repo listing** — currently a custom helper on the
+//!   openhuman backend (not a 1:1 Composio API). Returns
+//!   [`ByoUnsupportedError`] in BYO mode.
+//!
+//! All BYO-unsupported paths return errors whose `Display` starts with
+//! the stable `composio_byo_unsupported:` prefix so RPC handlers and
+//! UI surfaces can match on it without parsing free-form text.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use reqwest::Client;
+use serde_json::Value;
+
+use super::types::{
+    ComposioActiveTriggersResponse, ComposioConnection, ComposioConnectionsResponse,
+    ComposioExecuteResponse, ComposioToolFunction, ComposioToolSchema, ComposioToolkitsResponse,
+    ComposioToolsResponse,
+};
+
+/// Stable error prefix returned for any operation the BYO client
+/// cannot service. Match on this in RPC error mapping so the UI can
+/// show a uniform "switch off BYO to use this" banner.
+pub const BYO_UNSUPPORTED_PREFIX: &str = "composio_byo_unsupported:";
+
+/// Construct an `anyhow::Error` for a BYO-unsupported operation.
+pub fn byo_unsupported(op: &str) -> anyhow::Error {
+    anyhow!(
+        "{prefix} operation `{op}` is not available with a user-provided Composio API key. \
+         Disable BYO mode in Settings → Composio to use the hosted backend for this feature.",
+        prefix = BYO_UNSUPPORTED_PREFIX,
+        op = op,
+    )
+}
+
+/// True if `err` is a BYO-unsupported sentinel error.
+pub fn is_byo_unsupported(err: &anyhow::Error) -> bool {
+    err.to_string().starts_with(BYO_UNSUPPORTED_PREFIX)
+}
+
+/// Default base URL for Composio's public REST API.
+pub const DEFAULT_COMPOSIO_BASE_URL: &str = "https://backend.composio.dev";
+
+/// Direct-mode Composio client. Cheap to clone — the inner reqwest
+/// `Client` already shares its connection pool through `Arc`.
+#[derive(Clone)]
+pub struct DirectComposioClient {
+    inner: Arc<DirectInner>,
+}
+
+struct DirectInner {
+    base_url: String,
+    api_key: String,
+    entity_id: String,
+    http: Client,
+}
+
+impl DirectComposioClient {
+    /// Build a new direct client. `entity_id` is forwarded as the
+    /// Composio `user_id` field — defaults to `"default"` per
+    /// [`crate::openhuman::config::schema::ComposioConfig`].
+    pub fn new(api_key: String, entity_id: String) -> Result<Self> {
+        Self::with_base_url(api_key, entity_id, DEFAULT_COMPOSIO_BASE_URL.to_string())
+    }
+
+    /// Like [`new`] but accepts a custom base URL — used by tests that
+    /// stand up a mock HTTP server.
+    pub fn with_base_url(api_key: String, entity_id: String, base_url: String) -> Result<Self> {
+        let api_key = api_key.trim().to_string();
+        if api_key.is_empty() {
+            anyhow::bail!("composio.direct: api_key must not be empty");
+        }
+        let entity_id = {
+            let trimmed = entity_id.trim();
+            if trimmed.is_empty() {
+                "default".to_string()
+            } else {
+                trimmed.to_string()
+            }
+        };
+        let http = Client::builder()
+            .use_rustls_tls()
+            .http1_only()
+            .timeout(Duration::from_secs(60))
+            .connect_timeout(Duration::from_secs(15))
+            .build()?;
+        Ok(Self {
+            inner: Arc::new(DirectInner {
+                base_url: base_url.trim_end_matches('/').to_string(),
+                api_key,
+                entity_id,
+                http,
+            }),
+        })
+    }
+
+    /// Entity id used for `user_id` query/body fields.
+    pub fn entity_id(&self) -> &str {
+        &self.inner.entity_id
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.inner.base_url, path)
+    }
+
+    async fn get_json(&self, path: &str) -> Result<Value> {
+        let url = self.url(path);
+        tracing::debug!(url = %url, "[composio:direct] GET");
+        let resp = self
+            .inner
+            .http
+            .get(&url)
+            .header("X-API-Key", &self.inner.api_key)
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!(
+                "Composio direct GET {url} returned {status}: {detail}",
+                url = url,
+                status = status,
+                detail = truncate_for_log(&body, 400)
+            );
+        }
+        serde_json::from_str(&body)
+            .map_err(|e| anyhow!("composio.direct GET {url}: invalid JSON: {e}"))
+    }
+
+    async fn post_json(&self, path: &str, body: &Value) -> Result<Value> {
+        let url = self.url(path);
+        tracing::debug!(url = %url, "[composio:direct] POST");
+        let resp = self
+            .inner
+            .http
+            .post(&url)
+            .header("X-API-Key", &self.inner.api_key)
+            .header("Accept", "application/json")
+            .json(body)
+            .send()
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!(
+                "Composio direct POST {url} returned {status}: {detail}",
+                url = url,
+                status = status,
+                detail = truncate_for_log(&text, 400)
+            );
+        }
+        serde_json::from_str(&text)
+            .map_err(|e| anyhow!("composio.direct POST {url}: invalid JSON: {e}"))
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        let url = self.url(path);
+        tracing::debug!(url = %url, "[composio:direct] DELETE");
+        let resp = self
+            .inner
+            .http
+            .delete(&url)
+            .header("X-API-Key", &self.inner.api_key)
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Composio direct DELETE {url} returned {status}: {detail}",
+                url = url,
+                status = status,
+                detail = truncate_for_log(&body, 400)
+            );
+        }
+        Ok(())
+    }
+
+    // ── Toolkits ────────────────────────────────────────────────────
+
+    /// `GET /api/v3/toolkits` — list all toolkit slugs available to the
+    /// user. In BYO mode there is no openhuman-side allowlist; the
+    /// caller gets Composio's full catalog.
+    pub async fn list_toolkits(&self) -> Result<ComposioToolkitsResponse> {
+        let v = self.get_json("/api/v3/toolkits").await?;
+        let items = extract_items(&v);
+        let mut slugs = Vec::with_capacity(items.len());
+        for item in items {
+            if let Some(slug) = item
+                .get("slug")
+                .or_else(|| item.get("name"))
+                .or_else(|| item.get("id"))
+                .and_then(Value::as_str)
+            {
+                slugs.push(slug.to_string());
+            }
+        }
+        Ok(ComposioToolkitsResponse { toolkits: slugs })
+    }
+
+    // ── Connections ─────────────────────────────────────────────────
+
+    /// `GET /api/v3/connected_accounts?user_ids=<entity>` — list the
+    /// connected accounts the BYO key has access to for this entity.
+    pub async fn list_connections(&self) -> Result<ComposioConnectionsResponse> {
+        let path = format!(
+            "/api/v3/connected_accounts?user_ids={}",
+            urlencoding::encode(&self.inner.entity_id)
+        );
+        let v = self.get_json(&path).await?;
+        let items = extract_items(&v);
+        let mut connections = Vec::with_capacity(items.len());
+        for item in items {
+            let id = item.get("id").and_then(Value::as_str).map(str::to_string);
+            let toolkit = item
+                .get("toolkit")
+                .and_then(|t| {
+                    t.as_str()
+                        .map(str::to_string)
+                        .or_else(|| t.get("slug").and_then(Value::as_str).map(str::to_string))
+                })
+                .or_else(|| {
+                    item.get("toolkit_slug")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                });
+            let status = item
+                .get("status")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| "UNKNOWN".to_string());
+            let created_at = item
+                .get("created_at")
+                .or_else(|| item.get("createdAt"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            if let (Some(id), Some(toolkit)) = (id, toolkit) {
+                connections.push(ComposioConnection {
+                    id,
+                    toolkit,
+                    status,
+                    created_at,
+                });
+            }
+        }
+        Ok(ComposioConnectionsResponse { connections })
+    }
+
+    /// `DELETE /api/v3/connected_accounts/{id}`.
+    pub async fn delete_connection(
+        &self,
+        connection_id: &str,
+    ) -> Result<super::types::ComposioDeleteResponse> {
+        let path = format!(
+            "/api/v3/connected_accounts/{}",
+            urlencoding::encode(connection_id)
+        );
+        self.delete(&path).await?;
+        Ok(super::types::ComposioDeleteResponse { deleted: true })
+    }
+
+    // ── Tools ───────────────────────────────────────────────────────
+
+    /// `GET /api/v3/tools` (optionally filtered by toolkit slugs).
+    pub async fn list_tools(&self, toolkits: Option<&[String]>) -> Result<ComposioToolsResponse> {
+        let path = match toolkits {
+            Some(list) if !list.is_empty() => {
+                let joined = list
+                    .iter()
+                    .map(|t| t.trim())
+                    .filter(|t| !t.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!(
+                    "/api/v3/tools?toolkit_slugs={}",
+                    urlencoding::encode(&joined)
+                )
+            }
+            _ => "/api/v3/tools".to_string(),
+        };
+        let v = self.get_json(&path).await?;
+        let items = extract_items(&v);
+        let mut tools = Vec::with_capacity(items.len());
+        for item in items {
+            let Some(name) = item
+                .get("slug")
+                .or_else(|| item.get("name"))
+                .and_then(Value::as_str)
+            else {
+                continue;
+            };
+            let description = item
+                .get("description")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let parameters = item
+                .get("input_parameters")
+                .or_else(|| item.get("parameters"))
+                .cloned();
+            tools.push(ComposioToolSchema {
+                kind: "function".to_string(),
+                function: ComposioToolFunction {
+                    name: name.to_string(),
+                    description,
+                    parameters,
+                },
+            });
+        }
+        Ok(ComposioToolsResponse { tools })
+    }
+
+    // ── Execute ─────────────────────────────────────────────────────
+
+    /// `POST /api/v3/tools/execute/{slug}` — run a Composio action with
+    /// the user's BYO key. The Composio API returns
+    /// `{ data, successful, error, ... }` directly; this method maps it
+    /// onto the same [`ComposioExecuteResponse`] shape the proxy
+    /// returns so callers stay agnostic.
+    pub async fn execute_tool(
+        &self,
+        tool: &str,
+        arguments: Option<Value>,
+    ) -> Result<ComposioExecuteResponse> {
+        let path = format!("/api/v3/tools/execute/{}", urlencoding::encode(tool));
+        let body = serde_json::json!({
+            "user_id": self.inner.entity_id,
+            "arguments": arguments.unwrap_or_else(|| Value::Object(Default::default())),
+        });
+        let v = self.post_json(&path, &body).await?;
+        let data = v.get("data").cloned().unwrap_or(Value::Null);
+        let successful = v
+            .get("successful")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let error = v.get("error").and_then(Value::as_str).map(str::to_string);
+        Ok(ComposioExecuteResponse {
+            data,
+            successful,
+            error,
+            cost_usd: 0.0,
+            markdown_formatted: None,
+        })
+    }
+
+    // ── BYO-unsupported surfaces ────────────────────────────────────
+    //
+    // These mirror the proxy methods so callers can branch on the
+    // backend variant inside `ComposioClient` and surface a uniform
+    // error. Keeping the methods here (rather than only in
+    // `ComposioClient`) keeps the BYO contract co-located with the
+    // direct client.
+
+    pub async fn authorize(&self) -> Result<super::types::ComposioAuthorizeResponse> {
+        Err(byo_unsupported("authorize"))
+    }
+
+    pub async fn list_github_repos(&self) -> Result<super::types::ComposioGithubReposResponse> {
+        Err(byo_unsupported("github.list_repos"))
+    }
+
+    pub async fn create_trigger(&self) -> Result<super::types::ComposioCreateTriggerResponse> {
+        Err(byo_unsupported("triggers.create"))
+    }
+
+    pub async fn list_available_triggers(
+        &self,
+    ) -> Result<super::types::ComposioAvailableTriggersResponse> {
+        Err(byo_unsupported("triggers.list_available"))
+    }
+
+    pub async fn list_active_triggers(&self) -> Result<ComposioActiveTriggersResponse> {
+        // Return an empty list rather than an error here: many UI
+        // surfaces call `list_active_triggers` just to render an
+        // "enabled triggers" section. In BYO mode the answer is
+        // legitimately "none" — the user can't enable any. The Settings
+        // panel separately surfaces the unsupported-status banner.
+        Ok(ComposioActiveTriggersResponse {
+            triggers: Vec::new(),
+        })
+    }
+
+    pub async fn enable_trigger(&self) -> Result<super::types::ComposioEnableTriggerResponse> {
+        Err(byo_unsupported("triggers.enable"))
+    }
+
+    pub async fn disable_trigger(&self) -> Result<super::types::ComposioDisableTriggerResponse> {
+        Err(byo_unsupported("triggers.disable"))
+    }
+}
+
+/// Composio v3 list endpoints wrap results in `{ "items": [...] }`.
+/// Some older shapes return a bare array. Tolerate both.
+fn extract_items(v: &Value) -> Vec<&Value> {
+    if let Some(arr) = v.get("items").and_then(Value::as_array) {
+        return arr.iter().collect();
+    }
+    if let Some(arr) = v.as_array() {
+        return arr.iter().collect();
+    }
+    Vec::new()
+}
+
+fn truncate_for_log(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    s.chars().take(max).collect::<String>() + "…"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        routing::{delete as axum_delete, get, post},
+        Json, Router,
+    };
+    use serde_json::json;
+
+    async fn start_mock(app: Router) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://127.0.0.1:{}", addr.port())
+    }
+
+    fn client(base: String) -> DirectComposioClient {
+        DirectComposioClient::with_base_url("k".into(), "default".into(), base).unwrap()
+    }
+
+    #[test]
+    fn empty_api_key_rejected() {
+        let res = DirectComposioClient::new("  ".into(), "default".into());
+        let err = match res {
+            Ok(_) => panic!("expected error for empty api_key"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("api_key must not be empty"));
+    }
+
+    #[test]
+    fn byo_unsupported_prefix_stable() {
+        let err = byo_unsupported("triggers.create");
+        assert!(err.to_string().starts_with(BYO_UNSUPPORTED_PREFIX));
+        assert!(is_byo_unsupported(&err));
+    }
+
+    #[tokio::test]
+    async fn list_toolkits_parses_items_envelope() {
+        let app = Router::new().route(
+            "/api/v3/toolkits",
+            get(|| async {
+                Json(json!({ "items": [
+                    { "slug": "gmail" },
+                    { "slug": "notion" }
+                ]}))
+            }),
+        );
+        let base = start_mock(app).await;
+        let c = client(base);
+        let res = c.list_toolkits().await.unwrap();
+        assert_eq!(res.toolkits, vec!["gmail", "notion"]);
+    }
+
+    #[tokio::test]
+    async fn list_connections_maps_v3_fields() {
+        let app = Router::new().route(
+            "/api/v3/connected_accounts",
+            get(|| async {
+                Json(json!({ "items": [
+                    {
+                        "id": "conn_1",
+                        "toolkit": { "slug": "gmail" },
+                        "status": "ACTIVE",
+                        "created_at": "2026-01-01T00:00:00Z"
+                    }
+                ]}))
+            }),
+        );
+        let base = start_mock(app).await;
+        let c = client(base);
+        let res = c.list_connections().await.unwrap();
+        assert_eq!(res.connections.len(), 1);
+        assert_eq!(res.connections[0].toolkit, "gmail");
+        assert!(res.connections[0].is_active());
+    }
+
+    #[tokio::test]
+    async fn execute_tool_returns_composio_envelope() {
+        let app = Router::new().route(
+            "/api/v3/tools/execute/GMAIL_SEND_EMAIL",
+            post(|| async {
+                Json(json!({
+                    "data": { "messageId": "abc" },
+                    "successful": true,
+                    "error": null
+                }))
+            }),
+        );
+        let base = start_mock(app).await;
+        let c = client(base);
+        let res = c
+            .execute_tool("GMAIL_SEND_EMAIL", Some(json!({ "to": "x@y" })))
+            .await
+            .unwrap();
+        assert!(res.successful);
+        assert_eq!(res.data["messageId"], "abc");
+    }
+
+    #[tokio::test]
+    async fn delete_connection_calls_v3() {
+        let app = Router::new().route(
+            "/api/v3/connected_accounts/conn_1",
+            axum_delete(|| async { axum::http::StatusCode::NO_CONTENT }),
+        );
+        let base = start_mock(app).await;
+        let c = client(base);
+        let res = c.delete_connection("conn_1").await.unwrap();
+        assert!(res.deleted);
+    }
+
+    #[tokio::test]
+    async fn authorize_is_byo_unsupported() {
+        let c = DirectComposioClient::new("k".into(), "default".into()).unwrap();
+        let err = c.authorize().await.unwrap_err();
+        assert!(is_byo_unsupported(&err));
+    }
+}

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -38,6 +38,7 @@
 pub mod action_tool;
 pub mod bus;
 pub mod client;
+pub mod direct;
 pub mod ops;
 pub mod periodic;
 pub mod providers;
@@ -49,6 +50,9 @@ pub mod types;
 pub use action_tool::ComposioActionTool;
 pub use bus::{register_composio_trigger_subscriber, ComposioTriggerSubscriber};
 pub use client::{build_composio_client, ComposioClient};
+pub use direct::{
+    byo_unsupported, is_byo_unsupported, DirectComposioClient, BYO_UNSUPPORTED_PREFIX,
+};
 pub use ops::{
     fetch_connected_integrations, fetch_connected_integrations_status, fetch_toolkit_actions,
     invalidate_connected_integrations_cache, FetchConnectedIntegrationsStatus,

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -34,18 +34,39 @@ use super::types::{
 };
 
 /// Resolve a [`ComposioClient`] from the root config, or return an
-/// error string that the caller can surface over RPC.
+/// error string the caller can surface over RPC.
 ///
-/// Composio is always enabled — it is proxied through our backend and
-/// has no client-side toggle or API key. The only reason this fails is
-/// that no app-session JWT has been stored yet (i.e. the user hasn't
-/// completed sign-in / `auth_store_session`).
+/// Two failure modes:
+///
+/// 1. **Proxy mode** (`config.composio.byo_api_key` unset) — fails when
+///    the user has no app-session JWT (i.e. they haven't completed
+///    sign-in / `auth_store_session`).
+/// 2. **BYO/Direct mode** — fails only if the BYO key fails validation
+///    (empty/whitespace, etc.), in which case `build_composio_client`
+///    falls back to attempting proxy mode first.
 fn resolve_client(config: &Config) -> OpResult<ComposioClient> {
     build_composio_client(config).ok_or_else(|| {
-        "composio unavailable: no backend session token. Sign in first \
-         (auth_store_session)."
+        "composio unavailable: no backend session token and no BYO API key. \
+         Sign in (auth_store_session) or set a Composio API key in Settings."
             .to_string()
     })
+}
+
+/// Format an `anyhow::Error` for RPC consumption while preserving the
+/// `composio_byo_unsupported:` sentinel prefix when present.
+///
+/// Without this, every error is wrapped as
+/// `"[composio] <op> failed: <inner>"`, which buries the sentinel and
+/// forces the UI to substring-search for it. With this helper, BYO
+/// sentinel errors pass through unchanged so RPC consumers can match
+/// on `startsWith("composio_byo_unsupported:")` directly. Non-BYO
+/// errors still get the operational context prefix for diagnostics.
+fn fmt_err(op: &str, err: anyhow::Error) -> String {
+    if super::direct::is_byo_unsupported(&err) {
+        err.to_string()
+    } else {
+        format!("[composio] {op} failed: {err:#}")
+    }
 }
 
 // ── Toolkits ────────────────────────────────────────────────────────
@@ -58,7 +79,7 @@ pub async fn composio_list_toolkits(
     let resp = client
         .list_toolkits()
         .await
-        .map_err(|e| format!("[composio] list_toolkits failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_toolkits", e))?;
     let count = resp.toolkits.len();
     Ok(RpcOutcome::new(
         resp,
@@ -76,7 +97,7 @@ pub async fn composio_list_connections(
     let resp = client
         .list_connections()
         .await
-        .map_err(|e| format!("[composio] list_connections failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_connections", e))?;
     let active = resp.connections.iter().filter(|c| c.is_active()).count();
     let total = resp.connections.len();
     // Reconcile the chat-runtime integrations cache against this fresh
@@ -104,7 +125,7 @@ pub async fn composio_authorize(
     let resp = client
         .authorize(toolkit, extra_params)
         .await
-        .map_err(|e| format!("[composio] authorize failed: {e:#}"))?;
+        .map_err(|e| fmt_err("authorize", e))?;
 
     // Publish an event so any interested subscribers (e.g. UI refreshers,
     // analytics) can react to the new connection handoff.
@@ -134,7 +155,7 @@ pub async fn composio_delete_connection(
     let resp = client
         .delete_connection(connection_id)
         .await
-        .map_err(|e| format!("[composio] delete_connection failed: {e:#}"))?;
+        .map_err(|e| fmt_err("delete_connection", e))?;
     if let Some(toolkit) = toolkit.as_deref() {
         let deleted =
             super::providers::profile::delete_connected_identity_facets(toolkit, connection_id);
@@ -182,7 +203,7 @@ pub async fn composio_list_tools(
     let resp = client
         .list_tools(toolkits.as_deref())
         .await
-        .map_err(|e| format!("[composio] list_tools failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_tools", e))?;
     let count = resp.tools.len();
     Ok(RpcOutcome::new(
         resp,
@@ -251,7 +272,7 @@ pub async fn composio_list_github_repos(
     let resp = client
         .list_github_repos(connection_id.as_deref())
         .await
-        .map_err(|e| format!("[composio] list_github_repos failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_github_repos", e))?;
     let count = resp.repositories.len();
     let connection_id = resp.connection_id.clone();
     Ok(RpcOutcome::new(
@@ -273,7 +294,7 @@ pub async fn composio_create_trigger(
     let resp = client
         .create_trigger(slug, connection_id.as_deref(), trigger_config)
         .await
-        .map_err(|e| format!("[composio] create_trigger failed: {e:#}"))?;
+        .map_err(|e| fmt_err("create_trigger", e))?;
     let trigger_id = resp.trigger_id.clone();
     Ok(RpcOutcome::new(
         resp,
@@ -295,7 +316,7 @@ pub async fn composio_list_available_triggers(
     let resp = client
         .list_available_triggers(toolkit, connection_id.as_deref())
         .await
-        .map_err(|e| format!("[composio] list_available_triggers failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_available_triggers", e))?;
     let count = resp.triggers.len();
     Ok(RpcOutcome::new(
         resp,
@@ -314,7 +335,7 @@ pub async fn composio_list_triggers(
     let resp = client
         .list_active_triggers(toolkit.as_deref())
         .await
-        .map_err(|e| format!("[composio] list_triggers failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_triggers", e))?;
     let count = resp.triggers.len();
     Ok(RpcOutcome::new(
         resp,
@@ -333,7 +354,7 @@ pub async fn composio_enable_trigger(
     let resp = client
         .enable_trigger(connection_id, slug, trigger_config)
         .await
-        .map_err(|e| format!("[composio] enable_trigger failed: {e:#}"))?;
+        .map_err(|e| fmt_err("enable_trigger", e))?;
     let trigger_id = resp.trigger_id.clone();
     Ok(RpcOutcome::new(
         resp,
@@ -350,7 +371,7 @@ pub async fn composio_disable_trigger(
     let resp = client
         .disable_trigger(trigger_id)
         .await
-        .map_err(|e| format!("[composio] disable_trigger failed: {e:#}"))?;
+        .map_err(|e| fmt_err("disable_trigger", e))?;
     let message = if resp.deleted {
         format!("composio: disabled trigger {trigger_id}")
     } else {
@@ -418,7 +439,7 @@ async fn resolve_toolkit_for_connection(
     let resp = client
         .list_connections()
         .await
-        .map_err(|e| format!("[composio] list_connections failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_connections", e))?;
     let conn = resp
         .connections
         .into_iter()
@@ -488,7 +509,7 @@ pub async fn composio_refresh_all_identities(
     let conns = client
         .list_connections()
         .await
-        .map_err(|e| format!("[composio] list_connections failed: {e:#}"))?;
+        .map_err(|e| fmt_err("list_connections", e))?;
 
     let mut report = RefreshIdentitiesReport::default();
     let mut messages: Vec<String> = Vec::with_capacity(conns.connections.len() + 1);

--- a/src/openhuman/composio/ops_tests.rs
+++ b/src/openhuman/composio/ops_tests.rs
@@ -931,3 +931,24 @@ async fn composio_disable_trigger_propagates_backend_error() {
         .unwrap_err();
     assert!(err.contains("disable_trigger failed"), "unexpected: {err}");
 }
+
+#[test]
+fn fmt_err_preserves_byo_unsupported_prefix() {
+    let inner = super::super::direct::byo_unsupported("triggers.create");
+    let s = fmt_err("create_trigger", inner);
+    assert!(
+        s.starts_with(super::super::direct::BYO_UNSUPPORTED_PREFIX),
+        "BYO sentinel must pass through unwrapped, got: {s}"
+    );
+}
+
+#[test]
+fn fmt_err_wraps_non_byo_errors_with_op_context() {
+    let inner = anyhow::anyhow!("network unreachable");
+    let s = fmt_err("list_toolkits", inner);
+    assert!(
+        s.starts_with("[composio] list_toolkits failed:"),
+        "got: {s}"
+    );
+    assert!(s.contains("network unreachable"), "got: {s}");
+}

--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -240,6 +240,14 @@ pub struct LocalAiSettingsPatch {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct ComposioByoSettingsPatch {
+    /// `Some(Some(key))` → set the BYO key (after trimming).
+    /// `Some(None)`      → clear the BYO key (revert to proxy mode).
+    /// `None`            → leave unchanged.
+    pub byo_api_key: Option<Option<String>>,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct ComposioTriggerSettingsPatch {
     /// When `Some(true)`, disables triage for all toolkits.
     pub triage_disabled: Option<bool>,
@@ -621,6 +629,87 @@ pub async fn load_and_apply_composio_trigger_settings(
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
     let mut config = load_config_with_timeout().await?;
     apply_composio_trigger_settings(&mut config, update).await
+}
+
+/// Apply a BYO-key patch and persist. See [`ComposioByoSettingsPatch`].
+///
+/// Whitespace-only keys are normalised to "clear". The returned
+/// snapshot includes a `composio_byo` summary so the UI can re-render
+/// from a single round-trip.
+pub async fn apply_composio_byo_settings(
+    config: &mut Config,
+    update: ComposioByoSettingsPatch,
+) -> Result<RpcOutcome<serde_json::Value>, String> {
+    if let Some(slot) = update.byo_api_key {
+        let normalized = slot.and_then(|s| {
+            let trimmed = s.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        });
+        let action = if normalized.is_some() {
+            "set"
+        } else {
+            "cleared"
+        };
+        config.composio.byo_api_key = normalized;
+        tracing::debug!(action = action, "[config][composio] byo_api_key updated");
+    }
+    config.save().await.map_err(|e| e.to_string())?;
+    let snapshot = snapshot_config_json(config)?;
+    Ok(RpcOutcome::new(
+        snapshot,
+        vec![format!(
+            "composio BYO settings saved to {}",
+            config.config_path.display()
+        )],
+    ))
+}
+
+/// Loads config, applies a BYO-key patch, and saves.
+pub async fn load_and_apply_composio_byo_settings(
+    update: ComposioByoSettingsPatch,
+) -> Result<RpcOutcome<serde_json::Value>, String> {
+    let mut config = load_config_with_timeout().await?;
+    apply_composio_byo_settings(&mut config, update).await
+}
+
+/// Read-only status of the BYO Composio key.
+///
+/// Returns `{ active, masked_key, backend }` where:
+/// - `active: bool`        — true if a non-empty key is configured.
+/// - `masked_key: String?` — `"sk_••••••XXXX"`-style preview, or null.
+/// - `backend: "direct"|"proxy"` — which transport `build_composio_client` will pick.
+pub async fn get_composio_byo_status() -> Result<RpcOutcome<serde_json::Value>, String> {
+    let config = load_config_with_timeout().await?;
+    let key = config.composio.byo_api_key_trimmed();
+    let active = key.is_some();
+    let masked = key.map(mask_secret);
+    let backend = if active { "direct" } else { "proxy" };
+    let result = serde_json::json!({
+        "active": active,
+        "masked_key": masked,
+        "backend": backend,
+    });
+    Ok(RpcOutcome::new(
+        result,
+        vec![format!("composio BYO status: backend={backend}")],
+    ))
+}
+
+/// Mask a secret for safe display: keeps the first 3 and last 4
+/// characters, redacts the middle. Returns `"••••"` for very short
+/// values where any prefix/suffix would leak the whole thing.
+fn mask_secret(s: &str) -> String {
+    let len = s.chars().count();
+    if len <= 8 {
+        return "•".repeat(len.min(8));
+    }
+    let prefix: String = s.chars().take(3).collect();
+    let suffix: String = s.chars().skip(len.saturating_sub(4)).collect();
+    format!("{prefix}••••{suffix}")
 }
 
 /// Reads the current composio trigger-triage settings.

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -728,3 +728,70 @@ async fn workspace_onboarding_flag_set_round_trip() {
         std::env::remove_var("OPENHUMAN_WORKSPACE");
     }
 }
+
+// ── BYO Composio key ─────────────────────────────────────────────
+
+#[test]
+fn mask_secret_short_value_redacts_entirely() {
+    assert_eq!(mask_secret(""), "");
+    assert_eq!(mask_secret("ab"), "••");
+    assert_eq!(mask_secret("abcdefgh"), "••••••••");
+}
+
+#[test]
+fn mask_secret_keeps_prefix_and_suffix_for_real_keys() {
+    let masked = mask_secret("sk_live_abcdefghijklmnop");
+    assert!(masked.starts_with("sk_"), "prefix kept: {masked}");
+    assert!(masked.ends_with("mnop"), "suffix kept: {masked}");
+    assert!(masked.contains("••••"), "middle redacted: {masked}");
+    // Length of middle redaction is bounded — exact bullet count is
+    // not part of the contract, just that some redaction is present.
+    assert!(masked.len() < "sk_live_abcdefghijklmnop".len() + 4);
+}
+
+#[tokio::test]
+async fn apply_composio_byo_settings_sets_key() {
+    let mut config = Config::default();
+    let tmp = tempfile::tempdir().unwrap();
+    config.config_path = tmp.path().join("config.toml");
+    config.workspace_dir = tmp.path().to_path_buf();
+    let patch = ComposioByoSettingsPatch {
+        byo_api_key: Some(Some("  sk_live_xyz  ".to_string())),
+    };
+    apply_composio_byo_settings(&mut config, patch)
+        .await
+        .unwrap();
+    assert_eq!(config.composio.byo_api_key.as_deref(), Some("sk_live_xyz"));
+}
+
+#[tokio::test]
+async fn apply_composio_byo_settings_clears_with_null() {
+    let mut config = Config::default();
+    let tmp = tempfile::tempdir().unwrap();
+    config.config_path = tmp.path().join("config.toml");
+    config.workspace_dir = tmp.path().to_path_buf();
+    config.composio.byo_api_key = Some("sk_live_existing".to_string());
+    let patch = ComposioByoSettingsPatch {
+        byo_api_key: Some(None),
+    };
+    apply_composio_byo_settings(&mut config, patch)
+        .await
+        .unwrap();
+    assert!(config.composio.byo_api_key.is_none());
+}
+
+#[tokio::test]
+async fn apply_composio_byo_settings_treats_empty_string_as_clear() {
+    let mut config = Config::default();
+    let tmp = tempfile::tempdir().unwrap();
+    config.config_path = tmp.path().join("config.toml");
+    config.workspace_dir = tmp.path().to_path_buf();
+    config.composio.byo_api_key = Some("sk_live_existing".to_string());
+    let patch = ComposioByoSettingsPatch {
+        byo_api_key: Some(Some("   ".to_string())),
+    };
+    apply_composio_byo_settings(&mut config, patch)
+        .await
+        .unwrap();
+    assert!(config.composio.byo_api_key.is_none());
+}

--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -1315,6 +1315,18 @@ impl Config {
             );
             self.context.tool_result_budget_bytes = self.agent.tool_result_budget_bytes;
         }
+
+        // `COMPOSIO_API_KEY` — user's BYO Composio API key. When set
+        // (non-empty), the core bypasses the openhuman backend proxy and
+        // calls api.composio.dev directly. Empty / whitespace-only
+        // values are ignored.
+        if let Some(key) = env.get("COMPOSIO_API_KEY") {
+            let trimmed = key.trim();
+            if !trimmed.is_empty() {
+                self.composio.byo_api_key = Some(trimmed.to_string());
+                tracing::debug!("[composio:config] BYO key loaded from COMPOSIO_API_KEY env");
+            }
+        }
     }
 
     pub async fn save(&self) -> Result<()> {

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -1302,3 +1302,32 @@ default_temperature = 0.7
         std::env::remove_var("OPENHUMAN_WORKSPACE");
     }
 }
+
+// ── COMPOSIO_API_KEY env override ────────────────────────────────
+
+#[test]
+fn env_overlay_sets_composio_byo_key() {
+    let env = HashMapEnv::new().with("COMPOSIO_API_KEY", "  sk_env_xyz  ");
+    let mut cfg = Config::default();
+    cfg.apply_env_overlay_with(&env);
+    assert_eq!(cfg.composio.byo_api_key.as_deref(), Some("sk_env_xyz"));
+}
+
+#[test]
+fn env_overlay_ignores_blank_composio_byo_key() {
+    let env = HashMapEnv::new().with("COMPOSIO_API_KEY", "   ");
+    let mut cfg = Config::default();
+    cfg.composio.byo_api_key = Some("existing".to_string());
+    cfg.apply_env_overlay_with(&env);
+    // Blank env value must not clobber an existing config value.
+    assert_eq!(cfg.composio.byo_api_key.as_deref(), Some("existing"));
+}
+
+#[test]
+fn env_overlay_no_composio_var_leaves_key_unchanged() {
+    let env = HashMapEnv::new();
+    let mut cfg = Config::default();
+    cfg.composio.byo_api_key = Some("from-toml".to_string());
+    cfg.apply_env_overlay_with(&env);
+    assert_eq!(cfg.composio.byo_api_key.as_deref(), Some("from-toml"));
+}

--- a/src/openhuman/config/schema/tools.rs
+++ b/src/openhuman/config/schema/tools.rs
@@ -267,10 +267,35 @@ pub struct ComposioConfig {
     /// field (e.g. `["gmail", "slack"]`).
     #[serde(default)]
     pub triage_disabled_toolkits: Vec<String>,
+    /// User-supplied Composio API key. When set, the core bypasses the
+    /// openhuman backend proxy (`/agent-integrations/composio/*`) and
+    /// talks to the Composio REST API directly using this key. The
+    /// backend proxy is the default when `None` or empty.
+    ///
+    /// Triggers (webhooks) are not supported in BYO mode — they require
+    /// the hosted backend to receive HMAC-verified Composio callbacks
+    /// and fan them out over Socket.IO. BYO trigger calls return a
+    /// `composio_byo_unsupported` error so the UI can surface a clear
+    /// "switch off BYO to use triggers" message.
+    ///
+    /// Env override: `COMPOSIO_API_KEY`.
+    #[serde(default)]
+    pub byo_api_key: Option<String>,
 }
 
 fn default_entity_id() -> String {
     "default".into()
+}
+
+impl ComposioConfig {
+    /// Returns `Some(trimmed)` only when the user actually supplied a
+    /// non-empty BYO key. Whitespace-only values are treated as unset.
+    pub fn byo_api_key_trimmed(&self) -> Option<&str> {
+        self.byo_api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
 }
 
 impl Default for ComposioConfig {
@@ -280,6 +305,7 @@ impl Default for ComposioConfig {
             entity_id: default_entity_id(),
             triage_disabled: false,
             triage_disabled_toolkits: Vec::new(),
+            byo_api_key: None,
         }
     }
 }

--- a/src/openhuman/config/schemas.rs
+++ b/src/openhuman/config/schemas.rs
@@ -88,6 +88,32 @@ struct LocalAiSettingsUpdate {
     usage_subconscious: Option<bool>,
 }
 
+/// Update params for the BYO Composio API key.
+///
+/// Field handling:
+/// - omitted        → leave key unchanged.
+/// - `null`         → clear the key (revert to proxy mode).
+/// - `""` / spaces  → clear the key.
+/// - non-empty str  → set the key.
+///
+/// `serde(default, deserialize_with = ...)` is used so we can
+/// distinguish "field omitted" from "field present and null".
+#[derive(Debug, Default, Deserialize)]
+struct ComposioByoSettingsUpdate {
+    #[serde(default, deserialize_with = "deserialize_optional_optional_string")]
+    byo_api_key: Option<Option<String>>,
+}
+
+fn deserialize_optional_optional_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(Some(opt))
+}
+
 #[derive(Debug, Deserialize)]
 struct SetBrowserAllowAllParams {
     enabled: bool,
@@ -165,6 +191,8 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("update_voice_server_settings"),
         schemas("update_composio_trigger_settings"),
         schemas("get_composio_trigger_settings"),
+        schemas("update_composio_byo_settings"),
+        schemas("get_composio_byo_status"),
     ]
 }
 
@@ -277,6 +305,14 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("get_composio_trigger_settings"),
             handler: handle_get_composio_trigger_settings,
+        },
+        RegisteredController {
+            schema: schemas("update_composio_byo_settings"),
+            handler: handle_update_composio_byo_settings,
+        },
+        RegisteredController {
+            schema: schemas("get_composio_byo_status"),
+            handler: handle_get_composio_byo_status,
         },
     ]
 }
@@ -741,6 +777,52 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 },
             ],
         },
+        "update_composio_byo_settings" => ControllerSchema {
+            namespace: "config",
+            function: "update_composio_byo_settings",
+            description:
+                "Set or clear the user-provided Composio API key. When set, the core \
+                 talks to api.composio.dev directly using this key. Triggers (webhooks) \
+                 are unavailable in BYO mode and return `composio_byo_unsupported:`. \
+                 Pass `null` or empty string to clear and revert to proxy mode.",
+            inputs: vec![FieldSchema {
+                name: "byo_api_key",
+                ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+                comment:
+                    "Composio API key to use (`null`/empty to clear). Omit to leave unchanged.",
+                required: false,
+            }],
+            outputs: vec![json_output("snapshot", "Updated config snapshot.")],
+        },
+        "get_composio_byo_status" => ControllerSchema {
+            namespace: "config",
+            function: "get_composio_byo_status",
+            description:
+                "Read the current BYO Composio key status: whether a key is configured, \
+                 a masked preview for display, and which backend `build_composio_client` \
+                 will pick (`\"direct\"` for BYO, `\"proxy\"` otherwise).",
+            inputs: vec![],
+            outputs: vec![
+                FieldSchema {
+                    name: "active",
+                    ty: TypeSchema::Bool,
+                    comment: "True when a BYO key is configured (non-empty).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "masked_key",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+                    comment: "Masked preview of the key, e.g. `sk_••••••abcd`. Null when unset.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "backend",
+                    ty: TypeSchema::String,
+                    comment: "`\"direct\"` (BYO active) or `\"proxy\"` (using openhuman backend).",
+                    required: true,
+                },
+            ],
+        },
         _ => ControllerSchema {
             namespace: "config",
             function: "unknown",
@@ -1087,6 +1169,48 @@ fn handle_get_composio_trigger_settings(_params: Map<String, Value>) -> Controll
             }
             Err(err) => {
                 log::warn!("[config][rpc] get_composio_trigger_settings failed: {err}");
+                Err(err)
+            }
+        }
+    })
+}
+
+fn handle_update_composio_byo_settings(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        log::debug!("[config][rpc] update_composio_byo_settings enter");
+        let update = match deserialize_params::<ComposioByoSettingsUpdate>(params) {
+            Ok(u) => u,
+            Err(err) => {
+                log::warn!("[config][rpc] update_composio_byo_settings invalid params: {err}");
+                return Err(err);
+            }
+        };
+        let patch = config_rpc::ComposioByoSettingsPatch {
+            byo_api_key: update.byo_api_key,
+        };
+        match config_rpc::load_and_apply_composio_byo_settings(patch).await {
+            Ok(outcome) => {
+                log::debug!("[config][rpc] update_composio_byo_settings ok");
+                to_json(outcome)
+            }
+            Err(err) => {
+                log::warn!("[config][rpc] update_composio_byo_settings failed: {err}");
+                Err(err)
+            }
+        }
+    })
+}
+
+fn handle_get_composio_byo_status(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async {
+        log::debug!("[config][rpc] get_composio_byo_status enter");
+        match config_rpc::get_composio_byo_status().await {
+            Ok(outcome) => {
+                log::debug!("[config][rpc] get_composio_byo_status ok");
+                to_json(outcome)
+            }
+            Err(err) => {
+                log::warn!("[config][rpc] get_composio_byo_status failed: {err}");
                 Err(err)
             }
         }


### PR DESCRIPTION
## Summary

- New \`composio.byo_api_key\` config field (+ \`COMPOSIO_API_KEY\` env override). When set, the core bypasses the openhuman backend proxy and talks to \`api.composio.dev/api/v3/*\` directly with \`X-API-Key\`.
- Default behaviour unchanged: any user without a BYO key still goes through the hosted backend proxy.
- \`ComposioClient\` becomes an internal \`Proxy | Direct\` dispatch enum behind a stable public surface — \`ops.rs\`, \`tools.rs\`, \`schemas.rs\`, \`bus.rs\` are untouched on the call side.
- New Settings panel **Composio API Key (BYO)** (Settings → Developer Options) with key input, show/hide toggle, masked status preview, and clear/replace.
- Triggers (5 client methods) return a stable \`composio_byo_unsupported:\` sentinel in BYO mode. New \`fmt_err\` helper preserves the sentinel through error wrapping so the UI can match on \`startsWith()\`.

## Problem

Today every Composio call goes through the openhuman backend's \`/agent-integrations/composio/*\` routes, which means the hosted backend holds the shared Composio key, owns billing/margin, and enforces the toolkit allowlist. Users who want their own safety boundaries — own toolkit allowlist, own billing, no third-party key in the path — have no way to opt out. This PR adds that opt-out.

## Solution

Layered behind the existing \`ComposioClient\` so the call sites don't change:

1. **Config** — \`composio.byo_api_key: Option<String>\` plus \`COMPOSIO_API_KEY\` env override (whitespace-only values ignored).
2. **Client routing** — \`build_composio_client(&config)\` picks Direct if BYO is set, else Proxy (today's path). \`ComposioClient::is_byo()\` / \`backend_label()\` for diagnostics.
3. **Direct client** — \`src/openhuman/composio/direct.rs\` hits Composio v3 REST: \`/toolkits\`, \`/connected_accounts\`, \`/tools\`, \`/tools/execute/<slug>\`. Uses \`X-API-Key\` and forwards \`config.composio.entity_id\` as \`user_id\`.
4. **BYO-unsupported surfaces** — \`authorize\`, \`list_github_repos\`, and all 5 trigger methods return a stable \`composio_byo_unsupported:\` sentinel error. Triggers need a public webhook endpoint that only the hosted backend can provide; \`authorize\` needs a pre-provisioned \`auth_config_id\` in the user's Composio dashboard. \`list_active_triggers\` returns an empty list (so polling UI doesn't error). The Settings panel surfaces the caveat explicitly.
5. **RPC** — new \`config_update_composio_byo_settings\` (set/clear with \`null\`-or-empty semantics) and \`config_get_composio_byo_status\` (returns \`{ active, masked_key, backend: "direct"|"proxy" }\`). Mask keeps first 3 / last 4 chars, redacts the middle.
6. **UI** — \`ComposioByoPanel\` with key input (password by default, show/hide), masked active-key preview, BYO caveats card, and clear-back-to-hosted button.

### Tests added

- 7 direct-client tests (mocked Composio v3: toolkits, connections, execute, delete, BYO-unsupported).
- 4 client-routing tests (BYO selection, whitespace fallback, trigger gating, empty active-triggers).
- 4 config-ops tests (set / clear via null / clear via empty / mask_secret short+long).
- 3 env-overlay tests (\`COMPOSIO_API_KEY\` set / blank / absent).
- 2 \`fmt_err\` tests (sentinel passthrough vs op-context wrapping).

Local: \`cargo test --lib composio::\` → 413 passing. \`cargo test --lib config::ops::tests::\` → 43 passing.

### Pre-push hook note

The pre-push hook flagged a pre-existing TS error on \`main\` — \`app/src/services/analytics.ts:22 Cannot find module 'react-ga4'\` (introduced in #1533, untouched by this PR). Pushed with \`--no-verify\` per CLAUDE.md guidance for unrelated pre-existing breakage. All of this PR's own changes \`cargo fmt\`, \`cargo check\`, and prettier cleanly.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via \`diff-cover\`) meet the gate enforced by [\`.github/workflows/coverage.yml\`](../.github/workflows/coverage.yml). Run \`pnpm test:coverage\` and \`pnpm test:rust\` locally; PRs below 80% on changed lines will not merge.
- [ ] N/A: feature surfaces aren't tracked in the matrix today — this is a new opt-in toggle, not a renamed/removed capability
- [ ] N/A: no matrix feature IDs to list (see previous item)
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] N/A: BYO is opt-in via Developer Options and doesn't change default behaviour — not a release-cut smoke surface
- [ ] N/A: no linked issue — feature came from in-session request

## Impact

- **Desktop only.** Tauri host unchanged. No mobile/CLI surface touched.
- **Performance:** identical to today for non-BYO users (default path). BYO mode adds one extra HTTP hop's worth of latency saved (no proxy round-trip) but loses backend-side caching.
- **Security:** BYO key is stored in \`config.toml\` (same as other user-supplied credentials). Never logged or echoed; settings panel only ever shows a masked preview (\`sk_••••••abcd\`). Triggers/webhooks remain on the hosted backend with HMAC verification.
- **Migration:** none. Existing \`config.toml\` files without \`composio.byo_api_key\` keep proxy behaviour exactly.
- **Composio v3 endpoint shapes:** implemented against my read of Composio's public REST API. Tests exercise the mapped shapes via a local mock HTTP server, but live-key end-to-end validation needs a manual smoke pass.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - Live-key smoke test against \`api.composio.dev\` to validate v3 endpoint mappings (toolkits / connected_accounts / tools / execute).
  - Consider surfacing a \"BYO key is set but failed handshake\" banner if the first call after enabling returns 401.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/composio-byo-api-key
- Commit SHA: facd8f8438089665dfd4e70b50956bd7c6cbfbeb

### Validation Run
- [ ] N/A: \`pnpm --filter openhuman-app format:check\` — ran \`npx prettier\` on touched TS files, passes
- [ ] N/A: \`pnpm typecheck\` — pre-existing \`react-ga4\` error on \`main\` blocks the project-wide run; touched files type-check cleanly (see \"Pre-push hook note\" above)
- [x] Focused tests: \`cargo test --lib composio::\` (413 passing), \`cargo test --lib config::ops::tests::\` (43 passing), \`pnpm debug unit ComposioTriagePanel\` (7 passing), \`pnpm debug unit DeveloperOptionsPanel\` (13 passing), \`pnpm debug unit config\` (81 passing)
- [x] Rust fmt/check (if changed): \`cargo fmt\` applied, \`cargo check\` clean
- [ ] N/A: Tauri fmt/check (if changed) — no Tauri shell code touched

### Validation Blocked
- \`command:\` \`pnpm typecheck\`
- \`error:\` \`src/services/analytics.ts:22 Cannot find module 'react-ga4'\`
- \`impact:\` Pre-existing on \`main\` (introduced in #1533) — independent of this PR; project-wide \`tsc --noEmit\` won't pass until that is addressed

### Behavior Changes
- Intended behavior change: opt-in BYO mode that routes Composio API calls directly to \`api.composio.dev\` using a user-supplied key, bypassing the hosted backend for tool calls
- User-visible effect: new Settings panel; users with a BYO key see backend badge change from \"proxy\" to \"direct\"; triggers return a clear unsupported message in BYO mode

### Parity Contract
- Legacy behavior preserved: \`build_composio_client\` returns a proxy-backed client identical to before whenever \`composio.byo_api_key\` is unset (the default). All 27 existing proxy mock-HTTP tests pass unchanged.
- Guard/fallback/dispatch parity checks: input validation (\`authorize\`, \`delete_connection\`, \`execute_tool\`, trigger methods) runs on both backends before any HTTP work, returning the same error messages.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Composio API Key (BYO)" settings panel to manage your own Composio API key.
  * Support for `COMPOSIO_API_KEY` environment variable configuration.
  * Users can switch between bring-your-own mode and hosted backend.
  * Direct API mode available when BYO key is configured; note that webhook/trigger features require hosted backend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1671)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->