### PR TITLE
fix(lint): make commands-tokens script fail with a clear error when ripgrep is missing + add to CONTRIBUTING prereqs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 | Rust | `1.93.0` from [`rust-toolchain.toml`](rust-toolchain.toml) | Install with `rustup`; `rustfmt` and `clippy` are required components. |
 | CMake | Current stable | Required by native Rust dependencies such as Whisper bindings. |
 | Ninja | Current stable | Required on macOS to build the bundled CEF helper. CMake delegates the actual compile to Ninja; without it the `cef-dll-sys` build script aborts. |
+| ripgrep (`rg`) | Current stable | Used by the `lint:commands-tokens` pre-push step (scans `app/src/components/commands/`). Without it, `git push` fails the hook with `rg: command not found`. |
 | Tauri vendored sources | Git submodules under `app/src-tauri/vendor/` | Required for the CEF-aware Tauri CLI and notification plugin patches. |
 | macOS tools | Xcode Command Line Tools | Needed for local desktop builds on macOS. |
 | Linux desktop packages | System GTK/WebKit/AppIndicator build deps | Install the package set Tauri requires for your distro before attempting desktop builds. |
@@ -109,7 +110,7 @@ clang -v
 Example macOS bootstrap with Homebrew:
 
 ```bash
-brew install node@24 pnpm rustup-init cmake ninja
+brew install node@24 pnpm rustup-init cmake ninja ripgrep
 rustup toolchain install 1.93.0 --profile minimal
 rustup component add rustfmt clippy --toolchain 1.93.0
 # CEF builds a universal binary, so the x86_64 target is required even on Apple Silicon

--- a/app/package.json
+++ b/app/package.json
@@ -56,7 +56,7 @@
     "format:check": "prettier --check . && pnpm rust:format:check",
     "lint": "eslint . --ext .ts,.tsx --cache",
     "lint:fix": "eslint . --ext .ts,.tsx --fix --cache",
-    "lint:commands-tokens": "bash -c '! rg -nU \"(bg|text|border|ring|shadow)-(neutral|primary|sage|amber|canvas|stone|slate)\" src/components/commands/'",
+    "lint:commands-tokens": "bash -c 'command -v rg >/dev/null 2>&1 || { echo \"lint:commands-tokens requires ripgrep. Install: brew install ripgrep (macOS) / apt install ripgrep (Debian/Ubuntu) / see https://github.com/BurntSushi/ripgrep#installation\" >&2; exit 1; }; ! rg -nU \"(bg|text|border|ring|shadow)-(neutral|primary|sage|amber|canvas|stone|slate)\" src/components/commands/'",
     "knip": "knip --config knip.json",
     "knip:production": "knip --config knip.json --production"
   },


### PR DESCRIPTION
## Summary

- Adds `ripgrep (rg)` to the prerequisites table in `CONTRIBUTING.md` (right after Ninja) with a one-line note explaining it's needed by the `lint:commands-tokens` pre-push step.
- Appends `ripgrep` to the macOS bootstrap snippet's `brew install` line.
- Wraps `lint:commands-tokens` in `app/package.json` with a `command -v rg` guard that prints an actionable install hint (brew / apt / upstream link) and exits 1 — instead of falling through to a cryptic `rg: command not found`.

## Problem

After following `CONTRIBUTING.md` exactly on a clean macOS install, the first `git push` triggers the pre-push hook → `pnpm lint:commands-tokens` → `bash: rg: command not found` (exit 127). The contributor has no indication which step failed, what tool is missing, or how to install it. Reproduces on every fresh macOS contributor; hit it personally during #1786.

## Solution

Doc + script change, no behavior change for contributors who already have ripgrep:

- `CONTRIBUTING.md`: one new row in the prerequisites table, one extra package in the bootstrap snippet.
- `app/package.json`: prepend `command -v rg >/dev/null 2>&1 || { echo "…" >&2; exit 1; };` to the existing `lint:commands-tokens` bash command. JSON validity verified with `node -e 'JSON.parse(require("fs").readFileSync("app/package.json"))'`.

Verified locally:
- `pnpm lint:commands-tokens` with rg present → silent pass (same as before).
- `PATH=/usr/bin:/bin pnpm lint:commands-tokens` (rg missing) → prints the install hint and exits 1.

## Submission Checklist

- [x] N/A — script-prefix change; the existing happy-path test is `pnpm lint:commands-tokens` itself, which still passes with rg present (verified locally).
- [x] N/A — script string change in `package.json`; no Vitest- or cargo-llvm-cov-covered code lines added.
- [x] N/A — no feature rows affected.
- [x] N/A — no feature IDs touched.
- [x] N/A — `ripgrep` is a documented prereq, not a new runtime dependency introduced into a process or build artifact.
- [x] N/A — no release-cut surfaces touched (release builds don't run pre-push hooks).
- [x] Linked issue closed via `Closes #1866` in the `## Related` section.

## Impact

Fresh macOS contributors get an immediately-actionable error instead of `rg: command not found`. No change to CI (the lint:commands-tokens step on CI runs in an environment where ripgrep is already installed), no change to released binaries, no change to runtime behavior for contributors who already have ripgrep.

## Related

- Closes: #1866
- Follow-up from: #1786 (where the missing ripgrep prereq was first hit and called out as a follow-up TODO).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> N/A — Human-authored fix. AI-assisted drafting; not a Codex/Linear autonomous PR.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `docs/ripgrep-prereq`
- Commit SHA: `fe1582a0`

### Validation Run
- [x] N/A — no JS/TS source files changed (only the script-string in `package.json`).
- [x] N/A — no TS types changed.
- [x] N/A — no TS to compile (only the script value changed; tsc doesn't read scripts).
- [x] N/A — no Rust changed.
- [x] N/A — no Tauri code changed.

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check` may still exit 101 on upstream `main` (the inherited `cargo check --manifest-path src-tauri/Cargo.toml` failure documented in #1786). This branch only edits `CONTRIBUTING.md` and `app/package.json` so the failure cannot be caused by this change.
- `error:` (as above)
- `impact:` Pushed with `--no-verify`. The actual `lint:commands-tokens` step itself was verified locally — both the rg-present (silent pass) and rg-missing (friendly error, exit 1) paths.

### Behavior Changes
- Intended behavior change: `pnpm lint:commands-tokens` (and therefore the pre-push hook) now prints an actionable install hint when ripgrep is missing, instead of bubbling up bash's `command not found`.
- User-visible effect: fresh macOS contributors no longer have to grep the pre-push hook source to figure out why their first push failed.

### Parity Contract
- Legacy behavior preserved: Yes — for contributors who already have ripgrep, the guard short-circuits in microseconds and the existing `rg -nU …` invocation runs unchanged.
- Guard/fallback/dispatch parity checks: N/A — no dispatch path touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None. Open PRs #1859 and #1420 both touch `app/package.json` but at different line ranges (scripts table additions, deps); no line-level conflict with this change. No open PR touches `CONTRIBUTING.md`.
- Canonical PR: This one.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to include `ripgrep` as a required prerequisite, with updated macOS bootstrap commands.

* **Chores**
  * Enhanced linting script validation to verify required tooling is installed and provide clearer error guidance when dependencies are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->