### PR TITLE
feat(composio): expose capability matrix

### DIFF
--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -77,8 +77,9 @@ pub use trigger_history::{
     global as global_composio_trigger_history, init_global as init_composio_trigger_history,
 };
 pub use types::{
-    ComposioAuthorizeResponse, ComposioConnection, ComposioConnectionsResponse,
-    ComposioDeleteResponse, ComposioExecuteResponse, ComposioToolFunction, ComposioToolSchema,
-    ComposioToolkitsResponse, ComposioToolsResponse, ComposioTriggerEvent,
-    ComposioTriggerHistoryEntry, ComposioTriggerHistoryResult, ComposioTriggerMetadata,
+    ComposioAuthorizeResponse, ComposioCapabilitiesResponse, ComposioCapability,
+    ComposioConnection, ComposioConnectionsResponse, ComposioDeleteResponse,
+    ComposioExecuteResponse, ComposioToolFunction, ComposioToolSchema, ComposioToolkitsResponse,
+    ComposioToolsResponse, ComposioTriggerEvent, ComposioTriggerHistoryEntry,
+    ComposioTriggerHistoryResult, ComposioTriggerMetadata,
 };

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -26,14 +26,14 @@ use super::client::{
     direct_list_tools, ComposioClient, ComposioClientKind,
 };
 use super::providers::{
-    get_provider, ProviderContext, ProviderUserProfile, SyncOutcome, SyncReason,
+    capability_matrix, get_provider, ProviderContext, ProviderUserProfile, SyncOutcome, SyncReason,
 };
 use super::types::{
     ComposioActiveTriggersResponse, ComposioAuthorizeResponse, ComposioAvailableTriggersResponse,
-    ComposioConnectionsResponse, ComposioCreateTriggerResponse, ComposioDeleteResponse,
-    ComposioDisableTriggerResponse, ComposioEnableTriggerResponse, ComposioExecuteResponse,
-    ComposioGithubReposResponse, ComposioToolkitsResponse, ComposioToolsResponse,
-    ComposioTriggerHistoryResult,
+    ComposioCapabilitiesResponse, ComposioConnectionsResponse, ComposioCreateTriggerResponse,
+    ComposioDeleteResponse, ComposioDisableTriggerResponse, ComposioEnableTriggerResponse,
+    ComposioExecuteResponse, ComposioGithubReposResponse, ComposioToolkitsResponse,
+    ComposioToolsResponse, ComposioTriggerHistoryResult,
 };
 
 /// Resolve a backend-mode [`ComposioClient`] from the root config, or
@@ -195,6 +195,20 @@ pub async fn composio_list_toolkits(
             ))
         }
     }
+}
+
+pub async fn composio_list_capabilities(
+    _config: &Config,
+) -> OpResult<RpcOutcome<ComposioCapabilitiesResponse>> {
+    tracing::debug!("[composio] rpc list_capabilities");
+    let resp = ComposioCapabilitiesResponse {
+        capabilities: capability_matrix(),
+    };
+    let count = resp.capabilities.len();
+    Ok(RpcOutcome::new(
+        resp,
+        vec![format!("composio: {count} capability row(s) listed")],
+    ))
 }
 
 // ── Connections ─────────────────────────────────────────────────────

--- a/src/openhuman/composio/ops_test.rs
+++ b/src/openhuman/composio/ops_test.rs
@@ -65,6 +65,21 @@ async fn composio_list_toolkits_errors_without_session() {
 }
 
 #[tokio::test]
