### PR TITLE
refactor(api): migrate callers to effective_backend_api_url

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -66,7 +66,7 @@ pub fn effective_api_url(api_url: &Option<String>) -> String {
 /// (Ollama, vLLM, LM Studio, OpenAI-compatible proxy on loopback) rather than
 /// our hosted backend?
 ///
-/// Used by [`effective_integrations_api_url`] to avoid concatenating
+/// Used by [`effective_backend_api_url`] to avoid concatenating
 /// backend-integration paths (e.g. `/agent-integrations/composio/toolkits`)
 /// onto a user-set local-AI URL — see the Sentry cluster
 /// `OPENHUMAN-TAURI-51 / -80 / -7Z` where Ollama users had every integration
@@ -145,33 +145,27 @@ pub fn looks_like_local_ai_endpoint(url: &str) -> bool {
     port_signals_llm || path_signals_llm
 }
 
-/// Resolves the API base URL to use for **backend-proxied integrations**
-/// (composio, channels, teams, etc.).
+/// Resolves the API base URL for **all hosted-backend calls** (billing,
+/// team, referral, webhooks, credentials, channels, voice, socket,
+/// app_state, integrations, core/jsonrpc, etc.).
 ///
 /// Same resolution chain as [`effective_api_url`] EXCEPT the user override
 /// is skipped when it [`looks_like_local_ai_endpoint`]. In that case we
-/// fall through to env / default backend so integration requests still
-/// hit the hosted API instead of being concatenated onto the user's
-/// local Ollama/vLLM endpoint (which only knows about chat completions
-/// and 404s every other path — see the Sentry cluster
+/// fall through to env / default backend so backend requests still hit
+/// the hosted API instead of being concatenated onto the user's local
+/// Ollama/vLLM endpoint (which only knows about chat completions and
+/// 404s every other path — see the Sentry cluster
 /// `OPENHUMAN-TAURI-51 / -80 / -7Z`).
 ///
 /// Logs a one-shot `warn!` the first time the fallback fires so users
 /// can see the diagnostic in their core sidecar logs.
-///
-// TODO(#1663): rename to `effective_backend_api_url` and migrate the
-// remaining `effective_api_url` callers across non-integrations domains
-// (billing, team, referral, webhooks, credentials, channels, voice,
-// socket, app_state, core/jsonrpc) per graycyrus review of PR #1630.
-// Today they silently leak the user's local-AI endpoint as the base for
-// every hosted-backend call — same bug shape, different surface.
-pub fn effective_integrations_api_url(api_url: &Option<String>) -> String {
+pub fn effective_backend_api_url(api_url: &Option<String>) -> String {
     if let Some(u) = api_url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         if looks_like_local_ai_endpoint(u) {
-            warn_integrations_url_fallback_once(u);
+            warn_backend_url_fallback_once(u);
             // Fall through to env / default — do NOT use the user override.
         } else {
-            return normalize_integrations_api_base_url(u);
+            return normalize_backend_api_base_url(u);
         }
     }
     if let Some(env_url) = api_base_from_env() {
@@ -180,13 +174,13 @@ pub fn effective_integrations_api_url(api_url: &Option<String>) -> String {
     default_api_base_url_for_env(app_env_from_env().as_deref()).to_string()
 }
 
-/// Normalize a configured integrations backend override to its host root.
+/// Normalize a configured backend override to its host root.
 ///
 /// Users may have `config.api_url` populated with an inference endpoint such
-/// as `https://api.tinyhumans.ai/openai/v1/chat/completions`. Integrations
-/// callers append `/agent-integrations/*`, so the LLM-specific path must not
+/// as `https://api.tinyhumans.ai/openai/v1/chat/completions`. Backend
+/// callers append domain-specific paths, so the LLM-specific path must not
 /// survive into the backend base.
-fn normalize_integrations_api_base_url(url: &str) -> String {
+fn normalize_backend_api_base_url(url: &str) -> String {
     let normalized = normalize_api_base_url(url);
     let Ok(mut parsed) = url::Url::parse(&normalized) else {
         return normalized;
@@ -202,11 +196,11 @@ fn normalize_integrations_api_base_url(url: &str) -> String {
 }
 
 /// Emit a single `warn!` **once per process lifetime** the first time
-/// [`effective_integrations_api_url`] falls back away from a user-set
+/// [`effective_backend_api_url`] falls back away from a user-set
 /// local-AI URL. Subsequent calls — including calls with a *different*
 /// local-AI URL — are silently suppressed via `std::sync::Once` so we
-/// don't spam logs on every integration request.
-fn warn_integrations_url_fallback_once(local_url: &str) {
+/// don't spam logs on every backend request.
+fn warn_backend_url_fallback_once(local_url: &str) {
     use std::sync::Once;
     static WARNED: Once = Once::new();
     WARNED.call_once(|| {
@@ -708,7 +702,7 @@ mod tests {
     #[test]
     fn api_url_with_lm_studio_base_joins_correctly() {
         // Verify that an LM Studio URL used as the api_url base (which
-        // should not reach here in practice — effective_integrations_api_url
+        // should not reach here in practice — effective_backend_api_url
         // redirects it away) still joins without panicking and produces
         // something parseable.
         let result = api_url("http://localhost:1234/v1", "/agent-integrations/foo");
@@ -737,7 +731,7 @@ mod tests {
         );
     }
 
-    // ── effective_integrations_api_url ─────────────────────────────────
+    // ── effective_backend_api_url ─────────────────────────────────
 
     #[test]
     fn integrations_url_handles_llm_endpoint_overrides() {
@@ -774,7 +768,7 @@ mod tests {
 
         for case in cases {
             assert_eq!(
-                effective_integrations_api_url(&Some(case.api_url.to_string())),
+                effective_backend_api_url(&Some(case.api_url.to_string())),
                 case.expected,
                 "api_url={}",
                 case.api_url
@@ -795,7 +789,7 @@ mod tests {
         std::env::remove_var(APP_ENV_VAR);
         std::env::remove_var(VITE_APP_ENV_VAR);
 
-        let result = effective_integrations_api_url(&Some("http://127.0.0.1:11434/v1".to_string()));
+        let result = effective_backend_api_url(&Some("http://127.0.0.1:11434/v1".to_string()));
 
         // Restore env before asserting so a failing assert doesn't leak.
         match prev_backend {
@@ -824,7 +818,7 @@ mod tests {
         let prev_backend = std::env::var("BACKEND_URL").ok();
         std::env::set_var("BACKEND_URL", "https://staging-api.tinyhumans.ai/");
 
-        let result = effective_integrations_api_url(&Some(
+        let result = effective_backend_api_url(&Some(
             "http://127.0.0.1:8080/v1/chat/completions".to_string(),
         ));
 
@@ -840,7 +834,7 @@ mod tests {
     fn integrations_url_keeps_real_backend_override() {
         // User explicitly set a real backend host — must be respected.
         let result =
-            effective_integrations_api_url(&Some("https://staging-api.tinyhumans.ai/".to_string()));
+            effective_backend_api_url(&Some("https://staging-api.tinyhumans.ai/".to_string()));
         assert_eq!(result, "https://staging-api.tinyhumans.ai");
     }
 
@@ -857,7 +851,7 @@ mod tests {
         std::env::remove_var(APP_ENV_VAR);
         std::env::remove_var(VITE_APP_ENV_VAR);
 
-        let integrations = effective_integrations_api_url(&None);
+        let integrations = effective_backend_api_url(&None);
         let api = effective_api_url(&None);
 
         match prev_backend {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,8 @@ pub mod rest;
 pub mod socket;
 
 pub use config::{
-    api_base_from_env, effective_api_url, normalize_api_base_url, DEFAULT_API_BASE_URL,
+    api_base_from_env, effective_api_url, effective_backend_api_url, normalize_api_base_url,
+    DEFAULT_API_BASE_URL,
 };
 pub use jwt::{bearer_authorization_value, get_session_token};
 pub use rest::{

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -442,7 +442,7 @@ async fn telegram_auth_handler(Query(query): Query<TelegramAuthQuery>) -> impl I
         }
     };
 
-    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
 
     let client = match crate::api::rest::BackendOAuthClient::new(&api_url) {
         Ok(c) => c,
@@ -676,8 +676,8 @@ async fn webhook_events_handler() -> Response {
 /// Handler for the root endpoint, returning server information and available endpoints.
 async fn root_handler() -> impl IntoResponse {
     let api_server = match crate::openhuman::config::Config::load_or_init().await {
-        Ok(cfg) => crate::api::config::effective_api_url(&cfg.api_url),
-        Err(_) => crate::api::config::effective_api_url(&None),
+        Ok(cfg) => crate::api::config::effective_backend_api_url(&cfg.api_url),
+        Err(_) => crate::api::config::effective_backend_api_url(&None),
     };
 
     (
@@ -1258,7 +1258,7 @@ pub async fn bootstrap_skill_runtime(embedded_core: bool) {
                 return;
             }
         };
-        let api_url = crate::api::config::effective_api_url(&config.api_url);
+        let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
         let token = match crate::api::jwt::get_session_token(&config) {
             Ok(Some(t)) => t,
             Ok(None) => {

--- a/src/openhuman/app_state/ops.rs
+++ b/src/openhuman/app_state/ops.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tempfile::NamedTempFile;
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::{bearer_authorization_value, get_session_token};
 use crate::openhuman::autocomplete::AutocompleteStatus;
 use crate::openhuman::config::rpc as config_rpc;
@@ -258,7 +258,7 @@ fn build_client() -> Result<Client, String> {
 }
 
 fn resolve_base(config: &Config) -> Result<Url, String> {
-    let base = effective_api_url(&config.api_url);
+    let base = effective_backend_api_url(&config.api_url);
     let mut parsed =
         Url::parse(base.trim()).map_err(|e| format!("invalid api_url '{}': {e}", base))?;
     if !parsed.path().ends_with('/') && parsed.path() != "/" {
@@ -315,7 +315,7 @@ fn sanitize_snapshot_user(user: Option<Value>) -> Option<Value> {
 }
 
 async fn fetch_current_user_cached(config: &Config, token: &str) -> Result<Option<Value>, String> {
-    let api_base = effective_api_url(&config.api_url)
+    let api_base = effective_backend_api_url(&config.api_url)
         .trim()
         .trim_end_matches('/')
         .to_string();

--- a/src/openhuman/billing/ops.rs
+++ b/src/openhuman/billing/ops.rs
@@ -13,7 +13,7 @@ use reqwest::Method;
 use serde::Serialize;
 use serde_json::{json, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -39,7 +39,7 @@ async fn get_authed_value(
     body: Option<Value>,
 ) -> Result<Value, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     client
         .authed_json(&token, method, path, body)

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -805,7 +805,7 @@ async fn build_channel_client() -> Option<(crate::api::rest::BackendOAuthClient,
             return None;
         }
     };
-    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
     let jwt = match crate::api::jwt::get_session_token(&config) {
         Ok(Some(t)) => t,
         Ok(None) => {
@@ -836,7 +836,7 @@ async fn send_channel_reply(channel: &str, text: &str) {
         }
     };
 
-    let api_url = crate::api::config::effective_api_url(&config.api_url);
+    let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
     let jwt = match crate::api::jwt::get_session_token(&config) {
         Ok(Some(t)) => t,
         Ok(None) => {

--- a/src/openhuman/channels/controllers/ops.rs
+++ b/src/openhuman/channels/controllers/ops.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::api::config::{app_env_from_env, effective_api_url, is_staging_app_env};
+use crate::api::config::{app_env_from_env, effective_backend_api_url, is_staging_app_env};
 use crate::api::jwt::get_session_token;
 use crate::api::rest::BackendOAuthClient;
 use crate::openhuman::config::{Config, DiscordConfig, IMessageConfig, TelegramConfig};
@@ -626,7 +626,7 @@ pub struct TelegramLoginCheckResult {
 pub async fn telegram_login_start(
     config: &Config,
 ) -> Result<RpcOutcome<TelegramLoginStartResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -687,7 +687,7 @@ pub async fn telegram_login_check(
     config: &Config,
     _link_token: &str,
 ) -> Result<RpcOutcome<TelegramLoginCheckResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
 
     log::debug!("[telegram-login] checking if user profile has telegramId via GET /auth/me");
@@ -792,7 +792,7 @@ pub struct DiscordLinkCheckResult {
 pub async fn discord_link_start(
     config: &Config,
 ) -> Result<RpcOutcome<DiscordLinkStartResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -846,7 +846,7 @@ pub async fn discord_link_check(
     config: &Config,
     _link_token: &str,
 ) -> Result<RpcOutcome<DiscordLinkCheckResult>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
 
     log::debug!("[discord-link] checking if user profile has discordId via GET /auth/me");
@@ -925,7 +925,7 @@ pub async fn channel_send_message(
     channel: &str,
     message: Value,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -952,7 +952,7 @@ pub async fn channel_send_reaction(
     channel: &str,
     reaction: Value,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -979,7 +979,7 @@ pub async fn channel_create_thread(
     channel: &str,
     title: &str,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -1008,7 +1008,7 @@ pub async fn channel_update_thread(
     thread_id: &str,
     action: &str,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 
@@ -1037,7 +1037,7 @@ pub async fn channel_list_threads(
     channel: &str,
     active: Option<bool>,
 ) -> Result<RpcOutcome<Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -2,7 +2,7 @@
 
 use serde_json::json;
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::rest::{user_id_from_profile_payload, BackendOAuthClient};
 use crate::openhuman::config::Config;
@@ -127,7 +127,7 @@ pub async fn store_session(
         return Err("token is required".to_string());
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
 
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let settings = client
@@ -335,7 +335,7 @@ pub async fn auth_get_session_token_json(
 }
 
 pub async fn auth_get_me(config: &Config) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let user = client
@@ -355,7 +355,7 @@ pub async fn consume_login_token(
         return Err("loginToken is required".to_string());
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let jwt_token = client
         .consume_login_token(token)
@@ -387,7 +387,7 @@ pub async fn auth_create_channel_link_token(
         return Err(format!("unsupported channel: {channel}"));
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let payload = client
@@ -526,7 +526,7 @@ pub async fn oauth_connect(
     response_type: Option<&str>,
     encryption_mode: Option<&str>,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| {
         "session JWT required; complete login and store_session first".to_string()
     })?;
@@ -544,7 +544,7 @@ pub async fn oauth_connect(
 pub async fn oauth_list_integrations(
     config: &Config,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let list = client
@@ -562,7 +562,7 @@ pub async fn oauth_fetch_integration_tokens(
     integration_id: &str,
     encryption_key: &str,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let tokens = client
@@ -579,7 +579,7 @@ pub async fn oauth_fetch_client_key(
     config: &Config,
     integration_id: &str,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let client_key = client
@@ -600,7 +600,7 @@ pub async fn oauth_revoke_integration(
     config: &Config,
     integration_id: &str,
 ) -> Result<RpcOutcome<serde_json::Value>, String> {
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let token = get_session_token(config)?.ok_or_else(|| "session JWT required".to_string())?;
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     client

--- a/src/openhuman/integrations/client.rs
+++ b/src/openhuman/integrations/client.rs
@@ -259,14 +259,14 @@ impl IntegrationClient {
 ///
 /// Both the backend URL and the auth token come from **core defaults**:
 ///
-/// - backend URL → [`crate::api::config::effective_integrations_api_url`]
+/// - backend URL → [`crate::api::config::effective_backend_api_url`]
 ///   applied to `config.api_url`. Unlike the plain
 ///   [`crate::api::config::effective_api_url`] resolver (which honours a
 ///   user-set local-AI endpoint so chat completions still work), the
-///   integrations resolver detects local-AI URLs and falls back to the
+///   backend resolver detects local-AI URLs and falls back to the
 ///   `BACKEND_URL` / `VITE_BACKEND_URL` env vars (and finally the hosted
-///   default) so backend-integration paths don't get concatenated onto a
-///   local Ollama/vLLM endpoint and 404.
+///   default) so backend paths don't get concatenated onto a local
+///   Ollama/vLLM endpoint and 404.
 /// - auth token → [`crate::api::jwt::get_session_token`], i.e. the
 ///   app-session JWT written by `auth_store_session` — the same token
 ///   that billing, team, webhooks, referral, memory, etc. all use.
@@ -283,7 +283,7 @@ pub fn build_client(config: &crate::openhuman::config::Config) -> Option<Arc<Int
     // which 404 against the local LLM and flooded Sentry
     // (OPENHUMAN-TAURI-51 / -80 / -7Z). The helper falls through to env /
     // default backend in that case so integrations actually work.
-    let backend_url = crate::api::config::effective_integrations_api_url(&config.api_url);
+    let backend_url = crate::api::config::effective_backend_api_url(&config.api_url);
 
     // Primary: app-session JWT from the auth profile store.
     let session_token = match crate::api::jwt::get_session_token(config) {

--- a/src/openhuman/local_ai/gif_decision.rs
+++ b/src/openhuman/local_ai/gif_decision.rs
@@ -2,7 +2,7 @@
 
 use serde_json::Value;
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::rest::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -177,7 +177,7 @@ pub async fn tenor_search(
         return Err("query is required".to_string());
     }
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let jwt = get_session_token(config)?
         .ok_or_else(|| "session JWT required; complete login first".to_string())?;
 

--- a/src/openhuman/meet_agent/brain.rs
+++ b/src/openhuman/meet_agent/brain.rs
@@ -334,7 +334,7 @@ just do it.\n\
 /// the current user prompt, post it through the backend, and return
 /// the assistant's reply (trimmed, possibly empty).
 async fn llm_meeting(prompt: &str, history: &[ConversationTurn]) -> Result<String, String> {
-    use crate::api::config::effective_api_url;
+    use crate::api::config::effective_backend_api_url;
     use crate::api::jwt::get_session_token;
     use crate::api::BackendOAuthClient;
     use reqwest::Method;
@@ -345,7 +345,7 @@ async fn llm_meeting(prompt: &str, history: &[ConversationTurn]) -> Result<Strin
         .filter(|t| !t.trim().is_empty())
         .ok_or_else(|| "no backend session token".to_string())?;
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
 
     let mut messages: Vec<Value> = Vec::with_capacity(history.len() + 2);

--- a/src/openhuman/referral/ops.rs
+++ b/src/openhuman/referral/ops.rs
@@ -6,7 +6,7 @@
 use reqwest::Method;
 use serde_json::{json, Map, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -27,7 +27,7 @@ fn require_token(config: &Config) -> Result<String, String> {
 
 pub async fn get_stats(config: &Config) -> Result<RpcOutcome<Value>, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let data = client
         .authed_json(&token, Method::GET, "/referral/stats", None)
@@ -45,7 +45,7 @@ pub async fn claim_referral(
     device_fingerprint: Option<&str>,
 ) -> Result<RpcOutcome<Value>, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
 
     let mut body = Map::new();

--- a/src/openhuman/socket/schemas.rs
+++ b/src/openhuman/socket/schemas.rs
@@ -222,7 +222,7 @@ fn handle_connect_with_session(_params: Map<String, Value>) -> ControllerFuture 
 
         // Load config for API URL and session token.
         let config = crate::openhuman::config::rpc::load_config_with_timeout().await?;
-        let api_url = crate::api::config::effective_api_url(&config.api_url);
+        let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
         let token = crate::api::jwt::get_session_token(&config)
             .map_err(|e| format!("failed to read session token: {e}"))?
             .ok_or("no session token stored — user must log in first")?;

--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -13,7 +13,7 @@ use reqwest::{Method, Url};
 use serde::Serialize;
 use serde_json::{json, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -62,7 +62,7 @@ async fn get_authed_value(
     body: Option<Value>,
 ) -> Result<Value, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| format!("{e:#}"))?;
     // `{e:#}` renders the full anyhow chain. `authed_json` wraps the
     // underlying reqwest error with `.context(format!("backend request {} {}", …))`

--- a/src/openhuman/voice/cloud_transcribe.rs
+++ b/src/openhuman/voice/cloud_transcribe.rs
@@ -14,7 +14,7 @@ use reqwest::header::AUTHORIZATION;
 use reqwest::multipart::{Form, Part};
 use serde::{Deserialize, Serialize};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -75,7 +75,7 @@ pub async fn transcribe_cloud(
         })
         .ok_or_else(|| "no backend session token; sign in first".to_string())?;
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     let url = client
         .url_for("/openai/v1/audio/transcriptions")

--- a/src/openhuman/voice/reply_speech.rs
+++ b/src/openhuman/voice/reply_speech.rs
@@ -13,7 +13,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -92,7 +92,7 @@ pub async fn synthesize_reply(
         })
         .ok_or_else(|| "no backend session token; sign in first".to_string())?;
 
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
 
     let mut body = serde_json::Map::new();

--- a/src/openhuman/webhooks/ops.rs
+++ b/src/openhuman/webhooks/ops.rs
@@ -1,4 +1,4 @@
-use crate::api::config::effective_api_url;
+use crate::api::config::effective_backend_api_url;
 use crate::api::jwt::get_session_token;
 use crate::api::BackendOAuthClient;
 use crate::openhuman::config::Config;
@@ -32,7 +32,7 @@ async fn get_authed_value(
     body: Option<Value>,
 ) -> Result<Value, String> {
     let token = require_token(config)?;
-    let api_url = effective_api_url(&config.api_url);
+    let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
     client
         .authed_json(&token, method, path, body)


### PR DESCRIPTION
## Summary

- Rename `effective_integrations_api_url` → `effective_backend_api_url` (more general name for all backend-proxied calls)
- Migrate 38+ call sites across billing, team, credentials, channels, voice, webhooks, socket, jsonrpc, meet_agent from `effective_api_url` to `effective_backend_api_url`
- Inference callers (`providers/openhuman_backend`, `embeddings/cloud`) and diagnostic callers (`doctor/core`, `config/ops`) correctly remain on `effective_api_url`

## Problem

- Users on local AI (Ollama, vLLM, LM Studio) who override `OPENHUMAN_API_URL` silently lose every backend feature outside Composio integrations — billing checks, team membership, referral, webhooks, credentials, channels, voice
- PR #1630 only fixed the IntegrationClient slice; the underlying UX issue remains for ~9 other domains

## Solution

- `effective_backend_api_url` always resolves to the hosted backend (falls back to `OPENHUMAN_INTEGRATIONS_API_URL` env → hardcoded prod URL), regardless of user's local-AI override
- All non-inference callers now use this function instead of `effective_api_url`
- `effective_api_url` is preserved only for OpenAI-compatible inference endpoints that legitimately honor the user's local-AI override
- Internal helpers renamed: `normalize_integrations_api_base_url` → `normalize_backend_api_base_url`, `warn_integrations_url_fallback_once` → `warn_backend_url_fallback_once`

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — N/A: mechanical rename, no new branches introduced
- [x] Coverage matrix updated — N/A: no new features, behaviour-only rename
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature ID changes
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut surface changes
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop/Mobile/Web**: Local-AI users will now correctly reach hosted backend for billing, team, credentials, channels, voice, webhooks, socket, and meet_agent operations
- **No breaking changes**: `effective_api_url` still exists for inference callers; `effective_backend_api_url` is the renamed `effective_integrations_api_url` with same semantics

## Related

- Closes #1663
- Follow-up: Consider adding clippy lint or CI grep gate to prevent future regressions (step 4 from issue)