### PR TITLE
docs(README): add Ninja + ripgrep to the Contributing-from-source prereqs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ OpenHuman is an open-source agentic assistant designed to integrate with you in 
 
 New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands. The short path is:
 
-1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, and the platform desktop build prerequisites.
+1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep, and the platform desktop build prerequisites.
 2. Fork and clone the repo, then run `git submodule update --init --recursive` before `pnpm install` so the vendored Tauri/CEF sources are present.
 3. Use `pnpm dev` for web-only UI work, `pnpm --filter openhuman-app dev:app` for the desktop shell, and focused checks such as `pnpm typecheck`, `pnpm format:check`, and `cargo check -p openhuman --lib` before opening a PR.
 


### PR DESCRIPTION
## Summary

- Adds `Ninja` and `ripgrep` to bullet 1 of the README's "Contributing from source" section so the short-path tool list matches `CONTRIBUTING.md`'s prerequisites table.

## Problem

The README's "Contributing from source" summary lists `Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (rustfmt + clippy), CMake, and the platform desktop build prerequisites`. That list is stale: `CONTRIBUTING.md` already requires `Ninja` (added in #1783), and `ripgrep` is being added in #1867. Contributors who read only the README's short path install the wrong set of tools and hit the same fresh-contributor failures we filed those PRs to document.

## Solution

One-line edit to `README.md`. Inserts `Ninja, ripgrep` between `CMake` and `and the platform desktop build prerequisites`. No changes to structure, headings, or the deeper-link block beneath bullet 3 — those continue to point at `CONTRIBUTING.md` for the full table.

## Submission Checklist

- [x] N/A — pure prose change to a markdown file; no behavior to test.
- [x] N/A — markdown line not covered by Vitest or cargo-llvm-cov.
- [x] N/A — no feature rows affected.
- [x] N/A — no feature IDs touched.
- [x] N/A — no external dependencies introduced; documents existing prereqs.
- [x] N/A — no release-cut surfaces touched.
- [x] Linked issue closed via `Closes #1868` in the `## Related` section.

## Impact

Fresh contributors who read only the README still install Ninja and ripgrep, and don't hit the two `git push` failures (`cef-dll-sys` CMake abort / `rg: command not found`) that motivated #1783 and #1867.

## Related

- Closes: #1868
- Soft dependency on #1867: that PR adds `ripgrep` to `CONTRIBUTING.md`'s full prerequisites table. This PR's README mention of `ripgrep` stands on its own (the actual requirement is the `lint:commands-tokens` script in `app/package.json`, which exists on `main` today), but reviewers may prefer to merge #1867 first so both docs land in sync. Happy to rebase / split if preferred.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> N/A — Human-authored fix. AI-assisted drafting; not a Codex/Linear autonomous PR.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `docs/readme-prereqs-sync`
- Commit SHA: `3b629745`

### Validation Run
- [x] N/A — no JS/TS changed.
- [x] N/A — no TS types changed.
- [x] N/A — no TS to compile.
- [x] N/A — no Rust changed.
- [x] N/A — no Tauri code changed.

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check` (`cargo check --manifest-path src-tauri/Cargo.toml`) may still exit 101 on upstream `main` (inherited failure documented in #1786). This branch only edits `README.md` so the failure cannot be caused by this change.
- `error:` (as above)
- `impact:` Pushed with `--no-verify` per `CLAUDE.md` guidance for hook failures unrelated to the change.

### Behavior Changes
- Intended behavior change: None — documentation only.
- User-visible effect: Fresh contributors reading only the README see the correct tool list.

### Parity Contract
- Legacy behavior preserved: Yes — no runtime code touched.
- Guard/fallback/dispatch parity checks: N/A — no dispatch path touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None. Verified no open PR touches `README.md` (28 open PRs scanned via GitHub API at commit time).
- Canonical PR: This one.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing setup prerequisites to include additional tooling (Ninja and ripgrep) required for building from source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->