+async fn composio_list_capabilities_does_not_require_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = test_config(&tmp);
+    let outcome = composio_list_capabilities(&config).await.unwrap();
+    assert!(outcome
+        .value
+        .capabilities
+        .iter()
+        .any(|entry| { entry.toolkit == "gmail" && entry.native_provider && entry.memory_ingest }));
+    assert!(outcome.value.capabilities.iter().any(|entry| {
+        entry.toolkit == "googlecalendar" && !entry.native_provider && entry.curated_tools
+    }));
+}
+
+#[tokio::test]
 async fn composio_list_connections_errors_without_session() {
     let tmp = tempfile::tempdir().unwrap();
     let config = test_config(&tmp);

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -54,6 +54,83 @@ pub mod registry;
 pub mod slack;
 pub mod sync_state;
 
+use crate::openhuman::composio::types::ComposioCapability;
+
+const CAPABILITY_TOOLKITS: &[&str] = &[
+    "gmail",
+    "notion",
+    "slack",
+    "github",
+    "discord",
+    "googlecalendar",
+    "googledrive",
+    "googledocs",
+    "googlesheets",
+    "outlook",
+    "microsoft_teams",
+    "linear",
+    "jira",
+    "trello",
+    "asana",
+    "dropbox",
+    "twitter",
+    "spotify",
+    "telegram",
+    "whatsapp",
+    "shopify",
+    "stripe",
+    "hubspot",
+    "salesforce",
+    "airtable",
+    "figma",
+    "youtube",
+];
+
+fn native_provider_sync_interval(toolkit: &str) -> Option<u64> {
+    match toolkit {
+        "gmail" => Some(gmail::GmailProvider::new().sync_interval_secs()),
+        "notion" => Some(notion::NotionProvider::new().sync_interval_secs()),
+        "slack" => Some(slack::SlackProvider::new().sync_interval_secs()),
+        _ => None,
+    }
+    .flatten()
+}
+
+fn has_native_provider(toolkit: &str) -> bool {
+    matches!(toolkit, "gmail" | "notion" | "slack")
+}
+
+/// Static overview of the Composio integrations supported by this core build.
+///
+/// This deliberately does not consult the live Composio backend/direct tenant:
+/// it is an observability surface for OpenHuman's own capability tiers. Use
+/// `composio_list_toolkits` / `composio_list_connections` when callers need
+/// the currently signed-in user's allowlist or OAuth state.
+pub fn capability_matrix() -> Vec<ComposioCapability> {
+    CAPABILITY_TOOLKITS
+        .iter()
+        .map(|toolkit| {
+            let native_provider = has_native_provider(toolkit);
+            let catalog = catalog_for_toolkit(toolkit);
+            let sync_interval_secs = native_provider_sync_interval(toolkit);
+            ComposioCapability {
+                toolkit: (*toolkit).to_string(),
+                description: toolkit_description(toolkit).to_string(),
+                native_provider,
+                curated_tools: catalog.is_some(),
+                curated_tool_count: catalog.map_or(0, <[CuratedTool]>::len),
+                tool_execution: catalog.is_some(),
+                user_profile: native_provider,
+                initial_sync: native_provider,
+                periodic_sync: sync_interval_secs.is_some(),
+                sync_interval_secs,
+                trigger_webhooks: native_provider,
+                memory_ingest: native_provider,
+            }
+        })
+        .collect()
+}
+
 /// Static toolkit → curated catalog map.
 ///
 /// This is consulted by the meta-tool layer alongside any registered
@@ -204,6 +281,39 @@ mod tests {
         assert_eq!(s, "\"connection_created\"");
         let back: SyncReason = serde_json::from_str(&s).unwrap();
         assert_eq!(back, SyncReason::ConnectionCreated);
+    }
+
+    #[test]
+    fn capability_matrix_distinguishes_native_from_catalog_only_toolkits() {
+        let matrix = capability_matrix();
+
+        let gmail = matrix
+            .iter()
+            .find(|entry| entry.toolkit == "gmail")
+            .expect("gmail capability row");
+        assert!(gmail.native_provider);
+        assert!(gmail.curated_tools);
+        assert!(gmail.curated_tool_count > 0);
+        assert!(gmail.user_profile);
+        assert!(gmail.initial_sync);
+        assert!(gmail.periodic_sync);
+        assert_eq!(gmail.sync_interval_secs, Some(15 * 60));
+        assert!(gmail.trigger_webhooks);
+        assert!(gmail.memory_ingest);
+
+        let google_calendar = matrix
+            .iter()
+            .find(|entry| entry.toolkit == "googlecalendar")
+            .expect("googlecalendar capability row");
+        assert!(!google_calendar.native_provider);
+        assert!(google_calendar.curated_tools);
+        assert!(google_calendar.curated_tool_count > 0);
+        assert!(google_calendar.tool_execution);
+        assert!(!google_calendar.user_profile);
+        assert!(!google_calendar.initial_sync);
+        assert!(!google_calendar.periodic_sync);
+        assert_eq!(google_calendar.sync_interval_secs, None);
+        assert!(!google_calendar.memory_ingest);
     }
 
     #[test]

--- a/src/openhuman/composio/schemas.rs
+++ b/src/openhuman/composio/schemas.rs
@@ -3,6 +3,7 @@
 //! Exposes the domain over the shared registry at
 //! `openhuman.composio_*`:
 //!   - `composio.list_toolkits`       → `openhuman.composio_list_toolkits`
+//!   - `composio.list_capabilities`   → `openhuman.composio_list_capabilities`
 //!   - `composio.list_connections`    → `openhuman.composio_list_connections`
 //!   - `composio.authorize`           → `openhuman.composio_authorize`
 //!   - `composio.delete_connection`   → `openhuman.composio_delete_connection`
@@ -60,6 +61,7 @@ struct EnableTriggerParams {
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
     vec![
         schemas("list_toolkits"),
+        schemas("list_capabilities"),
         schemas("list_connections"),
         schemas("authorize"),
         schemas("delete_connection"),
@@ -88,6 +90,10 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("list_toolkits"),
             handler: handle_list_toolkits,
+        },
+        RegisteredController {
+            schema: schemas("list_capabilities"),
+            handler: handle_list_capabilities,
         },
         RegisteredController {
             schema: schemas("list_connections"),
@@ -183,6 +189,18 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 name: "toolkits",
                 ty: TypeSchema::Array(Box::new(TypeSchema::String)),
                 comment: "Toolkit slugs enabled by the backend (e.g. gmail, notion).",
+                required: true,
+            }],
+        },
+        "list_capabilities" => ControllerSchema {
+            namespace: "composio",
+            function: "list_capabilities",
+            description: "List OpenHuman's built-in Composio capability matrix without requiring a signed-in Composio session.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "capabilities",
+                ty: TypeSchema::Json,
+                comment: "Array of capability rows describing native providers, curated catalogs, sync, trigger, and memory-ingest support.",
                 required: true,
             }],
         },
