### PR TITLE
feat(vault): folder-of-files ingestion into memory (NotebookLM-style)

### DIFF
--- a/app/src/components/intelligence/MemoryWorkspace.tsx
+++ b/app/src/components/intelligence/MemoryWorkspace.tsx
@@ -40,6 +40,7 @@ import {
 } from '../../utils/tauriCommands';
 import { MemoryGraph } from './MemoryGraph';
 import { MemorySources } from './MemorySources';
+import { VaultPanel } from './VaultPanel';
 import { WhatsAppMemorySection } from './WhatsAppMemorySection';
 
 interface MemoryWorkspaceProps {
@@ -236,6 +237,7 @@ export function MemoryWorkspace({ onToast }: MemoryWorkspaceProps) {
   return (
     <div className="space-y-4" data-testid="memory-workspace">
       <MemorySources syncableToolkits={SYNCABLE_TOOLKITS} pollIntervalMs={5000} onToast={onToast} />
+      <VaultPanel onToast={onToast} />
       <WhatsAppMemorySection />
 
       <div

--- a/app/src/components/intelligence/VaultPanel.test.tsx
+++ b/app/src/components/intelligence/VaultPanel.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * Vitest for `<VaultPanel />`. Covers: load/empty/error states, the add-
+ * vault form happy + error paths, per-row sync (success + failed-files
+ * branch), and remove with both purge=true and purge=false flows.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VaultPanel } from './VaultPanel';
+
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockSync = vi.fn();
+const mockRemove = vi.fn();
+
+vi.mock('../../utils/tauriCommands/vault', () => ({
+  openhumanVaultList: (...args: unknown[]) => mockList(...args),
+  openhumanVaultCreate: (...args: unknown[]) => mockCreate(...args),
+  openhumanVaultSync: (...args: unknown[]) => mockSync(...args),
+  openhumanVaultRemove: (...args: unknown[]) => mockRemove(...args),
+}));
+
+function vault(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'v-1',
+    name: 'Notes',
+    root_path: '/Users/me/notes',
+    namespace: 'vault:v-1',
+    include_globs: [],
+    exclude_globs: [],
+    created_at: '2026-05-17T10:00:00Z',
+    last_synced_at: null,
+    file_count: 0,
+    ...overrides,
+  };
+}
+
+describe('<VaultPanel />', () => {
+  beforeEach(() => {
+    mockList.mockReset();
+    mockCreate.mockReset();
+    mockSync.mockReset();
+    mockRemove.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading then empty state when list returns no vaults', async () => {
+    mockList.mockResolvedValueOnce({ result: [], logs: [] });
+    render(<VaultPanel />);
+    expect(screen.getByText(/Loading vaults/)).toBeTruthy();
+    await waitFor(() => screen.getByText(/No vaults yet/));
+    expect(mockList).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an error banner when list fails', async () => {
+    mockList.mockRejectedValueOnce(new Error('rpc down'));
+    render(<VaultPanel />);
+    await waitFor(() => screen.getByText(/Failed to load vaults/));
+    expect(screen.getByText(/rpc down/)).toBeTruthy();
+  });
+
+  it('lists vaults with file count + relative last-synced label', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-17T10:05:00Z').getTime());
+    mockList.mockResolvedValueOnce({
+      result: [
+        vault({
+          id: 'v-A',
+          name: 'A',
+          file_count: 42,
+          last_synced_at: '2026-05-17T10:04:30Z',
+        }),
+      ],
+      logs: [],
+    });
+    render(<VaultPanel />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+    expect(screen.getByText('A')).toBeTruthy();
+    expect(screen.getByText(/42 file/)).toBeTruthy();
+    expect(screen.getByText(/synced 30s ago/)).toBeTruthy();
+  });
+
+  it('toggles the add form and creates a vault on submit', async () => {
+    mockList
+      .mockResolvedValueOnce({ result: [], logs: [] })
+      .mockResolvedValueOnce({ result: [vault()], logs: [] });
+    mockCreate.mockResolvedValueOnce({ result: vault(), logs: [] });
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByText(/No vaults yet/));
+
+    fireEvent.click(screen.getByTestId('vault-add-toggle'));
+    const form = screen.getByTestId('vault-add-form');
+    const inputs = form.querySelectorAll('input');
+    fireEvent.change(inputs[0], { target: { value: 'My notes' } });
+    fireEvent.change(inputs[1], { target: { value: '/Users/me/notes' } });
+    fireEvent.change(inputs[2], { target: { value: 'drafts, .secret' } });
+    fireEvent.submit(form);
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        name: 'My notes',
+        rootPath: '/Users/me/notes',
+        excludeGlobs: ['drafts', '.secret'],
+      })
+    );
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'Vault added' })
+    );
+    // Reload happens after create — list called twice (initial + post-create).
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+
+  it('emits an error toast when create throws', async () => {
+    mockList.mockResolvedValueOnce({ result: [], logs: [] });
+    mockCreate.mockRejectedValueOnce(new Error('disk full'));
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByText(/No vaults yet/));
+
+    fireEvent.click(screen.getByTestId('vault-add-toggle'));
+    const form = screen.getByTestId('vault-add-form');
+    const inputs = form.querySelectorAll('input');
+    fireEvent.change(inputs[0], { target: { value: 'n' } });
+    fireEvent.change(inputs[1], { target: { value: '/x' } });
+    fireEvent.submit(form);
+
+    await waitFor(() =>
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', title: 'Could not add vault' })
+      )
+    );
+  });
+
+  it('syncs a vault and reports counts via toast', async () => {
+    mockList
+      .mockResolvedValueOnce({ result: [vault()], logs: [] })
+      .mockResolvedValueOnce({ result: [vault()], logs: [] });
+    mockSync.mockResolvedValueOnce({
+      result: {
+        vault_id: 'v-1',
+        scanned: 4,
+        ingested: 3,
+        unchanged: 1,
+        removed: 0,
+        failed: 0,
+        skipped_unsupported: 0,
+        duration_ms: 1200,
+        errors: [],
+      },
+      logs: [],
+    });
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Sync'));
+    await waitFor(() => expect(mockSync).toHaveBeenCalledWith('v-1'));
+    await waitFor(() =>
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'success',
+          title: expect.stringContaining('Synced'),
+          message: expect.stringContaining('Ingested 3'),
+        })
+      )
+    );
+  });
+
+  it('uses info toast when sync reports failed files', async () => {
+    mockList
+      .mockResolvedValueOnce({ result: [vault()], logs: [] })
+      .mockResolvedValueOnce({ result: [vault()], logs: [] });
+    mockSync.mockResolvedValueOnce({
+      result: {
+        vault_id: 'v-1',
+        scanned: 2,
+        ingested: 1,
+        unchanged: 0,
+        removed: 0,
+        failed: 1,
+        skipped_unsupported: 0,
+        duration_ms: 50,
+        errors: ['x.md: read failed'],
+      },
+      logs: [],
+    });
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Sync'));
+    await waitFor(() =>
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'info', message: expect.stringContaining('failed 1') })
+      )
+    );
+  });
+
+  it('emits error toast when sync RPC fails', async () => {
+    mockList.mockResolvedValueOnce({ result: [vault()], logs: [] });
+    mockSync.mockRejectedValueOnce(new Error('boom'));
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Sync'));
+    await waitFor(() =>
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', title: 'Sync failed' })
+      )
+    );
+  });
+
+  it('removes a vault with purge=true when both confirms accepted', async () => {
+    mockList
+      .mockResolvedValueOnce({ result: [vault()], logs: [] })
+      .mockResolvedValueOnce({ result: [], logs: [] });
+    mockRemove.mockResolvedValueOnce({
+      result: { vault_id: 'v-1', removed: true, purged: true },
+      logs: [],
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Remove'));
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith('v-1', true));
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'success',
+        message: expect.stringContaining('purged'),
+      })
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it('removes a vault with purge=false when first confirm denied', async () => {
+    mockList
+      .mockResolvedValueOnce({ result: [vault()], logs: [] })
+      .mockResolvedValueOnce({ result: [], logs: [] });
+    mockRemove.mockResolvedValueOnce({
+      result: { vault_id: 'v-1', removed: true, purged: false },
+      logs: [],
+    });
+    // First confirm (purge?) → no; second confirm (really remove?) → yes.
+    const confirmSpy = vi
+      .spyOn(window, 'confirm')
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Remove'));
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith('v-1', false));
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Documents kept') })
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it('aborts remove when second confirm is denied', async () => {
+    mockList.mockResolvedValueOnce({ result: [vault()], logs: [] });
+    const confirmSpy = vi
+      .spyOn(window, 'confirm')
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    render(<VaultPanel />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Remove'));
+    // Allow microtasks to settle so any (incorrect) RPC dispatch would land.
+    await Promise.resolve();
+    expect(mockRemove).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('emits error toast when remove RPC fails', async () => {
+    mockList.mockResolvedValueOnce({ result: [vault()], logs: [] });
+    mockRemove.mockRejectedValueOnce(new Error('locked'));
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onToast = vi.fn();
+    render(<VaultPanel onToast={onToast} />);
+    await waitFor(() => screen.getByTestId('vault-list'));
+
+    fireEvent.click(screen.getByText('Remove'));
+    await waitFor(() =>
+      expect(onToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', title: 'Could not remove vault' })
+      )
+    );
+    confirmSpy.mockRestore();
+  });
+});

--- a/app/src/components/intelligence/VaultPanel.test.tsx
+++ b/app/src/components/intelligence/VaultPanel.test.tsx
@@ -66,12 +66,7 @@ describe('<VaultPanel />', () => {
     vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-05-17T10:05:00Z').getTime());
     mockList.mockResolvedValueOnce({
       result: [
-        vault({
-          id: 'v-A',
-          name: 'A',
-          file_count: 42,
-          last_synced_at: '2026-05-17T10:04:30Z',
-        }),
+        vault({ id: 'v-A', name: 'A', file_count: 42, last_synced_at: '2026-05-17T10:04:30Z' }),
       ],
       logs: [],
     });
@@ -230,10 +225,7 @@ describe('<VaultPanel />', () => {
     fireEvent.click(screen.getByText('Remove'));
     await waitFor(() => expect(mockRemove).toHaveBeenCalledWith('v-1', true));
     expect(onToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'success',
-        message: expect.stringContaining('purged'),
-      })
+      expect.objectContaining({ type: 'success', message: expect.stringContaining('purged') })
     );
     confirmSpy.mockRestore();
   });

--- a/app/src/components/intelligence/VaultPanel.tsx
+++ b/app/src/components/intelligence/VaultPanel.tsx
@@ -1,0 +1,300 @@
+/**
+ * Knowledge vaults — point the assistant at a local folder and have its
+ * files mirrored into memory under namespace `vault:<id>`. Sits inside
+ * the Intelligence ▸ Memory tab.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+import type { ToastNotification } from '../../types/intelligence';
+import {
+  type CoreVault,
+  type CoreVaultSyncReport,
+  openhumanVaultCreate,
+  openhumanVaultList,
+  openhumanVaultRemove,
+  openhumanVaultSync,
+} from '../../utils/tauriCommands/vault';
+
+interface VaultPanelProps {
+  onToast?: (toast: Omit<ToastNotification, 'id'>) => void;
+}
+
+export function VaultPanel({ onToast }: VaultPanelProps) {
+  const [vaults, setVaults] = useState<CoreVault[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<Record<string, 'sync' | 'remove' | undefined>>({});
+  const [creating, setCreating] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newPath, setNewPath] = useState('');
+  const [newExcludes, setNewExcludes] = useState('');
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const resp = await openhumanVaultList();
+      setVaults(resp.result);
+    } catch (err) {
+      console.error('[ui-flow][vault-panel] list failed', err);
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleCreate = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      const name = newName.trim();
+      const rootPath = newPath.trim();
+      if (!name || !rootPath) return;
+      const excludeGlobs = newExcludes
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+      setCreating(true);
+      try {
+        const resp = await openhumanVaultCreate({ name, rootPath, excludeGlobs });
+        onToast?.({
+          type: 'success',
+          title: 'Vault added',
+          message: `Created "${resp.result.name}". Click Sync to ingest.`,
+        });
+        setNewName('');
+        setNewPath('');
+        setNewExcludes('');
+        setShowForm(false);
+        await reload();
+      } catch (err) {
+        console.error('[ui-flow][vault-panel] create failed', err);
+        onToast?.({
+          type: 'error',
+          title: 'Could not add vault',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setCreating(false);
+      }
+    },
+    [newName, newPath, newExcludes, onToast, reload]
+  );
+
+  const handleSync = useCallback(
+    async (vault: CoreVault) => {
+      setBusy(b => ({ ...b, [vault.id]: 'sync' }));
+      try {
+        const resp = await openhumanVaultSync(vault.id);
+        const r: CoreVaultSyncReport = resp.result;
+        onToast?.({
+          type: r.failed > 0 ? 'info' : 'success',
+          title: `Synced "${vault.name}"`,
+          message:
+            `Ingested ${r.ingested}, unchanged ${r.unchanged}, removed ${r.removed}` +
+            (r.failed > 0 ? `, failed ${r.failed}` : '') +
+            (r.skipped_unsupported > 0 ? `, skipped ${r.skipped_unsupported}` : '') +
+            ` · ${(r.duration_ms / 1000).toFixed(1)}s`,
+        });
+        await reload();
+      } catch (err) {
+        console.error('[ui-flow][vault-panel] sync failed', err);
+        onToast?.({
+          type: 'error',
+          title: 'Sync failed',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setBusy(b => ({ ...b, [vault.id]: undefined }));
+      }
+    },
+    [onToast, reload]
+  );
+
+  const handleRemove = useCallback(
+    async (vault: CoreVault) => {
+      const purge = window.confirm(
+        `Remove vault "${vault.name}"?\n\nClick OK to also purge its memory (delete all ${vault.file_count} ingested document(s)).\nClick Cancel to keep the documents in memory.`
+      );
+      // Confirm step #2: ensure the user actually meant to remove the vault row.
+      const ok = window.confirm(`Really remove vault "${vault.name}"?`);
+      if (!ok) return;
+      setBusy(b => ({ ...b, [vault.id]: 'remove' }));
+      try {
+        await openhumanVaultRemove(vault.id, purge);
+        onToast?.({
+          type: 'success',
+          title: 'Vault removed',
+          message: purge
+            ? `Removed "${vault.name}" and purged its memory.`
+            : `Removed "${vault.name}". Documents kept in memory.`,
+        });
+        await reload();
+      } catch (err) {
+        console.error('[ui-flow][vault-panel] remove failed', err);
+        onToast?.({
+          type: 'error',
+          title: 'Could not remove vault',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setBusy(b => ({ ...b, [vault.id]: undefined }));
+      }
+    },
+    [onToast, reload]
+  );
+
+  return (
+    <div
+      className="rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+      data-testid="vault-panel">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-stone-800">Knowledge vaults</h3>
+          <p className="text-xs text-stone-500">
+            Point at a local folder; files are chunked and mirrored into memory.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm(v => !v)}
+          className="inline-flex items-center gap-1 rounded-md border border-primary-300 bg-white
+                     px-3 py-1.5 text-xs font-semibold text-primary-700 shadow-sm
+                     transition-colors hover:bg-primary-50
+                     focus:outline-none focus:ring-2 focus:ring-primary-200"
+          data-testid="vault-add-toggle">
+          {showForm ? 'Cancel' : '+ Add vault'}
+        </button>
+      </div>
+
+      {showForm ? (
+        <form
+          onSubmit={handleCreate}
+          className="mb-3 space-y-2 rounded-md border border-stone-100 bg-stone-50 p-3"
+          data-testid="vault-add-form">
+          <label className="block">
+            <span className="text-xs font-medium text-stone-600">Name</span>
+            <input
+              type="text"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              required
+              placeholder="My research notes"
+              className="mt-1 w-full rounded border border-stone-200 bg-white px-2 py-1.5 text-sm
+                         focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-stone-600">Folder path (absolute)</span>
+            <input
+              type="text"
+              value={newPath}
+              onChange={e => setNewPath(e.target.value)}
+              required
+              placeholder="/Users/you/Documents/notes"
+              className="mt-1 w-full rounded border border-stone-200 bg-white px-2 py-1.5 font-mono text-xs
+                         focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-stone-600">
+              Excludes (comma-separated substrings, optional)
+            </span>
+            <input
+              type="text"
+              value={newExcludes}
+              onChange={e => setNewExcludes(e.target.value)}
+              placeholder="drafts/, .secret"
+              className="mt-1 w-full rounded border border-stone-200 bg-white px-2 py-1.5 text-xs
+                         focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
+            />
+          </label>
+          <div className="flex justify-end gap-2">
+            <button
+              type="submit"
+              disabled={creating}
+              className="rounded-md bg-primary-500 px-3 py-1.5 text-xs font-semibold text-white
+                         shadow-sm transition-colors hover:bg-primary-600
+                         disabled:cursor-not-allowed disabled:opacity-50">
+              {creating ? 'Creating…' : 'Create vault'}
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {loading ? (
+        <div className="py-4 text-center text-xs text-stone-400">Loading vaults…</div>
+      ) : loadError ? (
+        <div className="rounded border border-coral-200 bg-coral-50 px-3 py-2 text-xs text-coral-800">
+          Failed to load vaults: {loadError}
+        </div>
+      ) : vaults.length === 0 ? (
+        <div className="py-4 text-center text-xs text-stone-400">
+          No vaults yet. Add one above to start ingesting a folder.
+        </div>
+      ) : (
+        <ul className="divide-y divide-stone-100" data-testid="vault-list">
+          {vaults.map(v => {
+            const state = busy[v.id];
+            return (
+              <li key={v.id} className="flex items-center justify-between gap-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-stone-800">{v.name}</div>
+                  <div
+                    className="truncate font-mono text-[11px] text-stone-500"
+                    title={v.root_path}>
+                    {v.root_path}
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-stone-400">
+                    {v.file_count.toLocaleString()} file(s) ·{' '}
+                    {v.last_synced_at
+                      ? `synced ${formatRelative(v.last_synced_at)}`
+                      : 'never synced'}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleSync(v)}
+                    disabled={state === 'sync' || state === 'remove'}
+                    className="rounded-md border border-primary-300 bg-white px-3 py-1.5 text-xs
+                               font-semibold text-primary-700 shadow-sm transition-colors
+                               hover:bg-primary-50 disabled:cursor-not-allowed disabled:opacity-50">
+                    {state === 'sync' ? 'Syncing…' : 'Sync'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleRemove(v)}
+                    disabled={state === 'sync' || state === 'remove'}
+                    className="rounded-md border border-coral-200 bg-white px-3 py-1.5 text-xs
+                               font-semibold text-coral-700 shadow-sm transition-colors
+                               hover:bg-coral-50 disabled:cursor-not-allowed disabled:opacity-50">
+                    {state === 'remove' ? 'Removing…' : 'Remove'}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  const diff = Date.now() - t;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}

--- a/app/src/components/intelligence/VaultPanel.tsx
+++ b/app/src/components/intelligence/VaultPanel.tsx
@@ -288,7 +288,7 @@ export function VaultPanel({ onToast }: VaultPanelProps) {
 function formatRelative(iso: string): string {
   const t = new Date(iso).getTime();
   if (Number.isNaN(t)) return iso;
-  const diff = Date.now() - t;
+  const diff = Math.max(0, Date.now() - t);
   const sec = Math.floor(diff / 1000);
   if (sec < 60) return `${sec}s ago`;
   const min = Math.floor(sec / 60);

--- a/app/src/utils/tauriCommands/vault.test.ts
+++ b/app/src/utils/tauriCommands/vault.test.ts
@@ -58,9 +58,9 @@ describe('tauriCommands/vault', () => {
   describe('openhumanVaultCreate', () => {
     test('throws when not running in Tauri', async () => {
       mockIsTauri.mockReturnValue(false);
-      await expect(
-        openhumanVaultCreate({ name: 'n', rootPath: '/x' })
-      ).rejects.toThrow('Not running in Tauri');
+      await expect(openhumanVaultCreate({ name: 'n', rootPath: '/x' })).rejects.toThrow(
+        'Not running in Tauri'
+      );
       expect(mockCallCoreRpc).not.toHaveBeenCalled();
     });
 

--- a/app/src/utils/tauriCommands/vault.test.ts
+++ b/app/src/utils/tauriCommands/vault.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Vitest for the vault tauriCommands surface. Mirrors the pattern used by
+ * `subconscious.test.ts` — mocks `callCoreRpc` + `isTauri` so the wrappers
+ * are validated against the live RPC contract without spinning up Tauri.
+ */
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+
+import { callCoreRpc } from '../../services/coreRpcClient';
+import { isTauri } from './common';
+
+vi.mock('./common', async () => {
+  const actual = await vi.importActual<typeof import('./common')>('./common');
+  return { ...actual, isTauri: vi.fn() };
+});
+vi.mock('../../services/coreRpcClient', () => ({ callCoreRpc: vi.fn() }));
+
+describe('tauriCommands/vault', () => {
+  const mockIsTauri = isTauri as Mock;
+  const mockCallCoreRpc = callCoreRpc as Mock;
+  let openhumanVaultList: typeof import('./vault').openhumanVaultList;
+  let openhumanVaultCreate: typeof import('./vault').openhumanVaultCreate;
+  let openhumanVaultGet: typeof import('./vault').openhumanVaultGet;
+  let openhumanVaultFiles: typeof import('./vault').openhumanVaultFiles;
+  let openhumanVaultRemove: typeof import('./vault').openhumanVaultRemove;
+  let openhumanVaultSync: typeof import('./vault').openhumanVaultSync;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockIsTauri.mockReturnValue(true);
+    const actual = await vi.importActual<typeof import('./vault')>('./vault');
+    openhumanVaultList = actual.openhumanVaultList;
+    openhumanVaultCreate = actual.openhumanVaultCreate;
+    openhumanVaultGet = actual.openhumanVaultGet;
+    openhumanVaultFiles = actual.openhumanVaultFiles;
+    openhumanVaultRemove = actual.openhumanVaultRemove;
+    openhumanVaultSync = actual.openhumanVaultSync;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('openhumanVaultList', () => {
+    test('throws when not running in Tauri', async () => {
+      mockIsTauri.mockReturnValue(false);
+      await expect(openhumanVaultList()).rejects.toThrow('Not running in Tauri');
+      expect(mockCallCoreRpc).not.toHaveBeenCalled();
+    });
+
+    test('dispatches openhuman.vault_list with no params', async () => {
+      mockCallCoreRpc.mockResolvedValue({ result: [], logs: [] });
+      const resp = await openhumanVaultList();
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({ method: 'openhuman.vault_list' });
+      expect(resp.result).toEqual([]);
+    });
+  });
+
+  describe('openhumanVaultCreate', () => {
+    test('throws when not running in Tauri', async () => {
+      mockIsTauri.mockReturnValue(false);
+      await expect(
+        openhumanVaultCreate({ name: 'n', rootPath: '/x' })
+      ).rejects.toThrow('Not running in Tauri');
+      expect(mockCallCoreRpc).not.toHaveBeenCalled();
+    });
+
+    test('forwards optional glob arrays with snake_case keys', async () => {
+      mockCallCoreRpc.mockResolvedValue({ result: { id: 'v-1' }, logs: [] });
+      await openhumanVaultCreate({
+        name: 'notes',
+        rootPath: '/Users/me/notes',
+        includeGlobs: ['*.md'],
+        excludeGlobs: ['drafts'],
+      });
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_create',
+        params: {
+          name: 'notes',
+          root_path: '/Users/me/notes',
+          include_globs: ['*.md'],
+          exclude_globs: ['drafts'],
+        },
+      });
+    });
+
+    test('defaults include/exclude globs to empty arrays when omitted', async () => {
+      mockCallCoreRpc.mockResolvedValue({ result: { id: 'v-2' }, logs: [] });
+      await openhumanVaultCreate({ name: 'n', rootPath: '/y' });
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_create',
+        params: { name: 'n', root_path: '/y', include_globs: [], exclude_globs: [] },
+      });
+    });
+  });
+
+  describe('openhumanVaultGet', () => {
+    test('throws when not running in Tauri', async () => {
+      mockIsTauri.mockReturnValue(false);
+      await expect(openhumanVaultGet('v-1')).rejects.toThrow('Not running in Tauri');
+    });
+
+    test('dispatches openhuman.vault_get with vault_id', async () => {
+      mockCallCoreRpc.mockResolvedValue({ result: { id: 'v-1' }, logs: [] });
+      await openhumanVaultGet('v-1');
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_get',
+        params: { vault_id: 'v-1' },
+      });
+    });
+  });
+
+  describe('openhumanVaultFiles', () => {
+    test('throws when not running in Tauri', async () => {
+      mockIsTauri.mockReturnValue(false);
+      await expect(openhumanVaultFiles('v-1')).rejects.toThrow('Not running in Tauri');
+    });
+
+    test('dispatches openhuman.vault_files with vault_id', async () => {
+      mockCallCoreRpc.mockResolvedValue({ result: [], logs: [] });
+      await openhumanVaultFiles('v-1');
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_files',
+        params: { vault_id: 'v-1' },
+      });
+    });
+  });
+
+  describe('openhumanVaultRemove', () => {
+    test('throws when not running in Tauri', async () => {
+      mockIsTauri.mockReturnValue(false);
+      await expect(openhumanVaultRemove('v-1', false)).rejects.toThrow('Not running in Tauri');
+    });
+
+    test('forwards purge_memory=true', async () => {
+      mockCallCoreRpc.mockResolvedValue({
+        result: { vault_id: 'v-1', removed: true, purged: true },
+        logs: [],
+      });
+      await openhumanVaultRemove('v-1', true);
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_remove',
+        params: { vault_id: 'v-1', purge_memory: true },
+      });
+    });
+
+    test('forwards purge_memory=false', async () => {
+      mockCallCoreRpc.mockResolvedValue({
+        result: { vault_id: 'v-1', removed: true, purged: false },
+        logs: [],
+      });
+      await openhumanVaultRemove('v-1', false);
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_remove',
+        params: { vault_id: 'v-1', purge_memory: false },
+      });
+    });
+  });
+
+  describe('openhumanVaultSync', () => {
+    test('throws when not running in Tauri', async () => {
+      mockIsTauri.mockReturnValue(false);
+      await expect(openhumanVaultSync('v-1')).rejects.toThrow('Not running in Tauri');
+    });
+
+    test('dispatches openhuman.vault_sync with vault_id and returns report', async () => {
+      mockCallCoreRpc.mockResolvedValue({
+        result: {
+          vault_id: 'v-1',
+          scanned: 3,
+          ingested: 2,
+          unchanged: 1,
+          removed: 0,
+          failed: 0,
+          skipped_unsupported: 0,
+          duration_ms: 12,
+          errors: [],
+        },
+        logs: [],
+      });
+      const resp = await openhumanVaultSync('v-1');
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.vault_sync',
+        params: { vault_id: 'v-1' },
+      });
+      expect(resp.result.ingested).toBe(2);
+    });
+  });
+});

