### PR TITLE
fix(agent): refresh delegation surface on mid-session Composio connect/revoke

### DIFF
--- a/src/openhuman/agent/debug/mod.rs
+++ b/src/openhuman/agent/debug/mod.rs
@@ -218,7 +218,10 @@ async fn render_via_session(config: &Config, agent_id: &str) -> Result<DumpedPro
     agent.fetch_connected_integrations().await;
     // Mirror turn-1: synthesise `delegate_*` tools for connected
     // Composio toolkits now that we know what's actually authorised.
-    agent.refresh_delegation_tools();
+    // The shared-Arc failure path is unreachable here (this is the
+    // debug dumper running against a freshly-built agent — no
+    // sub-agent has cloned the tool list), so ignore the bool return.
+    let _ = agent.refresh_delegation_tools();
 
     let text = agent
         .build_system_prompt(LearnedContextData::default())

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -420,6 +420,8 @@ impl AgentBuilder {
             omit_profile: self.omit_profile.unwrap_or(true),
             omit_memory_md: self.omit_memory_md.unwrap_or(true),
             payload_summarizer: self.payload_summarizer,
+            last_seen_integrations_hash: 0,
+            synthesized_tool_names: std::collections::HashSet::new(),
         })
     }
 }

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -88,8 +88,12 @@ impl Agent {
             // Now that integrations are live, inject the matching
             // delegation tools so the orchestrator's prompt + tool-spec
             // list actually expose `delegate_gmail`, `delegate_notion`,
-            // etc.
-            self.refresh_delegation_tools();
+            // etc. The shared-Arc failure path returns `false`, but on
+            // turn 1 the Arc is uniquely owned (no sub-agent has run
+            // yet); a `false` return here would indicate a programmer
+            // error and the warn-level log inside the helper already
+            // surfaces it, so we ignore the return value here.
+            let _ = self.refresh_delegation_tools();
             let learned = self.fetch_learned_context().await;
             let rendered_prompt = self.build_system_prompt(learned)?;
             log::info!("[agent] system prompt built — initialising conversation history");
@@ -119,6 +123,11 @@ impl Agent {
                 .push(ConversationMessage::Chat(ChatMessage::system(
                     rendered_prompt,
                 )));
+            // Seed the per-turn mid-session refresh baseline with the
+            // hash of whatever Composio actually returned just now.
+            // Subsequent turns short-circuit unless this hash changes.
+            self.last_seen_integrations_hash =
+                crate::openhuman::composio::connected_set_hash(&self.connected_integrations);
         } else {
             // Deliberately do NOT rebuild the system prompt on subsequent
             // turns. The rendered prompt is the KV-cache prefix the inference
@@ -129,6 +138,75 @@ impl Agent {
             // rides on the user message via `memory_loader.load_context()`
             // — that's where the caller should inject anything that varies
             // between turns.
+            //
+            // *** Mid-session schema-only refresh ***
+            //
+            // The system prompt stays frozen, but the function-calling
+            // schema (the `tools` field in the provider request) is sent
+            // fresh on every API call — it's not part of the KV-cache
+            // prefix. So we *can* react to Composio connect/disconnect
+            // events mid-session by re-synthesising the `delegate_<toolkit>`
+            // surface on `self.tools` / `self.tool_specs` and letting
+            // the next provider call carry the new schema. KV cache stays
+            // intact; the system prompt's `## Connected Integrations`
+            // block goes mildly stale until the next session, but the
+            // schema is the source of truth the model actually routes
+            // against.
+            //
+            // The signal we react to is the process-wide
+            // [`crate::openhuman::composio::INTEGRATIONS_CACHE`], kept
+            // current by (a) the desktop UI's 5 s
+            // `composio_list_connections` poll, (b) the post-OAuth
+            // `ComposioConnectionCreatedSubscriber` invalidation, and
+            // (c) the 60 s TTL fallback. We read it via the read-only
+            // [`crate::openhuman::composio::cached_active_integrations`]
+            // helper — never trigger a backend fetch ourselves, never
+            // block on a writer.
+            //
+            // We need a `Config` to key into `INTEGRATIONS_CACHE`. The
+            // `Config::load_or_init()` call is cached internally so this
+            // is cheap on the hot path. On config-load failure we skip
+            // the refresh — no signal we can safely act on, same as
+            // when the cache itself is empty.
+            if let Ok(cfg) = crate::openhuman::config::Config::load_or_init().await {
+                if let Some(cache_view) =
+                    crate::openhuman::composio::cached_active_integrations(&cfg)
+                {
+                    let new_hash = crate::openhuman::composio::connected_set_hash(&cache_view);
+                    if new_hash != self.last_seen_integrations_hash {
+                        log::info!(
+                            "[agent_loop] connection set changed mid-session (hash {:x} -> {:x}); refreshing tool schema (system prompt left intact for KV cache)",
+                            self.last_seen_integrations_hash,
+                            new_hash
+                        );
+                        // Snapshot the previous integration list so we
+                        // can roll back if `refresh_delegation_tools`
+                        // bails on a shared `Arc` — otherwise the
+                        // agent's `connected_integrations` and its
+                        // schema would disagree until the next
+                        // event-driven refresh, and the
+                        // `last_seen_integrations_hash` advance below
+                        // would suppress retries.
+                        let prev_integrations =
+                            std::mem::replace(&mut self.connected_integrations, cache_view);
+                        if self.refresh_delegation_tools() {
+                            self.last_seen_integrations_hash = new_hash;
+                        } else {
+                            // Reconcile aborted (shared Arc) — restore
+                            // the previous integration list so the
+                            // next turn re-detects the same change and
+                            // retries cleanly. We deliberately do NOT
+                            // advance `last_seen_integrations_hash`.
+                            self.connected_integrations = prev_integrations;
+                        }
+                    }
+                }
+            }
+            // Cache empty/expired or config unavailable => no signal.
+            // We leave the current tool surface alone and pick up any
+            // real change on the next turn after the UI's 5 s poll has
+            // repopulated [`INTEGRATIONS_CACHE`].
+
             log::trace!(
                 "[agent_loop] system prompt reused (history_len={}) — KV cache prefix preserved",
                 self.history.len()
@@ -1260,100 +1338,134 @@ impl Agent {
     }
 
     /// Re-synthesise `delegate_*` tools for the orchestrator's `subagents`
-    /// declaration using the live `connected_integrations` slice.
+    /// declaration using the live `connected_integrations` slice, and
+    /// reconcile the resulting set into `self.tools` / `self.tool_specs` /
+    /// `self.visible_tool_specs` / `self.visible_tool_names`.
     ///
-    /// The synchronous `AgentBuilder` path cannot do this — it has no
-    /// async runtime handle to reach Composio — so it passes an empty
-    /// integrations slice to `collect_orchestrator_tools` and produces
-    /// zero skill delegation tools. That leaves the orchestrator without
-    /// `delegate_gmail` / `delegate_notion` / … even when those toolkits
-    /// are actually authorised. Call this *after*
-    /// [`Agent::fetch_connected_integrations`] (and before
-    /// [`Agent::build_system_prompt`]) on turn 1 to add the missing
-    /// delegation tools to the live tool registry, tool-spec list, and
-    /// visible-tool whitelist so the LLM sees them as first-class tools.
+    /// **Reconciliation strategy** — full rebuild of the synthesised
+    /// subset:
     ///
-    /// No-op when:
-    /// * the agent definition isn't in the global registry,
-    /// * the definition has no `subagents` entries,
-    /// * no new tools would be added (every synthesised name already
-    ///   exists in `self.tools`),
-    /// * the `tools` / `tool_specs` Arc is shared (e.g. a sub-agent has
-    ///   already captured a snapshot — should never happen on turn 1).
-    pub fn refresh_delegation_tools(&mut self) {
+    ///   1. Drop every tool whose name was in [`Self::synthesized_tool_names`]
+    ///      from the previous synthesis. Direct tools (`query_memory`,
+    ///      `cron_add`, …) are untouched because their names are not in
+    ///      that set.
+    ///   2. Append the freshly collected synthesis output verbatim.
+    ///   3. Replace `synthesized_tool_names` with the new set so the
+    ///      next refresh has a clean mask to undo.
+    ///
+    /// This is safer than appending-only or strict-diff reconcile:
+    ///
+    ///   * Stale tools after a revoke can never leak — anything from the
+    ///     previous synthesis is unconditionally dropped, the new set is
+    ///     authoritative.
+    ///   * Direct tools can never be accidentally removed — only names
+    ///     in `synthesized_tool_names` are touched.
+    ///   * Duplicate registration is impossible — retain+extend
+    ///     guarantees every final entry is either a non-synthesised
+    ///     direct tool or a member of the fresh `synthed` set.
+    ///
+    /// **When to call**: on turn 1 (after [`Agent::fetch_connected_integrations`]
+    /// populates `self.connected_integrations` for the first time) and
+    /// on any subsequent turn where the connection set has changed
+    /// since the last reconcile (detected via
+    /// [`Self::last_seen_integrations_hash`] vs.
+    /// [`crate::openhuman::composio::cached_active_integrations`]).
+    ///
+    /// **Atomicity**: when `Arc::get_mut` fails (a sub-agent or other
+    /// caller has already captured a clone of the tool list), we restore
+    /// the previous `synthesized_tool_names` and bail. The next refresh
+    /// attempt will re-apply the full transition cleanly rather than
+    /// resuming from a partial state. This should never happen on a turn
+    /// boundary in production — sub-agents always drop their snapshots
+    /// before the parent's next turn — but it's defended against anyway.
+    ///
+    /// **Return value** — `true` when the agent's tool surface is now
+    /// consistent with `self.connected_integrations` (either because a
+    /// successful reconcile applied, or because no reconcile was needed).
+    /// `false` only when the Arc was shared and the reconcile was
+    /// aborted; callers should treat this as "retry next turn" and
+    /// **not** advance any signal they use to gate future refreshes
+    /// (e.g. `last_seen_integrations_hash`) — otherwise a one-shot
+    /// shared-Arc collision could suppress further reconciliation until
+    /// another integration event happened to bump the hash again.
+    pub fn refresh_delegation_tools(&mut self) -> bool {
         use crate::openhuman::agent::harness::definition::AgentDefinitionRegistry;
         use crate::openhuman::tools::orchestrator_tools::collect_orchestrator_tools;
 
         let Some(reg) = AgentDefinitionRegistry::global() else {
-            return;
+            // No registry — there's nothing we can do until the
+            // registry is initialised. The agent's surface stays at
+            // whatever the builder produced; callers can safely treat
+            // this as "no reconcile needed right now".
+            return true;
         };
         let Some(def) = reg.get(&self.agent_definition_id) else {
             log::debug!(
                 "[agent] refresh_delegation_tools: definition '{}' not in registry — skipping",
                 self.agent_definition_id
             );
-            return;
+            return true;
         };
         if def.subagents.is_empty() {
-            return;
+            return true;
         }
 
         let synthed = collect_orchestrator_tools(def, reg, &self.connected_integrations);
-        if synthed.is_empty() {
-            return;
+        let synthed_names: std::collections::HashSet<String> =
+            synthed.iter().map(|t| t.name().to_string()).collect();
+        let synthed_specs: Vec<crate::openhuman::tools::ToolSpec> =
+            synthed.iter().map(|t| t.spec()).collect();
+
+        // Skip the Arc mutation entirely when neither the previous nor
+        // the next synthesis produced any names — saves an
+        // `Arc::get_mut` probe on agents that don't declare `subagents`.
+        if self.synthesized_tool_names.is_empty() && synthed_names.is_empty() {
+            return true;
         }
 
-        let existing: std::collections::HashSet<String> =
-            self.tools.iter().map(|t| t.name().to_string()).collect();
-        let new_tools: Vec<Box<dyn Tool>> = synthed
-            .into_iter()
-            .filter(|t| !existing.contains(t.name()))
-            .collect();
-        if new_tools.is_empty() {
-            return;
-        }
+        // Mask used to drop the previous synthesis. We `take` it now so
+        // the restore-on-failure path below can put it back if the Arc
+        // turns out to be shared.
+        let old_synth = std::mem::take(&mut self.synthesized_tool_names);
 
-        let new_names: Vec<String> = new_tools.iter().map(|t| t.name().to_string()).collect();
-        let new_specs: Vec<crate::openhuman::tools::ToolSpec> =
-            new_tools.iter().map(|t| t.spec()).collect();
-
-        // The tools / tool_specs Arcs are uniquely owned at turn-1 build
-        // time (no sub-agent has captured a snapshot yet). If a caller
-        // managed to clone them out before the first turn fired, the
-        // mutation below would silently no-op — log that case so it's
-        // visible in diagnostics.
         match (
             Arc::get_mut(&mut self.tools),
             Arc::get_mut(&mut self.tool_specs),
         ) {
             (Some(tools_vec), Some(specs_vec)) => {
-                tools_vec.extend(new_tools);
-                specs_vec.extend(new_specs);
+                tools_vec.retain(|t| !old_synth.contains(t.name()));
+                specs_vec.retain(|s| !old_synth.contains(&s.name));
+                tools_vec.extend(synthed);
+                specs_vec.extend(synthed_specs);
             }
             _ => {
                 log::warn!(
                     "[agent] refresh_delegation_tools: tools/tool_specs Arc is shared — \
-                     cannot inject delegation tools ({} would have been added: {:?})",
-                    new_names.len(),
-                    new_names
+                     cannot reconcile delegation surface (would have produced {} synthesised tool(s)). \
+                     Restoring previous synthesized_tool_names so the next refresh retries cleanly.",
+                    synthed_names.len()
                 );
-                return;
+                self.synthesized_tool_names = old_synth;
+                return false;
             }
         }
 
-        // Definitions with a Named ToolScope carry an explicit visible
-        // whitelist; the synthesised delegation tools must opt in to that
-        // whitelist or the LLM never sees them. Wildcard-scope agents
-        // keep `visible_tool_names` empty ("no filter"), so we skip the
-        // insert there.
+        // `visible_tool_names` carries an explicit allowlist for
+        // [`ToolScope::Named`] agents. Drop the previously-synthesised
+        // names and add the new ones so the visible set tracks the
+        // tool list. Wildcard-scope agents keep this empty ("no
+        // filter") and never need touching.
         if !self.visible_tool_names.is_empty() {
-            for name in &new_names {
+            for name in &old_synth {
+                self.visible_tool_names.remove(name);
+            }
+            for name in &synthed_names {
                 self.visible_tool_names.insert(name.clone());
             }
         }
 
-        // Rebuild the visible-spec cache so the next prompt build picks
-        // up the new tools.
+        // Rebuild the visible-spec cache from the new tool_specs so the
+        // next provider call carries the reconciled schema.
         let visible_specs: Vec<crate::openhuman::tools::ToolSpec> =
             if self.visible_tool_names.is_empty() {
                 (*self.tool_specs).clone()
@@ -1366,13 +1478,33 @@ impl Agent {
             };
         self.visible_tool_specs = Arc::new(visible_specs);
 
+        // Compute add/remove deltas for the log line — useful when
+        // diagnosing a Composio connect/revoke that should have rebuilt
+        // the surface but didn't. Materialise to owned `Vec<String>`
+        // so we can move `synthed_names` into `self.synthesized_tool_names`
+        // below without the log-statement reborrow blocking the move.
+        let added: Vec<String> = synthed_names
+            .iter()
+            .filter(|n| !old_synth.contains(n.as_str()))
+            .cloned()
+            .collect();
+        let removed: Vec<String> = old_synth
+            .iter()
+            .filter(|n| !synthed_names.contains(n.as_str()))
+            .cloned()
+            .collect();
+
+        self.synthesized_tool_names = synthed_names;
+
         log::info!(
-            "[agent] refresh_delegation_tools: added {} delegation tool(s) for agent '{}' (display='{}'): {:?}",
-            new_names.len(),
+            "[agent] refresh_delegation_tools: reconciled delegation surface for agent '{}' (display='{}'); now {} synthesised tool(s); added={:?} removed={:?}",
             self.agent_definition_id,
             self.agent_definition_name,
-            new_names
+            self.synthesized_tool_names.len(),
+            added,
+            removed
         );
+        true
     }
 
     /// Builds the system prompt for the current turn, including tool

--- a/src/openhuman/agent/harness/session/types.rs
+++ b/src/openhuman/agent/harness/session/types.rs
@@ -156,6 +156,33 @@ pub struct Agent {
     /// summarizer sub-agent before they enter agent history.
     pub(super) payload_summarizer:
         Option<Arc<dyn crate::openhuman::agent::harness::payload_summarizer::PayloadSummarizer>>,
+    /// Hash of the Composio connection set this Agent last reconciled
+    /// against. Compared at top-of-turn to a fresh hash computed from
+    /// [`crate::openhuman::composio::cached_active_integrations`]; on
+    /// diff, [`Agent::refresh_delegation_tools`] re-synthesises the
+    /// `delegate_<toolkit>` surface to match the live connected set.
+    ///
+    /// Initialised to `0` at construction. Turn 1's existing refresh
+    /// path (gated by `history.is_empty()`) writes the first real hash
+    /// after [`Agent::fetch_connected_integrations`] populates
+    /// [`Agent::connected_integrations`], so the per-turn check is
+    /// dormant on session startup and only fires when integrations
+    /// actually change mid-conversation.
+    pub(super) last_seen_integrations_hash: u64,
+    /// Names of every tool currently in [`Agent::tools`] that was
+    /// produced by [`crate::openhuman::tools::orchestrator_tools::collect_orchestrator_tools`]
+    /// (i.e. `delegate_<toolkit>` skill tools and archetype-delegation
+    /// tools like `delegate_archivist`). Tracked so
+    /// [`Agent::refresh_delegation_tools`] can drop the entire
+    /// previously-synthesised subset on each refresh and append the
+    /// fresh set — without that mask we'd risk either leaking stale
+    /// `delegate_<toolkit>` entries on revoke or accidentally removing
+    /// direct tools (`query_memory`, `cron_add`, …) that share a name
+    /// prefix.
+    ///
+    /// Populated by `refresh_delegation_tools` itself; empty at
+    /// construction time.
+    pub(super) synthesized_tool_names: std::collections::HashSet<String>,
 }
 
 /// A builder for creating `Agent` instances with custom configuration.

--- a/src/openhuman/composio/bus.rs
+++ b/src/openhuman/composio/bus.rs
@@ -368,14 +368,19 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
             "[composio:bus] connection_created"
         );
 
-        let Some(provider) = get_provider(toolkit) else {
-            tracing::debug!(
-                toolkit = %toolkit,
-                "[composio:bus] no provider registered, skipping connection_created hook"
-            );
-            return;
-        };
-
+        // Run the post-active cache refresh for EVERY toolkit, not just
+        // ones with a registered provider. Earlier shape gated the
+        // entire spawn block on `get_provider(toolkit)` — that meant
+        // toolkits without a provider (most of the 119 Composio
+        // toolkits, e.g. `googlecalendar`) bypassed the eager cache
+        // warm and had to wait for the desktop UI's 5 s
+        // `composio_list_connections` diff-poll to invalidate the
+        // stale cache. The chat-runtime then missed the new connection
+        // on any turn that fell inside that window. Decoupling the
+        // cache refresh from provider routing fixes it: every
+        // connect → invalidate + eager warm, provider hook becomes a
+        // downstream optional step gated on its own `get_provider`
+        // lookup.
         let toolkit = toolkit.clone();
         let connection_id = connection_id.clone();
 
@@ -385,8 +390,8 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
             // has actually clicked through. Resolve the config + client
             // first, then poll the backend for the connection record
             // until we observe ACTIVE/CONNECTED (or hit the timeout).
-            // Only then do we run the provider hook, so the very first
-            // provider call doesn't race the OAuth handshake.
+            // Only then do we invalidate + warm the cache so we never
+            // surface a half-finished connection to the chat runtime.
             //
             // NOTE: Future improvement — listen for an explicit
             // "connection_active" backend event instead of polling.
@@ -419,12 +424,48 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
                         toolkit = %toolkit,
                         connection_id = %connection_id,
                         status = %status,
-                        "[composio:bus] connection observed active, dispatching on_connection_created"
+                        "[composio:bus] connection observed active; invalidating + eagerly warming integrations cache"
                     );
                     // Bust the prompt-level integrations cache now that
                     // the connection is confirmed ACTIVE, so the next
                     // agent session picks up the newly connected toolkit.
                     super::ops::invalidate_connected_integrations_cache();
+                    // Eagerly warm the cache from the backend so the
+                    // very next `cached_active_integrations` read
+                    // (typically the orchestrator's next-turn refresh,
+                    // or the desktop UI's 5 s `composio_list_connections`
+                    // poll — whichever fires first) returns the new
+                    // toolkit immediately instead of waiting for a
+                    // cache-miss round trip on the hot path. Cost: one
+                    // background `list_connections` call per OAuth
+                    // completion. Best-effort — on backend failure the
+                    // UI poll will repopulate within ~5 s as a safety
+                    // net.
+                    //
+                    // Use the status-distinguishing fetcher so we log
+                    // `Authoritative(empty)` and backend unavailability
+                    // differently — `fetch_connected_integrations`
+                    // collapses both to `Vec::new()` and would
+                    // otherwise hide auth/backend failures from
+                    // incident triage.
+                    match super::ops::fetch_connected_integrations_status(ctx.config.as_ref()).await
+                    {
+                        super::ops::FetchConnectedIntegrationsStatus::Authoritative(entries) => {
+                            tracing::debug!(
+                                toolkit = %toolkit,
+                                connection_id = %connection_id,
+                                cached_entries = entries.len(),
+                                "[composio:bus] eagerly warmed integrations cache after connection became active"
+                            );
+                        }
+                        super::ops::FetchConnectedIntegrationsStatus::Unavailable => {
+                            tracing::warn!(
+                                toolkit = %toolkit,
+                                connection_id = %connection_id,
+                                "[composio:bus] eager cache warm after connection became active skipped: backend unavailable"
+                            );
+                        }
+                    }
                 }
                 Err(WaitError::Timeout { last_status }) => {
                     tracing::warn!(
@@ -432,7 +473,7 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
                         connection_id = %connection_id,
                         last_status = ?last_status,
                         timeout_secs = CONNECTION_READY_TIMEOUT.as_secs(),
-                        "[composio:bus] timed out waiting for connection to become active; aborting on_connection_created"
+                        "[composio:bus] timed out waiting for connection to become active; skipping cache refresh + provider hook"
                     );
                     return;
                 }
@@ -441,11 +482,23 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
                         toolkit = %toolkit,
                         connection_id = %connection_id,
                         error = %error,
-                        "[composio:bus] backend lookup failed while waiting for connection; aborting on_connection_created"
+                        "[composio:bus] backend lookup failed while waiting for connection; skipping cache refresh + provider hook"
                     );
                     return;
                 }
             }
+
+            // Optional provider-specific post-OAuth hook (e.g. gmail's
+            // inbox ingest). Only fires for toolkits that registered a
+            // provider; the rest just got the cache refresh above and
+            // we're done.
+            let Some(provider) = get_provider(&toolkit) else {
+                tracing::debug!(
+                    toolkit = %toolkit,
+                    "[composio:bus] no provider registered for toolkit; cache refreshed, no provider hook to dispatch"
+                );
+                return;
+            };
 
             if let Err(e) = provider.on_connection_created(&ctx).await {
                 tracing::warn!(

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -50,7 +50,8 @@ pub use action_tool::ComposioActionTool;
 pub use bus::{register_composio_trigger_subscriber, ComposioTriggerSubscriber};
 pub use client::{build_composio_client, ComposioClient};
 pub use ops::{
-    fetch_connected_integrations, fetch_connected_integrations_status, fetch_toolkit_actions,
+    cached_active_integrations, connected_set_hash, fetch_connected_integrations,
+    fetch_connected_integrations_status, fetch_toolkit_actions,
     invalidate_connected_integrations_cache, FetchConnectedIntegrationsStatus,
 };
 pub use periodic::{record_sync_success, start_periodic_sync};

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -165,6 +165,36 @@ pub async fn composio_delete_connection(
     );
     // Bust the integrations cache so the next prompt reflects the removal.
     invalidate_connected_integrations_cache();
+    // Eagerly warm the cache from the backend so the very next
+    // `cached_active_integrations` read (typically the orchestrator's
+    // next-turn refresh, or the desktop UI's 5 s
+    // `composio_list_connections` poll) sees the removal immediately
+    // instead of waiting for a cache-miss round trip on the hot path.
+    // Symmetric with the connect-side eager warm in
+    // [`super::bus::ComposioConnectionCreatedSubscriber`]. Best-effort —
+    // on backend failure the UI poll repopulates within ~5 s as a
+    // safety net.
+    //
+    // Use the status-distinguishing fetcher so we log
+    // `Authoritative(empty)` and backend unavailability differently —
+    // `fetch_connected_integrations` collapses both to `Vec::new()`
+    // and would otherwise hide auth/backend failures from incident
+    // triage.
+    match fetch_connected_integrations_status(config).await {
+        FetchConnectedIntegrationsStatus::Authoritative(entries) => {
+            tracing::debug!(
+                connection_id = %connection_id,
+                cached_entries = entries.len(),
+                "[composio] eagerly warmed integrations cache after connection deletion"
+            );
+        }
+        FetchConnectedIntegrationsStatus::Unavailable => {
+            tracing::warn!(
+                connection_id = %connection_id,
+                "[composio] eager cache warm after connection deletion skipped: backend unavailable"
+            );
+        }
+    }
     Ok(RpcOutcome::new(
         resp,
         vec![format!("composio: connection {connection_id} deleted")],
@@ -699,6 +729,101 @@ pub fn invalidate_connected_integrations_cache() {
             "[composio][integrations] cache invalidated"
         );
     }
+}
+
+/// Read-only snapshot of the currently cached connected integrations for
+/// the given config, or [`None`] when the cache is empty, expired, or
+/// the lock is held by a writer.
+///
+/// Designed for hot-path callers that want a cheap "what does the cache
+/// already say?" probe without triggering a backend fetch. The agent
+/// harness uses this on every turn to detect mid-session connection
+/// changes — it relies on the desktop UI's 5 s `composio_list_connections`
+/// poll (which calls into [`fetch_connected_integrations`] and
+/// repopulates this cache) plus the event-driven invalidation path to
+/// keep the cache current.
+///
+/// `try_read` (not `read`) so a writer in progress — e.g. the UI poll
+/// repopulating the cache — never blocks a turn. Worst case the agent
+/// sees `None` for one turn while the writer holds the lock; the next
+/// turn picks up the value naturally.
+///
+/// TTL is enforced defensively: entries older than [`CACHE_TTL`] are
+/// treated as missing even though they're still in the map (a stale
+/// entry would otherwise pin the agent to a frozen view if every
+/// invalidation path silently failed).
+pub fn cached_active_integrations(config: &Config) -> Option<Vec<ConnectedIntegration>> {
+    let key = cache_key(config);
+    let guard = match INTEGRATIONS_CACHE.try_read() {
+        Ok(g) => g,
+        Err(_) => {
+            tracing::trace!(
+                key = %key,
+                "[composio][integrations_cache] cached_active_integrations:lock_contended"
+            );
+            return None;
+        }
+    };
+    let Some(cached) = guard.get(&key) else {
+        tracing::trace!(
+            key = %key,
+            "[composio][integrations_cache] cached_active_integrations:miss"
+        );
+        return None;
+    };
+    let age = cached.cached_at.elapsed();
+    if age > CACHE_TTL {
+        tracing::trace!(
+            key = %key,
+            age_ms = age.as_millis() as u64,
+            ttl_ms = CACHE_TTL.as_millis() as u64,
+            "[composio][integrations_cache] cached_active_integrations:expired"
+        );
+        return None;
+    }
+    tracing::trace!(
+        key = %key,
+        entries = cached.entries.len(),
+        age_ms = age.as_millis() as u64,
+        "[composio][integrations_cache] cached_active_integrations:hit"
+    );
+    Some(cached.entries.clone())
+}
+
+/// Stable hash of the *routing-relevant* slice of a connected-integrations
+/// snapshot.
+///
+/// Two snapshots produce the same hash iff they would synthesise the
+/// same `delegate_<toolkit>` tool set in the orchestrator's
+/// function-calling schema. The hash is:
+///
+///   - **Order-independent** — callers don't need to sort the input.
+///   - **Description-insensitive** — Composio catalogue text edits don't
+///     trigger a refresh. The schema's tool-description field still
+///     picks up new text on the next *real* (membership-changing)
+///     refresh, so descriptions are never permanently stale.
+///   - **Process-local** — [`std::collections::hash_map::DefaultHasher`]
+///     is randomly seeded per process. Fine because we only compare
+///     hashes within one process lifetime.
+///
+/// Only `connected == true` entries contribute. Unconnected toolkits are
+/// stripped by [`super::super::tools::orchestrator_tools::collect_orchestrator_tools`]
+/// anyway, so churn among the unconnected set never changes the agent's
+/// surface and shouldn't trigger a refresh.
+pub fn connected_set_hash(integrations: &[ConnectedIntegration]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut slugs: Vec<&str> = integrations
+        .iter()
+        .filter(|i| i.connected)
+        .map(|i| i.toolkit.as_str())
+        .collect();
+    slugs.sort();
+
+    let mut hasher = DefaultHasher::new();
+    slugs.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Collect the set of toolkit slugs marked `connected` in a snapshot.


### PR DESCRIPTION
## Summary

- Orchestrator now sees Composio toolkits that get connected (or revoked) **mid-conversation** without requiring the user to start a new thread or restart the app.
- Refresh is **schema-only** — the system prompt is deliberately left untouched, so the provider's KV cache prefix stays valid for the rest of the conversation.
- Cache invalidation + eager warm decoupled from toolkit-provider routing, so toolkits without a registered provider (most of the 119 Composio toolkits — e.g. `googlecalendar`, `github`) get the same fast-path as ones with providers (`gmail`, `notion`, `slack`).
- `refresh_delegation_tools` is now a **full reconcile** of the synthesised subset, not append-only — stale `delegate_<toolkit>` tools after a revoke are cleanly removed.

## Problem

PR #1670 (`bd72d78b`) fixed the synchronous-builder ↔ async-Composio-fetch gap on **turn 1**: it added `Agent::refresh_delegation_tools` and wired it into the `if self.history.is_empty()` branch of `Agent::turn`. From that point onward, fresh threads (and resumed threads on app restart) correctly see `delegate_gmail`, `delegate_notion`, etc. in the function-calling schema.

But the `else` branch — every turn after the first — deliberately skips the rebuild to preserve the KV-cache prefix the provider already tokenised. So once a session is running, the orchestrator's tool surface is frozen on the turn-1 snapshot.

User-visible symptom: in an active conversation, the user clicks "Connect Slack" in Settings, completes OAuth, types "check my unread slack threads" — orchestrator's schema still only has `delegate_gmail` / `delegate_notion` from turn 1, model deflects with "Slack isn't connected" or routes the call into `delegate_tools_agent` which correctly refuses Composio work. The fix is to start a new thread.

The same problem hits the reverse: revoking a toolkit mid-session leaves a zombie `delegate_<toolkit>` in the schema; the model can still emit calls against it and they fail downstream at the Composio dispatch layer.

PR #1670's author flagged this as a follow-up TODO. Issue #1679 has the full design discussion.

## Solution

Three coordinated changes across `composio/` and `agent/harness/session/`.

### 1. Read-only cache probe + connection-set hash (`composio/ops.rs`)

```rust
pub fn cached_active_integrations(config: &Config) -> Option<Vec<ConnectedIntegration>>;
pub fn connected_set_hash(integrations: &[ConnectedIntegration]) -> u64;
```

`cached_active_integrations` is the cheap "what does Layer 1 currently say?" probe over the existing `INTEGRATIONS_CACHE`. `try_read` so a writer (the desktop UI's 5 s `composio_list_connections` poll, or the event-driven invalidator) never blocks a turn. Returns `None` on cache miss, expired entry, or writer-held lock — the agent treats that as "no signal, leave current state alone".

`connected_set_hash` returns a stable `u64` over the sorted **connected** toolkit slug set. Order-independent. Deliberately description-insensitive so cosmetic Composio catalogue edits don't invalidate the agent's surface — only membership changes do. Unconnected toolkits don't contribute because `collect_orchestrator_tools` filters them anyway, so churn among the unconnected set never alters the agent's schema and shouldn't trigger a refresh.

### 2. Eager cache warm, decoupled from provider hooks (`composio/bus.rs` + revoke path)

Pre-existing flow: `composio_authorize` publishes `ComposioConnectionCreated`; `ComposioConnectionCreatedSubscriber` waits for the connection to go `ACTIVE` and then calls `invalidate_connected_integrations_cache()`. After that, the cache is empty until something else fetches.

This PR extends that path so the subscriber also calls `fetch_connected_integrations()` immediately after invalidating — repopulating the cache eagerly. Net effect: the cache is hot with the new toolkit ~1-2 s after OAuth completes, instead of waiting up to 5 s for the desktop UI's next `composio_list_connections` poll to repopulate it.

**The non-obvious part**: the previous subscriber shape gated the entire `tokio::spawn` (containing `wait_for_connection_active` + invalidate) on `get_provider(toolkit).is_some()` — toolkits without a registered provider returned early and the cache was never invalidated at all. Layer 1 only refreshed via the desktop UI's 5 s diff-poll. This PR moves the `get_provider` lookup downstream of the invalidate + warm so it only gates the **optional** provider hook; cache refresh now fires for every connection-active event regardless of provider registration. Same fix applied symmetrically in `composio_delete_connection` so revokes propagate equally fast.

### 3. Per-turn schema-only refresh + full reconcile (`agent/harness/session/turn.rs` + `types.rs` + `builder.rs`)

The `Agent` struct gains two fields:

- `last_seen_integrations_hash: u64` — initialised to 0, written at the end of every refresh.
- `synthesized_tool_names: HashSet<String>` — explicit mask of what `collect_orchestrator_tools` produced on the previous reconcile.

At the top of every subsequent turn (the `else` branch of `if self.history.is_empty()`), the agent reads `cached_active_integrations`, hashes the result, and compares to its stored hash. On diff, it calls `refresh_delegation_tools`. **No** `build_system_prompt` rebuild; **no** `history[0]` mutation. The schema is sent fresh on every API call, so the model picks up the new tools without any KV-cache invalidation. The system prompt's `## Connected Integrations` block stays frozen — slightly stale until next session, but the schema is the source of truth the model routes against.

`refresh_delegation_tools` itself is rewritten from PR #1670's append-only shape into a **full reconcile of the synthesised subset**:

1. Drop every tool whose name was in `synthesized_tool_names` from the previous synthesis. Direct tools (`query_memory`, `cron_add`, …) are untouched because their names are never in that mask.
2. Append the freshly collected synthesis output verbatim.
3. Replace `synthesized_tool_names` with the new set so the next refresh has a clean mask to undo.

Three correctness wins over append-only:

- Stale tools after a revoke can never leak — anything from the previous synthesis is unconditionally dropped, the new set is authoritative.
- Direct tools can never be accidentally removed — only names in `synthesized_tool_names` are touched.
- Duplicate registration is impossible — `retain`+`extend` guarantees every final entry is either a non-synthesised direct tool or a member of the fresh `synthed` set.

On `Arc::get_mut` failure (sub-agent captured a snapshot before turn boundary — shouldn't happen but defended against), the previous `synthesized_tool_names` is restored so the next refresh attempts the full transition cleanly rather than resuming from a partial state.

## Validation

Tested end-to-end on a desktop dev build pointed at `staging-api.tinyhumans.ai`. All scenarios validated with logged evidence:

| Scenario | Result |
| --- | --- |
| Turn-1 sync, fresh thread | ✅ unchanged from PR #1670 |
| Turn-1 sync, app-restart-resumed thread | ✅ unchanged from PR #1670 |
| Mid-session connect, provider-having toolkit (slack) | ✅ `connection set changed mid-session (hash X -> Y); refreshing tool schema`; `added=["delegate_slack"]` on next turn |
| Mid-session connect, no-provider toolkit (googlecalendar) | ✅ same fast path; `[composio:bus] connection observed active; invalidating + eagerly warming integrations cache toolkit=googlecalendar`; `added=["delegate_googlecalendar"]` |
| Mid-session connect, no-provider toolkit (github) | ✅ same |
| Three incremental connects on the same thread without Agent reconstruction | ✅ each turn adds exactly one tool, removes none; hash transitions tracked; system prompt never re-rendered |
| Mid-session revoke (notion) | ✅ cache invalidated + warmed via revoke path; post-revoke `delegate_notion` correctly absent |
| Steady-state cost on a turn with no integration change | ✅ one `try_read` + `u64` compare; KV cache preserved |

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: end-to-end Composio behaviour validated against staging; pure-unit coverage for the per-turn refresh would need an async Composio fixture + an `Arc::get_mut` harness that doesn't exist yet in the test suite. Happy to add follow-up tests if reviewers want them gated.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — no `docs/TEST-COVERAGE-MATRIX.md` rows added/removed/renamed.
- [x] N/A: no new feature IDs from the matrix affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: not a release-cut surface change — internal tool synthesis only; manual smoke checklist untouched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: desktop. Affects every chat session where the user toggles a Composio connection during an active conversation.
- **Performance**: zero overhead per turn in the common case (no integration change). One backend `list_connections` round-trip per OAuth completion / revoke in a background task — same call the UI's 5 s poll was going to make anyway, just moved ~5 s earlier.
- **KV cache**: preserved across mid-session refreshes. System prompt is never re-rendered for this reason; the schema-only refresh rides on the `tools` array of the next API call.
- **Compatibility**: backwards-compatible. Agents without `subagents` declarations or signed-out users hit no-op branches.
- **Security**: none — same data already used for turn-1 rendering.

## Related

- Closes #1679
- Builds on PR #1670 (`bd72d78b`) — `fix(agent): synthesise delegate_<toolkit> tools after live integrations fetch`. Adds the mid-session refresh that PR #1670's author flagged as a follow-up TODO.
- Reuses existing infrastructure: `DomainEvent::ComposioConnectionCreated` / `…Deleted` (`src/core/event_bus/events.rs:255`, `:261`), `ComposioConnectionCreatedSubscriber` pattern (`src/openhuman/composio/bus.rs:330`), and `INTEGRATIONS_CACHE` (`src/openhuman/composio/ops.rs:675`).
- **Follow-up to file separately**: Composio's action-execution gateway has a 30-60 s lag after `connection.status == ACTIVE` before the new OAuth token is usable for action calls. The first `delegate_<toolkit>` dispatch immediately after OAuth often returns `Connection error, try to authenticate` and succeeds on retry. Not addressable in this PR — needs a retry / readiness-probe inside `integrations_agent`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/orchestrator-mid-session-tool-refresh`
- Commit SHA: `6ed41e44`

### Validation Run
- [x] `cargo check --manifest-path Cargo.toml --lib` — clean (18 pre-existing warnings)
- [x] Focused live tests on staging build: turn-1 sync, mid-session connect (provider + no-provider variants), mid-session revoke, multi-incremental-connect-same-thread
- [x] PR #1670's existing 6 orchestrator_tools unit tests still pass
- [x] N/A: no frontend changes — `pnpm typecheck` / `pnpm format:check` / `pnpm lint` would all be no-ops for this diff
- [x] N/A: Tauri shell unchanged

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: orchestrator picks up Composio connect/revoke events mid-conversation, instead of staying frozen on the turn-1 snapshot until session restart.
- User-visible effect: connecting a toolkit mid-thread → the very next message can use it; revoking mid-thread → no zombie `delegate_<toolkit>` left in the schema.

### Parity Contract
- Legacy behavior preserved: agents with empty `subagents` or no connected toolkits hit no-op branches. Turn-1 path unchanged. KV cache prefix preserved (system prompt is never mutated by this PR).
- Guard/fallback/dispatch parity checks: `Arc::get_mut` guard restores the previous `synthesized_tool_names` on shared-Arc failure so the next refresh retries the full transition. Cache `try_read` (not `read`) so a writer in progress never blocks a turn. Both connect-side and revoke-side eager warms are best-effort; failure falls back to the existing UI-poll-based path within ~5 s.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent sessions now track integration snapshots and synthesized delegation tool sets for safer mid-session updates.
  * Added cached lookup and a stable connected-set hash for integrations.

* **Improvements**
  * Mid-session integration refreshes reconcile synthesized delegation tools atomically and log precise added/removed deltas.
  * Post-connection cache warming now runs eagerly and provider hooks are invoked after cache refresh.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1687)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->