### PR TITLE
docs(CONTRIBUTING): add missing macOS prereqs (Ninja, x86_64 target, …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 | pnpm | `pnpm@10.10.0` from [`package.json`](package.json) | The repo enforces pnpm via the root `packageManager` field. |
 | Rust | `1.93.0` from [`rust-toolchain.toml`](rust-toolchain.toml) | Install with `rustup`; `rustfmt` and `clippy` are required components. |
 | CMake | Current stable | Required by native Rust dependencies such as Whisper bindings. |
+| Ninja | Current stable | Required on macOS to build the bundled CEF helper. CMake delegates the actual compile to Ninja; without it the `cef-dll-sys` build script aborts. |
 | Tauri vendored sources | Git submodules under `app/src-tauri/vendor/` | Required for the CEF-aware Tauri CLI and notification plugin patches. |
 | macOS tools | Xcode Command Line Tools | Needed for local desktop builds on macOS. |
 | Linux desktop packages | System GTK/WebKit/AppIndicator build deps | Install the package set Tauri requires for your distro before attempting desktop builds. |
@@ -102,14 +103,17 @@ clang -v
 - **Linux desktop builds** require extra system packages beyond Node/Rust. Follow the distro-specific Tauri dependency list before running desktop commands, then use the OpenHuman scripts below. For deeper platform troubleshooting, see [`gitbooks/developing/getting-set-up.md`](gitbooks/developing/getting-set-up.md).
 - **Windows 10 WSL + classic X11 forwarding** is unsupported for the desktop app. The Tauri/CEF stack can hang, render blank windows, or crash before useful app logs are available. Use native Windows development, or Windows 11 WSLg if you need a Linux GUI workflow. OpenHuman logs a startup warning when it detects WSL with `DISPLAY` set but no `WAYLAND_DISPLAY`/WSLg markers.
 - **Windows desktop builds** additionally require Visual Studio C++ Build Tools (MSVC v143), LLVM/Clang, and CMake. See [Windows-specific setup](#windows-specific-setup) for the full list and install order.
+- **macOS desktop builds** require a one-time codesigning cert. After cloning, run `bash scripts/setup-dev-codesign.sh` once to create the local "OpenHuman Dev Signer" self-signed certificate that Tauri uses when bundling dev builds. Without it, `pnpm --filter openhuman-app dev:app` fails at the bundle/sign step with `OpenHuman Dev Signer: no identity found`.
 - **Skills development** happens in the separate [`tinyhumansai/openhuman-skills`](https://github.com/tinyhumansai/openhuman-skills) repository. This repo consumes built skill bundles from GitHub or a local override path; it does not vendor the skills source as a submodule.
 
 Example macOS bootstrap with Homebrew:
 
 ```bash
-brew install node@24 pnpm rustup-init cmake
+brew install node@24 pnpm rustup-init cmake ninja
 rustup toolchain install 1.93.0 --profile minimal
 rustup component add rustfmt clippy --toolchain 1.93.0
+# CEF builds a universal binary, so the x86_64 target is required even on Apple Silicon
+rustup target add x86_64-apple-darwin
 ```
 
 ### 2. Clone and install


### PR DESCRIPTION
## Summary

- Adds `ninja` to the prerequisites table — required by CMake when building the CEF helper on macOS.
- Adds `rustup target add x86_64-apple-darwin` to the macOS bootstrap snippet — the CEF helper builds a universal binary, so the x86_64 target is needed even on Apple Silicon.
- Adds a macOS platform-notes bullet pointing contributors at the existing `scripts/setup-dev-codesign.sh` first-run helper.

## Problem

Following CONTRIBUTING.md exactly on a clean macOS install fails three times in sequence on `pnpm --filter openhuman-app dev:app` (Ninja missing, x86_64 target missing, signing identity missing) before reaching a working app. None of these prerequisites are mentioned today.

## Solution

Doc-only change to CONTRIBUTING.md. No code, scripts, or behavior changed. The `scripts/setup-dev-codesign.sh` already exists in the repo — we just reference it from the place a fresh contributor would actually look.

## Submission Checklist

- [ ] N/A — docs-only change, no behavior to test
- [ ] N/A — docs-only change, no code lines under coverage
- [ ] N/A — docs-only change, no feature rows affected
- [ ] N/A — docs-only change, no feature IDs
- [ ] N/A — docs-only change, no external dependencies introduced
- [ ] N/A — docs-only change, no release-cut surfaces touched
- [x] Linked issue closed via `Closes #1781` in the `## Related` section

## Impact

Reduces fresh-contributor friction on macOS from "three failed builds, internet-search the errors" to "follow the doc, app boots." No runtime, performance, security, migration, or compatibility implications.

## Related

- Closes: #1781
- Follow-up PR(s)/TODOs:
  - Fix the partition-list bug in `scripts/setup-dev-codesign.sh` (the freshly-imported cert needs `security set-key-partition-list` to grant codesign access without a Keychain dialog every build).
  - Consider adding `ripgrep` to the prerequisites table — the `lint:commands-tokens` pre-push step shells out to `rg` without a presence check.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> N/A — Human-authored docs PR.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `docs/contributing-setup-macos`
- Commit SHA: `70df9119`

### Validation Run
- [ ] N/A — docs-only, no JS/TS changed
- [ ] N/A — docs-only, no TS types changed
- [ ] N/A — docs-only
- [ ] N/A — docs-only, no Rust changed
- [ ] N/A — docs-only, no Tauri code changed

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check` (`cargo check --manifest-path src-tauri/Cargo.toml`)
- `error:` exits 101 on the unmodified `upstream/main` HEAD (commit `f583829d`); this branch only edits `CONTRIBUTING.md`, so the failure is inherited from upstream and unrelated to this PR.
- `impact:` Pushed with `--no-verify` per `CLAUDE.md` guidance for hook failures unrelated to the change.

### Behavior Changes
- Intended behavior change: None — doc clarification only.
- User-visible effect: Fresh contributors hit zero setup failures on macOS.

### Parity Contract
- Legacy behavior preserved: Yes — no runtime code touched.
- Guard/fallback/dispatch parity checks: N/A — no dispatch path touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None
- Canonical PR: This one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions and prerequisites for macOS builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1783)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->