### PR TITLE
ci: let staging override skip all pretests

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -84,13 +84,13 @@ on:
           the Tauri shell since #1061).
         type: boolean
         default: false
-      skip_e2e_pretest:
+      skip_pretests:
         description:
           Metadata-only flag propagated by caller workflows when they
-          intentionally bypass the upstream E2E pretest gate. This reusable
-          build workflow does not execute E2E itself, but it logs the policy so
-          the build run captures whether the normal release pretest contract was
-          relaxed for this invocation.
+          intentionally bypass the upstream pretest phase. This reusable build
+          workflow does not execute pretests itself, but it logs the policy so
+          the build run captures whether the normal release gate was relaxed for
+          this invocation.
         type: boolean
         default: false
       with_updater:
@@ -143,7 +143,7 @@ jobs:
       - name: Log build policy
         shell: bash
         run: |
-          echo "[build-desktop] tag=${{ inputs.tag }} build_ref=${{ inputs.build_ref }} skip_e2e_pretest=${{ inputs.skip_e2e_pretest }}"
+          echo "[build-desktop] tag=${{ inputs.tag }} build_ref=${{ inputs.build_ref }} skip_pretests=${{ inputs.skip_pretests }}"
       - name: Set Xcode version
         if: matrix.settings.platform == 'macos-latest'
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -220,7 +220,8 @@ jobs:
     name: Build desktop matrix
     needs: [prepare-build, pretest-tests, pretest-e2e]
     if: >-
-      (needs.pretest-tests.result == 'success'
+      always()
+      && (needs.pretest-tests.result == 'success'
           || (inputs.skip_e2e && needs.pretest-tests.result == 'skipped'))
       && (needs.pretest-e2e.result == 'success'
           || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))
@@ -268,7 +269,8 @@ jobs:
     name: "Docker: build (no push)"
     needs: [prepare-build, pretest-tests, pretest-e2e]
     if: >-
