### PR TITLE
feat: expose embedding provider model signatures

### DIFF
--- a/src/openhuman/embeddings/cloud.rs
+++ b/src/openhuman/embeddings/cloud.rs
@@ -92,6 +92,10 @@ impl EmbeddingProvider for OpenHumanCloudEmbedding {
         "cloud"
     }
 
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+
     fn dimensions(&self) -> usize {
         self.dims
     }
@@ -120,7 +124,9 @@ mod tests {
             DEFAULT_CLOUD_EMBEDDING_DIMENSIONS,
         );
         assert_eq!(p.name(), "cloud");
+        assert_eq!(p.model_id(), DEFAULT_CLOUD_EMBEDDING_MODEL);
         assert_eq!(p.dimensions(), DEFAULT_CLOUD_EMBEDDING_DIMENSIONS);
+        assert_eq!(p.signature(), "provider=cloud;model=embedding-v1;dims=1024");
     }
 
     #[test]

--- a/src/openhuman/embeddings/mod.rs
+++ b/src/openhuman/embeddings/mod.rs
@@ -41,7 +41,9 @@ mod tests {
     fn noop_name_and_dims() {
         let p = NoopEmbedding;
         assert_eq!(p.name(), "none");
+        assert_eq!(p.model_id(), "none");
         assert_eq!(p.dimensions(), 0);
+        assert_eq!(p.signature(), "provider=none;model=none;dims=0");
     }
 
     #[tokio::test]
@@ -72,13 +74,16 @@ mod tests {
     fn factory_ollama() {
         let p = create_embedding_provider("ollama", DEFAULT_OLLAMA_MODEL, 768).unwrap();
         assert_eq!(p.name(), "ollama");
+        assert_eq!(p.model_id(), DEFAULT_OLLAMA_MODEL);
         assert_eq!(p.dimensions(), 768);
+        assert_eq!(p.signature(), "provider=ollama;model=bge-m3;dims=768");
     }
 
     #[test]
     fn factory_openai() {
         let p = create_embedding_provider("openai", "text-embedding-3-small", 1536).unwrap();
         assert_eq!(p.name(), "openai");
+        assert_eq!(p.model_id(), "text-embedding-3-small");
         assert_eq!(p.dimensions(), 1536);
     }
 

--- a/src/openhuman/embeddings/noop.rs
+++ b/src/openhuman/embeddings/noop.rs
@@ -14,6 +14,10 @@ impl EmbeddingProvider for NoopEmbedding {
         "none"
     }
 
+    fn model_id(&self) -> &str {
+        "none"
+    }
+
     fn dimensions(&self) -> usize {
         0
     }

--- a/src/openhuman/embeddings/ollama.rs
+++ b/src/openhuman/embeddings/ollama.rs
@@ -185,6 +185,10 @@ impl EmbeddingProvider for OllamaEmbedding {
         "ollama"
     }
 
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+
     fn dimensions(&self) -> usize {
         self.dims
     }

--- a/src/openhuman/embeddings/ollama_tests.rs
+++ b/src/openhuman/embeddings/ollama_tests.rs
@@ -121,7 +121,9 @@ fn accessor_methods() {
     let p = OllamaEmbedding::new("http://x:1", "m", 42);
     assert_eq!(p.base_url(), "http://x:1");
     assert_eq!(p.model(), "m");
+    assert_eq!(p.model_id(), "m");
     assert_eq!(p.dimensions(), 42);
+    assert_eq!(p.signature(), "provider=ollama;model=m;dims=42");
 }
 
 // ── embed — empty / whitespace ──────────────────────────

--- a/src/openhuman/embeddings/openai.rs
+++ b/src/openhuman/embeddings/openai.rs
@@ -80,6 +80,10 @@ impl EmbeddingProvider for OpenAiEmbedding {
         "openai"
     }
 
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+
     fn dimensions(&self) -> usize {
         self.dims
     }

--- a/src/openhuman/embeddings/openai_tests.rs
+++ b/src/openhuman/embeddings/openai_tests.rs
@@ -36,6 +36,8 @@ fn accessors() {
     assert_eq!(p.base_url(), "http://x");
     assert_eq!(p.model(), "m");
     assert_eq!(p.name(), "openai");
+    assert_eq!(p.model_id(), "m");
+    assert_eq!(p.signature(), "provider=openai;model=m;dims=1");
 }
 
 #[test]

--- a/src/openhuman/embeddings/provider_trait.rs
+++ b/src/openhuman/embeddings/provider_trait.rs
@@ -8,8 +8,25 @@ pub trait EmbeddingProvider: Send + Sync {
     /// Returns the name of the provider (e.g., "ollama", "openai").
     fn name(&self) -> &str;
 
+    /// Returns the stable model identifier used to generate embeddings.
+    fn model_id(&self) -> &str;
+
     /// Returns the number of dimensions in the generated embeddings.
     fn dimensions(&self) -> usize;
+
+    /// Returns a stable signature for the embedding space.
+    ///
+    /// Changing any component means existing vectors may no longer be
+    /// comparable with newly-generated vectors and should be stored / queried
+    /// separately by follow-up storage migrations.
+    fn signature(&self) -> String {
+        format!(
+            "provider={};model={};dims={}",
+            self.name(),
+            self.model_id(),
+            self.dimensions()
+        )
+    }
 
     /// Generates embeddings for a batch of strings.
     async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>>;

--- a/src/openhuman/embeddings/store_tests.rs
+++ b/src/openhuman/embeddings/store_tests.rs
@@ -11,6 +11,9 @@ impl EmbeddingProvider for FakeEmbedding {
     fn name(&self) -> &str {
         "fake"
     }
+    fn model_id(&self) -> &str {
+        "fake"
+    }
     fn dimensions(&self) -> usize {
         self.dims
     }
@@ -38,6 +41,9 @@ struct MismatchEmbedding;
 #[async_trait::async_trait]
 impl EmbeddingProvider for MismatchEmbedding {
     fn name(&self) -> &str {
+        "mismatch"
+    }
+    fn model_id(&self) -> &str {
         "mismatch"
     }
     fn dimensions(&self) -> usize {


### PR DESCRIPTION
## Summary
- add `EmbeddingProvider::model_id()` so each embedder can expose the configured embedding model
- add a default `EmbeddingProvider::signature()` derived from provider, model, and dimensions
- cover cloud, Ollama, OpenAI, noop, factory, and store test fake providers

## Why this slice
This is the first small, reviewable step toward #1574. It creates a stable embedding-space identity that later storage/migration PRs can attach to rows without changing vector storage behavior in this PR.

## Non-goals
- no schema migration
- no per-row storage changes
- no retrieval filtering changes yet

## Test Plan
- `cargo fmt --all`
- `RUSTC=/Users/lee/.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rustc GGML_NATIVE=OFF cargo test -p openhuman --lib openhuman::embeddings -- --nocapture` (109 passed)
- `RUSTC=/Users/lee/.rustup/toolchains/1.93.0-aarch64-apple-darwin/bin/rustc GGML_NATIVE=OFF cargo check -p openhuman`
- `git diff --check`

Refs #1574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedding providers now explicitly expose their configured model identifier.
  * Added signature generation to identify and verify embedding configuration (provider, model, and dimensions), enabling compatibility checks with previously generated embeddings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->