### PR TITLE
fix(secrets): throttle .secret_key read failures and filter from Sentry (OPENHUMAN-TAURI-GN)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -131,6 +131,20 @@ pub async fn rpc_handler(State(state): State<AppState>, Json(req): Json<RpcReque
                     error = %redacted,
                     "[rpc] transient downstream failure — not reporting to Sentry (message redacted)"
                 );
+            } else if is_secret_key_file_error(&display_message) {
+                // The `.secret_key` file is unreadable — usually a Windows AV
+                // scanner holding a transient lock or an ACL regression. The
+                // failure cache in `SecretStore::load_or_create_key` already
+                // throttles repeated disk I/O to once per 60 s and logs a
+                // `warn!`. Re-reporting every surviving poll as a Sentry event
+                // caused OPENHUMAN-TAURI-GN (12k+ events in one session). Log
+                // at warn for local observability and skip the Sentry report.
+                tracing::warn!(
+                    method = %method,
+                    elapsed_ms = ms as u64,
+                    "[rpc] secret key file unreadable — not reporting to Sentry (Windows AV/permissions): {}",
+                    display_message
+                );
             } else {
                 crate::core::observability::report_error_or_expected(
                     display_message.as_str(),
@@ -267,6 +281,16 @@ fn is_param_validation_error(msg: &str) -> bool {
     msg.starts_with("unknown param '")
         || msg.starts_with("missing required param '")
         || msg.starts_with("invalid params: ")
+}
+
+/// Returns true when the error originates from a `.secret_key` file read
+/// failure. On Windows, AV scanners (Defender, etc.) can hold a transient read
+/// lock on the file; a persistent ACL regression produces the same error on
+/// every call. The `SecretStore` failure cache already throttles disk I/O to
+/// once per 60 s — this filter prevents the surviving first error per window
+/// from being reported to Sentry (OPENHUMAN-TAURI-GN: 12 k+ events/session).
+fn is_secret_key_file_error(msg: &str) -> bool {
+    msg.contains("Failed to read secret key file")
 }
 
 /// Internal method invocation logic.

--- a/src/openhuman/security/secrets.rs
+++ b/src/openhuman/security/secrets.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Length of the random encryption key in bytes (256-bit, matches `ChaCha20`).
 const KEY_LEN: usize = 32;
@@ -187,8 +187,17 @@ impl SecretStore {
             return Ok(cached);
         }
 
+        // If a previous read attempt failed recently, return the cached error
+        // immediately. This prevents repeated polls (e.g. every ~2 s from
+        // `app_state_snapshot`) from each triggering 5×retry disk I/O and a
+        // new Sentry event. The TTL lets the next attempt retry disk so the
+        // process self-heals if the transient lock (AV scanner, etc.) clears.
+        if let Some(err_msg) = cached_failure(&cache_key_path) {
+            return Err(anyhow::anyhow!("{err_msg}"));
+        }
+
         if self.key_path.exists() {
-            let hex_key = read_key_file_with_retry(&self.key_path).with_context(|| {
+            let hex_key = match read_key_file_with_retry(&self.key_path).with_context(|| {
                 let mut msg = format!(
                     "Failed to read secret key file at {}",
                     self.key_path.display()
@@ -203,13 +212,27 @@ impl SecretStore {
                     );
                 }
                 msg
-            })?;
+            }) {
+                Ok(k) => k,
+                Err(e) => {
+                    let msg = e.to_string();
+                    cache_failure(&cache_key_path, &msg);
+                    log::warn!(
+                        "[secrets] key file unreadable (cached for {}s): {}",
+                        FAILURE_CACHE_TTL.as_secs(),
+                        msg
+                    );
+                    return Err(anyhow::anyhow!("{msg}"));
+                }
+            };
             let key = hex_decode(hex_key.trim()).context("Secret key file is corrupt")?;
             anyhow::ensure!(
                 key.len() == KEY_LEN,
                 "Secret key file has wrong length: expected {KEY_LEN} bytes, got {}",
                 key.len()
             );
+            // Successful read — clear any stale failure cache entry and store the key.
+            clear_failure_cache(&cache_key_path);
             cache_key(&cache_key_path, &key);
             Ok(key)
         } else {
@@ -308,6 +331,53 @@ pub(super) fn clear_cached_key(path: &Path) {
     if let Ok(mut cache) = key_cache().lock() {
         cache.remove(&normalized);
     }
+}
+
+/// How long to remember a key-file read failure before retrying disk I/O.
+///
+/// Windows AV scanners hold the file for a few seconds at most, so 60 s is
+/// generous. The important property is that repeated polls (e.g. every 2 s
+/// from `app_state_snapshot`) don't each trigger 5×retry disk I/O and a new
+/// Sentry event — they return the cached error immediately within the window.
+const FAILURE_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Process-wide cache of key-file read failures, keyed by normalized path.
+///
+/// Maps path → (time of first failure, stringified error message).
+/// Entries expire after `FAILURE_CACHE_TTL`. Production code never evicts
+/// them manually — the TTL expiry lets the next attempt retry disk in case
+/// a transient lock (AV scanner, etc.) has been released.
+fn key_failure_cache() -> &'static Mutex<HashMap<PathBuf, (Instant, String)>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, (Instant, String)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_failure(path: &Path) -> Option<String> {
+    key_failure_cache()
+        .lock()
+        .ok()?
+        .get(path)
+        .filter(|(t, _)| t.elapsed() < FAILURE_CACHE_TTL)
+        .map(|(_, msg)| msg.clone())
+}
+
+fn cache_failure(path: &Path, message: &str) {
+    if let Ok(mut cache) = key_failure_cache().lock() {
+        cache.insert(path.to_path_buf(), (Instant::now(), message.to_string()));
+    }
+}
+
+fn clear_failure_cache(path: &Path) {
+    if let Ok(mut cache) = key_failure_cache().lock() {
+        cache.remove(path);
+    }
+}
+
+/// Clear the cached failure for `path`. Test-only.
+#[cfg(test)]
+pub(super) fn clear_cached_failure(path: &Path) {
+    let normalized = normalize_cache_path(path);
+    clear_failure_cache(&normalized);
 }
 
 /// Read the key file, retrying transient errors a handful of times.

--- a/src/openhuman/security/secrets_tests.rs
+++ b/src/openhuman/security/secrets_tests.rs
@@ -616,3 +616,51 @@ fn key_file_has_restricted_permissions() {
         "Key file must be owner-only (0600)"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn key_file_read_failure_is_cached_for_ttl() {
+    // When the key file exists but is unreadable (mode 0000 on Unix, or an
+    // AV-scanner hold on Windows), the first failed read must be cached so
+    // subsequent calls within the TTL return immediately without retrying
+    // disk I/O.  This is the fix for OPENHUMAN-TAURI-GN: 12 k+ Sentry
+    // events per session caused by every `app_state_snapshot` poll retrying
+    // and failing to read `.secret_key`.
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let store = SecretStore::new(tmp.path(), true);
+
+    // Write a valid key file, then make it unreadable.
+    store.encrypt("setup").unwrap();
+    fs::set_permissions(&store.key_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Clear success cache so the next call actually hits disk.
+    super::clear_cached_key(&store.key_path);
+
+    // First call: hits disk, fails, caches the failure.
+    let err1 = store.encrypt("should fail").unwrap_err();
+    assert!(
+        err1.to_string().contains("Failed to read secret key file"),
+        "expected key-file error, got: {err1:?}"
+    );
+
+    // Make the file readable again — but the failure cache should prevent a
+    // new disk read for the duration of the TTL.
+    fs::set_permissions(&store.key_path, fs::Permissions::from_mode(0o600)).unwrap();
+
+    // Second call within TTL: must return the cached error without touching disk.
+    let err2 = store.encrypt("still cached failure").unwrap_err();
+    assert!(
+        err2.to_string().contains("Failed to read secret key file"),
+        "expected cached failure, got: {err2:?}"
+    );
+
+    // Clearing the failure cache allows the next attempt to succeed.
+    super::clear_cached_failure(&store.key_path);
+    let ok = store.encrypt("now succeeds").unwrap();
+    assert!(
+        ok.starts_with("enc2:"),
+        "expected encrypted value after cache cleared"
+    );
+}


### PR DESCRIPTION
## Summary

- Added a 60-second failure cache to `SecretStore::load_or_create_key` so repeated RPC polls do not trigger repeated disk retries when `.secret_key` is unreadable.
- Added `is_secret_key_file_error` filtering in the RPC error handler to downgrade these failures to `warn!` logs and skip Sentry reporting.
- Added automatic cache eviction/self-healing after successful reads via `clear_failure_cache`.
- Added regression coverage for the full failure-cache lifecycle (`key_file_read_failure_is_cached_for_ttl`).
- Reduces Windows-specific Sentry flood scenarios caused by AV/ACL-related `.secret_key` read failures.

## Problem

- On Windows, AV scanners (Defender, etc.) can temporarily lock `.secret_key` after creation, and some users encounter ACL regressions that make the file unreadable.
- `load_or_create_key` previously had only a success cache, so every `app_state_snapshot` poll retried disk reads 5× and propagated failures into Sentry.
- This resulted in large-scale Sentry noise (`OPENHUMAN-TAURI-GN`) and unnecessary disk I/O during transient lock conditions.

## Solution

- Added a failure cache in `secrets.rs` keyed by normalized file path, storing stringified read errors for a 60-second TTL.
- Requests during the TTL immediately return the cached failure without retrying disk I/O.
- Added `is_secret_key_file_error` filtering in `jsonrpc.rs` so matching failures log locally but do not trigger Sentry reporting.
- Added automatic cache clearing after successful reads so transient lock conditions self-heal without restart.
- Tradeoff: users with permanent ACL issues may wait up to 60 seconds after fixing permissions before recovery occurs, but this is preferable to continuous retries and Sentry flooding.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no feature matrix rows affected`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: no release-cut surface changes`
- Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: originated from Sentry issue OPENHUMAN-TAURI-GN`

## Impact

- Runtime/platform impact: primarily affects Windows desktop users, though the failure cache behavior is platform-neutral.
- Performance impact: reduces repeated disk retry I/O and prevents excessive Sentry reporting during transient failures.
- Security impact: no secret material is cached; only error strings are stored in the failure cache.
- Compatibility/migration impact: fully backward-compatible additive behavior with no schema or migration changes.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and messages for secret key file read failures
  * Added Windows-specific guidance for permission-related issues
  * Reduced redundant file system checks when key file access encounters issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1820)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->