### PR TITLE
fix(settings): add type=button to analytics toggle for Windows WebView2 (#1698)

### DIFF
--- a/app/src/components/settings/panels/PrivacyPanel.tsx
+++ b/app/src/components/settings/panels/PrivacyPanel.tsx
@@ -162,6 +162,7 @@ const PrivacyPanel = () => {
                   </p>
                 </div>
                 <button
+                  type="button"
                   onClick={handleToggleAnalytics}
                   className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
                     analyticsEnabled ? 'bg-primary-500' : 'bg-stone-600'

--- a/app/src/components/settings/panels/__tests__/PrivacyPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyPanel.test.tsx
@@ -8,10 +8,11 @@ import PrivacyPanel from '../PrivacyPanel';
 vi.mock('../../../../utils/tauriCommands/aboutApp', () => ({ listCapabilities: vi.fn() }));
 
 const setMeetAutoOrchestratorHandoffMock = vi.fn();
+const setAnalyticsEnabledMock = vi.fn();
 vi.mock('../../../../providers/CoreStateProvider', () => ({
   useCoreState: () => ({
     snapshot: { analyticsEnabled: false, meetAutoOrchestratorHandoff: false },
-    setAnalyticsEnabled: vi.fn(),
+    setAnalyticsEnabled: (v: boolean) => setAnalyticsEnabledMock(v),
     setMeetAutoOrchestratorHandoff: (v: boolean) => setMeetAutoOrchestratorHandoffMock(v),
   }),
 }));
@@ -59,6 +60,22 @@ const unannotated: Capability = {
 describe('PrivacyPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('flips the analytics toggle when clicked (#1698)', async () => {
+    vi.mocked(listCapabilities).mockResolvedValue([]);
+    renderWithProviders(<PrivacyPanel />);
+
+    // Analytics toggle is the first role="switch" on the page (before meet-handoff).
+    const toggles = await screen.findAllByRole('switch');
+    const toggle = toggles[0];
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(setAnalyticsEnabledMock).toHaveBeenCalledWith(true);
+    });
   });
 
   it('renders annotated capabilities returned by about_app.list', async () => {


### PR DESCRIPTION
## Summary

- Add `type="button"` to the "Share Anonymized Usage Data" toggle in Privacy settings
- Fixes the button appearing broken on Windows WebView2 (Edge Chromium)

## Problem

The analytics toggle used a bare `<button>` which defaults to `type="submit"` per the HTML spec. On Windows WebView2, if any ancestor is a `<form>`, clicking the button triggers form submission instead of the click handler, making the toggle appear broken.

## Solution

Added `type="button"` to explicitly prevent default submit behavior. Also added test coverage for the analytics toggle click path (previously only the meet-handoff toggle had coverage).

## Submission Checklist

- [x] Tests added or updated
- [x] Diff coverage >= 80%
- [x] Coverage matrix updated: N/A — behaviour-only change
- [x] No new external network dependencies
- [x] Manual smoke checklist: N/A
- [x] Linked issue closed

## Impact

- Windows desktop: analytics toggle now works correctly in privacy settings
- Other platforms: no behavioral change

## Related

- Closes #1698

## AI Authored PR Metadata

### Commit & Branch
- Branch: fix/windows-toggle-1698
- Commit SHA: 50c10684

### Validation Run
- [x] `pnpm typecheck`
- [x] Focused tests: PrivacyPanel 5 passed (5)

### Behavior Changes
- Intended behavior change: analytics toggle works on Windows
- User-visible effect: Windows users can toggle usage data sharing