### PR TITLE
fix(scripts): codesign setup pops keychain dialog on every build + dr…

### DIFF
--- a/scripts/setup-dev-codesign.sh
+++ b/scripts/setup-dev-codesign.sh
@@ -3,16 +3,16 @@
 # openhuman-core sidecar. Run this once per development machine.
 #
 # Why: macOS TCC identifies unsigned binaries by content hash (Mach-O UUID).
-# Every `yarn core:stage` recompiles the sidecar, changing its hash, so TCC
+# Every `pnpm core:stage` recompiles the sidecar, changing its hash, so TCC
 # no longer matches the old grant. Signing with a stable certificate causes
 # TCC to use the certificate identity instead — grants persist across rebuilds.
 #
 # After running this script:
-#   1. yarn core:stage        (signs the sidecar with the new cert)
+#   1. pnpm core:stage        (signs the sidecar with the new cert)
 #   2. In OpenHuman → Request Permissions (removes old stale TCC entry,
 #      registers current binary)
 #   3. Grant in System Settings → Refresh Status
-#   From this point the grant survives future `yarn core:stage` runs.
+#   From this point the grant survives future `pnpm core:stage` runs.
 
 set -euo pipefail
 
@@ -32,7 +32,7 @@ trap cleanup EXIT
 # ── Check if already set up ──────────────────────────────────────────────────
 if security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
   echo "[setup-dev-codesign] Certificate \"$IDENTITY\" already exists — nothing to do."
-  echo "[setup-dev-codesign] Run 'yarn core:stage' to sign the sidecar."
+  echo "[setup-dev-codesign] Run 'pnpm core:stage' to sign the sidecar."
   exit 0
 fi
 
@@ -89,6 +89,23 @@ security import "$P12" \
   -T /usr/bin/codesign \
   -T /usr/bin/security
 
+# ── Grant codesign explicit partition access ─────────────────────────────────
+# The `-T /usr/bin/codesign` flag on `security import` above adds codesign to
+# the key's trusted-applications ACL, but macOS additionally requires the
+# *partition list* to be committed via `set-key-partition-list` before that
+# access actually takes effect. Without this step, the first `codesign`
+# invocation during `pnpm --filter openhuman-app dev:app` aborts with
+# `errSecInternalComponent` (or pops a Keychain password dialog for every
+# helper bundle, mid-build).
+#
+# This will prompt ONCE for your login keychain password (usually the same as
+# your macOS account password). From then on codesign uses the key silently.
+echo "[setup-dev-codesign] Granting codesign access to the private key — you'll be prompted for your login keychain password once."
+security set-key-partition-list \
+  -S apple-tool:,apple:,unsigned: \
+  -s \
+  "$KEYCHAIN"
+
 # ── Trust for code signing ───────────────────────────────────────────────────
 # Note: we add both basic and codeSign trust.
 security add-trusted-cert \
@@ -102,9 +119,9 @@ echo ""
 echo "[setup-dev-codesign] Done. Certificate \"$IDENTITY\" added to login Keychain."
 echo ""
 echo "Next steps:"
-echo "  1. yarn core:stage          — rebuilds and signs the sidecar"
+echo "  1. pnpm core:stage          — rebuilds and signs the sidecar"
 echo "  2. In OpenHuman click 'Request Permissions' to register the signed binary"
 echo "  3. Grant in System Settings → Privacy & Security → Accessibility"
 echo "  4. Click 'Refresh Status'"
 echo ""
-echo "After this, accessibility grants will survive future 'yarn core:stage' runs."
+echo "After this, accessibility grants will survive future 'pnpm core:stage' runs."


### PR DESCRIPTION
## Summary

- Adds the missing `security set-key-partition-list` call after the `security import` in `scripts/setup-dev-codesign.sh`, so codesign can use the just-imported private key on subsequent `pnpm --filter openhuman-app dev:app` runs without `errSecInternalComponent` or per-helper keychain dialogs.
- Replaces all six `yarn core:stage` occurrences in the same script (header comment, "already set up" echo, and the post-success "Next steps" block) with `pnpm core:stage` to match the repo's migration from yarn to pnpm.

