### PR TITLE
fix(i18n): complete zh-CN onboarding translations

### DIFF
--- a/app/src/lib/i18n/__tests__/I18nContext.test.tsx
+++ b/app/src/lib/i18n/__tests__/I18nContext.test.tsx
@@ -6,8 +6,18 @@ import { describe, expect, it } from 'vitest';
 import localeReducer, { setLocale } from '../../../store/localeSlice';
 import en from '../en';
 import { I18nProvider, useT } from '../I18nContext';
-import type { Locale } from '../types';
+import type { Locale, TranslationMap } from '../types';
 import zhCN from '../zh-CN';
+
+function unwrapTranslationMap(map: TranslationMap): TranslationMap {
+  const raw = map as unknown as Record<string, unknown>;
+  return raw != null &&
+    typeof raw === 'object' &&
+    'default' in raw &&
+    typeof raw.default === 'object'
+    ? (raw.default as TranslationMap)
+    : map;
+}
 
 function Probe() {
   const { locale, t } = useT();
@@ -46,8 +56,11 @@ describe('I18nProvider', () => {
   });
 
   it('keeps the Simplified Chinese locale complete against English keys', () => {
-    const missingKeys = Object.keys(en).filter(key => !(key in zhCN));
+    const englishKeys = Object.keys(unwrapTranslationMap(en));
+    const simplifiedChinese = unwrapTranslationMap(zhCN);
+    const missingKeys = englishKeys.filter(key => !(key in simplifiedChinese));
 
+    expect(englishKeys.length).toBeGreaterThan(0);
     expect(missingKeys).toEqual([]);
   });
 });

--- a/app/src/lib/i18n/__tests__/I18nContext.test.tsx
+++ b/app/src/lib/i18n/__tests__/I18nContext.test.tsx
@@ -4,8 +4,10 @@ import { Provider } from 'react-redux';
 import { describe, expect, it } from 'vitest';
 
 import localeReducer, { setLocale } from '../../../store/localeSlice';
+import en from '../en';
 import { I18nProvider, useT } from '../I18nContext';
 import type { Locale } from '../types';
