### PR TITLE
fix(composer): prevent sending during IME composition (#1718)

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -855,6 +855,9 @@ const Conversations = ({ variant = 'page', composer = 'text' }: ConversationsPro
     }
 
     if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) {
+        return;
+      }
       e.preventDefault();
       void handleSendMessage();
     }

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -670,4 +670,69 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
       model: 'reasoning-v1',
     });
   });
+
+  describe('IME composition guard (#1718)', () => {
+    it('does not send when Enter is pressed during IME composition', async () => {
+      const { textarea } = await renderSelectedConversation();
+      vi.mocked(chatSend).mockClear();
+
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '你好' } });
+      });
+
+      await act(async () => {
+        fireEvent.keyDown(textarea, {
+          key: 'Enter',
+          keyCode: 229,
+          code: 'Enter',
+          which: 229,
+          bubbles: true,
+          cancelable: true,
+        });
+      });
+
+      expect(chatSend).not.toHaveBeenCalled();
+
+      // Press Enter normally — should send.
+      await act(async () => {
+        fireEvent.keyDown(textarea, {
+          key: 'Enter',
+          keyCode: 13,
+          code: 'Enter',
+          which: 13,
+          bubbles: true,
+          cancelable: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(chatSend).toHaveBeenCalled();
+      });
+    });
+
+    it('sends normally when Enter is pressed without IME composition', async () => {
+      const { textarea } = await renderSelectedConversation();
+      vi.mocked(chatSend).mockClear();
+      vi.mocked(threadApi.appendMessage).mockClear();
+
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: 'hello' } });
+      });
+
+      await act(async () => {
+        fireEvent.keyDown(textarea, {
+          key: 'Enter',
+          keyCode: 13,
+          code: 'Enter',
+          which: 13,
+          bubbles: true,
+          cancelable: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(chatSend).toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Guard Enter-to-send in the chat composer against IME composition events
- Prevents partial CJK/IME text from being sent when Enter is pressed to confirm composed input

## Problem

The chat composer's `handleInputKeyDown` fired `handleSendMessage()` on every Enter keydown without checking whether an IME was actively composing. On macOS and other IME-based input flows, pressing Enter to confirm composed Chinese/Japanese/Korean text would send the message prematurely.

## Solution

Added an `isComposing` guard before the Enter handler in `handleInputKeyDown`, following the existing project pattern in `hotkeyManager.ts:44-45`. Checks both `e.nativeEvent.isComposing` and `e.nativeEvent.keyCode === 229` for broad IME compatibility.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case)
- [ ] Diff coverage >= 80% — changed lines
- [x] Coverage matrix updated: N/A — behaviour-only change
- [x] All affected feature IDs: composer, IME input
- [x] No new external network dependencies
- [x] Manual smoke checklist: N/A
- [x] Linked issue closed

## Impact

- Desktop (all platforms): CJK/IME users no longer accidentally send during composition
- No performance impact — single boolean check on Enter keydown

## Related

- Closes #1718

## AI Authored PR Metadata

### Commit & Branch
- Branch: fix/ime-composition-send-1718
- Commit SHA: bb287774

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: both IME composition tests pass (2 passed, 17 skipped)
- [ ] Rust fmt/check: N/A (frontend only)
- [ ] Tauri fmt/check: N/A

### Behavior Changes
- Intended behavior change: Enter during IME composition no longer sends the message
- User-visible effect: CJK users can compose text without accidental early sends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where messages were unintentionally sent when using text input methods for East Asian languages. The Enter key during active text composition now properly completes input without triggering message sending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1721)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->