### PR TITLE
ci: fix staging release workflow gating

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -84,6 +84,15 @@ on:
           the Tauri shell since #1061).
         type: boolean
         default: false
+      skip_e2e_pretest:
+        description:
+          Metadata-only flag propagated by caller workflows when they
+          intentionally bypass the upstream E2E pretest gate. This reusable
+          build workflow does not execute E2E itself, but it logs the policy so
+          the build run captures whether the normal release pretest contract was
+          relaxed for this invocation.
+        type: boolean
+        default: false
       with_updater:
         description:
           When true, set `WITH_UPDATER=true` so the Tauri bundler emits the
@@ -131,6 +140,10 @@ jobs:
           ref: ${{ inputs.build_ref }}
           fetch-depth: 1
           submodules: recursive
+      - name: Log build policy
+        shell: bash
+        run: |
+          echo "[build-desktop] tag=${{ inputs.tag }} build_ref=${{ inputs.build_ref }} skip_e2e_pretest=${{ inputs.skip_e2e_pretest }}"
       - name: Set Xcode version
         if: matrix.settings.platform == 'macos-latest'
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -58,7 +58,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   e2e-linux:

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -1,7 +1,16 @@
 ---
 name: Release Staging
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      skip_e2e:
+        description:
+          Skip the full E2E pretest gate and continue with unit/rust pretests
+          plus the desktop/docker staging build. Use only when the E2E signal is
+          already known and you need to unblock a staging cut.
+        required: false
+        type: boolean
+        default: false
 permissions:
   # `contents: write` is required for the patch bump commit and the
   # `v<version>-staging` tag push performed by `prepare-build` below.
@@ -16,7 +25,8 @@ concurrency:
 #   prepare-build
 #        │
 #        ├── pretest-tests   (reusable test-reusable.yml — unit + rust)
-#        ├── pretest-e2e     (reusable e2e-reusable.yml — all 3 OS, full suite)
+#        ├── pretest-e2e     (reusable e2e-reusable.yml — all 3 OS, full suite;
+#        │                    optional when `skip_e2e` is true)
 #        │
 #        ├── build-desktop      (delegated to .github/workflows/build-desktop.yml)
 #        ├── build-docker       (build only — no GHCR push on staging)
@@ -191,6 +201,7 @@ jobs:
   pretest-e2e:
     name: Pretest — E2E (all OS, full suite)
     needs: [prepare-build]
+    if: ${{ !inputs.skip_e2e }}
     uses: ./.github/workflows/e2e-reusable.yml
     with:
       ref: ${{ needs.prepare-build.outputs.build_ref }}
@@ -205,6 +216,10 @@ jobs:
   build-desktop:
     name: Build desktop matrix
     needs: [prepare-build, pretest-tests, pretest-e2e]
+    if: >-
+      needs.pretest-tests.result == 'success'
+      && (needs.pretest-e2e.result == 'success'
+          || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))
     uses: ./.github/workflows/build-desktop.yml
     secrets: inherit
     with:
@@ -234,6 +249,7 @@ jobs:
       # real consumer. Set `build_sidecar: true` to re-enable a per-platform
       # CLI Actions artifact + its Sentry DIF upload for QA spot-checks.
       build_sidecar: false
+      skip_e2e_pretest: ${{ inputs.skip_e2e }}
 
   # =========================================================================
   # Phase 2b: Build the openhuman-core Docker image without pushing.
@@ -247,6 +263,10 @@ jobs:
   build-docker:
     name: "Docker: build (no push)"
     needs: [prepare-build, pretest-tests, pretest-e2e]
+    if: >-
+      needs.pretest-tests.result == 'success'
+      && (needs.pretest-e2e.result == 'success'
+          || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))
     runs-on: ubuntu-latest
     environment: Production
     steps:

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -35,7 +35,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   unit-tests:

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -13,6 +13,7 @@ This is the **only** acceptable substitute for a `🚫` row in [`TEST-COVERAGE-M
 3. Tick each box only after you have verified the expected outcome with your own eyes.
 4. Paste the completed checklist + sign-off block into the release PR description.
 5. Any item that is genuinely not applicable for this release: mark `N/A` with a one-line reason; do not silently skip.
+6. If `release-staging.yml` was dispatched with `skip_e2e=true`, record the reason and link the most recent relevant green E2E run in the PR notes. That override is for operator recovery, not the default release path.
 
 ---
 


### PR DESCRIPTION
## Summary

- remove the unnecessary `pull-requests: read` permission request from the reusable test/E2E workflows so `release-staging.yml` no longer fails validation at startup
- add a `skip_e2e` `workflow_dispatch` input to `release-staging.yml` and gate the downstream build jobs so an intentional E2E skip still allows the staging build to run
- pass the skip state into `build-desktop.yml` and log it there so the build record shows when the normal E2E pretest contract was relaxed
- update the release manual smoke checklist to require documenting the reason and prior green E2E signal when the override is used

## Problem

- `Release Staging` run [#25957728832](https://github.com/tinyhumansai/openhuman/actions/runs/25957728832) failed during workflow startup, before any jobs ran.
- The concrete validation error was: `test-reusable.yml` requested `pull-requests: read`, but `release-staging.yml` only granted `pull-requests: none` to called workflows.
- Operators also had no supported way to cut a staging build while intentionally bypassing the slow all-OS E2E gate.

## Solution

- narrow the reusable workflow permission surface to `contents: read`, which is all these jobs actually use
- add an explicit `skip_e2e` dispatch flag on `release-staging.yml`
- make `pretest-e2e` conditional on that flag, and allow `build-desktop` / `build-docker` to proceed only when unit/rust pretests passed and E2E either passed or was intentionally skipped
- keep the override visible by threading a metadata flag into `build-desktop.yml` and documenting the operator expectation in the release smoke checklist

## Submission Checklist

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- affects GitHub Actions release-cut behavior only
- fixes staging workflow startup validation and adds an explicit operator-only bypass for the full E2E pretest gate
- no runtime desktop, core, or Tauri behavior changed

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/fix-staging-skip-e2e`
- Commit SHA: `c59c8864`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `gh workflow view .github/workflows/release-staging.yml`
- [x] Rust fmt/check (if changed): `pnpm rust:check`
- [ ] Tauri fmt/check (if changed): N/A: workflow/docs-only change

### Validation Blocked
- `command:` `actionlint .github/workflows/*.yml`
- `error:` `actionlint` is not installed in this environment
- `impact:` workflow syntax was sanity-checked with `gh workflow view`, but no local actionlint pass or live Actions dry run was available

### Behavior Changes
- Intended behavior change: staging releases can now be dispatched with `skip_e2e=true`, and the reusable permission mismatch no longer blocks workflow startup
- User-visible effect: release operators can cut a staging build without waiting on the full E2E matrix when they intentionally choose that override

### Parity Contract
- Legacy behavior preserved: default `release-staging.yml` dispatch still runs the full E2E pretest gate before building
- Guard/fallback/dispatch parity checks: downstream build jobs require unit/rust pretests to pass and accept E2E only when it succeeded or was explicitly skipped

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline permissions configuration for improved security controls.
  * Added optional capability to skip E2E testing during staging releases when necessary.

* **Documentation**
  * Added guidance for release operators on the process for bypassing E2E validation and documenting the rationale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->