### PR TITLE
fix(app): clean up boot services during HMR

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -22,15 +22,27 @@ import { MascotFrameProducer } from './features/meet/MascotFrameProducer';
 import { I18nProvider } from './lib/i18n/I18nContext';
 // [#1123] Commented out — welcome-agent onboarding replaced by Joyride walkthrough
 // import { isWelcomeLocked } from './lib/coreState/store';
-import { startNativeNotificationsService } from './lib/nativeNotifications';
-import { startWebviewNotificationsService } from './lib/webviewNotifications';
+import {
+  startNativeNotificationsService,
+  stopNativeNotificationsService,
+} from './lib/nativeNotifications';
+import {
+  startWebviewNotificationsService,
+  stopWebviewNotificationsService,
+} from './lib/webviewNotifications';
 import ChatRuntimeProvider from './providers/ChatRuntimeProvider';
 import CoreStateProvider, { useCoreState } from './providers/CoreStateProvider';
 import SocketProvider from './providers/SocketProvider';
 import { trackPageView } from './services/analytics';
-import { startCoreHealthMonitor } from './services/coreHealthMonitor';
-import { startInternetStatusListener } from './services/internetStatusListener';
-import { startWebviewAccountService } from './services/webviewAccountService';
+import { startCoreHealthMonitor, stopCoreHealthMonitor } from './services/coreHealthMonitor';
+import {
+  startInternetStatusListener,
+  stopInternetStatusListener,
+} from './services/internetStatusListener';
+import {
+  startWebviewAccountService,
+  stopWebviewAccountService,
+} from './services/webviewAccountService';
 import { persistor, store } from './store';
 // [#1123] useAppDispatch commented out — welcome-agent onboarding replaced by Joyride walkthrough
 import { useAppSelector } from './store/hooks';
