### PR TITLE
fix(security): truncate command in policy error message (closes #1941)

### DIFF
--- a/src/openhuman/security/policy.rs
+++ b/src/openhuman/security/policy.rs
@@ -498,11 +498,11 @@ impl SecurityPolicy {
         approved: bool,
     ) -> Result<CommandRiskLevel, String> {
         if !self.is_command_allowed(command) {
-            log::warn!(
-                "[openhuman:policy] Command blocked by allowlist: {}",
-                &command[..floor_char_boundary(command, 80)]
-            );
-            return Err(format!("Command not allowed by security policy: {command}"));
+            let truncated: String = command.chars().take(80).collect();
+            log::warn!("[openhuman:policy] Command blocked by allowlist: {truncated}");
+            return Err(format!(
+                "Command not allowed by security policy: {truncated}"
+            ));
         }
 
         let risk = self.command_risk_level(command);


### PR DESCRIPTION
## Summary

Truncate the full command string returned in error messages from `validate_command_execution` to prevent leaking potentially-sensitive command arguments in error responses.

## Changes

- Reused existing `truncated` variable (80 chars, Unicode-safe via `.chars().take(80)`) in the `Err()` return  
- Updated log line to use the same `truncated` variable for consistency  
- No new imports needed — `floor_char_boundary` is still used elsewhere in the file

## Checklist

- [x] `cargo check` passes  
- [x] `cargo fmt --check` passes  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent truncation of blocked commands in security messages: both warning logs and error responses now show the first 80 characters of a blocked command, yielding clearer and more uniform feedback to users. No external-facing APIs or signatures were changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->