### PR TITLE
fix(voice): forward audio setup errors through setup_tx (OPENHUMAN-TAURI-AE)

### DIFF
--- a/src/openhuman/voice/audio_capture.rs
+++ b/src/openhuman/voice/audio_capture.rs
@@ -232,25 +232,61 @@ fn record_on_thread(
     }
 
     let host = cpal::default_host();
-    let device = host
-        .default_input_device()
-        .ok_or_else(|| "no default audio input device found".to_string())?;
+    let device = match host.default_input_device() {
+        Some(d) => d,
+        None => {
+            // Forward via setup_tx so `start_recording`'s caller sees the
+            // real reason instead of the generic "capture thread exited
+            // before signalling readiness" fallback that fires when
+            // setup_tx is dropped (OPENHUMAN-TAURI-AE). Without this, the
+            // user — and Sentry — gets no signal about *which* audio
+            // failure occurred.
+            let msg = "no default audio input device found".to_string();
+            error!("{LOG_PREFIX} {msg}");
+            let _ = setup_tx.send(Err(msg.clone()));
+            return Err(msg);
+        }
+    };
 
     let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
     info!("{LOG_PREFIX} using input device: {device_name}");
 
     let config = match device.supported_input_configs() {
-        Ok(supported) => find_best_config(supported).unwrap_or_else(|e| {
-            warn!("{LOG_PREFIX} find_best_config failed ({e}), falling back to default");
-            device
-                .default_input_config()
-                .expect("no default input config available")
-        }),
+        Ok(supported) => match find_best_config(supported) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                warn!("{LOG_PREFIX} find_best_config failed ({e}), falling back to default");
+                match device.default_input_config() {
+                    Ok(cfg) => cfg,
+                    Err(e2) => {
+                        // Replaces a `.expect()` that would have panicked
+                        // and dropped setup_tx — see OPENHUMAN-TAURI-AE.
+                        let msg = format!(
+                            "no default input config available (best-config failed: {e}; default lookup: {e2})"
+                        );
+                        error!("{LOG_PREFIX} {msg}");
+                        let _ = setup_tx.send(Err(msg.clone()));
+                        return Err(msg);
+                    }
+                }
+            }
+        },
         Err(e) => {
             warn!("{LOG_PREFIX} failed to query input configs ({e}), using default");
-            device
-                .default_input_config()
-                .map_err(|e2| format!("no default input config: {e2}"))?
+            match device.default_input_config() {
+                Ok(cfg) => cfg,
+                Err(e2) => {
+                    // Forward via setup_tx so callers see the real cpal
+                    // error rather than the generic dropped-tx fallback
+                    // (OPENHUMAN-TAURI-AE).
+                    let msg = format!(
+                        "no default input config: {e2} (supported-configs query failed: {e})"
+                    );
+                    error!("{LOG_PREFIX} {msg}");
+                    let _ = setup_tx.send(Err(msg.clone()));
+                    return Err(msg);
+                }
+            }
         }
     };
     let source_sample_rate = config.sample_rate().0;


### PR DESCRIPTION
## Summary

- `record_on_thread` in `src/openhuman/voice/audio_capture.rs` had three early-exit paths that propagated `Err` without first sending through `setup_tx` — the channel the capture OS thread uses to signal readiness (or the reason it can't start) to `start_recording`'s caller:
  1. `host.default_input_device().ok_or_else(...)?` (no input device on the system)
  2. `device.default_input_config().expect("no default input config available")` (panic on the supported-configs-OK / best-config-fallback path)
  3. `device.default_input_config().map_err(...)?` (the supported-configs-failed fallback arm)
- When `setup_tx` is dropped without sending, `setup_rx.recv()` returns Err and `start_recording` reports the generic `"capture thread exited before signalling readiness"` — useless to the user (and Sentry) for diagnosing the actual audio failure (OPENHUMAN-TAURI-AE — 1 event on macOS 26.4.1, Apple Silicon Mac16,10).
- Mirror the existing pattern already used at lines 407-409, 416-417, 425-426 in the same function (preferred-config fallback / no-default-config / stream.play paths) — every setup failure now sends `Err(msg)` through `setup_tx` before returning, so the caller surfaces the real cpal error.

## Impact

- User gets a real error message (e.g. `"no default audio input device found"`) as a toast → actionable: check mic plug, switch input device, grant Microphone permission to OpenHuman in System Settings.
- Sentry groups on the actual failure mode instead of one unactionable bucket for every audio-system failure shape.
- The `"capture thread exited before signalling readiness"` fallback stays meaningful for the cases it was designed for: a panic or an OS thread that exits without surfacing a reason.

## Test plan

- [x] `cargo fmt` + `cargo check --manifest-path Cargo.toml` — pass.
- [x] `cargo test --lib voice::audio_capture` — 16 pass (the existing pure-function tests for `to_mono`, `resample`, `find_best_config`, `silence_gate`, `finalize`, `update_peak_rms`).
- [x] N/A: code mirrors existing in-file pattern at lines 407-409, 416-417, 425-426 (already validated at runtime in the preferred-config fallback / no-default-config / stream.play paths); reproducing "no default input device" deterministically on CI requires cpal mocking scaffold out of scope for this fix. Original step was: manual on macOS without a default input device (Audio MIDI Setup → uncheck all input devices, or unplug all mics) — trigger voice recording from the UI, confirm the toast shows `"no default audio input device found"` instead of `"capture thread exited..."`.

No regression test added: exercising `record_on_thread`'s early-exit paths requires either mocking cpal (significant scaffolding) or running on a real system without input devices (non-deterministic on CI). The new code is structurally identical to three existing in-file patterns that already do the same thing, all covered by the integration of the voice subsystem at runtime.

## Closes

Fixes OPENHUMAN-TAURI-AE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio device configuration error handling with improved fallback mechanisms and more detailed error messaging, resulting in better reliability when audio input devices are unavailable or misconfigured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1770)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
