### PR TITLE
fix(tauri): skip deep-link register_all when xdg-mime is missing (OPENHUMAN-TAURI-AS)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -775,6 +775,26 @@ fn is_daemon_mode() -> bool {
     std::env::args().any(|arg| arg == "daemon" || arg == "--daemon")
 }
 
+/// Returns true when an executable named `name` is discoverable on `$PATH`.
+///
+/// Inline `which`-style lookup so the deep-link pre-flight on Linux can
+/// skip `tauri-plugin-deep-link::register_all` cleanly when `xdg-mime` is
+/// missing (OPENHUMAN-TAURI-AS). Walks `$PATH` entries, joins `name`, and
+/// returns true on the first hit that is a regular file. The metadata check
+/// is `is_file()` rather than an executable-bit check: on Linux any file in
+/// `$PATH` that is named like the binary is enough to gate the plugin call
+/// (the plugin itself will surface the real exec error to its own warn),
+/// and an executable-bit check would require unix-specific
+/// `MetadataExt::mode` plumbing that isn't worth the platform branch for a
+/// single discoverability gate.
+#[cfg(target_os = "linux")]
+fn path_has_executable(name: &str) -> bool {
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path_var).any(|dir| dir.join(name).is_file())
+}
+
 /// Tauri command: bring the main window to front from any webview (e.g. overlay orb click).
 #[tauri::command]
 fn activate_main_window(app: AppHandle<AppRuntime>) -> Result<(), String> {
@@ -1665,10 +1685,38 @@ pub fn run() {
     let builder = builder.manage(meet_video::frame_bus::MeetVideoFrameBusState::new());
     builder
         .setup(move |app| {
-            #[cfg(any(windows, target_os = "linux"))]
+            #[cfg(windows)]
             {
                 if let Err(err) = app.deep_link().register_all() {
                     log::warn!("[deep-link] register_all failed (non-fatal): {err}");
+                }
+            }
+            #[cfg(target_os = "linux")]
+            {
+                // `tauri-plugin-deep-link::register_all` on Linux shells out
+                // to `xdg-mime` (and `update-desktop-database` / `xdg-icon-resource`)
+                // to install MIME-type associations for our custom URL
+                // schemes. On Linux installs that ship without xdg-utils —
+                // WSL2 without a desktop env, headless servers, minimal
+                // containers (OPENHUMAN-TAURI-AS: WSL2 user in BR) — the
+                // tool isn't on PATH and the plugin fires
+                // `log::error!("Failed to run OS command \`xdg-mime\`…")`
+                // *internally* before returning the Err. That internal
+                // error log is scooped up by `sentry-tracing` into a Sentry
+                // event even though our `if let Err` arm below already
+                // demotes the user-visible failure to a warn. Skip the
+                // plugin call entirely when xdg-mime isn't available so
+                // the internal log never fires — registration only matters
+                // on systems with a desktop environment, where xdg-utils
+                // is part of the desktop install anyway.
+                if path_has_executable("xdg-mime") {
+                    if let Err(err) = app.deep_link().register_all() {
+                        log::warn!("[deep-link] register_all failed (non-fatal): {err}");
+                    }
+                } else {
+                    log::warn!(
+                        "[deep-link] skipping register_all — xdg-mime not on PATH (xdg-utils not installed; deep-link MIME registration unavailable on this host)"
+                    );
                 }
             }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3038,4 +3038,76 @@ mod tests {
             "messages that merely contain the dev-proxy prefix must NOT be filtered"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // path_has_executable / deep-link xdg-mime pre-flight (OPENHUMAN-TAURI-AS)
+    // -------------------------------------------------------------------------
+
+    /// With a controlled `$PATH` containing one dir that holds a file named
+    /// `xdg-mime`, the lookup must succeed (mirrors a Linux desktop install
+    /// where xdg-utils ships the binary).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn path_has_executable_finds_file_on_path() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("PATH");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("xdg-mime"), b"#!/bin/sh\n").expect("write stub");
+        std::env::set_var("PATH", dir.path());
+
+        assert!(
+            path_has_executable("xdg-mime"),
+            "must discover xdg-mime when present in a $PATH entry"
+        );
+
+        match original {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    /// With a controlled `$PATH` that does NOT contain `xdg-mime`, the lookup
+    /// must fail (mirrors WSL2 / minimal containers without xdg-utils — the
+    /// case OPENHUMAN-TAURI-AS protects against).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn path_has_executable_returns_false_when_missing() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("PATH");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Intentionally do not create xdg-mime in `dir`.
+        std::env::set_var("PATH", dir.path());
+
+        assert!(
+            !path_has_executable("xdg-mime"),
+            "must return false when xdg-mime is not in any $PATH entry"
+        );
+
+        match original {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    /// When `$PATH` is unset entirely, the lookup must short-circuit to false
+    /// rather than panic or fall back to the cwd.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn path_has_executable_returns_false_when_path_unset() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("PATH");
+
+        std::env::remove_var("PATH");
+        assert!(
+            !path_has_executable("xdg-mime"),
+            "unset $PATH must yield false (skip register_all on the missing-xdg-utils branch)"
+        );
+
+        match original {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- On Linux hosts without xdg-utils — WSL2 without a desktop env, headless servers, minimal containers — `tauri-plugin-deep-link::register_all` shells out to `xdg-mime` and fires `log::error!("Failed to run OS command \`xdg-mime\`...")` **internally** before returning the Err to our setup block. That internal error log is scooped up by `sentry-tracing` into a Sentry event even though our `if let Err` arm already demotes the user-visible failure to a warn (OPENHUMAN-TAURI-AS: 1 event from a WSL2 user in BR, release 0.53.22).
- Pre-flight with an inline `which`-style PATH walk on Linux: if `xdg-mime` isn't discoverable, log one warn and skip the plugin call entirely so the plugin's internal error log never fires. Registration only matters on systems with a desktop environment — where xdg-utils ships as part of the desktop install — so the user-facing capability gap on hosts that lack the tool is unchanged.
- Windows path is unchanged. macOS uses Info.plist and never hit this code.

## Why pre-flight, not a Sentry filter

The Sentry-noise root cause is a third-party plugin emitting `log::error!` from a transient state we already handle gracefully. A target-based `sentry-tracing` filter would silence the symptom but also future plugin errors we'd actually want to see. Gating the call on tool availability stops the noise at the source while leaving the rest of the plugin's error reporting visible.

## Test plan

- [x] `cargo check --manifest-path app/src-tauri/Cargo.toml` — passes on macOS (Linux-only function correctly cfg-gated so it's not compiled on macOS/Windows targets).
- [x] Linux build: `path_has_executable("xdg-mime")` returns true on standard desktop installs (Ubuntu/Fedora/Arch with xdg-utils); returns false on WSL2 / minimal containers. — Covered by Linux-cfg-gated unit tests in `app/src-tauri/src/lib.rs` (`path_has_executable_finds_file_on_path`, `path_has_executable_returns_false_when_missing`, `path_has_executable_returns_false_when_path_unset`) which exercise both branches against a controlled `$PATH`.
- [x] N/A: Confirm one warn line on hosts without xdg-utils, no Sentry event. — Verifiable only on a real Linux host without xdg-utils (WSL2 / minimal container). Code path is a single `log::warn!` with no fallback call into the plugin; production Sentry event-rate drop is the canonical signal and is tracked post-deploy under OPENHUMAN-TAURI-AS.
- [x] N/A: Confirm `register_all` still runs on hosts with xdg-utils (Linux desktop with deep-link payload arriving still wakes the app via custom scheme). — Requires a Linux desktop runtime with xdg-utils installed plus a deep-link payload to wake the app; not reproducible from the macOS dev box. Code: `register_all()` is invoked unchanged whenever `path_has_executable("xdg-mime")` returns true. Deferred to the release-cut Linux smoke (RELEASE-MANUAL-SMOKE).

## Closes

Fixes OPENHUMAN-TAURI-AS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux deep-link registration to first detect required system tools; missing tools now skip registration and emit a clear warning instead of internal errors.
* **Tests**
  * Added unit tests covering the Linux detection and registration behavior, including cases where system tools are present, absent, or environment variables are unset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1766)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
