### PR TITLE
chore(build): remove redundant if-skip_resources guards in build.rs

### DIFF
--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -20,18 +20,14 @@ fn maybe_override_tauri_config_for_local_builds() {
     }
 
     let mut merge_config = serde_json::json!({});
-    if skip_resources {
-        merge_config["bundle"]["resources"] = serde_json::json!([]);
-        // Keep sidecars enabled for local/debug builds so the desktop host can
-        // exercise the same core process launch path as packaged builds.
-    }
+    merge_config["bundle"]["resources"] = serde_json::json!([]);
+    // Keep sidecars enabled for local/debug builds so the desktop host can
+    // exercise the same core process launch path as packaged builds.
 
     match serde_json::to_string(&merge_config) {
         Ok(json) => {
             env::set_var("TAURI_CONFIG", json);
-            if skip_resources {
-                println!("cargo:warning=TAURI resources disabled for local build");
-            }
+            println!("cargo:warning=TAURI resources disabled for local build");
         }
         Err(err) => {
             println!("cargo:warning=Failed to serialize TAURI_CONFIG override: {err}");


### PR DESCRIPTION
## Summary

Removes two redundant `if skip_resources` guards in `maybe_override_tauri_config_for_local_builds()`.

After the early return on `!skip_resources` (line 18-20), the variable is always `true` inside the remaining block. The two inner `if skip_resources {` wrappers are dead code — their conditions can never be false.

## Changes

- Remove `if skip_resources {` wrapper around `merge_config["bundle"]["resources"]` assignment
- Remove `if skip_resources {` wrapper around the `println!` warning
- Dedent both blocks

## Testing

- Logic-identical change (no behavior change at runtime)
- The function's control flow is unchanged: early return on `!skip_resources`, then unconditional execution

Closes #1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized build configuration logic for local development builds to improve consistency and reduce unnecessary processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1747)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->