### PR TITLE
fix(memory): use floor_char_boundary in body_preview slice

### DIFF
--- a/src/openhuman/memory/tree/ingest.rs
+++ b/src/openhuman/memory/tree/ingest.rs
@@ -173,9 +173,7 @@ async fn persist(
     // sources are conversational and have no trailing structure worth scanning, so
     // they get body_preview = None.
     let body_preview: Option<String> = match source_kind_for_store {
-        SourceKind::Email | SourceKind::Document => {
-            Some(build_body_preview(&canonical.markdown))
-        }
+        SourceKind::Email | SourceKind::Document => Some(build_body_preview(&canonical.markdown)),
         _ => None,
     };
 
@@ -556,8 +554,7 @@ mod tests {
     fn body_preview_long_ascii_truncates_to_trailing_bytes() {
         let long = "A".repeat(4096);
         let preview = super::build_body_preview(&long);
-        assert!(preview.len() >= 2048);
-        assert!(preview.len() <= 2048 + 3); // at most 3 extra bytes from boundary rounding
+        assert_eq!(preview.len(), 2048); // ASCII has no multibyte rounding
     }
 
     #[test]

--- a/src/openhuman/memory/tree/ingest.rs
+++ b/src/openhuman/memory/tree/ingest.rs
@@ -150,6 +150,16 @@ async fn already_ingested(
         .map_err(|e| anyhow::anyhow!("already_ingested join error: {e}"))?
 }
 
+/// Build a trailing body preview (last ~2048 bytes), safe for multibyte UTF-8.
+fn build_body_preview(md: &str) -> String {
+    let len = md.len();
+    if len <= 2048 {
+        return md.to_string();
+    }
+    let start = crate::openhuman::util::floor_char_boundary(md, len - 2048);
+    md[start..].to_string()
+}
+
 async fn persist(
     config: &Config,
     source_id: &str,
@@ -164,13 +174,7 @@ async fn persist(
     // they get body_preview = None.
     let body_preview: Option<String> = match source_kind_for_store {
         SourceKind::Email | SourceKind::Document => {
-            let md = &canonical.markdown;
-            let len = md.len();
-            Some(if len <= 2048 {
-                md.clone()
-            } else {
-                md[len - 2048..].to_string()
-            })
+            Some(build_body_preview(&canonical.markdown))
         }
         _ => None,
     };
@@ -540,5 +544,34 @@ mod tests {
         drain_until_idle(&cfg).await.unwrap();
         assert_eq!(count_chunks(&cfg).unwrap(), 1);
         assert_eq!(count_scores(&cfg).unwrap(), 1);
+    }
+
+    #[test]
+    fn body_preview_short_string_returned_whole() {
+        let short = "Hello world";
+        assert_eq!(super::build_body_preview(short), short);
+    }
+
+    #[test]
+    fn body_preview_long_ascii_truncates_to_trailing_bytes() {
+        let long = "A".repeat(4096);
+        let preview = super::build_body_preview(&long);
+        assert!(preview.len() >= 2048);
+        assert!(preview.len() <= 2048 + 3); // at most 3 extra bytes from boundary rounding
+    }
+
+    #[test]
+    fn body_preview_multibyte_at_cut_point_does_not_panic() {
+        // U+200C (ZWNJ) is 3 bytes: E2 80 8C
+        // Construct so len - 2048 lands inside the 3-byte codepoint.
+        let prefix = "X".repeat(2045);
+        let zwnj = "\u{200C}"; // 3 bytes at positions 2045..2048
+        let suffix = "Y".repeat(2046); // total = 2045 + 3 + 2046 = 4094; len-2048 = 2046 → inside ZWNJ
+        let input = format!("{}{}{}", prefix, zwnj, suffix);
+        assert_eq!(input.len(), 4094);
+        // This is the exact regression case: len - 2048 = 2046, byte index inside ZWNJ
+        let preview = super::build_body_preview(&input); // must not panic
+        assert!(preview.is_char_boundary(0));
+        assert!(preview.len() >= 2046); // at least the suffix
     }
 }


### PR DESCRIPTION
## Summary

- Fix fatal panic in memory tree ingest when `body_preview` slice lands inside a multibyte UTF-8 codepoint.
- Extract `build_body_preview` helper using existing `floor_char_boundary` util.
- Add 3 unit tests covering short string, long ASCII, and multibyte-at-boundary cases.

## Problem

- `src/openhuman/memory/tree/ingest.rs:172` slices canonical markdown with raw byte indexing: `md[len - 2048..]`.
- When `len - 2048` lands inside a multibyte UTF-8 char (e.g. U+200C ZWNJ, 3 bytes), Rust panics with `byte index N is not a char boundary`.
- Fatal panic kills the tokio blocking thread mid Gmail sync. Sentry: OPENHUMAN-TAURI-CP (4 occurrences).

## Solution

- Use `crate::openhuman::util::floor_char_boundary(md, len - 2048)` to round the cut-point down to the nearest char boundary before slicing.
- Extracted into a `build_body_preview` helper for independent testability.
- Same pattern already used in 10+ other callsites (web_fetch, inject, routing, etc.).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case)
- [x] Diff coverage >= 80% — 3 tests cover all new/changed lines
- [x] Coverage matrix updated — N/A: bugfix-only, no new feature rows
- [x] All affected feature IDs from the matrix are listed — N/A: bugfix
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated — N/A: internal memory pipeline
- [x] Linked issue closed via `Closes #NNN` in the Related section

## Impact

- Desktop only (Tauri sidecar). No web/mobile/CLI impact.
- Fixes fatal crash during Gmail sync for emails containing multibyte chars near the 2KB boundary.
- No performance regression — `floor_char_boundary` is O(1) to O(3) byte scan.

## Related

- Closes #1654

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

- N/A (human PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview generation now safely truncates text at UTF-8 character boundaries, preventing corruption for email and document previews.

* **Tests**
  * Added tests covering short inputs, exact-size truncation, and multibyte boundary cases to ensure stable preview behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1681)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->