### PR TITLE
perf (prompt_injection): cache classifier behind Lazy<> (was Box-alloc per call)

### DIFF
--- a/src/openhuman/prompt_injection/detector.rs
+++ b/src/openhuman/prompt_injection/detector.rs
@@ -174,14 +174,24 @@ static DETECTION_RULES: Lazy<Vec<DetectionRule>> = Lazy::new(|| {
     ]
 });
 
-fn optional_classifier() -> Option<Box<dyn OptionalClassifier>> {
+static OPTIONAL_CLASSIFIER: Lazy<Option<Box<dyn OptionalClassifier>>> = Lazy::new(|| {
     let choice = env::var("OPENHUMAN_PROMPT_INJECTION_CLASSIFIER")
         .unwrap_or_else(|_| "off".to_string())
         .to_ascii_lowercase();
-    match choice.as_str() {
+    let classifier: Option<Box<dyn OptionalClassifier>> = match choice.as_str() {
         "heuristic" => Some(Box::new(HeuristicClassifier)),
         _ => None,
-    }
+    };
+    tracing::debug!(
+        "[prompt_injection] optional classifier resolved choice={:?} active={}",
+        choice,
+        classifier.is_some()
+    );
+    classifier
+});
+
+fn optional_classifier() -> Option<&'static dyn OptionalClassifier> {
+    OPTIONAL_CLASSIFIER.as_deref()
 }
 
 fn normalize_prompt(input: &str) -> NormalizedPrompt {


### PR DESCRIPTION
## Summary

Wraps `optional_classifier()` in [`src/openhuman/prompt_injection/detector.rs`](https://github.com/tinyhumansai/openhuman/blob/main/src/openhuman/prompt_injection/detector.rs) with `Lazy<Option<Box<dyn OptionalClassifier>>>` so the env-var read and `Box` allocation run once per process instead of once per prompt analysis. Closes #1943.

## Problem

`optional_classifier()` reads the `OPENHUMAN_PROMPT_INJECTION_CLASSIFIER` env var, allocates two `String`s (the `"off"` fallback and the `to_ascii_lowercase` copy), and on `"heuristic"` allocates a fresh `Box<dyn OptionalClassifier>`, all on every call. The single caller is `analyze_prompt` on the prompt-screening hot path, so every agent prompt analysis pays this cost. The env var is fixed at startup and the classifier choice is deterministic; redoing the resolution per call is wasted work.

## Solution

Promote the resolution to a `static Lazy<Option<Box<dyn OptionalClassifier>>>` so it runs at most once. Pattern matches the file's other `Lazy::new(...)` statics (`SPACE_RE`, `BASE64_RE`, `DETECTION_RULES`):

```rust
static OPTIONAL_CLASSIFIER: Lazy<Option<Box<dyn OptionalClassifier>>> = Lazy::new(|| {
    let choice = env::var("OPENHUMAN_PROMPT_INJECTION_CLASSIFIER")
        .unwrap_or_else(|_| "off".to_string())
        .to_ascii_lowercase();
    let classifier: Option<Box<dyn OptionalClassifier>> = match choice.as_str() {
        "heuristic" => Some(Box::new(HeuristicClassifier)),
        _ => None,
    };
    tracing::debug!(
        "[prompt_injection] optional classifier resolved choice={:?} active={}",
        choice,
        classifier.is_some()
    );
    classifier
});

fn optional_classifier() -> Option<&'static dyn OptionalClassifier> {
    OPTIONAL_CLASSIFIER.as_deref()
}
```

Return type shifts from owned `Box<dyn OptionalClassifier>` to borrowed `&'static dyn OptionalClassifier`. `analyze_prompt`'s use of `if let Some(classifier) = optional_classifier() { classifier.classify(&normalized) }` compiles unchanged because trait-method dispatch works the same on `&dyn` as on `Box<dyn>`.

`tracing::debug!` inside the initializer fires once at startup and reports the resolved choice for diagnosability; env-var value only, no PII.

Net diff: +13 -3 in one file.

## Submission Checklist

- [x] N/A: perf refactor preserves the function's contract; the existing `prompt_injection` test suite (`blocks_direct_override_and_exfiltration`, `allows_normal_prompt`, plus 5 others) covers the call site and continues to pass.
- [x] N/A: no new code lines under coverage gate; the refactor reuses already-tested behavior.
- [x] N/A: no feature rows affected.
- [x] N/A: no feature IDs touched.
- [x] N/A: no external dependencies introduced; `once_cell::sync::Lazy` already imported.
- [x] N/A: no release-cut surfaces touched.
- [x] Linked issue closed via `Closes #1943` in the `## Related` section.

## Impact

- Hot path: prompt-screening no longer does an env-var read + 2 `String` allocs + 1 `Box` alloc per call.
- No public API change (`optional_classifier` is private to the module).
- One-time debug log on first invocation surfaces the resolved classifier choice for future diagnosis.

## Related

- Closes: #1943

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> N/A: Human-authored, AI-assisted drafting.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `perf/prompt-injection-classifier-cache`
- Commit SHA: `90408fee`

### Validation Run
- [x] N/A: no JS/TS changed.
- [x] N/A: no TS types changed.
- [x] N/A: no TS to compile.
- [x] `cargo check -p openhuman --lib` and `cargo test --package openhuman --lib openhuman::prompt_injection` both pass locally (7/7 tests).
- [x] N/A: no Tauri code changed.

### Validation Blocked
- `command:` pre-push hook may exit on inherited `cargo check --manifest-path src-tauri/Cargo.toml` failure on upstream main (documented in PR #1786). This branch only edits `src/openhuman/prompt_injection/detector.rs` so it cannot be caused by this change. Per-file required checks (`cargo fmt --check` on `detector.rs`, focused `cargo test` on `prompt_injection`) re-run individually and pass.
- `error:` (as above)
- `impact:` Pushed with `--no-verify` per the per-file pre-push standards checklist.

### Behavior Changes
- Intended behavior change: none functionally; the function returns the same classifier choice for the same env var value. Performance: env-var read and `Box` allocation move from per-call to once-per-process.
- User-visible effect: no perceptible change to a single user; reduces cycles + allocator pressure on agent prompt-screening.

### Parity Contract
- Legacy behaviour preserved: Yes. Same env var, same choice mapping, same `None` fallback. Only the call signature changes from owned `Box<dyn>` to `&'static dyn`; the single caller's pattern match works on both.
- Guard/fallback/dispatch parity checks: N/A; no dispatch path touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None. Overlap check at branch-push time confirmed zero open PRs touch `src/openhuman/prompt_injection/`.
- Canonical PR: This one.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized prompt injection detector initialization to reduce redundant processing and improve performance efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->