### PR TITLE
feat(orchestrator): switch to hint:chat for low-TTFT chat tier

### DIFF
--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -296,9 +296,9 @@ mod tests {
     }
 
     #[test]
-    fn orchestrator_has_reasoning_hint_and_named_tools() {
+    fn orchestrator_has_chat_hint_and_named_tools() {
         let def = find("orchestrator");
-        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "reasoning"));
+        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "chat"));
         match def.tools {
             ToolScope::Named(tools) => {
                 // spawn_subagent was removed in #1141; spawn_worker_thread is the replacement

--- a/src/openhuman/agent/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent/agents/orchestrator/agent.toml
@@ -55,7 +55,12 @@ subagents = [
 ]
 
 [model]
-hint = "reasoning"
+# Orchestrator is the user-facing front-line agent; conversational latency
+# dominates UX. `hint:chat` resolves to the backend's fast chat tier
+# (currently `reasoning-quick-v1` — Kimi K2.6 Turbo) for low TTFT on
+# routing / direct-reply turns. Deep reasoning happens via delegation to
+# `planner` / `researcher`, which keep `hint:reasoning`.
+hint = "chat"
 
 [tools]
 # Direct tools — things the orchestrator calls itself rather than

--- a/src/openhuman/routing/policy.rs
+++ b/src/openhuman/routing/policy.rs
@@ -91,6 +91,9 @@ impl RoutingTarget {
 /// - `hint:reaction`, `hint:classify`, `hint:format`, `hint:sentiment`,
 ///   `hint:lightweight` → [`TaskCategory::Lightweight`]
 /// - `hint:summarize`, `hint:medium`, `hint:tool_lite` → [`TaskCategory::Medium`]
+/// - `hint:chat` → [`TaskCategory::Heavy`] (always remote — resolves to the
+///   backend's fast chat tier; the local model is too slow for the
+///   conversational TTFT budget that motivated this hint).
 /// - All other `hint:*` values and exact model names → [`TaskCategory::Heavy`]
 pub fn classify(model: &str) -> TaskCategory {
     match model.strip_prefix("hint:") {


### PR DESCRIPTION
## Summary

- Orchestrator now requests `hint:chat` instead of `hint:reasoning`, so the backend resolves it to the fast chat tier (`reasoning-quick-v1` / Kimi K2.6 Turbo per [tinyhumansai/backend#760](https://github.com/tinyhumansai/backend/pull/760)).
- Documented `hint:chat` as Heavy in the local/remote routing policy — it must always go remote; the local model is too slow for the TTFT budget that motivated this hint.
- Updated the orchestrator loader test to assert the new hint.

## Problem

The orchestrator is the user-facing front-line agent — conversational latency dominates UX. `hint:reasoning` resolves to the deep-reasoning tier (now DeepSeek V4 Pro), which has high TTFT and is overkill for the orchestrator's actual job (route / synthesise / direct reply). Deep reasoning happens inside delegated agents (`planner`, `researcher`), not in the orchestrator itself.

## Solution

- `src/openhuman/agent/agents/orchestrator/agent.toml`: `[model] hint = "chat"` with a comment explaining the rationale (front-line latency; deep work delegates down).
- `src/openhuman/agent/agents/loader.rs`: rename test → `orchestrator_has_chat_hint_and_named_tools` and update the expected hint string.
- `src/openhuman/routing/policy.rs`: document `hint:chat` in the `classify()` rustdoc as Heavy (always remote). Falls through the same default branch as before, so no behavior change for unknown hints; just makes the intent explicit.

Other agents (`planner`, `researcher`, `learning/reflection`, etc.) keep `hint:reasoning` and are unaffected.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] N/A: pure config / hint-string change with no new branches to cover beyond the updated loader assertion. **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] N/A: no user-visible feature added/removed/renamed — model-tier routing is implementation. Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change
- [ ] N/A: no matrix feature IDs touched. All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] N/A: change is internal to model routing — not a release-cut smoke surface. Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] N/A: no linked issue. Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: desktop only — affects which backend model resolves `hint:chat` for orchestrator turns. Lower TTFT and lower per-turn cost on the conversational hot path. No protocol or schema change.
- **Backend dependency**: requires the backend to map `hint:chat` → `reasoning-quick-v1` (shipped in [tinyhumansai/backend#760](https://github.com/tinyhumansai/backend/pull/760)). If a self-hosted backend lacks that mapping, the request falls through to the backend's default.
- **Custom providers**: users with `config.model_routes` configured will need a `chat` entry in their route table. Without one, the request falls through to the default provider model — same fallback behavior as any other unmapped hint.

## Related

- Backend PR: tinyhumansai/backend#760
- Closes:
- Follow-up PR(s)/TODOs: revisit whether other agents (e.g. `welcome`, currently `hint:fast`) should also adopt `hint:chat` once latency telemetry confirms the new tier in production.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/orchestrator-hint-chat
- Commit SHA: a2f1842e84cade7499270f3bcf2b0251ca968e9e

### Validation Run
- [ ] N/A: no app/ changes. `pnpm --filter openhuman-app format:check`
- [ ] N/A: no app/ changes. `pnpm typecheck`
- [x] Focused tests: `cargo test --lib agents::loader::tests::orchestrator` (both tests pass)
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml` clean
- [ ] N/A: no app/src-tauri changes. Tauri fmt/check (if changed):

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: orchestrator requests the fast chat tier instead of the deep reasoning tier from the OpenHuman backend.
- User-visible effect: lower TTFT on orchestrator replies; no API/UI change.

### Parity Contract
- Legacy behavior preserved: all other agents and `simple_chat("hint:reasoning")` call sites are unchanged. Routing policy still falls through to Heavy for unknown hints — the rustdoc addition is documentation-only.
- Guard/fallback/dispatch parity checks: `hint:chat` falls through the same Heavy branch in `routing::policy::classify` as before this PR; only the rustdoc names it explicitly. Router resolution path in `providers/router.rs` is unchanged.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Orchestrator agent now routes to the chat tier for faster response times and improved first-token latency.
  * Complex reasoning tasks are automatically delegated to specialized agents for deeper analysis.

* **Documentation**
  * Updated documentation to clarify chat tier routing behavior and delegation patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1782)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->