### PR TITLE
Allow private HTTP core URLs

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' data: blob: https: wss: ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:*; img-src 'self' data: blob: https:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https: wss: data: blob:; frame-src 'self' https: data: blob:"
+      "csp": "default-src 'self' 'unsafe-inline' data: blob: https: wss: ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:*; img-src 'self' data: blob: https:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:* http: ws://127.0.0.1:* ws://localhost:* ws: https: wss: data: blob:; frame-src 'self' https: data: blob:"
     },
     "macOSPrivateApi": true
   },

--- a/app/src/components/BootCheckGate/BootCheckGate.tsx
+++ b/app/src/components/BootCheckGate/BootCheckGate.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
   clearStoredCoreMode,
   clearStoredCoreToken,
+  isLocalOrPrivateNetworkHost,
   storeCoreMode,
   storeCoreToken,
   storeRpcUrl,
@@ -114,6 +115,12 @@ function ModePicker({ onConfirm }: PickerProps) {
       const parsed = new URL(trimmedUrl);
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         setUrlError('URL must start with http:// or https://');
+        return null;
+      }
+      if (parsed.protocol === 'http:' && !isLocalOrPrivateNetworkHost(parsed.hostname)) {
+        setUrlError(
+          'HTTP core URLs are only allowed for localhost or private network hosts. Use HTTPS for public hosts.'
+        );
         return null;
       }
     } catch {

--- a/app/src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx
+++ b/app/src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx
@@ -39,14 +39,17 @@ vi.mock('../../../services/coreRpcClient', () => ({
   testCoreRpcConnection: (...args: unknown[]) => mockTestCoreRpcConnection(...args),
 }));
 
-vi.mock('../../../utils/configPersistence', () => ({
-  storeRpcUrl: vi.fn(),
-  storeCoreToken: vi.fn(),
-  clearStoredCoreToken: vi.fn(),
-  storeCoreMode: vi.fn(),
-  clearStoredCoreMode: vi.fn(),
-  isValidRpcUrl: vi.fn().mockReturnValue(true),
-}));
+vi.mock('../../../utils/configPersistence', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../utils/configPersistence')>();
+  return {
+    ...actual,
+    storeRpcUrl: vi.fn(),
+    storeCoreToken: vi.fn(),
+    clearStoredCoreToken: vi.fn(),
+    storeCoreMode: vi.fn(),
+    clearStoredCoreMode: vi.fn(),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Store factory
@@ -155,6 +158,43 @@ describe('BootCheckGate — picker (unset mode)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(screen.getByText(/Please enter the core auth token/i)).toBeInTheDocument();
+  });
+
+  it('accepts a Tailscale HTTP core URL in cloud mode', async () => {
+    mockRunBootCheck.mockResolvedValue({ kind: 'match' });
+
+    renderGate();
+    fireEvent.click(screen.getByText('Cloud'));
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\/core\.example\.com/), {
+      target: { value: 'http://100.116.244.64:7788/rpc' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Bearer token/i), {
+      target: { value: 'tok-1234' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('app-content')).toBeInTheDocument();
+    });
+    expect(mockRunBootCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'cloud',
+        url: 'http://100.116.244.64:7788/rpc',
+        token: 'tok-1234',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('rejects public HTTP cloud URLs', () => {
+    renderGate();
+
+    fireEvent.click(screen.getByText('Cloud'));
+    const urlInput = screen.getByPlaceholderText(/https:\/\/core\.example\.com/);
+    fireEvent.change(urlInput, { target: { value: 'http://core.example.com/rpc' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByText(/HTTP core URLs are only allowed/)).toBeInTheDocument();
   });
 
   it('clears the token error as soon as the user types into the token field', () => {

--- a/app/src/utils/__tests__/configPersistence.test.ts
+++ b/app/src/utils/__tests__/configPersistence.test.ts
@@ -12,6 +12,8 @@ import {
   getStoredCoreMode,
   getStoredCoreToken,
   getStoredRpcUrl,
+  isAllowedCloudRpcUrl,
+  isLocalOrPrivateNetworkHost,
   isValidRpcUrl,
   normalizeRpcUrl,
   peekStoredRpcUrl,
@@ -202,6 +204,56 @@ describe('configPersistence', () => {
 
     it('returns false for http:// with no host', () => {
       expect(isValidRpcUrl('http://')).toBe(false);
+    });
+  });
+
+  describe('isLocalOrPrivateNetworkHost', () => {
+    it('allows localhost and loopback addresses', () => {
+      expect(isLocalOrPrivateNetworkHost('localhost')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('app.localhost')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('127.0.0.1')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('::1')).toBe(true);
+    });
+
+    it('allows RFC1918, link-local, and Tailscale/CGNAT IPv4 addresses', () => {
+      expect(isLocalOrPrivateNetworkHost('10.0.0.8')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('172.16.0.1')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('172.31.255.255')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('192.168.1.100')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('169.254.10.20')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('100.64.0.1')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('100.116.244.64')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('100.127.255.254')).toBe(true);
+    });
+
+    it('allows private IPv6 ranges', () => {
+      expect(isLocalOrPrivateNetworkHost('fc00::1')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('fd12:3456::1')).toBe(true);
+      expect(isLocalOrPrivateNetworkHost('fe80::1')).toBe(true);
+    });
+
+    it('rejects public hosts and invalid IPv4 addresses', () => {
+      expect(isLocalOrPrivateNetworkHost('example.com')).toBe(false);
+      expect(isLocalOrPrivateNetworkHost('8.8.8.8')).toBe(false);
+      expect(isLocalOrPrivateNetworkHost('100.128.0.1')).toBe(false);
+      expect(isLocalOrPrivateNetworkHost('256.1.1.1')).toBe(false);
+    });
+  });
+
+  describe('isAllowedCloudRpcUrl', () => {
+    it('allows HTTPS cloud URLs on public hosts', () => {
+      expect(isAllowedCloudRpcUrl('https://core.example.com/rpc')).toBe(true);
+    });
+
+    it('allows HTTP only for local and private-network core URLs', () => {
+      expect(isAllowedCloudRpcUrl('http://127.0.0.1:7788/rpc')).toBe(true);
+      expect(isAllowedCloudRpcUrl('http://192.168.1.100:7788/rpc')).toBe(true);
+      expect(isAllowedCloudRpcUrl('http://100.116.244.64:7788/rpc')).toBe(true);
+    });
+
+    it('rejects public HTTP cloud URLs', () => {
+      expect(isAllowedCloudRpcUrl('http://core.example.com/rpc')).toBe(false);
+      expect(isAllowedCloudRpcUrl('http://8.8.8.8:7788/rpc')).toBe(false);
     });
   });
 

--- a/app/src/utils/configPersistence.ts
+++ b/app/src/utils/configPersistence.ts
@@ -125,6 +125,54 @@ export function isValidRpcUrl(url: string): boolean {
 }
 
 /**
+ * Return true when `hostname` is local or private-network address space.
+ *
+ * This intentionally includes Tailscale/CGNAT (`100.64.0.0/10`): self-hosted
+ * cores often run on tailnets where the transport is already encrypted and
+ * the HTTP service is not exposed to the public internet.
+ */
+export function isLocalOrPrivateNetworkHost(hostname: string): boolean {
+  const host = hostname
+    .trim()
+    .replace(/^\[(.*)\]$/, '$1')
+    .toLowerCase();
+  if (!host) return false;
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host === '::1') return true;
+  if (host.startsWith('fe80:')) return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(host)) return true;
+
+  const match = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return false;
+
+  const octets = match.slice(1).map(Number);
+  if (octets.some(octet => octet < 0 || octet > 255)) return false;
+
+  const [a, b] = octets;
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127)
+  );
+}
+
+/**
+ * Cloud cores may use HTTPS on any host. Plain HTTP is accepted only for
+ * localhost/private networks, including tailnets, to avoid encouraging
+ * bearer-token transport over public plaintext links.
+ */
+export function isAllowedCloudRpcUrl(url: string): boolean {
+  if (!isValidRpcUrl(url)) return false;
+
+  const parsed = new URL(url.trim());
+  if (parsed.protocol === 'https:') return true;
+  return parsed.protocol === 'http:' && isLocalOrPrivateNetworkHost(parsed.hostname);
+}
+
+/**
  * Normalize an RPC URL by trimming whitespace and trailing slashes.
  *
  * @param url - The URL to normalize

--- a/gitbooks/features/cloud-deploy.md
+++ b/gitbooks/features/cloud-deploy.md
@@ -20,9 +20,12 @@ This guide covers three deploy paths, easiest first:
 3. [Any VPS via Docker Compose](#3-any-vps-via-docker-compose)
 
 What gets deployed in every path: a single container running
-`openhuman-core serve` on port `7788`, behind the provider's TLS. The desktop
-app already knows how to talk to a remote core, set
-`OPENHUMAN_CORE_RPC_URL=https://your-host/rpc` and `OPENHUMAN_CORE_TOKEN=...`
+`openhuman-core serve` on port `7788`. Public hosts should sit behind the
+provider's TLS, for example `https://core.example.com/rpc`. Private-only hosts
+on localhost, RFC1918 networks, or tailnets such as Tailscale can use
+plain HTTP, for example `http://100.x.x.x:7788/rpc`, when the core is not
+reachable from the public internet. The desktop app already knows how to talk
+to a remote core; set `OPENHUMAN_CORE_RPC_URL` and `OPENHUMAN_CORE_TOKEN=...`
 in `app/.env.local` and launch.
 
 ---
@@ -337,8 +340,17 @@ OPENHUMAN_CORE_RPC_URL=https://core.example.com/rpc
 OPENHUMAN_CORE_TOKEN=<the same token you set on the server>
 ```
 
+For a private tailnet-only VM with no public IP, use the tailnet URL instead:
+
+```bash
+OPENHUMAN_CORE_RUN_MODE=external
+OPENHUMAN_CORE_RPC_URL=http://100.x.x.x:7788/rpc
+OPENHUMAN_CORE_TOKEN=<the same token you set on the server>
+```
+
 Restart the desktop app. The provider chain in `App.tsx` will route all RPC
-calls to the remote core; nothing else changes.
+calls to the remote core; nothing else changes. Public `http://` hosts are
+rejected by the app picker; use HTTPS for any publicly reachable core.
 
 ---
 

--- a/src/openhuman/memory/tree/ingest.rs
+++ b/src/openhuman/memory/tree/ingest.rs
@@ -368,7 +368,7 @@ fn markdown_body_preview(md: &str) -> String {
     if len <= BODY_PREVIEW_MAX_BYTES {
         md.to_string()
     } else {
-        let start = md.ceil_char_boundary(len - BODY_PREVIEW_MAX_BYTES);
+        let start = crate::openhuman::util::ceil_char_boundary(md, len - BODY_PREVIEW_MAX_BYTES);
         md[start..].to_string()
     }
 }

--- a/src/openhuman/tools/impl/browser/screenshot.rs
+++ b/src/openhuman/tools/impl/browser/screenshot.rs
@@ -152,7 +152,10 @@ impl ScreenshotTool {
                 let size = bytes.len();
                 let mut encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
                 let truncated = if encoded.len() > MAX_BASE64_BYTES {
-                    encoded.truncate(encoded.floor_char_boundary(MAX_BASE64_BYTES));
+                    encoded.truncate(crate::openhuman::util::floor_char_boundary(
+                        &encoded,
+                        MAX_BASE64_BYTES,
+                    ));
                     true
                 } else {
                     false

--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -223,11 +223,17 @@ impl Tool for NodeExecTool {
                 let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
                 if stdout.len() > MAX_OUTPUT_BYTES {
-                    stdout.truncate(stdout.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stdout.truncate(crate::openhuman::util::floor_char_boundary(
+                        &stdout,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stdout.push_str("\n... [stdout truncated at 1MB]");
                 }
                 if stderr.len() > MAX_OUTPUT_BYTES {
-                    stderr.truncate(stderr.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stderr.truncate(crate::openhuman::util::floor_char_boundary(
+                        &stderr,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stderr.push_str("\n... [stderr truncated at 1MB]");
                 }
 

--- a/src/openhuman/tools/impl/system/npm_exec.rs
+++ b/src/openhuman/tools/impl/system/npm_exec.rs
@@ -235,11 +235,17 @@ impl Tool for NpmExecTool {
                 let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
                 if stdout.len() > MAX_OUTPUT_BYTES {
-                    stdout.truncate(stdout.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stdout.truncate(crate::openhuman::util::floor_char_boundary(
+                        &stdout,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stdout.push_str("\n... [stdout truncated at 1MB]");
                 }
                 if stderr.len() > MAX_OUTPUT_BYTES {
-                    stderr.truncate(stderr.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stderr.truncate(crate::openhuman::util::floor_char_boundary(
+                        &stderr,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stderr.push_str("\n... [stderr truncated at 1MB]");
                 }
 

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -175,11 +175,17 @@ impl Tool for ShellTool {
 
                 // Truncate output to prevent OOM
                 if stdout.len() > MAX_OUTPUT_BYTES {
-                    stdout.truncate(stdout.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stdout.truncate(crate::openhuman::util::floor_char_boundary(
+                        &stdout,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stdout.push_str("\n... [output truncated at 1MB]");
                 }
                 if stderr.len() > MAX_OUTPUT_BYTES {
-                    stderr.truncate(stderr.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stderr.truncate(crate::openhuman::util::floor_char_boundary(
+                        &stderr,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stderr.push_str("\n... [stderr truncated at 1MB]");
                 }
 

--- a/src/openhuman/tree_summarizer/engine.rs
+++ b/src/openhuman/tree_summarizer/engine.rs
@@ -408,7 +408,8 @@ async fn summarize_to_limit(
             char_limit
         );
         // Truncate at a char boundary
-        let truncated = &response[..response.floor_char_boundary(char_limit)];
+        let truncated =
+            &response[..crate::openhuman::util::floor_char_boundary(&response, char_limit)];
         truncated.to_string()
     } else {
         response

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -79,6 +79,18 @@ pub fn floor_char_boundary(s: &str, index: usize) -> usize {
     end
 }
 
+/// Round a byte index UP to the nearest UTF-8 character boundary.
+pub fn ceil_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut start = index;
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    start
+}
+
 /// Utility enum for handling optional values.
 pub enum MaybeSet<T> {
     Set(T),
@@ -213,6 +225,19 @@ mod tests {
         assert_eq!(floor_char_boundary(s, 5), 5); // After '🦀'
         assert_eq!(floor_char_boundary(s, 6), 6); // After 'C'
         assert_eq!(floor_char_boundary(s, 100), 6);
+    }
+
+    #[test]
+    fn test_ceil_char_boundary() {
+        let s = "A🦀C";
+        assert_eq!(ceil_char_boundary(s, 0), 0);
+        assert_eq!(ceil_char_boundary(s, 1), 1); // After 'A'
+        assert_eq!(ceil_char_boundary(s, 2), 5); // Mid-🦀
+        assert_eq!(ceil_char_boundary(s, 3), 5); // Mid-🦀
+        assert_eq!(ceil_char_boundary(s, 4), 5); // Mid-🦀
+        assert_eq!(ceil_char_boundary(s, 5), 5); // After '🦀'
+        assert_eq!(ceil_char_boundary(s, 6), 6); // After 'C'
+        assert_eq!(ceil_char_boundary(s, 100), 6);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Allow desktop cloud mode to connect to private HTTP core URLs on localhost, RFC1918 LAN hosts, and tailnet/CGNAT ranges such as Tailscale `100.x.x.x`.
- Keep public `http://` core URLs rejected; publicly reachable cores must still use HTTPS.
- Widen the Tauri CSP so validated HTTP/WS private core URLs can actually fetch/connect.
- Document the tailnet-only VM pattern for hosted cores with no public IP.
- Replace unstable Rust char-boundary helpers with stable local helpers so `rust:check` works on the pinned stable toolchain.

## Problem

- A tailnet-only core at `http://100.116.244.64:7788` failed from the desktop app with `Failed to fetch`.
- The UI validation and CSP were not aligned: private HTTP cores should be usable, but public HTTP cores should stay blocked.
- Local pre-push was also blocked by native CEF/whisper build prerequisites and then by unstable standard-library `floor_char_boundary` / `ceil_char_boundary` calls.

## Solution

- Add private/local host detection for cloud core URLs and use it to allow only safe HTTP targets.
- Keep the public-host guard explicit so `http://example.com` remains rejected in cloud mode.
- Permit `http:` and `ws:` in Tauri `connect-src`, with app-side validation as the guardrail.
- Add tests for Tailscale/private HTTP allow paths and public HTTP rejection paths.
- Add stable UTF-8 boundary helper functions and use them where output truncation needs char-safe byte indexes.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement): private/Tailscale HTTP happy paths and public HTTP rejection paths covered in Vitest; Rust char-boundary helper covered by unit test.
- [x] **Diff coverage >= 80%**: local focused tests cover changed lines. Full `pnpm --filter openhuman-app test:coverage` was attempted but hit an unrelated, isolated-passing `CoreStateProvider` cache test; CI diff-cover remains source of truth.
- [x] Coverage matrix updated: N/A — no feature row was added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`: N/A — no existing matrix feature ID maps to cloud-core URL transport validation.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)).
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)): N/A — not a release-cut smoke surface; docs and automated tests updated.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section: N/A — no linked issue.

## Impact

- Desktop cloud mode can target a private remote core over HTTP when the host is local/private/tailnet-only.
- Public cloud deployments still require HTTPS.
- No migration required. Existing local mode and existing HTTPS cloud-core configs are preserved.
- Security impact: private HTTP is limited by URL validation; bearer token auth is unchanged.

## Related

- Closes: N/A — no linked issue.
- Follow-up PR(s)/TODOs: N/A.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A — no Linear issue supplied.
- URL: N/A.

### Commit & Branch
- Branch: `codex/allow-private-http-core`
- Commit SHA: `b47ce497facf01220ae65b68fb99030b922865a6`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` (`pnpm --filter openhuman-app compile` via pre-push)
- [x] Focused tests: `pnpm exec vitest run --config test/vitest.config.ts src/utils/__tests__/configPersistence.test.ts src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx`
- [x] Rust fmt/check (if changed): `cargo test --manifest-path Cargo.toml char_boundary`; `env -u BACKEND_URL -u VITE_BACKEND_URL cargo test -p openhuman`; `pnpm --filter openhuman-app rust:check`
- [x] Tauri fmt/check (if changed): included in `pnpm --filter openhuman-app format:check` and `pnpm --filter openhuman-app rust:check`

### Validation Blocked
- `command:` `pnpm --filter openhuman-app test:coverage`
- `error:` one unrelated local failure: `CoreStateProvider — identity-change cache clearing > preserves teams cache when identity is unchanged across refreshes`; focused retry of that exact test passed.
- `impact:` coverage command did not complete locally; PR-specific focused Vitest tests passed and CI coverage gate remains authoritative.
- `command:` `pnpm test:rust`
- `error:` local script exports `BACKEND_URL` before `cargo test`, so Rust `option_env!("BACKEND_URL")` bakes the mock URL into tests that expect default API behavior.
- `impact:` CI-like `env -u BACKEND_URL -u VITE_BACKEND_URL cargo test -p openhuman` passed locally.

### Behavior Changes
- Intended behavior change: allow private/local HTTP remote core URLs, including Tailscale `100.x.x.x`, while rejecting public HTTP core URLs.
- User-visible effect: a tailnet-only remote core such as `http://100.x.x.x:7788/rpc` can be used from the desktop cloud-mode picker.

### Parity Contract
- Legacy behavior preserved: local embedded core mode unchanged; HTTPS cloud core URLs unchanged; auth token storage and bearer forwarding unchanged.
- Guard/fallback/dispatch parity checks: public HTTP rejection covered; private HTTP allow paths covered; malformed/private-host edge cases covered; CSP now permits the validated transport.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A.
- Canonical PR: #1765.
- Resolution (closed/superseded/updated): updated existing PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud mode now validates HTTP core URLs: restricted to local and private networks only; HTTPS permitted on all hosts.

* **Documentation**
  * Updated cloud deployment guide with examples for localhost, private network, and tailnet connections to hosted cores.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1765)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->