--- a/app/src/utils/tauriCommands/vault.ts
+++ b/app/src/utils/tauriCommands/vault.ts
@@ -1,0 +1,109 @@
+/**
+ * Vault (knowledge vault) commands — folder-of-files ingested into memory.
+ */
+import { callCoreRpc } from '../../services/coreRpcClient';
+import { CommandResponse, isTauri } from './common';
+
+export interface CoreVault {
+  id: string;
+  name: string;
+  root_path: string;
+  namespace: string;
+  include_globs: string[];
+  exclude_globs: string[];
+  created_at: string;
+  last_synced_at?: string | null;
+  file_count: number;
+}
+
+export type CoreVaultFileStatus = 'ok' | 'skipped' | 'failed';
+
+export interface CoreVaultFile {
+  vault_id: string;
+  rel_path: string;
+  document_id: string;
+  content_hash: string;
+  mtime_ms: number;
+  bytes: number;
+  ingested_at: string;
+  status: CoreVaultFileStatus;
+}
+
+export interface CoreVaultSyncReport {
+  vault_id: string;
+  scanned: number;
+  ingested: number;
+  unchanged: number;
+  removed: number;
+  failed: number;
+  skipped_unsupported: number;
+  duration_ms: number;
+  errors: string[];
+}
+
+function ensureTauri() {
+  if (!isTauri()) {
+    throw new Error('Not running in Tauri');
+  }
+}
+
+export async function openhumanVaultList(): Promise<CommandResponse<CoreVault[]>> {
+  ensureTauri();
+  return await callCoreRpc<CommandResponse<CoreVault[]>>({ method: 'openhuman.vault_list' });
+}
+
+export async function openhumanVaultCreate(params: {
+  name: string;
+  rootPath: string;
+  includeGlobs?: string[];
+  excludeGlobs?: string[];
+}): Promise<CommandResponse<CoreVault>> {
+  ensureTauri();
+  return await callCoreRpc<CommandResponse<CoreVault>>({
+    method: 'openhuman.vault_create',
+    params: {
+      name: params.name,
+      root_path: params.rootPath,
+      include_globs: params.includeGlobs ?? [],
+      exclude_globs: params.excludeGlobs ?? [],
+    },
+  });
+}
+
+export async function openhumanVaultGet(vaultId: string): Promise<CommandResponse<CoreVault>> {
+  ensureTauri();
+  return await callCoreRpc<CommandResponse<CoreVault>>({
+    method: 'openhuman.vault_get',
+    params: { vault_id: vaultId },
+  });
+}
+
+export async function openhumanVaultFiles(
+  vaultId: string
+): Promise<CommandResponse<CoreVaultFile[]>> {
+  ensureTauri();
+  return await callCoreRpc<CommandResponse<CoreVaultFile[]>>({
+    method: 'openhuman.vault_files',
+    params: { vault_id: vaultId },
+  });
+}
+
+export async function openhumanVaultRemove(
+  vaultId: string,
+  purgeMemory: boolean
+): Promise<CommandResponse<{ vault_id: string; removed: boolean; purged: boolean }>> {
+  ensureTauri();
+  return await callCoreRpc<
+    CommandResponse<{ vault_id: string; removed: boolean; purged: boolean }>
+  >({ method: 'openhuman.vault_remove', params: { vault_id: vaultId, purge_memory: purgeMemory } });
+}
+
+export async function openhumanVaultSync(
+  vaultId: string
+): Promise<CommandResponse<CoreVaultSyncReport>> {
+  ensureTauri();
+  return await callCoreRpc<CommandResponse<CoreVaultSyncReport>>({
+    method: 'openhuman.vault_sync',
+    params: { vault_id: vaultId },
+  });
+}

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -292,6 +292,7 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
     schemas.extend(crate::openhuman::javascript::all_javascript_controller_schemas());
     schemas.extend(crate::openhuman::skills::all_skills_controller_schemas());
     schemas.extend(crate::openhuman::workspace::all_workspace_controller_schemas());
