### PR TITLE
feat(orchestrator): use reasoning-quick-v1 for low-latency chat

### DIFF
--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn orchestrator_has_reasoning_hint_and_named_tools() {
         let def = find("orchestrator");
-        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "reasoning"));
+        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "reasoning-quick"));
         match def.tools {
             ToolScope::Named(tools) => {
                 // spawn_subagent was removed in #1141; spawn_worker_thread is the replacement

--- a/src/openhuman/agent/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent/agents/orchestrator/agent.toml
@@ -55,7 +55,14 @@ subagents = [
 ]
 
 [model]
-hint = "reasoning"
+# `reasoning-quick` (Kimi K2.6 Turbo on Fireworks via backend PR #760)
+# is tuned for low time-to-first-token on conversational turns. The
+# orchestrator is a planner/router that mostly picks a delegate and
+# synthesises sub-agent output — workload that doesn't benefit from
+# the slower deep-reasoning tier. Sub-agents that need heavier
+# reasoning can still opt into `reasoning-v1` (DeepSeek V4 Pro) via
+# `ModelSpec::Hint("reasoning")` in their own definitions.
+hint = "reasoning-quick"
 
 [tools]
 # Direct tools — things the orchestrator calls itself rather than

--- a/src/openhuman/agent/cost.rs
+++ b/src/openhuman/agent/cost.rs
@@ -69,6 +69,15 @@ pub const PRICING_TABLE: &[ModelPricing] = &[
         cached_input_per_mtok_usd: 1.50,
         output_per_mtok_usd: 75.00,
     },
+    // Quick reasoning tier — Kimi K2.6 Turbo on Fireworks (backend PR
+    // #760). Low TTFT, 128k context, `supportsThinking: false`. Rates
+    // track Fireworks' published Kimi turbo pricing at time of writing.
+    ModelPricing {
+        model: "reasoning-quick-v1",
+        input_per_mtok_usd: 0.60,
+        cached_input_per_mtok_usd: 0.06,
+        output_per_mtok_usd: 2.50,
+    },
     // Agentic tier — maps to Sonnet-class models.
     ModelPricing {
         model: "agentic-v1",
@@ -95,14 +104,21 @@ pub fn lookup_pricing(model: &str) -> ModelPricing {
         return *row;
     }
     let lower = model.to_ascii_lowercase();
+    let by_tier = |tier: &str| {
+        PRICING_TABLE
+            .iter()
+            .find(|row| row.model == tier)
+            .copied()
+            .unwrap_or(FALLBACK_PRICING)
+    };
     if lower.contains("opus") {
-        return PRICING_TABLE[0];
+        return by_tier("reasoning-v1");
     }
     if lower.contains("coding") {
-        return PRICING_TABLE[2];
+        return by_tier("coding-v1");
     }
     if lower.contains("sonnet") || lower.contains("agentic") {
-        return PRICING_TABLE[1];
+        return by_tier("agentic-v1");
     }
     FALLBACK_PRICING
 }

--- a/src/openhuman/config/mod.rs
+++ b/src/openhuman/config/mod.rs
@@ -36,7 +36,8 @@ pub use schema::{
     SecretsConfig, SecurityConfig, SlackConfig, StorageConfig, StorageProviderConfig,
     StorageProviderSection, StreamMode, TelegramConfig, UpdateConfig, UpdateRestartStrategy,
     VoiceActivationMode, VoiceServerConfig, WebSearchConfig, WebhookConfig,
-    DEFAULT_CLOUD_LLM_MODEL, DEFAULT_MODEL, MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_V1,
+    DEFAULT_CLOUD_LLM_MODEL, DEFAULT_MODEL, MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_QUICK_V1,
+    MODEL_REASONING_V1,
 };
 pub use schema::{
     clear_active_user, default_root_openhuman_dir, pre_login_user_dir, read_active_user_id,

--- a/src/openhuman/config/mod.rs
+++ b/src/openhuman/config/mod.rs
@@ -36,8 +36,8 @@ pub use schema::{
     SecretsConfig, SecurityConfig, SlackConfig, StorageConfig, StorageProviderConfig,
     StorageProviderSection, StreamMode, TelegramConfig, UpdateConfig, UpdateRestartStrategy,
     VoiceActivationMode, VoiceServerConfig, WebSearchConfig, WebhookConfig,
-    DEFAULT_CLOUD_LLM_MODEL, DEFAULT_MODEL, MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_QUICK_V1,
-    MODEL_REASONING_V1,
+    DEFAULT_CLOUD_LLM_MODEL, DEFAULT_MODEL, MODEL_AGENTIC_V1, MODEL_CODING_V1,
+    MODEL_REASONING_QUICK_V1, MODEL_REASONING_V1,
 };
 pub use schema::{
     clear_active_user, default_root_openhuman_dir, pre_login_user_dir, read_active_user_id,

--- a/src/openhuman/config/schema/identity_cost.rs
+++ b/src/openhuman/config/schema/identity_cost.rs
@@ -68,7 +68,9 @@ impl Default for CostConfig {
 
 /// Default pricing for popular models (USD per 1M tokens)
 fn get_default_pricing() -> HashMap<String, ModelPricing> {
-    use super::types::{MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_V1};
+    use super::types::{
+        MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_QUICK_V1, MODEL_REASONING_V1,
+    };
 
     let mut prices = HashMap::new();
 
@@ -77,6 +79,14 @@ fn get_default_pricing() -> HashMap<String, ModelPricing> {
         ModelPricing {
             input: 0.84,
             output: 2.52,
+        },
+    );
+    // Kimi K2.6 Turbo on Fireworks — see backend PR #760.
+    prices.insert(
+        MODEL_REASONING_QUICK_V1.into(),
+        ModelPricing {
+            input: 0.60,
+            output: 2.50,
         },
     );
     prices.insert(

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -9,6 +9,13 @@ use std::path::PathBuf;
 /// Standard model identifiers matching the backend model registry.
 pub const MODEL_AGENTIC_V1: &str = "agentic-v1";
 pub const MODEL_REASONING_V1: &str = "reasoning-v1";
+/// Low-latency reasoning tier. Backend maps this to Kimi K2.6 Turbo on
+/// Fireworks (128k context, `supportsThinking: false`) — tuned for
+/// time-to-first-token on conversational turns. See backend PR #760.
+/// The orchestrator (user-facing front-line agent) rides on this tier
+/// by default so chat responses feel snappy; reach for the slower
+/// `reasoning-v1` (DeepSeek V4 Pro) only when deep reasoning is needed.
+pub const MODEL_REASONING_QUICK_V1: &str = "reasoning-quick-v1";
 pub const MODEL_CODING_V1: &str = "coding-v1";
 /// Default model used when no explicit model is configured.
 ///

--- a/src/openhuman/providers/router.rs
+++ b/src/openhuman/providers/router.rs
@@ -3,12 +3,14 @@ use super::Provider;
 use async_trait::async_trait;
 use std::collections::HashMap;
 
-/// Maps OpenHuman's abstract tier model names (`reasoning-v1`, `agentic-v1`,
-/// `coding-v1`, `summarization-v1`) to the hint slot in `model_routes`.
-/// Returns `None` for any model the router shouldn't rewrite.
+/// Maps OpenHuman's abstract tier model names (`reasoning-v1`,
+/// `reasoning-quick-v1`, `agentic-v1`, `coding-v1`, `summarization-v1`)
+/// to the hint slot in `model_routes`. Returns `None` for any model the
+/// router shouldn't rewrite.
 fn openhuman_tier_to_hint(model: &str) -> Option<&'static str> {
     match model {
         "reasoning-v1" => Some("reasoning"),
+        "reasoning-quick-v1" => Some("reasoning-quick"),
         "agentic-v1" => Some("agentic"),
         "coding-v1" => Some("coding"),
         "summarization-v1" => Some("summarization"),

--- a/src/openhuman/routing/provider.rs
+++ b/src/openhuman/routing/provider.rs
@@ -17,7 +17,9 @@ use std::time::Instant;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::openhuman::config::{MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_V1};
+use crate::openhuman::config::{
+    MODEL_AGENTIC_V1, MODEL_CODING_V1, MODEL_REASONING_QUICK_V1, MODEL_REASONING_V1,
+};
 use crate::openhuman::providers::traits::{
     ChatMessage, ChatRequest, ChatResponse, Provider, ProviderCapabilities, StreamChunk,
     StreamError, StreamOptions, StreamResult, ToolsPayload,
@@ -93,6 +95,7 @@ impl IntelligentRoutingProvider {
         // Keep remote model naming aligned with backend modelRegistry.
         match requested_model.strip_prefix("hint:") {
             Some("reasoning") => MODEL_REASONING_V1.to_string(),
+            Some("reasoning-quick") => MODEL_REASONING_QUICK_V1.to_string(),
             Some("agentic") => MODEL_AGENTIC_V1.to_string(),
             Some("coding") => MODEL_CODING_V1.to_string(),
             _ => requested_model.to_string(),


### PR DESCRIPTION
## Summary

- Switch the orchestrator's model hint from `reasoning` → `reasoning-quick` so user-facing chat rides Kimi K2.6 Turbo (Fireworks, 128k context, low TTFT) instead of DeepSeek V4 Pro.
- Wire the new `reasoning-quick-v1` tier added in backend PR [tinyhumansai/backend#760](https://github.com/tinyhumansai/backend/pull/760) through the abstract-tier router and the intelligent routing provider.
- Add pricing rows for `reasoning-quick-v1` in both the agent cost table and the identity-cost defaults.
- Rework `agent::cost::lookup_pricing` vendor-name fallback to look up by tier name rather than `PRICING_TABLE` index (adding the new row shifted indices and would have mispriced Sonnet/agentic).

## Problem

The orchestrator is the front-line, user-facing agent — it routes, judges and synthesises sub-agent output. That workload is dispatch-heavy, not deep-reasoning-heavy. Pinning it to `reasoning-v1` (now DeepSeek V4 Pro per backend #760) means every chat turn pays the slow-tier latency cost just to pick a delegate. Backend #760 introduced `reasoning-quick-v1` (Kimi K2.6 Turbo, `supportsThinking: false`) precisely for this kind of low-TTFT conversational turn — we just had to wire it through the core.

## Solution

- New `MODEL_REASONING_QUICK_V1` constant in `config/schema/types.rs` + re-export.
- `providers/router.rs`: tier name `reasoning-quick-v1` → hint slot `reasoning-quick` so custom providers configured via `model_routes` translate the tier id correctly.
- `routing/provider.rs` (`IntelligentRoutingProvider::resolve_remote_model`): `hint:reasoning-quick` → `MODEL_REASONING_QUICK_V1` on the heavy-task path.
- `agent/cost.rs`: `PRICING_TABLE` row for `reasoning-quick-v1` at Kimi turbo Fireworks pricing ($0.60 / $2.50 per Mtok); fallback path now resolves by tier name so future insertions don't break Sonnet/agentic lookups.
- `config/schema/identity_cost.rs`: default cost-budget pricing entry.
- `agent/agents/orchestrator/agent.toml`: `[model] hint = "reasoning-quick"` (with a comment explaining the choice and how sub-agents that need deep reasoning still opt into `reasoning-v1` via their own `ModelSpec::Hint`).
- Updated the existing `orchestrator_has_reasoning_hint_and_named_tools` loader test.

The pre-push hook auto-applied a one-line rustfmt re-wrap on `config/mod.rs` (commit `chore: apply auto-fixes`) — committed as instructed by the hook, no `--no-verify` used.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: pure tier-routing rewire — the new logic is exercised by the existing orchestrator-loader test, the cost `lookup_pricing_handles_concrete_vendor_names` test (which would have failed under the old index-based fallback after the insertion), and the existing router/policy tests. No new code paths to add coverage for.
- [x] N/A: behaviour-only change to model selection — no new feature row to add or remove in the coverage matrix.
- [x] N/A: no feature IDs touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: model-tier wiring; does not touch any release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md`.
- [x] N/A: no linked issue.

## Impact

- **Desktop chat latency**: orchestrator turns should drop noticeably in TTFT once this lands and the backend rolls `reasoning-quick-v1` to clients. Backend PR #760 measured 617 ms TTFT / 1334 ms total on the new tier vs. the slow-reasoning baseline.
- **Cost**: orchestrator chat cost drops ~25× (Kimi turbo $0.60 / $2.50 per Mtok vs. DeepSeek V4 Pro / Opus tier).
- **Behavioural risk**: orchestrator no longer has chain-of-thought (`supportsThinking: false` on the new tier). It's still a routing/synthesis agent, but if any orchestrator prompt was implicitly depending on hidden reasoning tokens, that's gone. Sub-agents that need deep reasoning (`researcher`, `planner`, `critic`) continue to ride `reasoning-v1` via their own `ModelSpec::Hint("reasoning")`.
- **Backend dependency**: requires backend tinyhumansai/backend#760 deployed for `reasoning-quick-v1` to resolve; older backends will 404. The orchestrator hint will fall back through the router's passthrough path if the model id is unknown.

## Related

- Closes:
- Follow-up PR(s)/TODOs: tune Kimi-turbo pricing once the latency benchmark from backend #760 runs at N=10–20 under sustained load.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/reasoning-quick-v1-orchestrator
- Commit SHA: 7048cc231750eb3ab6bf94d9e187a8ae81194b06

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (auto-applied by pre-push hook)
- [x] N/A: `pnpm typecheck` — no frontend changes
- [x] Focused tests: `cargo test --lib openhuman::agent::agents::loader::tests::orchestrator_has_reasoning_hint_and_named_tools openhuman::agent::cost openhuman::providers::router openhuman::routing::provider` (all pass)
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml` clean
- [x] N/A: Tauri fmt/check — no app/src-tauri changes

### Validation Blocked
- N/A

### Behavior Changes
- Intended behavior change: orchestrator chat turns now ride `reasoning-quick-v1` (Kimi turbo) instead of `reasoning-v1` (DeepSeek V4 Pro). Sub-agents untouched.
- User-visible effect: lower TTFT and lower cost on chat replies; no chain-of-thought on orchestrator turns.

### Parity Contract
- Legacy behavior preserved: yes — `reasoning-v1` tier still wired end-to-end for sub-agents that need it; the new tier is purely additive at the routing layer.
- Guard/fallback/dispatch parity checks: `openhuman_tier_to_hint` keeps all pre-existing tiers; `resolve_remote_model` keeps all pre-existing `Some(...)` branches; `PRICING_TABLE` keeps all pre-existing rows.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "reasoning-quick" model tier with dedicated pricing configuration and routing support.

* **Configuration Updates**
  * Updated orchestrator agent configuration to utilize the new reasoning-quick tier.
  * Extended pricing table with specific rates for the new tier.
  * Updated routing logic to recognize and properly map the new tier across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1761)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
