### PR TITLE
fix(security): guard OpenhumanLinkModal against arbitrary event paths (closes #1945)

### DIFF
--- a/app/src/components/OpenhumanLinkModal.tsx
+++ b/app/src/components/OpenhumanLinkModal.tsx
@@ -40,13 +40,27 @@ interface OpenhumanLinkEvent {
 
 export const OPENHUMAN_LINK_EVENT = 'openhuman-link';
 
+const ALLOWED_PATHS = [
+  'settings/notifications',
+  'settings/billing',
+  'settings/messaging',
+  'community/discord',
+  'accounts/setup',
+] as const;
+
+type AllowedPath = (typeof ALLOWED_PATHS)[number];
+
+const ALLOWED_PATHS_SET = new Set<string>(ALLOWED_PATHS);
+
 const OpenhumanLinkModal = () => {
-  const [activePath, setActivePath] = useState<string | null>(null);
+  const [activePath, setActivePath] = useState<AllowedPath | null>(null);
 
   useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<OpenhumanLinkEvent>).detail;
-      if (detail?.path) setActivePath(detail.path);
+      if (detail?.path && ALLOWED_PATHS_SET.has(detail.path)) {
+        setActivePath(detail.path as AllowedPath);
+      }
     };
     window.addEventListener(OPENHUMAN_LINK_EVENT, handler);
     return () => window.removeEventListener(OPENHUMAN_LINK_EVENT, handler);
@@ -143,7 +157,7 @@ const MessagingSetupBridge = ({ onClose }: { onClose: () => void }) => {
   return <ChannelSetupModal definition={telegram} onClose={onClose} />;
 };
 
-function titleForPath(path: string): string {
+function titleForPath(path: AllowedPath): string {
   switch (path) {
     case 'settings/notifications':
       return 'Allow notifications';
@@ -155,12 +169,10 @@ function titleForPath(path: string): string {
       return 'Join the community';
     case 'accounts/setup':
       return 'Connect your apps';
-    default:
-      return 'Settings';
   }
 }
 
-function renderBody(path: string, close: () => void) {
+function renderBody(path: AllowedPath, close: () => void) {
   switch (path) {
     case 'settings/notifications':
       return <NotificationsBody close={close} />;
@@ -176,16 +188,6 @@ function renderBody(path: string, close: () => void) {
       return <DiscordBody close={close} />;
     case 'accounts/setup':
       return <AccountsSetupBody close={close} />;
-    default:
-      return (
-        <div className="space-y-3 text-sm text-stone-700">
-          <p>
-            This setting isn't ready in the popup yet. Open the full settings page when you're
-            ready.
-          </p>
-          <DoneFooter close={close} />
-        </div>
-      );
   }
 }
 


### PR DESCRIPTION
## Summary

Guard `OpenhumanLinkModal` against arbitrary event paths by defining a strict allowlist of 5 known paths. Unknown paths are silently dropped instead of opening the modal.

## Changes

- Added `ALLOWED_PATHS` as `as const` array with all 5 valid paths  
- Derived `AllowedPath` union type from the array for compile-time exhaustiveness  
- Added `ALLOWED_PATHS_SET` for O(1) runtime lookup  
- Typed `activePath` state as `AllowedPath | null`  
- Both `titleForPath` and `renderBody` switched from `string` to `AllowedPath` param  
- Removed `default` switch arms — TS catches missing cases at compile time

## Checklist

- [x] `pnpm typecheck` passes  
- [x] `pnpm lint` passes  
- [x] `pnpm format:check` passes  
- [x] `pnpm test` passes (2192 tests)  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened modal path validation so only approved routes can open the modal, preventing unexpected or invalid paths from showing.
  * Modal content rendering tightened to only display known, allowed views—unknown paths will no longer produce fallback content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->