### PR TITLE
fix(tauri): remove redundant if skip_resources guards in build.rs

### DIFF
--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -20,18 +20,14 @@ fn maybe_override_tauri_config_for_local_builds() {
     }
 
     let mut merge_config = serde_json::json!({});
-    if skip_resources {
-        merge_config["bundle"]["resources"] = serde_json::json!([]);
-        // Keep sidecars enabled for local/debug builds so the desktop host can
-        // exercise the same core process launch path as packaged builds.
-    }
+    merge_config["bundle"]["resources"] = serde_json::json!([]);
+    // Keep sidecars enabled for local/debug builds so the desktop host can
+    // exercise the same core process launch path as packaged builds.
 
     match serde_json::to_string(&merge_config) {
         Ok(json) => {
             env::set_var("TAURI_CONFIG", json);
-            if skip_resources {
-                println!("cargo:warning=TAURI resources disabled for local build");
-            }
+            println!("cargo:warning=TAURI resources disabled for local build");
         }
         Err(err) => {
             println!("cargo:warning=Failed to serialize TAURI_CONFIG override: {err}");


### PR DESCRIPTION
## Summary

Remove two redundant `if skip_resources { }` blocks in `app/src-tauri/build.rs`. The function already returns early at line 21 when `skip_resources` is false, so the guards are always true at those points.

## Problem

The `maybe_override_tauri_config_for_local_builds` function checks `skip_resources` at line 18 and returns immediately if it`s false. By lines 23 and 32, `skip_resources` is guaranteed to be true, making the surrounding `if` blocks dead code.

## Related

Closes #1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build script resource handling to improve efficiency in local development builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1799)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->