### PR TITLE
fix(config): isolate backend API URL resolution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,30 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Guard hosted backend URL resolver usage
+        run: |
+          set -eu
+          if git grep -n -E '(^|[^[:alnum:]_])effective_api_url[[:space:]]*\(' -- \
+            src/core/jsonrpc.rs \
+            src/openhuman/app_state \
+            src/openhuman/billing \
+            src/openhuman/channels \
+            src/openhuman/config/ops.rs \
+            src/openhuman/credentials \
+            src/openhuman/embeddings \
+            src/openhuman/integrations \
+            src/openhuman/local_ai/gif_decision.rs \
+            src/openhuman/meet_agent/brain.rs \
+            src/openhuman/memory \
+            src/openhuman/referral \
+            src/openhuman/socket \
+            src/openhuman/team \
+            src/openhuman/voice \
+            src/openhuman/webhooks; then
+            echo "Hosted backend callers must use effective_backend_api_url to avoid local-AI URL leaks."
+            exit 1
+          fi
+
       - name: Test core crate (openhuman)
         run: cargo test -p openhuman
 

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -9,14 +9,6 @@ pub const APP_ENV_VAR: &str = "OPENHUMAN_APP_ENV";
 /// Vite-exposed app-environment selector used by the frontend bundle.
 pub const VITE_APP_ENV_VAR: &str = "VITE_OPENHUMAN_APP_ENV";
 
-/// Resolves the hosted API base URL (no path suffix).
-///
-/// Order:
-/// 1. Non-empty `api_url` from config (user explicitly set it)
-/// 2. `BACKEND_URL` / `VITE_BACKEND_URL` runtime env vars (each checked independently)
-/// 3. `BACKEND_URL` / `VITE_BACKEND_URL` baked in at compile time via `option_env!`
-/// 4. Environment-aware default: `app_env_from_env()` == `staging` →
-///    [`DEFAULT_STAGING_API_BASE_URL`], otherwise [`DEFAULT_API_BASE_URL`]
 /// Default path the OpenHuman backend exposes for its OpenAI-compatible
 /// inference proxy. Joined onto [`effective_api_url`] when the user has not
 /// configured a custom `inference_url`.
@@ -31,7 +23,7 @@ pub const OPENHUMAN_INFERENCE_PATH: &str = "/openai/v1/chat/completions";
 ///    via the safe [`api_url`] helper, so inference flows through the OpenHuman
 ///    backend's OpenAI-compat proxy.
 ///
-/// This split is what keeps account/auth/billing calls (always `effective_api_url`)
+/// This split is what keeps hosted backend calls (via [`effective_backend_api_url`])
 /// separate from inference (this function). Mixing them is what caused
 /// `/auth/me`, `/auth/google/login`, and `/voice/*` to start hitting
 /// `api.openai.com` when the user pointed `api_url` at a custom provider.
@@ -52,6 +44,17 @@ pub fn effective_inference_url(
     )
 }
 
