### PR TITLE
feat(memory/chunker): recognize all 6 ATX heading levels (h1-h6) per CommonMark

### DIFF
--- a/src/openhuman/memory/chunker.rs
+++ b/src/openhuman/memory/chunker.rs
@@ -130,17 +130,34 @@ pub fn chunk_markdown(text: &str, max_tokens: usize) -> Vec<Chunk> {
     chunks
 }
 
-/// Identifies top-level markdown headings and groups their following text.
-///
-/// Recognizes `#`, `##`, and `###` as section boundaries.
+/// Returns `true` if `line` starts with a valid ATX markdown heading
+/// (1 to 6 `#` characters followed by a space).
+fn is_atx_heading(line: &str) -> bool {
+    const PREFIXES: &[&str] = &["# ", "## ", "### ", "#### ", "##### ", "###### "];
+    PREFIXES.iter().any(|p| line.starts_with(p))
+}
+
+/// Identifies markdown ATX headings and groups their following text into
+/// sections.
 fn split_on_headings(text: &str) -> Vec<(Option<String>, String)> {
+    log::debug!(
+        "[memory::chunker] split_on_headings: entry text_len={}",
+        text.len()
+    );
     let mut sections = Vec::new();
     let mut current_heading: Option<String> = None;
     let mut current_body = String::new();
 
+    // Log lengths only, not heading or body text: a heading could contain
+    // PII the user pasted into their docs (emails, usernames, etc.).
     for line in text.lines() {
-        if line.starts_with("# ") || line.starts_with("## ") || line.starts_with("### ") {
+        if is_atx_heading(line) {
             if !current_body.trim().is_empty() || current_heading.is_some() {
+                log::debug!(
+                    "[memory::chunker] split_on_headings: flushing section heading_len={} body_len={}",
+                    current_heading.as_deref().map(str::len).unwrap_or(0),
+                    current_body.len()
+                );
                 sections.push((current_heading.take(), std::mem::take(&mut current_body)));
             }
             current_heading = Some(line.to_string());
@@ -151,9 +168,18 @@ fn split_on_headings(text: &str) -> Vec<(Option<String>, String)> {
     }
 
     if !current_body.trim().is_empty() || current_heading.is_some() {
+        log::debug!(
+            "[memory::chunker] split_on_headings: flushing final section heading_len={} body_len={}",
+            current_heading.as_deref().map(str::len).unwrap_or(0),
+            current_body.len()
+        );
         sections.push((current_heading, current_body));
     }
 
+    log::debug!(
+        "[memory::chunker] split_on_headings: exit sections={}",
+        sections.len()
+    );
     sections
 }
 
@@ -299,15 +325,66 @@ mod tests {
     }
 
     #[test]
-    fn deeply_nested_headings_ignored() {
-        // #### and deeper are NOT treated as heading splits
+    fn deep_atx_headings_split_through_h6() {
         let text = "# Top\nIntro\n#### Deep heading\nDeep content";
         let chunks = chunk_markdown(text, 512);
-        // "#### Deep heading" should stay with its parent section
-        assert!(!chunks.is_empty());
-        let all_content: String = chunks.iter().map(|c| c.content.clone()).collect();
-        assert!(all_content.contains("Deep heading"));
-        assert!(all_content.contains("Deep content"));
+        assert!(
+            chunks.len() >= 2,
+            "expected the #### heading to start a new section, got {} chunk(s)",
+            chunks.len(),
+        );
+        let deep = chunks
+            .iter()
+            .find(|c| c.heading.as_deref() == Some("#### Deep heading"));
+        assert!(
+            deep.is_some(),
+            "expected a chunk with heading '#### Deep heading'; chunks: {chunks:?}",
+        );
+    }
+
+    #[test]
+    fn all_atx_heading_levels_h1_through_h6_split() {
+        let text = "# H1\na\n\n## H2\nb\n\n### H3\nc\n\n#### H4\nd\n\n##### H5\ne\n\n###### H6\nf";
+        let chunks = chunk_markdown(text, 512);
+        let headings: Vec<_> = chunks.iter().filter_map(|c| c.heading.as_deref()).collect();
+        assert_eq!(
+            headings,
+            vec![
+                "# H1",
+                "## H2",
+                "### H3",
+                "#### H4",
+                "##### H5",
+                "###### H6"
+            ],
+            "each ATX heading depth h1-h6 must split into its own section",
+        );
+    }
+
+    #[test]
+    fn seven_or_more_hashes_are_not_a_heading() {
+        let text = "# Top\nIntro\n####### Not a heading\nMore content";
+        let chunks = chunk_markdown(text, 512);
+        assert_eq!(
+            chunks.len(),
+            1,
+            "7-hash line should not split; expected 1 chunk, got {}",
+            chunks.len(),
+        );
+        assert_eq!(chunks[0].heading.as_deref(), Some("# Top"));
+        assert!(chunks[0].content.contains("####### Not a heading"));
+    }
+
+    #[test]
+    fn atx_heading_requires_trailing_space() {
+        let text = "# Real heading\nIntro\n###NoSpace\nbody";
+        let chunks = chunk_markdown(text, 512);
+        assert_eq!(
+            chunks.len(),
+            1,
+            "missing trailing space disqualifies the heading"
+        );
+        assert_eq!(chunks[0].heading.as_deref(), Some("# Real heading"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extends `split_on_headings` in [src/openhuman/memory/chunker.rs](https://github.com/tinyhumansai/openhuman/blob/main/src/openhuman/memory/chunker.rs) from h1-h3 to all six CommonMark ATX heading levels (h1-h6). Adds a small `is_atx_heading` helper, replaces the bug-documenting test with four positive/negative tests.

## Problem

The chunker only matched `#`, `##`, `###` as section boundaries. CommonMark valid ATX headings are 1-6 leading `#` followed by a space. Deep-nested technical docs (API references, multi-level READMEs, anything user-ingested with deeper nesting) dumped entire `####`+ subtrees into the parent section, producing oversized chunks and the wrong `chunk.heading` for retrieval. The previous test [`deeply_nested_headings_ignored`](https://github.com/tinyhumansai/openhuman/blob/02cf2cee/src/openhuman/memory/chunker.rs#L302-L312) asserted the buggy behavior as documentation; it passes clean on `upstream/main` at commit `02cf2cee`, confirming the bug exists exactly as described.

`git log -S` on the original `starts_with("### ")` line shows it came in via [PR #52 "Feat/refactor UI code"](https://github.com/tinyhumansai/openhuman/pull/52) (32678 additions / 52517 deletions across 100 files), whose description was the blank template and whose comments never mention headings, depth, or the chunker. No recorded rationale for the h1-h3 cap, which reads as an oversight in a massive UI refactor rather than a deliberate design choice. See #1877 for the full investigation.

## Solution

New private helper backed by a static prefix list:

```rust
fn is_atx_heading(line: &str) -> bool {
    const PREFIXES: &[&str] = &["# ", "## ", "### ", "#### ", "##### ", "###### "];
    PREFIXES.iter().any(|p| line.starts_with(p))
}
```

Naturally enforces both CommonMark rules in one place: 1-6 hashes (the list has exactly 6 entries, so 7+ hashes match no prefix) and trailing space required (every prefix ends with a space, so `###heading` matches none). Zero allocation (static strings baked into the binary). `split_on_headings` swaps its inline three-way `starts_with` chain for a single call to this helper.

The existing `deeply_nested_headings_ignored` test (whose premise is the bug) is replaced with four new tests:

- `deep_atx_headings_split_through_h6`: `#### Deep heading` produces its own chunk with the right `.heading` field.
- `all_atx_heading_levels_h1_through_h6_split`: feeds one heading at each depth and asserts all six `.heading` fields land correctly.
- `seven_or_more_hashes_are_not_a_heading`: `####### Foo` stays as body of the parent section.
- `atx_heading_requires_trailing_space`: `###NoSpace` stays as body.

Net diff: +60 -11 in one file. All 22 chunker tests pass locally (`cargo test --package openhuman --lib openhuman::memory::chunker`).

## Submission Checklist

- [x] Tests added (4 new: happy-path h1-h6 split + two failure-path negatives for 7+ hashes and missing trailing space). Replaces the prior bug-documenting test.
- [x] Diff coverage: every line of the new helper and the changed `split_on_headings` is exercised by one of the 4 new tests plus the existing tests that cover the h1-h3 paths.
- [x] N/A: no feature rows affected (`docs/TEST-COVERAGE-MATRIX.md` covers user-visible features; chunker internals are not a row).
- [x] N/A: no feature IDs touched.
- [x] N/A: no external dependencies introduced; stdlib only.
- [x] N/A: no release-cut surfaces touched.
- [x] Linked issue closed via `Closes #1877` in the `## Related` section.

## Impact

- Memory chunks for docs with `####`+ now split at the deeper boundary, so retrieval gets the right granularity and the correct `chunk.heading` for surface display.
- No behavior change for documents using only h1-h3.
- No public API change (`is_atx_heading` is a private helper).

## Related

- Closes: #1877
- Follow-ups already on the contribution roadmap (separate PRs): chunker single-long-line splitter, code-fence-aware splitting so deep headings inside a ``` block aren't misinterpreted.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> N/A: Human-authored, AI-assisted drafting.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `feat/chunker-deep-headings`
- Commit SHA: `6760780d`

### Validation Run
- [x] N/A: no JS/TS changed.
- [x] N/A: no TS types changed.
- [x] N/A: no TS to compile.
- [x] `cargo test --package openhuman --lib openhuman::memory::chunker` passes (22/22, 0 failed) locally on this branch.
- [x] N/A: no Tauri code changed.

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check` (`cargo check --manifest-path src-tauri/Cargo.toml`) may still exit 101 on upstream `main` (inherited failure documented in [PR #1786, codesign script fix](https://github.com/tinyhumansai/openhuman/pull/1786)). This branch only edits `src/openhuman/memory/chunker.rs` so the failure cannot be caused by this change.
- `error:` (as above)
- `impact:` Pushed with `--no-verify` per `CLAUDE.md` guidance for hook failures unrelated to the change.

### Behavior Changes
- Intended behavior change: documents using `####`-`######` headings now split at those boundaries, where previously they were glued to the parent section.
- User-visible effect: better-grained memory chunks and correct `heading` field for deep-nested doc content.

### Parity Contract
- Legacy behavior preserved: Yes for h1-h3 inputs (same chunks, same `heading` fields). For 7+ hash and no-trailing-space inputs, behavior is now spec-correct.
- Guard/fallback/dispatch parity checks: N/A; no dispatch path touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None. Overlap check at branch-push time: 28 open PRs scanned via `gh pr list`; only [PR #1657 "Feat/gmail unsubscribe agent"](https://github.com/tinyhumansai/openhuman/pull/1657) touches `src/openhuman/memory/`, and a file-level inspection confirmed it does not touch `chunker.rs`.
- Canonical PR: This one.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown chunking to recognize ATX heading levels 1–6 so deeper headings now start new sections; lines with seven hashes are not treated as headings and headings must include a trailing space.

* **Tests**
  * Added/updated tests covering h1–h6 splitting, exclusion of 7+ hashes, and trailing-space heading validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->