### PR TITLE
ci: add explicit permissions to build-desktop workflow

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -13,6 +13,9 @@
 name: Build Desktop (reusable)
 on:
   workflow_call:
+permissions:
+  contents: read
+  actions: write
     inputs:
       build_ref:
         description: Git ref to check out for the build (tag or SHA).


### PR DESCRIPTION
## Summary
- Adds an explicit `permissions` block to `.github/workflows/build-desktop.yml`
- Grants `contents: read` (checkout + Sentry debug file uploads) and `actions: write` (cache + artifact uploads)

## Context
The build-desktop reusable workflow handles code signing secrets (Apple certificates, Tauri signing key, Sentry auth tokens) but was the only workflow in `.github/workflows/` that did not declare explicit permissions. Without an explicit block, the workflow inherits the repository's default `GITHUB_TOKEN` permissions, which may be broader than necessary.

All other workflows in the repo already declare their permissions. This change aligns build-desktop.yml with the existing pattern and follows the principle of least privilege.

## Test plan
- [ ] Verify staging and production release workflows still trigger build-desktop correctly
- [ ] Confirm `actions/upload-artifact` and `actions/cache` still work with `actions: write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enhance build process security and permissions management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1739)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->