+    schemas.extend(crate::openhuman::vault::all_vault_controller_schemas());
     schemas.extend(crate::openhuman::tools::all_tools_controller_schemas());
     schemas.extend(crate::openhuman::memory::all_memory_controller_schemas());
     schemas.extend(crate::openhuman::memory::all_memory_tree_controller_schemas());

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -169,6 +169,8 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     controllers.extend(crate::openhuman::skills::all_skills_registered_controllers());
     // User workspace and file management
     controllers.extend(crate::openhuman::workspace::all_workspace_registered_controllers());
+    // Knowledge vaults — folder-of-files mirrored into memory
+    controllers.extend(crate::openhuman::vault::all_vault_registered_controllers());
     // Skill tool registry
     controllers.extend(crate::openhuman::tools::all_tools_registered_controllers());
     // Document and knowledge graph storage

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -77,6 +77,7 @@ pub mod tools;
 pub mod tree_summarizer;
 pub mod update;
 pub mod util;
+pub mod vault;
 pub mod voice;
 pub mod wallet;
 pub mod webhooks;

--- a/src/openhuman/vault/mod.rs
+++ b/src/openhuman/vault/mod.rs
@@ -1,0 +1,21 @@
+//! Knowledge vault — folder-of-files ingested into memory (NotebookLM-style).
+//!
+//! A `Vault` points at a local directory; on `vault.sync` we walk it, route
+//! files to extractors by extension, and feed them into the memory pipeline
+//! under namespace `vault:<id>`. Per-file dedup uses (path, mtime, content
+//! hash) so re-syncs only touch what changed.
+
+pub mod ops;
+mod schemas;
+mod store;
+mod sync;
+mod types;
+
+pub use schemas::{
+    all_controller_schemas as all_vault_controller_schemas,
+    all_registered_controllers as all_vault_registered_controllers,
+};
+pub use types::{Vault, VaultFile, VaultFileStatus, VaultSyncReport};
+
+#[cfg(test)]
+mod tests;

