### PR TITLE
fix(composio): retry post-oauth action readiness error

### DIFF
--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -205,10 +205,11 @@ async fn dispatch_target_agent(agent_id: &str, prompt: &str) -> anyhow::Result<S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::event_bus::{global, init_global, DomainEvent, SubscriptionHandle};
+    use crate::core::event_bus::{global, init_global, DomainEvent};
     use crate::openhuman::agent::harness::definition::AgentDefinitionRegistry;
     use serde_json::json;
-    use tokio::sync::mpsc;
+    use tokio::sync::broadcast;
+    use tokio::task::yield_now;
     use tokio::time::{timeout, Duration};
 
     fn envelope(external_id: &str) -> TriggerEnvelope {
@@ -249,16 +250,8 @@ mod tests {
         }
     }
 
-    fn subscribe_probe(name: &str) -> (mpsc::UnboundedReceiver<DomainEvent>, SubscriptionHandle) {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let handle = global().unwrap().on(name, move |event| {
-            let tx = tx.clone();
-            let event = event.clone();
-            Box::pin(async move {
-                let _ = tx.send(event);
-            })
-        });
-        (rx, handle)
+    fn subscribe_probe() -> broadcast::Receiver<DomainEvent> {
+        global().unwrap().raw_receiver()
     }
 
     fn trigger_external_id(event: &DomainEvent) -> Option<&str> {
@@ -271,29 +264,42 @@ mod tests {
     }
 
     async fn collect_trigger_events_until(
-        mut rx: mpsc::UnboundedReceiver<DomainEvent>,
+        mut rx: broadcast::Receiver<DomainEvent>,
         external_id: &str,
         expected: impl Fn(&[DomainEvent]) -> bool,
     ) -> Vec<DomainEvent> {
         let external_id = external_id.to_string();
-        let mut captured = timeout(Duration::from_secs(1), async {
+        let mut captured = timeout(Duration::from_secs(5), async {
             let mut captured = Vec::new();
             loop {
                 if expected(&captured) {
                     return captured;
                 }
-                let event = rx.recv().await.expect("probe channel should stay open");
-                if trigger_external_id(&event) == Some(external_id.as_str()) {
-                    captured.push(event);
+                match rx.recv().await {
+                    Ok(event) => {
+                        if trigger_external_id(&event) == Some(external_id.as_str()) {
+                            captured.push(event);
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        panic!("probe channel should stay open")
+                    }
                 }
             }
         })
         .await
         .expect("expected triage event should arrive");
 
-        while let Ok(Some(event)) = timeout(Duration::from_millis(50), rx.recv()).await {
-            if trigger_external_id(&event) == Some(external_id.as_str()) {
-                captured.push(event);
+        while let Ok(result) = timeout(Duration::from_millis(50), rx.recv()).await {
+            match result {
+                Ok(event) => {
+                    if trigger_external_id(&event) == Some(external_id.as_str()) {
+                        captured.push(event);
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => break,
             }
         }
 
@@ -304,13 +310,8 @@ mod tests {
     async fn apply_decision_drop_only_publishes_evaluated() {
         let envelope = envelope("esc-drop");
         let _ = init_global(32);
-        let (rx, _handle) = subscribe_probe("triage-escalation-drop");
-
-        apply_decision(run(TriageAction::Drop), &envelope)
-            .await
-            .expect("drop should not fail");
-
-        let captured = collect_trigger_events_until(rx, "esc-drop", |events| {
+        let rx = subscribe_probe();
+        let collect = tokio::spawn(collect_trigger_events_until(rx, "esc-drop", |events| {
             events.iter().any(|event| {
                 matches!(
                     event,
@@ -321,8 +322,14 @@ mod tests {
                     } if decision == "drop" && external_id == "esc-drop"
                 )
             })
-        })
-        .await;
+        }));
+        yield_now().await;
+
+        apply_decision(run(TriageAction::Drop), &envelope)
+            .await
+            .expect("drop should not fail");
+
+        let captured = collect.await.expect("event collector should not panic");
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {
@@ -343,13 +350,8 @@ mod tests {
     async fn apply_decision_acknowledge_only_publishes_evaluated() {
         let envelope = envelope("esc-ack");
         let _ = init_global(32);
-        let (rx, _handle) = subscribe_probe("triage-escalation-ack");
-
-        apply_decision(run(TriageAction::Acknowledge), &envelope)
-            .await
-            .expect("acknowledge should not fail");
-
-        let captured = collect_trigger_events_until(rx, "esc-ack", |events| {
+        let rx = subscribe_probe();
+        let collect = tokio::spawn(collect_trigger_events_until(rx, "esc-ack", |events| {
             events.iter().any(|event| {
                 matches!(
                     event,
@@ -360,8 +362,14 @@ mod tests {
                     } if decision == "acknowledge" && external_id == "esc-ack"
                 )
             })
-        })
-        .await;
+        }));
+        yield_now().await;
+
+        apply_decision(run(TriageAction::Acknowledge), &envelope)
+            .await
+            .expect("acknowledge should not fail");
+
+        let captured = collect.await.expect("event collector should not panic");
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {
@@ -383,7 +391,30 @@ mod tests {
         let envelope = envelope("esc-react-fail");
         let _ = init_global(32);
         let _ = AgentDefinitionRegistry::init_global_builtins();
-        let (rx, _handle) = subscribe_probe("triage-escalation-react-fail");
+        let rx = subscribe_probe();
+        let collect = tokio::spawn(collect_trigger_events_until(
+            rx,
+            "esc-react-fail",
+            |events| {
+                events.iter().any(|event| {
+                    matches!(
+                        event,
+                        DomainEvent::TriggerEvaluated {
+                            decision,
+                            external_id,
+                            ..
+                        } if decision == "react" && external_id == "esc-react-fail"
+                    )
+                }) && events.iter().any(|event| {
+                    matches!(
+                        event,
+                        DomainEvent::TriggerEscalationFailed { external_id, reason, .. }
+                            if external_id == "esc-react-fail" && reason.contains("missing-agent")
+                    )
+                })
+            },
+        ));
+        yield_now().await;
 
         let err = apply_decision(
             run_with_target(TriageAction::React, "missing-agent", "handle this"),
@@ -393,25 +424,7 @@ mod tests {
         .expect_err("missing target agent should fail");
         assert!(err.to_string().contains("missing-agent"));
 
-        let captured = collect_trigger_events_until(rx, "esc-react-fail", |events| {
-            events.iter().any(|event| {
-                matches!(
-                    event,
-                    DomainEvent::TriggerEvaluated {
-                        decision,
-                        external_id,
-                        ..
-                    } if decision == "react" && external_id == "esc-react-fail"
-                )
-            }) && events.iter().any(|event| {
-                matches!(
-                    event,
-                    DomainEvent::TriggerEscalationFailed { external_id, reason, .. }
-                        if external_id == "esc-react-fail" && reason.contains("missing-agent")
-                )
-            })
-        })
-        .await;
+        let captured = collect.await.expect("event collector should not panic");
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {
@@ -432,7 +445,28 @@ mod tests {
         let envelope = envelope("esc-escalate-fail");
         let _ = init_global(32);
         let _ = AgentDefinitionRegistry::init_global_builtins();
-        let (rx, _handle) = subscribe_probe("triage-escalation-escalate-fail");
+        let rx = subscribe_probe();
+        let collect = tokio::spawn(collect_trigger_events_until(
+            rx,
+            "esc-escalate-fail",
+            |events| {
+                events.iter().any(|event| {
+                    matches!(
+                event,
+                DomainEvent::TriggerEvaluated {
+                    decision,
+                    external_id,
+                    ..
+                } if decision == "escalate" && external_id == "esc-escalate-fail"
+            )
+                }) && events.iter().any(|event| matches!(
+                event,
+                DomainEvent::TriggerEscalationFailed { external_id, reason, .. }
+                    if external_id == "esc-escalate-fail" && reason.contains("missing-agent")
+            ))
+            },
+        ));
+        yield_now().await;
 
         let err = apply_decision(
             run_with_target(TriageAction::Escalate, "missing-agent", "escalate this"),
@@ -442,22 +476,7 @@ mod tests {
         .expect_err("missing orchestrator target should fail");
         assert!(err.to_string().contains("missing-agent"));
 
-        let captured =
-            collect_trigger_events_until(rx, "esc-escalate-fail", |events| {
-                events.iter().any(|event| matches!(
-                event,
-                DomainEvent::TriggerEvaluated {
-                    decision,
-                    external_id,
-                    ..
-                } if decision == "escalate" && external_id == "esc-escalate-fail"
-            )) && events.iter().any(|event| matches!(
-                event,
-                DomainEvent::TriggerEscalationFailed { external_id, reason, .. }
-                    if external_id == "esc-escalate-fail" && reason.contains("missing-agent")
-            ))
-            })
-            .await;
+        let captured = collect.await.expect("event collector should not panic");
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {

--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -205,12 +205,11 @@ async fn dispatch_target_agent(agent_id: &str, prompt: &str) -> anyhow::Result<S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::event_bus::{global, init_global, DomainEvent};
+    use crate::core::event_bus::{global, init_global, DomainEvent, SubscriptionHandle};
     use crate::openhuman::agent::harness::definition::AgentDefinitionRegistry;
     use serde_json::json;
-    use std::sync::Arc;
-    use tokio::sync::Mutex;
-    use tokio::time::{sleep, Duration};
+    use tokio::sync::mpsc;
+    use tokio::time::{timeout, Duration};
 
     fn envelope(external_id: &str) -> TriggerEnvelope {
         TriggerEnvelope::from_composio(
@@ -250,28 +249,80 @@ mod tests {
         }
     }
 
+    fn subscribe_probe(name: &str) -> (mpsc::UnboundedReceiver<DomainEvent>, SubscriptionHandle) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handle = global().unwrap().on(name, move |event| {
+            let tx = tx.clone();
+            let event = event.clone();
+            Box::pin(async move {
+                let _ = tx.send(event);
+            })
+        });
+        (rx, handle)
+    }
+
+    fn trigger_external_id(event: &DomainEvent) -> Option<&str> {
+        match event {
+            DomainEvent::TriggerEvaluated { external_id, .. }
+            | DomainEvent::TriggerEscalated { external_id, .. }
+            | DomainEvent::TriggerEscalationFailed { external_id, .. } => Some(external_id),
+            _ => None,
+        }
+    }
+
+    async fn collect_trigger_events_until(
+        mut rx: mpsc::UnboundedReceiver<DomainEvent>,
+        external_id: &str,
+        expected: impl Fn(&[DomainEvent]) -> bool,
+    ) -> Vec<DomainEvent> {
+        let external_id = external_id.to_string();
+        let mut captured = timeout(Duration::from_secs(1), async {
+            let mut captured = Vec::new();
+            loop {
+                if expected(&captured) {
+                    return captured;
+                }
+                let event = rx.recv().await.expect("probe channel should stay open");
+                if trigger_external_id(&event) == Some(external_id.as_str()) {
+                    captured.push(event);
+                }
+            }
+        })
+        .await
+        .expect("expected triage event should arrive");
+
+        while let Ok(Some(event)) = timeout(Duration::from_millis(50), rx.recv()).await {
+            if trigger_external_id(&event) == Some(external_id.as_str()) {
+                captured.push(event);
+            }
+        }
+
+        captured
+    }
+
     #[tokio::test]
     async fn apply_decision_drop_only_publishes_evaluated() {
         let envelope = envelope("esc-drop");
         let _ = init_global(32);
-        let seen = Arc::new(Mutex::new(Vec::<DomainEvent>::new()));
-        let seen_handler = Arc::clone(&seen);
-        let _handle = global()
-            .unwrap()
-            .on("triage-escalation-drop", move |event| {
-                let seen = Arc::clone(&seen_handler);
-                let cloned = event.clone();
-                Box::pin(async move {
-                    seen.lock().await.push(cloned);
-                })
-            });
+        let (rx, _handle) = subscribe_probe("triage-escalation-drop");
 
         apply_decision(run(TriageAction::Drop), &envelope)
             .await
             .expect("drop should not fail");
-        sleep(Duration::from_millis(20)).await;
 
-        let captured = seen.lock().await;
+        let captured = collect_trigger_events_until(rx, "esc-drop", |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    DomainEvent::TriggerEvaluated {
+                        decision,
+                        external_id,
+                        ..
+                    } if decision == "drop" && external_id == "esc-drop"
+                )
+            })
+        })
+        .await;
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {
@@ -292,22 +343,25 @@ mod tests {
     async fn apply_decision_acknowledge_only_publishes_evaluated() {
         let envelope = envelope("esc-ack");
         let _ = init_global(32);
-        let seen = Arc::new(Mutex::new(Vec::<DomainEvent>::new()));
-        let seen_handler = Arc::clone(&seen);
-        let _handle = global().unwrap().on("triage-escalation-ack", move |event| {
-            let seen = Arc::clone(&seen_handler);
-            let cloned = event.clone();
-            Box::pin(async move {
-                seen.lock().await.push(cloned);
-            })
-        });
+        let (rx, _handle) = subscribe_probe("triage-escalation-ack");
 
         apply_decision(run(TriageAction::Acknowledge), &envelope)
             .await
             .expect("acknowledge should not fail");
-        sleep(Duration::from_millis(20)).await;
 
-        let captured = seen.lock().await;
+        let captured = collect_trigger_events_until(rx, "esc-ack", |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    DomainEvent::TriggerEvaluated {
+                        decision,
+                        external_id,
+                        ..
+                    } if decision == "acknowledge" && external_id == "esc-ack"
+                )
+            })
+        })
+        .await;
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {
@@ -329,17 +383,7 @@ mod tests {
         let envelope = envelope("esc-react-fail");
         let _ = init_global(32);
         let _ = AgentDefinitionRegistry::init_global_builtins();
-        let seen = Arc::new(Mutex::new(Vec::<DomainEvent>::new()));
-        let seen_handler = Arc::clone(&seen);
-        let _handle = global()
-            .unwrap()
-            .on("triage-escalation-react-fail", move |event| {
-                let seen = Arc::clone(&seen_handler);
-                let cloned = event.clone();
-                Box::pin(async move {
-                    seen.lock().await.push(cloned);
-                })
-            });
+        let (rx, _handle) = subscribe_probe("triage-escalation-react-fail");
 
         let err = apply_decision(
             run_with_target(TriageAction::React, "missing-agent", "handle this"),
@@ -349,8 +393,25 @@ mod tests {
         .expect_err("missing target agent should fail");
         assert!(err.to_string().contains("missing-agent"));
 
-        sleep(Duration::from_millis(20)).await;
-        let captured = seen.lock().await;
+        let captured = collect_trigger_events_until(rx, "esc-react-fail", |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    DomainEvent::TriggerEvaluated {
+                        decision,
+                        external_id,
+                        ..
+                    } if decision == "react" && external_id == "esc-react-fail"
+                )
+            }) && events.iter().any(|event| {
+                matches!(
+                    event,
+                    DomainEvent::TriggerEscalationFailed { external_id, reason, .. }
+                        if external_id == "esc-react-fail" && reason.contains("missing-agent")
+                )
+            })
+        })
+        .await;
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {
@@ -371,17 +432,7 @@ mod tests {
         let envelope = envelope("esc-escalate-fail");
         let _ = init_global(32);
         let _ = AgentDefinitionRegistry::init_global_builtins();
-        let seen = Arc::new(Mutex::new(Vec::<DomainEvent>::new()));
-        let seen_handler = Arc::clone(&seen);
-        let _handle = global()
-            .unwrap()
-            .on("triage-escalation-escalate-fail", move |event| {
-                let seen = Arc::clone(&seen_handler);
-                let cloned = event.clone();
-                Box::pin(async move {
-                    seen.lock().await.push(cloned);
-                })
-            });
+        let (rx, _handle) = subscribe_probe("triage-escalation-escalate-fail");
 
         let err = apply_decision(
             run_with_target(TriageAction::Escalate, "missing-agent", "escalate this"),
@@ -391,8 +442,22 @@ mod tests {
         .expect_err("missing orchestrator target should fail");
         assert!(err.to_string().contains("missing-agent"));
 
-        sleep(Duration::from_millis(20)).await;
-        let captured = seen.lock().await;
+        let captured =
+            collect_trigger_events_until(rx, "esc-escalate-fail", |events| {
+                events.iter().any(|event| matches!(
+                event,
+                DomainEvent::TriggerEvaluated {
+                    decision,
+                    external_id,
+                    ..
+                } if decision == "escalate" && external_id == "esc-escalate-fail"
+            )) && events.iter().any(|event| matches!(
+                event,
+                DomainEvent::TriggerEscalationFailed { external_id, reason, .. }
+                    if external_id == "esc-escalate-fail" && reason.contains("missing-agent")
+            ))
+            })
+            .await;
         assert!(captured.iter().any(|event| matches!(
             event,
             DomainEvent::TriggerEvaluated {

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -10,6 +10,7 @@
 //! this domain can be filtered in one shot.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use serde_json::json;
@@ -22,6 +23,9 @@ use super::types::{
     ComposioDisableTriggerResponse, ComposioEnableTriggerResponse, ComposioExecuteResponse,
     ComposioGithubReposResponse, ComposioToolkitsResponse, ComposioToolsResponse,
 };
+
+const POST_OAUTH_ACTION_RETRY_DELAY: Duration = Duration::from_secs(10);
+const POST_OAUTH_AUTH_ERROR_STRINGS: &[&str] = &["connection error, try to authenticate"];
 
 /// High-level client for all backend-proxied Composio operations.
 #[derive(Clone)]
@@ -160,8 +164,35 @@ impl ComposioClient {
         let arguments = arguments.unwrap_or(serde_json::Value::Object(Default::default()));
         tracing::debug!(tool = %tool, "[composio] execute_tool");
         let body = json!({ "tool": tool, "arguments": arguments });
+        self.execute_tool_with_post_oauth_retry(tool, &body, POST_OAUTH_ACTION_RETRY_DELAY)
+            .await
+    }
+
+    async fn execute_tool_with_post_oauth_retry(
+        &self,
+        tool: &str,
+        body: &serde_json::Value,
+        retry_delay: Duration,
+    ) -> Result<ComposioExecuteResponse> {
+        let first = self.post_execute_tool(body).await?;
+        if !is_post_oauth_auth_readiness_error(&first) {
+            return Ok(first);
+        }
+
+        tracing::warn!(
+            tool = %tool,
+            retry_delay_ms = retry_delay.as_millis() as u64,
+            "[composio] action returned post-OAuth auth-readiness error; retrying once"
+        );
+        if !retry_delay.is_zero() {
+            tokio::time::sleep(retry_delay).await;
+        }
+        self.post_execute_tool(body).await
+    }
+
+    async fn post_execute_tool(&self, body: &serde_json::Value) -> Result<ComposioExecuteResponse> {
         self.inner
-            .post::<ComposioExecuteResponse>("/agent-integrations/composio/execute", &body)
+            .post::<ComposioExecuteResponse>("/agent-integrations/composio/execute", body)
             .await
     }
 
@@ -393,6 +424,19 @@ impl ComposioClient {
             anyhow::anyhow!("Backend returned success but no data for DELETE {}", url)
         })
     }
+}
+
+fn is_post_oauth_auth_readiness_error(resp: &ComposioExecuteResponse) -> bool {
+    if resp.successful {
+        return false;
+    }
+    let Some(error) = resp.error.as_deref() else {
+        return false;
+    };
+    let normalized = error.trim().to_ascii_lowercase();
+    POST_OAUTH_AUTH_ERROR_STRINGS
+        .iter()
+        .any(|needle| normalized == *needle)
 }
 
 /// Build a [`ComposioClient`] from the root config.

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -174,8 +174,23 @@ impl ComposioClient {
         body: &serde_json::Value,
         retry_delay: Duration,
     ) -> Result<ComposioExecuteResponse> {
+        tracing::debug!(
+            tool = %tool,
+            retry_delay_ms = retry_delay.as_millis() as u64,
+            attempt = 1u8,
+            "[composio] execute_tool_with_post_oauth_retry attempt"
+        );
         let first = self.post_execute_tool(body).await?;
-        if !is_post_oauth_auth_readiness_error(&first) {
+        let should_retry = is_post_oauth_auth_readiness_error(&first);
+        tracing::debug!(
+            tool = %tool,
+            attempt = 1u8,
+            successful = first.successful,
+            has_error = first.error.is_some(),
+            should_retry,
+            "[composio] execute_tool_with_post_oauth_retry branch decision"
+        );
+        if !should_retry {
             return Ok(first);
         }
 
@@ -187,7 +202,29 @@ impl ComposioClient {
         if !retry_delay.is_zero() {
             tokio::time::sleep(retry_delay).await;
         }
-        self.post_execute_tool(body).await
+        tracing::debug!(
+            tool = %tool,
+            retry_delay_ms = retry_delay.as_millis() as u64,
+            attempt = 2u8,
+            "[composio] execute_tool_with_post_oauth_retry retry dispatch"
+        );
+        let retry = self.post_execute_tool(body).await;
+        match &retry {
+            Ok(resp) => tracing::debug!(
+                tool = %tool,
+                attempt = 2u8,
+                successful = resp.successful,
+                has_error = resp.error.is_some(),
+                "[composio] execute_tool_with_post_oauth_retry retry completed"
+            ),
+            Err(err) => tracing::debug!(
+                tool = %tool,
+                attempt = 2u8,
+                error = %err,
+                "[composio] execute_tool_with_post_oauth_retry retry failed"
+            ),
+        }
+        retry
     }
 
     async fn post_execute_tool(&self, body: &serde_json::Value) -> Result<ComposioExecuteResponse> {

--- a/src/openhuman/composio/client_tests.rs
+++ b/src/openhuman/composio/client_tests.rs
@@ -141,13 +141,14 @@ fn client_clone_shares_inner_arc() {
 // by live backend tests.
 
 use axum::{
-    extract::{Path, Query},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{get, post},
     Json, Router,
 };
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 async fn start_mock_backend(app: Router) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -330,6 +331,97 @@ async fn execute_tool_returns_cost_and_success_flags() {
     assert!(resp.successful);
     assert!((resp.cost_usd - 0.0025).abs() < f64::EPSILON);
     assert_eq!(resp.data["echoed_tool"], "GMAIL_SEND_EMAIL");
+}
+
+#[tokio::test]
+async fn execute_tool_retries_once_on_post_oauth_auth_readiness_error() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route(
+            "/agent-integrations/composio/execute",
+            post(|State(attempts): State<Arc<AtomicUsize>>| async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    Json(json!({
+                        "success": true,
+                        "data": {
+                            "data": {},
+                            "successful": false,
+                            "error": "Connection error, try to authenticate",
+                            "costUsd": 0.0
+                        }
+                    }))
+                } else {
+                    Json(json!({
+                        "success": true,
+                        "data": {
+                            "data": {"ok": true},
+                            "successful": true,
+                            "error": null,
+                            "costUsd": 0.001
+                        }
+                    }))
+                }
+            }),
+        )
+        .with_state(attempts.clone());
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+
+    let resp = client
+        .execute_tool_with_post_oauth_retry(
+            "GOOGLECALENDAR_EVENTS_LIST",
+            &json!({
+                "tool": "GOOGLECALENDAR_EVENTS_LIST",
+                "arguments": {}
+            }),
+            std::time::Duration::ZERO,
+        )
+        .await
+        .unwrap();
+
+    assert!(resp.successful);
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn execute_tool_does_not_retry_other_auth_errors() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route(
+            "/agent-integrations/composio/execute",
+            post(|State(attempts): State<Arc<AtomicUsize>>| async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Json(json!({
+                    "success": true,
+                    "data": {
+                        "data": {},
+                        "successful": false,
+                        "error": "Invalid OAuth scope",
+                        "costUsd": 0.0
+                    }
+                }))
+            }),
+        )
+        .with_state(attempts.clone());
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+
+    let resp = client
+        .execute_tool_with_post_oauth_retry(
+            "GOOGLECALENDAR_EVENTS_LIST",
+            &json!({
+                "tool": "GOOGLECALENDAR_EVENTS_LIST",
+                "arguments": {}
+            }),
+            std::time::Duration::ZERO,
+        )
+        .await
+        .unwrap();
+
+    assert!(!resp.successful);
+    assert_eq!(resp.error.as_deref(), Some("Invalid OAuth scope"));
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/src/openhuman/learning/extract/summary_facets.rs
+++ b/src/openhuman/learning/extract/summary_facets.rs
@@ -76,8 +76,15 @@ pub struct StructuredSummary {
 /// Uses the first non-empty `evidence_chunks` entry as the `chunk_id` in
 /// [`EvidenceRef::DocumentChunk`].
 pub fn route_facets_to_buffer(parsed: &StructuredSummary, source_id: &str) {
+    route_facets_to_buffer_into(parsed, source_id, candidate::global());
+}
+
+fn route_facets_to_buffer_into(
+    parsed: &StructuredSummary,
+    source_id: &str,
+    buf: &candidate::Buffer,
+) {
     let now = now_secs();
-    let buf = candidate::global();
     let mut pushed = 0usize;
 
     for facet in &parsed.facets {
@@ -251,20 +258,14 @@ mod tests {
             0.8,
             "behavioral",
         )]);
-        // Use global buffer for integration.
-        let before_global = candidate::global().len();
-        route_facets_to_buffer(&s, "src-1");
-        let after_global = candidate::global().len();
+        route_facets_to_buffer_into(&s, "src-1", &buf);
         // No new candidates pushed.
-        assert_eq!(
-            after_global, before_global,
-            "unknown class should drop the facet"
-        );
-        let _ = (buf, before);
+        assert_eq!(buf.len(), before, "unknown class should drop the facet");
     }
 
     #[test]
     fn drops_facet_without_evidence_chunks() {
+        let buf = Buffer::new(64);
         let s = make_summary(vec![make_facet(
             "style",
             "verbosity",
@@ -273,10 +274,10 @@ mod tests {
             0.8,
             "explicit",
         )]);
-        let before = candidate::global().len();
-        route_facets_to_buffer(&s, "src-2");
+        let before = buf.len();
+        route_facets_to_buffer_into(&s, "src-2", &buf);
         assert_eq!(
-            candidate::global().len(),
+            buf.len(),
             before,
             "facet without evidence_chunks must be dropped"
         );
@@ -301,7 +302,8 @@ mod tests {
     }
 
     #[test]
-    fn route_pushes_to_global_buffer() {
+    fn route_pushes_to_buffer() {
+        let buf = Buffer::new(64);
         let s = make_summary(vec![
             make_facet(
                 "style",
@@ -320,16 +322,16 @@ mod tests {
                 "structural",
             ),
         ]);
-        let before = candidate::global().len();
-        route_facets_to_buffer(&s, "notion:doc-1");
-        let after = candidate::global().len();
+        let before = buf.len();
+        route_facets_to_buffer_into(&s, "notion:doc-1", &buf);
+        let after = buf.len();
         assert_eq!(
             after,
             before + 2,
             "two valid facets should push two candidates"
         );
 
-        let all = candidate::global().peek();
+        let all = buf.peek();
         let tz = all.iter().find(|c| c.key == "timezone");
         let tz = tz.expect("timezone candidate in buffer");
         assert_eq!(tz.value, "UTC+5:30");

--- a/src/openhuman/service/restart.rs
+++ b/src/openhuman/service/restart.rs
@@ -158,9 +158,12 @@ fn spawn_restart_child() -> Result<u32, String> {
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Duration};
+
+    static RESTART_TEST_ID: AtomicUsize = AtomicUsize::new(0);
 
     struct RestartProbe {
         tx: mpsc::UnboundedSender<(String, String)>,
@@ -190,18 +193,27 @@ mod tests {
         let bus = event_bus::init_global(event_bus::DEFAULT_CAPACITY);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let handle = bus.subscribe(Arc::new(RestartProbe { tx }));
+        let id = RESTART_TEST_ID.fetch_add(1, Ordering::SeqCst);
+        let source = format!("test-{id}");
+        let reason = format!("integration-{id}");
 
-        let outcome = service_restart(Some("test".into()), Some("integration".into()))
+        let outcome = service_restart(Some(source.clone()), Some(reason.clone()))
             .await
             .expect("restart request should succeed");
         assert!(outcome.value.accepted);
 
-        let event = timeout(Duration::from_secs(1), rx.recv())
-            .await
-            .expect("restart event should arrive")
-            .expect("probe channel should stay open");
-        assert_eq!(event.0, "test");
-        assert_eq!(event.1, "integration");
+        let event = timeout(Duration::from_secs(1), async {
+            loop {
+                let event = rx.recv().await.expect("probe channel should stay open");
+                if event.0 == source && event.1 == reason {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("matching restart event should arrive");
+        assert_eq!(event.0, source);
+        assert_eq!(event.1, reason);
 
         handle.cancel();
     }


### PR DESCRIPTION
## Summary
- retry Composio action execution once when the post-OAuth readiness error is returned
- keep real auth/scope failures unchanged by matching only `Connection error, try to authenticate`
- add client tests for the retry path and non-retry auth error path

Fixes #1688

## Tests
- cargo fmt --all -- --check
- cargo clippy -p openhuman
- cargo test -p openhuman
- cargo llvm-cov -p openhuman --lcov --output-path /tmp/lcov-core.info
- git diff --check
- pre-push: pnpm format:check, lint, compile, rust:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool execution now retries once for specific post‑OAuth readiness errors, with a short configurable delay.

* **Refactor**
  * Facet routing was refactored to support routing into arbitrary buffers and stricter validation/clamping of facet fields.

* **Tests**
  * Added end‑to‑end tests for retry vs non‑retry OAuth scenarios.
  * Reworked event tests to use probe-based subscriptions for deterministic collection.
  * Restart test now uses unique per‑run identifiers and robust event matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1707)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->