### PR TITLE
fix(onboarding): keep skip completion moving after task sync failure

### DIFF
--- a/app/src/pages/onboarding/OnboardingLayout.tsx
+++ b/app/src/pages/onboarding/OnboardingLayout.tsx
@@ -65,15 +65,19 @@ const OnboardingLayout = () => {
       connectedSources: draft.connectedSources,
     });
 
-    await setOnboardingTasks({
-      accessibilityPermissionGranted:
-        snapshot.localState.onboardingTasks?.accessibilityPermissionGranted ?? false,
-      localModelConsentGiven: false,
-      localModelDownloadStarted: false,
-      enabledTools: getDefaultEnabledTools(),
-      connectedSources: draft.connectedSources,
-      updatedAtMs: Date.now(),
-    });
+    try {
+      await setOnboardingTasks({
+        accessibilityPermissionGranted:
+          snapshot.localState.onboardingTasks?.accessibilityPermissionGranted ?? false,
+        localModelConsentGiven: false,
+        localModelDownloadStarted: false,
+        enabledTools: getDefaultEnabledTools(),
+        connectedSources: draft.connectedSources,
+        updatedAtMs: Date.now(),
+      });
+    } catch (e) {
+      console.warn('[onboarding] Failed to persist onboarding tasks; continuing completion', e);
+    }
 
     try {
       await userApi.onboardingComplete();

--- a/app/src/pages/onboarding/__tests__/OnboardingLayout.test.tsx
+++ b/app/src/pages/onboarding/__tests__/OnboardingLayout.test.tsx
@@ -228,4 +228,21 @@ describe('OnboardingLayout — Joyride walkthrough integration (#1123)', () => {
     // Navigation should still proceed even when the flag cannot be written.
     expect(screen.getByTestId('home-page')).toBeInTheDocument();
   });
+
+  it('still completes onboarding when persisting onboarding tasks fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { mockSetOnboardingCompletedFlag, mockSetOnboardingTasks } = await setupLayout();
+    mockSetOnboardingTasks.mockRejectedValueOnce(
+      new Error('Core RPC openhuman.app_state_snapshot timed out after 30000ms')
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('complete-btn'));
+    });
+
+    expect(mockSetOnboardingCompletedFlag).toHaveBeenCalledWith(true);
+    expect(screen.getByTestId('home-page')).toBeInTheDocument();
+
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

- Allows onboarding completion to continue when persisting onboarding task metadata fails.
- Adds a focused regression test for the `openhuman.app_state_snapshot timed out after 30000ms` failure path.
- Keeps the existing completion flag write as the required source of truth for finishing onboarding.

## Problem

- In issue #1728, rejecting Google auth could leave users stuck when skipping onboarding.
- `setOnboardingTasks` persists onboarding metadata and refreshes core local state; that refresh can call `openhuman.app_state_snapshot` and time out.
- When that best-effort metadata write rejected, `completeAndExit` stopped before setting the onboarding completed flag or navigating home.

## Solution

- Wrap the onboarding task metadata persistence in a try/catch and log the failure.
- Continue through backend notification, `setOnboardingCompletedFlag(true)`, walkthrough state, and navigation.
- Add a regression test that rejects `setOnboardingTasks` with the reported timeout and asserts onboarding still completes.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - focused regression covers the changed failure branch; CI coverage gate remains authoritative.
- [x] Coverage matrix updated - N/A: behavior-only onboarding completion resilience; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no matrix feature IDs changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) - N/A: no release-cut smoke checklist surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Frontend onboarding only.
- No API, schema, migration, dependency, Rust, or Tauri behavior changes.
- User-visible effect: Skip/Continue can reach Home even if the onboarding task metadata refresh times out.

## Related

- Closes: #1728
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: codex/1728-onboarding-skip-timeout-fork
- Commit SHA: ca2f3cb3af64f3ffd38360d7e9bbdda6f0f8f8ac

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` - blocked locally on fork-main baseline drift; see Validation Blocked. Touched files pass targeted Prettier check.
- [x] `pnpm typecheck` - passed.
- [x] Focused tests: `pnpm --dir app exec vitest run src/pages/onboarding/__tests__/OnboardingLayout.test.tsx --config test/vitest.config.ts` - passed, 7 tests.
- [x] Rust fmt/check (if changed): N/A: no Rust files changed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked
- `command:` `pnpm format:check`
- `error:` Local fork baseline (`openhuman-app@0.53.43`) reports pre-existing Prettier drift in 26 unrelated files, for example `package.json`, `src/pages/Conversations.tsx`, and `test/wdio.conf.ts`. The two touched onboarding files pass targeted Prettier check.
- `impact:` Full local format check cannot be used on this fork baseline, but the patch files are formatted and GitHub CI should evaluate the merge result against current upstream main.

### Behavior Changes
- Intended behavior change: onboarding task metadata persistence is best-effort during completion.
- User-visible effect: users are no longer blocked from reaching Home by an `openhuman.app_state_snapshot` timeout while skipping/completing onboarding.

### Parity Contract
- Legacy behavior preserved: the app still attempts to persist onboarding task metadata before completing.
- Guard/fallback/dispatch parity checks: `setOnboardingCompletedFlag(true)` remains required and still rejects on failure; only the metadata sync failure is swallowed.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found for `#1728`, `app_state_snapshot`, or onboarding skip timeout. Broad open-PR search returned unrelated #1768, #1518, and #1321.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced onboarding flow to handle persistence failures gracefully. If task data fails to save, users can still complete onboarding and proceed instead of getting stuck.

* **Tests**
  * Added test coverage verifying onboarding completes successfully when task persistence fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1771)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->