### PR TITLE
fix(app): tame core state and rewards timeout noise

### DIFF
--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -44,6 +44,7 @@ const log = debugFactory('core-state');
 
 const POLL_MS = 2000;
 const MAX_BOOTSTRAP_RETRIES = 5;
+const SUPPRESS_POLL_WARNING_AT = MAX_BOOTSTRAP_RETRIES + 1;
 
 /** Extract only non-sensitive fields from an RPC/fetch error. */
 function sanitizeError(error: unknown): { message?: string; code?: string; status?: number } {
@@ -59,6 +60,19 @@ function sanitizeError(error: unknown): { message?: string; code?: string; statu
     };
   }
   return { message: String(error) };
+}
+
+export function coreStatePollFailureWarningMessage(failureCount: number): string | null {
+  if (failureCount <= 0) {
+    return null;
+  }
+  if (failureCount <= MAX_BOOTSTRAP_RETRIES) {
+    return `[core-state] poll failed (attempt ${failureCount}/${MAX_BOOTSTRAP_RETRIES}):`;
+  }
+  if (failureCount === SUPPRESS_POLL_WARNING_AT) {
+    return '[core-state] poll failed repeatedly; suppressing further warnings until core state recovers:';
+  }
+  return null;
 }
 
 interface CoreStateContextValue extends CoreState {
@@ -375,10 +389,10 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
             MAX_BOOTSTRAP_RETRIES,
             safe
           );
-          console.warn(
-            `[core-state] poll failed (attempt ${bootstrapFailCountRef.current}/${MAX_BOOTSTRAP_RETRIES}):`,
-            safe
-          );
+          const warningMessage = coreStatePollFailureWarningMessage(bootstrapFailCountRef.current);
+          if (warningMessage) {
+            console.warn(warningMessage, safe);
+          }
           if (bootstrapFailCountRef.current >= MAX_BOOTSTRAP_RETRIES) {
             commitState(previous => {
               if (previous.isBootstrapping) {

--- a/app/src/providers/__tests__/CoreStateProvider.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.test.tsx
@@ -219,6 +219,28 @@ describe('CoreStateProvider — identity-change cache clearing', () => {
     await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('ready'));
   });
 
+  it('warns when the initial core state poll fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      fetchSnapshot.mockRejectedValue(new Error('core offline'));
+
+      render(
+        <CoreStateProvider>
+          <Consumer />
+        </CoreStateProvider>
+      );
+
+      await waitFor(() =>
+        expect(warnSpy).toHaveBeenCalledWith('[core-state] poll failed (attempt 1/5):', {
+          message: 'core offline',
+        })
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('backfills snapshot.currentUser from auth.user when currentUser is missing', async () => {
     fetchSnapshot.mockResolvedValue(
       makeSnapshot({

--- a/app/src/providers/__tests__/CoreStateProvider.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.test.tsx
@@ -5,7 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as coreStateApi from '../../services/coreStateApi';
 import * as tauriCommands from '../../utils/tauriCommands';
 import { setCoreStateSnapshot } from '../../lib/coreState/store';
-import CoreStateProvider, { useCoreState } from '../CoreStateProvider';
+import CoreStateProvider, {
+  coreStatePollFailureWarningMessage,
+  useCoreState,
+} from '../CoreStateProvider';
 
 vi.mock('../../services/coreStateApi');
 vi.mock('../../services/analytics', () => ({ syncAnalyticsConsent: vi.fn() }));
@@ -348,5 +351,17 @@ describe('CoreStateProvider — identity-change cache clearing', () => {
     expect(vi.mocked(tauriCommands.openhumanUpdateMeetSettings)).toHaveBeenCalledWith({
       auto_orchestrator_handoff: false,
     });
+  });
+});
+
+describe('coreStatePollFailureWarningMessage', () => {
+  it('logs bounded bootstrap failures and one suppression notice', () => {
+    expect(coreStatePollFailureWarningMessage(0)).toBeNull();
+    expect(coreStatePollFailureWarningMessage(1)).toBe('[core-state] poll failed (attempt 1/5):');
+    expect(coreStatePollFailureWarningMessage(5)).toBe('[core-state] poll failed (attempt 5/5):');
+    expect(coreStatePollFailureWarningMessage(6)).toBe(
+      '[core-state] poll failed repeatedly; suppressing further warnings until core state recovers:'
+    );
+    expect(coreStatePollFailureWarningMessage(7)).toBeNull();
   });
 });

--- a/app/src/services/api/__tests__/rewardsApi.test.ts
+++ b/app/src/services/api/__tests__/rewardsApi.test.ts
@@ -101,7 +101,7 @@ describe('rewardsApi', () => {
 
     const snapshot = await rewardsApi.getMyRewards();
 
-    expect(apiClient.get).toHaveBeenCalledWith('/rewards/me');
+    expect(apiClient.get).toHaveBeenCalledWith('/rewards/me', { timeout: 15000 });
     expect(snapshot.discord.membershipStatus).toBe('not_linked');
     expect(snapshot.summary.totalCount).toBe(8);
   });

--- a/app/src/services/api/rewardsApi.ts
+++ b/app/src/services/api/rewardsApi.ts
@@ -2,6 +2,8 @@ import type { ApiResponse } from '../../types/api';
 import type { RewardsAchievement, RewardsSnapshot } from '../../types/rewards';
 import { apiClient } from '../apiClient';
 
+const REWARDS_SNAPSHOT_TIMEOUT_MS = 15_000;
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -106,7 +108,9 @@ export function normalizeRewardsSnapshot(payload: unknown): RewardsSnapshot {
 
 export const rewardsApi = {
   async getMyRewards(): Promise<RewardsSnapshot> {
-    const response = await apiClient.get<ApiResponse<unknown>>('/rewards/me');
+    const response = await apiClient.get<ApiResponse<unknown>>('/rewards/me', {
+      timeout: REWARDS_SNAPSHOT_TIMEOUT_MS,
+    });
     if (!response.success) {
       throw {
         success: false,


### PR DESCRIPTION
## Summary

- bound repeated core-state poll console warnings to the bootstrap retry budget plus one suppression notice
- give the rewards snapshot request a 15s timeout so the existing recoverable Rewards error state appears promptly
- add focused regression coverage for the core-state warning behavior and rewards request timeout option

## Why

Refs #1235. The app currently keeps logging core-state poll failures after bootstrap retries are exhausted, and rewards uses the global 120s API timeout for `/rewards/me`. This keeps diagnostics useful without flooding the console and lets the Rewards page fail into its existing retry UI sooner.

## Validation

- `pnpm exec vitest run --config test/vitest.config.ts src/providers/__tests__/CoreStateProvider.test.tsx src/services/api/__tests__/rewardsApi.test.ts`
- `pnpm exec prettier --check src/providers/CoreStateProvider.tsx src/providers/__tests__/CoreStateProvider.test.tsx src/services/api/rewardsApi.ts src/services/api/__tests__/rewardsApi.test.ts`
- `pnpm exec eslint src/providers/CoreStateProvider.tsx src/providers/__tests__/CoreStateProvider.test.tsx src/services/api/rewardsApi.ts src/services/api/__tests__/rewardsApi.test.ts --ext .ts,.tsx`
- `pnpm --filter openhuman-app compile`
- `git diff --check`

Note: the local pre-push hook could not complete because this machine does not have `cargo` on PATH for the Rust format check. This PR only changes TypeScript frontend files, and the frontend checks above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced console warning spam by suppressing repeated polling failure messages after bootstrap retry threshold is exceeded.

* **Performance**
  * Added request timeout to rewards API calls to prevent indefinite request hanging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1822)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->