### PR TITLE
fix(mock-api): close leaked TCP sockets that exhaust ephemeral port range

### DIFF
--- a/scripts/mock-api/server.mjs
+++ b/scripts/mock-api/server.mjs
@@ -101,6 +101,11 @@ export function getMockServerPort() {
   return typeof address === "object" && address ? address.port : null;
 }
 
+// Reap sockets that the peer (or we) half-closed but never fully tore down.
+// Without this, abandoned keep-alive and WS connections accumulate in
+// CLOSE_WAIT / FIN_WAIT_2 and exhaust the macOS ephemeral port range.
+const SOCKET_IDLE_TIMEOUT_MS = 30_000;
+
 function createServerInstance() {
   const nextServer = http.createServer((req, res) => {
     handleRequest(req, res).catch((err) => {
@@ -108,9 +113,16 @@ function createServerInstance() {
       json(res, 500, { success: false, error: "Internal mock error" });
     });
   });
+  // Short keep-alive so abandoned HTTP connections are recycled quickly
+  // rather than parked in FIN_WAIT_2 for minutes after Node's FIN.
+  nextServer.keepAliveTimeout = 1_000;
+  nextServer.headersTimeout = 5_000;
+  nextServer.requestTimeout = 10_000;
   nextServer.on("connection", (socket) => {
     openSockets.add(socket);
     socket.on("close", () => openSockets.delete(socket));
+    socket.setTimeout(SOCKET_IDLE_TIMEOUT_MS);
+    socket.on("timeout", () => socket.destroy());
   });
   nextServer.on("upgrade", (req, socket) => handleWebSocketUpgrade(req, socket));
   return nextServer;

--- a/scripts/mock-api/socket.mjs
+++ b/scripts/mock-api/socket.mjs
@@ -125,7 +125,10 @@ export function handleWebSocketUpgrade(req, socket) {
       }
       buffer = buffer.subarray(totalLen);
       if (opcode === 0x08) {
-        socket.end();
+        // Hard close: socket.end() leaves us in FIN_WAIT_2 if the peer never
+        // returns its FIN, which on macOS never reclaims and exhausts the
+        // ephemeral port range under sustained mock-server load.
+        socket.destroy();
         return;
       }
       if (opcode === 0x09) {


### PR DESCRIPTION
## Summary

A long-running `node scripts/mock-api-server.mjs` was accumulating thousands of half-closed TCP sockets (≈50/50 split between `CLOSE_WAIT` and `FIN_WAIT_2`), eventually exhausting the macOS ephemeral port range (49152–65535). Once exhausted, every outbound `connect()` on the host failed immediately with `EADDRNOTAVAIL` ("Can't assign requested address") — including the core sidecar's `custom_openai` native chat transport trying to reach `http://127.0.0.1:8000/v1/chat/completions`. Killing the mock server resolved everything; this PR makes the mock not leak in the first place.

## Root cause

Two contributing paths in `scripts/mock-api/`:

1. **WS close-frame handler** ([`socket.mjs:128`](../blob/main/scripts/mock-api/socket.mjs#L128)) used `socket.end()` on opcode `0x08`. That's a graceful half-close — it sends our FIN and waits for the peer's FIN. If the peer never returns its FIN, the socket sits in `FIN_WAIT_2` forever (macOS has no aggressive FIN_WAIT_2 reclaim, unlike Linux's `tcp_fin_timeout`). Engine.io clients send a close frame every time their `pingTimeout` expires, and our mock never sends server-side pings, so this fired on essentially every WS session.

2. **No per-socket idle timeout on the HTTP server** ([`server.mjs`](../blob/main/scripts/mock-api/server.mjs)). Abandoned keep-alive connections — peer process killed, agent pool dropped, e2e teardown rough — parked in `CLOSE_WAIT` (peer FINed, we never noticed) or `FIN_WAIT_2` (Node FINed first, peer never returned its FIN) indefinitely.

## Fix

- **`socket.mjs`**: WS close-frame path now calls `socket.destroy()` (hard close) instead of `socket.end()`. Eliminates the FIN_WAIT_2 source.
- **`server.mjs`**: Per-socket 30s idle reaper (`socket.setTimeout` + `'timeout' → destroy`), plus shortened `keepAliveTimeout` (1s), `headersTimeout` (5s), `requestTimeout` (10s). Catches both halves of the leak regardless of peer behavior.

13-line net diff.

## Verification

Started the patched mock on `:18999`, hammered with 500 concurrent `/socket.io/` polling requests:
- Peak: 125 ESTABLISHED, only 2 transient `CLOSE_WAIT` during the burst.
- After 35s idle: TCP socket count dropped to **1** (listen socket only). Zero accumulation.

No unit/integration test added — deterministically reproducing the leak requires peer-side kernel state (a peer that ACKs FIN but never sends its own FIN) that can't be faked cleanly from inside Node without flake. Flagging this explicitly rather than shipping a flaky bounded-count assertion.

## Note on `--no-verify`

Pushed with `--no-verify` because the pre-push hook's `cargo check --manifest-path app/src-tauri/Cargo.toml` fails on `main` independently of this change (this PR only touches two `.mjs` files). Flagging per CLAUDE.md convention.

## Test plan

- [ ] CI passes (no Rust/TS surface touched).
- [ ] On macOS: `MOCK_API_PORT=18999 node scripts/mock-api-server.mjs &` + run the e2e suite + watch `lsof -nP -iTCP -p <pid> | wc -l` stay bounded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock server stability by enhancing connection cleanup and resource management to prevent socket exhaustion during sustained use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1744)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->