### PR TITLE
fix: Fix installer retries for HTTP/2 download failures

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Unit tests (install.sh helpers)
+        run: bash scripts/test_install.sh
       - name: Run installer dry-run
         run: bash scripts/install.sh --dry-run --verbose
 

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -20,6 +20,10 @@ This is the **only** acceptable substitute for a `🚫` row in [`TEST-COVERAGE-M
 
 Applies to every release, all platforms.
 
+### Public installer script
+
+- [ ] **`scripts/install.sh` downloads the latest asset on a proxy/VPN network** — From a clean checkout, run `bash scripts/install.sh --dry-run --verbose`, then run the public `curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash` flow on one macOS or Linux host. Expected: release metadata resolves, the asset downloads successfully, and transient GitHub/CDN HTTP/2 failures retry over HTTP/1.1 instead of surfacing `curl: (16) Error in the HTTP2 framing layer`.
+
 ### macOS
 
 - [ ] **Gatekeeper accepts the signed `.app` on first launch** — Double-click the `.app` from a fresh download (Quarantine attribute set). Expected: app opens without `"OpenHuman" cannot be opened because the developer cannot be verified` dialog. If it appears, the build is unsigned or the notarization stapler is missing.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -200,11 +200,47 @@ PY
   printf '%s\n' "$url"
 }
 
+# curl can fail on GitHub/CDN HTTP/2 framing issues on some networks while the
+# same URL succeeds over HTTP/1.1. Try the normal path first, then a
+# compatibility retry before surfacing the failure.
+curl_get_file() {
+  local url="$1" output="$2" rc
+  if curl -fsSL "$url" -o "$output"; then
+    return 0
+  else
+    rc=$?
+  fi
+  log_warn "Request failed (curl rc=${rc}); retrying with HTTP/1.1."
+  curl --http1.1 -fsSL "$url" -o "$output"
+}
+
+curl_download_file() {
+  local url="$1" output="$2" rc
+  if curl -fL "$url" -o "$output"; then
+    return 0
+  else
+    rc=$?
+  fi
+  log_warn "Download failed (curl rc=${rc}); retrying with HTTP/1.1."
+  curl --http1.1 -fL "$url" -o "$output"
+}
+
+curl_head_with_http_fallback() {
+  local url="$1" rc
+  if curl -fsSI --max-time 10 "$url" >/dev/null 2>&1; then
+    return 0
+  else
+    rc=$?
+  fi
+  log_warn "Reachability check failed (curl rc=${rc}); retrying with HTTP/1.1."
+  curl --http1.1 -fsSI --max-time 10 "$url" >/dev/null 2>&1
+}
+
 # Retries an HTTP HEAD on the asset URL, fails loudly with the URL.
 verify_asset_reachable() {
   local url="$1" max_attempts=5 delay=2
   for i in $(seq 1 $max_attempts); do
-    if curl -fsSI --max-time 10 "$url" >/dev/null 2>&1; then
+    if curl_head_with_http_fallback "$url"; then
       return 0
     fi
     if [[ $i -lt $max_attempts ]]; then
@@ -217,7 +253,7 @@ verify_asset_reachable() {
 }
 
 resolve_from_latest_json() {
-  if ! curl -fsSL "${LATEST_JSON_URL}" -o "${LATEST_JSON_PATH}"; then
+  if ! curl_get_file "${LATEST_JSON_URL}" "${LATEST_JSON_PATH}"; then
     return 1
   fi
 
@@ -252,7 +288,7 @@ print(d.get('version', ''))
 }
 
 resolve_from_release_api() {
-  if ! curl -fsSL "${LATEST_RELEASE_API_URL}" -o "${RELEASE_JSON_PATH}"; then
+  if ! curl_get_file "${LATEST_RELEASE_API_URL}" "${RELEASE_JSON_PATH}"; then
     return 1
   fi
 
@@ -333,7 +369,7 @@ resolve_release_digest() {
     return 0
   fi
   if [ ! -s "${RELEASE_JSON_PATH}" ]; then
-    if ! curl -fsSL "${LATEST_RELEASE_API_URL}" -o "${RELEASE_JSON_PATH}"; then
+    if ! curl_get_file "${LATEST_RELEASE_API_URL}" "${RELEASE_JSON_PATH}"; then
       return 0
     fi
   fi
@@ -417,9 +453,9 @@ fi
 DOWNLOAD_PATH="${TMP_DIR}/${ASSET_NAME}"
 log_info "Downloading ${ASSET_NAME}"
 if [ "${DRY_RUN}" = true ]; then
-  echo "DRY RUN: curl -fL ${ASSET_URL} -o ${DOWNLOAD_PATH}"
+  echo "DRY RUN: curl -fL ${ASSET_URL} -o ${DOWNLOAD_PATH} (retrying with --http1.1 on failure)"
 else
-  curl -fL "${ASSET_URL}" -o "${DOWNLOAD_PATH}"
+  curl_download_file "${ASSET_URL}" "${DOWNLOAD_PATH}"
 fi
 
 compute_sha256() {

--- a/scripts/test_install.sh
+++ b/scripts/test_install.sh
@@ -30,4 +30,64 @@ if [[ "$missing_platform_rc" -ne 3 ]]; then
   exit 1
 fi
 
+(
+  CURL_CALLS=""
+  curl() {
+    CURL_CALLS="${CURL_CALLS}|$*"
+    case " $* " in
+      *" --http1.1 "*) return 0 ;;
+      *) return 16 ;;
+    esac
+  }
+
+  if ! curl_head_with_http_fallback "https://example.invalid/OpenHuman.app.tar.gz"; then
+    echo "FAIL: reachability fallback should succeed when HTTP/1.1 retry succeeds"
+    exit 1
+  fi
+  if [[ "${CURL_CALLS}" != *"--http1.1"* ]]; then
+    echo "FAIL: reachability check did not retry with --http1.1"
+    exit 1
+  fi
+)
+
+(
+  CURL_CALLS=""
+  curl() {
+    CURL_CALLS="${CURL_CALLS}|$*"
+    case " $* " in
+      *" --http1.1 "*) return 0 ;;
+      *) return 16 ;;
+    esac
+  }
+
+  if ! curl_get_file "https://example.invalid/latest.json" "/tmp/openhuman-test-latest.json"; then
+    echo "FAIL: metadata fetch fallback should succeed when HTTP/1.1 retry succeeds"
+    exit 1
+  fi
+  if [[ "${CURL_CALLS}" != *"--http1.1"* ]]; then
+    echo "FAIL: metadata fetch did not retry with --http1.1"
+    exit 1
+  fi
+)
+
+(
+  CURL_CALLS=""
+  curl() {
+    CURL_CALLS="${CURL_CALLS}|$*"
+    case " $* " in
+      *" --http1.1 "*) return 0 ;;
+      *) return 16 ;;
+    esac
+  }
+
+  if ! curl_download_file "https://example.invalid/OpenHuman.app.tar.gz" "/tmp/openhuman-test-download"; then
+    echo "FAIL: download fallback should succeed when HTTP/1.1 retry succeeds"
+    exit 1
+  fi
+  if [[ "${CURL_CALLS}" != *"--http1.1"* ]]; then
+    echo "FAIL: download did not retry with --http1.1"
+    exit 1
+  fi
+)
+
 echo "PASS"

--- a/scripts/test_install.sh
+++ b/scripts/test_install.sh
@@ -30,6 +30,22 @@ if [[ "$missing_platform_rc" -ne 3 ]]; then
   exit 1
 fi
 
+assert_retry_shape() {
+  local calls="$1" label="$2"
+  local _ first second extra
+  IFS='|' read -r _ first second extra <<<"${calls}"
+
+  if [[ -z "${first:-}" || -z "${second:-}" || -n "${extra:-}" ]]; then
+    echo "FAIL: ${label} should issue exactly 2 curl calls (base + HTTP/1.1 retry)"
+    exit 1
+  fi
+
+  if [[ "${first}" == *"--http1.1"* || "${second}" != *"--http1.1"* ]]; then
+    echo "FAIL: ${label} should retry with --http1.1 only on the second call"
+    exit 1
+  fi
+}
+
 (
   CURL_CALLS=""
   curl() {
@@ -44,10 +60,7 @@ fi
     echo "FAIL: reachability fallback should succeed when HTTP/1.1 retry succeeds"
     exit 1
   fi
-  if [[ "${CURL_CALLS}" != *"--http1.1"* ]]; then
-    echo "FAIL: reachability check did not retry with --http1.1"
-    exit 1
-  fi
+  assert_retry_shape "${CURL_CALLS}" "reachability check"
 )
 
 (
@@ -64,10 +77,7 @@ fi
     echo "FAIL: metadata fetch fallback should succeed when HTTP/1.1 retry succeeds"
     exit 1
   fi
-  if [[ "${CURL_CALLS}" != *"--http1.1"* ]]; then
-    echo "FAIL: metadata fetch did not retry with --http1.1"
-    exit 1
-  fi
+  assert_retry_shape "${CURL_CALLS}" "metadata fetch"
 )
 
 (
@@ -84,10 +94,7 @@ fi
     echo "FAIL: download fallback should succeed when HTTP/1.1 retry succeeds"
     exit 1
   fi
-  if [[ "${CURL_CALLS}" != *"--http1.1"* ]]; then
-    echo "FAIL: download did not retry with --http1.1"
-    exit 1
-  fi
+  assert_retry_shape "${CURL_CALLS}" "download"
 )
 
 echo "PASS"


### PR DESCRIPTION
## Summary

- Add HTTP/1.1 retry fallback around installer curl metadata, HEAD, and asset download requests.
- Cover curl exit 16 / HTTP/2 framing failures in the installer shell tests.
- Run installer smoke tests in the Unix installer smoke workflow.
- Document a public installer smoke case for proxy/VPN-sensitive networks and the HTTP/2 fallback path.

## Problem

- On some proxy/VPN/network paths, curl can fail GitHub release requests with HTTP/2 framing errors before the installer can download the OpenHuman app archive.
- Affected users see the installer resolve the release but fail before the asset download completes, even when retrying later or switching network/VPN state makes the same URL reachable.
- The existing installer tests did not cover curl's HTTP/2 failure mode, so regressions in the fallback path would not be caught locally or in CI.

## Solution

- Introduce small curl wrapper helpers in `scripts/install.sh` that first use the existing curl behavior, then retry once with `--http1.1` when the initial request fails.
- Reuse those helpers for `latest.json`, releases API metadata fallback, digest metadata refresh, asset HEAD reachability checks, and final asset downloads.
- Preserve existing retry counts, checksum verification, and dry-run behavior while making verbose dry-runs disclose the HTTP/1.1 retry behavior.
- Extend `scripts/test_install.sh` with fake-curl cases for metadata fetches, HEAD checks, and asset downloads that fail once with exit 16 and then succeed with `--http1.1`.
- Add the shell installer tests to `.github/workflows/installer-smoke.yml` and update the release manual smoke checklist for public installer runs through proxy/VPN networks.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — N/A: this change touches shell installer scripts/docs/workflow only; no Vitest/cargo coverage target exists for these shell lines, but `scripts/test_install.sh` adds focused failure-path coverage.
- [x] Coverage matrix updated — N/A: installer script robustness is not represented as an app feature row in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature IDs are affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no upstream GitHub issue or Linear issue was provided for this contribution.

## Impact

- Runtime/platform impact: installer-only change for macOS/Linux shell installs; app runtime behavior is unchanged.
- Compatibility: preserves existing GitHub release asset URLs, retry behavior, checksum verification, and install locations.
- Network behavior: users behind proxy/VPN/network paths that trigger curl HTTP/2 framing failures get an HTTP/1.1 retry before the installer reports failure.
- Security: no new network endpoints or unchecked downloads are introduced; checksum validation remains in place.

## Related

- Closes: N/A: no issue was provided.
- Follow-up PR(s)/TODOs: N/A.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A: no Linear issue was provided.
- URL: N/A: no Linear issue was provided.

### Commit & Branch
- Branch: `fix/installer-http1-fallback`
- Commit SHA: `28cabc62e6b9fa35208b563def3a26caa285e088`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `bash scripts/test_install.sh`; `bash -n scripts/install.sh && bash -n scripts/test_install.sh`; `bash scripts/install.sh --dry-run --verbose`; `git diff --check`; `sh .husky/pre-push`
- [x] Rust fmt/check (if changed): N/A: no root Rust files changed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: installer curl requests now retry once with `--http1.1` after an initial failure, addressing VPN/proxy-sensitive HTTP/2 framing failures.
- User-visible effect: installs that previously failed with curl HTTP/2 framing errors can complete without requiring users to disable VPN or manually retry on another network.

### Parity Contract
- Legacy behavior preserved: release resolution, asset selection, checksum verification, dry-run flow, and install destination behavior are preserved.
- Guard/fallback/dispatch parity checks: fake-curl tests assert that metadata, HEAD, and archive download paths only fall back to HTTP/1.1 after the first curl attempt fails.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A: no existing PR found or provided for this branch.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now automatically retries with an HTTP/1.1 fallback when transient HTTP/2 errors occur during downloads from GitHub/CDN.

* **Tests**
  * Added smoke tests that simulate network failures to verify the installer's HTTP/1.1 retry/fallback behavior.

* **Documentation**
  * Release manual updated with a public installer checklist covering proxy/VPN verification and expected retry behavior.

* **Chores**
  * CI smoke step added to run installer verification before the dry-run step.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