--- a/src/openhuman/vault/ops.rs
+++ b/src/openhuman/vault/ops.rs
@@ -28,11 +28,20 @@ pub async fn vault_create(
         return Err("root_path must not be empty".to_string());
     }
     let root = std::path::Path::new(trimmed_root);
+    if !root.is_absolute() {
+        return Err(format!("root_path must be absolute: {trimmed_root}"));
+    }
     if !root.is_dir() {
         return Err(format!("root_path is not a directory: {trimmed_root}"));
     }
 
     let id = Uuid::new_v4().to_string();
+    log::debug!(
+        "[vault] create: name={trimmed_name:?} root={trimmed_root:?} id={id} \
+         include_globs={} exclude_globs={}",
+        include_globs.len(),
+        exclude_globs.len(),
+    );
     let namespace = format!("vault:{id}");
     let vault = Vault {
         id: id.clone(),
@@ -58,6 +67,7 @@ pub async fn vault_create(
 
 pub async fn vault_list(config: &Config) -> Result<RpcOutcome<Vec<Vault>>, String> {
     let vaults = store::list_vaults(config).map_err(|e| e.to_string())?;
+    log::debug!("[vault] list: count={}", vaults.len());
     Ok(RpcOutcome::single_log(vaults, "vaults listed"))
 }
 
@@ -69,6 +79,7 @@ pub async fn vault_get(config: &Config, id: &str) -> Result<RpcOutcome<Vault>, S
     let vault = store::get_vault(config, id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("vault not found: {id}"))?;
+    log::debug!("[vault] get: id={id} files={}", vault.file_count);
     Ok(RpcOutcome::single_log(vault, "vault loaded"))
 }
 
@@ -78,6 +89,7 @@ pub async fn vault_files(config: &Config, id: &str) -> Result<RpcOutcome<Vec<Vau
         return Err("vault_id must not be empty".to_string());
     }
     let files = store::list_files(config, id).map_err(|e| e.to_string())?;
+    log::debug!("[vault] files: id={id} count={}", files.len());
     Ok(RpcOutcome::single_log(files, "vault files listed"))
 }
 
@@ -92,6 +104,7 @@ pub async fn vault_remove(
     }
     let vault = store::get_vault(config, id).map_err(|e| e.to_string())?;
     let removed = store::remove_vault(config, id).map_err(|e| e.to_string())?;
+    log::debug!("[vault] remove: id={id} removed={removed} purge_memory={purge_memory}");
 
     let mut purged = false;
     if removed && purge_memory {
@@ -101,6 +114,7 @@ pub async fn vault_remove(
             })
             .await
             {
+                log::warn!("[vault] remove: id={id} purge_namespace_failed err={err}");
                 return Ok(RpcOutcome::single_log(
                     serde_json::json!({
                         "vault_id": id,
@@ -134,7 +148,18 @@ pub async fn vault_sync(config: &Config, id: &str) -> Result<RpcOutcome<VaultSyn
     let vault = store::get_vault(config, id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("vault not found: {id}"))?;
+    log::debug!("[vault] sync: entry id={id} root={:?}", vault.root_path);
     let report = sync::sync_vault(config, &vault).await;
+    log::debug!(
+        "[vault] sync: exit id={id} scanned={} ingested={} unchanged={} removed={} failed={} skipped={} duration_ms={}",
+        report.scanned,
+        report.ingested,
+        report.unchanged,
+        report.removed,
+        report.failed,
+        report.skipped_unsupported,
+        report.duration_ms,
+    );
     let msg = format!(
         "vault sync done — ingested {}, unchanged {}, removed {}, failed {}",
         report.ingested, report.unchanged, report.removed, report.failed

--- a/src/openhuman/vault/ops.rs
+++ b/src/openhuman/vault/ops.rs
@@ -1,0 +1,143 @@
+//! RPC-facing operations for the vault domain.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::openhuman::config::Config;
+use crate::openhuman::memory::ops::{clear_namespace, ClearNamespaceParams};
+use crate::rpc::RpcOutcome;
+
+use super::store;
+use super::sync;
+use super::types::{Vault, VaultFile, VaultSyncReport};
+
+/// Create a new vault pointing at a local folder.
+pub async fn vault_create(
+    config: &Config,
+    name: &str,
+    root_path: &str,
+    include_globs: Vec<String>,
+    exclude_globs: Vec<String>,
+) -> Result<RpcOutcome<Vault>, String> {
+    let trimmed_name = name.trim();
+    if trimmed_name.is_empty() {
+        return Err("vault name must not be empty".to_string());
+    }
+    let trimmed_root = root_path.trim();
+    if trimmed_root.is_empty() {
+        return Err("root_path must not be empty".to_string());
+    }
+    let root = std::path::Path::new(trimmed_root);
+    if !root.is_dir() {
+        return Err(format!("root_path is not a directory: {trimmed_root}"));
+    }
+
+    let id = Uuid::new_v4().to_string();
+    let namespace = format!("vault:{id}");
+    let vault = Vault {
+        id: id.clone(),
+        name: trimmed_name.to_string(),
+        root_path: root
+            .canonicalize()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| trimmed_root.to_string()),
+        namespace,
+        include_globs,
+        exclude_globs,
+        created_at: Utc::now(),
+        last_synced_at: None,
+        file_count: 0,
+    };
+
+    store::insert_vault(config, &vault).map_err(|e| e.to_string())?;
+    Ok(RpcOutcome::single_log(
+        vault,
+        format!("vault created: {id}"),
+    ))
+}
+
+pub async fn vault_list(config: &Config) -> Result<RpcOutcome<Vec<Vault>>, String> {
+    let vaults = store::list_vaults(config).map_err(|e| e.to_string())?;
+    Ok(RpcOutcome::single_log(vaults, "vaults listed"))
+}
+
+pub async fn vault_get(config: &Config, id: &str) -> Result<RpcOutcome<Vault>, String> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err("vault_id must not be empty".to_string());
+    }
+    let vault = store::get_vault(config, id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("vault not found: {id}"))?;
+    Ok(RpcOutcome::single_log(vault, "vault loaded"))
+}
+
+pub async fn vault_files(config: &Config, id: &str) -> Result<RpcOutcome<Vec<VaultFile>>, String> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err("vault_id must not be empty".to_string());
+    }
+    let files = store::list_files(config, id).map_err(|e| e.to_string())?;
+    Ok(RpcOutcome::single_log(files, "vault files listed"))
+}
+
+pub async fn vault_remove(
+    config: &Config,
+    id: &str,
+    purge_memory: bool,
+) -> Result<RpcOutcome<serde_json::Value>, String> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err("vault_id must not be empty".to_string());
+    }
+    let vault = store::get_vault(config, id).map_err(|e| e.to_string())?;
+    let removed = store::remove_vault(config, id).map_err(|e| e.to_string())?;
+
+    let mut purged = false;
+    if removed && purge_memory {
+        if let Some(v) = vault {
+            if let Err(err) = clear_namespace(ClearNamespaceParams {
+                namespace: v.namespace.clone(),
+            })
+            .await
+            {
+                return Ok(RpcOutcome::single_log(
+                    serde_json::json!({
+                        "vault_id": id,
+                        "removed": removed,
+                        "purged": false,
+                        "purge_error": err,
+                    }),
+                    format!("vault removed with purge error: {id}"),
+                ));
+            }
+            purged = true;
+        }
+    }
+
+    Ok(RpcOutcome::single_log(
+        serde_json::json!({
+            "vault_id": id,
+            "removed": removed,
+            "purged": purged,
+        }),
+        format!("vault removed: {id}"),
+    ))
+}
+
+/// Trigger an immediate sync of a vault. Blocks until complete.
+pub async fn vault_sync(config: &Config, id: &str) -> Result<RpcOutcome<VaultSyncReport>, String> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Err("vault_id must not be empty".to_string());
+    }
+    let vault = store::get_vault(config, id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("vault not found: {id}"))?;
+    let report = sync::sync_vault(config, &vault).await;
+    let msg = format!(
+        "vault sync done — ingested {}, unchanged {}, removed {}, failed {}",
+        report.ingested, report.unchanged, report.removed, report.failed
+    );
+    Ok(RpcOutcome::single_log(report, msg))
+}

