### PR TITLE
fix: handle missing installer channel value

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,11 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     --channel)
+      if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+        log_err "Missing value for --channel"
+        usage
+        exit 1
+      fi
       CHANNEL="${2:-}"
       shift 2
       ;;

--- a/scripts/test_install.sh
+++ b/scripts/test_install.sh
@@ -30,6 +30,20 @@ if [[ "$missing_platform_rc" -ne 3 ]]; then
   exit 1
 fi
 
+set +e
+missing_channel_output=$(bash "$REPO_ROOT/scripts/install.sh" --channel 2>&1)
+missing_channel_rc=$?
+set -e
+if [[ "$missing_channel_rc" -eq 0 ]]; then
+  echo "FAIL: install.sh --channel should fail when the value is missing"
+  exit 1
+fi
+if [[ "$missing_channel_output" != *"Missing value for --channel"* ]]; then
+  echo "FAIL: install.sh --channel should explain that the value is missing"
+  echo "$missing_channel_output"
+  exit 1
+fi
+
 assert_retry_shape() {
   local calls="$1" label="$2"
   local _ first second extra


### PR DESCRIPTION
## Summary

- Print a clear error when `install.sh --channel` is passed without a value.
- Add a regression check to the existing installer smoke test.

## Problem

Running `bash scripts/install.sh --channel` exited non-zero without explaining what was wrong because the parser shifted past the missing option value.

## Solution

Validate that `--channel` has a following value before assigning it.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: **Diff coverage ≥ 80%** — shell installer smoke test, no coverage artifact generated locally
- [x] N/A: Coverage matrix updated — installer argument parsing only
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix feature ID applies
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated — installer argument validation only
- [x] N/A: Linked issue closed via `Closes #NNN` — no matching issue found

## Impact

Installer CLI only. No runtime, desktop, core, or API behavior changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs: tighten generic Rust CLI parameter missing-value errors

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/install-channel-missing-value
- Commit SHA: 016cbeed

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — shell-only change; not run locally
- [x] N/A: `pnpm typecheck` — shell-only change; not run locally
- [x] Focused tests: `bash scripts/test_install.sh`; `bash -n scripts/install.sh scripts/test_install.sh`; manual `bash scripts/install.sh --channel`
- [x] Rust fmt/check (if changed): N/A
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked
- `command:` shellcheck scripts/install.sh scripts/test_install.sh
- `error:` shellcheck is not installed in this environment
- `impact:` shell lint was not run; focused shell smoke and syntax checks passed

### Behavior Changes
- Intended behavior change: `install.sh --channel` now reports the missing value instead of exiting silently.
- User-visible effect: invalid installer usage gives an actionable message.

### Parity Contract
- Legacy behavior preserved: valid `--channel stable`, `--dry-run`, and resolver helper paths are unchanged.
- Guard/fallback/dispatch parity checks: existing installer resolver smoke test still passes.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The installation script's `--channel` option now properly validates that a value is provided. If missing, the user receives a clear error message and the script exits with the appropriate status code, preventing incomplete installations.

* **Tests**
  * Added comprehensive test coverage to verify the `--channel` option validation behavior when invoked without required values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->