### PR TITLE
refactor(routing): rename hint:reasoning-quick → hint:chat

### DIFF
--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -301,9 +301,9 @@ mod tests {
     }
 
     #[test]
-    fn orchestrator_has_reasoning_hint_and_named_tools() {
+    fn orchestrator_has_chat_hint_and_named_tools() {
         let def = find("orchestrator");
-        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "reasoning-quick"));
+        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "chat"));
         match def.tools {
             ToolScope::Named(tools) => {
                 // spawn_subagent was removed in #1141; spawn_worker_thread is the replacement

--- a/src/openhuman/agent/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent/agents/orchestrator/agent.toml
@@ -61,14 +61,15 @@ subagents = [
 ]
 
 [model]
-# `reasoning-quick` (Kimi K2.6 Turbo on Fireworks via backend PR #760)
-# is tuned for low time-to-first-token on conversational turns. The
-# orchestrator is a planner/router that mostly picks a delegate and
-# synthesises sub-agent output — workload that doesn't benefit from
-# the slower deep-reasoning tier. Sub-agents that need heavier
-# reasoning can still opt into `reasoning-v1` (DeepSeek V4 Pro) via
+# Front-line conversational agent: TTFT dominates UX. `hint:chat` resolves
+# to the fast chat tier (`reasoning-quick-v1` / Kimi K2.6 Turbo on
+# Fireworks via backend PR #760, 128k context, `supportsThinking: false`).
+# The orchestrator is a planner/router that picks a delegate and
+# synthesises sub-agent output — workload that doesn't benefit from the
+# slower deep-reasoning tier. Sub-agents that need heavier reasoning
+# can still opt into `reasoning-v1` (DeepSeek V4 Pro) via
 # `ModelSpec::Hint("reasoning")` in their own definitions.
-hint = "reasoning-quick"
+hint = "chat"
 
 [tools]
 # Direct tools — things the orchestrator calls itself rather than

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -9,12 +9,13 @@ use std::path::PathBuf;
 /// Standard model identifiers matching the backend model registry.
 pub const MODEL_AGENTIC_V1: &str = "agentic-v1";
 pub const MODEL_REASONING_V1: &str = "reasoning-v1";
-/// Low-latency reasoning tier. Backend maps this to Kimi K2.6 Turbo on
+/// Low-latency chat tier. Backend maps this to Kimi K2.6 Turbo on
 /// Fireworks (128k context, `supportsThinking: false`) — tuned for
 /// time-to-first-token on conversational turns. See backend PR #760.
 /// The orchestrator (user-facing front-line agent) rides on this tier
-/// by default so chat responses feel snappy; reach for the slower
-/// `reasoning-v1` (DeepSeek V4 Pro) only when deep reasoning is needed.
+/// by default (via `hint:chat`) so chat responses feel snappy; reach
+/// for the slower `reasoning-v1` (DeepSeek V4 Pro) only when deep
+/// reasoning is needed.
 pub const MODEL_REASONING_QUICK_V1: &str = "reasoning-quick-v1";
 pub const MODEL_CODING_V1: &str = "coding-v1";
 /// Default model used when no explicit model is configured.

--- a/src/openhuman/providers/router.rs
+++ b/src/openhuman/providers/router.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 fn openhuman_tier_to_hint(model: &str) -> Option<&'static str> {
     match model {
         "reasoning-v1" => Some("reasoning"),
-        "reasoning-quick-v1" => Some("reasoning-quick"),
+        "reasoning-quick-v1" => Some("chat"),
         "agentic-v1" => Some("agentic"),
         "coding-v1" => Some("coding"),
         "summarization-v1" => Some("summarization"),

--- a/src/openhuman/routing/policy.rs
+++ b/src/openhuman/routing/policy.rs
@@ -91,7 +91,10 @@ impl RoutingTarget {
 /// - `hint:reaction`, `hint:classify`, `hint:format`, `hint:sentiment`,
 ///   `hint:lightweight` → [`TaskCategory::Lightweight`]
 /// - `hint:summarize`, `hint:medium`, `hint:tool_lite` → [`TaskCategory::Medium`]
-/// - All other `hint:*` values and exact model names → [`TaskCategory::Heavy`]
+/// - `hint:chat`, `hint:reasoning`, and all other `hint:*` values and exact
+///   model names → [`TaskCategory::Heavy`]. `hint:chat` is the orchestrator's
+///   front-line conversational tier — it must always go remote because the
+///   local model is too slow for the TTFT budget that motivated the hint.
 pub fn classify(model: &str) -> TaskCategory {
     match model.strip_prefix("hint:") {
         Some("reaction" | "classify" | "format" | "sentiment" | "lightweight") => {

--- a/src/openhuman/routing/provider.rs
+++ b/src/openhuman/routing/provider.rs
@@ -95,7 +95,10 @@ impl IntelligentRoutingProvider {
         // Keep remote model naming aligned with backend modelRegistry.
         match requested_model.strip_prefix("hint:") {
             Some("reasoning") => MODEL_REASONING_V1.to_string(),
-            Some("reasoning-quick") => MODEL_REASONING_QUICK_V1.to_string(),
+            // Orchestrator's low-TTFT chat tier — Kimi K2.6 Turbo on the
+            // backend's `reasoning-quick-v1`. Backend support added in
+            // tinyhumansai/backend#760.
+            Some("chat") => MODEL_REASONING_QUICK_V1.to_string(),
             Some("agentic") => MODEL_AGENTIC_V1.to_string(),
             Some("coding") => MODEL_CODING_V1.to_string(),
             _ => requested_model.to_string(),

--- a/src/openhuman/routing/provider_tests.rs
+++ b/src/openhuman/routing/provider_tests.rs
@@ -388,6 +388,29 @@ async fn regression_reasoning_hint_routes_remote_with_backend_model_name() {
 }
 
 #[tokio::test]
+async fn regression_chat_hint_routes_remote_as_reasoning_quick_v1() {
+    let local = MockProvider::new("local", "l");
+    let remote = MockProvider::new("remote", "r");
+    let health = LocalHealthChecker::seeded(true);
+
+    let r = router(
+        Arc::clone(&local),
+        Arc::clone(&remote),
+        health,
+        RoutingHints::default(),
+    );
+    r.chat_with_system(None, "hi", "hint:chat", 0.7)
+        .await
+        .unwrap();
+
+    // hint:chat must be translated to the backend's reasoning-quick-v1 tier
+    // (Kimi K2.6 Turbo). Sending the literal "hint:chat" would 400 on the
+    // backend since modelRegistry has no `hint:*` aliases.
+    assert_eq!(remote.last_model(), "reasoning-quick-v1");
+    assert_eq!(local.calls(), 0);
+}
+
+#[tokio::test]
 async fn remote_failure_propagates_without_local_fallback() {
     let local = MockProvider::new("local", "l");
     let remote = MockProvider::new("remote", "r");


### PR DESCRIPTION
## Summary

Follow-up to #1761 — renames the orchestrator's hint slot from `reasoning-quick` to `chat`. Same end-to-end behavior; same backend model (`reasoning-quick-v1` / Kimi K2.6 Turbo via [backend#760](https://github.com/tinyhumansai/backend/pull/760)).

- `agent/agents/orchestrator/agent.toml`: `hint = "chat"`.
- `agent/agents/loader.rs`: loader test asserts `h == "chat"`.
- `providers/router.rs`: `openhuman_tier_to_hint("reasoning-quick-v1") = Some("chat")` for custom `model_routes` round-trip.
- `routing/provider.rs:resolve_remote_model`: `Some("chat") => MODEL_REASONING_QUICK_V1`.
- `routing/policy.rs`: rustdoc documents `hint:chat` as Heavy (always remote).
- `routing/provider_tests.rs`: new regression `regression_chat_hint_routes_remote_as_reasoning_quick_v1`.
- `config/schema/types.rs`: docstring on `MODEL_REASONING_QUICK_V1` references `hint:chat`.

## Problem

`hint:reasoning-quick` (introduced in #1761) lets the backend model id leak into the hint namespace. The orchestrator's actual job is *front-line conversational TTFT*, which is named better by `chat`. Hints should describe the workload, not the backend tier — the same way `hint:reasoning` doesn't say `hint:deepseek-v4-pro`.

## Solution

Rename the single hint slot. Backend mapping (`hint:chat` → `reasoning-quick-v1`) lives entirely client-side in `routing::provider::resolve_remote_model`, exactly where the other hint-to-model translations live. No backend changes needed — the constant `MODEL_REASONING_QUICK_V1` and the backend model id are unchanged.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: pure rename — diff is narrow and the new regression test exercises every changed line. **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml).
- [x] N/A: no user-visible feature added/removed/renamed — internal hint slot. Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change
- [x] N/A: no matrix feature IDs touched. All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: internal hint rename — not a release-cut smoke surface. Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] N/A: no linked issue. Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: desktop only. Behavior identical to #1761 — orchestrator turns still resolve to `reasoning-quick-v1` on the backend. Only the hint string in `agent.toml` and the route-table key change.
- **Custom providers**: users with `model_routes` need a `chat` entry instead of `reasoning-quick`. Without one, the request falls through to the default provider model (same fallback as any other unmapped hint).

## Related

- Builds on: #1761
- Backend tier (unchanged): tinyhumansai/backend#760
- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/hint-chat-translate-to-reasoning-quick-v1
- Commit SHA: b54ee2bf

### Validation Run
- [x] N/A: no \`app/\` changes. \`pnpm --filter openhuman-app format:check\`
- [x] N/A: no \`app/\` changes. \`pnpm typecheck\`
- [x] Focused tests: \`cargo test --lib regression_chat_hint_routes_remote_as_reasoning_quick_v1\` and \`cargo test --lib orchestrator_has_chat_hint_and_named_tools\` both pass.
- [x] Rust fmt/check (if changed): \`cargo check --manifest-path Cargo.toml\` clean.
- [x] N/A: no \`app/src-tauri\` changes. Tauri fmt/check (if changed):

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended behavior change: none beyond #1761 — pure rename of the hint string.
- User-visible effect: identical to #1761 (orchestrator on fast tier).

### Parity Contract
- Legacy behavior preserved: backend model id (`reasoning-quick-v1`) and constant (`MODEL_REASONING_QUICK_V1`) are unchanged. Cost rows and identity-cost defaults from #1761 stay put.
- Guard/fallback/dispatch parity checks: `routing::policy::classify` still buckets `hint:chat` as `Heavy`; `routing::provider::resolve_remote_model` translates `hint:chat` to the same backend model id #1761 used. Regression test confirms the end-to-end remote-model string.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: builds on #1761 (already merged).
- Resolution (closed/superseded/updated): updated.