### PR TITLE
feat(deploy): add Node B Komodo CI pipeline

### DIFF
--- a/.github/workflows/build-core-image.yml
+++ b/.github/workflows/build-core-image.yml
@@ -1,0 +1,222 @@
+---
+name: Build & push core image
+
+# Builds the openhuman-core Docker image and pushes it to GHCR on every push
+# to main that touches Rust source or the Dockerfile. This is the CI leg of
+# the Node B deploy pipeline; Komodo handles the actual container swap.
+#
+# REQUIRED secrets (build-and-push job — always runs):
+#   None beyond the automatic GITHUB_TOKEN.
+#
+# OPTIONAL secrets (deploy-node-b job — skipped until all four are set):
+#   TS_OAUTH_CLIENT_ID  — Tailscale OAuth client for joining the homelab net
+#   TS_OAUTH_SECRET     — Tailscale OAuth secret (pair with the above)
+#   KOMODO_API_KEY      — Komodo API key  (Infisical apps: HOMELAB_KOMODO_API_KEY)
+#   KOMODO_API_SECRET   — Komodo API secret  (HOMELAB_KOMODO_API_SECRET)
+#
+# Tags pushed on every main build:
+#   ghcr.io/tinyhumansai/openhuman-core:<full-sha>   — immutable, used by Komodo
+#   ghcr.io/tinyhumansai/openhuman-core:<short-sha>  — 12-char convenience alias
+#   ghcr.io/tinyhumansai/openhuman-core:node-b       — mutable channel tag
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - src/**
+  workflow_dispatch:
+    inputs:
+      channel_tag:
+        description: "Mutable channel tag to push (default: node-b)"
+        required: false
+        default: node-b
+      skip_deploy:
+        description: "Build and push only — do not trigger Komodo deploy"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tinyhumansai/openhuman-core
+
+jobs:
+  # ===========================================================================
+  # Build the Rust image on GitHub's runner — keeps Node B off the build path.
+  # ===========================================================================
+  build-and-push:
+    name: Build and push openhuman-core
+    runs-on: ubuntu-22.04
+    timeout-minutes: 50
+    outputs:
+      sha_tag: ${{ steps.tags.outputs.sha_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          CHANNEL: ${{ inputs.channel_tag || 'node-b' }}
+        run: |
+          set -euo pipefail
+          base="${REGISTRY}/${IMAGE_NAME}"
+          sha="${{ github.sha }}"
+          short="${sha:0:12}"
+          {
+            echo "sha_tag=${base}:${sha}"
+            echo "short_sha=${short}"
+            echo "tags<<EOF"
+            echo "${base}:${sha}"
+            echo "${base}:${short}"
+            echo "${base}:${CHANNEL}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=build-core-image
+          cache-to: type=gha,scope=build-core-image,mode=max
+
+      - name: Verify pushed image is pullable
+        run: |
+          set -euo pipefail
+          docker pull "${{ steps.tags.outputs.sha_tag }}"
+          docker image inspect "${{ steps.tags.outputs.sha_tag }}" >/dev/null
+          echo "Image verified: ${{ steps.tags.outputs.sha_tag }}"
+
+  # ===========================================================================
+  # Update OPENHUMAN_IMAGE_TAG in the Komodo stack and trigger a redeploy.
+  #
+  # Gated on four secrets that must all be configured as GitHub Actions repo
+  # secrets before this job will run.  Until then the build-and-push job above
+  # still runs on every qualifying push — the SHA-tagged image lands in GHCR
+  # ready for a manual first deploy.
+  #
+  # Manual first-deploy checklist (one-off, before wiring this job):
+  #   1. Create Komodo Stack resource named "openhuman-core" on Node B,
+  #      pointing at the ops repo path prod/openhuman-core/docker-compose.yml.
+  #   2. In Komodo stack environment set:
+  #        OPENHUMAN_IMAGE_TAG=<sha from build-and-push above>
+  #        OPENHUMAN_CORE_TOKEN=<openssl rand -hex 32>
+  #        BACKEND_URL=https://api.tinyhumans.ai
+  #        OPENHUMAN_APP_ENV=production
+  #   3. Click Deploy in the Komodo UI. Verify:
+  #        curl -fsS http://<node-b-ip>:7788/health
+  #        curl -fsS -H "Authorization: Bearer <token>" \
+  #          -d '{"jsonrpc":"2.0","id":1,"method":"openhuman.about_app_list","params":{}}' \
+  #          http://<node-b-ip>:7788/rpc
+  #   4. Add the four secrets listed above to GitHub Actions.  Subsequent
+  #      pushes to main will deploy automatically.
+  # ===========================================================================
+  deploy-node-b:
+    name: Deploy to Node B via Komodo
+    runs-on: ubuntu-22.04
+    needs: build-and-push
+    if: >-
+      ${{
+        github.ref == 'refs/heads/main'
+        && secrets.TS_OAUTH_CLIENT_ID != ''
+        && secrets.KOMODO_API_KEY != ''
+        && inputs.skip_deploy != true
+      }}
+
+    steps:
+      - name: Join Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Update OPENHUMAN_IMAGE_TAG in Komodo and redeploy
+        env:
+          SHA: ${{ github.sha }}
+          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
+          KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+          # Komodo core reachable via Tailscale after the join step above.
+          KOMODO_BASE_URL: http://100.92.54.45:3011
+          KOMODO_STACK: openhuman-core
+        run: |
+          set -euo pipefail
+
+          echo "[komodo] reading current stack config for ${KOMODO_STACK}"
+          STACK=$(curl -fsS -X POST "${KOMODO_BASE_URL}/read" \
+            -H "X-Api-Key: ${KOMODO_API_KEY}" \
+            -H "X-Api-Secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "{\"type\":\"GetStack\",\"params\":{\"stack\":\"${KOMODO_STACK}\"}}")
+
+          STACK_ID=$(echo "$STACK" | jq -r '.id')
+          if [ -z "$STACK_ID" ] || [ "$STACK_ID" = "null" ]; then
+            echo "[komodo] ERROR: could not resolve stack id — is '${KOMODO_STACK}' the correct name?"
+            echo "$STACK" | jq .
+            exit 1
+          fi
+
+          CURRENT_ENV=$(echo "$STACK" | jq -r '.config.environment // ""')
+
+          # Replace OPENHUMAN_IMAGE_TAG in place; add it if absent.
+          FILTERED=$(echo "$CURRENT_ENV" | grep -v '^OPENHUMAN_IMAGE_TAG=' || true)
+          if [ -n "$FILTERED" ]; then
+            UPDATED_ENV="${FILTERED}"$'\nOPENHUMAN_IMAGE_TAG='"${SHA}"
+          else
+            UPDATED_ENV="OPENHUMAN_IMAGE_TAG=${SHA}"
+          fi
+
+          echo "[komodo] updating stack environment (OPENHUMAN_IMAGE_TAG -> ${SHA:0:12})"
+          curl -fsS -X POST "${KOMODO_BASE_URL}/write" \
+            -H "X-Api-Key: ${KOMODO_API_KEY}" \
+            -H "X-Api-Secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg id  "$STACK_ID" \
+              --arg env "$UPDATED_ENV" \
+              '{"type":"UpdateStack","params":{"id":$id,"config":{"environment":$env}}}')"
+
+          echo "[komodo] triggering DeployStack for ${KOMODO_STACK}"
+          curl -fsS -X POST "${KOMODO_BASE_URL}/execute" \
+            -H "X-Api-Key: ${KOMODO_API_KEY}" \
+            -H "X-Api-Secret: ${KOMODO_API_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d "{\"type\":\"DeployStack\",\"params\":{\"stack\":\"${KOMODO_STACK}\"}}"
+
+          echo "[komodo] deploy triggered: ${KOMODO_STACK} @ ${SHA:0:12}"

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ tauri.key.pub
 /target/
 src-tauri/target/
 .target-codex/
+.worktrees/
 
 workflow
 .fastembed_cache

--- a/deploy/node-b/docker-compose.yml
+++ b/deploy/node-b/docker-compose.yml
@@ -1,0 +1,57 @@
+# OpenHuman Core — Node B production stack (Komodo-managed)
+#
+# Copy this file to the ops repo at:
+#   prod/openhuman-core/docker-compose.yml
+#
+# Komodo writes a .env file into the stack directory at deploy time using the
+# environment variables configured in the Stack resource.  Docker Compose reads
+# .env automatically for ${VAR} substitution in this file.
+#
+# Stack environment vars to configure in Komodo (not in git — no secrets here):
+#
+#   OPENHUMAN_IMAGE_TAG   Full git SHA from CI  (e.g. abc123def456...)
+#                         Updated automatically by the build-core-image CI job.
+#
+#   OPENHUMAN_CORE_TOKEN  Bearer token for /rpc  (openssl rand -hex 32)
+#
+#   BACKEND_URL           https://api.tinyhumans.ai   (or staging URL)
+#
+#   OPENHUMAN_APP_ENV     production  (or staging)
+#
+# Rollback: set OPENHUMAN_IMAGE_TAG back to the previous SHA in the Komodo
+# stack environment and click Deploy (or use the Komodo API).
+
+services:
+  openhuman-core:
+    image: ghcr.io/tinyhumansai/openhuman-core:${OPENHUMAN_IMAGE_TAG:-latest}
+    container_name: openhuman-core
+    restart: unless-stopped
+    # Bind to localhost only — Caddy or another proxy terminates TLS and
+    # forwards to this port.  Do NOT expose 7788 on 0.0.0.0 in production.
+    ports:
+      - "127.0.0.1:7788:7788"
+    environment:
+      OPENHUMAN_CORE_HOST: 0.0.0.0
+      OPENHUMAN_CORE_PORT: "7788"
+      OPENHUMAN_WORKSPACE: /home/openhuman/.openhuman
+      OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY: supervisor
+      OPENHUMAN_AUTO_UPDATE_RPC_MUTATIONS_ENABLED: "false"
+      RUST_LOG: info
+      # Injected from Komodo stack env → .env → docker compose substitution:
+      OPENHUMAN_CORE_TOKEN: ${OPENHUMAN_CORE_TOKEN}
+      BACKEND_URL: ${BACKEND_URL}
+      OPENHUMAN_APP_ENV: ${OPENHUMAN_APP_ENV:-production}
+    volumes:
+      - openhuman-workspace:/home/openhuman/.openhuman
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:7788/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
+volumes:
+  openhuman-workspace:
+    # Named volume — survives container recreations and image updates.
+    # Data lives at /var/lib/docker/volumes/openhuman-workspace on Node B.
+    name: openhuman-workspace


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-core-image.yml`: builds and pushes `ghcr.io/tinyhumansai/openhuman-core` on every push to `main` that touches Rust source or the Dockerfile. Tags pushed: `:<sha>`, `:<short-sha>`, `:node-b`. A conditional `deploy-node-b` job updates `OPENHUMAN_IMAGE_TAG` in the Komodo stack on Node B via Tailscale and triggers `DeployStack` (skipped until 4 repo secrets are configured — see below).
- Adds `deploy/node-b/docker-compose.yml`: reference compose already copied to `prod/openhuman-core/` in the ops repo and deployed on Node B.

## Node B deploy status

The `prod-openhuman-core` Komodo Stack on Node B is **already live** running `v0.53.43/latest`. Smoke tests passed.

## To enable automated CI deploy (deploy-node-b job)

Add these 4 secrets to the repo's **Settings → Secrets → Actions**:

| Secret | How to get it |
|--------|---------------|
| `TS_OAUTH_CLIENT_ID` | Tailscale admin → Settings → OAuth clients → New client (tag: `tag:ci`) |
| `TS_OAUTH_SECRET` | Pair with the above |
| `KOMODO_API_KEY` | `HOMELAB_KOMODO_API_KEY` in Infisical apps project |
| `KOMODO_API_SECRET` | `HOMELAB_KOMODO_API_SECRET` in Infisical apps project |

## Test plan

- [ ] Merge and verify `build-core-image` workflow triggers on next `src/` or `Dockerfile` change to `main`
- [ ] Confirm Node B container still healthy: `ssh sprooty@192.168.1.75 "curl -fsS http://localhost:7788/health"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated Docker image building, registry publication, and conditional deployment to Node B when required credentials are available.
  * Configured Node B production deployment stack with comprehensive environment setup, health checks, and persistent workspace volumes.
  * Updated development environment configuration patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->