### PR TITLE
fix(scripts): add missing security set-key-partition-list call and fix stale yarn refs in setup-dev-codesign.sh

### DIFF
--- a/scripts/setup-dev-codesign.sh
+++ b/scripts/setup-dev-codesign.sh
@@ -3,16 +3,16 @@
 # openhuman-core sidecar. Run this once per development machine.
 #
 # Why: macOS TCC identifies unsigned binaries by content hash (Mach-O UUID).
-# Every `yarn core:stage` recompiles the sidecar, changing its hash, so TCC
+# Every `pnpm core:stage` recompiles the sidecar, changing its hash, so TCC
 # no longer matches the old grant. Signing with a stable certificate causes
 # TCC to use the certificate identity instead — grants persist across rebuilds.
 #
 # After running this script:
-#   1. yarn core:stage        (signs the sidecar with the new cert)
+#   1. pnpm core:stage        (signs the sidecar with the new cert)
 #   2. In OpenHuman → Request Permissions (removes old stale TCC entry,
 #      registers current binary)
 #   3. Grant in System Settings → Refresh Status
-#   From this point the grant survives future `yarn core:stage` runs.
+#   From this point the grant survives future `pnpm core:stage` runs.
 
 set -euo pipefail
 
@@ -32,7 +32,7 @@ trap cleanup EXIT
 # ── Check if already set up ──────────────────────────────────────────────────
 if security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
   echo "[setup-dev-codesign] Certificate \"$IDENTITY\" already exists — nothing to do."
-  echo "[setup-dev-codesign] Run 'yarn core:stage' to sign the sidecar."
+  echo "[setup-dev-codesign] Run 'pnpm core:stage' to sign the sidecar."
   exit 0
 fi
 
@@ -89,6 +89,11 @@ security import "$P12" \
   -T /usr/bin/codesign \
   -T /usr/bin/security
 
+# Commit partition list so codesign can use the key without interactive dialog.
+# Without this, macOS pops a keychain password prompt or fails with
+# errSecInternalComponent on every build.
+security set-key-partition-list -S apple-tool:,apple:,unsigned: -s "$KEYCHAIN"
+
 # ── Trust for code signing ───────────────────────────────────────────────────
 # Note: we add both basic and codeSign trust.
 security add-trusted-cert \
@@ -102,9 +107,9 @@ echo ""
 echo "[setup-dev-codesign] Done. Certificate \"$IDENTITY\" added to login Keychain."
 echo ""
 echo "Next steps:"
-echo "  1. yarn core:stage          — rebuilds and signs the sidecar"
+echo "  1. pnpm core:stage          — rebuilds and signs the sidecar"
 echo "  2. In OpenHuman click 'Request Permissions' to register the signed binary"
 echo "  3. Grant in System Settings → Privacy & Security → Accessibility"
 echo "  4. Click 'Refresh Status'"
 echo ""
-echo "After this, accessibility grants will survive future 'yarn core:stage' runs."
+echo "After this, accessibility grants will survive future 'pnpm core:stage' runs."


### PR DESCRIPTION
## Summary

Fix two bugs in `scripts/setup-dev-codesign.sh` that surface on a fresh macOS contributor's first build:

1. **Missing partition list commit** — The `security import` step adds `-T /usr/bin/codesign` to the key's trusted-applications ACL, but macOS additionally requires `security set-key-partition-list` to be called before codesign can actually use the key. Without it, the next build fails with `errSecInternalComponent` or pops a keychain password dialog for every helper bundle.

2. **Stale `yarn` references** — Six occurrences of `yarn core:stage` remained after the repo migrated from yarn to pnpm. Updated all to `pnpm core:stage`.

## Changes

- Added `security set-key-partition-list -S apple-tool:,apple:,unsigned: -s ""` after the PKCS12 import
- Replaced all 6 `yarn core:stage` → `pnpm core:stage` (lines 6, 11, 15, 35, 105, 110)

## Related

Closes #1785
Follow-up from #1781 / #1783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS developer setup script with improved code signing configuration to streamline the development environment initialization process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1800)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->