--- a/src/openhuman/vault/schemas.rs
+++ b/src/openhuman/vault/schemas.rs
@@ -169,6 +169,12 @@ pub fn schemas(function: &str) -> ControllerSchema {
                             comment: "True when the memory namespace was also cleared.",
                             required: true,
                         },
+                        FieldSchema {
+                            name: "purge_error",
+                            ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+                            comment: "Error detail when purge was requested but failed.",
+                            required: false,
+                        },
                     ],
                 },
                 comment: "Removal result payload.",

--- a/src/openhuman/vault/schemas.rs
+++ b/src/openhuman/vault/schemas.rs
@@ -1,0 +1,297 @@
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use crate::openhuman::config::rpc as config_rpc;
+use crate::rpc::RpcOutcome;
+
+fn vault_id_input(comment: &'static str) -> FieldSchema {
+    FieldSchema {
+        name: "vault_id",
+        ty: TypeSchema::String,
+        comment,
+        required: true,
+    }
+}
+
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    vec![
+        schemas("create"),
+        schemas("list"),
+        schemas("get"),
+        schemas("files"),
+        schemas("remove"),
+        schemas("sync"),
+    ]
+}
+
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    vec![
+        RegisteredController {
+            schema: schemas("create"),
+            handler: handle_create,
+        },
+        RegisteredController {
+            schema: schemas("list"),
+            handler: handle_list,
+        },
+        RegisteredController {
+            schema: schemas("get"),
+            handler: handle_get,
+        },
+        RegisteredController {
+            schema: schemas("files"),
+            handler: handle_files,
+        },
+        RegisteredController {
+            schema: schemas("remove"),
+            handler: handle_remove,
+        },
+        RegisteredController {
+            schema: schemas("sync"),
+            handler: handle_sync,
+        },
+    ]
+}
+
+pub fn schemas(function: &str) -> ControllerSchema {
+    match function {
+        "create" => ControllerSchema {
+            namespace: "vault",
+            function: "create",
+            description: "Register a new local folder as a knowledge vault.",
+            inputs: vec![
+                FieldSchema {
+                    name: "name",
+                    ty: TypeSchema::String,
+                    comment: "Display name for the vault.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "root_path",
+                    ty: TypeSchema::String,
+                    comment: "Absolute path to the folder on disk.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "include_globs",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Array(Box::new(
+                        TypeSchema::String,
+                    )))),
+                    comment: "Optional include patterns (substring match).",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "exclude_globs",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Array(Box::new(
+                        TypeSchema::String,
+                    )))),
+                    comment: "Optional exclude patterns (substring match, case-insensitive).",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "vault",
+                ty: TypeSchema::Ref("Vault"),
+                comment: "The newly created vault.",
+                required: true,
+            }],
+        },
+        "list" => ControllerSchema {
+            namespace: "vault",
+            function: "list",
+            description: "List all registered vaults.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "vaults",
+                ty: TypeSchema::Array(Box::new(TypeSchema::Ref("Vault"))),
+                comment: "All registered vaults.",
+                required: true,
+            }],
+        },
+        "get" => ControllerSchema {
+            namespace: "vault",
+            function: "get",
+            description: "Fetch one vault by id.",
+            inputs: vec![vault_id_input("Identifier of the vault to fetch.")],
+            outputs: vec![FieldSchema {
+                name: "vault",
+                ty: TypeSchema::Ref("Vault"),
+                comment: "The requested vault.",
+                required: true,
+            }],
+        },
+        "files" => ControllerSchema {
+            namespace: "vault",
+            function: "files",
+            description: "List per-file ledger entries for a vault.",
+            inputs: vec![vault_id_input("Identifier of the vault.")],
+            outputs: vec![FieldSchema {
+                name: "files",
+                ty: TypeSchema::Array(Box::new(TypeSchema::Ref("VaultFile"))),
+                comment: "Per-file ledger rows.",
+                required: true,
+            }],
+        },
+        "remove" => ControllerSchema {
+            namespace: "vault",
+            function: "remove",
+            description: "Remove a vault. Optionally purge its memory namespace.",
+            inputs: vec![
+                vault_id_input("Identifier of the vault to remove."),
+                FieldSchema {
+                    name: "purge_memory",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Bool)),
+                    comment: "When true, also clear the vault's memory namespace.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Object {
+                    fields: vec![
+                        FieldSchema {
+                            name: "vault_id",
+                            ty: TypeSchema::String,
+                            comment: "Identifier requested for removal.",
+                            required: true,
+                        },
+                        FieldSchema {
+                            name: "removed",
+                            ty: TypeSchema::Bool,
+                            comment: "True when the vault row was deleted.",
+                            required: true,
+                        },
+                        FieldSchema {
+                            name: "purged",
+                            ty: TypeSchema::Bool,
+                            comment: "True when the memory namespace was also cleared.",
+                            required: true,
+                        },
+                    ],
+                },
+                comment: "Removal result payload.",
+                required: true,
+            }],
+        },
+        "sync" => ControllerSchema {
+            namespace: "vault",
+            function: "sync",
+            description: "Walk a vault's root folder and ingest changed files.",
+            inputs: vec![vault_id_input("Identifier of the vault to sync.")],
+            outputs: vec![FieldSchema {
+                name: "report",
+                ty: TypeSchema::Ref("VaultSyncReport"),
+                comment: "Summary of the sync run.",
+                required: true,
+            }],
+        },
+        _other => ControllerSchema {
+            namespace: "vault",
+            function: "unknown",
+            description: "Unknown vault controller function.",
+            inputs: vec![FieldSchema {
+                name: "function",
+                ty: TypeSchema::String,
+                comment: "Unknown function requested for schema lookup.",
+                required: true,
+            }],
+            outputs: vec![FieldSchema {
+                name: "error",
+                ty: TypeSchema::String,
+                comment: "Lookup error details.",
+                required: true,
+            }],
+        },
+    }
+}
+
+fn handle_create(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let name = read_required::<String>(&params, "name")?;
+        let root_path = read_required::<String>(&params, "root_path")?;
+        let include_globs =
+            read_optional::<Vec<String>>(&params, "include_globs")?.unwrap_or_default();
+        let exclude_globs =
+            read_optional::<Vec<String>>(&params, "exclude_globs")?.unwrap_or_default();
+        to_json(
+            crate::openhuman::vault::ops::vault_create(
+                &config,
+                &name,
+                &root_path,
+                include_globs,
+                exclude_globs,
+            )
+            .await?,
+        )
+    })
+}
+
+fn handle_list(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async {
+        let config = config_rpc::load_config_with_timeout().await?;
+        to_json(crate::openhuman::vault::ops::vault_list(&config).await?)
+    })
+}
+
+fn handle_get(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let vault_id = read_required::<String>(&params, "vault_id")?;
+        to_json(crate::openhuman::vault::ops::vault_get(&config, vault_id.trim()).await?)
+    })
+}
+
+fn handle_files(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let vault_id = read_required::<String>(&params, "vault_id")?;
+        to_json(crate::openhuman::vault::ops::vault_files(&config, vault_id.trim()).await?)
+    })
+}
+
+fn handle_remove(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let vault_id = read_required::<String>(&params, "vault_id")?;
+        let purge_memory = read_optional::<bool>(&params, "purge_memory")?.unwrap_or(false);
+        to_json(
+            crate::openhuman::vault::ops::vault_remove(&config, vault_id.trim(), purge_memory)
+                .await?,
+        )
+    })
+}
+
+fn handle_sync(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let vault_id = read_required::<String>(&params, "vault_id")?;
+        to_json(crate::openhuman::vault::ops::vault_sync(&config, vault_id.trim()).await?)
+    })
+}
+
+fn read_required<T: DeserializeOwned>(params: &Map<String, Value>, key: &str) -> Result<T, String> {
+    let value = params
+        .get(key)
+        .cloned()
+        .ok_or_else(|| format!("missing required param '{key}'"))?;
+    serde_json::from_value(value).map_err(|e| format!("invalid '{key}': {e}"))
+}
+
+fn read_optional<T: DeserializeOwned>(
+    params: &Map<String, Value>,
+    key: &str,
+) -> Result<Option<T>, String> {
+    match params.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|e| format!("invalid '{key}': {e}")),
+    }
+}
+
+fn to_json<T: serde::Serialize>(outcome: RpcOutcome<T>) -> Result<Value, String> {
+    outcome.into_cli_compatible_json()
+}

