### PR TITLE
fix: add max size check on audio base64 input (closes #1944)

### DIFF
--- a/src/openhuman/voice/cloud_transcribe.rs
+++ b/src/openhuman/voice/cloud_transcribe.rs
@@ -22,6 +22,10 @@ use crate::rpc::RpcOutcome;
 
 const LOG_PREFIX: &str = "[voice_cloud_stt]";
 
+/// Maximum base64 audio input length (~25MB base64 → ~18MB decoded audio).
+/// Prevents OOM on unreasonably large payloads (multi-hour recordings).
+const MAX_AUDIO_BASE64_LEN: usize = 33_554_432;
+
 /// Default model id sent to the backend. The backend's controller currently
 /// resolves this to whichever provider it has configured for audio
 /// transcription (today: GMI Whisper). Callers can override.
@@ -55,6 +59,12 @@ pub async fn transcribe_cloud(
     let trimmed = audio_base64.trim();
     if trimmed.is_empty() {
         return Err("audio_base64 is required".to_string());
+    }
+    if trimmed.len() > MAX_AUDIO_BASE64_LEN {
+        return Err(format!(
+            "audio_base64 exceeds maximum size ({}MB)",
+            MAX_AUDIO_BASE64_LEN / 1_048_576
+        ));
     }
     let audio_bytes = BASE64
         .decode(trimmed)


### PR DESCRIPTION
## Summary

Add a maximum size guard on base64-encoded audio input before decoding to prevent OOM on excessively large payloads.

## Changes

- Added `MAX_AUDIO_BASE64_LEN` constant (33,554,432 bytes = 32 MiB of base64 text ≈ 24 MiB decoded)  
- Added early-return guard before `BASE64.decode()` in `cloud_transcribe.rs`  
- Returns friendly error message when limit is exceeded

## Checklist

- [x] `cargo check` passes  
- [x] `cargo fmt --check` passes  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud transcription now validates audio file size and rejects oversized requests with a clear error message, preventing upload issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->