### PR TITLE
fix(tauri): disable GPU on Linux for Mesa 26+ EGL compatibility (closes #1697)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1671,6 +1671,20 @@ pub fn run() {
             args.push(("--disable-gpu-compositing", None));
             log::info!("[cef-startup] Intel macOS detected: adding --disable-gpu-compositing (issue #1012)");
         }
+        // Issue #1697 — Linux AppImage fails to launch on Mesa 26+ (Arch,
+        // Manjaro, EndeavourOS, CachyOS) with EGL_BAD_ATTRIBUTE during GPU
+        // context creation. Chromium's EGL initialization returns
+        // EGL_BAD_ATTRIBUTE for both ES 3.0 and 2.0 contexts on Mesa 26+,
+        // producing ContextResult::kFatalFailure. Disabling the entire GPU
+        // process forces SwiftShader software rendering so the app launches
+        // on these distros. The same CEF version works on Ubuntu/deb-based
+        // distros with older Mesa; this flag degrades gracefully there
+        // (software-only rendering, no WebGL).
+        #[cfg(target_os = "linux")]
+        {
+            args.push(("--disable-gpu", None));
+            log::info!("[cef-startup] Linux detected: adding --disable-gpu (issue #1697)");
+        }
         tauri::Builder::<tauri::Cef>::new().command_line_args::<&str, &str>(args)
     };
 


### PR DESCRIPTION
## Summary

Add `--disable-gpu` flag to CEF command-line args on Linux, fixing the AppImage crash on Mesa 26+ (Arch, Manjaro, EndeavourOS, CachyOS).

## Problem

The AppImage fails to launch on Arch-based distros with Mesa 26.0.2+. The GPU process crashes during EGL initialization:

```
eglCreateContext ES 3.0 failed with error EGL_BAD_ATTRIBUTE
eglCreateContext ES 2.0 failed with error EGL_BAD_ATTRIBUTE
ContextResult::kFatalFailure: Failed to create shared context for virtualization.
```

This is a Chromium/CEF compatibility issue with Mesa 26's stricter EGL attribute validation. The same CEF build works on Ubuntu/deb-based distros with older Mesa.

Three users confirmed: Manjaro, EndeavourOS, CachyOS.

## Solution

Added `#[cfg(target_os = "linux")]` block that pushes `--disable-gpu` to the CEF command-line args, following the same pattern as the existing `--disable-gpu-compositing` flag for Intel macOS (issue #1012). This forces Chromium to use SwiftShader software rendering instead of failing on EGL initialization.

## Submission Checklist

- [x] Tests added or updated — N/A: CEF startup flag, no test harness for Tauri process args (verified via cargo check)
- [x] Diff coverage >= 80% — N/A: single Rust file, 14 lines added, no testable logic (config-time flag)
- [x] Coverage matrix updated — N/A: no feature tier or user-visible capability changed
- [x] Feature IDs listed — N/A: no TEST-COVERAGE-MATRIX rows touched
- [x] No new external network dependencies — no new crates or deps
- [x] Manual smoke checklist updated — N/A: does not touch packaging/scripts
- [x] Linked issue — Closes #1697

## Impact

- Linux AppImage (and all Linux builds) will use software rendering via SwiftShader
- GPU acceleration for WebGL, video decode is disabled; perf impact on GPU-intensive surfaces (mascot animations, embedded web apps)
- Fixes "app won't launch at all" on Arch-based distros with Mesa 26+
- Follows existing pattern for Intel macOS GPU workaround (#1012)

## Related

- Closes #1697
- Same pattern as Intel macOS GPU fix (#1012)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed startup issues on Linux systems

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1809)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->