--- a/src/openhuman/vault/store.rs
+++ b/src/openhuman/vault/store.rs
@@ -1,0 +1,217 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::openhuman::config::Config;
+
+use super::types::{Vault, VaultFile, VaultFileStatus};
+
+pub(crate) fn with_connection<T>(
+    config: &Config,
+    f: impl FnOnce(&Connection) -> Result<T>,
+) -> Result<T> {
+    let db_path = config.workspace_dir.join("vault").join("vault.db");
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create vault directory: {}", parent.display()))?;
+    }
+
+    let conn = Connection::open(&db_path)
+        .with_context(|| format!("Failed to open vault DB: {}", db_path.display()))?;
+
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         CREATE TABLE IF NOT EXISTS vaults (
+            id              TEXT PRIMARY KEY,
+            name            TEXT NOT NULL,
+            root_path       TEXT NOT NULL,
+            namespace       TEXT NOT NULL UNIQUE,
+            include_globs   TEXT NOT NULL DEFAULT '[]',
+            exclude_globs   TEXT NOT NULL DEFAULT '[]',
+            created_at      TEXT NOT NULL,
+            last_synced_at  TEXT
+         );
+         CREATE TABLE IF NOT EXISTS vault_files (
+            vault_id     TEXT NOT NULL,
+            rel_path     TEXT NOT NULL,
+            document_id  TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            mtime_ms     INTEGER NOT NULL,
+            bytes        INTEGER NOT NULL,
+            ingested_at  TEXT NOT NULL,
+            status       TEXT NOT NULL DEFAULT 'ok',
+            PRIMARY KEY (vault_id, rel_path),
+            FOREIGN KEY (vault_id) REFERENCES vaults(id) ON DELETE CASCADE
+         );
+         CREATE INDEX IF NOT EXISTS idx_vault_files_vault ON vault_files(vault_id);",
+    )
+    .context("Failed to initialize vault schema")?;
+
+    f(&conn)
+}
+
+pub fn insert_vault(config: &Config, vault: &Vault) -> Result<()> {
+    with_connection(config, |conn| {
+        conn.execute(
+            "INSERT INTO vaults (id, name, root_path, namespace, include_globs, exclude_globs, created_at, last_synced_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                vault.id,
+                vault.name,
+                vault.root_path,
+                vault.namespace,
+                serde_json::to_string(&vault.include_globs)?,
+                serde_json::to_string(&vault.exclude_globs)?,
+                vault.created_at.to_rfc3339(),
+                vault.last_synced_at.map(|t| t.to_rfc3339()),
+            ],
+        )
+        .context("Failed to insert vault")?;
+        Ok(())
+    })
+}
+
+pub fn list_vaults(config: &Config) -> Result<Vec<Vault>> {
+    with_connection(config, |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT v.id, v.name, v.root_path, v.namespace, v.include_globs, v.exclude_globs,
+                    v.created_at, v.last_synced_at,
+                    (SELECT COUNT(*) FROM vault_files vf WHERE vf.vault_id = v.id AND vf.status = 'ok')
+             FROM vaults v
+             ORDER BY v.created_at DESC",
+        )?;
+        let rows = stmt.query_map([], row_to_vault)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    })
+}
+
+pub fn get_vault(config: &Config, id: &str) -> Result<Option<Vault>> {
+    with_connection(config, |conn| {
+        conn.query_row(
+            "SELECT v.id, v.name, v.root_path, v.namespace, v.include_globs, v.exclude_globs,
+                    v.created_at, v.last_synced_at,
+                    (SELECT COUNT(*) FROM vault_files vf WHERE vf.vault_id = v.id AND vf.status = 'ok')
+             FROM vaults v WHERE v.id = ?1",
+            params![id],
+            row_to_vault,
+        )
+        .optional()
+        .context("Failed to read vault")
+    })
+}
+
+pub fn remove_vault(config: &Config, id: &str) -> Result<bool> {
+    with_connection(config, |conn| {
+        let n = conn
+            .execute("DELETE FROM vaults WHERE id = ?1", params![id])
+            .context("Failed to delete vault")?;
+        Ok(n > 0)
+    })
+}
+
+pub fn touch_last_synced(config: &Config, id: &str, when: DateTime<Utc>) -> Result<()> {
+    with_connection(config, |conn| {
+        conn.execute(
+            "UPDATE vaults SET last_synced_at = ?2 WHERE id = ?1",
+            params![id, when.to_rfc3339()],
+        )?;
+        Ok(())
+    })
+}
+
+pub fn list_files(config: &Config, vault_id: &str) -> Result<Vec<VaultFile>> {
+    with_connection(config, |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT vault_id, rel_path, document_id, content_hash, mtime_ms, bytes, ingested_at, status
+             FROM vault_files WHERE vault_id = ?1 ORDER BY rel_path",
+        )?;
+        let rows = stmt.query_map(params![vault_id], row_to_file)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    })
+}
+
+pub fn upsert_file(config: &Config, file: &VaultFile) -> Result<()> {
+    with_connection(config, |conn| {
+        conn.execute(
+            "INSERT INTO vault_files (vault_id, rel_path, document_id, content_hash, mtime_ms, bytes, ingested_at, status)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(vault_id, rel_path) DO UPDATE SET
+                document_id = excluded.document_id,
+                content_hash = excluded.content_hash,
+                mtime_ms = excluded.mtime_ms,
+                bytes = excluded.bytes,
+                ingested_at = excluded.ingested_at,
+                status = excluded.status",
+            params![
+                file.vault_id,
+                file.rel_path,
+                file.document_id,
+                file.content_hash,
+                file.mtime_ms,
+                file.bytes as i64,
+                file.ingested_at.to_rfc3339(),
+                file.status.as_str(),
+            ],
+        )?;
+        Ok(())
+    })
+}
+
+pub fn delete_file(config: &Config, vault_id: &str, rel_path: &str) -> Result<()> {
+    with_connection(config, |conn| {
+        conn.execute(
+            "DELETE FROM vault_files WHERE vault_id = ?1 AND rel_path = ?2",
+            params![vault_id, rel_path],
+        )?;
+        Ok(())
+    })
+}
+
+fn row_to_vault(row: &rusqlite::Row<'_>) -> rusqlite::Result<Vault> {
+    let include_raw: String = row.get(4)?;
+    let exclude_raw: String = row.get(5)?;
+    let created_raw: String = row.get(6)?;
+    let last_raw: Option<String> = row.get(7)?;
+    let file_count: i64 = row.get(8)?;
+    Ok(Vault {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        root_path: row.get(2)?,
+        namespace: row.get(3)?,
+        include_globs: serde_json::from_str(&include_raw).unwrap_or_default(),
+        exclude_globs: serde_json::from_str(&exclude_raw).unwrap_or_default(),
+        created_at: parse_dt(&created_raw),
+        last_synced_at: last_raw.as_deref().map(parse_dt),
+        file_count: file_count.max(0) as u64,
+    })
+}
+
+fn row_to_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<VaultFile> {
+    let ingested_raw: String = row.get(6)?;
+    let status_raw: String = row.get(7)?;
+    let bytes: i64 = row.get(5)?;
+    Ok(VaultFile {
+        vault_id: row.get(0)?,
+        rel_path: row.get(1)?,
+        document_id: row.get(2)?,
+        content_hash: row.get(3)?,
+        mtime_ms: row.get(4)?,
+        bytes: bytes.max(0) as u64,
+        ingested_at: parse_dt(&ingested_raw),
+        status: VaultFileStatus::parse(&status_raw),
+    })
+}
+
+fn parse_dt(raw: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|t| t.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc::now())
+}

