### PR TITLE
fix(security): enforce DNS-aware URL validation

### DIFF
--- a/src/openhuman/tools/impl/network/curl.rs
+++ b/src/openhuman/tools/impl/network/curl.rs
@@ -6,7 +6,7 @@
 //! `http_request.allowed_domains` so there is one allowlist to reason
 //! about.
 
-use super::url_guard::{normalize_allowed_domains, validate_url};
+use super::url_guard::{normalize_allowed_domains, validate_url_with_dns_check};
 use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 use async_trait::async_trait;
@@ -86,7 +86,7 @@ impl CurlTool {
     }
 
     fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
-        validate_url(raw_url, &self.allowed_domains)
+        validate_url_with_dns_check(raw_url, &self.allowed_domains)
     }
 
     fn default_filename_from_url(url: &str) -> String {
@@ -464,6 +464,17 @@ mod tests {
         let t = tool(&tmp, vec!["example.com"]);
         assert!(t.resolve_dest("").is_err());
         assert!(t.resolve_dest("   ").is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_disallowed_domain() {
+        let tmp = TempDir::new().unwrap();
+        let t = tool(&tmp, vec!["example.com"]);
+        let err = t
+            .validate_url("https://evil.test/archive.tar.gz")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("allowed_domains"));
     }
 
     #[test]

--- a/src/openhuman/tools/impl/network/curl.rs
+++ b/src/openhuman/tools/impl/network/curl.rs
@@ -85,8 +85,8 @@ impl CurlTool {
         Ok(resolved)
     }
 
-    fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
-        validate_url_with_dns_check(raw_url, &self.allowed_domains)
+    async fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
+        validate_url_with_dns_check(raw_url, &self.allowed_domains).await
     }
 
     fn default_filename_from_url(url: &str) -> String {
@@ -170,7 +170,7 @@ impl Tool for CurlTool {
             return Ok(ToolResult::error("Action blocked: rate limit exceeded"));
         }
 
-        let url = match self.validate_url(url) {
+        let url = match self.validate_url(url).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::debug!(target: "[curl]", url = %url, reason = %e, "url validation failed");
@@ -466,12 +466,13 @@ mod tests {
         assert!(t.resolve_dest("   ").is_err());
     }
 
-    #[test]
-    fn validate_url_rejects_disallowed_domain() {
+    #[tokio::test]
+    async fn validate_url_rejects_disallowed_domain() {
         let tmp = TempDir::new().unwrap();
         let t = tool(&tmp, vec!["example.com"]);
         let err = t
             .validate_url("https://evil.test/archive.tar.gz")
+            .await
             .unwrap_err()
             .to_string();
         assert!(err.contains("allowed_domains"));

--- a/src/openhuman/tools/impl/network/http_request.rs
+++ b/src/openhuman/tools/impl/network/http_request.rs
@@ -30,8 +30,8 @@ impl HttpRequestTool {
         }
     }
 
-    fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
-        validate_url_with_dns_check(raw_url, &self.allowed_domains)
+    async fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
+        validate_url_with_dns_check(raw_url, &self.allowed_domains).await
     }
 
     fn validate_method(&self, method: &str) -> anyhow::Result<reqwest::Method> {
@@ -176,7 +176,7 @@ impl Tool for HttpRequestTool {
             return Ok(ToolResult::error("Action blocked: rate limit exceeded"));
         }
 
-        let url = match self.validate_url(url) {
+        let url = match self.validate_url(url).await {
             Ok(v) => v,
             Err(e) => return Ok(ToolResult::error(e.to_string())),
         };

--- a/src/openhuman/tools/impl/network/http_request.rs
+++ b/src/openhuman/tools/impl/network/http_request.rs
@@ -1,4 +1,4 @@
-use super::url_guard::{normalize_allowed_domains, validate_url};
+use super::url_guard::{normalize_allowed_domains, validate_url_with_dns_check};
 use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{Tool, ToolResult};
 use async_trait::async_trait;
@@ -31,7 +31,7 @@ impl HttpRequestTool {
     }
 
     fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
-        validate_url(raw_url, &self.allowed_domains)
+        validate_url_with_dns_check(raw_url, &self.allowed_domains)
     }
 
     fn validate_method(&self, method: &str) -> anyhow::Result<reqwest::Method> {

--- a/src/openhuman/tools/impl/network/http_request_tests.rs
+++ b/src/openhuman/tools/impl/network/http_request_tests.rs
@@ -33,11 +33,12 @@ fn validate_rejects_invalid_method() {
     assert!(err.contains("Unsupported HTTP method"));
 }
 
-#[test]
-fn validate_url_rejects_disallowed_domain() {
+#[tokio::test]
+async fn validate_url_rejects_disallowed_domain() {
     let tool = test_tool(vec!["example.com"]);
     let err = tool
         .validate_url("https://evil.test/path")
+        .await
         .unwrap_err()
         .to_string();
     assert!(err.contains("allowed_domains"));

--- a/src/openhuman/tools/impl/network/http_request_tests.rs
+++ b/src/openhuman/tools/impl/network/http_request_tests.rs
@@ -33,6 +33,16 @@ fn validate_rejects_invalid_method() {
     assert!(err.contains("Unsupported HTTP method"));
 }
 
+#[test]
+fn validate_url_rejects_disallowed_domain() {
+    let tool = test_tool(vec!["example.com"]);
+    let err = tool
+        .validate_url("https://evil.test/path")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("allowed_domains"));
+}
+
 #[tokio::test]
 async fn execute_blocks_readonly_mode() {
     let security = Arc::new(SecurityPolicy {

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -23,6 +23,7 @@
 //! callers should use [`validate_url_with_dns_check`] which resolves the
 //! hostname and re-validates the resolved IPs before the request is made.
 
+use std::future::Future;
 use std::net::{IpAddr, ToSocketAddrs};
 
 /// Validate a URL against the allowlist + SSRF rules. Returns the
@@ -69,20 +70,21 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
 ///
 /// Callers should use this function instead of `validate_url` in all
 /// paths that make outbound HTTP requests.
-pub(super) fn validate_url_with_dns_check(
+pub(super) async fn validate_url_with_dns_check(
     raw_url: &str,
     allowed_domains: &[String],
 ) -> anyhow::Result<String> {
-    validate_url_with_dns_check_with_resolver(raw_url, allowed_domains, resolve_host_ips)
+    validate_url_with_dns_check_with_resolver(raw_url, allowed_domains, resolve_host_ips).await
 }
 
-fn validate_url_with_dns_check_with_resolver<F>(
+async fn validate_url_with_dns_check_with_resolver<F, Fut>(
     raw_url: &str,
     allowed_domains: &[String],
     resolver: F,
 ) -> anyhow::Result<String>
 where
-    F: Fn(&str, u16) -> anyhow::Result<Vec<IpAddr>>,
+    F: FnOnce(String, u16) -> Fut,
+    Fut: Future<Output = anyhow::Result<Vec<IpAddr>>>,
 {
     let url = validate_url(raw_url, allowed_domains)?;
 
@@ -96,7 +98,7 @@ where
 
     let port = extract_port(&url)?;
     log::debug!("[url_guard] resolving DNS for host={host} port={port}");
-    let addrs = resolver(&host, port)?;
+    let addrs = resolver(host.clone(), port).await?;
 
     if addrs.is_empty() {
         anyhow::bail!("DNS resolution returned no addresses for '{host}'");
@@ -117,14 +119,22 @@ where
     Ok(url)
 }
 
-fn resolve_host_ips(host: &str, port: u16) -> anyhow::Result<Vec<IpAddr>> {
-    (host, port)
-        .to_socket_addrs()
-        .map_err(|e| {
-            log::debug!("[url_guard] DNS resolution failed host={host} port={port} error={e}");
-            anyhow::anyhow!("DNS resolution failed for '{host}': {e}")
-        })
-        .map(|iter| iter.map(|addr| addr.ip()).collect())
+async fn resolve_host_ips(host: String, port: u16) -> anyhow::Result<Vec<IpAddr>> {
+    let log_host = host.clone();
+    tokio::task::spawn_blocking(move || {
+        (host.as_str(), port)
+            .to_socket_addrs()
+            .map_err(|e| {
+                log::debug!("[url_guard] DNS resolution failed host={host} port={port} error={e}");
+                anyhow::anyhow!("DNS resolution failed for '{host}': {e}")
+            })
+            .map(|iter| iter.map(|addr| addr.ip()).collect())
+    })
+    .await
+    .map_err(|e| {
+        log::debug!("[url_guard] DNS resolution task failed host={log_host} port={port} error={e}");
+        anyhow::anyhow!("DNS resolution task failed for '{log_host}': {e}")
+    })?
 }
 
 pub(super) fn normalize_allowed_domains(domains: Vec<String>) -> Vec<String> {
@@ -579,14 +589,15 @@ mod tests {
 
     // ── DNS rebinding protection ─────────────────────────────────
 
-    #[test]
-    fn dns_check_blocks_localhost_resolution() {
+    #[tokio::test]
+    async fn dns_check_blocks_localhost_resolution() {
         // "localhost" resolves to 127.0.0.1 on most systems. Even if
         // someone adds it to the allowlist, the DNS check should block it.
         let allow = vec!["localhost".to_string()];
         // validate_url itself already blocks "localhost" via the hostname check,
         // but validate_url_with_dns_check should also catch it.
         let err = validate_url_with_dns_check("https://localhost", &allow)
+            .await
             .unwrap_err()
             .to_string();
         assert!(
@@ -595,66 +606,75 @@ mod tests {
         );
     }
 
-    #[test]
-    fn dns_check_passes_for_public_resolved_ip() {
+    #[tokio::test]
+    async fn dns_check_passes_for_public_resolved_ip() {
         let allow = vec!["example.com".to_string()];
         let got = validate_url_with_dns_check_with_resolver(
             "https://example.com",
             &allow,
-            |host, port| {
+            |host, port| async move {
                 assert_eq!(host, "example.com");
                 assert_eq!(port, 443);
                 Ok(vec!["93.184.216.34".parse().unwrap()])
             },
         )
+        .await
         .unwrap();
         assert_eq!(got, "https://example.com");
     }
 
-    #[test]
-    fn dns_check_blocks_private_resolved_ip() {
+    #[tokio::test]
+    async fn dns_check_blocks_private_resolved_ip() {
         let allow = vec!["example.com".to_string()];
-        let err =
-            validate_url_with_dns_check_with_resolver("https://example.com", &allow, |_, _| {
-                Ok(vec!["127.0.0.1".parse().unwrap()])
-            })
-            .unwrap_err()
-            .to_string();
+        let err = validate_url_with_dns_check_with_resolver(
+            "https://example.com",
+            &allow,
+            |_, _| async { Ok(vec!["127.0.0.1".parse().unwrap()]) },
+        )
+        .await
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("DNS rebinding blocked"));
     }
 
-    #[test]
-    fn dns_check_uses_explicit_port_for_resolution() {
+    #[tokio::test]
+    async fn dns_check_uses_explicit_port_for_resolution() {
         let allow = vec!["api.example.com".to_string()];
         let got = validate_url_with_dns_check_with_resolver(
             "http://api.example.com:8080/status",
             &allow,
-            |host, port| {
+            |host, port| async move {
                 assert_eq!(host, "api.example.com");
                 assert_eq!(port, 8080);
                 Ok(vec!["93.184.216.34".parse().unwrap()])
             },
         )
+        .await
         .unwrap();
         assert_eq!(got, "http://api.example.com:8080/status");
     }
 
-    #[test]
-    fn dns_check_returns_resolver_failure() {
+    #[tokio::test]
+    async fn dns_check_returns_resolver_failure() {
         let allow = vec!["example.com".to_string()];
-        let err =
-            validate_url_with_dns_check_with_resolver("https://example.com", &allow, |host, _| {
+        let err = validate_url_with_dns_check_with_resolver(
+            "https://example.com",
+            &allow,
+            |host, _| async move {
                 anyhow::bail!("DNS resolution failed for '{host}': resolver unavailable")
-            })
-            .unwrap_err()
-            .to_string();
+            },
+        )
+        .await
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("DNS resolution failed"));
     }
 
-    #[test]
-    fn dns_check_rejects_ip_literal_private() {
+    #[tokio::test]
+    async fn dns_check_rejects_ip_literal_private() {
         let allow = vec!["10.0.0.1".to_string()];
         let err = validate_url_with_dns_check("https://10.0.0.1", &allow)
+            .await
             .unwrap_err()
             .to_string();
         assert!(err.contains("local/private"));

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -23,7 +23,7 @@
 //! callers should use [`validate_url_with_dns_check`] which resolves the
 //! hostname and re-validates the resolved IPs before the request is made.
 
-use std::net::ToSocketAddrs;
+use std::net::{IpAddr, ToSocketAddrs};
 
 /// Validate a URL against the allowlist + SSRF rules. Returns the
 /// original URL on success.
@@ -73,6 +73,17 @@ pub(super) fn validate_url_with_dns_check(
     raw_url: &str,
     allowed_domains: &[String],
 ) -> anyhow::Result<String> {
+    validate_url_with_dns_check_with_resolver(raw_url, allowed_domains, resolve_host_ips)
+}
+
+fn validate_url_with_dns_check_with_resolver<F>(
+    raw_url: &str,
+    allowed_domains: &[String],
+    resolver: F,
+) -> anyhow::Result<String>
+where
+    F: Fn(&str, u16) -> anyhow::Result<Vec<IpAddr>>,
+{
     let url = validate_url(raw_url, allowed_domains)?;
 
     let host = extract_host(&url)?;
@@ -83,16 +94,9 @@ pub(super) fn validate_url_with_dns_check(
         return Ok(url);
     }
 
-    // Resolve the hostname and check all returned addresses.
-    let socket_addr = format!("{host}:443");
-    log::debug!("[url_guard] resolving DNS for host={host}");
-    let addrs: Vec<std::net::SocketAddr> = socket_addr
-        .to_socket_addrs()
-        .map_err(|e| {
-            log::debug!("[url_guard] DNS resolution failed host={host} error={e}");
-            anyhow::anyhow!("DNS resolution failed for '{host}': {e}")
-        })?
-        .collect();
+    let port = extract_port(&url)?;
+    log::debug!("[url_guard] resolving DNS for host={host} port={port}");
+    let addrs = resolver(&host, port)?;
 
     if addrs.is_empty() {
         anyhow::bail!("DNS resolution returned no addresses for '{host}'");
@@ -101,7 +105,7 @@ pub(super) fn validate_url_with_dns_check(
     log::debug!("[url_guard] DNS resolved host={host} addrs={}", addrs.len());
 
     for addr in &addrs {
-        let ip_str = addr.ip().to_string();
+        let ip_str = addr.to_string();
         if is_private_or_local_host(&ip_str) {
             log::debug!("[url_guard] DNS rebinding blocked host={host} resolved_ip={ip_str}");
             anyhow::bail!(
@@ -111,6 +115,16 @@ pub(super) fn validate_url_with_dns_check(
     }
 
     Ok(url)
+}
+
+fn resolve_host_ips(host: &str, port: u16) -> anyhow::Result<Vec<IpAddr>> {
+    (host, port)
+        .to_socket_addrs()
+        .map_err(|e| {
+            log::debug!("[url_guard] DNS resolution failed host={host} port={port} error={e}");
+            anyhow::anyhow!("DNS resolution failed for '{host}': {e}")
+        })
+        .map(|iter| iter.map(|addr| addr.ip()).collect())
 }
 
 pub(super) fn normalize_allowed_domains(domains: Vec<String>) -> Vec<String> {
@@ -188,6 +202,34 @@ pub(super) fn extract_host(url: &str) -> anyhow::Result<String> {
     }
 
     Ok(host)
+}
+
+fn extract_port(url: &str) -> anyhow::Result<u16> {
+    let is_http = url.starts_with("http://");
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .ok_or_else(|| anyhow::anyhow!("Only http:// and https:// URLs are allowed"))?;
+
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Invalid URL"))?;
+
+    if authority.starts_with('[') {
+        anyhow::bail!("IPv6 hosts are not supported in http_request");
+    }
+
+    if let Some((_, port)) = authority.rsplit_once(':') {
+        if port.is_empty() || !port.chars().all(|ch| ch.is_ascii_digit()) {
+            anyhow::bail!("URL port must be numeric");
+        }
+        return port
+            .parse::<u16>()
+            .map_err(|_| anyhow::anyhow!("URL port is out of range"));
+    }
+
+    Ok(if is_http { 80 } else { 443 })
 }
 
 pub(super) fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
@@ -554,21 +596,59 @@ mod tests {
     }
 
     #[test]
-    fn dns_check_passes_for_public_domain() {
-        // google.com should resolve to public IPs and pass.
-        let allow = vec!["google.com".to_string()];
-        // This test requires network; skip gracefully if DNS fails (CI).
-        match validate_url_with_dns_check("https://google.com", &allow) {
-            Ok(url) => assert_eq!(url, "https://google.com"),
-            Err(e) => {
-                let msg = e.to_string();
-                // DNS failure in sandboxed CI is acceptable
-                assert!(
-                    msg.contains("DNS resolution failed"),
-                    "Unexpected error: {msg}"
-                );
-            }
-        }
+    fn dns_check_passes_for_public_resolved_ip() {
+        let allow = vec!["example.com".to_string()];
+        let got = validate_url_with_dns_check_with_resolver(
+            "https://example.com",
+            &allow,
+            |host, port| {
+                assert_eq!(host, "example.com");
+                assert_eq!(port, 443);
+                Ok(vec!["93.184.216.34".parse().unwrap()])
+            },
+        )
+        .unwrap();
+        assert_eq!(got, "https://example.com");
+    }
+
+    #[test]
+    fn dns_check_blocks_private_resolved_ip() {
+        let allow = vec!["example.com".to_string()];
+        let err =
+            validate_url_with_dns_check_with_resolver("https://example.com", &allow, |_, _| {
+                Ok(vec!["127.0.0.1".parse().unwrap()])
+            })
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("DNS rebinding blocked"));
+    }
+
+    #[test]
+    fn dns_check_uses_explicit_port_for_resolution() {
+        let allow = vec!["api.example.com".to_string()];
+        let got = validate_url_with_dns_check_with_resolver(
+            "http://api.example.com:8080/status",
+            &allow,
+            |host, port| {
+                assert_eq!(host, "api.example.com");
+                assert_eq!(port, 8080);
+                Ok(vec!["93.184.216.34".parse().unwrap()])
+            },
+        )
+        .unwrap();
+        assert_eq!(got, "http://api.example.com:8080/status");
+    }
+
+    #[test]
+    fn dns_check_returns_resolver_failure() {
+        let allow = vec!["example.com".to_string()];
+        let err =
+            validate_url_with_dns_check_with_resolver("https://example.com", &allow, |host, _| {
+                anyhow::bail!("DNS resolution failed for '{host}': resolver unavailable")
+            })
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("DNS resolution failed"));
     }
 
     #[test]

--- a/src/openhuman/tools/impl/network/web_fetch.rs
+++ b/src/openhuman/tools/impl/network/web_fetch.rs
@@ -6,7 +6,7 @@
 //! the agent reaches for when researching: returns the response body
 //! as text, capped, with a tiny preamble (status + final URL).
 
-use super::url_guard::{normalize_allowed_domains, validate_url};
+use super::url_guard::{normalize_allowed_domains, validate_url_with_dns_check};
 use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 use async_trait::async_trait;
@@ -109,7 +109,7 @@ impl Tool for WebFetchTool {
             ));
         }
 
-        let url = match validate_url(raw_url, &self.allowed_domains) {
+        let url = match validate_url_with_dns_check(raw_url, &self.allowed_domains) {
             Ok(u) => u,
             Err(e) => return Ok(ToolResult::error(format!("URL rejected: {e}"))),
         };

--- a/src/openhuman/tools/impl/network/web_fetch.rs
+++ b/src/openhuman/tools/impl/network/web_fetch.rs
@@ -109,7 +109,7 @@ impl Tool for WebFetchTool {
             ));
         }
 
-        let url = match validate_url_with_dns_check(raw_url, &self.allowed_domains) {
+        let url = match validate_url_with_dns_check(raw_url, &self.allowed_domains).await {
             Ok(u) => u,
             Err(e) => return Ok(ToolResult::error(format!("URL rejected: {e}"))),
         };


### PR DESCRIPTION
## Summary

- Migrate `http_request`, `curl`, and `web_fetch` to the existing DNS-aware URL guard before outbound requests are made.
- Keep the existing allowlist and local/private host policy unchanged while adding resolved-IP validation against DNS rebinding.
- Make the DNS guard testable with an injectable resolver so rebinding coverage is deterministic and no longer depends on live `google.com` DNS.
- Add focused tests for public resolved IPs, private resolved IP blocking, resolver failures, explicit ports, and caller validation surfaces.

## Problem

- #1926 reports that network tools validate the hostname string but still make requests through callers that use `validate_url()` only.
- A domain can pass the allowlist as a public-looking hostname while DNS resolves to a loopback, RFC1918, link-local, or other non-global address.
- The DNS-aware guard existed, but the outbound request paths were not using it.

## Solution

- Route the three request-making network tools through `validate_url_with_dns_check()`.
- Split DNS resolution into a small resolver helper and test-only injection path, preserving production behavior while making tests deterministic.
- Validate the DNS lookup port from the URL, including explicit ports, before checking resolved IPs.
- Replace the previous live-DNS `google.com` test with resolver-injected coverage for public and private address outcomes.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are covered by focused Rust tests; CI coverage gate remains authoritative.
- [x] N/A: Coverage matrix updated — internal security hardening only, no feature row added/removed/renamed.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no feature ID affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces — no release-cut UI or installer surface touched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust core network tools only; no frontend or Tauri behavior changes.
- Security: outbound network tools now reject allowlisted hostnames whose resolved IPs are local/private/non-global before making requests.
- Compatibility: existing URL scheme, allowlist, redirect-disabled behavior, timeout, and response-size behavior are unchanged.
- Performance: adds one DNS resolution step before request-making network tools; failures surface before attempting the HTTP request.

## Related

Closes #1926

- Follow-up PR(s)/TODOs: none for this focused migration.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A — GitHub issue #1926
- URL: https://github.com/tinyhumansai/openhuman/issues/1926

### Commit & Branch
- Branch: `codex/OH-1926-dns-rebinding-network-tools`
- Commit SHA: `9eb89beeed1b9fe4a4a931151852a0d8e8d26400`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed via pre-push hook
- [x] `pnpm typecheck` — passed
- [x] Focused tests: `pnpm debug rust -- --lib url_guard -- --nocapture`; `pnpm debug rust -- --lib http_request -- --nocapture`; `pnpm debug rust -- --lib curl -- --nocapture`; `pnpm debug rust -- --lib web_fetch -- --nocapture`; `pnpm debug rust -- --lib network -- --nocapture`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --all --check`; `cargo check --manifest-path Cargo.toml`; `git diff --check`; `CODEX_EXPECT_REPO_PATH=/home/ubuntu/workflow/openhuman node scripts/codex-pr-preflight.mjs --strict-path --lightweight`
- [x] Tauri fmt/check (if changed): N/A: no Tauri source changed; pre-push hook also ran `cargo check --manifest-path app/src-tauri/Cargo.toml` successfully.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: `http_request`, `curl`, and `web_fetch` now perform DNS resolved-IP SSRF checks before outbound requests.
- User-visible effect: requests to allowlisted hostnames that resolve to private/local/non-global IPs now fail early with a DNS rebinding/private-address error.

### Parity Contract
- Legacy behavior preserved: existing allowlist matching, URL scheme restrictions, redirect policy, response truncation, and tool parameter contracts remain unchanged.
- Guard/fallback/dispatch parity checks: focused tests cover URL guard allow/deny behavior and each migrated network tool path; deterministic resolver tests cover the DNS rebinding branch without relying on live DNS.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for `#1926`, `DNS rebinding`, or `validate_url_with_dns_check` among open PRs before starting.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened URL validation for network requests by adding DNS-based checks and improved allowlist enforcement to reject disallowed domains.
  * DNS rebinding protections made more robust and port-aware to prevent private-address bypasses.

* **Tests**
  * Added deterministic async unit tests covering disallowed domains, localhost/private IP rejection, explicit-port resolution, and resolver failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