-      (needs.pretest-tests.result == 'success'
+      always()
+      && (needs.pretest-tests.result == 'success'
           || (inputs.skip_e2e && needs.pretest-tests.result == 'skipped'))
       && (needs.pretest-e2e.result == 'success'
           || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       skip_e2e:
         description:
-          Skip the full E2E pretest gate and continue with unit/rust pretests
-          plus the desktop/docker staging build. Use only when the E2E signal is
-          already known and you need to unblock a staging cut.
+          Skip the entire pretest phase (unit/rust plus E2E) and continue
+          directly to the desktop/docker staging build. Use only when the
+          required pretest signal is already known and you need to unblock a
+          staging cut.
         required: false
         type: boolean
         default: false
@@ -24,7 +25,8 @@ concurrency:
 #
 #   prepare-build
 #        │
-#        ├── pretest-tests   (reusable test-reusable.yml — unit + rust)
+#        ├── pretest-tests   (reusable test-reusable.yml — unit + rust;
+#        │                    optional when `skip_e2e` is true)
 #        ├── pretest-e2e     (reusable e2e-reusable.yml — all 3 OS, full suite;
 #        │                    optional when `skip_e2e` is true)
 #        │
@@ -195,6 +197,7 @@ jobs:
   pretest-tests:
     name: Pretest — unit + rust
     needs: [prepare-build]
+    if: ${{ !inputs.skip_e2e }}
     uses: ./.github/workflows/test-reusable.yml
     with:
       ref: ${{ needs.prepare-build.outputs.build_ref }}
@@ -217,7 +220,8 @@ jobs:
     name: Build desktop matrix
     needs: [prepare-build, pretest-tests, pretest-e2e]
     if: >-
-      needs.pretest-tests.result == 'success'
+      (needs.pretest-tests.result == 'success'
+          || (inputs.skip_e2e && needs.pretest-tests.result == 'skipped'))
       && (needs.pretest-e2e.result == 'success'
           || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))
     uses: ./.github/workflows/build-desktop.yml
@@ -249,7 +253,7 @@ jobs:
       # real consumer. Set `build_sidecar: true` to re-enable a per-platform
       # CLI Actions artifact + its Sentry DIF upload for QA spot-checks.
       build_sidecar: false
-      skip_e2e_pretest: ${{ inputs.skip_e2e }}
+      skip_pretests: ${{ inputs.skip_e2e }}
 
   # =========================================================================
   # Phase 2b: Build the openhuman-core Docker image without pushing.
@@ -264,7 +268,8 @@ jobs:
     name: "Docker: build (no push)"
     needs: [prepare-build, pretest-tests, pretest-e2e]
     if: >-
-      needs.pretest-tests.result == 'success'
+      (needs.pretest-tests.result == 'success'
+          || (inputs.skip_e2e && needs.pretest-tests.result == 'skipped'))
       && (needs.pretest-e2e.result == 'success'
           || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))
     runs-on: ubuntu-latest

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -13,7 +13,7 @@ This is the **only** acceptable substitute for a `🚫` row in [`TEST-COVERAGE-M
 3. Tick each box only after you have verified the expected outcome with your own eyes.
 4. Paste the completed checklist + sign-off block into the release PR description.
 5. Any item that is genuinely not applicable for this release: mark `N/A` with a one-line reason; do not silently skip.
-6. If `release-staging.yml` was dispatched with `skip_e2e=true`, record the reason and link the most recent relevant green E2E run in the PR notes. That override is for operator recovery, not the default release path.
+6. If `release-staging.yml` was dispatched with `skip_e2e=true`, record the reason and link the most recent relevant green pretest evidence in the PR notes (unit/rust and E2E as applicable). That override is for operator recovery, not the default release path.
 
 ---
 


### PR DESCRIPTION
## Summary

- make `release-staging.yml` treat `skip_e2e=true` as a full pretest bypass, not just an E2E-only bypass
- allow the downstream staging build jobs to run after intentionally skipped pretest jobs by adding `always()` to the gated `if:` expressions
- rename the reusable build workflow's internal metadata flag to `skip_pretests` so the build logs match the policy being applied
- update the release smoke note so operators must link the relevant prior pretest evidence when using the override

## Problem

- The first staging follow-up only skipped the E2E pretest job; `Pretest — unit + rust` still ran, which does not match the operator intent for the override.
- The dispatched staging run `25969391067` also showed a second issue: even with pretests in the expected state, `Build desktop matrix` and `Docker: build (no push)` were skipped entirely.
- Root cause for the second issue: GitHub Actions treats skipped `needs:` dependencies specially; without `always()` on the downstream `if:`, the job can be skipped before the rest of the condition is considered.

## Solution

- gate both `pretest-tests` and `pretest-e2e` on the existing `skip_e2e` dispatch input so the override suppresses the whole pretest phase
- update the downstream build job conditions to accept either `success` or the intentional `skipped` state for those dependencies
- prefix those downstream conditions with `always()` so GitHub evaluates the skip-aware logic instead of short-circuiting the job
- keep the reusable build log and release-ops docs aligned with the new semantics

## Submission Checklist

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — `N/A: behaviour-only workflow/docs change`
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- affects GitHub Actions staging release behavior only
- fixes two operator-path bugs: the override now skips all pretests, and the desktop/docker build jobs no longer get skipped due to `needs` semantics when that override is used
- no runtime desktop/core behavior changed

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: rerun `release-staging.yml` with `skip_e2e=true` after this merges

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/fix-staging-skip-all-pretests`
- Commit SHA: `b90f1fff`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `gh workflow view .github/workflows/release-staging.yml`
- [x] Rust fmt/check (if changed): `pnpm rust:check`
- [ ] Tauri fmt/check (if changed): N/A: workflow/docs-only change

### Validation Blocked
- `command:` `actionlint .github/workflows/*.yml`
- `error:` `actionlint` is not installed in this environment
- `impact:` workflow syntax was sanity-checked with `gh workflow view`, but no local actionlint pass or live dry-run of the fixed staging workflow was available

### Behavior Changes
- Intended behavior change: `skip_e2e=true` now bypasses the entire staging pretest phase, and the downstream build jobs still execute under that intentional skipped state
- User-visible effect: release operators can dispatch the staging release override and actually get desktop/docker artifacts instead of a green run with all build jobs skipped

### Parity Contract
- Legacy behavior preserved: default `release-staging.yml` dispatch still requires the full pretest gate before building
- Guard/fallback/dispatch parity checks: downstream build jobs now require either successful pretests or an explicit skipped state paired with the override flag, and they use `always()` so GitHub evaluates that contract correctly

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed workflow inputs and refined CI/CD job dependencies for improved clarity and control when skipping pretests during staging builds.

* **Documentation**
  * Updated release smoke testing procedures to specify required pretest evidence when E2E testing is skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->