--- a/src/openhuman/vault/sync.rs
+++ b/src/openhuman/vault/sync.rs
@@ -105,31 +105,51 @@ pub async fn sync_vault(config: &Config, vault: &Vault) -> VaultSyncReport {
         .map(|f| (f.rel_path.clone(), f.clone()))
         .collect();
 
+    let user_includes: Vec<String> = vault
+        .include_globs
+        .iter()
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
     let user_excludes: Vec<String> = vault
         .exclude_globs
         .iter()
         .map(|s| s.to_ascii_lowercase())
         .collect();
 
-    for entry in WalkDir::new(&root).follow_links(false) {
+    log::debug!(
+        "[vault] sync_vault: entry id={} root={:?} ledger_rows={} includes={} excludes={}",
+        vault.id,
+        vault.root_path,
+        existing.len(),
+        user_includes.len(),
+        user_excludes.len(),
+    );
+
+    // Prune builtin-excluded directory subtrees at traversal time so we never
+    // descend into node_modules / target / .git etc.
+    let walker = WalkDir::new(&root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            if !e.file_type().is_dir() {
+                return true;
+            }
+            e.file_name()
+                .to_str()
+                .map(|name| !BUILTIN_EXCLUDE_DIRS.contains(&name))
+                .unwrap_or(true)
+        });
+
+    for entry in walker {
         let entry = match entry {
             Ok(e) => e,
             Err(err) => {
+                log::debug!("[vault] sync_vault: walk error err={err}");
                 report.errors.push(format!("walk error: {err}"));
                 continue;
             }
         };
 
-        // Skip builtin-excluded directories at any depth.
-        if entry.file_type().is_dir() {
-            if let Some(name) = entry.file_name().to_str() {
-                if BUILTIN_EXCLUDE_DIRS.contains(&name) {
-                    // skip the subtree by checking parent paths later
-                    continue;
-                }
-            }
-            continue;
-        }
         if !entry.file_type().is_file() {
             continue;
         }
@@ -139,14 +159,17 @@ pub async fn sync_vault(config: &Config, vault: &Vault) -> VaultSyncReport {
             Ok(p) => p.to_string_lossy().to_string(),
             Err(_) => continue,
         };
+        let rel_path_lc = rel_path.to_ascii_lowercase();
 
+        // Defence-in-depth: filter_entry above prunes subtrees, but a future
+        // refactor that drops it shouldn't silently let excluded files through.
         if path_is_inside_excluded_dir(path, &root) {
             continue;
         }
-        if user_excludes
-            .iter()
-            .any(|pat| rel_path.to_ascii_lowercase().contains(pat))
-        {
+        if !user_includes.is_empty() && !user_includes.iter().any(|pat| rel_path_lc.contains(pat)) {
+            continue;
+        }
+        if user_excludes.iter().any(|pat| rel_path_lc.contains(pat)) {
             continue;
         }
 
@@ -256,13 +279,18 @@ pub async fn sync_vault(config: &Config, vault: &Vault) -> VaultSyncReport {
                     status: VaultFileStatus::Ok,
                 };
                 if let Err(err) = store::upsert_file(config, &file) {
+                    log::debug!(
+                        "[vault] sync_vault: ledger write failed path={rel_path} err={err}"
+                    );
                     report
                         .errors
                         .push(format!("{rel_path}: ledger write failed: {err}"));
                 }
+                log::trace!("[vault] sync_vault: ingested path={rel_path}");
                 report.ingested += 1;
             }
             Err(err) => {
+                log::debug!("[vault] sync_vault: ingest failed path={rel_path} err={err}");
                 report.failed += 1;
                 report
                     .errors
@@ -276,17 +304,43 @@ pub async fn sync_vault(config: &Config, vault: &Vault) -> VaultSyncReport {
         if seen.contains(path) {
             continue;
         }
-        let _ = doc_delete(DeleteDocParams {
+        if let Err(err) = doc_delete(DeleteDocParams {
             namespace: vault.namespace.clone(),
             document_id: prev.document_id.clone(),
         })
-        .await;
-        let _ = store::delete_file(config, &vault.id, path);
+        .await
+        {
+            log::debug!("[vault] sync_vault: doc delete failed path={path} err={err}");
+            report
+                .errors
+                .push(format!("{path}: doc delete failed: {err}"));
+            continue;
+        }
+        if let Err(err) = store::delete_file(config, &vault.id, path) {
+            log::debug!("[vault] sync_vault: ledger delete failed path={path} err={err}");
+            report
+                .errors
+                .push(format!("{path}: ledger delete failed: {err}"));
+            continue;
+        }
         report.removed += 1;
     }
 
-    let _ = store::touch_last_synced(config, &vault.id, Utc::now());
+    if let Err(err) = store::touch_last_synced(config, &vault.id, Utc::now()) {
+        log::debug!("[vault] sync_vault: touch_last_synced failed err={err}");
+    }
     report.duration_ms = (Utc::now() - started).num_milliseconds();
+    log::debug!(
+        "[vault] sync_vault: exit id={} scanned={} ingested={} unchanged={} removed={} failed={} skipped={} duration_ms={}",
+        vault.id,
+        report.scanned,
+        report.ingested,
+        report.unchanged,
+        report.removed,
+        report.failed,
+        report.skipped_unsupported,
+        report.duration_ms,
+    );
     report
 }
 

--- a/src/openhuman/vault/sync.rs
+++ b/src/openhuman/vault/sync.rs
@@ -1,0 +1,318 @@
+//! Walk a vault's root directory and ingest changed/new files into memory.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+use crate::openhuman::config::Config;
+use crate::openhuman::memory::ops::{doc_delete, doc_ingest, DeleteDocParams, IngestDocParams};
+
+use super::store;
+use super::types::{Vault, VaultFile, VaultFileStatus, VaultSyncReport};
+
+/// Built-in exclude patterns we never traverse. Kept tiny and obvious.
+const BUILTIN_EXCLUDE_DIRS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".cache",
+    ".venv",
+    "__pycache__",
+    ".DS_Store",
+];
+
+/// Max single-file size we read into memory for ingestion (5 MiB).
+const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// File extensions we currently extract as plain UTF-8.
+pub fn supported_extension(ext: &str) -> bool {
+    matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "md" | "mdx"
+            | "txt"
+            | "rst"
+            | "json"
+            | "yaml"
+            | "yml"
+            | "toml"
+            | "csv"
+            | "html"
+            | "htm"
+            | "rs"
+            | "ts"
+            | "tsx"
+            | "js"
+            | "jsx"
+            | "py"
+            | "go"
+            | "java"
+            | "rb"
+            | "php"
+            | "sh"
+            | "bash"
+            | "zsh"
+            | "sql"
+            | "css"
+            | "scss"
+            | "swift"
+            | "kt"
+            | "c"
+            | "cc"
+            | "cpp"
+            | "h"
+            | "hpp"
+            | "log"
+    )
+}
+
+/// Walk `vault.root_path`, ingest new/changed files into memory, delete docs
+/// whose source files vanished, and record per-file state in the ledger.
+pub async fn sync_vault(config: &Config, vault: &Vault) -> VaultSyncReport {
+    let started = Utc::now();
+    let mut report = VaultSyncReport {
+        vault_id: vault.id.clone(),
+        ..Default::default()
+    };
+
+    let root = PathBuf::from(&vault.root_path);
+    if !root.is_dir() {
+        report
+            .errors
+            .push(format!("root_path is not a directory: {}", vault.root_path));
+        report.duration_ms = (Utc::now() - started).num_milliseconds();
+        return report;
+    }
+
+    // Snapshot existing ledger so we can compute deletions at the end.
+    let existing = match store::list_files(config, &vault.id) {
+        Ok(rows) => rows,
+        Err(err) => {
+            report.errors.push(format!("ledger read failed: {err}"));
+            return report;
+        }
+    };
+    let mut seen: HashSet<String> = HashSet::new();
+    let by_path: std::collections::HashMap<String, VaultFile> = existing
+        .iter()
+        .map(|f| (f.rel_path.clone(), f.clone()))
+        .collect();
+
+    let user_excludes: Vec<String> = vault
+        .exclude_globs
+        .iter()
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+
+    for entry in WalkDir::new(&root).follow_links(false) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                report.errors.push(format!("walk error: {err}"));
+                continue;
+            }
+        };
+
+        // Skip builtin-excluded directories at any depth.
+        if entry.file_type().is_dir() {
+            if let Some(name) = entry.file_name().to_str() {
+                if BUILTIN_EXCLUDE_DIRS.contains(&name) {
+                    // skip the subtree by checking parent paths later
+                    continue;
+                }
+            }
+            continue;
+        }
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        let rel_path = match path.strip_prefix(&root) {
+            Ok(p) => p.to_string_lossy().to_string(),
+            Err(_) => continue,
+        };
+
+        if path_is_inside_excluded_dir(path, &root) {
+            continue;
+        }
+        if user_excludes
+            .iter()
+            .any(|pat| rel_path.to_ascii_lowercase().contains(pat))
+        {
+            continue;
+        }
+
+        report.scanned += 1;
+
+        let ext = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if !supported_extension(&ext) {
+            report.skipped_unsupported += 1;
+            seen.insert(rel_path.clone()); // keep ledger entries pruned
+            continue;
+        }
+
+        let metadata = match std::fs::metadata(path) {
+            Ok(m) => m,
+            Err(err) => {
+                report.failed += 1;
+                report
+                    .errors
+                    .push(format!("{rel_path}: stat failed: {err}"));
+                continue;
+            }
+        };
+        if metadata.len() > MAX_FILE_BYTES {
+            report.skipped_unsupported += 1;
+            report.errors.push(format!(
+                "{rel_path}: skipped — {} bytes exceeds {}",
+                metadata.len(),
+                MAX_FILE_BYTES
+            ));
+            seen.insert(rel_path.clone());
+            continue;
+        }
+
+        let mtime_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(err) => {
+                report.failed += 1;
+                report
+                    .errors
+                    .push(format!("{rel_path}: read failed: {err}"));
+                continue;
+            }
+        };
+        let hash = sha256_hex(&content);
+
+        seen.insert(rel_path.clone());
+
+        // Dedup: if hash and mtime unchanged, skip ingest.
+        if let Some(prev) = by_path.get(&rel_path) {
+            if prev.status == VaultFileStatus::Ok
+                && prev.content_hash == hash
+                && prev.mtime_ms == mtime_ms
+            {
+                report.unchanged += 1;
+                continue;
+            }
+        }
+
+        let key = rel_path.clone();
+        let title = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(&rel_path)
+            .to_string();
+        let ingest_params = IngestDocParams {
+            namespace: vault.namespace.clone(),
+            key,
+            title,
+            content,
+            source_type: "vault".to_string(),
+            priority: "medium".to_string(),
+            tags: vec![format!("vault:{}", vault.id), format!("ext:{ext}")],
+            metadata: serde_json::json!({
+                "vault_id": vault.id,
+                "rel_path": rel_path,
+                "mtime_ms": mtime_ms,
+                "bytes": metadata.len(),
+            }),
+            category: "user".to_string(),
+            session_id: None,
+            document_id: by_path.get(&rel_path).map(|p| p.document_id.clone()),
+            config: None,
+        };
+
+        match doc_ingest(ingest_params).await {
+            Ok(outcome) => {
+                let document_id = outcome.value.document_id.clone();
+                let file = VaultFile {
+                    vault_id: vault.id.clone(),
+                    rel_path: rel_path.clone(),
+                    document_id,
+                    content_hash: hash,
+                    mtime_ms,
+                    bytes: metadata.len(),
+                    ingested_at: Utc::now(),
+                    status: VaultFileStatus::Ok,
+                };
+                if let Err(err) = store::upsert_file(config, &file) {
+                    report
+                        .errors
+                        .push(format!("{rel_path}: ledger write failed: {err}"));
+                }
+                report.ingested += 1;
+            }
+            Err(err) => {
+                report.failed += 1;
+                report
+                    .errors
+                    .push(format!("{rel_path}: ingest failed: {err}"));
+            }
+        }
+    }
+
+    // Anything in ledger we didn't see this pass is gone — delete it.
+    for (path, prev) in by_path.iter() {
+        if seen.contains(path) {
+            continue;
+        }
+        let _ = doc_delete(DeleteDocParams {
+            namespace: vault.namespace.clone(),
+            document_id: prev.document_id.clone(),
+        })
+        .await;
+        let _ = store::delete_file(config, &vault.id, path);
+        report.removed += 1;
+    }
+
+    let _ = store::touch_last_synced(config, &vault.id, Utc::now());
+    report.duration_ms = (Utc::now() - started).num_milliseconds();
+    report
+}
+
+fn path_is_inside_excluded_dir(path: &Path, root: &Path) -> bool {
+    let Ok(rel) = path.strip_prefix(root) else {
+        return false;
+    };
+    for component in rel.components() {
+        if let std::path::Component::Normal(os) = component {
+            if let Some(name) = os.to_str() {
+                if BUILTIN_EXCLUDE_DIRS.contains(&name) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter() {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}

--- a/src/openhuman/vault/tests.rs
+++ b/src/openhuman/vault/tests.rs
@@ -1,0 +1,130 @@
+//! Unit tests for the vault domain. Hits a real SQLite db in a tempdir,
+//! but skips memory ingestion (covered in higher-level integration tests).
+
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+use crate::openhuman::config::Config;
+
+use super::store;
+use super::sync::supported_extension;
+use super::types::{Vault, VaultFile, VaultFileStatus};
+
+fn make_config(tmp: &TempDir) -> Config {
+    let mut config = Config::default();
+    config.workspace_dir = tmp.path().to_path_buf();
+    config
+}
+
+fn sample_vault(root: PathBuf) -> Vault {
+    Vault {
+        id: "vault-test-1".to_string(),
+        name: "Test".to_string(),
+        root_path: root.to_string_lossy().to_string(),
+        namespace: "vault:vault-test-1".to_string(),
+        include_globs: vec![],
+        exclude_globs: vec![],
+        created_at: chrono::Utc::now(),
+        last_synced_at: None,
+        file_count: 0,
+    }
+}
+
+#[test]
+fn supported_extension_accepts_md_and_code() {
+    assert!(supported_extension("md"));
+    assert!(supported_extension("MD"));
+    assert!(supported_extension("rs"));
+    assert!(supported_extension("tsx"));
+    assert!(!supported_extension("png"));
+    assert!(!supported_extension("zip"));
+    assert!(!supported_extension(""));
+}
+
+#[test]
+fn store_insert_get_list_remove_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let config = make_config(&tmp);
+    let vault = sample_vault(tmp.path().to_path_buf());
+
+    store::insert_vault(&config, &vault).unwrap();
+
+    let listed = store::list_vaults(&config).unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, vault.id);
+    assert_eq!(listed[0].namespace, vault.namespace);
+    assert_eq!(listed[0].file_count, 0);
+
+    let fetched = store::get_vault(&config, &vault.id).unwrap();
+    assert!(fetched.is_some());
+    assert_eq!(fetched.unwrap().name, "Test");
+
+    let removed = store::remove_vault(&config, &vault.id).unwrap();
+    assert!(removed);
+    assert!(store::list_vaults(&config).unwrap().is_empty());
+}
+
+#[test]
+fn store_files_upsert_and_delete() {
+    let tmp = TempDir::new().unwrap();
+    let config = make_config(&tmp);
+    let vault = sample_vault(tmp.path().to_path_buf());
+    store::insert_vault(&config, &vault).unwrap();
+
+    let file = VaultFile {
+        vault_id: vault.id.clone(),
+        rel_path: "notes/one.md".to_string(),
+        document_id: "doc-1".to_string(),
+        content_hash: "h1".to_string(),
+        mtime_ms: 100,
+        bytes: 42,
+        ingested_at: chrono::Utc::now(),
+        status: VaultFileStatus::Ok,
+    };
+    store::upsert_file(&config, &file).unwrap();
+
+    let listed = store::list_files(&config, &vault.id).unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].document_id, "doc-1");
+
+    // Re-upsert with same key should update, not duplicate.
+    let mut updated = file.clone();
+    updated.content_hash = "h2".to_string();
+    updated.mtime_ms = 200;
+    store::upsert_file(&config, &updated).unwrap();
+    let listed = store::list_files(&config, &vault.id).unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].content_hash, "h2");
+    assert_eq!(listed[0].mtime_ms, 200);
+
+    // File count on vault list should reflect 1 OK row.
+    let vaults = store::list_vaults(&config).unwrap();
+    assert_eq!(vaults[0].file_count, 1);
+
+    store::delete_file(&config, &vault.id, "notes/one.md").unwrap();
+    assert!(store::list_files(&config, &vault.id).unwrap().is_empty());
+}
+
+#[test]
+fn remove_vault_cascades_files() {
+    let tmp = TempDir::new().unwrap();
+    let config = make_config(&tmp);
+    let vault = sample_vault(tmp.path().to_path_buf());
+    store::insert_vault(&config, &vault).unwrap();
+
+    let file = VaultFile {
+        vault_id: vault.id.clone(),
+        rel_path: "a.md".to_string(),
+        document_id: "doc-a".to_string(),
+        content_hash: "h".to_string(),
+        mtime_ms: 1,
+        bytes: 1,
+        ingested_at: chrono::Utc::now(),
+        status: VaultFileStatus::Ok,
+    };
+    store::upsert_file(&config, &file).unwrap();
+
+    store::remove_vault(&config, &vault.id).unwrap();
+    // Cascade should have wiped vault_files rows for this id.
+    assert!(store::list_files(&config, &vault.id).unwrap().is_empty());
+}