+/// Resolves the raw API base URL (no path suffix), honoring a user override.
+///
+/// Hosted backend callers should use [`effective_backend_api_url`] instead so
+/// local-AI chat-completions overrides do not capture non-inference requests.
+///
+/// Order:
+/// 1. Non-empty `api_url` from config (user explicitly set it)
+/// 2. `BACKEND_URL` / `VITE_BACKEND_URL` runtime env vars (each checked independently)
+/// 3. `BACKEND_URL` / `VITE_BACKEND_URL` baked in at compile time via `option_env!`
+/// 4. Environment-aware default: `app_env_from_env()` == `staging` →
+///    [`DEFAULT_STAGING_API_BASE_URL`], otherwise [`DEFAULT_API_BASE_URL`]
 pub fn effective_api_url(api_url: &Option<String>) -> String {
     if let Some(u) = api_url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         return normalize_api_base_url(u);
@@ -66,12 +69,12 @@ pub fn effective_api_url(api_url: &Option<String>) -> String {
 /// (Ollama, vLLM, LM Studio, OpenAI-compatible proxy on loopback) rather than
 /// our hosted backend?
 ///
-/// Used by [`effective_integrations_api_url`] to avoid concatenating
-/// backend-integration paths (e.g. `/agent-integrations/composio/toolkits`)
+/// Used by [`effective_backend_api_url`] to avoid concatenating
+/// backend paths (e.g. `/agent-integrations/composio/toolkits`)
 /// onto a user-set local-AI URL — see the Sentry cluster
 /// `OPENHUMAN-TAURI-51 / -80 / -7Z` where Ollama users had every integration
 /// request 404 because `config.api_url` was reused as both the chat base AND
-/// the integrations base.
+/// the backend base.
 ///
 /// Heuristic is intentionally tight:
 /// - Path explicitly ends with the OpenAI-style chat-completions endpoint
@@ -145,12 +148,12 @@ pub fn looks_like_local_ai_endpoint(url: &str) -> bool {
     port_signals_llm || path_signals_llm
 }
 
-/// Resolves the API base URL to use for **backend-proxied integrations**
+/// Resolves the API base URL to use for **hosted backend calls**
 /// (composio, channels, teams, etc.).
 ///
 /// Same resolution chain as [`effective_api_url`] EXCEPT the user override
 /// is skipped when it [`looks_like_local_ai_endpoint`]. In that case we
-/// fall through to env / default backend so integration requests still
+/// fall through to env / default backend so backend requests still
 /// hit the hosted API instead of being concatenated onto the user's
 /// local Ollama/vLLM endpoint (which only knows about chat completions
 /// and 404s every other path — see the Sentry cluster
@@ -158,17 +161,10 @@ pub fn looks_like_local_ai_endpoint(url: &str) -> bool {
 ///
 /// Logs a one-shot `warn!` the first time the fallback fires so users
 /// can see the diagnostic in their core sidecar logs.
-///
-// TODO(#1663): rename to `effective_backend_api_url` and migrate the
-// remaining `effective_api_url` callers across non-integrations domains
-// (billing, team, referral, webhooks, credentials, channels, voice,
-// socket, app_state, core/jsonrpc) per graycyrus review of PR #1630.
-// Today they silently leak the user's local-AI endpoint as the base for
-// every hosted-backend call — same bug shape, different surface.
-pub fn effective_integrations_api_url(api_url: &Option<String>) -> String {
+pub fn effective_backend_api_url(api_url: &Option<String>) -> String {
     if let Some(u) = api_url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         if looks_like_local_ai_endpoint(u) {
-            warn_integrations_url_fallback_once(u);
+            warn_backend_url_fallback_once(u);
             // Fall through to env / default — do NOT use the user override.
         } else {
             return normalize_api_base_url(u);
@@ -181,21 +177,33 @@ pub fn effective_integrations_api_url(api_url: &Option<String>) -> String {
 }
 
 /// Emit a single `warn!` **once per process lifetime** the first time
-/// [`effective_integrations_api_url`] falls back away from a user-set
+/// [`effective_backend_api_url`] falls back away from a user-set
 /// local-AI URL. Subsequent calls — including calls with a *different*
 /// local-AI URL — are silently suppressed via `std::sync::Once` so we
-/// don't spam logs on every integration request.
-fn warn_integrations_url_fallback_once(local_url: &str) {
+/// don't spam logs on every hosted backend request.
+fn warn_backend_url_fallback_once(local_url: &str) {
     use std::sync::Once;
     static WARNED: Once = Once::new();
     WARNED.call_once(|| {
+        let redacted_local_url = redact_url_for_logs(local_url);
         tracing::warn!(
-            local_url = %local_url,
+            local_url = %redacted_local_url,
             "[api/config] config.api_url looks like a local-AI endpoint; \
-             integrations base will fall back to env/default backend so \
-             /agent-integrations/* requests don't 404 against your local LLM"
+             backend base will fall back to env/default backend so \
+             hosted backend requests don't 404 against your local LLM"
         );
     });
+}
+
+fn redact_url_for_logs(raw_url: &str) -> String {
+    let Ok(mut parsed) = url::Url::parse(raw_url.trim()) else {
+        return "<invalid-url>".to_string();
+    };
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+    parsed.to_string().trim_end_matches('/').to_string()
 }
 
 /// Trim and strip trailing slashes so paths join consistently.
@@ -524,7 +532,7 @@ mod tests {
     fn looks_like_local_ai_matches_private_lan_hosts() {
         // LAN-hosted Ollama / vLLM on RFC 1918 ranges — covered by the
         // private-IP arm so users with `http://192.168.x.x:11434/v1`
-        // configurations don't see integration requests routed at the
+        // configurations don't see backend requests routed at the
         // local LLM and 404.
         assert!(looks_like_local_ai_endpoint(
             "http://192.168.1.100:11434/v1"
@@ -576,10 +584,19 @@ mod tests {
         assert!(!looks_like_local_ai_endpoint("/v1/chat/completions"));
     }
 
-    // ── effective_integrations_api_url ─────────────────────────────────
+    #[test]
+    fn redact_url_for_logs_removes_secrets() {
+        assert_eq!(
+            redact_url_for_logs("http://user:password@127.0.0.1:11434/v1?api_key=secret#fragment"),
+            "http://127.0.0.1:11434/v1"
+        );
+        assert_eq!(redact_url_for_logs("not a url"), "<invalid-url>");
+    }
+
+    // ── effective_backend_api_url ─────────────────────────────────
 
     #[test]
-    fn integrations_url_falls_back_to_default_when_override_is_local_ai() {
+    fn backend_url_falls_back_to_default_when_override_is_local_ai() {
         let _guard = ENV_LOCK.get_or_init(Mutex::default).lock().unwrap();
         // Clear env so we deterministically hit the default branch.
         let prev_backend = std::env::var("BACKEND_URL").ok();
@@ -591,7 +608,7 @@ mod tests {
         std::env::remove_var(APP_ENV_VAR);
         std::env::remove_var(VITE_APP_ENV_VAR);
 
-        let result = effective_integrations_api_url(&Some("http://127.0.0.1:11434/v1".to_string()));
+        let result = effective_backend_api_url(&Some("http://127.0.0.1:11434/v1".to_string()));
 
         // Restore env before asserting so a failing assert doesn't leak.
         match prev_backend {
@@ -615,12 +632,12 @@ mod tests {
     }
 
     #[test]
-    fn integrations_url_falls_back_to_env_when_override_is_local_ai() {
+    fn backend_url_falls_back_to_env_when_override_is_local_ai() {
         let _guard = ENV_LOCK.get_or_init(Mutex::default).lock().unwrap();
         let prev_backend = std::env::var("BACKEND_URL").ok();
         std::env::set_var("BACKEND_URL", "https://staging-api.tinyhumans.ai/");
 
-        let result = effective_integrations_api_url(&Some(
+        let result = effective_backend_api_url(&Some(
             "http://127.0.0.1:8080/v1/chat/completions".to_string(),
         ));
 
@@ -633,15 +650,15 @@ mod tests {
     }
 
     #[test]
-    fn integrations_url_keeps_real_backend_override() {
+    fn backend_url_keeps_real_backend_override() {
         // User explicitly set a real backend host — must be respected.
         let result =
-            effective_integrations_api_url(&Some("https://staging-api.tinyhumans.ai/".to_string()));
+            effective_backend_api_url(&Some("https://staging-api.tinyhumans.ai/".to_string()));
         assert_eq!(result, "https://staging-api.tinyhumans.ai");
     }
 
     #[test]
-    fn integrations_url_matches_effective_api_url_without_override() {
+    fn backend_url_matches_effective_api_url_without_override() {
         let _guard = ENV_LOCK.get_or_init(Mutex::default).lock().unwrap();
         // No override, no env → both helpers must agree.
         let prev_backend = std::env::var("BACKEND_URL").ok();
@@ -653,7 +670,7 @@ mod tests {
         std::env::remove_var(APP_ENV_VAR);
         std::env::remove_var(VITE_APP_ENV_VAR);
 
-        let integrations = effective_integrations_api_url(&None);
+        let backend = effective_backend_api_url(&None);
         let api = effective_api_url(&None);
 
         match prev_backend {
@@ -673,6 +690,6 @@ mod tests {
             None => std::env::remove_var(VITE_APP_ENV_VAR),
         }
 
-        assert_eq!(integrations, api);
+        assert_eq!(backend, api);
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,8 @@ pub mod rest;
 pub mod socket;
 
 pub use config::{
-    api_base_from_env, effective_api_url, normalize_api_base_url, DEFAULT_API_BASE_URL,
+    api_base_from_env, effective_api_url, effective_backend_api_url, normalize_api_base_url,
+    DEFAULT_API_BASE_URL,
 };
 pub use jwt::{bearer_authorization_value, get_session_token};
 pub use rest::{

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -442,7 +442,7 @@ async fn telegram_auth_handler(Query(query): Query<TelegramAuthQuery>) -> impl I
         }
     };
 
-    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
 
     let client = match crate::api::rest::BackendOAuthClient::new(&api_url) {
         Ok(c) => c,
@@ -676,8 +676,8 @@ async fn webhook_events_handler() -> Response {
 /// Handler for the root endpoint, returning server information and available endpoints.
 async fn root_handler() -> impl IntoResponse {
     let api_server = match crate::openhuman::config::Config::load_or_init().await {
-        Ok(cfg) => crate::api::config::effective_api_url(&cfg.api_url),
-        Err(_) => crate::api::config::effective_api_url(&None),
+        Ok(cfg) => crate::api::config::effective_backend_api_url(&cfg.api_url),
+        Err(_) => crate::api::config::effective_backend_api_url(&None),
     };
 
     (
@@ -1258,7 +1258,7 @@ pub async fn bootstrap_skill_runtime(embedded_core: bool) {
                 return;
             }
         };
-        let api_url = crate::api::config::effective_api_url(&config.api_url);
+        let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
         let token = match crate::api::jwt::get_session_token(&config) {
             Ok(Some(t)) => t,
             Ok(None) => {

--- a/src/openhuman/app_state/ops.rs
+++ b/src/openhuman/app_state/ops.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tempfile::NamedTempFile;
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::{bearer_authorization_value, get_session_token};
 use crate::openhuman::autocomplete::AutocompleteStatus;
 use crate::openhuman::config::rpc as config_rpc;
@@ -258,7 +258,7 @@ fn build_client() -> Result<Client, String> {
 }
 
 fn resolve_base(config: &Config) -> Result<Url, String> {
-    let base = effective_api_url(&config.api_url);
+    let base = effective_backend_api_url(&config.api_url);
     let mut parsed =
         Url::parse(base.trim()).map_err(|e| format!("invalid api_url '{}': {e}", base))?;
     if !parsed.path().ends_with('/') && parsed.path() != "/" {
@@ -315,7 +315,7 @@ fn sanitize_snapshot_user(user: Option<Value>) -> Option<Value> {
 }
 
 async fn fetch_current_user_cached(config: &Config, token: &str) -> Result<Option<Value>, String> {
-    let api_base = effective_api_url(&config.api_url)
+    let api_base = effective_backend_api_url(&config.api_url)
         .trim()
         .trim_end_matches('/')
         .to_string();

--- a/src/openhuman/billing/ops.rs
+++ b/src/openhuman/billing/ops.rs
@@ -13,7 +13,7 @@ use reqwest::Method;
 use serde::Serialize;
 use serde_json::{json, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -39,7 +39,7 @@ async fn get_authed_value(
     body: Option<Value>,
 ) -> Result<Value, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     client
         .authed_json(&token, method, path, body)

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -805,7 +805,7 @@ async fn build_channel_client() -> Option<(crate::api::rest::BackendOAuthClient,
             return None;
         }
     };
-    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
     let jwt = match crate::api::jwt::get_session_token(&config) {
         Ok(Some(t)) => t,
         Ok(None) => {
@@ -836,7 +836,7 @@ async fn send_channel_reply(channel: &str, text: &str) {
         }
     };
 
-    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
     let jwt = match crate::api::jwt::get_session_token(&config) {
         Ok(Some(t)) => t,
         Ok(None) => {

--- a/src/openhuman/channels/controllers/ops.rs
+++ b/src/openhuman/channels/controllers/ops.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::api::config::{app_env_from_env, effective_api_url, is_staging_app_env};
+use crate::api::config::{app_env_from_env, effective_backend_api_url, is_staging_app_env};
 use crate::api::jwt::get_session_token;
 use crate::api::rest::BackendOAuthClient;
 use crate::openhuman::config::{Config, DiscordConfig, IMessageConfig, TelegramConfig};
@@ -626,7 +626,7 @@ pub struct TelegramLoginCheckResult {
 pub async fn telegram_login_start(
     config: &Config,
 ) -> Result<RpcOutcome<TelegramLoginStartResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -687,7 +687,7 @@ pub async fn telegram_login_check(
     config: &Config,
     _link_token: &str,
 ) -> Result<RpcOutcome<TelegramLoginCheckResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
 
     log::debug!("[telegram-login] checking if user profile has telegramId via GET /auth/me");
@@ -792,7 +792,7 @@ pub struct DiscordLinkCheckResult {
 pub async fn discord_link_start(
     config: &Config,
 ) -> Result<RpcOutcome<DiscordLinkStartResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -846,7 +846,7 @@ pub async fn discord_link_check(
     config: &Config,
     _link_token: &str,
 ) -> Result<RpcOutcome<DiscordLinkCheckResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
 
     log::debug!("[discord-link] checking if user profile has discordId via GET /auth/me");
@@ -925,7 +925,7 @@ pub async fn channel_send_message(
     channel: &str,
     message: Value,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -952,7 +952,7 @@ pub async fn channel_send_reaction(
     channel: &str,
     reaction: Value,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -979,7 +979,7 @@ pub async fn channel_create_thread(
     channel: &str,
     title: &str,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -1008,7 +1008,7 @@ pub async fn channel_update_thread(
     thread_id: &str,
     action: &str,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -1037,7 +1037,7 @@ pub async fn channel_list_threads(
     channel: &str,
     active: Option<bool>,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 

--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -649,7 +649,7 @@ pub async fn get_composio_trigger_settings() -> Result<RpcOutcome<serde_json::Va
 /// Resolves the effective API URL from configuration or defaults.
 pub async fn load_and_resolve_api_url() -> Result<RpcOutcome<serde_json::Value>, String> {
     let config = load_config_with_timeout().await?;
-    let resolved = crate::api::config::effective_api_url(&config.api_url);
+    let resolved = crate::api::config::effective_backend_api_url(&config.api_url);
     Ok(RpcOutcome::new(json!({ "api_url": resolved }), Vec::new()))
 }
 

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -2,7 +2,7 @@
 
 use serde_json::json;
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::rest::{user_id_from_profile_payload, BackendOAuthClient};
 use crate::openhuman::config::Config;
@@ -127,7 +127,7 @@ pub async fn store_session(
         return Err("token is required".to_string());
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
 
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let settings = client
@@ -335,7 +335,7 @@ pub async fn auth_get_session_token_json(
 }
 
 pub async fn auth_get_me(config: &Config) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let user = client
@@ -355,7 +355,7 @@ pub async fn consume_login_token(
         return Err("loginToken is required".to_string());
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let jwt_token = client
         .consume_login_token(token)
@@ -387,7 +387,7 @@ pub async fn auth_create_channel_link_token(
         return Err(format!("unsupported channel: {channel}"));
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let payload = client
@@ -526,7 +526,7 @@ pub async fn oauth_connect(
     response_type: Option<&str>,
     encryption_mode: Option<&str>,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| {
         "session JWT required; complete login and store_session first".to_string()
     })?;
@@ -544,7 +544,7 @@ pub async fn oauth_connect(
 pub async fn oauth_list_integrations(
     config: &Config,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let list = client
@@ -562,7 +562,7 @@ pub async fn oauth_fetch_integration_tokens(
     integration_id: &str,
     encryption_key: &str,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let tokens = client
@@ -579,7 +579,7 @@ pub async fn oauth_fetch_client_key(
     config: &Config,
     integration_id: &str,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let client_key = client
@@ -600,7 +600,7 @@ pub async fn oauth_revoke_integration(
     config: &Config,
     integration_id: &str,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     client

--- a/src/openhuman/embeddings/cloud.rs
+++ b/src/openhuman/embeddings/cloud.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 
 use super::openai::OpenAiEmbedding;
 use super::EmbeddingProvider;
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::openhuman::credentials::{AuthService, APP_SESSION_PROVIDER};
 
 /// Default cloud embedding model — backed by `voyage-3.5` (1024 dims) on the
@@ -39,7 +39,7 @@ pub struct OpenHumanCloudEmbedding {
 impl OpenHumanCloudEmbedding {
     /// Construct a cloud embedder. `api_url` and `openhuman_dir` are looked up
     /// per request; pass `None` to fall back to the runtime defaults
-    /// ([`effective_api_url`] / `~/.openhuman`).
+    /// ([`effective_backend_api_url`] / `~/.openhuman`).
     pub fn new(
         api_url: Option<String>,
         openhuman_dir: Option<PathBuf>,
@@ -81,7 +81,7 @@ impl OpenHumanCloudEmbedding {
     }
 
     fn base_url(&self) -> String {
-        let u = effective_api_url(&self.api_url);
+        let u = effective_backend_api_url(&self.api_url);
         format!("{}/openai/v1", u.trim_end_matches('/'))
     }
 }

--- a/src/openhuman/integrations/client.rs
+++ b/src/openhuman/integrations/client.rs
@@ -259,13 +259,13 @@ impl IntegrationClient {
 ///
 /// Both the backend URL and the auth token come from **core defaults**:
 ///
-/// - backend URL → [`crate::api::config::effective_integrations_api_url`]
+/// - backend URL → [`crate::api::config::effective_backend_api_url`]
 ///   applied to `config.api_url`. Unlike the plain
 ///   [`crate::api::config::effective_api_url`] resolver (which honours a
 ///   user-set local-AI endpoint so chat completions still work), the
-///   integrations resolver detects local-AI URLs and falls back to the
+///   backend resolver detects local-AI URLs and falls back to the
 ///   `BACKEND_URL` / `VITE_BACKEND_URL` env vars (and finally the hosted
-///   default) so backend-integration paths don't get concatenated onto a
+///   default) so backend paths don't get concatenated onto a
 ///   local Ollama/vLLM endpoint and 404.
 /// - auth token → [`crate::api::jwt::get_session_token`], i.e. the
 ///   app-session JWT written by `auth_store_session` — the same token
@@ -275,15 +275,15 @@ impl IntegrationClient {
 /// callers that need a kill switch (e.g. twilio, google_places,
 /// parallel) gate tool registration at their own level.
 pub fn build_client(config: &crate::openhuman::config::Config) -> Option<Arc<IntegrationClient>> {
-    // Use the integrations-specific resolver: when `config.api_url` is set
+    // Use the hosted-backend resolver: when `config.api_url` is set
     // to a local-AI endpoint (Ollama, vLLM, …), it would still be perfect
     // for `/v1/chat/completions`, but reusing it as the base for backend
-    // integration paths produces URLs like
+    // backend paths produces URLs like
     //   http://127.0.0.1:11434/v1/agent-integrations/composio/toolkits
     // which 404 against the local LLM and flooded Sentry
     // (OPENHUMAN-TAURI-51 / -80 / -7Z). The helper falls through to env /
-    // default backend in that case so integrations actually work.
-    let backend_url = crate::api::config::effective_integrations_api_url(&config.api_url);
+    // default backend in that case so hosted backend features actually work.
+    let backend_url = crate::api::config::effective_backend_api_url(&config.api_url);
 
     // Primary: app-session JWT from the auth profile store.
     let session_token = match crate::api::jwt::get_session_token(config) {

--- a/src/openhuman/local_ai/gif_decision.rs
+++ b/src/openhuman/local_ai/gif_decision.rs
@@ -2,7 +2,7 @@
 
 use serde_json::Value;
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::rest::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -177,7 +177,7 @@ pub async fn tenor_search(
         return Err("query is required".to_string());
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 

--- a/src/openhuman/meet_agent/brain.rs
+++ b/src/openhuman/meet_agent/brain.rs
@@ -334,7 +334,7 @@ just do it.\n\
 /// the current user prompt, post it through the backend, and return
 /// the assistant's reply (trimmed, possibly empty).
 async fn llm_meeting(prompt: &str, history: &[ConversationTurn]) -> Result<String, String> {
-    use crate::api::config::effective_api_url;
+    use crate::api::config::effective_backend_api_url;
     use crate::api::jwt::get_session_token;
     use crate::api::BackendOAuthClient;
     use reqwest::Method;
@@ -345,7 +345,7 @@ async fn llm_meeting(prompt: &str, history: &[ConversationTurn]) -> Result<Strin
         .filter(|t| !t.trim().is_empty())
         .ok_or_else(|| "no backend session token".to_string())?;
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
 
     let mut messages: Vec<Value> = Vec::with_capacity(history.len() + 2);

--- a/src/openhuman/memory/tree/score/embed/cloud.rs
+++ b/src/openhuman/memory/tree/score/embed/cloud.rs
@@ -37,9 +37,9 @@ pub struct CloudEmbedder {
 
 impl CloudEmbedder {
     /// Build a cloud embedder using the same backend resolution as the
-    /// main embeddings path: `api_url` falls back to
-    /// [`effective_api_url`](crate::api::config::effective_api_url) and
-    /// the workspace dir comes from `config.workspace_dir` so the auth
+    /// main embeddings path: local-AI-looking `api_url` values fall back via
+    /// [`effective_backend_api_url`](crate::api::config::effective_backend_api_url),
+    /// and the workspace dir comes from `config.workspace_dir` so the auth
     /// service finds the user's session JWT.
     pub fn new(config: &Config) -> Self {
         let openhuman_dir = config.config_path.parent().map(std::path::PathBuf::from);

--- a/src/openhuman/referral/ops.rs
+++ b/src/openhuman/referral/ops.rs
@@ -6,7 +6,7 @@
 use reqwest::Method;
 use serde_json::{json, Map, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -27,7 +27,7 @@ fn require_token(config: &Config) -> Result<String, String> {
 
 pub async fn get_stats(config: &Config) -> Result<RpcOutcome<Value>, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let data = client
         .authed_json(&token, Method::GET, "/referral/stats", None)
@@ -45,7 +45,7 @@ pub async fn claim_referral(
     device_fingerprint: Option<&str>,
 ) -> Result<RpcOutcome<Value>, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
 
     let mut body = Map::new();

--- a/src/openhuman/socket/schemas.rs
+++ b/src/openhuman/socket/schemas.rs
@@ -222,7 +222,7 @@ fn handle_connect_with_session(_params: Map<String, Value>) -> ControllerFuture 
 
         // Load config for API URL and session token.
         let config = crate::openhuman::config::rpc::load_config_with_timeout().await?;
-        let api_url = crate::api::config::effective_api_url(&config.api_url);
+        let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
         let token = crate::api::jwt::get_session_token(&config)
             .map_err(|e| format!("failed to read session token: {e}"))?
             .ok_or("no session token stored — user must log in first")?;

--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -13,7 +13,7 @@ use reqwest::{Method, Url};
 use serde::Serialize;
 use serde_json::{json, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -62,7 +62,7 @@ async fn get_authed_value(
     body: Option<Value>,
 ) -> Result<Value, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| format!("{e:#}"))?;
     // `{e:#}` renders the full anyhow chain. `authed_json` wraps the
     // underlying reqwest error with `.context(format!("backend request {} {}", …))`

--- a/src/openhuman/voice/cloud_transcribe.rs
+++ b/src/openhuman/voice/cloud_transcribe.rs
@@ -14,7 +14,7 @@ use reqwest::header::AUTHORIZATION;
 use reqwest::multipart::{Form, Part};
 use serde::{Deserialize, Serialize};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -75,7 +75,7 @@ pub async fn transcribe_cloud(
         })
         .ok_or_else(|| "no backend session token; sign in first".to_string())?;
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let url = client
         .url_for("/openai/v1/audio/transcriptions")

--- a/src/openhuman/voice/reply_speech.rs
+++ b/src/openhuman/voice/reply_speech.rs
@@ -13,7 +13,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -92,7 +92,7 @@ pub async fn synthesize_reply(
         })
         .ok_or_else(|| "no backend session token; sign in first".to_string())?;
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
 
     let mut body = serde_json::Map::new();

--- a/src/openhuman/webhooks/ops.rs
+++ b/src/openhuman/webhooks/ops.rs
@@ -1,4 +1,4 @@
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -32,7 +32,7 @@ async fn get_authed_value(
     body: Option<Value>,
 ) -> Result<Value, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     client
         .authed_json(&token, method, path, body)


### PR DESCRIPTION
## Summary
- add `effective_backend_api_url` so hosted backend calls ignore local-AI `api_url` overrides
- migrate backend-facing call sites to the backend resolver while keeping provider/chat completions on `effective_api_url`
- add a CI grep guard to prevent regressions in backend call sites

Fixes #1663

## Testing
- cargo fmt --all -- --check
- git diff --check
- cargo test -p openhuman
- cargo clippy -p openhuman
- cargo llvm-cov -p openhuman --lcov --output-path /tmp/lcov-core.info
- pnpm --filter openhuman-app compile
- pnpm --filter openhuman-app format:check
- pnpm --filter openhuman-app lint
- app: pnpm test:coverage
- cargo test --manifest-path app/src-tauri/Cargo.toml
- cargo llvm-cov --manifest-path app/src-tauri/Cargo.toml --lcov --output-path /tmp/lcov-tauri.info
- bash scripts/install.sh --dry-run --verbose
- cargo tauri build --bundles deb
- pre-push hook: format:check, lint, compile, rust:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a hosted-backend URL resolver so backend requests ignore overrides that appear to target local-AI endpoints, preventing misrouted requests and 404s.
  * Updated app modules to use the backend-specific resolver for all backend calls, aligning cached keys and OAuth/client flows with the backend URL.

* **Tests**
  * Added a CI guard that detects and blocks direct use of the old API resolver pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1701)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->