### PR TITLE
fix(api): avoid logging bearer tokens in request diagnostics

### DIFF
--- a/app/src/services/__tests__/apiClient.test.ts
+++ b/app/src/services/__tests__/apiClient.test.ts
@@ -4,10 +4,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tauri-apps/api/app', () => ({ getVersion: vi.fn() }));
 
+const configMock = vi.hoisted(() => ({ isDev: true }));
+
+vi.mock('../../utils/config', () => ({
+  APP_VERSION: '0.0.0-test',
+  get IS_DEV() {
+    return configMock.isDev;
+  },
+}));
+
 describe('apiClient version headers', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    configMock.isDev = true;
     vi.mocked(isTauri).mockReturnValue(false);
     vi.stubGlobal('fetch', vi.fn());
   });
@@ -47,6 +57,54 @@ describe('apiClient version headers', () => {
     const headers = requestInit.headers as Record<string, string>;
     expect(headers['x-tauri-version']).toBe('1.2.3desktop+build');
     expect(headers).not.toHaveProperty('x-web-version');
+  });
+
+  it('logs request diagnostics in dev without leaking authorization headers', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({ success: true }),
+    } as Response);
+
+    const { apiClient, setStoreForApiClient } = await import('../apiClient');
+    setStoreForApiClient(() => 'secret-session-token');
+
+    await apiClient.post('/version-check', { ok: true });
+
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const requestHeaders = requestInit.headers as Record<string, string>;
+    expect(requestHeaders.Authorization).toBe('Bearer secret-session-token');
+
+    const logMock = vi.mocked(console.log);
+    expect(logMock).toHaveBeenCalledWith(
+      'request',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String),
+          authorization: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it('does not log request diagnostics in production', async () => {
+    configMock.isDev = false;
+
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({ success: true }),
+    } as Response);
+
+    const { apiClient, setStoreForApiClient } = await import('../apiClient');
+    setStoreForApiClient(() => 'secret-session-token');
+
+    await apiClient.get('/version-check');
+
+    expect(console.log).not.toHaveBeenCalledWith('request', expect.anything());
   });
 
   it('retries tauri version lookup after a transient failure', async () => {

--- a/app/src/services/apiClient.ts
+++ b/app/src/services/apiClient.ts
@@ -1,4 +1,5 @@
 import type { ApiError } from '../types/api';
+import { IS_DEV } from '../utils/config';
 import { getBackendUrl } from './backendUrl';
 import { getClientVersionHeaders } from './clientVersionHeaders';
 
@@ -37,7 +38,7 @@ class ApiClient {
   /**
    * Build headers for the request
    */
-  private async buildHeaders(options: RequestOptions): Promise<HeadersInit> {
+  private async buildHeaders(options: RequestOptions): Promise<Record<string, string>> {
     const versionHeaders = await getClientVersionHeaders();
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -56,6 +57,13 @@ class ApiClient {
     return headers;
   }
 
+  private sanitizeRequestLogHeaders(headers: HeadersInit): Record<string, string> {
+    const safeHeaders = { ...(headers as Record<string, string>) };
+    delete safeHeaders.Authorization;
+    delete safeHeaders.authorization;
+    return safeHeaders;
+  }
+
   /**
    * Make an API request
    */
@@ -66,7 +74,9 @@ class ApiClient {
     const url = `${baseUrl}${endpoint}`;
     const headers = await this.buildHeaders({ ...options, requireAuth });
 
-    console.log('request', { url, headers, body, method });
+    if (IS_DEV) {
+      console.log('request', { url, headers: this.sanitizeRequestLogHeaders(headers), method });
+    }
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout);


### PR DESCRIPTION
## Summary

- Limits shared API request diagnostics to dev builds.
- Redacts `Authorization` / `authorization` headers before logging request diagnostics.
- Adds regression tests for dev log redaction and production log suppression.

## Problem

`apiClient` logged outbound request diagnostics with full headers. For authenticated requests, those headers can include `Authorization: Bearer <token>`, which could expose session tokens through console output.

## Solution

Request diagnostics now only run when `IS_DEV` is true. In dev builds, the logged headers are copied and stripped of auth header fields before logging. The actual request headers are unchanged, so authenticated API calls still send the bearer token.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines covered by `pnpm test:coverage`
- [x] Coverage matrix updated — N/A: security logging behavior-only change
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature ID
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface changed
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Improves frontend security by preventing bearer tokens from appearing in production request logs. Dev request diagnostics are preserved, but auth headers are redacted. API request behavior is unchanged.

## Related

- Closes #1921
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/1921-api-client-safe-request-log`
- Commit SHA: `d3f6efc5`

### Validation Run
- [x] `pnpm.cmd format:check`
- [x] `pnpm.cmd typecheck`
- [x] `pnpm.cmd lint`
- [x] `pnpm.cmd test:coverage`
- [x] Focused tests: `pnpm.cmd --dir app exec vitest run --config test/vitest.config.ts src/services/__tests__/apiClient.test.ts`
- [x] Rust fmt/check: N/A, frontend-only change
- [x] Tauri fmt/check: N/A, frontend-only change

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: production builds no longer emit API request diagnostics; dev diagnostics redact auth headers.
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: authenticated API requests still send `Authorization` headers.
- Guard/fallback/dispatch parity checks: tests verify fetch receives the bearer token while console diagnostics omit it.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development-mode request diagnostics logging to aid debugging.
  * Logs are sanitized to strip authentication headers before output.

* **Tests**
  * Added tests covering diagnostic logging in both dev and production modes, ensuring logs are emitted only in dev and that auth headers are omitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->