### PR TITLE
fix(update): keep dismissed repeated errors hidden

### DIFF
--- a/app/src/components/AppUpdatePrompt.tsx
+++ b/app/src/components/AppUpdatePrompt.tsx
@@ -13,7 +13,7 @@
  * Visual conventions mirror `LocalAIDownloadSnackbar` — bottom-right portal,
  * stone-900 panel, primary gradient progress bar.
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useAppUpdate } from '../hooks/useAppUpdate';
@@ -48,12 +48,14 @@ const AppUpdatePrompt = (props: AppUpdatePromptProps) => {
 
   const [dismissed, setDismissed] = useState(false);
   const [prevPhase, setPrevPhase] = useState(phase);
-  // Re-show on every transition INTO a visible phase, even if the user had
-  // dismissed a previous error/prompt earlier in the session.
+  const dismissedErrorRef = useRef<string | null>(null);
+  const currentErrorKey = error ?? 'Update failed. See logs for details.';
+  // Re-show on every transition INTO a visible non-error phase, or when a new
+  // error differs from the one the user already dismissed this session.
   if (phase !== prevPhase) {
     setPrevPhase(phase);
     if (shouldShow(phase) && !shouldShow(prevPhase)) {
-      setDismissed(false);
+      setDismissed(phase === 'error' && dismissedErrorRef.current === currentErrorKey);
     }
   }
 
@@ -66,15 +68,17 @@ const AppUpdatePrompt = (props: AppUpdatePromptProps) => {
   }, []);
 
   const handleRetryDownload = useCallback(() => {
+    dismissedErrorRef.current = null;
     setDismissed(false);
     reset();
     void download();
   }, [reset, download]);
 
   const handleDismissError = useCallback(() => {
+    dismissedErrorRef.current = currentErrorKey;
     reset();
     setDismissed(true);
-  }, [reset]);
+  }, [currentErrorKey, reset]);
 
   if (!shouldShow(phase) || dismissed) return null;
 

--- a/app/src/components/__tests__/AppUpdatePrompt.test.tsx
+++ b/app/src/components/__tests__/AppUpdatePrompt.test.tsx
@@ -225,6 +225,28 @@ describe('AppUpdatePrompt', () => {
     });
   });
 
+  it('does not re-open the same dismissed update error on the next background cycle', async () => {
+    renderWithProviders(
+      <AppUpdatePrompt autoCheck={false} initialCheckDelayMs={0} recheckIntervalMs={0} />
+    );
+    await waitFor(() => expect(statusListeners.length).toBeGreaterThan(0));
+
+    emitStatus('error');
+    await waitFor(() => expect(screen.getByText('Update failed')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /^Dismiss$/i }));
+    await waitFor(() => {
+      expect(screen.queryByText('Update failed')).not.toBeInTheDocument();
+    });
+
+    emitStatus('checking');
+    emitStatus('error');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Update failed')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders nothing when not in Tauri', async () => {
     mockIsTauri.mockReturnValue(false);
 

--- a/app/src/components/__tests__/AppUpdatePrompt.test.tsx
+++ b/app/src/components/__tests__/AppUpdatePrompt.test.tsx
@@ -8,7 +8,7 @@
  *     (`ready_to_install`)
  *   - error surface with retry path
  */
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../test/test-utils';
@@ -239,12 +239,11 @@ describe('AppUpdatePrompt', () => {
       expect(screen.queryByText('Update failed')).not.toBeInTheDocument();
     });
 
-    emitStatus('checking');
-    emitStatus('error');
-
-    await waitFor(() => {
-      expect(screen.queryByText('Update failed')).not.toBeInTheDocument();
+    await act(async () => {
+      emitStatus('checking');
+      emitStatus('error');
     });
+    expect(screen.queryByText('Update failed')).not.toBeInTheDocument();
   });
 
   it('renders nothing when not in Tauri', async () => {


### PR DESCRIPTION
﻿## Summary

- Keeps a dismissed app-update error prompt hidden when the same error cycles again in the same session.
- Still allows non-error update prompts, new error messages, and manual retry flows to surface normally.
- Adds a focused regression test for a repeated `checking -> error` cycle after dismiss.

## Problem

- Issue #1772 reports a popup repeatedly appearing after app open.
- The global update prompt re-opens whenever the update hook transitions from a non-visible phase into `error`.
- If a background update probe or download keeps cycling through the same failure, dismissing the prompt does not provide a durable session-level snooze for that same error.

## Solution

- Track the dismissed update error message in a ref for the current session.
- On later transitions into `error`, keep the prompt dismissed if the error matches the one the user already dismissed.
- Clear the dismissed error when the user chooses retry so the retry path can surface fresh state.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - focused regression covers the changed repeated-error branch; CI coverage gate remains authoritative.
- [x] Coverage matrix updated - N/A: behavior-only update prompt resilience; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no matrix feature IDs changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) - N/A: no release-cut smoke checklist surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Frontend update prompt only.
- No API, schema, migration, dependency, Rust, or Tauri behavior changes.
- User-visible effect: dismissing a repeated update-error popup suppresses that same error for the rest of the session.

## Related

- Closes: #1772
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: codex/1772-snooze-update-error-popup
- Commit SHA: 94a24ef4a47c9a67365c13f04f314d91cb5150e1

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` - blocked locally on fork-main baseline drift; see Validation Blocked. Touched files pass targeted Prettier check.
- [x] `pnpm typecheck` - passed.
- [x] Focused tests: `pnpm --dir app exec vitest run src/components/__tests__/AppUpdatePrompt.test.tsx --config test/vitest.config.ts` - passed, 11 tests.
- [x] Rust fmt/check (if changed): N/A: no Rust files changed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked
- `command:` `pnpm format:check`
- `error:` Local fork baseline (`openhuman-app@0.53.43`) reports pre-existing Prettier drift in 26 unrelated files, for example `package.json`, `src/pages/Conversations.tsx`, and `test/wdio.conf.ts`. The two touched files pass targeted Prettier check.
- `impact:` Full local format check cannot be used on this fork baseline, but the patch files are formatted and GitHub CI should evaluate the merge result against current upstream main.

### Behavior Changes
- Intended behavior change: repeated update errors that match a dismissed error stay hidden for the current session.
- User-visible effect: users can dismiss a recurring update-error popup instead of seeing the same prompt repeatedly.

### Parity Contract
- Legacy behavior preserved: ready-to-install/installing/restarting prompts still show; new update errors still show; retry still starts download.
- Guard/fallback/dispatch parity checks: error snooze is scoped to the exact error message and session only.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found for `#1772` or an exact repeated update-error popup fix. Broad popup/update search returned unrelated open PRs.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update error banner behavior so dismissed errors stay dismissed during subsequent checks; "Try again" clears dismissal and restarts the update flow.
* **Tests**
  * Added a regression test ensuring a dismissed "Update failed" banner does not reappear after background status changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1773)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->