### PR TITLE
Fix composio integrations URL base normalization

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -346,6 +346,38 @@ mod tests {
     // parallel test execution (std::env is process-global).
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+    struct EnvSnapshot {
+        vars: [(&'static str, Option<String>); 4],
+    }
+
+    impl EnvSnapshot {
+        fn clear_backend_env() -> Self {
+            let vars = [
+                ("BACKEND_URL", std::env::var("BACKEND_URL").ok()),
+                ("VITE_BACKEND_URL", std::env::var("VITE_BACKEND_URL").ok()),
+                (APP_ENV_VAR, std::env::var(APP_ENV_VAR).ok()),
+                (VITE_APP_ENV_VAR, std::env::var(VITE_APP_ENV_VAR).ok()),
+            ];
+
+            for (key, _) in vars.iter() {
+                std::env::remove_var(*key);
+            }
+
+            Self { vars }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in self.vars.iter() {
+                match value {
+                    Some(v) => std::env::set_var(*key, v),
+                    None => std::env::remove_var(*key),
+                }
+            }
+        }
+    }
+
     #[test]
     fn api_url_empty_path_returns_normalized_base() {
         assert_eq!(
@@ -598,6 +630,49 @@ mod tests {
     }
 
     // ── effective_integrations_api_url ─────────────────────────────────
+
+    #[test]
+    fn integrations_url_handles_llm_endpoint_overrides() {
+        let _guard = ENV_LOCK.get_or_init(Mutex::default).lock().unwrap();
+        let _env = EnvSnapshot::clear_backend_env();
+
+        struct Case {
+            api_url: &'static str,
+            expected: &'static str,
+        }
+
+        let cases = [
+            Case {
+                api_url: "https://api.tinyhumans.ai/openai/v1/chat/completions",
+                expected: "https://api.tinyhumans.ai",
+            },
+            Case {
+                api_url: "http://localhost:11434/v1/chat/completions",
+                expected: DEFAULT_API_BASE_URL,
+            },
+            Case {
+                api_url: "https://api.tinyhumans.ai",
+                expected: "https://api.tinyhumans.ai",
+            },
+            Case {
+                api_url: "https://api.tinyhumans.ai/openai/v1/",
+                expected: "https://api.tinyhumans.ai",
+            },
+            Case {
+                api_url: "https://openrouter.ai/api/v1/chat/completions",
+                expected: DEFAULT_API_BASE_URL,
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                effective_integrations_api_url(&Some(case.api_url.to_string())),
+                case.expected,
+                "api_url={}",
+                case.api_url
+            );
+        }
+    }
 
     #[test]
     fn integrations_url_falls_back_to_default_when_override_is_local_ai() {

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -171,13 +171,34 @@ pub fn effective_integrations_api_url(api_url: &Option<String>) -> String {
             warn_integrations_url_fallback_once(u);
             // Fall through to env / default — do NOT use the user override.
         } else {
-            return normalize_api_base_url(u);
+            return normalize_integrations_api_base_url(u);
         }
     }
     if let Some(env_url) = api_base_from_env() {
         return env_url;
     }
     default_api_base_url_for_env(app_env_from_env().as_deref()).to_string()
+}
+
+/// Normalize a configured integrations backend override to its host root.
+///
+/// Users may have `config.api_url` populated with an inference endpoint such
+/// as `https://api.tinyhumans.ai/openai/v1/chat/completions`. Integrations
+/// callers append `/agent-integrations/*`, so the LLM-specific path must not
+/// survive into the backend base.
+fn normalize_integrations_api_base_url(url: &str) -> String {
+    let normalized = normalize_api_base_url(url);
+    let Ok(mut parsed) = url::Url::parse(&normalized) else {
+        return normalized;
+    };
+
+    if parsed.path() != "/" {
+        parsed.set_path("");
+    }
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+
+    parsed.to_string().trim_end_matches('/').to_string()
 }
 
 /// Emit a single `warn!` **once per process lifetime** the first time


### PR DESCRIPTION
## Summary

- Normalize integrations API override URLs to their scheme/host/port root before appending `/agent-integrations/*`.
- Preserve the existing local-AI fallback for localhost/Ollama-style and third-party chat-completions endpoints.
- Add typed config regression coverage for TinyHumans, localhost Ollama, trailing `/openai/v1/`, and OpenRouter URL shapes.

## Problem

- `config.api_url` can contain an inference endpoint like `https://api.tinyhumans.ai/openai/v1/chat/completions`.
- Integrations reuse that setting as the backend base and then append `/agent-integrations/...`, producing concatenated 404 URLs.
- PR #1630 covered the local-AI fallback path; non-local backend overrides with LLM paths still needed host-root normalization.

## Solution

- Parse non-local integration overrides with `url::Url` and strip path/query/fragment down to `scheme://host[:port]`.
- Keep malformed URL behavior on the existing trim/normalize fallback.
- Leave local-AI detection first so localhost/Ollama and third-party chat endpoints still fall back to env/default backend.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: Diff coverage >= 80% -- full diff-cover was not run locally for this one-file Rust fix; changed behavior is covered by focused unit tests.
- [x] N/A: Coverage matrix updated -- no feature rows were added, removed, or renamed.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` -- no coverage-matrix feature IDs changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated -- no release-cut manual smoke surface changed.
- [x] N/A: Linked issue closed via `Closes #NNN` in the `## Related` section -- no GitHub issue number; Sentry IDs are listed below with closing keywords.

## Impact

- Desktop/core integration requests now resolve TinyHumans-hosted LLM proxy configs to the hosted API root before Composio paths are appended.
- Local AI endpoints continue to fall back to the hosted integrations base instead of hitting local LLM servers.
- No migration, security, or performance impact beyond URL normalization.

## Related

- Closes OPENHUMAN-TAURI-FJ
- Closes OPENHUMAN-TAURI-FM
- Closes OPENHUMAN-TAURI-BX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API URL handling to prevent LLM endpoint paths from interfering with agent integrations operations. Configured URLs are now properly normalized to extract the host root, ensuring integrations work reliably regardless of base API URL configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1715)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->