### PR TITLE
fix(security): surface Windows ACL repair hint when .secret_key is unreadable

### DIFF
--- a/src/openhuman/security/secrets.rs
+++ b/src/openhuman/security/secrets.rs
@@ -189,7 +189,10 @@ impl SecretStore {
 
         if self.key_path.exists() {
             let hex_key = read_key_file_with_retry(&self.key_path).with_context(|| {
-                let mut msg = format!("Failed to read secret key file at {}", self.key_path.display());
+                let mut msg = format!(
+                    "Failed to read secret key file at {}",
+                    self.key_path.display()
+                );
                 #[cfg(windows)]
                 {
                     msg.push_str(

--- a/src/openhuman/security/secrets.rs
+++ b/src/openhuman/security/secrets.rs
@@ -188,8 +188,19 @@ impl SecretStore {
         }
 
         if self.key_path.exists() {
-            let hex_key = read_key_file_with_retry(&self.key_path)
-                .context("Failed to read secret key file")?;
+            let hex_key = read_key_file_with_retry(&self.key_path).with_context(|| {
+                let mut msg = format!("Failed to read secret key file at {}", self.key_path.display());
+                #[cfg(windows)]
+                {
+                    msg.push_str(
+                        "\n\nThis is often caused by incorrect file permissions on Windows. \
+                         Try repairing ACLs on the .openhuman directory:\n\
+                         icacls \"%USERPROFILE%\\.openhuman\" /reset /t /c\n\
+                         icacls \"%USERPROFILE%\\.openhuman\\.secret_key\" /reset /c",
+                    );
+                }
+                msg
+            })?;
             let key = hex_decode(hex_key.trim()).context("Secret key file is corrupt")?;
             anyhow::ensure!(
                 key.len() == KEY_LEN,


### PR DESCRIPTION
## Summary

When `.secret_key` exists but cannot be read on Windows (ACL/permission issue from the installer), the error now includes:

1. The full file path (so users know which file is blocked)
2. Actionable `icacls` commands to repair permissions

Previously the error was a generic `"Failed to read secret key file"` that users mistook for an OAuth failure (see #1742 — both Google and GitHub sign-in appeared broken).

## Problem

On Windows 11 with the official installer, `.openhuman/.secret_key` can be created with incorrect ACL/ownership, making it unreadable. The app shows a generic OAuth failure instead of pointing to the real issue.

## Changes

- `src/openhuman/security/secrets.rs`: Replace `.context("Failed to read secret key file")` with `.with_context(|| ...)` that:
  - Always includes the file path
  - On Windows (`#[cfg(windows)]`), appends specific `icacls /reset` repair commands

## Example error output (Windows)

```
Failed to read secret key file at C:\Users\alice\.openhuman\.secret_key

This is often caused by incorrect file permissions on Windows. Try repairing ACLs on the .openhuman directory:
icacls "%USERPROFILE%\.openhuman" /reset /t /c
icacls "%USERPROFILE%\.openhuman\.secret_key" /reset /c
```

## Testing

- `#[cfg(windows)]` guard ensures zero impact on macOS/Linux builds
- The existing retry logic in `read_key_file_with_retry` is unchanged
- Non-Windows platforms see only the improved path-inclusive message

Closes #1742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for secret key loading failures: messages now include the key file path and actionable remediation guidance to help resolve permission or access issues. On Windows, guidance includes specific commands to fix directory/file permissions for quicker recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1748)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->