### PR TITLE
fix(updater): quiet passive check failures

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -330,6 +330,15 @@ struct AppUpdateInfo {
     body: Option<String>,
 }
 
+fn no_app_update_available(current_version: String) -> AppUpdateInfo {
+    AppUpdateInfo {
+        current_version,
+        available: false,
+        available_version: None,
+        body: None,
+    }
+}
+
 /// Probe the updater endpoint and report whether a newer shell build is available.
 /// Does NOT download or install. Pair with `apply_app_update` to actually upgrade.
 #[tauri::command]
@@ -359,16 +368,13 @@ async fn check_app_update(app: tauri::AppHandle<AppRuntime>) -> Result<AppUpdate
         }
         Ok(None) => {
             log::info!("[app-update] no update available");
-            Ok(AppUpdateInfo {
-                current_version,
-                available: false,
-                available_version: None,
-                body: None,
-            })
+            Ok(no_app_update_available(current_version))
         }
         Err(e) => {
-            log::warn!("[app-update] check failed: {e}");
-            Err(format!("update check failed: {e}"))
+            log::warn!(
+                "[app-update] check failed; treating as no update available for this probe: {e}"
+            );
+            Ok(no_app_update_available(current_version))
         }
     }
 }
@@ -2512,6 +2518,16 @@ mod tests {
         // The type alias exists at module scope and is used throughout.
         fn _check_runtime<R: tauri::Runtime>() {}
         // _check_runtime::<AppRuntime>(); // Would require importing
+    }
+
+    #[test]
+    fn no_app_update_available_result_is_quiet_unavailable() {
+        let info = no_app_update_available("0.53.43".to_string());
+
+        assert_eq!(info.current_version, "0.53.43");
+        assert!(!info.available);
+        assert!(info.available_version.is_none());
+        assert!(info.body.is_none());
     }
 
     /// Verify tray logging patterns exist (grep-friendly)


### PR DESCRIPTION
﻿## Summary
- Treat passive app updater probe failures as a quiet "no update available" result instead of returning an error to the auto-check path.
- Reuse the same unavailable result shape for both `Ok(None)` and reachability failures.
- Keep manual download/apply flows unchanged, so explicit update attempts still emit error status when they fail.

Closes #1614.

## Validation
- PASS: `rustfmt app\src-tauri\src\lib.rs --edition 2021 --check`
- PASS: `git diff --check`
- BLOCKED: `cargo test --manifest-path app\src-tauri\Cargo.toml no_app_update_available_result_is_quiet_unavailable --lib` cannot finish on this Windows machine because native build dependencies are missing: `libclang` for `whisper-rs-sys` and `ninja` for `cef-dll-sys`.
- BLOCKED: `node scripts\codex-pr-preflight.mjs --lightweight` still reports missing repo file `docs/src/README.md`; all other relevant checks, including branch naming and changed file readability, pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app update checking to consistently report unavailable status when no updates are found or checks fail, preventing unnecessary error messages.

* **Tests**
  * Added unit test for update availability checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1685)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->