### PR TITLE
fix(channels): demote channel-message 404s to typed error (OPENHUMAN-TAURI-2Y)

### DIFF
--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -10,6 +10,36 @@ use std::time::Duration;
 
 use super::jwt::bearer_authorization_value;
 
+/// Typed errors surfaced by `authed_json` for expected backend states that
+/// callers should recover from in-flow rather than funnel into Sentry.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendApiError {
+    /// Edit / delete of a channel message returned 404. Happens when the
+    /// user deletes the message on the provider side (Telegram, Discord,
+    /// Slack, …) but our local `StreamingState` still has the id, or when
+    /// the backend GC'd the relay row before we got around to editing it.
+    /// Callers should clear stale state and skip the retry. Targets
+    /// `OPENHUMAN-TAURI-2Y` (~454 events on `/channels/telegram/messages/<id>`).
+    #[error("message not found on {provider}: {message_id}")]
+    MessageNotFound {
+        /// Channel provider segment (e.g. `"telegram"`, `"discord"`).
+        provider: String,
+        /// Provider-specific message id from the URL.
+        message_id: String,
+    },
+}
+
+/// Extract `(provider, message_id)` from a backend channel path of the
+/// shape `/channels/<provider>/messages/<id>`. Returns `None` for paths
+/// with a different segment count or non-`channels` first segment.
+fn parse_message_path(path: &str) -> Option<(&str, &str)> {
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() == 4 && segments[0] == "channels" && segments[2] == "messages" {
+        return Some((segments[1], segments[3]));
+    }
+    None
+}
+
 const CLIENT_VERSION_HEADER_MAX_LEN: usize = 64;
 
 fn sanitize_client_version(raw: &str) -> Option<String> {
@@ -471,6 +501,32 @@ impl BackendOAuthClient {
         if !status.is_success() {
             let status_code = status.as_u16();
             let status_str = status_code.to_string();
+
+            // 404 on `/channels/<provider>/messages/<id>` is an expected
+            // state (user deleted the message provider-side, or backend
+            // GC'd the relay row) — not a code bug. Surface a typed
+            // `BackendApiError::MessageNotFound` so callers (`bus.rs`
+            // streaming/thinking/delete/final paths) can clear stale
+            // ids and skip retry, without funneling the 404 into
+            // `report_error`. Targets `OPENHUMAN-TAURI-2Y` (~454 events).
+            if status_code == 404 {
+                if let Some((provider, message_id)) = parse_message_path(url.path()) {
+                    tracing::info!(
+                        domain = "backend_api",
+                        operation = "authed_json",
+                        provider = provider,
+                        message_id = message_id,
+                        "[backend_api] message-not-found 404 on {} {} — surfacing typed error",
+                        method.as_str(),
+                        url.path(),
+                    );
+                    return Err(anyhow::Error::new(BackendApiError::MessageNotFound {
+                        provider: provider.to_string(),
+                        message_id: message_id.to_string(),
+                    }));
+                }
+            }
+
             // These are transient infrastructure errors (proxy/CDN/backend
             // temporarily unavailable). They are not code bugs and callers already
             // implement retry/disable logic, so skip Sentry to avoid noise.

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,10 +1,11 @@
-use super::{key_bytes_from_string, sanitize_client_version, BackendOAuthClient};
+use super::{key_bytes_from_string, sanitize_client_version, BackendApiError, BackendOAuthClient};
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
+use reqwest::Method;
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
@@ -266,5 +267,90 @@ async fn backend_raw_client_inherits_x_core_version_default_header() {
     assert_eq!(
         version,
         sanitize_client_version(env!("CARGO_PKG_VERSION")).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn authed_json_surfaces_message_not_found_on_404() {
+    let app = Router::new()
+        .route(
+            "/channels/telegram/messages/1103",
+            post(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+        )
+        .route(
+            "/channels/discord/messages/abc",
+            post(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base_url = format!("http://{addr}");
+    let client = BackendOAuthClient::new(&base_url).unwrap();
+
+    // Telegram path — matches OPENHUMAN-TAURI-2Y shape.
+    let err = client
+        .authed_json(
+            "mock-jwt",
+            Method::POST,
+            "/channels/telegram/messages/1103",
+            None,
+        )
+        .await
+        .unwrap_err();
+    let typed = err.downcast_ref::<BackendApiError>().unwrap();
+    let BackendApiError::MessageNotFound {
+        provider,
+        message_id,
+    } = typed;
+    assert_eq!(provider, "telegram");
+    assert_eq!(message_id, "1103");
+
+    // Discord path — proves the helper is provider-agnostic.
+    let err = client
+        .authed_json(
+            "mock-jwt",
+            Method::POST,
+            "/channels/discord/messages/abc",
+            None,
+        )
+        .await
+        .unwrap_err();
+    let typed = err.downcast_ref::<BackendApiError>().unwrap();
+    let BackendApiError::MessageNotFound {
+        provider,
+        message_id,
+    } = typed;
+    assert_eq!(provider, "discord");
+    assert_eq!(message_id, "abc");
+}
+
+#[tokio::test]
+async fn authed_json_404_outside_messages_path_still_reports() {
+    // 404 on a non-`/channels/<provider>/messages/<id>` path should NOT be
+    // demoted to MessageNotFound — it's a real backend bug or routing
+    // mistake and must keep its Sentry signal.
+    let app = Router::new().route(
+        "/auth/profile",
+        get(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base_url = format!("http://{addr}");
+    let client = BackendOAuthClient::new(&base_url).unwrap();
+
+    let err = client
+        .authed_json("mock-jwt", Method::GET, "/auth/profile", None)
+        .await
+        .unwrap_err();
+    assert!(
+        err.downcast_ref::<BackendApiError>().is_none(),
+        "non-channel-message 404 must not be classified as MessageNotFound"
     );
 }

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -438,6 +438,18 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
             }
             Err(err) => {
                 state.edit_failures += 1;
+                if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
+                    err.downcast_ref::<crate::api::rest::BackendApiError>()
+                {
+                    tracing::info!(
+                        "[channel-inbound][stream] edit channel='{}' msg_id={} — message gone provider-side (404), clearing stale id and disabling further edits",
+                        channel,
+                        message_id,
+                    );
+                    state.message_id = None;
+                    state.edit_disabled = true;
+                    return;
+                }
                 tracing::warn!(
                     "[channel-inbound][stream] edit failed channel='{}' msg_id={} err={} (failures={}/{})",
                     channel,
@@ -545,16 +557,28 @@ async fn flush_thinking_message(channel: &str, state: &mut StreamingState) {
         return;
     };
 
-    if let Some(ref msg_id) = state.thinking_message_id {
+    if let Some(msg_id) = state.thinking_message_id.clone() {
         // Edit existing thinking message with updated content.
         let body = json!({ "text": text });
-        if let Err(err) = client.send_channel_edit(channel, msg_id, &jwt, body).await {
-            tracing::debug!(
-                "[channel-inbound][thinking] edit failed channel='{}' msg_id={} err={}",
-                channel,
-                msg_id,
-                err,
-            );
+        if let Err(err) = client.send_channel_edit(channel, &msg_id, &jwt, body).await {
+            if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
+                err.downcast_ref::<crate::api::rest::BackendApiError>()
+            {
+                tracing::info!(
+                    "[channel-inbound][thinking] edit channel='{}' msg_id={} — thinking msg gone provider-side (404), clearing id and disabling further thinking edits",
+                    channel,
+                    msg_id,
+                );
+                state.thinking_message_id = None;
+                state.thinking_edit_disabled = true;
+            } else {
+                tracing::debug!(
+                    "[channel-inbound][thinking] edit failed channel='{}' msg_id={} err={}",
+                    channel,
+                    msg_id,
+                    err,
+                );
+            }
         }
     } else {
         // Send initial thinking message.
@@ -694,12 +718,22 @@ async fn delete_channel_message(channel: &str, message_id: &str) {
             );
         }
         Err(err) => {
-            tracing::warn!(
-                "[channel-inbound] failed to delete ephemeral msg channel='{}' msg_id={} err={}",
-                channel,
-                message_id,
-                err,
-            );
+            if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
+                err.downcast_ref::<crate::api::rest::BackendApiError>()
+            {
+                tracing::info!(
+                    "[channel-inbound] delete channel='{}' msg_id={} — message already gone provider-side (404), nothing to clean up",
+                    channel,
+                    message_id,
+                );
+            } else {
+                tracing::warn!(
+                    "[channel-inbound] failed to delete ephemeral msg channel='{}' msg_id={} err={}",
+                    channel,
+                    message_id,
+                    err,
+                );
+            }
         }
     }
 }
@@ -742,15 +776,26 @@ async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final
                         );
                     }
                     Err(err) => {
-                        tracing::warn!(
-                            "[channel-inbound] final edit failed channel='{}' msg_id={} err={} — deleting orphan draft and sending fresh atomic reply so user still sees the canonical response",
-                            channel,
-                            message_id,
-                            err,
-                        );
-                        let orphan = message_id.clone();
-                        delete_channel_message(channel, &orphan).await;
-                        send_channel_reply(channel, final_text).await;
+                        if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
+                            err.downcast_ref::<crate::api::rest::BackendApiError>()
+                        {
+                            tracing::info!(
+                                "[channel-inbound] final edit channel='{}' msg_id={} — draft already gone provider-side (404), sending fresh atomic reply",
+                                channel,
+                                message_id,
+                            );
+                            send_channel_reply(channel, final_text).await;
+                        } else {
+                            tracing::warn!(
+                                "[channel-inbound] final edit failed channel='{}' msg_id={} err={} — deleting orphan draft and sending fresh atomic reply so user still sees the canonical response",
+                                channel,
+                                message_id,
+                                err,
+                            );
+                            let orphan = message_id.clone();
+                            delete_channel_message(channel, &orphan).await;
+                            send_channel_reply(channel, final_text).await;
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary

- Add typed \`BackendApiError::MessageNotFound { provider, message_id }\` and surface it from \`authed_json\` whenever a 404 lands on \`/channels/<provider>/messages/<id>\`.
- Four call sites in \`src/openhuman/channels/bus.rs\` (streaming edit, thinking edit, ephemeral delete, final edit) now downcast and recover in-flow instead of bubbling the 404 into \`report_error\`.
- Targets \`OPENHUMAN-TAURI-2Y\` (~454 events) — by far the dominant telegram-channel Sentry issue. The other 8 telegram noise issues (502/503/504 shapes) are already filtered by upstream \`is_transient_backend_api_failure\` in \`before_send\`.

## Problem

Telegram (and Discord/Slack) users can delete a message on the provider side between the backend storing the relay row and our streaming loop issuing an edit. The follow-up PATCH/DELETE/POST then 404s on \`/channels/<provider>/messages/<id>\`. The current \`authed_json\` non-transient non_2xx path treats this as a backend bug and emits \`report_error\` for every event, producing \`OPENHUMAN-TAURI-2Y\` at ~454 events/wk. From a UX perspective the right answer is to clear the stale id and fall back to atomic delivery — not to surface a Sentry error.

## Solution

- \`src/api/rest.rs\` — introduce \`BackendApiError::MessageNotFound\`, gate it behind a narrow \`parse_message_path\` helper (exact 4-segment shape, literal \`channels\` / \`messages\` anchors) so a 404 on any other route — auth probes, integration endpoints, mis-routed proxies — keeps its Sentry signal. Drop is emitted as \`tracing::info\` at the site for grep-visible triage without crossing the \`report_error\` threshold.
- \`src/openhuman/channels/bus.rs\` — four downcast sites:
  - \`flush_streaming_edit\` clears \`state.message_id\`, latches \`edit_disabled\`, returns early so the next dirty-buffer tick falls back to atomic delivery.
  - \`flush_thinking_message\` clears \`state.thinking_message_id\` + latches \`thinking_edit_disabled\` (cloned borrow so the mutation is allowed).
  - \`delete_channel_message\` demotes the warn! to info! since "message already gone" is a no-op success.
  - \`finalize_channel_reply\` skips the orphan-draft delete (nothing to delete) and goes straight to \`send_channel_reply\` so the user still sees the canonical reply.
- \`src/api/rest_tests.rs\` — two integration tests against the existing axum scaffolding: one proving telegram + discord 404 paths downcast correctly, one proving a 404 outside \`/channels/<provider>/messages/<id>\` falls through to the existing \`report_error\` path.

Phase A scope from the original Jules plan (transient HTTP \`is_transient_provider_http_failure\` + before_send wiring) was dropped — \`is_transient_provider_http_failure\` / \`is_transient_backend_api_failure\` / \`is_transient_integrations_failure\` are already shipped in \`src/core/observability.rs\` + bilateral before_send in \`src/main.rs\` + \`app/src-tauri/src/lib.rs\`. Duplicating it would have collided with the existing classifier names.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via \`diff-cover\`) meet the gate enforced by [\`.github/workflows/coverage.yml\`](../.github/workflows/coverage.yml). Run \`pnpm test:coverage\` and \`pnpm test:rust\` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change to existing channel-message routing — Coverage matrix updated — added/removed/renamed feature rows in [\`docs/TEST-COVERAGE-MATRIX.md\`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change
- [x] All affected feature IDs from the matrix are listed in the PR description under \`## Related\`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: no release-cut surface touched — Manual smoke checklist updated if this touches release-cut surfaces ([\`docs/RELEASE-MANUAL-SMOKE.md\`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via \`Closes #NNN\` in the \`## Related\` section

## Impact

- Desktop core binary (\`openhuman-core\`) and Tauri shell (\`app/src-tauri\`) both load the new \`BackendApiError\` variant through \`openhuman_core\`. No frontend / JS surface touched. No migration.
- Sentry: expect \`OPENHUMAN-TAURI-2Y\` event volume to drop to ~0 once a build hits production (currently ~454 events/wk). Other 404s on non-channel paths keep their existing report path.
- Performance: one extra \`downcast_ref\` per channel edit failure (negligible). One \`parse_message_path\` call per non-200 \`authed_json\` response (string split, allocation-free on the success path).

## Related

- Closes OPENHUMAN-TAURI-2Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gracefully handle messages that were deleted server-side: avoid repeated edit attempts, stop retry loops, and treat delete-of-already-gone messages as success.
  * If a final edit target is missing, send a fresh reply instead of failing or duplicating output; disable further edit attempts when appropriate.
* **Tests**
  * Added tests verifying 404s for missing channel messages are classified and handled correctly, while other 404s remain unclassified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1732)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->