### PR TITLE
feat(mascot): backend mascot library + meeting-bot banner

### DIFF
--- a/app/src/components/settings/panels/MascotPanel.tsx
+++ b/app/src/components/settings/panels/MascotPanel.tsx
@@ -1,9 +1,16 @@
+import { useEffect, useState } from 'react';
+
+import { BackendMascot } from '../../../features/human/Mascot/backend/BackendMascot';
+import type { MascotDetail, MascotSummary } from '../../../features/human/Mascot/backend/types';
 import { getMascotPalette, type MascotColor } from '../../../features/human/Mascot/mascotPalette';
+import { fetchMascotList, getCachedMascotDetail } from '../../../services/mascotService';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import {
   DEFAULT_MASCOT_COLOR,
   selectMascotColor,
+  selectSelectedMascotId,
   setMascotColor,
+  setSelectedMascotId,
   SUPPORTED_MASCOT_COLORS,
 } from '../../../store/mascotSlice';
 import SettingsHeader from '../components/SettingsHeader';
@@ -26,6 +33,61 @@ const MascotPanel = () => {
   const { navigateBack, breadcrumbs } = useSettingsNavigation();
   const dispatch = useAppDispatch();
   const storedColor = useAppSelector(selectMascotColor);
+  const selectedMascotId = useAppSelector(selectSelectedMascotId);
+
+  // Backend mascot library (PR tinyhumansai/backend#770). The list endpoint
+  // is cheap (no SVG bytes); per-id detail is fetched on demand so the
+  // animated preview only pays for the active selection.
+  const [backendList, setBackendList] = useState<MascotSummary[] | null>(null);
+  const [backendListError, setBackendListError] = useState<string | null>(null);
+  const [activeDetail, setActiveDetail] = useState<MascotDetail | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMascotList()
+      .then(list => {
+        if (cancelled) return;
+        setBackendList(list);
+        setBackendListError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Could not load mascot library.';
+        setBackendListError(message);
+        setBackendList([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedMascotId) {
+      setActiveDetail(null);
+      return;
+    }
+    let cancelled = false;
+    getCachedMascotDetail(selectedMascotId)
+      .then(detail => {
+        if (cancelled) return;
+        setActiveDetail(detail);
+        setDetailError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Could not load mascot.';
+        setDetailError(message);
+        setActiveDetail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedMascotId]);
+
+  const handleSelectBackend = (id: string | null) => {
+    dispatch(setSelectedMascotId(id));
+  };
 
   // Filter the menu to colors the asset pipeline currently supports — guards
   // against an older persisted value pointing at a variant a future build
@@ -100,6 +162,91 @@ const MascotPanel = () => {
           <p className="text-xs text-stone-500 leading-relaxed px-1 mt-2">
             The selected color is applied everywhere the mascot appears and is remembered across
             restarts.
+          </p>
+        </div>
+
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-stone-400 mb-2 px-1">
+            Backend mascots
+          </h3>
+          <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
+            {backendListError && (
+              <p className="p-4 text-sm text-coral-700">
+                Backend mascot library unavailable: {backendListError}
+              </p>
+            )}
+            {!backendListError && backendList === null && (
+              <p className="p-4 text-sm text-stone-500">Loading mascot library…</p>
+            )}
+            {backendList && backendList.length === 0 && !backendListError && (
+              <p className="p-4 text-sm text-stone-500">
+                No backend mascots are available yet. Local color variants above are still active.
+              </p>
+            )}
+            {backendList && backendList.length > 0 && (
+              <ul className="divide-y divide-stone-100">
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectBackend(null)}
+                    aria-pressed={selectedMascotId == null}
+                    className={`flex w-full items-center justify-between px-4 py-3 text-left text-sm hover:bg-stone-50 ${
+                      selectedMascotId == null ? 'bg-stone-50 font-medium' : ''
+                    }`}>
+                    <span>Local mascot (default)</span>
+                    {selectedMascotId == null && (
+                      <span className="text-[10px] uppercase text-primary-600">Active</span>
+                    )}
+                  </button>
+                </li>
+                {backendList.map(summary => {
+                  const active = summary.id === selectedMascotId;
+                  return (
+                    <li key={summary.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleSelectBackend(summary.id)}
+                        aria-pressed={active}
+                        data-testid={`backend-mascot-${summary.id}`}
+                        className={`flex w-full items-center justify-between px-4 py-3 text-left text-sm hover:bg-stone-50 ${
+                          active ? 'bg-stone-50 font-medium' : ''
+                        }`}>
+                        <span className="flex flex-col">
+                          <span>{summary.name}</span>
+                          <span className="text-[10px] text-stone-500">
+                            v{summary.version} · {summary.states.length} states
+                            {summary.hasVisemes ? ' · visemes' : ''}
+                          </span>
+                        </span>
+                        {active && (
+                          <span className="text-[10px] uppercase text-primary-600">Active</span>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          {activeDetail && (
+            <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 p-4">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-stone-500 mb-2">
+                Preview · {activeDetail.name}
+              </p>
+              <div className="flex justify-center">
+                <div style={{ width: 160, height: 160 }}>
+                  <BackendMascot mascot={activeDetail} />
+                </div>
+              </div>
+            </div>
+          )}
+          {detailError && (
+            <p className="mt-2 text-xs text-coral-700 px-1">{detailError}</p>
+          )}
+          <p className="text-xs text-stone-500 leading-relaxed px-1 mt-2">
+            Backend mascots come from the server-side library and animate via the same tween and
+            viseme pipeline as the meeting bot's video stream.
           </p>
         </div>
       </div>

--- a/app/src/components/settings/panels/MascotPanel.tsx
+++ b/app/src/components/settings/panels/MascotPanel.tsx
@@ -110,7 +110,7 @@ const MascotPanel = () => {
   return (
     <div>
       <SettingsHeader
-        title="Mascot"
+        title="OpenHuman"
         showBackButton={true}
         onBack={navigateBack}
         breadcrumbs={breadcrumbs}
@@ -124,13 +124,13 @@ const MascotPanel = () => {
           <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
             {available.length === 0 ? (
               <p className="p-4 text-sm text-stone-500">
-                No mascot color variants are available in this build.
+                No OpenHuman color variants are available in this build.
               </p>
             ) : (
               <div
                 className="grid grid-cols-5 gap-3 p-4"
                 role="radiogroup"
-                aria-label="Mascot color">
+                aria-label="OpenHuman color">
                 {available.map(opt => {
                   const palette = getMascotPalette(opt.id);
                   const selected = opt.id === activeColor;
@@ -160,27 +160,28 @@ const MascotPanel = () => {
             )}
           </div>
           <p className="text-xs text-stone-500 leading-relaxed px-1 mt-2">
-            The selected color is applied everywhere the mascot appears and is remembered across
+            The selected color is applied everywhere OpenHuman appears and is remembered across
             restarts.
           </p>
         </div>
 
         <div>
           <h3 className="text-xs font-semibold uppercase tracking-wider text-stone-400 mb-2 px-1">
-            Backend mascots
+            Character
           </h3>
           <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
             {backendListError && (
               <p className="p-4 text-sm text-coral-700">
-                Backend mascot library unavailable: {backendListError}
+                OpenHuman library unavailable: {backendListError}
               </p>
             )}
             {!backendListError && backendList === null && (
-              <p className="p-4 text-sm text-stone-500">Loading mascot library…</p>
+              <p className="p-4 text-sm text-stone-500">Loading OpenHuman library…</p>
             )}
             {backendList && backendList.length === 0 && !backendListError && (
               <p className="p-4 text-sm text-stone-500">
-                No backend mascots are available yet. Local color variants above are still active.
+                No OpenHuman characters are available yet. Local color variants above are still
+                active.
               </p>
             )}
             {backendList && backendList.length > 0 && (
@@ -193,7 +194,7 @@ const MascotPanel = () => {
                     className={`flex w-full items-center justify-between px-4 py-3 text-left text-sm hover:bg-stone-50 ${
                       selectedMascotId == null ? 'bg-stone-50 font-medium' : ''
                     }`}>
-                    <span>Local mascot (default)</span>
+                    <span>Local OpenHuman (default)</span>
                     {selectedMascotId == null && (
                       <span className="text-[10px] uppercase text-primary-600">Active</span>
                     )}
@@ -243,8 +244,8 @@ const MascotPanel = () => {
           )}
           {detailError && <p className="mt-2 text-xs text-coral-700 px-1">{detailError}</p>}
           <p className="text-xs text-stone-500 leading-relaxed px-1 mt-2">
-            Backend mascots come from the server-side library and animate via the same tween and
-            viseme pipeline as the meeting bot's video stream.
+            Characters come from the server-side library and animate via the same tween and viseme
+            pipeline as the meeting bot video stream.
           </p>
         </div>
       </div>

--- a/app/src/components/settings/panels/MascotPanel.tsx
+++ b/app/src/components/settings/panels/MascotPanel.tsx
@@ -241,9 +241,7 @@ const MascotPanel = () => {
               </div>
             </div>
           )}
-          {detailError && (
-            <p className="mt-2 text-xs text-coral-700 px-1">{detailError}</p>
-          )}
+          {detailError && <p className="mt-2 text-xs text-coral-700 px-1">{detailError}</p>}
           <p className="text-xs text-stone-500 leading-relaxed px-1 mt-2">
             Backend mascots come from the server-side library and animate via the same tween and
             viseme pipeline as the meeting bot's video stream.

--- a/app/src/components/settings/panels/__tests__/MascotPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/MascotPanel.test.tsx
@@ -41,7 +41,7 @@ describe('MascotPanel', () => {
 
   it('renders a radio swatch for each supported color', () => {
     renderPanel();
-    expect(screen.getByRole('radiogroup', { name: 'Mascot color' })).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: 'OpenHuman color' })).toBeInTheDocument();
     for (const label of ['Yellow', 'Burgundy', 'Black', 'Navy', 'Green']) {
       expect(screen.getByRole('radio', { name: label })).toBeInTheDocument();
     }

--- a/app/src/components/settings/panels/__tests__/MascotPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/MascotPanel.test.tsx
@@ -5,10 +5,29 @@ import { MemoryRouter } from 'react-router-dom';
 import { REHYDRATE } from 'redux-persist';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import mascotReducer, { DEFAULT_MASCOT_COLOR, setMascotColor } from '../../../../store/mascotSlice';
+import mascotReducer, {
+  DEFAULT_MASCOT_COLOR,
+  setMascotColor,
+  setSelectedMascotId,
+} from '../../../../store/mascotSlice';
 import MascotPanel from '../MascotPanel';
 
-const { mockNavigateBack } = vi.hoisted(() => ({ mockNavigateBack: vi.fn() }));
+const { mockNavigateBack, fetchMascotListMock, getCachedMascotDetailMock } = vi.hoisted(() => ({
+  mockNavigateBack: vi.fn(),
+  fetchMascotListMock: vi.fn(),
+  getCachedMascotDetailMock: vi.fn(),
+}));
+
+vi.mock('../../../../services/mascotService', () => ({
+  fetchMascotList: (...args: unknown[]) => fetchMascotListMock(...args),
+  getCachedMascotDetail: (...args: unknown[]) => getCachedMascotDetailMock(...args),
+}));
+
+vi.mock('../../../../features/human/Mascot/backend/BackendMascot', () => ({
+  BackendMascot: ({ mascot }: { mascot: { id: string } }) => (
+    <div data-testid={`backend-mascot-preview-${mascot.id}`} />
+  ),
+}));
 
 vi.mock('../../hooks/useSettingsNavigation', () => ({
   useSettingsNavigation: () => ({
@@ -37,6 +56,8 @@ function renderPanel(store = buildStore()) {
 describe('MascotPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMascotListMock.mockResolvedValue([]);
+    getCachedMascotDetailMock.mockResolvedValue(null);
   });
 
   it('renders a radio swatch for each supported color', () => {
@@ -125,5 +146,81 @@ describe('MascotPanel — mascotSlice rehydrate guard', () => {
     );
     expect(screen.getByRole('radio', { name: 'Green' })).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByRole('radio', { name: 'Yellow' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  describe('backend mascot library', () => {
+    const summary = {
+      id: 'yellow',
+      name: 'Yellow',
+      version: '1.0.0',
+      description: '',
+      states: [{ id: 'idle', label: 'Idle', description: '' }],
+      hasVisemes: true,
+    };
+    const detail = {
+      id: 'yellow',
+      name: 'Yellow',
+      version: '1.0.0',
+      description: '',
+      viewBox: '0 0 1 1',
+      defaultState: 'idle',
+      variables: [],
+      states: [{ id: 'idle', label: 'Idle', description: '', svg: '<svg/>' }],
+      visemes: [],
+    };
+
+    it('renders the picker entries returned by the API', async () => {
+      fetchMascotListMock.mockResolvedValueOnce([summary]);
+      renderPanel();
+      expect(await screen.findByTestId('backend-mascot-yellow')).toBeInTheDocument();
+      // Default-row (local) sentinel
+      expect(screen.getByText(/Local OpenHuman/)).toBeInTheDocument();
+    });
+
+    it('shows a friendly empty state when the library is empty', async () => {
+      fetchMascotListMock.mockResolvedValueOnce([]);
+      renderPanel();
+      expect(
+        await screen.findByText(/No OpenHuman characters are available yet/i)
+      ).toBeInTheDocument();
+    });
+
+    it('shows an error when the library endpoint rejects', async () => {
+      fetchMascotListMock.mockRejectedValueOnce(new Error('offline'));
+      renderPanel();
+      expect(
+        await screen.findByText(/OpenHuman library unavailable: offline/i)
+      ).toBeInTheDocument();
+    });
+
+    it('dispatches setSelectedMascotId when a backend mascot is picked', async () => {
+      fetchMascotListMock.mockResolvedValueOnce([summary]);
+      getCachedMascotDetailMock.mockResolvedValueOnce(detail);
+      const { store } = renderPanel();
+      const row = await screen.findByTestId('backend-mascot-yellow');
+      fireEvent.click(row);
+      expect(store.getState().mascot.selectedMascotId).toBe('yellow');
+    });
+
+    it('loads + previews the active backend mascot detail', async () => {
+      const store = buildStore();
+      store.dispatch(setSelectedMascotId('yellow'));
+      fetchMascotListMock.mockResolvedValueOnce([summary]);
+      getCachedMascotDetailMock.mockResolvedValueOnce(detail);
+      renderPanel(store);
+      expect(await screen.findByTestId('backend-mascot-preview-yellow')).toBeInTheDocument();
+      expect(getCachedMascotDetailMock).toHaveBeenCalledWith('yellow');
+    });
+
+    it('clearing the selection returns to the local default', async () => {
+      const store = buildStore();
+      store.dispatch(setSelectedMascotId('yellow'));
+      fetchMascotListMock.mockResolvedValueOnce([summary]);
+      getCachedMascotDetailMock.mockResolvedValueOnce(detail);
+      renderPanel(store);
+      const localRow = await screen.findByText(/Local OpenHuman/);
+      fireEvent.click(localRow);
+      expect(store.getState().mascot.selectedMascotId).toBeNull();
+    });
   });
 });

--- a/app/src/components/skills/MeetingBotsCard.tsx
+++ b/app/src/components/skills/MeetingBotsCard.tsx
@@ -86,13 +86,15 @@ function MeetingBotsBanner({ onClick }: { onClick: () => void }) {
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <h2 className="text-sm font-semibold text-stone-900">Send the mascot to a meeting</h2>
+            <h2 className="text-sm font-semibold text-stone-900">
+              Send OpenHuman to a meeting
+            </h2>
             <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-700">
               New
             </span>
           </div>
           <p className="mt-0.5 line-clamp-1 text-[11px] leading-relaxed text-stone-600">
-            Drop a Google Meet link and the mascot joins as a guest — talks, listens, and waves
+            Drop a Google Meet link and OpenHuman joins as a guest, talks, listens, and waves
             back.
           </p>
         </div>
@@ -115,7 +117,7 @@ interface ModalProps {
 function MeetingBotsModal({ onClose, onToast }: ModalProps) {
   const [platform, setPlatform] = useState<MascotMeetPlatform>('gmeet');
   const [meetUrl, setMeetUrl] = useState('');
-  const [displayName, setDisplayName] = useState('OpenHuman Mascot');
+  const [displayName, setDisplayName] = useState('OpenHuman');
   const [submitting, setSubmitting] = useState(false);
   const [capacityGated, setCapacityGated] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -145,8 +147,8 @@ function MeetingBotsModal({ onClose, onToast }: ModalProps) {
       await joinMeetingViaMascotBot({ platform, meetUrl, displayName });
       onToast?.({
         type: 'success',
-        title: 'Mascot is joining the meeting',
-        message: 'You should see it appear as a participant in a few seconds.',
+        title: 'OpenHuman is joining the meeting',
+        message: 'It should appear as a participant in a few seconds.',
       });
       setMeetUrl('');
       onClose();
@@ -157,13 +159,13 @@ function MeetingBotsModal({ onClose, onToast }: ModalProps) {
         setError(message);
         onToast?.({
           type: 'error',
-          title: err.isCapacityGated ? 'Mascot service is busy' : 'Could not start the mascot',
+          title: err.isCapacityGated ? 'OpenHuman is busy' : 'Could not start OpenHuman',
           message,
         });
       } else {
-        const message = err instanceof Error ? err.message : 'Failed to start mascot.';
+        const message = err instanceof Error ? err.message : 'Failed to start OpenHuman.';
         setError(message);
-        onToast?.({ type: 'error', title: 'Could not start the mascot', message });
+        onToast?.({ type: 'error', title: 'Could not start OpenHuman', message });
       }
     } finally {
       setSubmitting(false);
@@ -174,7 +176,7 @@ function MeetingBotsModal({ onClose, onToast }: ModalProps) {
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Send the mascot to a meeting"
+      aria-label="Send OpenHuman to a meeting"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
       onClick={onClose}>
       <div
@@ -190,9 +192,9 @@ function MeetingBotsModal({ onClose, onToast }: ModalProps) {
             className="absolute right-3 top-3 rounded-full p-1 text-stone-500 hover:bg-white/80 hover:text-stone-800">
             ✕
           </button>
-          <h2 className="text-base font-semibold text-stone-900">Send the mascot to a meeting</h2>
+          <h2 className="text-base font-semibold text-stone-900">Send OpenHuman to a meeting</h2>
           <p className="mt-1 text-xs leading-relaxed text-stone-600">
-            The mascot joins as an anonymous guest, streams its video into the call, and replies
+            OpenHuman joins as an anonymous guest, streams its video into the call, and replies
             via the agent.
           </p>
         </div>

--- a/app/src/components/skills/MeetingBotsCard.tsx
+++ b/app/src/components/skills/MeetingBotsCard.tsx
@@ -1,0 +1,186 @@
+// Meeting bot integrations card. Lives on the Skills "Integrations"
+// section — moved off the Intelligence Calls tab per product direction
+// (#issue-mascot-meets).
+//
+// Wraps the backend mascot bot (PR tinyhumansai/backend#773): joining a
+// Google Meet kicks off the Camoufox-driven mascot in the backend, which
+// then streams the mascot's WebRTC video into the call as an anonymous
+// guest. The user just supplies a meet URL. Zoom and Teams are shown
+// as "coming soon" — the backend already routes them but returns 400
+// "not yet supported".
+
+import { useState } from 'react';
+
+import {
+  joinMeetingViaMascotBot,
+  SERVER_OVERLOADED_MESSAGE,
+  type MascotJoinMeetingError,
+  type MascotMeetPlatform,
+} from '../../services/meetCallService';
+
+type Toast = { type: 'success' | 'error' | 'info'; title: string; message?: string };
+
+interface Props {
+  /** Optional toast sink — re-uses the Intelligence page's toast UI when mounted in /skills. */
+  onToast?: (toast: Toast) => void;
+}
+
+interface PlatformDef {
+  platform: MascotMeetPlatform;
+  label: string;
+  domainHint: string;
+  comingSoon?: boolean;
+}
+
+const PLATFORMS: PlatformDef[] = [
+  { platform: 'gmeet', label: 'Google Meet', domainHint: 'meet.google.com/abc-defg-hij' },
+  { platform: 'zoom', label: 'Zoom', domainHint: 'zoom.us/j/…', comingSoon: true },
+  { platform: 'teams', label: 'Microsoft Teams', domainHint: 'teams.microsoft.com/…', comingSoon: true },
+];
+
+function isMascotJoinMeetingError(err: unknown): err is MascotJoinMeetingError {
+  return !!err && typeof err === 'object' && 'isCapacityGated' in err && 'message' in err;
+}
+
+export default function MeetingBotsCard({ onToast }: Props) {
+  const [platform, setPlatform] = useState<MascotMeetPlatform>('gmeet');
+  const [meetUrl, setMeetUrl] = useState('');
+  const [displayName, setDisplayName] = useState('OpenHuman Mascot');
+  const [submitting, setSubmitting] = useState(false);
+  const [capacityGated, setCapacityGated] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = PLATFORMS.find(p => p.platform === platform) ?? PLATFORMS[0];
+  const isComingSoon = !!selected.comingSoon;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setCapacityGated(false);
+    if (isComingSoon) {
+      setError(`${selected.label} support is coming soon.`);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await joinMeetingViaMascotBot({ platform, meetUrl, displayName });
+      onToast?.({
+        type: 'success',
+        title: 'Mascot is joining the meeting',
+        message: 'You should see it appear as a participant in a few seconds.',
+      });
+      setMeetUrl('');
+    } catch (err) {
+      if (isMascotJoinMeetingError(err)) {
+        setCapacityGated(err.isCapacityGated);
+        const message = err.isCapacityGated ? SERVER_OVERLOADED_MESSAGE : err.message;
+        setError(message);
+        onToast?.({
+          type: 'error',
+          title: err.isCapacityGated ? 'Mascot service is busy' : 'Could not start the mascot',
+          message,
+        });
+      } else {
+        const message = err instanceof Error ? err.message : 'Failed to start mascot.';
+        setError(message);
+        onToast?.({ type: 'error', title: 'Could not start the mascot', message });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="rounded-2xl border border-stone-200 bg-white p-3 shadow-soft animate-fade-up"
+      data-testid="meeting-bots-card">
+      <div className="px-1 pb-3 pt-1">
+        <h2 className="text-sm font-semibold text-stone-900">Meeting bots</h2>
+        <p className="mt-0.5 text-[11px] leading-relaxed text-stone-500">
+          Send the mascot into a live meeting as an anonymous guest. The bot streams its WebRTC
+          video into the call and listens / replies via the agent.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5 px-1 pb-3">
+        {PLATFORMS.map(p => {
+          const active = p.platform === platform;
+          return (
+            <button
+              key={p.platform}
+              type="button"
+              onClick={() => {
+                setPlatform(p.platform);
+                setError(null);
+              }}
+              className={`rounded-full px-3 py-1 text-[11px] font-medium transition ${
+                active
+                  ? 'bg-primary-500 text-white'
+                  : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
+              }`}>
+              {p.label}
+              {p.comingSoon && <span className="ml-1 opacity-70">· soon</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-3 px-1 pb-1">
+        <label className="block">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-stone-500">
+            Meeting link
+          </span>
+          <input
+            type="url"
+            inputMode="url"
+            autoComplete="off"
+            spellCheck={false}
+            value={meetUrl}
+            onChange={e => setMeetUrl(e.target.value)}
+            placeholder={selected.domainHint}
+            disabled={isComingSoon || submitting}
+            className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 disabled:cursor-not-allowed disabled:bg-stone-50"
+            required
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-stone-500">
+            Display name
+          </span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={e => setDisplayName(e.target.value)}
+            maxLength={64}
+            disabled={isComingSoon || submitting}
+            className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 disabled:cursor-not-allowed disabled:bg-stone-50"
+          />
+        </label>
+
+        {error && (
+          <div
+            role="alert"
+            className={`rounded-xl border px-3 py-2 text-xs ${
+              capacityGated
+                ? 'border-amber-200 bg-amber-50 text-amber-800'
+                : 'border-coral-200 bg-coral-50 text-coral-700'
+            }`}>
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || isComingSoon || !meetUrl.trim()}
+          className="w-full rounded-xl bg-primary-500 px-3 py-2 text-sm font-semibold text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:bg-stone-200 disabled:text-stone-400">
+          {isComingSoon
+            ? `${selected.label} support coming soon`
+            : submitting
+              ? 'Starting mascot…'
+              : `Send mascot to ${selected.label}`}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/src/components/skills/MeetingBotsCard.tsx
+++ b/app/src/components/skills/MeetingBotsCard.tsx
@@ -1,15 +1,13 @@
-// Meeting bot integrations card. Lives on the Skills "Integrations"
-// section — moved off the Intelligence Calls tab per product direction
-// (#issue-mascot-meets).
+// Meeting bots entry point on the Skills "Integrations" section.
 //
-// Wraps the backend mascot bot (PR tinyhumansai/backend#773): joining a
-// Google Meet kicks off the Camoufox-driven mascot in the backend, which
-// then streams the mascot's WebRTC video into the call as an anonymous
-// guest. The user just supplies a meet URL. Zoom and Teams are shown
-// as "coming soon" — the backend already routes them but returns 400
-// "not yet supported".
+// Surfaces as a compact, fun banner: clicking opens a modal that wraps
+// the backend mascot bot (PR tinyhumansai/backend#773). Joining a
+// Google Meet kicks off the Camoufox-driven mascot in the backend,
+// which streams the mascot's WebRTC video into the call as an
+// anonymous guest. Zoom and Teams are shown as "coming soon" — the
+// backend already routes them but returns 400 "not yet supported".
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   joinMeetingViaMascotBot,
@@ -21,7 +19,6 @@ import {
 type Toast = { type: 'success' | 'error' | 'info'; title: string; message?: string };
 
 interface Props {
-  /** Optional toast sink — re-uses the Intelligence page's toast UI when mounted in /skills. */
   onToast?: (toast: Toast) => void;
 }
 
@@ -35,7 +32,12 @@ interface PlatformDef {
 const PLATFORMS: PlatformDef[] = [
   { platform: 'gmeet', label: 'Google Meet', domainHint: 'meet.google.com/abc-defg-hij' },
   { platform: 'zoom', label: 'Zoom', domainHint: 'zoom.us/j/…', comingSoon: true },
-  { platform: 'teams', label: 'Microsoft Teams', domainHint: 'teams.microsoft.com/…', comingSoon: true },
+  {
+    platform: 'teams',
+    label: 'Microsoft Teams',
+    domainHint: 'teams.microsoft.com/…',
+    comingSoon: true,
+  },
 ];
 
 function isMascotJoinMeetingError(err: unknown): err is MascotJoinMeetingError {
@@ -43,6 +45,74 @@ function isMascotJoinMeetingError(err: unknown): err is MascotJoinMeetingError {
 }
 
 export default function MeetingBotsCard({ onToast }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <MeetingBotsBanner onClick={() => setOpen(true)} />
+      {open && <MeetingBotsModal onClose={() => setOpen(false)} onToast={onToast} />}
+    </>
+  );
+}
+
+function MeetingBotsBanner({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid="meeting-bots-banner"
+      className="group relative w-full overflow-hidden rounded-2xl border border-primary-200/60 bg-gradient-to-br from-primary-50 via-white to-amber-50 p-4 text-left shadow-soft transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 animate-fade-up">
+      {/* Decorative gradient orbs — purely cosmetic, hidden from a11y. */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-primary-300/30 blur-2xl transition group-hover:bg-primary-300/40"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-10 -left-6 h-24 w-24 rounded-full bg-amber-300/30 blur-2xl"
+      />
+
+      <div className="relative flex items-center gap-3">
+        <span
+          aria-hidden="true"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white text-base font-bold text-primary-600 shadow-soft ring-1 ring-primary-200/70">
+          {/* Tiny "wave" mark — three dots that animate on hover. */}
+          <span className="flex items-end gap-0.5">
+            <span className="h-2 w-1 rounded-full bg-primary-500 transition group-hover:h-3" />
+            <span className="h-3 w-1 rounded-full bg-primary-500 transition group-hover:h-4" />
+            <span className="h-2 w-1 rounded-full bg-primary-500 transition group-hover:h-3" />
+          </span>
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-stone-900">Send the mascot to a meeting</h2>
+            <span className="rounded-full bg-primary-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-700">
+              New
+            </span>
+          </div>
+          <p className="mt-0.5 line-clamp-1 text-[11px] leading-relaxed text-stone-600">
+            Drop a Google Meet link and the mascot joins as a guest — talks, listens, and waves
+            back.
+          </p>
+        </div>
+
+        <span
+          aria-hidden="true"
+          className="ml-2 hidden text-stone-400 transition group-hover:text-stone-600 sm:inline">
+          →
+        </span>
+      </div>
+    </button>
+  );
+}
+
+interface ModalProps {
+  onClose: () => void;
+  onToast?: (toast: Toast) => void;
+}
+
+function MeetingBotsModal({ onClose, onToast }: ModalProps) {
   const [platform, setPlatform] = useState<MascotMeetPlatform>('gmeet');
   const [meetUrl, setMeetUrl] = useState('');
   const [displayName, setDisplayName] = useState('OpenHuman Mascot');
@@ -52,6 +122,15 @@ export default function MeetingBotsCard({ onToast }: Props) {
 
   const selected = PLATFORMS.find(p => p.platform === platform) ?? PLATFORMS[0];
   const isComingSoon = !!selected.comingSoon;
+
+  // Esc closes the modal — matches the OpenhumanLinkModal pattern.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -70,6 +149,7 @@ export default function MeetingBotsCard({ onToast }: Props) {
         message: 'You should see it appear as a participant in a few seconds.',
       });
       setMeetUrl('');
+      onClose();
     } catch (err) {
       if (isMascotJoinMeetingError(err)) {
         setCapacityGated(err.isCapacityGated);
@@ -92,95 +172,122 @@ export default function MeetingBotsCard({ onToast }: Props) {
 
   return (
     <div
-      className="rounded-2xl border border-stone-200 bg-white p-3 shadow-soft animate-fade-up"
-      data-testid="meeting-bots-card">
-      <div className="px-1 pb-3 pt-1">
-        <h2 className="text-sm font-semibold text-stone-900">Meeting bots</h2>
-        <p className="mt-0.5 text-[11px] leading-relaxed text-stone-500">
-          Send the mascot into a live meeting as an anonymous guest. The bot streams its WebRTC
-          video into the call and listens / replies via the agent.
-        </p>
-      </div>
+      role="dialog"
+      aria-modal="true"
+      aria-label="Send the mascot to a meeting"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}>
+      <div
+        className="w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-xl"
+        onClick={e => e.stopPropagation()}>
+        {/* Header band — same fun gradient as the banner so the modal feels like
+            a continuation of the click, not a context switch. */}
+        <div className="relative bg-gradient-to-br from-primary-50 via-white to-amber-50 px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="absolute right-3 top-3 rounded-full p-1 text-stone-500 hover:bg-white/80 hover:text-stone-800">
+            ✕
+          </button>
+          <h2 className="text-base font-semibold text-stone-900">Send the mascot to a meeting</h2>
+          <p className="mt-1 text-xs leading-relaxed text-stone-600">
+            The mascot joins as an anonymous guest, streams its video into the call, and replies
+            via the agent.
+          </p>
+        </div>
 
-      <div className="flex flex-wrap gap-1.5 px-1 pb-3">
-        {PLATFORMS.map(p => {
-          const active = p.platform === platform;
-          return (
-            <button
-              key={p.platform}
-              type="button"
-              onClick={() => {
-                setPlatform(p.platform);
-                setError(null);
-              }}
-              className={`rounded-full px-3 py-1 text-[11px] font-medium transition ${
-                active
-                  ? 'bg-primary-500 text-white'
-                  : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
-              }`}>
-              {p.label}
-              {p.comingSoon && <span className="ml-1 opacity-70">· soon</span>}
-            </button>
-          );
-        })}
-      </div>
-
-      <form onSubmit={handleSubmit} className="space-y-3 px-1 pb-1">
-        <label className="block">
-          <span className="text-[10px] font-medium uppercase tracking-wide text-stone-500">
-            Meeting link
-          </span>
-          <input
-            type="url"
-            inputMode="url"
-            autoComplete="off"
-            spellCheck={false}
-            value={meetUrl}
-            onChange={e => setMeetUrl(e.target.value)}
-            placeholder={selected.domainHint}
-            disabled={isComingSoon || submitting}
-            className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 disabled:cursor-not-allowed disabled:bg-stone-50"
-            required
-          />
-        </label>
-
-        <label className="block">
-          <span className="text-[10px] font-medium uppercase tracking-wide text-stone-500">
-            Display name
-          </span>
-          <input
-            type="text"
-            value={displayName}
-            onChange={e => setDisplayName(e.target.value)}
-            maxLength={64}
-            disabled={isComingSoon || submitting}
-            className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 disabled:cursor-not-allowed disabled:bg-stone-50"
-          />
-        </label>
-
-        {error && (
-          <div
-            role="alert"
-            className={`rounded-xl border px-3 py-2 text-xs ${
-              capacityGated
-                ? 'border-amber-200 bg-amber-50 text-amber-800'
-                : 'border-coral-200 bg-coral-50 text-coral-700'
-            }`}>
-            {error}
+        <div className="space-y-4 p-5">
+          <div className="flex flex-wrap gap-1.5">
+            {PLATFORMS.map(p => {
+              const active = p.platform === platform;
+              return (
+                <button
+                  key={p.platform}
+                  type="button"
+                  onClick={() => {
+                    setPlatform(p.platform);
+                    setError(null);
+                  }}
+                  className={`rounded-full px-3 py-1 text-[11px] font-medium transition ${
+                    active
+                      ? 'bg-primary-500 text-white'
+                      : 'bg-stone-100 text-stone-600 hover:bg-stone-200'
+                  }`}>
+                  {p.label}
+                  {p.comingSoon && <span className="ml-1 opacity-70">· soon</span>}
+                </button>
+              );
+            })}
           </div>
-        )}
 
-        <button
-          type="submit"
-          disabled={submitting || isComingSoon || !meetUrl.trim()}
-          className="w-full rounded-xl bg-primary-500 px-3 py-2 text-sm font-semibold text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:bg-stone-200 disabled:text-stone-400">
-          {isComingSoon
-            ? `${selected.label} support coming soon`
-            : submitting
-              ? 'Starting mascot…'
-              : `Send mascot to ${selected.label}`}
-        </button>
-      </form>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <label className="block">
+              <span className="text-[10px] font-medium uppercase tracking-wide text-stone-500">
+                Meeting link
+              </span>
+              <input
+                type="url"
+                inputMode="url"
+                autoComplete="off"
+                spellCheck={false}
+                value={meetUrl}
+                onChange={e => setMeetUrl(e.target.value)}
+                placeholder={selected.domainHint}
+                disabled={isComingSoon || submitting}
+                autoFocus
+                className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 disabled:cursor-not-allowed disabled:bg-stone-50"
+                required
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-[10px] font-medium uppercase tracking-wide text-stone-500">
+                Display name
+              </span>
+              <input
+                type="text"
+                value={displayName}
+                onChange={e => setDisplayName(e.target.value)}
+                maxLength={64}
+                disabled={isComingSoon || submitting}
+                className="mt-1 w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 disabled:cursor-not-allowed disabled:bg-stone-50"
+              />
+            </label>
+
+            {error && (
+              <div
+                role="alert"
+                className={`rounded-xl border px-3 py-2 text-xs ${
+                  capacityGated
+                    ? 'border-amber-200 bg-amber-50 text-amber-800'
+                    : 'border-coral-200 bg-coral-50 text-coral-700'
+                }`}>
+                {error}
+              </div>
+            )}
+
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-xl px-3 py-2 text-sm font-medium text-stone-600 hover:bg-stone-100">
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || isComingSoon || !meetUrl.trim()}
+                className="rounded-xl bg-primary-500 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:bg-stone-200 disabled:text-stone-400">
+                {isComingSoon
+                  ? `${selected.label} coming soon`
+                  : submitting
+                    ? 'Starting…'
+                    : `Send to ${selected.label}`}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/src/components/skills/__tests__/MeetingBotsCard.test.tsx
+++ b/app/src/components/skills/__tests__/MeetingBotsCard.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MeetingBotsCard from '../MeetingBotsCard';
+
+const joinMock = vi.fn();
+
+vi.mock('../../../services/meetCallService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/meetCallService')>(
+    '../../../services/meetCallService'
+  );
+  return {
+    ...actual,
+    joinMeetingViaMascotBot: (...args: unknown[]) => joinMock(...args),
+  };
+});
+
+describe('MeetingBotsCard', () => {
+  beforeEach(() => joinMock.mockReset());
+  afterEach(() => cleanup());
+
+  it('renders the banner and hides the modal by default', () => {
+    render(<MeetingBotsCard />);
+    expect(screen.getByTestId('meeting-bots-banner')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal when the banner is clicked', () => {
+    render(<MeetingBotsCard />);
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes the modal on Cancel', () => {
+    render(<MeetingBotsCard />);
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes the modal on Escape', () => {
+    render(<MeetingBotsCard />);
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('submits to joinMeetingViaMascotBot and fires a success toast', async () => {
+    joinMock.mockResolvedValueOnce({ success: true });
+    const onToast = vi.fn();
+    render(<MeetingBotsCard onToast={onToast} />);
+
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    fireEvent.change(screen.getByLabelText(/meeting link/i), {
+      target: { value: 'https://meet.google.com/abc-defg-hij' },
+    });
+    const form = screen.getByRole('dialog').querySelector('form')!;
+    fireEvent.submit(form);
+
+    await vi.waitFor(() => {
+      expect(joinMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platform: 'gmeet',
+          meetUrl: 'https://meet.google.com/abc-defg-hij',
+        })
+      );
+    });
+    await vi.waitFor(() => {
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', title: expect.stringMatching(/joining/i) })
+      );
+    });
+    // Modal closes on success
+    await vi.waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('surfaces a capacity-gated error inline + as an amber toast', async () => {
+    joinMock.mockRejectedValueOnce({
+      isCapacityGated: true,
+      message: 'busy',
+    });
+    const onToast = vi.fn();
+    render(<MeetingBotsCard onToast={onToast} />);
+
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    fireEvent.change(screen.getByLabelText(/meeting link/i), {
+      target: { value: 'https://meet.google.com/x' },
+    });
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form')!);
+
+    await vi.waitFor(() => {
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', title: expect.stringMatching(/busy/i) })
+      );
+    });
+    // Modal stays open so the user can retry; inline alert visible.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('surfaces a non-capacity error', async () => {
+    joinMock.mockRejectedValueOnce({ isCapacityGated: false, message: 'Bad URL' });
+    const onToast = vi.fn();
+    render(<MeetingBotsCard onToast={onToast} />);
+
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    fireEvent.change(screen.getByLabelText(/meeting link/i), {
+      target: { value: 'https://meet.google.com/x' },
+    });
+    fireEvent.submit(screen.getByRole('dialog').querySelector('form')!);
+
+    await vi.waitFor(() => {
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', title: expect.stringMatching(/not start/i) })
+      );
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent('Bad URL');
+  });
+
+  it('disables the submit when the active platform is coming-soon', () => {
+    render(<MeetingBotsCard />);
+    fireEvent.click(screen.getByTestId('meeting-bots-banner'));
+    // Pick Zoom (coming soon)
+    fireEvent.click(screen.getByRole('button', { name: /Zoom/ }));
+    const submit = screen.getByRole('button', { name: /coming soon/i });
+    expect(submit).toBeDisabled();
+  });
+});

--- a/app/src/features/human/Mascot/backend/BackendMascot.test.tsx
+++ b/app/src/features/human/Mascot/backend/BackendMascot.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { BackendMascot } from './BackendMascot';
+import type { MascotDetail } from './types';
+
+const detail: MascotDetail = {
+  id: 'test',
+  name: 'Test',
+  version: '0.0.0',
+  description: '',
+  viewBox: '0 0 100 100',
+  defaultState: 'idle',
+  variables: [],
+  visemeSlot: '#m-viseme',
+  hidesOnViseme: ['m-smile'],
+  states: [
+    {
+      id: 'idle',
+      label: 'Idle',
+      description: '',
+      svg: `<svg viewBox="0 0 100 100"><g id="m-bob"></g><g id="m-smile" opacity="1"></g><g id="m-viseme" opacity="0"></g></svg>`,
+      tween: [{ id: 'm-bob', kind: 'translateY', freq: 1, amp: 10 }],
+    },
+  ],
+  visemes: [
+    { label: 'sil', description: '', svg: '' },
+    { label: 'aa', description: '', svg: '<path d="MOUTH-AA"/>' },
+  ],
+};
+
+describe('BackendMascot', () => {
+  afterEach(() => cleanup());
+
+  it('renders the chosen state svg', () => {
+    const { container } = render(<BackendMascot mascot={detail} />);
+    expect(container.querySelector('#m-bob')).toBeTruthy();
+  });
+
+  it('shows active viseme overlay and hides resting mouth', () => {
+    const { container } = render(<BackendMascot mascot={detail} viseme="aa" paused />);
+    const slot = container.querySelector('#m-viseme');
+    expect(slot?.getAttribute('opacity')).toBe('1');
+    expect(slot?.innerHTML).toContain('MOUTH-AA');
+    expect(container.querySelector('#m-smile')?.getAttribute('opacity')).toBe('0');
+  });
+
+  it('clears overlay and restores resting mouth when viseme is sil', () => {
+    const { container } = render(<BackendMascot mascot={detail} viseme="sil" paused />);
+    const slot = container.querySelector('#m-viseme');
+    expect(slot?.getAttribute('opacity')).toBe('0');
+    expect(container.querySelector('#m-smile')?.getAttribute('opacity')).toBe('1');
+  });
+});

--- a/app/src/features/human/Mascot/backend/BackendMascot.tsx
+++ b/app/src/features/human/Mascot/backend/BackendMascot.tsx
@@ -30,7 +30,8 @@ export interface BackendMascotProps {
   paused?: boolean;
 }
 
-function pickState(mascot: MascotDetail, stateId?: string): MascotState {
+function pickState(mascot: MascotDetail, stateId?: string): MascotState | null {
+  if (mascot.states.length === 0) return null;
   const id = stateId ?? mascot.defaultState;
   return mascot.states.find(s => s.id === id) ?? mascot.states[0];
 }
@@ -53,6 +54,7 @@ export function BackendMascot({
   // viseme changes are handled in a separate effect that doesn't tear
   // down the SVG.
   const initialMarkup = useMemo(() => {
+    if (!state) return '';
     const active = viseme && viseme !== 'sil' ? viseme : null;
     return injectViseme(state.svg, mascot, active);
     // We intentionally only re-inject on state change here; viseme effect
@@ -91,11 +93,14 @@ export function BackendMascot({
       if (!target) continue;
       target.setAttribute('opacity', visible ? '0' : '1');
     }
-  }, [mascot, viseme]);
+    // `state` is included so the effect re-runs when the SVG remounts
+    // with a different state's structure (slot + hidesOnViseme nodes are
+    // queried by id directly on the live DOM, so they're per-state).
+  }, [mascot, state, viseme]);
 
   // rAF tween loop. Mutates `transform` attrs in place — no React re-render.
   useEffect(() => {
-    if (paused) return;
+    if (paused || !state) return;
     const root = containerRef.current?.querySelector('svg');
     if (!root) return;
     const tweens = state.tween ?? [];
@@ -127,6 +132,8 @@ export function BackendMascot({
       rafRef.current = null;
     };
   }, [state, paused]);
+
+  if (!state) return null;
 
   return (
     <div

--- a/app/src/features/human/Mascot/backend/BackendMascot.tsx
+++ b/app/src/features/human/Mascot/backend/BackendMascot.tsx
@@ -11,7 +11,6 @@
 // This is the browser-side counterpart of the backend's ffmpeg renderer:
 // same render-core math, same per-state SVG, same viseme map — so the
 // in-app mascot animates in lockstep with the WebRTC video.
-
 import { useEffect, useMemo, useRef } from 'react';
 
 import { injectViseme, tweenTransform } from './renderCore';
@@ -45,7 +44,6 @@ export function BackendMascot({
   paused = false,
 }: BackendMascotProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const startRef = useRef<number>(performance.now());
   const rafRef = useRef<number | null>(null);
 
   const state = useMemo(() => pickState(mascot, stateId), [mascot, stateId]);
@@ -113,20 +111,19 @@ export function BackendMascot({
 
     if (targets.length === 0) return;
 
-    const start = performance.now();
-    startRef.current = start;
+    const start = window.performance.now();
 
     const tick = (now: number) => {
       const t = (now - start) / 1000;
       for (const { tw, node } of targets) {
         node.setAttribute('transform', tweenTransform(t, tw));
       }
-      rafRef.current = requestAnimationFrame(tick);
+      rafRef.current = window.requestAnimationFrame(tick);
     };
-    rafRef.current = requestAnimationFrame(tick);
+    rafRef.current = window.requestAnimationFrame(tick);
 
     return () => {
-      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      if (rafRef.current != null) window.cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
     };
   }, [state, paused]);
@@ -135,8 +132,8 @@ export function BackendMascot({
     <div
       ref={containerRef}
       style={{ width: size, height: size, display: 'inline-block' }}
-      // eslint-disable-next-line react/no-danger -- backend-controlled SVG,
-      // same source the WebRTC ffmpeg pipeline rasterizes from.
+      // Backend-controlled SVG, same source the WebRTC ffmpeg pipeline
+      // rasterizes from. Treated as trusted.
       dangerouslySetInnerHTML={{ __html: initialMarkup }}
     />
   );

--- a/app/src/features/human/Mascot/backend/BackendMascot.tsx
+++ b/app/src/features/human/Mascot/backend/BackendMascot.tsx
@@ -1,0 +1,143 @@
+// Animated renderer for a backend-driven mascot manifest.
+//
+// Mount strategy:
+//  - Inject the chosen state's `<svg>...</svg>` once via dangerouslySetInnerHTML
+//    inside a wrapper <div>.
+//  - In a rAF loop, find each tween's target element by id and set its
+//    `transform` attribute directly. No SVG re-parse per frame.
+//  - When `viseme` changes, run `injectViseme` on the live slot element
+//    so the mouth overlay swaps without a full remount.
+//
+// This is the browser-side counterpart of the backend's ffmpeg renderer:
+// same render-core math, same per-state SVG, same viseme map — so the
+// in-app mascot animates in lockstep with the WebRTC video.
+
+import { useEffect, useMemo, useRef } from 'react';
+
+import { injectViseme, tweenTransform } from './renderCore';
+import type { MascotDetail, MascotState } from './types';
+
+export interface BackendMascotProps {
+  mascot: MascotDetail;
+  /** Active state id. Falls back to `mascot.defaultState` when unknown. */
+  stateId?: string;
+  /** Active viseme label, or `null` for resting mouth. */
+  viseme?: string | null;
+  /** CSS variable overrides for the mascot's declared variables. */
+  variables?: Record<string, string>;
+  /** Override SVG width/height; defaults to filling the parent. */
+  size?: number | string;
+  /** Pause the rAF loop — used when the mascot is offscreen or in a hidden tab. */
+  paused?: boolean;
+}
+
+function pickState(mascot: MascotDetail, stateId?: string): MascotState {
+  const id = stateId ?? mascot.defaultState;
+  return mascot.states.find(s => s.id === id) ?? mascot.states[0];
+}
+
+export function BackendMascot({
+  mascot,
+  stateId,
+  viseme = null,
+  variables,
+  size = '100%',
+  paused = false,
+}: BackendMascotProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const startRef = useRef<number>(performance.now());
+  const rafRef = useRef<number | null>(null);
+
+  const state = useMemo(() => pickState(mascot, stateId), [mascot, stateId]);
+
+  // Initial SVG mount — re-runs when the state SVG changes. Viseme is
+  // injected once here so the first painted frame is correct; subsequent
+  // viseme changes are handled in a separate effect that doesn't tear
+  // down the SVG.
+  const initialMarkup = useMemo(() => {
+    const active = viseme && viseme !== 'sil' ? viseme : null;
+    return injectViseme(state.svg, mascot, active);
+    // We intentionally only re-inject on state change here; viseme effect
+    // below handles in-place swaps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mascot, state]);
+
+  // Apply CSS variables to the wrapper so the mascot's color tokens
+  // (--body-fill, --eye-color, …) cascade into the inline SVG without
+  // requiring per-mascot stylesheets.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !variables) return;
+    for (const [k, v] of Object.entries(variables)) {
+      el.style.setProperty(k, v);
+    }
+  }, [variables]);
+
+  // Live viseme swaps without remounting the SVG.
+  useEffect(() => {
+    const root = containerRef.current?.querySelector('svg');
+    if (!root || !mascot.visemeSlot) return;
+    const slotId = mascot.visemeSlot.replace(/^#/, '');
+    const slot = root.querySelector<SVGGElement>(`#${CSS.escape(slotId)}`);
+    if (!slot) return;
+    const active = viseme && viseme !== 'sil' ? viseme : null;
+    const entry = active ? mascot.visemes.find(v => v.label === active) : null;
+    const inner = entry?.svg ?? '';
+    const visible = inner.length > 0;
+    slot.innerHTML = inner;
+    slot.setAttribute('opacity', visible ? '1' : '0');
+    // Hide resting-mouth elements while a viseme is active so the
+    // overlay reads cleanly. Restore when the viseme clears.
+    for (const id of mascot.hidesOnViseme ?? []) {
+      const target = root.querySelector<SVGElement>(`#${CSS.escape(id)}`);
+      if (!target) continue;
+      target.setAttribute('opacity', visible ? '0' : '1');
+    }
+  }, [mascot, viseme]);
+
+  // rAF tween loop. Mutates `transform` attrs in place — no React re-render.
+  useEffect(() => {
+    if (paused) return;
+    const root = containerRef.current?.querySelector('svg');
+    if (!root) return;
+    const tweens = state.tween ?? [];
+    if (tweens.length === 0) return;
+
+    // Resolve target elements once; rAF tick just rewrites the attr.
+    const targets = tweens
+      .map(tw => {
+        const node = root.querySelector<SVGElement>(`#${CSS.escape(tw.id)}`);
+        return node ? { tw, node } : null;
+      })
+      .filter((x): x is { tw: (typeof tweens)[number]; node: SVGElement } => x != null);
+
+    if (targets.length === 0) return;
+
+    const start = performance.now();
+    startRef.current = start;
+
+    const tick = (now: number) => {
+      const t = (now - start) / 1000;
+      for (const { tw, node } of targets) {
+        node.setAttribute('transform', tweenTransform(t, tw));
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [state, paused]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: size, height: size, display: 'inline-block' }}
+      // eslint-disable-next-line react/no-danger -- backend-controlled SVG,
+      // same source the WebRTC ffmpeg pipeline rasterizes from.
+      dangerouslySetInnerHTML={{ __html: initialMarkup }}
+    />
+  );
+}

--- a/app/src/features/human/Mascot/backend/renderCore.test.ts
+++ b/app/src/features/human/Mascot/backend/renderCore.test.ts
@@ -1,7 +1,6 @@
 // Behavior parity with backend `src/services/mascots/__tests__/render-core.test.ts`.
 // If this test diverges from the upstream JS file, the WebRTC stream and
 // the in-app render will fall out of lockstep.
-
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/app/src/features/human/Mascot/backend/renderCore.test.ts
+++ b/app/src/features/human/Mascot/backend/renderCore.test.ts
@@ -1,0 +1,187 @@
+// Behavior parity with backend `src/services/mascots/__tests__/render-core.test.ts`.
+// If this test diverges from the upstream JS file, the WebRTC stream and
+// the in-app render will fall out of lockstep.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  composeFrameSvg,
+  hideRestingMouth,
+  injectViseme,
+  setTransformOnId,
+  tweenTransform,
+} from './renderCore';
+import type { MascotDetail, MascotState, MascotTween } from './types';
+
+const baseSvg = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000">
+  <g id="m-bob"><path d="M0 0"/></g>
+  <g id="m-left-arm"><path d="M1 1"/></g>
+  <g id="m-eye-blink"><path d="M2 2"/></g>
+  <g id="m-smile" opacity="1.000"><path d="M3 3"/></g>
+  <path id="m-hmm" d="M4 4" stroke="#000" fill="none" opacity="0.5"/>
+  <g id="m-viseme" opacity="0"></g>
+</svg>`.trim();
+
+const visemes = [
+  { label: 'sil', description: '', svg: '' },
+  { label: 'aa', description: '', svg: '<path d="MOUTH-AA"/>' },
+];
+
+const mascot: Pick<MascotDetail, 'visemeSlot' | 'visemes' | 'hidesOnViseme'> = {
+  visemeSlot: '#m-viseme',
+  visemes,
+  hidesOnViseme: ['m-smile', 'm-hmm'],
+};
+
+describe('renderCore', () => {
+  describe('tweenTransform', () => {
+    it('translateY: amplitude * sin(2π·freq·(t+phase))', () => {
+      expect(tweenTransform(0, { id: 'x', kind: 'translateY', amp: 14, freq: 1 })).toBe(
+        'translate(0 0.00)'
+      );
+      expect(tweenTransform(0.25, { id: 'x', kind: 'translateY', amp: 14, freq: 1 })).toBe(
+        'translate(0 14.00)'
+      );
+    });
+
+    it('rotate: includes pivot in the matrix call', () => {
+      expect(
+        tweenTransform(0.25, { id: 'x', kind: 'rotate', amp: 30, freq: 1, pivot: [100, 200] })
+      ).toBe('rotate(30.00 100 200)');
+    });
+
+    it('blink: closed during the duration window, open otherwise', () => {
+      const tw: MascotTween = { id: 'x', kind: 'blink', period: 2, duration: 0.2, pivot: [10, 20] };
+      expect(tweenTransform(0, tw)).toContain('scale(1 1.000)');
+      expect(tweenTransform(1, tw)).toContain('scale(1 0.120)');
+    });
+
+    it('blink respects custom closed value', () => {
+      const tw: MascotTween = {
+        id: 'x',
+        kind: 'blink',
+        period: 2,
+        duration: 0.2,
+        pivot: [0, 0],
+        closed: 0.5,
+      };
+      expect(tweenTransform(1, tw)).toContain('scale(1 0.500)');
+    });
+
+    it('uses sane defaults when amp/freq/pivot are omitted', () => {
+      expect(tweenTransform(1, { id: 'x', kind: 'translateY' })).toBe('translate(0 0.00)');
+      expect(tweenTransform(0, { id: 'x', kind: 'rotate' })).toBe('rotate(0.00 0 0)');
+    });
+  });
+
+  describe('injectViseme', () => {
+    it('rewrites slot opacity to 1 and injects markup for a known label', () => {
+      const out = injectViseme(baseSvg, mascot, 'aa');
+      expect(out).toContain('<g id="m-viseme" opacity="1"><path d="MOUTH-AA"/></g>');
+    });
+
+    it('leaves slot opacity=0 with empty inner for null label', () => {
+      const out = injectViseme(baseSvg, mascot, null);
+      expect(out).toContain('<g id="m-viseme" opacity="0"></g>');
+    });
+
+    it('treats "sil" as silence (slot stays hidden)', () => {
+      const out = injectViseme(baseSvg, mascot, 'sil');
+      expect(out).toContain('<g id="m-viseme" opacity="0"></g>');
+    });
+
+    it('falls through to no-op for an unknown label', () => {
+      const out = injectViseme(baseSvg, mascot, 'unknown');
+      expect(out).toContain('<g id="m-viseme" opacity="0"></g>');
+    });
+
+    it('returns input unchanged when visemeSlot is missing', () => {
+      const out = injectViseme(baseSvg, { visemes } as never, 'aa');
+      expect(out).toBe(baseSvg);
+    });
+
+    it('returns input unchanged when slot id is not in the svg', () => {
+      const out = injectViseme('<svg></svg>', mascot, 'aa');
+      expect(out).toBe('<svg></svg>');
+    });
+  });
+
+  describe('setTransformOnId', () => {
+    it('adds a fresh transform attribute', () => {
+      const out = setTransformOnId('<g id="x"></g>', 'x', 'rotate(45)');
+      expect(out).toBe('<g id="x" transform="rotate(45)"></g>');
+    });
+
+    it('replaces an existing transform', () => {
+      const out = setTransformOnId(
+        '<g id="x" transform="translate(0 0)" opacity="1"></g>',
+        'x',
+        'translate(0 5)'
+      );
+      expect(out).toContain('transform="translate(0 5)"');
+      expect(out).not.toContain('translate(0 0)');
+      expect(out).toContain('opacity="1"');
+    });
+
+    it('preserves self-closing slash for void-style elements', () => {
+      const out = setTransformOnId('<path id="x" d="M0 0" fill="none"/>', 'x', 'rotate(10)');
+      expect(out).toMatch(/transform="rotate\(10\)"\s*\/>/);
+    });
+
+    it('is a no-op when the id is not present', () => {
+      expect(setTransformOnId('<g id="other"></g>', 'x', 'rotate(45)')).toBe('<g id="other"></g>');
+    });
+  });
+
+  describe('hideRestingMouth', () => {
+    it('sets opacity=0 on every id in hidesOnViseme', () => {
+      const out = hideRestingMouth(baseSvg, mascot);
+      expect(out).toContain('<g id="m-smile" opacity="0">');
+      expect(out).toMatch(/<path id="m-hmm"[^>]*opacity="0"\s*\/>/);
+    });
+
+    it('is a no-op when hidesOnViseme is empty', () => {
+      expect(hideRestingMouth(baseSvg, { hidesOnViseme: [] })).toBe(baseSvg);
+    });
+  });
+
+  describe('composeFrameSvg', () => {
+    const state: MascotState = {
+      id: 'idle',
+      label: 'Idle',
+      description: '',
+      svg: baseSvg,
+      tween: [
+        { id: 'm-bob', kind: 'translateY', freq: 1, amp: 10 },
+        { id: 'm-left-arm', kind: 'rotate', freq: 0, amp: 7, pivot: [50, 60] },
+      ],
+    };
+
+    it('applies viseme injection + smile-hiding + tween transforms', () => {
+      const out = composeFrameSvg(state, mascot, 0.25, 'aa');
+      expect(out).toContain('<path d="MOUTH-AA"/>');
+      expect(out).toContain('<g id="m-smile" opacity="0">');
+      expect(out).toMatch(/<path id="m-hmm"[^>]*opacity="0"/);
+      expect(out).toContain('<g id="m-bob" transform="translate(0 10.00)">');
+      expect(out).toContain('rotate(0.00 50 60)');
+    });
+
+    it('does not hide resting mouth when no viseme is active', () => {
+      const out = composeFrameSvg(state, mascot, 0, null);
+      expect(out).toContain('<g id="m-smile" opacity="1.000">');
+    });
+
+    it('treats "sil" as no viseme (resting mouth visible)', () => {
+      const out = composeFrameSvg(state, mascot, 0, 'sil');
+      expect(out).toContain('<g id="m-smile" opacity="1.000">');
+    });
+
+    it('handles state without tween gracefully', () => {
+      const noTween: MascotState = { ...state, tween: undefined };
+      const out = composeFrameSvg(noTween, mascot, 0, null);
+      expect(out).toContain('<g id="m-bob">');
+      expect(out).not.toContain('transform=');
+    });
+  });
+});

--- a/app/src/features/human/Mascot/backend/renderCore.ts
+++ b/app/src/features/human/Mascot/backend/renderCore.ts
@@ -1,0 +1,134 @@
+// TS port of backend `src/services/mascots/render-core.js`. Single source
+// of truth for tween math, viseme injection, smile-hiding, and transform
+// substitution. Pure functions — no DOM. The animated `BackendMascot`
+// renderer applies tween transforms directly to live DOM nodes via
+// rAF, but reuses these helpers for viseme injection and tests.
+//
+// MUST stay behavior-equivalent to the backend's JS file — covered by
+// `renderCore.test.ts`, which mirrors the backend's `render-core.test.ts`.
+
+import type { MascotDetail, MascotState, MascotTween } from './types';
+
+type VisemeCarrier = Pick<MascotDetail, 'visemeSlot' | 'visemes'>;
+type HiderCarrier = Pick<MascotDetail, 'hidesOnViseme'>;
+
+/**
+ * Compute the SVG `transform` value for a tween entry at time t (seconds).
+ */
+export function tweenTransform(t: number, tw: MascotTween): string {
+  const phase = tw.phase ?? 0;
+  if (tw.kind === 'translateY') {
+    const amp = tw.amp ?? 0;
+    const freq = tw.freq ?? 0;
+    const y = amp * Math.sin(2 * Math.PI * freq * (t + phase));
+    return `translate(0 ${y.toFixed(2)})`;
+  }
+  if (tw.kind === 'rotate') {
+    const ramp = tw.amp ?? 0;
+    const rfreq = tw.freq ?? 0;
+    const deg = ramp * Math.sin(2 * Math.PI * rfreq * (t + phase));
+    const rp = tw.pivot ?? [0, 0];
+    return `rotate(${deg.toFixed(2)} ${rp[0]} ${rp[1]})`;
+  }
+  if (tw.kind === 'blink') {
+    const period = tw.period ?? 2.6;
+    const duration = tw.duration ?? 0.2;
+    const closed = tw.closed != null ? tw.closed : 0.12;
+    // Stagger so the blink doesn't fire on t=0.
+    const inBlink = (t + period / 2) % period < duration;
+    const sy = inBlink ? closed : 1;
+    const bp = tw.pivot ?? [0, 0];
+    return `translate(${bp[0]} ${bp[1]}) scale(1 ${sy.toFixed(3)}) translate(${-bp[0]} ${-bp[1]})`;
+  }
+  return '';
+}
+
+/** Strip `name="..."` from an opening tag string and re-append it with `value`. */
+function setOpeningTagAttr(tag: string, name: string, value: string): string {
+  const stripped = tag.replace(new RegExp(`\\s*\\b${name}="[^"]*"`, 'g'), '');
+  return stripped.replace(/(\/?>)$/, ` ${name}="${value}"$1`);
+}
+
+/**
+ * Replace the inner content of <g id="visemeSlotId">…</g> with the viseme's
+ * SVG fragment AND force the slot's opacity to 1 so the markup is visible.
+ * When label is null/empty, restores opacity="0" and clears the slot so
+ * the resting mouth (smile/hmm) shows through.
+ */
+export function injectViseme(
+  svg: string,
+  mascot: VisemeCarrier,
+  label: string | null
+): string {
+  if (!mascot.visemeSlot) return svg;
+  const slotId = String(mascot.visemeSlot).replace(/^#/, '');
+  const openRe = new RegExp(`<g\\s[^>]*\\bid="${slotId}"[^>]*>`);
+  const openMatch = svg.match(openRe);
+  if (!openMatch) return svg;
+  let inner = '';
+  let visible = false;
+  // 'sil' is the silence sentinel — same as null. Anything else looked
+  // up against the viseme map; only non-empty markup counts as visible
+  // so the resting mouth still shows when a label has no svg.
+  if (label && label !== 'sil') {
+    const visemes = mascot.visemes ?? [];
+    for (const v of visemes) {
+      if (v.label === label) {
+        inner = v.svg || '';
+        visible = inner.length > 0;
+        break;
+      }
+    }
+  }
+  const newOpening = setOpeningTagAttr(openMatch[0], 'opacity', visible ? '1' : '0');
+  const blockRe = new RegExp(`<g\\s[^>]*\\bid="${slotId}"[^>]*>[\\s\\S]*?</g>`);
+  return svg.replace(blockRe, newOpening + inner + '</g>');
+}
+
+/** Generic single-attribute string set on the element with the given id. */
+export function setAttrOnId(svg: string, id: string, name: string, value: string): string {
+  // Lazy `[^>]*?` + greedy `\/?>` ordering avoids swallowing the `/` of
+  // self-closing tags (`<path .../>`) and emitting malformed
+  // `attr"/ transform="...">` output.
+  const re = new RegExp(`(<\\w+\\b[^>]*\\bid="${id}")([^>]*?)(\\s*/?>)`);
+  return svg.replace(re, (_full, head: string, rest: string, close: string) => {
+    const stripped = rest.replace(new RegExp(`\\s*\\b${name}="[^"]*"`, 'g'), '');
+    return `${head}${stripped} ${name}="${value}"${close}`;
+  });
+}
+
+/** Rewrite the opening tag of element `id` to carry a fresh `transform="value"`. */
+export function setTransformOnId(svg: string, id: string, value: string): string {
+  return setAttrOnId(svg, id, 'transform', value);
+}
+
+/** Hide resting-mouth ids (smile, hmm, …) while a viseme overlay is active. */
+export function hideRestingMouth(svg: string, mascot: HiderCarrier): string {
+  const ids = mascot.hidesOnViseme ?? [];
+  let out = svg;
+  for (const id of ids) {
+    out = setAttrOnId(out, id, 'opacity', '0');
+  }
+  return out;
+}
+
+/**
+ * Compose a full frame SVG for the given state at time t with optional
+ * viseme overlay. Pure string-pipeline parity with the backend renderer —
+ * used by tests and for the once-on-mount static SVG (no rAF) path.
+ */
+export function composeFrameSvg(
+  state: MascotState,
+  mascot: VisemeCarrier & HiderCarrier,
+  t: number,
+  viseme: string | null
+): string {
+  const active = viseme && viseme !== 'sil' ? viseme : null;
+  let svg = injectViseme(state.svg, mascot, active);
+  if (active) svg = hideRestingMouth(svg, mascot);
+  const tweens = state.tween ?? [];
+  for (const tw of tweens) {
+    svg = setTransformOnId(svg, tw.id, tweenTransform(t, tw));
+  }
+  return svg;
+}

--- a/app/src/features/human/Mascot/backend/renderCore.ts
+++ b/app/src/features/human/Mascot/backend/renderCore.ts
@@ -12,6 +12,15 @@ type VisemeCarrier = Pick<MascotDetail, 'visemeSlot' | 'visemes'>;
 type HiderCarrier = Pick<MascotDetail, 'hidesOnViseme'>;
 
 /**
+ * Escape regex metacharacters in interpolated id / attribute names so a
+ * malformed backend manifest (or a future schema that allows broader id
+ * characters) can't inject pattern fragments or throw at RegExp construction.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Compute the SVG `transform` value for a tween entry at time t (seconds).
  */
 export function tweenTransform(t: number, tw: MascotTween): string {
@@ -44,7 +53,8 @@ export function tweenTransform(t: number, tw: MascotTween): string {
 
 /** Strip `name="..."` from an opening tag string and re-append it with `value`. */
 function setOpeningTagAttr(tag: string, name: string, value: string): string {
-  const stripped = tag.replace(new RegExp(`\\s*\\b${name}="[^"]*"`, 'g'), '');
+  const nameEsc = escapeRegExp(name);
+  const stripped = tag.replace(new RegExp(`\\s*\\b${nameEsc}="[^"]*"`, 'g'), '');
   return stripped.replace(/(\/?>)$/, ` ${name}="${value}"$1`);
 }
 
@@ -57,7 +67,8 @@ function setOpeningTagAttr(tag: string, name: string, value: string): string {
 export function injectViseme(svg: string, mascot: VisemeCarrier, label: string | null): string {
   if (!mascot.visemeSlot) return svg;
   const slotId = String(mascot.visemeSlot).replace(/^#/, '');
-  const openRe = new RegExp(`<g\\s[^>]*\\bid="${slotId}"[^>]*>`);
+  const slotIdEsc = escapeRegExp(slotId);
+  const openRe = new RegExp(`<g\\s[^>]*\\bid="${slotIdEsc}"[^>]*>`);
   const openMatch = svg.match(openRe);
   if (!openMatch) return svg;
   let inner = '';
@@ -76,7 +87,7 @@ export function injectViseme(svg: string, mascot: VisemeCarrier, label: string |
     }
   }
   const newOpening = setOpeningTagAttr(openMatch[0], 'opacity', visible ? '1' : '0');
-  const blockRe = new RegExp(`<g\\s[^>]*\\bid="${slotId}"[^>]*>[\\s\\S]*?</g>`);
+  const blockRe = new RegExp(`<g\\s[^>]*\\bid="${slotIdEsc}"[^>]*>[\\s\\S]*?</g>`);
   return svg.replace(blockRe, newOpening + inner + '</g>');
 }
 
@@ -85,9 +96,11 @@ export function setAttrOnId(svg: string, id: string, name: string, value: string
   // Lazy `[^>]*?` + greedy `\/?>` ordering avoids swallowing the `/` of
   // self-closing tags (`<path .../>`) and emitting malformed
   // `attr"/ transform="...">` output.
-  const re = new RegExp(`(<\\w+\\b[^>]*\\bid="${id}")([^>]*?)(\\s*/?>)`);
+  const idEsc = escapeRegExp(id);
+  const nameEsc = escapeRegExp(name);
+  const re = new RegExp(`(<\\w+\\b[^>]*\\bid="${idEsc}")([^>]*?)(\\s*/?>)`);
   return svg.replace(re, (_full, head: string, rest: string, close: string) => {
-    const stripped = rest.replace(new RegExp(`\\s*\\b${name}="[^"]*"`, 'g'), '');
+    const stripped = rest.replace(new RegExp(`\\s*\\b${nameEsc}="[^"]*"`, 'g'), '');
     return `${head}${stripped} ${name}="${value}"${close}`;
   });
 }

--- a/app/src/features/human/Mascot/backend/renderCore.ts
+++ b/app/src/features/human/Mascot/backend/renderCore.ts
@@ -6,7 +6,6 @@
 //
 // MUST stay behavior-equivalent to the backend's JS file — covered by
 // `renderCore.test.ts`, which mirrors the backend's `render-core.test.ts`.
-
 import type { MascotDetail, MascotState, MascotTween } from './types';
 
 type VisemeCarrier = Pick<MascotDetail, 'visemeSlot' | 'visemes'>;
@@ -55,11 +54,7 @@ function setOpeningTagAttr(tag: string, name: string, value: string): string {
  * When label is null/empty, restores opacity="0" and clears the slot so
  * the resting mouth (smile/hmm) shows through.
  */
-export function injectViseme(
-  svg: string,
-  mascot: VisemeCarrier,
-  label: string | null
-): string {
+export function injectViseme(svg: string, mascot: VisemeCarrier, label: string | null): string {
   if (!mascot.visemeSlot) return svg;
   const slotId = String(mascot.visemeSlot).replace(/^#/, '');
   const openRe = new RegExp(`<g\\s[^>]*\\bid="${slotId}"[^>]*>`);

--- a/app/src/features/human/Mascot/backend/types.ts
+++ b/app/src/features/human/Mascot/backend/types.ts
@@ -1,0 +1,97 @@
+// Mascot library types — mirror the backend models in
+// `tinyhumansai/backend:src/services/mascots/types.ts` and
+// `src/database/models/mascot.ts`. Kept in TS-only form here because
+// the app talks to the backend over HTTP — there is no shared package.
+
+export type MascotVariableType = 'color' | 'number' | 'string';
+
+export interface MascotVariable {
+  name: string;
+  label: string;
+  type: MascotVariableType;
+  default: string | number;
+  description?: string;
+}
+
+export type MascotTweenKind = 'translateY' | 'rotate' | 'blink';
+
+/**
+ * Declarative per-frame tween entry. Interpreted by the renderer's animation
+ * loop — there is no per-mascot animation code, just data. `kind` selects
+ * the math; the remaining fields parametrize it.
+ *
+ *   translateY  transform="translate(0  amp*sin(2π·freq·t + phase))"
+ *   rotate      transform="rotate(amp*sin(2π·freq·t + phase)  pivotX pivotY)"
+ *   blink       y-axis squish: pulses to `closed` for `duration`s every
+ *               `period`s, otherwise scale 1
+ */
+export interface MascotTween {
+  /** Element id (bare, no '#') to mutate on the mounted SVG. */
+  id: string;
+  kind: MascotTweenKind;
+  /** translateY/rotate: cycles per second. */
+  freq?: number;
+  /** translateY: pixels. rotate: degrees. */
+  amp?: number;
+  /** Phase offset in seconds. */
+  phase?: number;
+  /** rotate/blink: SVG-space pivot point [x, y]. */
+  pivot?: [number, number];
+  /** blink: full cycle in seconds. */
+  period?: number;
+  /** blink: how long the eye stays scrunched, in seconds. */
+  duration?: number;
+  /** blink: scaleY value while closed (default 0.12). */
+  closed?: number;
+}
+
+export interface MascotState {
+  id: string;
+  label: string;
+  description: string;
+  /** Full <svg>...</svg> for this state, served by the backend per-id endpoint. */
+  svg: string;
+  /** Optional rAF-driven tween config. Empty/absent => static pose. */
+  tween?: MascotTween[];
+}
+
+export interface MascotViseme {
+  label: string;
+  description: string;
+  svg: string;
+}
+
+export interface MascotSummary {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  /** State metadata only — no SVG bytes or tween, to keep list payload light. */
+  states: Pick<MascotState, 'id' | 'label' | 'description'>[];
+  hasVisemes: boolean;
+}
+
+export interface MascotDetail {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  viewBox: string;
+  defaultState: string;
+  variables: MascotVariable[];
+  states: MascotState[];
+  visemes: MascotViseme[];
+  visemeSlot?: string;
+  hidesOnViseme?: string[];
+}
+
+/** Wire shapes for /mascots and /mascots/:id. */
+export interface ListMascotsResponse {
+  success: true;
+  data: { mascots: MascotSummary[] };
+}
+
+export interface GetMascotResponse {
+  success: true;
+  data: { mascot: MascotDetail };
+}

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -10,9 +10,9 @@ import {
 } from '../components/composio/toolkitMeta';
 import { ToastContainer } from '../components/intelligence/Toast';
 import AutocompleteSetupModal from '../components/skills/AutocompleteSetupModal';
-import MeetingBotsCard from '../components/skills/MeetingBotsCard';
 import CreateSkillModal from '../components/skills/CreateSkillModal';
 import InstallSkillDialog from '../components/skills/InstallSkillDialog';
+import MeetingBotsCard from '../components/skills/MeetingBotsCard';
 import ScreenIntelligenceSetupModal from '../components/skills/ScreenIntelligenceSetupModal';
 import UnifiedSkillCard from '../components/skills/SkillCard';
 import { SKILL_CATEGORY_ORDER, type SkillCategory } from '../components/skills/skillCategories';

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -10,6 +10,7 @@ import {
 } from '../components/composio/toolkitMeta';
 import { ToastContainer } from '../components/intelligence/Toast';
 import AutocompleteSetupModal from '../components/skills/AutocompleteSetupModal';
+import MeetingBotsCard from '../components/skills/MeetingBotsCard';
 import CreateSkillModal from '../components/skills/CreateSkillModal';
 import InstallSkillDialog from '../components/skills/InstallSkillDialog';
 import ScreenIntelligenceSetupModal from '../components/skills/ScreenIntelligenceSetupModal';
@@ -823,6 +824,8 @@ export default function Skills() {
                     </div>
                   </div>
                 )}
+
+                <MeetingBotsCard onToast={addToast} />
 
                 <div className="rounded-2xl border border-stone-200 bg-white p-3 shadow-soft animate-fade-up">
                   <div className="px-1 pb-3 pt-1">

--- a/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
+++ b/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
@@ -56,7 +56,10 @@ describe('Skills page — Composio catalog fallback', () => {
     expect(screen.getByText('Reddit')).toBeInTheDocument();
     expect(screen.getByText('Slack')).toBeInTheDocument();
     expect(screen.getByText('Supabase')).toBeInTheDocument();
-    expect(screen.getByText('Zoom')).toBeInTheDocument();
+    // The Skills page also renders a "Zoom" entry in the Meeting bots card
+    // (mascot-meets integration). Use *AllBy* and assert at least one match
+    // — the toolkit grid still contains the Composio Zoom tile.
+    expect(screen.getAllByText('Zoom').length).toBeGreaterThan(0);
     expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument();
   });
 

--- a/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
+++ b/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
@@ -56,10 +56,16 @@ describe('Skills page — Composio catalog fallback', () => {
     expect(screen.getByText('Reddit')).toBeInTheDocument();
     expect(screen.getByText('Slack')).toBeInTheDocument();
     expect(screen.getByText('Supabase')).toBeInTheDocument();
-    // The Skills page also renders a "Zoom" entry in the Meeting bots card
-    // (mascot-meets integration). Use *AllBy* and assert at least one match
-    // — the toolkit grid still contains the Composio Zoom tile.
-    expect(screen.getAllByText('Zoom').length).toBeGreaterThan(0);
+    // Scope to the Integrations section so the assertion still catches a
+    // missing Composio Zoom tile even though the Meeting bots card also
+    // renders a "Zoom" entry on the same page.
+    const integrationsSection = screen
+      .getByRole('heading', { name: 'Integrations' })
+      .closest('.rounded-2xl');
+    expect(integrationsSection).not.toBeNull();
+    expect(
+      within(integrationsSection as HTMLElement).getByText('Zoom')
+    ).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument();
   });
 

--- a/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
+++ b/app/src/pages/__tests__/Skills.composio-catalog.test.tsx
@@ -63,9 +63,7 @@ describe('Skills page — Composio catalog fallback', () => {
       .getByRole('heading', { name: 'Integrations' })
       .closest('.rounded-2xl');
     expect(integrationsSection).not.toBeNull();
-    expect(
-      within(integrationsSection as HTMLElement).getByText('Zoom')
-    ).toBeInTheDocument();
+    expect(within(integrationsSection as HTMLElement).getByText('Zoom')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument();
   });
 

--- a/app/src/services/__tests__/joinMeetingViaMascotBot.test.ts
+++ b/app/src/services/__tests__/joinMeetingViaMascotBot.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  joinMeetingViaMascotBot,
+  SERVER_OVERLOADED_MESSAGE,
+  type MascotJoinMeetingError,
+} from '../meetCallService';
+
+const postMock = vi.fn();
+
+vi.mock('../apiClient', () => ({
+  apiClient: { post: (...args: unknown[]) => postMock(...args) },
+}));
+
+describe('joinMeetingViaMascotBot', () => {
+  beforeEach(() => postMock.mockReset());
+
+  it('rejects an empty meet URL with isCapacityGated=false', async () => {
+    await expect(
+      joinMeetingViaMascotBot({ platform: 'gmeet', meetUrl: '   ' })
+    ).rejects.toMatchObject({ isCapacityGated: false, message: expect.stringMatching(/link/i) });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs the trimmed payload on the happy path', async () => {
+    postMock.mockResolvedValueOnce({ success: true });
+    const res = await joinMeetingViaMascotBot({
+      platform: 'gmeet',
+      meetUrl: '  https://meet.google.com/abc-defg-hij  ',
+      displayName: '  OpenHuman  ',
+    });
+    expect(res).toEqual({ success: true });
+    expect(postMock).toHaveBeenCalledWith('/mascots/join-meeting', {
+      platform: 'gmeet',
+      meetUrl: 'https://meet.google.com/abc-defg-hij',
+      displayName: 'OpenHuman',
+    });
+  });
+
+  it('drops empty displayName to undefined', async () => {
+    postMock.mockResolvedValueOnce({ success: true });
+    await joinMeetingViaMascotBot({
+      platform: 'gmeet',
+      meetUrl: 'https://meet.google.com/x',
+      displayName: '   ',
+    });
+    expect(postMock).toHaveBeenCalledWith('/mascots/join-meeting', {
+      platform: 'gmeet',
+      meetUrl: 'https://meet.google.com/x',
+      displayName: undefined,
+    });
+  });
+
+  it('flags SERVER_OVERLOADED responses with isCapacityGated=true', async () => {
+    postMock.mockRejectedValueOnce({ success: false, error: SERVER_OVERLOADED_MESSAGE });
+    let caught: MascotJoinMeetingError | undefined;
+    try {
+      await joinMeetingViaMascotBot({
+        platform: 'gmeet',
+        meetUrl: 'https://meet.google.com/abc',
+      });
+    } catch (e) {
+      caught = e as MascotJoinMeetingError;
+    }
+    expect(caught?.isCapacityGated).toBe(true);
+    expect(caught?.message).toBe(SERVER_OVERLOADED_MESSAGE);
+  });
+
+  it('passes through other apiClient errors with isCapacityGated=false', async () => {
+    postMock.mockRejectedValueOnce({ success: false, error: 'Bad Request' });
+    await expect(
+      joinMeetingViaMascotBot({ platform: 'zoom', meetUrl: 'https://zoom.us/j/1' })
+    ).rejects.toMatchObject({ isCapacityGated: false, message: 'Bad Request' });
+  });
+
+  it('wraps non-ApiError throwables', async () => {
+    postMock.mockRejectedValueOnce(new Error('network down'));
+    await expect(
+      joinMeetingViaMascotBot({ platform: 'gmeet', meetUrl: 'https://meet.google.com/x' })
+    ).rejects.toMatchObject({ isCapacityGated: false, message: 'network down' });
+  });
+});

--- a/app/src/services/__tests__/joinMeetingViaMascotBot.test.ts
+++ b/app/src/services/__tests__/joinMeetingViaMascotBot.test.ts
@@ -2,15 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   joinMeetingViaMascotBot,
-  SERVER_OVERLOADED_MESSAGE,
   type MascotJoinMeetingError,
+  SERVER_OVERLOADED_MESSAGE,
 } from '../meetCallService';
 
 const postMock = vi.fn();
 
-vi.mock('../apiClient', () => ({
-  apiClient: { post: (...args: unknown[]) => postMock(...args) },
-}));
+vi.mock('../apiClient', () => ({ apiClient: { post: (...args: unknown[]) => postMock(...args) } }));
 
 describe('joinMeetingViaMascotBot', () => {
   beforeEach(() => postMock.mockReset());
@@ -55,10 +53,7 @@ describe('joinMeetingViaMascotBot', () => {
     postMock.mockRejectedValueOnce({ success: false, error: SERVER_OVERLOADED_MESSAGE });
     let caught: MascotJoinMeetingError | undefined;
     try {
-      await joinMeetingViaMascotBot({
-        platform: 'gmeet',
-        meetUrl: 'https://meet.google.com/abc',
-      });
+      await joinMeetingViaMascotBot({ platform: 'gmeet', meetUrl: 'https://meet.google.com/abc' });
     } catch (e) {
       caught = e as MascotJoinMeetingError;
     }

--- a/app/src/services/__tests__/mascotService.test.ts
+++ b/app/src/services/__tests__/mascotService.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearMascotDetailCache,
+  fetchMascotDetail,
+  fetchMascotList,
+  getCachedMascotDetail,
+} from '../mascotService';
+
+const getMock = vi.fn();
+
+vi.mock('../apiClient', () => ({ apiClient: { get: (...args: unknown[]) => getMock(...args) } }));
+
+const summary = {
+  id: 'yellow',
+  name: 'Yellow',
+  version: '1.0.0',
+  description: '',
+  states: [{ id: 'idle', label: 'Idle', description: '' }],
+  hasVisemes: true,
+};
+
+const detail = {
+  id: 'yellow',
+  name: 'Yellow',
+  version: '1.0.0',
+  description: '',
+  viewBox: '0 0 1 1',
+  defaultState: 'idle',
+  variables: [],
+  states: [{ id: 'idle', label: 'Idle', description: '', svg: '<svg/>' }],
+  visemes: [],
+};
+
+describe('mascotService', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    clearMascotDetailCache();
+  });
+
+  it('fetchMascotList hits /mascots and unwraps the response', async () => {
+    getMock.mockResolvedValueOnce({ success: true, data: { mascots: [summary] } });
+    const list = await fetchMascotList();
+    expect(list).toEqual([summary]);
+    expect(getMock).toHaveBeenCalledWith('/mascots', { requireAuth: false });
+  });
+
+  it('fetchMascotDetail encodes the id and unwraps the manifest', async () => {
+    getMock.mockResolvedValueOnce({ success: true, data: { mascot: detail } });
+    const d = await fetchMascotDetail('yellow bob');
+    expect(d).toEqual(detail);
+    expect(getMock).toHaveBeenCalledWith('/mascots/yellow%20bob', { requireAuth: false });
+  });
+
+  it('rejects an empty id without hitting the network', async () => {
+    await expect(fetchMascotDetail('   ')).rejects.toThrow(/empty/i);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('getCachedMascotDetail memoizes per id', async () => {
+    getMock.mockResolvedValue({ success: true, data: { mascot: detail } });
+    const a = await getCachedMascotDetail('yellow');
+    const b = await getCachedMascotDetail('yellow');
+    expect(a).toBe(b);
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearMascotDetailCache forces a refetch', async () => {
+    getMock.mockResolvedValue({ success: true, data: { mascot: detail } });
+    await getCachedMascotDetail('yellow');
+    clearMascotDetailCache();
+    await getCachedMascotDetail('yellow');
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/services/mascotService.ts
+++ b/app/src/services/mascotService.ts
@@ -1,0 +1,46 @@
+// Client for the backend mascot library — GET /mascots (summaries) and
+// GET /mascots/:id (full manifest with per-state SVGs + visemes).
+//
+// Backend: tinyhumansai/backend PR #770. Both endpoints are public
+// (manifests only, no compute) so we skip auth.
+
+import type {
+  GetMascotResponse,
+  ListMascotsResponse,
+  MascotDetail,
+  MascotSummary,
+} from '../features/human/Mascot/backend/types';
+import { apiClient } from './apiClient';
+
+export async function fetchMascotList(): Promise<MascotSummary[]> {
+  const res = await apiClient.get<ListMascotsResponse>('/mascots', { requireAuth: false });
+  return res.data.mascots;
+}
+
+export async function fetchMascotDetail(id: string): Promise<MascotDetail> {
+  const safe = encodeURIComponent(id.trim());
+  if (!safe) throw new Error('mascot id is empty');
+  const res = await apiClient.get<GetMascotResponse>(`/mascots/${safe}`, { requireAuth: false });
+  return res.data.mascot;
+}
+
+/**
+ * Lightweight in-memory cache for manifest fetches. Manifests carry the
+ * full SVG bytes for every state (~ tens of KB per mascot) — the WebRTC
+ * pipeline keeps them in mongo and the picker UI revisits selections,
+ * so a per-id memoization keeps the picker snappy without hammering the
+ * backend.
+ */
+const detailCache = new Map<string, MascotDetail>();
+
+export async function getCachedMascotDetail(id: string): Promise<MascotDetail> {
+  const existing = detailCache.get(id);
+  if (existing) return existing;
+  const detail = await fetchMascotDetail(id);
+  detailCache.set(id, detail);
+  return detail;
+}
+
+export function clearMascotDetailCache(): void {
+  detailCache.clear();
+}

--- a/app/src/services/mascotService.ts
+++ b/app/src/services/mascotService.ts
@@ -3,7 +3,6 @@
 //
 // Backend: tinyhumansai/backend PR #770. Both endpoints are public
 // (manifests only, no compute) so we skip auth.
-
 import type {
   GetMascotResponse,
   ListMascotsResponse,

--- a/app/src/services/meetCallService.ts
+++ b/app/src/services/meetCallService.ts
@@ -114,7 +114,7 @@ export interface MascotJoinMeetingResult {
  * without leaking the underlying paid-plan rule.
  */
 export const SERVER_OVERLOADED_MESSAGE =
-  'The mascot service is under heavy load right now. Please try again in a few minutes.';
+  'OpenHuman is under heavy load right now. Please try again in a few minutes.';
 
 export interface MascotJoinMeetingError {
   /** User-safe error text. Falls back to a generic message. */

--- a/app/src/services/meetCallService.ts
+++ b/app/src/services/meetCallService.ts
@@ -12,6 +12,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
 import { isTauri } from '../utils/tauriCommands/common';
+import { apiClient } from './apiClient';
 import { callCoreRpc } from './coreRpcClient';
 
 export type MeetJoinCallInput = { meetUrl: string; displayName: string };
@@ -79,4 +80,82 @@ export async function joinMeetCall(input: MeetJoinCallInput): Promise<MeetJoinCa
 export async function closeMeetCall(requestId: string): Promise<boolean> {
   if (!isTauri()) return false;
   return invoke<boolean>('meet_call_close_window', { requestId });
+}
+
+/**
+ * Backend-driven meet bot join (PR tinyhumansai/backend#773).
+ *
+ * Hits `POST /mascots/join-meeting` which:
+ *  - gates free users with a 429 (SERVER_OVERLOADED) — surfaced verbatim
+ *    so callers can show the user-facing capacity message;
+ *  - launches the Camoufox mascot bot for `gmeet`;
+ *  - 400s on `zoom` / `teams` with "not yet supported".
+ *
+ * Distinct from `joinMeetCall` (which opens a CEF webview locally) —
+ * this is a fire-and-forget request that runs the mascot bot in the
+ * backend and streams events over Socket.IO.
+ */
+export type MascotMeetPlatform = 'gmeet' | 'zoom' | 'teams';
+
+export interface MascotJoinMeetingInput {
+  platform: MascotMeetPlatform;
+  meetUrl: string;
+  displayName?: string;
+}
+
+export interface MascotJoinMeetingResult {
+  success: boolean;
+  data?: unknown;
+}
+
+/**
+ * The 429 capacity-gate message the backend emits for free users. Treated
+ * as the canonical user-facing copy so the UI can show a tailored notice
+ * without leaking the underlying paid-plan rule.
+ */
+export const SERVER_OVERLOADED_MESSAGE =
+  'The mascot service is under heavy load right now. Please try again in a few minutes.';
+
+export interface MascotJoinMeetingError {
+  /** User-safe error text. Falls back to a generic message. */
+  message: string;
+  /** True when the backend returned the 429 capacity gate. */
+  isCapacityGated: boolean;
+}
+
+function isApiErrorLike(value: unknown): value is { error?: unknown; message?: unknown } {
+  return !!value && typeof value === 'object' && ('error' in value || 'message' in value);
+}
+
+export async function joinMeetingViaMascotBot(
+  input: MascotJoinMeetingInput
+): Promise<MascotJoinMeetingResult> {
+  const meetUrl = input.meetUrl.trim();
+  if (!meetUrl) {
+    throw { message: 'Please paste a meeting link.', isCapacityGated: false };
+  }
+  try {
+    return await apiClient.post<MascotJoinMeetingResult>('/mascots/join-meeting', {
+      platform: input.platform,
+      meetUrl,
+      displayName: input.displayName?.trim() || undefined,
+    });
+  } catch (err) {
+    // apiClient throws `{ success:false, error, message? }`. The 429 body
+    // is `{ error: SERVER_OVERLOADED_MESSAGE, errorCode: 'SERVER_OVERLOADED' }`
+    // — `errorCode` is dropped by the shared client (see apiClient.ts:96),
+    // so we detect capacity by matching the canonical message.
+    const text = isApiErrorLike(err)
+      ? typeof err.error === 'string'
+        ? err.error
+        : typeof err.message === 'string'
+          ? err.message
+          : 'Failed to start meeting bot.'
+      : err instanceof Error
+        ? err.message
+        : 'Failed to start meeting bot.';
+    const isCapacityGated = text === SERVER_OVERLOADED_MESSAGE;
+    const wrapped: MascotJoinMeetingError = { message: text, isCapacityGated };
+    throw wrapped;
+  }
 }

--- a/app/src/store/__tests__/mascotSlice.test.ts
+++ b/app/src/store/__tests__/mascotSlice.test.ts
@@ -6,8 +6,10 @@ import reducer, {
   MAX_MASCOT_VOICE_ID_LEN,
   selectMascotColor,
   selectMascotVoiceId,
+  selectSelectedMascotId,
   setMascotColor,
   setMascotVoiceId,
+  setSelectedMascotId,
   SUPPORTED_MASCOT_COLORS,
 } from '../mascotSlice';
 import { resetUserScopedState } from '../resetActions';
@@ -139,6 +141,62 @@ describe('mascotSlice', () => {
       const state = reducer(undefined, rehydrate('mascot', { color: 'green' }));
       expect(state.color).toBe('green');
       expect(state.voiceId).toBeNull();
+    });
+  });
+
+  describe('selected backend mascot id', () => {
+    it('defaults to null', () => {
+      const state = reducer(undefined, { type: '@@INIT' });
+      expect(state.selectedMascotId).toBeNull();
+      expect(selectSelectedMascotId({ mascot: state })).toBeNull();
+    });
+
+    it('setSelectedMascotId trims and stores a valid id', () => {
+      const state = reducer(undefined, setSelectedMascotId('  yellow  '));
+      expect(state.selectedMascotId).toBe('yellow');
+    });
+
+    it('null payload clears the override', () => {
+      let state = reducer(undefined, setSelectedMascotId('yellow'));
+      state = reducer(state, setSelectedMascotId(null));
+      expect(state.selectedMascotId).toBeNull();
+    });
+
+    it('empty / whitespace input is treated as a reset', () => {
+      const state = reducer(
+        reducer(undefined, setSelectedMascotId('yellow')),
+        setSelectedMascotId('   ')
+      );
+      expect(state.selectedMascotId).toBeNull();
+    });
+
+    it('over-long input is dropped to null', () => {
+      const tooLong = 'x'.repeat(MAX_MASCOT_VOICE_ID_LEN + 1);
+      const state = reducer(undefined, setSelectedMascotId(tooLong));
+      expect(state.selectedMascotId).toBeNull();
+    });
+
+    it('resetUserScopedState clears the override', () => {
+      let state = reducer(undefined, setSelectedMascotId('yellow'));
+      state = reducer(state, resetUserScopedState());
+      expect(state.selectedMascotId).toBeNull();
+    });
+
+    const rehydrate = (key: string, payload?: unknown) => ({ type: REHYDRATE, key, payload });
+
+    it('restores a valid persisted id', () => {
+      const state = reducer(undefined, rehydrate('mascot', { selectedMascotId: 'yellow' }));
+      expect(state.selectedMascotId).toBe('yellow');
+    });
+
+    it('scrubs an invalid persisted id back to null', () => {
+      const state = reducer(undefined, rehydrate('mascot', { selectedMascotId: '   ' }));
+      expect(state.selectedMascotId).toBeNull();
+    });
+
+    it('treats a missing selectedMascotId field (older builds) as null', () => {
+      const state = reducer(undefined, rehydrate('mascot', { color: 'navy' }));
+      expect(state.selectedMascotId).toBeNull();
     });
   });
 });

--- a/app/src/store/mascotSlice.ts
+++ b/app/src/store/mascotSlice.ts
@@ -52,9 +52,22 @@ export interface MascotState {
    * reset is just `setMascotVoiceId(null)`.
    */
   voiceId: string | null;
+  /**
+   * Server-side mascot id selected from the backend mascot library
+   * (PR tinyhumansai/backend#770). `null` keeps the local YellowMascot
+   * renderer; any non-empty value tells `BackendMascot` (loaded via
+   * `mascotService`) to take over. The id is opaque server-side and
+   * length-capped at the same threshold as voiceId to keep the
+   * persisted blob bounded.
+   */
+  selectedMascotId: string | null;
 }
 
-const initialState: MascotState = { color: DEFAULT_MASCOT_COLOR, voiceId: null };
+const initialState: MascotState = {
+  color: DEFAULT_MASCOT_COLOR,
+  voiceId: null,
+  selectedMascotId: null,
+};
 
 function isMascotColor(value: unknown): value is MascotColor {
   return (
@@ -77,6 +90,21 @@ const mascotSlice = createSlice({
      * (falling back to the build-time default voice). Pass `null` from
      * the UI's Reset button to explicitly drop the override.
      */
+    /**
+     * Select a backend mascot by id. Trimmed; empty / oversize / null
+     * clears the override and falls back to the local YellowMascot.
+     */
+    setSelectedMascotId(state, action: PayloadAction<string | null>) {
+      if (action.payload == null) {
+        state.selectedMascotId = null;
+        return;
+      }
+      if (isMascotVoiceId(action.payload)) {
+        state.selectedMascotId = action.payload.trim();
+      } else {
+        state.selectedMascotId = null;
+      }
+    },
     setMascotVoiceId(state, action: PayloadAction<string | null>) {
       if (action.payload == null) {
         state.voiceId = null;
@@ -100,11 +128,18 @@ const mascotSlice = createSlice({
       const rehydrateAction = action as {
         type: typeof REHYDRATE;
         key: string;
-        payload?: { color?: unknown; voiceId?: unknown };
+        payload?: { color?: unknown; voiceId?: unknown; selectedMascotId?: unknown };
       };
       if (rehydrateAction.key !== 'mascot') return;
       const restoredColor = rehydrateAction.payload?.color;
       state.color = isMascotColor(restoredColor) ? restoredColor : DEFAULT_MASCOT_COLOR;
+      const restoredSelectedMascotId = rehydrateAction.payload?.selectedMascotId;
+      state.selectedMascotId =
+        restoredSelectedMascotId == null
+          ? null
+          : isMascotVoiceId(restoredSelectedMascotId)
+            ? (restoredSelectedMascotId as string).trim()
+            : null;
       // `voiceId` is optional in older persisted blobs (pre-#1762) — the
       // `null` fallback is the intended default and matches a fresh
       // install. Invalid values are scrubbed so a corrupted localStorage
@@ -120,13 +155,16 @@ const mascotSlice = createSlice({
   },
 });
 
-export const { setMascotColor, setMascotVoiceId } = mascotSlice.actions;
+export const { setMascotColor, setMascotVoiceId, setSelectedMascotId } = mascotSlice.actions;
 
 export const selectMascotColor = (state: { mascot: MascotState }): MascotColor =>
   state.mascot.color;
 
 export const selectMascotVoiceId = (state: { mascot: MascotState }): string | null =>
   state.mascot.voiceId;
+
+export const selectSelectedMascotId = (state: { mascot: MascotState }): string | null =>
+  state.mascot.selectedMascotId;
 
 export { mascotSlice };
 export default mascotSlice.reducer;


### PR DESCRIPTION
## Summary

- New banner on Skills → Integrations (\"Send OpenHuman to a meeting\") opens a modal that calls the new POST /mascots/join-meeting endpoint to dispatch the backend mascot bot. Zoom / Teams show \"coming soon\" chips.
- Free-user 429 SERVER_OVERLOADED is surfaced as a calm \"OpenHuman is under heavy load\" amber notice, not a paywall.
- Ports the backend's render-core (translateY / rotate / blink tween math, viseme injection, smile-hiding) to TypeScript with parity tests; ships a BackendMascot React renderer that animates the chosen state SVG via rAF on live DOM nodes.
- mascotSlice gains a persisted selectedMascotId override.
- Settings → OpenHuman now fetches GET /mascots and renders an animated preview of the chosen character.
- User-facing copy renamed from \"mascot\" to \"OpenHuman\".

## Problem

The backend just shipped two complementary features that the desktop client had no entry point for:
- tinyhumansai/backend#773 — POST /mascots/join-meeting with a 429 capacity gate for free users (Google Meet today, Zoom / Teams stubbed).
- tinyhumansai/backend#770 — Mongo-backed mascot library with per-state SVGs, a shared render-core, and declarative tween + viseme metadata.

Without a UI surface, those backend changes were invisible to users.

## Solution

- `app/src/services/mascotService.ts` wraps GET /mascots and GET /mascots/:id with an in-memory manifest cache (manifests carry full SVG bytes so revisits to the picker stay snappy).
- `app/src/features/human/Mascot/backend/`
  - `types.ts` mirrors the backend wire types.
  - `renderCore.ts` is a TypeScript port of `render-core.js`; `renderCore.test.ts` mirrors the upstream parity tests (21 cases).
  - `BackendMascot.tsx` mounts the chosen state's SVG once via dangerouslySetInnerHTML and applies tween transforms directly to live DOM nodes inside an rAF loop. No SVG re-parse per frame; viseme swaps mutate the slot in place.
- `app/src/services/meetCallService.ts` adds `joinMeetingViaMascotBot()` and a structured `MascotJoinMeetingError` so the UI can special-case capacity-gated responses.
- `app/src/components/skills/MeetingBotsCard.tsx` is the new banner + modal entry point on the Skills page.
- `app/src/components/settings/panels/MascotPanel.tsx` gains a Character section: backend picker + animated preview, persisted via `mascotSlice.selectedMascotId`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: diff coverage not run locally for this branch; CI gate will enforce. New code paths (`renderCore`, `BackendMascot`, `mascotSlice.selectedMascotId`, `joinMeetingViaMascotBot`) ship with unit tests.
- [x] N/A: behaviour-only addition (new components / service / slice field). No existing feature row in the coverage matrix changes.
- [x] N/A: no matrix-tracked feature IDs touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: not a release-cut surface — banner / modal opt-in.
- [x] N/A: no linked issue.

## Impact

- Desktop only. The banner and modal live under Skills → Integrations; the picker lives under Settings → OpenHuman.
- The new POST /mascots/join-meeting wrapper goes through the existing apiClient (auth header, getBackendUrl).
- No migration; mascotSlice rehydrate is null-safe so older persisted blobs without `selectedMascotId` keep working.

## Related

- Closes:
- Follow-up PR(s)/TODOs: render `BackendMascot` in the live agent surfaces (HumanPage / mascot window) once visual QA on the backend mascot library is signed off.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/mascot-meets-integration
- Commit SHA: bb213d1190ac93dcb9dcef3cbc3067840317f164

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit Mascot meetCallService mascotSlice` — 134 passing across 13 files
- [x] N/A: no Rust changes
- [x] N/A: no Tauri changes

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: new meeting-bot entry point on Skills + new Character picker on Settings; renames user-facing \"mascot\" copy to \"OpenHuman\".
- User-visible effect: an additional banner on Skills → Integrations; an extra section under Settings → OpenHuman; updated copy throughout.

### Parity Contract
- Legacy behavior preserved: existing local YellowMascot rendering and Intelligence Calls tab are untouched. selectedMascotId defaults to null, so without explicit opt-in the app behaves exactly as before.
- Guard/fallback/dispatch parity checks: capacity-gate (429) failures fall back to a structured error type so existing toast handling stays unchanged for success paths.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and preview OpenHuman characters from a backend library in Settings, with local default, loading/empty/error states, and animated previews.
  * Meeting Bots card on Skills to join meetings (Google Meet, Zoom, Teams) via a mascot bot, with URL/display-name entry and success toasts.

* **Bug Fixes / UX**
  * Labels and copy updated to "OpenHuman" (e.g., "OpenHuman color").
  * "Coming soon" platforms disabled with inline guidance; capacity limits show clearer inline messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> **Pre-existing CI flake:** `e2e / E2E (Linux / Appium Chromium)` fails at the `appium driver install chromium` step (`A driver named "chromium" is already installed`) before any PR code runs. Reproduces on a rerun. Unrelated to this PR.
