### PR TITLE
fix(security): audit-log set_browser_allow_all RPC transitions

### DIFF
--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -817,17 +817,49 @@ pub fn get_runtime_flags() -> RpcOutcome<RuntimeFlagsOut> {
 }
 
 /// Updates the `OPENHUMAN_BROWSER_ALLOW_ALL` environment flag.
+///
+/// **Security note:** when enabled, this disables the browser tool's
+/// per-domain allowlist for the entire process. Both transitions are
+/// audit-logged at WARN level with a `[SECURITY]` prefix so operators
+/// (and `journalctl -g '\[SECURITY\]'` style scrapes) can spot
+/// allowlist toggles in the live log stream.
+///
+/// `is_private_host` checks still apply to the resolved IP, so this
+/// flag does not unlock loopback / RFC1918 destinations.
 pub fn set_browser_allow_all(enabled: bool) -> RpcOutcome<RuntimeFlagsOut> {
+    let was_enabled = env_flag_enabled("OPENHUMAN_BROWSER_ALLOW_ALL");
     if enabled {
         std::env::set_var("OPENHUMAN_BROWSER_ALLOW_ALL", "1");
     } else {
         std::env::remove_var("OPENHUMAN_BROWSER_ALLOW_ALL");
     }
+    let now_enabled = env_flag_enabled("OPENHUMAN_BROWSER_ALLOW_ALL");
     let flags = RuntimeFlagsOut {
-        browser_allow_all: env_flag_enabled("OPENHUMAN_BROWSER_ALLOW_ALL"),
+        browser_allow_all: now_enabled,
         log_prompts: env_flag_enabled("OPENHUMAN_LOG_PROMPTS"),
     };
-    RpcOutcome::single_log(flags, "browser allow-all flag updated")
+
+    if was_enabled != now_enabled {
+        if now_enabled {
+            tracing::warn!(
+                "[SECURITY] browser allow-all enabled via RPC: \
+                 per-domain allowlist is now bypassed for all sessions \
+                 (private-host check still applies)"
+            );
+        } else {
+            tracing::info!(
+                "[SECURITY] browser allow-all disabled via RPC: \
+                 per-domain allowlist re-enforced"
+            );
+        }
+    }
+
+    let log_msg = if now_enabled {
+        "[SECURITY] browser allow-all flag set to enabled"
+    } else {
+        "[SECURITY] browser allow-all flag set to disabled"
+    };
+    RpcOutcome::single_log(flags, log_msg)
 }
 
 /// Checks if a specific onboarding flag file exists in the workspace.

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -167,6 +167,45 @@ fn set_browser_allow_all_toggles_env_var() {
     }
 }
 
+#[test]
+fn set_browser_allow_all_emits_security_audit_log() {
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let before = std::env::var("OPENHUMAN_BROWSER_ALLOW_ALL").ok();
+
+    let enable_outcome = set_browser_allow_all(true);
+    assert_eq!(enable_outcome.logs.len(), 1);
+    let enable_log = &enable_outcome.logs[0];
+    assert!(
+        enable_log.contains("[SECURITY]"),
+        "enable log should be audit-tagged: {enable_log}"
+    );
+    assert!(
+        enable_log.contains("enabled"),
+        "enable log should mention enabled state: {enable_log}"
+    );
+    assert!(enable_outcome.value.browser_allow_all);
+
+    let disable_outcome = set_browser_allow_all(false);
+    assert_eq!(disable_outcome.logs.len(), 1);
+    let disable_log = &disable_outcome.logs[0];
+    assert!(
+        disable_log.contains("[SECURITY]"),
+        "disable log should be audit-tagged: {disable_log}"
+    );
+    assert!(
+        disable_log.contains("disabled"),
+        "disable log should mention disabled state: {disable_log}"
+    );
+    assert!(!disable_outcome.value.browser_allow_all);
+
+    unsafe {
+        match before {
+            Some(v) => std::env::set_var("OPENHUMAN_BROWSER_ALLOW_ALL", v),
+            None => std::env::remove_var("OPENHUMAN_BROWSER_ALLOW_ALL"),
+        }
+    }
+}
+
 // ── snapshot_config_json ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
The set_browser_allow_all RPC mutates the process-wide OPENHUMAN_BROWSER_ALLOW_ALL env var, which (when enabled) bypasses the browser tool domain allowlist for every concurrent session and agent. Previously the only operational signal that this had happened was a generic "browser allow-all flag updated" log line indistinguishable from routine config writes.

Add a [SECURITY]-tagged audit log on every successful change:

- WARN on disabled -> enabled transitions, calling out that the per-domain allowlist is now bypassed.
- INFO on enabled -> disabled transitions.
- The transition log is only emitted when the effective flag value changes, so repeated no-op calls do not spam the audit stream.
- The RpcOutcome single_log message is also retagged with [SECURITY] and the new state, so dashboard log surfaces and journalctl scrapes using "[SECURITY]" prefix matching pick the event up consistently.

Behaviour is otherwise unchanged: existing callers continue to work, get_runtime_flags still reports the same shape, and the is_private_host guard in the browser tool still blocks loopback / RFC1918 destinations regardless of this flag.

A regression test (set_browser_allow_all_emits_security_audit_log) asserts the RpcOutcome carries the [SECURITY] tag for both enable and disable paths.

Refs #1899

## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [ ] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key:
- URL:

### Commit & Branch
- Branch:
- Commit SHA:

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check`
- [ ] `pnpm typecheck`
- [ ] Focused tests:
- [ ] Rust fmt/check (if changed):
- [ ] Tauri fmt/check (if changed):

### Validation Blocked
- `command:`
- `error:`
- `impact:`

### Behavior Changes
- Intended behavior change:
- User-visible effect:

### Parity Contract
- Legacy behavior preserved:
- Guard/fallback/dispatch parity checks:

### Duplicate / Superseded PR Handling
- Duplicate PR(s):
- Canonical PR:
- Resolution (closed/superseded/updated):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audit logging for browser permission configuration changes with clearer state-change notifications.

* **Tests**
  * Added test coverage to verify security logging behavior when browser permissions are updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->