### PR TITLE
feat: allow inline model pinning for subagents

### DIFF
--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -105,8 +105,21 @@ pub(super) fn resolve_subagent_provider(
     config: Option<&crate::openhuman::config::Config>,
     parent_provider: std::sync::Arc<dyn Provider>,
     parent_model: String,
+    model_override: Option<&str>,
 ) -> (std::sync::Arc<dyn Provider>, String) {
     use crate::openhuman::agent::harness::definition::ModelSpec;
+    if let Some(model) = model_override
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+    {
+        log::info!(
+            "[subagent_runner] agent_id={} using inline model override model={}",
+            agent_id,
+            model
+        );
+        return (parent_provider, model.to_string());
+    }
+
     match spec {
         ModelSpec::Hint(workload) => match config {
             Some(cfg) => match crate::openhuman::providers::create_chat_provider(workload, cfg) {
@@ -285,6 +298,7 @@ async fn run_typed_mode(
         config_loaded.as_ref().ok(),
         parent.provider.clone(),
         parent.model_name.clone(),
+        options.model_override.as_deref(),
     );
     let temperature = definition.temperature;
 

--- a/src/openhuman/agent/harness/subagent_runner/ops_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops_tests.rs
@@ -144,6 +144,7 @@ use std::sync::Arc;
 struct CapturedRequest {
     messages: Vec<crate::openhuman::providers::ChatMessage>,
     tool_count: usize,
+    model: String,
 }
 
 struct ScriptedProvider {
@@ -175,12 +176,13 @@ impl Provider for ScriptedProvider {
     async fn chat(
         &self,
         request: PChatRequest<'_>,
-        _model: &str,
+        model: &str,
         _temperature: f64,
     ) -> anyhow::Result<ChatResponse> {
         self.captured.lock().push(CapturedRequest {
             messages: request.messages.to_vec(),
             tool_count: request.tools.map_or(0, |tools| tools.len()),
+            model: model.to_string(),
         });
         let mut q = self.responses.lock();
         if q.is_empty() {
@@ -378,6 +380,7 @@ async fn typed_mode_returns_text_through_runner() {
                 skill_filter_override: None,
                 toolkit_override: None,
                 context: None,
+                model_override: None,
                 task_id: Some("t1".into()),
                 worker_thread_id: None,
             },
@@ -486,6 +489,7 @@ async fn typed_mode_filters_tools_by_skill_filter() {
                 skill_filter_override: Some("notion".into()),
                 toolkit_override: None,
                 context: None,
+                model_override: None,
                 task_id: None,
                 worker_thread_id: None,
             },
@@ -588,6 +592,31 @@ async fn runner_errors_outside_parent_context() {
     let def = make_def_named_tools(&[]);
     let result = run_subagent(&def, "x", SubagentRunOptions::default()).await;
     assert!(matches!(result, Err(SubagentRunError::NoParentContext)));
+}
+
+#[tokio::test]
+async fn typed_mode_model_override_pins_exact_model_for_spawn() {
+    let provider = ScriptedProvider::new(vec![text_response("ok")]);
+    let parent = make_parent(provider.clone(), vec![]);
+    let mut def = make_def_named_tools(&[]);
+    def.model = ModelSpec::Inherit;
+
+    let _ = with_parent_context(parent, async {
+        run_subagent(
+            &def,
+            "use the pinned model",
+            SubagentRunOptions {
+                model_override: Some("deepseek/deepseek-r2".into()),
+                ..Default::default()
+            },
+        )
+        .await
+    })
+    .await
+    .expect("runner should succeed");
+
+    let captured = provider.captured.lock();
+    assert_eq!(captured[0].model, "deepseek/deepseek-r2");
 }
 
 /// #1122 — when the parent attaches a progress sink, the inner loop
@@ -705,6 +734,7 @@ fn resolve_subagent_provider_inherit_uses_parent_provider_and_model() {
         None,
         parent.clone(),
         "parent-model-x".to_string(),
+        None,
     );
     assert!(
         arc_ptr_eq(&parent, &resolved_provider),
@@ -725,12 +755,31 @@ fn resolve_subagent_provider_exact_overrides_only_model() {
         None,
         parent.clone(),
         "parent-model-x".to_string(),
+        None,
     );
     assert!(
         arc_ptr_eq(&parent, &resolved_provider),
         "Exact must keep the parent's provider — only the model name changes"
     );
     assert_eq!(resolved_model, "haiku-mini");
+}
+
+#[test]
+fn resolve_subagent_provider_spawn_override_wins_over_definition_model() {
+    let parent: Arc<dyn Provider> = ScriptedProvider::new(vec![]);
+    let (resolved_provider, resolved_model) = super::resolve_subagent_provider(
+        &ModelSpec::Exact("definition-model".to_string()),
+        "test_agent",
+        None,
+        parent.clone(),
+        "parent-model-x".to_string(),
+        Some("spawn-model-y"),
+    );
+    assert!(
+        arc_ptr_eq(&parent, &resolved_provider),
+        "inline spawn override should not change the provider"
+    );
+    assert_eq!(resolved_model, "spawn-model-y");
 }
 
 #[test]
@@ -747,6 +796,7 @@ fn resolve_subagent_provider_hint_with_no_config_falls_back() {
         None, // no config loaded
         parent.clone(),
         "real-claude-id".to_string(),
+        None,
     );
     assert!(
         arc_ptr_eq(&parent, &resolved_provider),
@@ -781,6 +831,7 @@ fn resolve_subagent_provider_hint_with_config_routes_via_factory() {
         Some(&config),
         parent.clone(),
         "parent-model-ignored-on-hint".to_string(),
+        None,
     );
     assert_eq!(
         resolved_model, "agentic-specific-model",
@@ -807,6 +858,7 @@ fn resolve_subagent_provider_hint_falls_back_on_factory_error() {
         Some(&config),
         parent.clone(),
         "fallback-model".to_string(),
+        None,
     );
     assert!(
         arc_ptr_eq(&parent, &resolved_provider),

--- a/src/openhuman/agent/harness/subagent_runner/types.rs
+++ b/src/openhuman/agent/harness/subagent_runner/types.rs
@@ -29,6 +29,11 @@ pub struct SubagentRunOptions {
     /// task prompt. Rendered as a `[Context]\n…\n` prefix.
     pub context: Option<String>,
 
+    /// Optional exact model id for this single spawn. When present it
+    /// wins over the agent definition's model spec but keeps the
+    /// parent's provider/routing unchanged.
+    pub model_override: Option<String>,
+
     /// Stable id for tracing / DomainEvents (defaults to a UUID).
     pub task_id: Option<String>,
 

--- a/src/openhuman/tools/impl/agent/archetype_delegation.rs
+++ b/src/openhuman/tools/impl/agent/archetype_delegation.rs
@@ -27,6 +27,10 @@ impl Tool for ArchetypeDelegationTool {
                 "prompt": {
                     "type": "string",
                     "description": "Clear instruction for what to do. Include all relevant context — the sub-agent has no memory of your conversation."
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Optional exact model id for this delegation only. Keeps the parent provider/routing, but pins the child agent to this model instead of the agent definition's default."
                 }
             }
         })
@@ -55,6 +59,19 @@ impl Tool for ArchetypeDelegationTool {
             )));
         }
 
-        super::dispatch_subagent(&self.agent_id, &self.tool_name, &prompt, None).await
+        let model_override = args
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        super::dispatch_subagent(
+            &self.agent_id,
+            &self.tool_name,
+            &prompt,
+            None,
+            model_override,
+        )
+        .await
     }
 }

--- a/src/openhuman/tools/impl/agent/dispatch.rs
+++ b/src/openhuman/tools/impl/agent/dispatch.rs
@@ -11,6 +11,7 @@ pub(crate) async fn dispatch_subagent(
     tool_name: &str,
     prompt: &str,
     skill_filter: Option<&str>,
+    model_override: Option<&str>,
 ) -> anyhow::Result<ToolResult> {
     let registry = match AgentDefinitionRegistry::global() {
         Some(reg) => reg,
@@ -67,6 +68,7 @@ pub(crate) async fn dispatch_subagent(
         skill_filter_override: None,
         toolkit_override: skill_filter.map(str::to_string),
         context: None,
+        model_override: model_override.map(str::to_string),
         task_id: Some(task_id.clone()),
         worker_thread_id: None,
     };
@@ -128,6 +130,7 @@ mod tests {
             "__definitely_not_a_real_agent__",
             "test_tool",
             "irrelevant prompt",
+            None,
             None,
         )
         .await

--- a/src/openhuman/tools/impl/agent/skill_delegation.rs
+++ b/src/openhuman/tools/impl/agent/skill_delegation.rs
@@ -195,7 +195,14 @@ impl Tool for SkillDelegationTool {
             slug,
             prompt.chars().count()
         );
-        super::dispatch_subagent("integrations_agent", &self.tool_name, &prompt, Some(&slug)).await
+        super::dispatch_subagent(
+            "integrations_agent",
+            &self.tool_name,
+            &prompt,
+            Some(&slug),
+            None,
+        )
+        .await
     }
 }
 

--- a/src/openhuman/tools/impl/agent/spawn_parallel_agents.rs
+++ b/src/openhuman/tools/impl/agent/spawn_parallel_agents.rs
@@ -430,6 +430,7 @@ async fn run_one_parallel_task(
         skill_filter_override: None,
         toolkit_override: task.toolkit.clone(),
         context: task.context.clone(),
+        model_override: None,
         task_id: Some(task_id.clone()),
         worker_thread_id: None,
     };

--- a/src/openhuman/tools/impl/agent/spawn_subagent.rs
+++ b/src/openhuman/tools/impl/agent/spawn_subagent.rs
@@ -122,6 +122,10 @@ impl Tool for SpawnSubagentTool {
                     "type": "string",
                     "description": "Optional context blob from prior task results. Rendered as a `[Context]` block before the prompt."
                 },
+                "model": {
+                    "type": "string",
+                    "description": "Optional exact model id for this spawn only. Keeps the parent provider/routing, but pins the child agent to this model instead of the agent definition's default."
+                },
                 "toolkit": {
                     "type": "string",
                     "description": "Composio toolkit slug to scope this spawn to — e.g. `gmail`, `notion`, `slack`. REQUIRED when `agent_id = \"integrations_agent\"`. Narrows the sub-agent's visible Composio actions AND its Connected Integrations prompt section to only that toolkit's catalogue, so the sub-agent's context window only carries the platform it was asked to operate on. Must match a currently-connected integration (see the Delegation Guide)."
@@ -159,6 +163,12 @@ impl Tool for SpawnSubagentTool {
             .get("context")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+
+        let model_override = args
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
 
         let toolkit_override = args
             .get("toolkit")
@@ -398,6 +408,7 @@ impl Tool for SpawnSubagentTool {
             skill_filter_override: None,
             toolkit_override,
             context,
+            model_override,
             task_id: Some(task_id.clone()),
             worker_thread_id: None,
         };
@@ -667,6 +678,20 @@ mod tests {
             .get("required")
             .and_then(|v| v.as_array())
             .map(|arr| arr.iter().all(|s| s.as_str() != Some("dedicated_thread")))
+            .unwrap_or(true));
+    }
+
+    #[test]
+    fn parameters_schema_advertises_optional_model_override() {
+        let tool = SpawnSubagentTool;
+        let schema = tool.parameters_schema();
+        let props = schema.get("properties").expect("schema has properties");
+        let model = props.get("model").expect("model override advertised");
+        assert_eq!(model.get("type").and_then(|v| v.as_str()), Some("string"));
+        assert!(schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().all(|s| s.as_str() != Some("model")))
             .unwrap_or(true));
     }
 

--- a/src/openhuman/tools/impl/agent/spawn_worker_thread.rs
+++ b/src/openhuman/tools/impl/agent/spawn_worker_thread.rs
@@ -224,6 +224,7 @@ impl Tool for SpawnWorkerThreadTool {
             skill_filter_override: None,
             toolkit_override,
             context,
+            model_override: None,
             task_id: None,
             worker_thread_id: Some(worker_thread_id.clone()),
         };


### PR DESCRIPTION
## Summary
- add an optional `model` parameter to `spawn_subagent` and archetype delegation tools
- thread that inline model override through `SubagentRunOptions` and `dispatch_subagent`
- resolve the child run with the parent provider/routing but the explicitly pinned model for that spawn
- keep existing auto-routing/default behavior unchanged when `model` is omitted

Refs #1837

## Tests
- `cargo fmt --all`
- `RUSTC=/Users/lee/.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rustc GGML_NATIVE=OFF cargo test -p openhuman --lib subagent_runner -- --nocapture`
- `RUSTC=/Users/lee/.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rustc GGML_NATIVE=OFF cargo test -p openhuman --lib spawn_subagent -- --nocapture`
- `RUSTC=/Users/lee/.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rustc GGML_NATIVE=OFF cargo test -p openhuman --lib archetype_delegation -- --nocapture`
- `RUSTC=/Users/lee/.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rustc GGML_NATIVE=OFF cargo check -p openhuman`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Subagent spawning now accepts an optional model parameter, allowing you to pin delegated tasks to a specific model of your choice.
  * Child agent execution can override model selection while preserving parent provider routing and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->