@@ -676,6 +694,13 @@ fn handle_list_toolkits(_params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async {
         let config = config_rpc::load_config_with_timeout().await?;
         to_json(super::ops::composio_list_toolkits(&config).await?)
+    })
+}
+
+fn handle_list_capabilities(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async {
+        let config = config_rpc::load_config_with_timeout().await?;
+        to_json(super::ops::composio_list_capabilities(&config).await?)
     })
 }
 

--- a/src/openhuman/composio/schemas_tests.rs
+++ b/src/openhuman/composio/schemas_tests.rs
@@ -26,6 +26,7 @@ fn all_schemas_use_composio_namespace_and_have_descriptions() {
 fn every_known_schema_key_resolves() {
     let keys = [
         "list_toolkits",
+        "list_capabilities",
         "list_connections",
         "authorize",
         "delete_connection",
@@ -42,6 +43,18 @@ fn every_known_schema_key_resolves() {
         assert_eq!(s.namespace, "composio");
         assert_ne!(s.function, "unknown", "key `{k}` fell through");
     }
+}
+
+#[test]
+fn list_capabilities_schema_has_matrix_output() {
+    let s = schemas("list_capabilities");
+    assert_eq!(s.namespace, "composio");
+    assert_eq!(s.function, "list_capabilities");
+    assert!(s.inputs.is_empty());
+    assert!(s
+        .outputs
+        .iter()
+        .any(|f| f.name == "capabilities" && f.required));
 }
 
 #[test]

--- a/src/openhuman/composio/types.rs
+++ b/src/openhuman/composio/types.rs
@@ -71,6 +71,36 @@ pub struct ComposioToolkitsResponse {
     pub toolkits: Vec<String>,
 }
 
+/// One row in OpenHuman's local Composio capability matrix.
+///
+/// Unlike `ComposioToolkitsResponse`, this is not tied to a signed-in
+/// backend/direct Composio session. It describes what this core build knows
+/// how to do for each toolkit: whether the toolkit has a native provider
+/// implementation, a curated tool catalog, profile/sync hooks, and memory
+/// ingestion support.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComposioCapability {
+    pub toolkit: String,
+    pub description: String,
+    pub native_provider: bool,
+    pub curated_tools: bool,
+    pub curated_tool_count: usize,
+    pub tool_execution: bool,
+    pub user_profile: bool,
+    pub initial_sync: bool,
+    pub periodic_sync: bool,
+    pub sync_interval_secs: Option<u64>,
+    pub trigger_webhooks: bool,
+    pub memory_ingest: bool,
+}
+
+/// Response body of `composio.list_capabilities`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ComposioCapabilitiesResponse {
+    #[serde(default)]
+    pub capabilities: Vec<ComposioCapability>,
+}
+
 // ── Connections ─────────────────────────────────────────────────────
 
 /// One connected Composio account (OAuth integration instance).


### PR DESCRIPTION
## Summary
- Add a static Composio capability matrix that records catalog support, curated tools, native-provider support, memory ingest, and trigger support per toolkit.
- Expose the matrix through a new `composio.list_capabilities` RPC/schema so clients can inspect supported integration capabilities without an authenticated Composio backend session.
- Add focused coverage for the no-session RPC path, schema registration/output shape, and Gmail vs Google Calendar capability distinctions.

## Test Plan
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF rustup run 1.93.0 cargo fmt --all`
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF rustup run 1.93.0 cargo test --manifest-path Cargo.toml composio_list_capabilities_does_not_require_session --lib`
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF rustup run 1.93.0 cargo test --manifest-path Cargo.toml capability_matrix_distinguishes_native_from_catalog_only_toolkits --lib`
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF rustup run 1.93.0 cargo test --manifest-path Cargo.toml list_capabilities_schema_has_matrix_output --lib`
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF rustup run 1.93.0 cargo check --manifest-path Cargo.toml`

## Notes
- This is intentionally a small read-only slice: it does not change auth, sync, execution, or trigger behavior.
- The new RPC is safe to call before Composio session setup, which lets UI/agents discover built-in integration capabilities before asking users to connect accounts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `composio.list_capabilities` RPC endpoint that retrieves a complete capability matrix for all supported toolkits, including information about sync intervals, native provider support, and feature availability.

* **Tests**
  * Added comprehensive tests to verify the capabilities endpoint functions correctly without requiring session setup and returns expected toolkit data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->