### PR TITLE
fix: report missing generic CLI parameter values

### DIFF
--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -447,6 +447,12 @@ fn parse_function_params(
         let raw_value = args
             .get(i + 1)
             .ok_or_else(|| format!("missing value for --{key}"))?;
+        if raw_value.starts_with("--") {
+            let next_key = raw_value.trim_start_matches("--").replace('-', "_");
+            if schema.inputs.iter().any(|input| input.name == next_key) {
+                return Err(format!("missing value for --{key}"));
+            }
+        }
         let value = parse_input_value(&spec.ty, raw_value)?;
         out.insert(key, value);
         i += 2;

--- a/src/core/cli_tests.rs
+++ b/src/core/cli_tests.rs
@@ -53,6 +53,37 @@ fn parse_function_params_rejects_unknown_param() {
 }
 
 #[test]
+fn parse_function_params_rejects_flag_like_missing_value() {
+    let schema = ControllerSchema {
+        namespace: "test",
+        function: "configure",
+        description: "test schema",
+        inputs: vec![
+            FieldSchema {
+                name: "enabled",
+                ty: TypeSchema::Bool,
+                required: true,
+                comment: "whether the feature is enabled",
+            },
+            FieldSchema {
+                name: "name",
+                ty: TypeSchema::String,
+                required: true,
+                comment: "feature name",
+            },
+        ],
+        outputs: vec![],
+    };
+    let args = vec![
+        "--enabled".to_string(),
+        "--name".to_string(),
+        "demo".to_string(),
+    ];
+    let err = parse_function_params(&schema, &args).expect_err("missing value should fail");
+    assert_eq!(err, "missing value for --enabled");
+}
+
+#[test]
 fn parse_input_value_rejects_invalid_bool() {
     let err =
         parse_input_value(&TypeSchema::Bool, "not-a-bool").expect_err("invalid bool should fail");


### PR DESCRIPTION
## Summary

- Treat a following known flag as a missing generic CLI parameter value.
- Add a focused regression test for `--enabled --name demo`-style input.

## Problem

The generic controller CLI parser treated the next argument as a value even when it was another known parameter flag. For boolean and numeric parameters, that produced a type parse error like `expected bool, got '--name'` instead of pointing to the missing value.

## Solution

Before parsing a parameter value, detect when the next token is another known input flag for the same schema and return `missing value for --<param>`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: **Diff coverage ≥ 80%** — Rust coverage was not generated locally because the Rust toolchain is unavailable in this environment
- [x] N/A: Coverage matrix updated — generic CLI parser behavior only
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix feature ID applies
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated — CLI parser error handling only
- [x] N/A: Linked issue closed via `Closes #NNN` — no matching issue found

## Impact

Core CLI only. No JSON-RPC, desktop, or API behavior changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/cli-missing-param-value
- Commit SHA: 087e8781

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust CLI-only change; not run locally
- [x] N/A: `pnpm typecheck` — Rust CLI-only change; not run locally
- [x] Focused tests: added `parse_function_params_rejects_flag_like_missing_value`; attempted targeted cargo test
- [x] Rust fmt/check (if changed): blocked locally; see below
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked
- `command:` `cargo test --manifest-path Cargo.toml core::cli::tests::parse_function_params_rejects_flag_like_missing_value -- --nocapture`
- `error:` `bash: cargo: command not found`
- `impact:` The regression test was added but could not be executed locally in this environment.

### Behavior Changes
- Intended behavior change: generic CLI commands now report a missing value when the next token is another known parameter flag.
- User-visible effect: malformed CLI input gets a clearer error message.

### Parity Contract
- Legacy behavior preserved: unknown flags still report `unknown param`; literal string values that do not match known input flags still parse as values.
- Guard/fallback/dispatch parity checks: change is limited to generic CLI argument parsing before controller dispatch.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A