## Problem

After `bash scripts/setup-dev-codesign.sh` on a clean Apple Silicon Mac and then `pnpm --filter openhuman-app dev:app`, codesign aborts on the first helper bundle:

```
Signing /.../OpenHuman Helper (Plugin).app: errSecInternalComponent
Error failed to bundle app: failed codesign application
```

Apple's `security import -T <tool>` flag adds the tool to the key's trusted-applications ACL, but macOS additionally requires the partition list to be committed via `security set-key-partition-list` before that access actually takes effect. Reproducible on every fresh contributor machine. 

## Solution

Shell-script-only change to `scripts/setup-dev-codesign.sh`. Adds an explicit `security set-key-partition-list -S apple-tool:,apple:,unsigned: -s "$KEYCHAIN"` call between the import and the trust step. The contributor is prompted **once** for their login keychain password during setup; subsequent codesign invocations run silently. Comment in-line explains why the step is required so future readers understand the macOS quirk.

The `yarn` → `pnpm` swaps are pure string fixes; the script logic doesn't shell out to either command.

## Submission Checklist

- [x] N/A — shell script with no runtime behavior to unit-test; the only verification is "run it on a clean Mac and dev:app builds without keychain prompts," which is what this PR is about.
- [x] N/A — shell script not covered by Vitest or cargo-llvm-cov.
- [x] N/A — no feature rows affected.
- [x] N/A — no feature IDs touched.
- [x] N/A — no external dependencies introduced; uses the macOS-bundled `security` CLI already invoked by the script.
- [x] N/A — no release-cut surfaces touched.
- [x] Linked issue closed via `Closes #1785` in the `## Related` section.

## Impact

Fresh macOS contributors who ran `setup-dev-codesign.sh` previously hit `errSecInternalComponent` on the first `dev:app` codesign step and had to dig into Apple's `security` man page (or fall back to ad-hoc signing) to get past it. After this change, `setup-dev-codesign.sh` is sufficient on its own. No change to CI, no change to released binaries (release builds use a real Apple Developer ID cert via `scripts/build-macos-signed.sh`, which is unaffected).

## Related

- Closes: #1785
- Follow-up from: #1781 / #1783 (both flagged this as a known follow-up).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> N/A — Human-authored fix. AI-assisted drafting; not a Codex/Linear autonomous PR.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/setup-dev-codesign-partition-list`
- Commit SHA: `3cde3825`

### Validation Run
- [x] N/A — no JS/TS changed
- [x] N/A — no TS types changed
- [x] N/A — no TS to compile
- [x] N/A — no Rust changed
- [x] N/A — no Tauri code changed

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check` (`cargo check --manifest-path src-tauri/Cargo.toml`)
- `error:` exits 101 on the unmodified `upstream/main` HEAD (commit `45cd01a9`); this branch only edits `scripts/setup-dev-codesign.sh`, so the failure is inherited from upstream and unrelated to this PR.
- `impact:` Pushed with `--no-verify` per `CLAUDE.md` guidance for hook failures unrelated to the change.

### Behavior Changes
- Intended behavior change: `setup-dev-codesign.sh` now ends with a working codesign cert (partition-list committed) instead of one that still triggers `errSecInternalComponent` on first use.
- User-visible effect: A single keychain password prompt during setup instead of repeated prompts (or hard failures) on every `dev:app` build.

### Parity Contract
- Legacy behavior preserved: Yes — the early-exit short-circuit at the top of the script still skips when the identity already exists, so re-running the script is a no-op on already-set-up machines.
- Guard/fallback/dispatch parity checks: N/A — no dispatch path touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None
- Canonical PR: This one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development code-signing setup script to use pnpm instead of yarn.
  * Improved macOS Keychain permission handling with clearer user prompts during environment setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1786)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->