--- a/src/openhuman/vault/types.rs
+++ b/src/openhuman/vault/types.rs
@@ -1,0 +1,69 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A user-registered local folder whose files are mirrored into memory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Vault {
+    pub id: String,
+    pub name: String,
+    pub root_path: String,
+    pub namespace: String,
+    pub include_globs: Vec<String>,
+    pub exclude_globs: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_synced_at: Option<DateTime<Utc>>,
+    pub file_count: u64,
+}
+
+/// Per-file ledger entry used for dedup on re-sync.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VaultFile {
+    pub vault_id: String,
+    pub rel_path: String,
+    pub document_id: String,
+    pub content_hash: String,
+    pub mtime_ms: i64,
+    pub bytes: u64,
+    pub ingested_at: DateTime<Utc>,
+    pub status: VaultFileStatus,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultFileStatus {
+    Ok,
+    Skipped,
+    Failed,
+}
+
+impl VaultFileStatus {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Skipped => "skipped",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub(crate) fn parse(raw: &str) -> Self {
+        match raw {
+            "skipped" => Self::Skipped,
+            "failed" => Self::Failed,
+            _ => Self::Ok,
+        }
+    }
+}
+
+/// Summary returned from `vault.sync`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct VaultSyncReport {
+    pub vault_id: String,
+    pub scanned: u64,
+    pub ingested: u64,
+    pub unchanged: u64,
+    pub removed: u64,
+    pub failed: u64,
+    pub skipped_unsupported: u64,
+    pub duration_ms: i64,
+    pub errors: Vec<String>,
+}


### PR DESCRIPTION
## Summary

- Add a new `vault` domain that lets users point at a local folder and have its files chunked + embedded into memory under namespace `vault:<id>` — NotebookLM-for-Drive, but for any local directory.
- Surface it in the existing Memory page (Intelligence ▸ Memory) via a new \`VaultPanel\` with add / list / sync / remove actions.
- Named \`vault\` (not \`workspace\`) to avoid colliding with the existing \`workspace\` domain that handles CLI \`init\` bootstrap.

## Problem

The memory system today accepts documents one at a time via \`memory.doc_ingest\` and is populated by composio sync (Gmail, etc.) or manual writes. There is no way to point the assistant at a folder of local files (notes, code, references) and have them ingested as a unit — the equivalent of NotebookLM's "add Drive folder" action.

## Solution

A small, self-contained \`vault\` domain mirroring the \`cron\` layout:

- **`src/openhuman/vault/store.rs`** — SQLite tables `vaults` + `vault_files`, FK cascade on delete, stored at `{workspace_dir}/vault/vault.db`.
- **`src/openhuman/vault/sync.rs`** — walks `root_path` with `walkdir`, skips built-in noise dirs (`.git`, `node_modules`, `target`, `dist`, `.venv`, …) and user-supplied excludes, hashes content with sha256, dedupes on `(content_hash, mtime)` so re-syncs only ingest changed files, deletes vault docs whose source files have vanished. 5 MiB per-file cap. ~30 supported text/code extensions.
- **`src/openhuman/vault/ops.rs`** — six RPCs: `vault_create`, `vault_list`, `vault_get`, `vault_files`, `vault_remove` (with optional `purge_memory` to also clear the namespace), `vault_sync`.
- **`src/openhuman/vault/schemas.rs`** — controller registry following the same pattern as `cron/schemas.rs`. Wired into `src/core/all.rs`.
- **TS surface**: `app/src/utils/tauriCommands/vault.ts` with hand-written interfaces matching the Rust types.
- **UI**: `VaultPanel.tsx` slotted into `MemoryWorkspace.tsx`. Add-vault form (name + absolute path + optional excludes), per-row Sync / Remove with two-step confirm and an OK-to-purge prompt.

Tradeoffs:
- No native folder picker yet (no `tauri-plugin-dialog` installed); user pastes an absolute path. Easy follow-up.
- No `notify` file-watching in v1 — explicit `vault.sync` only. Auto-watching is a v2 concern.
- Globs are substring matches today, not real glob patterns; keeps the dep tree small.
- Sync uses the existing `memory::ops::doc_ingest` path so the chunker + embedder behaviour matches everything else in memory.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: Diff coverage measurement not run locally; CI's diff-cover gate will report. Store/types covered by 4 unit tests in `src/openhuman/vault/tests.rs`; sync engine's external-effect path (memory ingestion) exercised in higher-level memory integration tests.
- [x] N/A: \`docs/TEST-COVERAGE-MATRIX.md\` is a separate matrix that's not currently in active use by this change set.
- [x] N/A: No matrix feature IDs apply to this new domain.
- [x] No new external network dependencies introduced (all local filesystem + existing memory pipeline)
- [x] N/A: Not a release-cut surface change; no manual smoke entry needed.
- [x] N/A: No linked issue — this lands a feature requested directly in chat.

## Impact

- **Platform**: desktop (Tauri host) only; the Rust core changes are shared with the CLI binary so \`openhuman-core\` CLI also picks up the \`vault.*\` RPCs.
- **Performance**: sync is sequential per file; large vaults will block the RPC for the duration. Dedup means re-syncs are cheap. 5 MiB per-file cap prevents huge files from OOMing the in-process embedder.
- **Security**: paths are validated server-side (must be an existing directory); we canonicalize when possible. No symlink-following (\`follow_links(false)\`). No execution of file contents.
- **Migration**: net-additive — creates a new SQLite db at \`{workspace_dir}/vault/vault.db\` on first call.
- **Compatibility**: opt-in feature; nothing else changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - Native folder picker via \`tauri-plugin-dialog\`.
  - Optional \`notify\`-based auto-resync.
  - PDF/DOCX extractor (currently skipped as unsupported extension).
  - Real glob matching (e.g. \`globset\`) instead of substring.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: \`feat/workspace-folder-ingestion\`
- Commit SHA: d077c9b50667d6c3604e9e9f21b29067d454b26b

### Validation Run
- [x] \`pnpm --filter openhuman-app format:check\` — ran \`pnpm format\` (writes); no diffs after formatter ran.
- [x] \`pnpm typecheck\`
- [x] Focused tests: \`cargo test --lib openhuman::vault::\` — 4/4 passing
- [x] Rust fmt/check (if changed): \`cargo check --manifest-path Cargo.toml\` clean
- [x] Tauri fmt/check (if changed): \`pnpm rust:check\` clean

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended behavior change: New \`vault.*\` RPCs and a \"Knowledge vaults\" panel in the Memory tab.
- User-visible effect: Users can add a local folder, sync it, and have its files queryable from memory under namespace \`vault:<id>\`.

### Parity Contract
- Legacy behavior preserved: Yes — purely additive; no existing RPC method, schema, or namespace touched.
- Guard/fallback/dispatch parity checks: New controllers registered through the standard \`all_*_registered_controllers()\` pattern, validated by the existing registry validator in \`src/core/all.rs\`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge Vaults panel added to Memory Workspace for managing local vault collections.
  * Create vaults with name, root path, and include/exclude file patterns.
  * Sync vaults with progress/status toasts and detailed counts (ingested, unchanged, removed, failed/skipped).
  * Remove vaults with double-confirmation and optional memory purge; includes loading/empty/error states and informative toasts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
