### PR TITLE
Add WeChat embedded webview support

### DIFF
--- a/app/src-tauri/src/webview_accounts/mod.rs
+++ b/app/src-tauri/src/webview_accounts/mod.rs
@@ -49,6 +49,7 @@ const GOOGLE_MEET_RECIPE_JS: &str = include_str!("../../recipes/google-meet/reci
 fn provider_url(provider: &str) -> Option<&'static str> {
     match provider {
         "whatsapp" => Some("https://web.whatsapp.com/"),
+        "wechat" => Some("https://web.wechat.com/"),
         "telegram" => Some("https://web.telegram.org/k/"),
         "linkedin" => Some("https://www.linkedin.com/messaging/"),
         "slack" => Some("https://app.slack.com/client/"),
@@ -87,6 +88,12 @@ fn provider_is_supported(provider: &str) -> bool {
 fn provider_allowed_hosts(provider: &str) -> &'static [&'static str] {
     match provider {
         "whatsapp" => &["whatsapp.com", "whatsapp.net", "wa.me"],
+        "wechat" => &[
+            "wechat.com",
+            "wx.qq.com",
+            "weixin.qq.com",
+            "login.weixin.qq.com",
+        ],
         "telegram" => &["telegram.org", "t.me"],
         "linkedin" => &[
             "linkedin.com",
@@ -649,6 +656,7 @@ async fn post_provider_surfaces_event(args: &RecipeEventArgs) -> Result<(), Stri
 pub fn provider_display_name(provider: &str) -> &'static str {
     match provider {
         "whatsapp" => "WhatsApp",
+        "wechat" => "WeChat",
         "telegram" => "Telegram",
         "linkedin" => "LinkedIn",
         "slack" => "Slack",
@@ -1751,12 +1759,13 @@ fn data_directory_for<R: Runtime>(app: &AppHandle<R>, account_id: &str) -> Resul
 
 /// Produce the `initialization_script` payload for this webview.
 ///
-/// Empty for the 5 migrated providers (whatsapp, telegram, slack, discord,
-/// browserscan) — they load with ZERO injected JS; their scraping runs via
-/// CDP, and the per-account CDP session opener (`cdp::session`) injects the
-/// notification-permission shim via `Page.addScriptToEvaluateOnNewDocument`
-/// before the real provider URL loads. The 2 deferred providers
-/// (linkedin, google-meet) still get the JS recipe bridge.
+/// Empty for the 6 zero-injection providers (whatsapp, wechat, telegram,
+/// slack, discord, browserscan) — they load with ZERO injected JS. Some have
+/// native/CDP scraper paths; WeChat is shell-only for now. The per-account
+/// CDP session opener (`cdp::session`) still injects the notification-permission
+/// shim via `Page.addScriptToEvaluateOnNewDocument` before the real provider
+/// URL loads. The 2 deferred providers (linkedin, google-meet) still get the
+/// JS recipe bridge.
 fn build_init_script(account_id: &str, provider: &str) -> String {
     let Some(recipe_js) = provider_recipe_js(provider) else {
         return String::new();
@@ -3368,6 +3377,27 @@ mod tests {
     #[test]
     fn zoom_registered_in_provider_url() {
         assert_eq!(provider_url("zoom"), Some("https://zoom.us/"));
+    }
+
+    #[test]
+    fn wechat_registered_in_provider_url() {
+        assert_eq!(provider_url("wechat"), Some("https://web.wechat.com/"));
+    }
+
+    #[test]
+    fn wechat_has_no_recipe_js_injection() {
+        assert!(provider_recipe_js("wechat").is_none());
+    }
+
+    #[test]
+    fn wechat_allowed_hosts_cover_web_and_login_domains() {
+        let hosts = provider_allowed_hosts("wechat");
+        assert!(hosts.contains(&"wechat.com"), "wechat.com in allowlist");
+        assert!(hosts.contains(&"wx.qq.com"), "wx.qq.com in allowlist");
+        assert!(
+            hosts.contains(&"login.weixin.qq.com"),
+            "login.weixin.qq.com in allowlist"
+        );
     }
 
     #[test]

--- a/app/src/components/OpenhumanLinkModal.tsx
+++ b/app/src/components/OpenhumanLinkModal.tsx
@@ -379,6 +379,7 @@ const DiscordBody = ({ close }: { close: () => void }) => {
  */
 const ACCOUNTS_SETUP_PROVIDERS: readonly AccountProvider[] = [
   'whatsapp',
+  'wechat',
   'telegram',
   'slack',
   'discord',

--- a/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
+++ b/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
@@ -66,6 +66,7 @@ describe('OpenhumanLinkModal accounts setup', () => {
     openAccountsModal();
 
     expect(screen.getByLabelText('Connect WhatsApp Web')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connect WeChat Web')).toBeInTheDocument();
     expect(screen.getByLabelText('Connect Telegram Web')).toBeInTheDocument();
     expect(screen.getByLabelText('Connect Slack')).toBeInTheDocument();
     expect(screen.getByLabelText('Connect Discord')).toBeInTheDocument();

--- a/app/src/components/accounts/WebviewHost.tsx
+++ b/app/src/components/accounts/WebviewHost.tsx
@@ -22,6 +22,7 @@ const LOADING_STATUSES: ReadonlySet<AccountStatus> = new Set(['pending', 'loadin
 
 const PROVIDER_COPY: Record<AccountProvider, string> = {
   whatsapp: 'WhatsApp',
+  wechat: 'WeChat',
   telegram: 'Telegram',
   linkedin: 'LinkedIn',
   slack: 'Slack',

--- a/app/src/components/accounts/providerIcons.tsx
+++ b/app/src/components/accounts/providerIcons.tsx
@@ -1,4 +1,4 @@
-import { FaLinkedin } from 'react-icons/fa';
+import { FaLinkedin, FaWeixin } from 'react-icons/fa';
 import { SiDiscord, SiGooglemeet, SiSlack, SiTelegram, SiWhatsapp, SiZoom } from 'react-icons/si';
 import { TbRobot } from 'react-icons/tb';
 
@@ -11,6 +11,7 @@ import type { AccountProvider } from '../../types/accounts';
  */
 const PROVIDER_COLOR: Record<AccountProvider, string> = {
   whatsapp: '#25D366',
+  wechat: '#07C160',
   telegram: '#229ED9',
   linkedin: '#0A66C2',
   slack: '#4A154B',
@@ -36,6 +37,8 @@ export const ProviderIcon = ({
   switch (provider) {
     case 'whatsapp':
       return <SiWhatsapp className={className} style={style} />;
+    case 'wechat':
+      return <FaWeixin className={className} style={style} />;
     case 'telegram':
       return <SiTelegram className={className} style={style} />;
     case 'linkedin':

--- a/app/src/lib/notificationRouter.test.ts
+++ b/app/src/lib/notificationRouter.test.ts
@@ -41,7 +41,7 @@ describe('resolveIntegrationRoute', () => {
     expect(resolveIntegrationRoute(n)).toBe('/chat?account=abc');
   });
 
-  it.each(['gmail', 'slack', 'whatsapp', 'telegram', 'discord', 'linkedin'])(
+  it.each(['gmail', 'slack', 'whatsapp', 'wechat', 'telegram', 'discord', 'linkedin'])(
     'routes %s provider to /chat',
     provider => {
       expect(resolveIntegrationRoute(makeIntegration({ provider }))).toBe('/chat');

--- a/app/src/lib/notificationRouter.ts
+++ b/app/src/lib/notificationRouter.ts
@@ -24,6 +24,7 @@ const MESSAGE_PROVIDERS = new Set([
   'gmail',
   'slack',
   'whatsapp',
+  'wechat',
   'telegram',
   'discord',
   'linkedin',

--- a/app/src/types/accounts.ts
+++ b/app/src/types/accounts.ts
@@ -2,6 +2,7 @@ import { IS_DEV } from '../utils/config';
 
 export type AccountProvider =
   | 'whatsapp'
+  | 'wechat'
   | 'telegram'
   | 'linkedin'
   | 'slack'
@@ -73,6 +74,12 @@ const BASE_PROVIDERS: ProviderDescriptor[] = [
     label: 'WhatsApp Web',
     description: 'Open web.whatsapp.com inside the app and stream chat updates.',
     serviceUrl: 'https://web.whatsapp.com/',
+  },
+  {
+    id: 'wechat',
+    label: 'WeChat Web',
+    description: 'Open WeChat in-app for QR sign-in and desktop chat access.',
+    serviceUrl: 'https://web.wechat.com/',
   },
   {
     id: 'telegram',

--- a/docs/wechat-message-scraping-issue.md
+++ b/docs/wechat-message-scraping-issue.md
@@ -1,0 +1,43 @@
+---
+name: Feature
+about: Used for new features or suggestions
+title: "Add WeChat message scraping into context and memory"
+type: Feature
+assignees: ""
+---
+
+Use a concise sentence-case title that describes the requested outcome. Do not add `Feature` or bracket prefixes to the title.
+
+## Summary
+
+Ingest messages from the embedded WeChat webview into OpenHuman so the agent can use recent WeChat conversations as context and persist useful history into memory.
+
+## Problem
+
+We can embed WeChat Web in the Tauri shell for sign-in and manual use, but OpenHuman does not yet extract message data from that surface. That leaves a gap for users who coordinate through WeChat, especially for China-based communities and teams. The work needs to respect platform limits in WeChat Web, avoid broad DOM scraping that breaks easily, and keep private message content scoped to explicit product surfaces and consented storage paths.
+
+## Solution (optional)
+
+Add a dedicated WeChat webview ingestion path, following the existing Franz-style account model but with provider-specific extraction for chats, messages, unread state, and stable account/chat identifiers. Scope should cover:
+
+- Tauri/app shell:
+  Add a WeChat-specific extractor path for the embedded webview, with clear load-state handling and bounded retries when login/session state changes.
+- Core:
+  Define a WeChat webview ingest contract that can write normalized message snapshots into context/memory namespaces, similar to other webview-account providers.
+- Product safeguards:
+  Gate persistence behind existing memory/write surfaces, document what is stored, and make it easy to disable or purge.
+
+## Acceptance criteria
+
+- [ ] **Embedded WeChat extraction** — OpenHuman can detect the active WeChat chat surface and extract normalized message data from the embedded webview.
+- [ ] **Context + memory ingestion** — extracted WeChat messages can be written into the existing context/memory pipeline with provider/account provenance.
+- [ ] **Unread/respond surfaces** — unread or actionable WeChat activity appears in the same provider-surface/respond-queue flows used by other messaging integrations where applicable.
+- [ ] **Privacy + control** — users can understand, disable, and purge stored WeChat-derived data using existing account/memory controls or clearly-scoped additions.
+- [ ] **Tests** — add focused Vitest and Rust coverage for the WeChat provider path, including at least one failure/edge case.
+- [ ] **Diff coverage ≥ 80%** — the implementing PR meets the changed-lines coverage gate (Vitest + cargo-llvm-cov, enforced by [`.github/workflows/coverage.yml`](../../.github/workflows/coverage.yml)).
+
+- Evaluate whether WeChat needs a native scanner path, injected bridge, or hybrid approach after validating what the embedded web client exposes at runtime.
+
+## Related
+
+- Follows the initial Tauri WeChat webview support added in `feat/wechat-webview-support`.

--- a/docs/wechat-message-scraping-issue.md
+++ b/docs/wechat-message-scraping-issue.md
@@ -1,10 +1,4 @@
----
-name: Feature
-about: Used for new features or suggestions
-title: "Add WeChat message scraping into context and memory"
-type: Feature
-assignees: ""
----
+# Add WeChat message scraping into context and memory
 
 ## Summary
 

--- a/docs/wechat-message-scraping-issue.md
+++ b/docs/wechat-message-scraping-issue.md
@@ -6,8 +6,6 @@ type: Feature
 assignees: ""
 ---
 
-Use a concise sentence-case title that describes the requested outcome. Do not add `Feature` or bracket prefixes to the title.
-
 ## Summary
 
 Ingest messages from the embedded WeChat webview into OpenHuman so the agent can use recent WeChat conversations as context and persist useful history into memory.

--- a/docs/wechat-message-scraping-issue.md
+++ b/docs/wechat-message-scraping-issue.md
@@ -34,7 +34,7 @@ Add a dedicated WeChat webview ingestion path, following the existing Franz-styl
 - [ ] **Unread/respond surfaces** — unread or actionable WeChat activity appears in the same provider-surface/respond-queue flows used by other messaging integrations where applicable.
 - [ ] **Privacy + control** — users can understand, disable, and purge stored WeChat-derived data using existing account/memory controls or clearly-scoped additions.
 - [ ] **Tests** — add focused Vitest and Rust coverage for the WeChat provider path, including at least one failure/edge case.
-- [ ] **Diff coverage ≥ 80%** — the implementing PR meets the changed-lines coverage gate (Vitest + cargo-llvm-cov, enforced by [`.github/workflows/coverage.yml`](../../.github/workflows/coverage.yml)).
+- [ ] **Diff coverage ≥ 80%** — the implementing PR meets the changed-lines coverage gate (Vitest + cargo-llvm-cov, enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml)).
 
 - Evaluate whether WeChat needs a native scanner path, injected bridge, or hybrid approach after validating what the embedded web client exposes at runtime.
 


### PR DESCRIPTION
## Summary

- add `wechat` as a first-class embedded account provider across the frontend provider registry, onboarding/link surfaces, icon map, and notification routing
- register WeChat in the Tauri `webview_accounts` provider URL, display-name, and host-allowlist registry with focused Rust tests
- fix the `WebviewHost` provider-copy exhaustiveness regression caught by typecheck during push validation
- add a checked-in draft plus upstream follow-up issue for future WeChat message scraping into context/memory

## Problem

- OpenHuman already has a Franz-style embedded webview account system, but WeChat was not exposed as a supported provider anywhere in the app or Tauri shell.
- Without that wiring, China-based users cannot open WeChat Web inside the desktop app, and future memory/context ingestion work has no provider surface to build on.
- The provider addition must stay honest about scope: shell/webview support now, message extraction later.

## Solution

- extend the shared `AccountProvider` union and provider descriptors with a `wechat` entry pointing at `https://web.wechat.com/`
- surface WeChat in the onboarding accounts modal and provider icon/copy registries so users can connect it like the existing embedded apps
- route WeChat integration notifications to `/chat`, matching the rest of the messaging-style providers
- add WeChat to the Tauri `webview_accounts` registry with a zero-injection shell-only configuration, explicit allowed hosts, and focused unit coverage
- open a follow-up issue for the separate message-scraping/context-memory implementation rather than overstating this PR’s scope

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are still enforced by CI; local `pnpm test:coverage` completed successfully and `pnpm test:rust` was attempted but hit unrelated pre-existing harness stack overflow noted below.
- [x] Coverage matrix updated — N/A: behaviour-only provider wiring change; no matrix row changes needed
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs were touched
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut smoke checklist rows changed
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: this PR enables provider wiring only; follow-up issue remains open

## Impact

- Desktop app/Tauri shell only.
- No new external services or runtime dependencies.
- User-visible effect: WeChat now appears anywhere users can connect embedded accounts, and the shell recognizes it as a supported webview provider.
- Scope guard: this does not scrape, persist, or index WeChat messages yet.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - #1990

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `feat/wechat-webview-support`
- Commit SHA: `e22fcb14`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/lib/notificationRouter.test.ts src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx`; `cargo test --manifest-path app/src-tauri/Cargo.toml wechat_ --lib`; `pnpm test:coverage`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path ../Cargo.toml --all --check` via hook
- [x] Tauri fmt/check (if changed): `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check` and `cargo check --manifest-path src-tauri/Cargo.toml` via hook

### Validation Blocked
- `command:` `pnpm test:rust`
- `error:` `thread 'openhuman::agent::harness::subagent_runner::ops::tests::typed_mode_blocks_unallowed_tool_calls' has overflowed its stack` (`signal: 6`, `SIGABRT`)
- `impact:` full local Rust-suite completion is blocked by a pre-existing unrelated harness failure; CI remains the authoritative merge gate for Rust coverage/results

### Behavior Changes
- Intended behavior change: users can add and open WeChat as an embedded webview account in the desktop app
- User-visible effect: WeChat appears in app-connection surfaces and is recognized by the Tauri shell/provider registries

### Parity Contract
- Legacy behavior preserved: existing embedded providers keep their current wiring and notification routing
- Guard/fallback/dispatch parity checks: `WebviewHost` provider copy remains exhaustive; WeChat stays zero-injection and shell-only until a dedicated ingest path lands

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WeChat as a supported account provider; appears in onboarding, provider lists, and UI with proper branding and icon.
  * WeChat integration notifications now route to the chat view for a smoother messaging experience.

* **Documentation**
  * Added a WeChat message scraping specification describing ingestion, privacy controls, and acceptance criteria.

* **Tests**
  * Expanded tests to cover WeChat provider registration and routing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->