### PR TITLE
fix(socket): use core auth user id for socket state scoping

### DIFF
--- a/app/src/services/__tests__/socketService.events.test.ts
+++ b/app/src/services/__tests__/socketService.events.test.ts
@@ -27,7 +27,9 @@ vi.mock('../../store/channelConnectionsSlice', () => ({
   upsertChannelConnection: vi.fn((x: unknown) => x),
 }));
 vi.mock('../../lib/coreState/store', () => ({
-  getCoreStateSnapshot: vi.fn(() => ({ snapshot: { sessionToken: null } })),
+  getCoreStateSnapshot: vi.fn(() => ({
+    snapshot: { auth: { userId: 'core-user-id' }, sessionToken: null },
+  })),
 }));
 class MockMCPTransport {}
 vi.mock('../../lib/mcp', () => ({ SocketIOMCPTransportImpl: MockMCPTransport }));

--- a/app/src/services/__tests__/socketService.test.ts
+++ b/app/src/services/__tests__/socketService.test.ts
@@ -131,6 +131,30 @@ describe('socketService — resolveCoreSocketBaseUrl uses getCoreRpcUrl', () => 
     });
   });
 
+  it('falls back to pending when the core auth snapshot is not available yet', async () => {
+    const { getCoreStateSnapshot } = await import('../../lib/coreState/store');
+    const { setStatusForUser } = await import('../../store/socketSlice');
+    const setStatusForUserMock = vi.mocked(setStatusForUser);
+
+    vi.mocked(getCoreStateSnapshot).mockReturnValue({
+      snapshot: { sessionToken: 'mock-token' },
+    } as ReturnType<typeof getCoreStateSnapshot>);
+
+    hoisted.getCoreRpcUrlMock.mockResolvedValue('http://127.0.0.1:7788/rpc');
+
+    const { socketService } = await import('../socketService');
+    socketService.disconnect();
+    setStatusForUserMock.mockClear();
+    socketService.connect('mock-token-with-missing-auth');
+
+    await pollUntil(() =>
+      expect(setStatusForUserMock).toHaveBeenCalledWith({
+        userId: '__pending__',
+        status: 'connecting',
+      })
+    );
+  });
+
   it('strips /rpc suffix from the resolved RPC URL to derive the socket base', async () => {
     const { io } = await import('socket.io-client');
     const ioMock = vi.mocked(io);

--- a/app/src/services/__tests__/socketService.test.ts
+++ b/app/src/services/__tests__/socketService.test.ts
@@ -47,7 +47,9 @@ vi.mock('../../store/connectivitySlice', () => ({
 
 // Mock coreState
 vi.mock('../../lib/coreState/store', () => ({
-  getCoreStateSnapshot: vi.fn(() => ({ snapshot: { sessionToken: null } })),
+  getCoreStateSnapshot: vi.fn(() => ({
+    snapshot: { auth: { userId: 'core-user-id' }, sessionToken: null },
+  })),
 }));
 
 // Mock MCP as a class so `new SocketIOMCPTransportImpl(...)` works at runtime.
@@ -96,6 +98,37 @@ describe('socketService — resolveCoreSocketBaseUrl uses getCoreRpcUrl', () => 
 
     // Wait until getCoreRpcUrl has actually been invoked (deterministic, no sleep)
     await pollUntil(() => expect(hoisted.getCoreRpcUrlMock).toHaveBeenCalled());
+  });
+
+  it('scopes socket state from core auth userId instead of decoding the JWT payload', async () => {
+    const { getCoreStateSnapshot } = await import('../../lib/coreState/store');
+    const { setStatusForUser } = await import('../../store/socketSlice');
+    const setStatusForUserMock = vi.mocked(setStatusForUser);
+    setStatusForUserMock.mockClear();
+
+    vi.mocked(getCoreStateSnapshot).mockReturnValue({
+      snapshot: {
+        auth: { userId: 'core-user-id' },
+        sessionToken: 'header.eyJ1c2VySWQiOiJqd3QtdXNlci1pZCJ9.signature',
+      },
+    } as ReturnType<typeof getCoreStateSnapshot>);
+
+    hoisted.getCoreRpcUrlMock.mockResolvedValue('http://127.0.0.1:7788/rpc');
+
+    const { socketService } = await import('../socketService');
+    socketService.disconnect();
+    socketService.connect('header.eyJ1c2VySWQiOiJqd3QtdXNlci1pZCJ9.signature');
+
+    await pollUntil(() =>
+      expect(setStatusForUserMock).toHaveBeenCalledWith({
+        userId: 'core-user-id',
+        status: 'connecting',
+      })
+    );
+    expect(setStatusForUserMock).not.toHaveBeenCalledWith({
+      userId: 'jwt-user-id',
+      status: 'connecting',
+    });
   });
 
   it('strips /rpc suffix from the resolved RPC URL to derive the socket base', async () => {

--- a/app/src/services/socketService.ts
+++ b/app/src/services/socketService.ts
@@ -93,7 +93,7 @@ function normalizeChannelConnectionUpdatePayload(
 }
 
 function getSocketUserId(): string {
-  return getCoreStateSnapshot().snapshot.auth.userId ?? '__pending__';
+  return getCoreStateSnapshot().snapshot?.auth?.userId ?? '__pending__';
 }
 
 class SocketService {

--- a/app/src/services/socketService.ts
+++ b/app/src/services/socketService.ts
@@ -39,12 +39,6 @@ async function resolveCoreSocketBaseUrl(): Promise<string> {
   return coreSocketBaseFromRpcUrl(rpcUrl);
 }
 
-interface JwtPayload {
-  tgUserId?: string;
-  userId?: string;
-  sub?: string;
-}
-
 interface ChannelConnectionUpdatedEvent {
   channel: ChannelType;
   authMode: ChannelAuthMode;
@@ -99,22 +93,7 @@ function normalizeChannelConnectionUpdatePayload(
 }
 
 function getSocketUserId(): string {
-  const token = getCoreStateSnapshot().snapshot.sessionToken;
-  if (!token) return '__pending__';
-
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return '__pending__';
-
-    const payloadBase64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const payloadJson = atob(payloadBase64);
-    const payload = JSON.parse(payloadJson) as JwtPayload;
-
-    const id = payload.tgUserId || payload.userId || payload.sub;
-    return id || '__pending__';
-  } catch {
-    return '__pending__';
-  }
+  return getCoreStateSnapshot().snapshot.auth.userId ?? '__pending__';
 }
 
 class SocketService {


### PR DESCRIPTION
## Summary

- Removed client-side JWT payload decoding from `socketService`.
- Scoped socket Redux state from the authenticated core state snapshot.
- Added regression coverage to ensure JWT payload user IDs are ignored.

## Problem

- `socketService` decoded `sessionToken` with `atob()` to derive a socket user ID.
- That duplicated auth interpretation in the frontend and could drift from the core-authenticated user snapshot.
- Socket state should trust core auth state, not token internals.

## Solution

- Updated `getSocketUserId()` to use `getCoreStateSnapshot().snapshot.auth.userId ?? '__pending__'`.
- Removed the JWT payload parsing type and decode path.
- Updated socket service mocks to include `auth.userId`.
- Added a focused test where the JWT payload contains a different user ID and the core snapshot still wins.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** - focused tests added for changed socket-service behavior; CI will enforce final changed-line coverage.
- [x] Coverage matrix updated - N/A: no feature added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no coverage-matrix feature row affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: frontend socket state source change only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Frontend socket state now follows the core-authenticated user ID.
- Reduces auth drift risk by removing frontend JWT interpretation.
- No new runtime dependencies, migrations, backend changes, or user-visible UI changes.

## Related

- Closes #1942
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/1942-socket-user-id-from-core-state`
- Commit SHA: `1801d215`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests:
  - `pnpm.cmd --dir app exec vitest run --config test/vitest.config.ts src/services/__tests__/socketService.test.ts src/services/__tests__/socketService.events.test.ts`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path ../Cargo.toml --all --check`
  - `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check`
  - `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] Tauri fmt/check (if changed):
  - `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check`
  - `cargo check --manifest-path src-tauri/Cargo.toml`

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: socket user state is keyed from core auth snapshot user ID instead of decoded JWT payload fields.
- User-visible effect: none expected.

### Parity Contract
- Legacy behavior preserved: socket connect/disconnect/backend status dispatch flow remains unchanged.
- Guard/fallback/dispatch parity checks: fallback remains `__pending__` when no core auth user ID is available; focused tests cover socket connection and event dispatch behavior.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User identity for socket connections is now resolved from the core auth state (reducing incorrect JWT-derived identities) and falls back to a pending placeholder when missing.
* **Tests**
  * Added and updated unit tests to verify socket user resolution behavior and the pending-user fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->