+import zhCN from '../zh-CN';
 
 function Probe() {
   const { locale, t } = useT();
@@ -41,5 +43,11 @@ describe('I18nProvider', () => {
     expect(screen.getByText('Bahasa')).toBeInTheDocument();
     expect(screen.getByText('Bersihkan Data Aplikasi')).toBeInTheDocument();
     expect(screen.getByText('Quit')).toBeInTheDocument();
+  });
+
+  it('keeps the Simplified Chinese locale complete against English keys', () => {
+    const missingKeys = Object.keys(en).filter(key => !(key in zhCN));
+
+    expect(missingKeys).toEqual([]);
   });
 });

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -86,6 +86,8 @@ const zhCN: TranslationMap = {
   'settings.logOutDesc': '退出当前账户',
   'settings.language': '语言',
   'settings.languageDesc': '应用界面显示语言',
+  'settings.alerts': '通知',
+  'settings.alertsDesc': '查看收件箱中的最新通知和活动',
 
   // Settings: Account
   'settings.account.recoveryPhrase': '恢复短语',
@@ -223,6 +225,96 @@ const zhCN: TranslationMap = {
   'onboarding.skip': '跳过',
   'onboarding.getStarted': '开始使用',
 
+  // Onboarding: runtime-choice step (Cloud vs Custom)
+  'onboarding.runtimeChoice.title': '你希望如何运行 OpenHuman？',
+  'onboarding.runtimeChoice.subtitle': '选择最适合你的设置。之后可在设置中更改。',
+  'onboarding.runtimeChoice.cloud.title': '简单模式',
+  'onboarding.runtimeChoice.cloud.tagline': '让 OpenHuman 为你管理一切。',
+  'onboarding.runtimeChoice.cloud.f1': '内置安全保护',
+  'onboarding.runtimeChoice.cloud.f2': '令牌压缩，让用量更耐用',
+  'onboarding.runtimeChoice.cloud.f3': '一个订阅，包含所有模型',
+  'onboarding.runtimeChoice.cloud.f4': '无需管理 API 密钥',
+  'onboarding.runtimeChoice.cloud.f5': '设置简单',
+  'onboarding.runtimeChoice.custom.title': '自定义运行',
+  'onboarding.runtimeChoice.custom.tagline': '使用你自己的密钥。完全掌控使用的服务。',
+  'onboarding.runtimeChoice.custom.f1': '几乎所有功能都需要 API 密钥',
+  'onboarding.runtimeChoice.custom.f2': '可复用你已经付费的服务',
+  'onboarding.runtimeChoice.custom.f3': '如果全部本地运行，也可以免费',
+  'onboarding.runtimeChoice.custom.f4': '更多设置，更多可调选项',
+  'onboarding.runtimeChoice.custom.f5': '最适合高级用户和开发者',
+  'onboarding.runtimeChoice.cloud.creditHighlight': '赠送 $1 额度用于试用',
+  'onboarding.runtimeChoice.continueCloud': '继续使用简单模式',
+  'onboarding.runtimeChoice.continueCustom': '继续使用自定义模式',
+  'onboarding.runtimeChoice.recommended': '推荐',
+
+  // Onboarding: API keys step (only when Custom is picked)
+  'onboarding.apiKeys.title': '添加你的 API 密钥',
+  'onboarding.apiKeys.subtitle':
+    '你可以现在粘贴，也可以跳过并稍后在设置 › AI 中添加。密钥会加密存储在此设备上。',
+  'onboarding.apiKeys.openaiLabel': 'OpenAI API 密钥',
+  'onboarding.apiKeys.openaiPlaceholder': 'sk-...',
+  'onboarding.apiKeys.anthropicLabel': 'Anthropic API 密钥',
+  'onboarding.apiKeys.anthropicPlaceholder': 'sk-ant-...',
+  'onboarding.apiKeys.saveError': '无法保存该密钥。请仔细检查后重试。',
+  'onboarding.apiKeys.skipForNow': '暂时跳过',
+  'onboarding.apiKeys.continue': '保存并继续',
+  'onboarding.apiKeys.saving': '保存中…',
+
+  // Onboarding: Custom wizard (Inference / Voice / OAuth / Search / Memory)
+  'onboarding.custom.stepperInference': '推理',
+  'onboarding.custom.stepperVoice': '语音',
+  'onboarding.custom.stepperOAuth': 'OAuth',
+  'onboarding.custom.stepperSearch': '搜索',
+  'onboarding.custom.stepperMemory': '记忆',
+  'onboarding.custom.stepCounter': '第 {n} 步，共 {total} 步',
+  'onboarding.custom.defaultTitle': '默认',
+  'onboarding.custom.defaultSubtitle': '让 OpenHuman 为你管理。',
+  'onboarding.custom.configureTitle': '配置',
+  'onboarding.custom.configureSubtitle': '我来选择使用什么。',
+  'onboarding.custom.progressAriaLabel': '入门进度',
+  'onboarding.custom.continue': '继续',
+  'onboarding.custom.back': '返回',
+  'onboarding.custom.finish': '完成设置',
+  'onboarding.custom.configureLater':
+    '你可以在入门流程结束后继续配置。完成后，我们会带你前往对应的设置页面。',
+  'onboarding.custom.openSettings': '在设置中打开',
+
+  // Onboarding: Custom > Inference (text)
+  'onboarding.custom.inference.title': '推理（文本）',
+  'onboarding.custom.inference.subtitle': '哪个语言模型应该回答你的问题并运行你的智能体？',
+  'onboarding.custom.inference.defaultDesc':
+    'OpenHuman 会为每种工作负载路由到合适的默认模型。无需密钥，无需设置。',
+  'onboarding.custom.inference.configureDesc':
+    '使用你自己的 OpenAI 或 Anthropic 密钥。我们会将它用于所有文本类工作负载。',
+
+  // Onboarding: Custom > Voice
+  'onboarding.custom.voice.title': '语音',
+  'onboarding.custom.voice.subtitle': '用于语音模式的语音转文本和文本转语音。',
+  'onboarding.custom.voice.defaultDesc': 'OpenHuman 内置托管的 STT/TTS，开箱即用。无需额外配置。',
+  'onboarding.custom.voice.configureDesc':
+    '使用你自己的 ElevenLabs、OpenAI Whisper 等服务。在设置 › 语音中配置。',
+
+  // Onboarding: Custom > OAuth (Composio)
+  'onboarding.custom.oauth.title': '连接（OAuth）',
+  'onboarding.custom.oauth.subtitle': 'Gmail、Slack、Notion 以及其他需要 OAuth 的连接服务。',
+  'onboarding.custom.oauth.defaultDesc':
+    'OpenHuman 使用托管的 Composio 工作区。之后每个服务都可一键连接。',
+  'onboarding.custom.oauth.configureDesc':
+    '使用你自己的 Composio 账户或 API 密钥。在设置 › 连接中配置。',
+
+  // Onboarding: Custom > Search
+  'onboarding.custom.search.title': '网页搜索',
+  'onboarding.custom.search.subtitle': 'OpenHuman 如何代表你搜索网页。',
+  'onboarding.custom.search.defaultDesc': 'OpenHuman 使用托管搜索后端。无需密钥。',
+  'onboarding.custom.search.configureDesc':
+    '使用你自己的搜索提供商密钥（Tavily、Brave 等）。在设置 › 工具中配置。',
+
+  // Onboarding: Custom > Memory
+  'onboarding.custom.memory.title': '记忆',
+  'onboarding.custom.memory.subtitle': 'OpenHuman 如何记住你的上下文、偏好和历史对话。',
+  'onboarding.custom.memory.defaultDesc': 'OpenHuman 会自动管理记忆存储和检索。无需设置。',
+  'onboarding.custom.memory.configureDesc': '你可以自行查看、导出或清除记忆。在设置 › 记忆中配置。',
+
   // Accounts
   'accounts.addAccount': '添加账户',
   'accounts.manageAccounts': '管理账户',
@@ -293,6 +385,7 @@ const zhCN: TranslationMap = {
   'misc.downloading': '下载中...',
   'misc.installing': '安装中...',
   'misc.beta': '测试版',
+  'misc.betaFeedback': '发送反馈',
 
   // Mnemonic / Recovery
   'mnemonic.title': '恢复短语',


### PR DESCRIPTION
## Summary

- Completes the Simplified Chinese translation map for the current onboarding/runtime-choice copy.
- Adds missing zh-CN strings for Settings alerts, runtime selection, custom API key setup, custom wizard steps, and beta feedback.
- Adds an i18n regression test that fails when zh-CN falls behind the English translation key set.

## Problem

- Closes #1947.
- The app already exposes Simplified Chinese as a selectable display language, but `zh-CN.ts` was missing 69 keys that exist in `en.ts`.
- Missing keys fell back to English, especially across onboarding and runtime setup, which creates a mixed-language first-run experience.

## Solution

- Added the missing Simplified Chinese strings in the same groups used by the English translation file.
- Added a focused drift guard in `I18nContext.test.tsx` so future English keys must be added to zh-CN deliberately.
- Left Indonesian fallback behavior unchanged; this PR only tightens zh-CN completeness.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — N/A: translation-map data plus a focused i18n drift guard; CI coverage gate remains authoritative for changed lines.
- [x] Coverage matrix updated — N/A: i18n translation completeness does not add/remove/rename feature rows.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature matrix IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: translation copy only, no release smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: frontend copy only; no Rust, Tauri, backend, or persistence changes.
- User-visible effect: Simplified Chinese users see localized onboarding/runtime setup strings instead of English fallback text.
- Performance/security/migration impact: none.

## Related

- Closes #1947
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `zh-cn-i18n-completeness`
- Commit SHA: `22be22af`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/lib/i18n/__tests__/I18nContext.test.tsx`
- [x] Focused review-fix tests: `pnpm debug unit src/lib/i18n/__tests__/I18nContext.test.tsx`
- [x] Lint: `pnpm lint` (exit 0; existing warning set remains)
- [x] Pre-push token lint: `pnpm --dir app run lint:commands-tokens`
- [x] Rust fmt/check (if changed): `pnpm rust:check` (exit 0; existing warning set remains)
- [x] Tauri fmt/check (if changed): covered by `pnpm --filter openhuman-app format:check` and `pnpm rust:check`

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Simplified Chinese locale now covers the onboarding/runtime-choice key set instead of falling back to English for those strings.
- User-visible effect: zh-CN users see localized setup and settings copy.

### Parity Contract
- Legacy behavior preserved: English and Indonesian translation fallback behavior remains unchanged.
- Guard/fallback/dispatch parity checks: Added zh-CN key completeness guard against `en.ts`; no routing or dispatch logic changed.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found for `Monking-21:zh-cn-i18n-completeness`.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Simplified Chinese translations for alerts/notifications settings.
  * Expanded Chinese localization for onboarding flows, including runtime choices, API key setup, and advanced/custom setup steps.
  * Added Chinese copy for beta feedback.

* **Tests**
  * Added a test that validates translation completeness to ensure no missing keys between English and Simplified Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->