@@ -50,6 +62,16 @@ startNativeNotificationsService();
 // health poll. Both idempotent via internal `started` guards.
 startInternetStatusListener();
 startCoreHealthMonitor();
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    stopWebviewAccountService();
+    stopWebviewNotificationsService();
+    stopNativeNotificationsService();
+    stopInternetStatusListener();
+    stopCoreHealthMonitor();
+  });
+}
 
 function App() {
   return (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -63,14 +63,16 @@ startNativeNotificationsService();
 startInternetStatusListener();
 startCoreHealthMonitor();
 
+export function stopBootServicesForHmr(): void {
+  stopWebviewAccountService();
+  stopWebviewNotificationsService();
+  stopNativeNotificationsService();
+  stopInternetStatusListener();
+  stopCoreHealthMonitor();
+}
+
 if (import.meta.hot) {
-  import.meta.hot.dispose(() => {
-    stopWebviewAccountService();
-    stopWebviewNotificationsService();
-    stopNativeNotificationsService();
-    stopInternetStatusListener();
-    stopCoreHealthMonitor();
-  });
+  import.meta.hot.dispose(stopBootServicesForHmr);
 }
 
 function App() {

--- a/app/src/__tests__/App.boot.test.tsx
+++ b/app/src/__tests__/App.boot.test.tsx
@@ -10,24 +10,40 @@ import { describe, expect, it, vi } from 'vitest';
 // ---- Service mocks that must be in place BEFORE App.tsx is imported ----
 
 const startInternetStatusListenerMock = vi.fn();
+const stopInternetStatusListenerMock = vi.fn();
 const startCoreHealthMonitorMock = vi.fn();
+const stopCoreHealthMonitorMock = vi.fn();
+const startWebviewAccountServiceMock = vi.fn();
+const stopWebviewAccountServiceMock = vi.fn();
+const startWebviewNotificationsServiceMock = vi.fn();
+const stopWebviewNotificationsServiceMock = vi.fn();
+const startNativeNotificationsServiceMock = vi.fn();
+const stopNativeNotificationsServiceMock = vi.fn();
 
 vi.mock('../services/internetStatusListener', () => ({
   startInternetStatusListener: startInternetStatusListenerMock,
+  stopInternetStatusListener: stopInternetStatusListenerMock,
 }));
 
 vi.mock('../services/coreHealthMonitor', () => ({
   startCoreHealthMonitor: startCoreHealthMonitorMock,
-  stopCoreHealthMonitor: vi.fn(),
+  stopCoreHealthMonitor: stopCoreHealthMonitorMock,
 }));
 
 // Stub out the heavy services that also run at module boot in App.tsx.
 vi.mock('../services/webviewAccountService', () => ({
-  startWebviewAccountService: vi.fn(),
+  startWebviewAccountService: startWebviewAccountServiceMock,
+  stopWebviewAccountService: stopWebviewAccountServiceMock,
   isTauri: vi.fn(() => false),
 }));
-vi.mock('../lib/webviewNotifications', () => ({ startWebviewNotificationsService: vi.fn() }));
-vi.mock('../lib/nativeNotifications', () => ({ startNativeNotificationsService: vi.fn() }));
+vi.mock('../lib/webviewNotifications', () => ({
+  startWebviewNotificationsService: startWebviewNotificationsServiceMock,
+  stopWebviewNotificationsService: stopWebviewNotificationsServiceMock,
+}));
+vi.mock('../lib/nativeNotifications', () => ({
+  startNativeNotificationsService: startNativeNotificationsServiceMock,
+  stopNativeNotificationsService: stopNativeNotificationsServiceMock,
+}));
 
 // Stub out all imports that would pull in Tauri or heavy React trees.
 vi.mock('../store', () => ({
@@ -78,5 +94,17 @@ describe('App.tsx boot-time service wiring (lines 50-51)', () => {
     await import('../App');
     expect(startInternetStatusListenerMock).toHaveBeenCalled();
     expect(startCoreHealthMonitorMock).toHaveBeenCalled();
+  });
+
+  it('stops boot-time services from the HMR cleanup helper', async () => {
+    const { stopBootServicesForHmr } = await import('../App');
+
+    stopBootServicesForHmr();
+
+    expect(stopWebviewAccountServiceMock).toHaveBeenCalled();
+    expect(stopWebviewNotificationsServiceMock).toHaveBeenCalled();
+    expect(stopNativeNotificationsServiceMock).toHaveBeenCalled();
+    expect(stopInternetStatusListenerMock).toHaveBeenCalled();
+    expect(stopCoreHealthMonitorMock).toHaveBeenCalled();
   });
 });

--- a/app/src/services/__tests__/internetStatusListener.test.ts
+++ b/app/src/services/__tests__/internetStatusListener.test.ts
@@ -17,23 +17,26 @@ vi.mock('../../store/connectivitySlice', () => ({
 }));
 
 describe('internetStatusListener', () => {
+  let stopCurrentListener: (() => void) | null = null;
+
   // Each test needs a fresh module so the `started` singleton is reset.
   beforeEach(() => {
     vi.resetModules();
     dispatchMock.mockClear();
     setInternetMock.mockClear();
+    stopCurrentListener = null;
   });
 
   afterEach(() => {
-    // Remove any event listeners that were added during the test.
-    window.removeEventListener('online', () => {});
-    window.removeEventListener('offline', () => {});
+    stopCurrentListener?.();
   });
 
   it('dispatches online when navigator.onLine is true on start (line 15-16)', async () => {
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
 
-    const { startInternetStatusListener } = await import('../internetStatusListener');
+    const { startInternetStatusListener, stopInternetStatusListener } =
+      await import('../internetStatusListener');
+    stopCurrentListener = stopInternetStatusListener;
     startInternetStatusListener();
 
     expect(setInternetMock).toHaveBeenCalledWith({ value: 'online' });
@@ -43,7 +46,9 @@ describe('internetStatusListener', () => {
   it('dispatches offline when navigator.onLine is false on start (line 15-16)', async () => {
     Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
 
-    const { startInternetStatusListener } = await import('../internetStatusListener');
+    const { startInternetStatusListener, stopInternetStatusListener } =
+      await import('../internetStatusListener');
+    stopCurrentListener = stopInternetStatusListener;
     startInternetStatusListener();
 
     expect(setInternetMock).toHaveBeenCalledWith({ value: 'offline' });
@@ -53,7 +58,9 @@ describe('internetStatusListener', () => {
   it('is idempotent — second call is a no-op (line 20)', async () => {
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
 
-    const { startInternetStatusListener } = await import('../internetStatusListener');
+    const { startInternetStatusListener, stopInternetStatusListener } =
+      await import('../internetStatusListener');
+    stopCurrentListener = stopInternetStatusListener;
     startInternetStatusListener();
     startInternetStatusListener(); // second call must not add extra listeners or dispatch
 
@@ -64,7 +71,9 @@ describe('internetStatusListener', () => {
   it('dispatches online when the window online event fires (lines 24-26)', async () => {
     Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
 
-    const { startInternetStatusListener } = await import('../internetStatusListener');
+    const { startInternetStatusListener, stopInternetStatusListener } =
+      await import('../internetStatusListener');
+    stopCurrentListener = stopInternetStatusListener;
     startInternetStatusListener();
 
     dispatchMock.mockClear();
@@ -81,7 +90,9 @@ describe('internetStatusListener', () => {
   it('dispatches offline when the window offline event fires (lines 24-26)', async () => {
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
 
-    const { startInternetStatusListener } = await import('../internetStatusListener');
+    const { startInternetStatusListener, stopInternetStatusListener } =
+      await import('../internetStatusListener');
+    stopCurrentListener = stopInternetStatusListener;
     startInternetStatusListener();
 
     dispatchMock.mockClear();
@@ -92,5 +103,24 @@ describe('internetStatusListener', () => {
 
     expect(setInternetMock).toHaveBeenCalledWith({ value: 'offline' });
     expect(dispatchMock).toHaveBeenCalled();
+  });
+
+  it('removes event listeners when stopped', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+
+    const { startInternetStatusListener, stopInternetStatusListener } =
+      await import('../internetStatusListener');
+    stopCurrentListener = stopInternetStatusListener;
+    startInternetStatusListener();
+
+    dispatchMock.mockClear();
+    setInternetMock.mockClear();
+
+    stopInternetStatusListener();
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    window.dispatchEvent(new Event('offline'));
+
+    expect(setInternetMock).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 });

--- a/app/src/services/internetStatusListener.ts
+++ b/app/src/services/internetStatusListener.ts
@@ -18,10 +18,19 @@ function snapshot(): void {
 
 export function startInternetStatusListener(): void {
   if (started) return;
-  started = true;
   if (typeof window === 'undefined') return;
+  started = true;
 
   snapshot();
   window.addEventListener('online', snapshot);
   window.addEventListener('offline', snapshot);
+}
+
+export function stopInternetStatusListener(): void {
+  if (!started) return;
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('online', snapshot);
+    window.removeEventListener('offline', snapshot);
+  }
+  started = false;
 }


### PR DESCRIPTION
## Summary

- Closes #1936.
- Registers a Vite HMR dispose handler for the boot-time singleton services started from `App.tsx`.
- Adds `stopInternetStatusListener()` so the online/offline window listeners join the existing cleanup path for webview accounts, webview notifications, native notifications, and core health polling.
- Extends the internet status listener test to prove `stopInternetStatusListener()` removes its event handlers.

## Why this is worth reviewing

`App.tsx` starts several module-scope services at renderer boot. Those services are idempotent for repeated starts, but without an HMR dispose path a replaced module can leave old listeners/timers alive during Vite dev sessions. The change is narrow and only affects cleanup during development/HMR plus the explicit listener stop function.

## Validation

- `pnpm exec vitest run --config test/vitest.config.ts src/services/__tests__/internetStatusListener.test.ts` (6 passed)
- `pnpm compile`
- `pnpm exec prettier --check src/App.tsx src/services/internetStatusListener.ts src/services/__tests__/internetStatusListener.test.ts`
- `git diff --check`

## Duplicate check

I checked existing PRs for `#1936`, `HMR`, `startWebviewAccountService`, `stopWebviewAccountService`, and the boot service cleanup path, and did not find an existing PR covering this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HMR teardown that cleanly stops background services during hot reload.

* **Bug Fixes**
  * Prevented background listener initialization from blocking in non-browser/SSR environments.
  * Ensured background services can be reliably stopped to avoid stale listeners.

* **Tests**
  * Improved lifecycle management and teardown tests for internet status monitoring.
  * Added tests verifying HMR teardown stops all boot-time services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/1997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->