### PR TITLE
fix(rust): remove unused import warnings across core domains

### DIFF
--- a/src/openhuman/channels/providers/telegram/channel.rs
+++ b/src/openhuman/channels/providers/telegram/channel.rs
@@ -11,6 +11,7 @@
 
 // Re-export so that the `#[path = "channel_tests.rs"]` test module can reach
 // `TelegramChannel` via `super::TelegramChannel`.
+#[allow(unused_imports)]
 pub use super::channel_types::TelegramChannel;
 #[cfg(test)]
 pub(super) use super::channel_types::TelegramTypingTask;

--- a/src/openhuman/channels/providers/telegram/channel_send.rs
+++ b/src/openhuman/channels/providers/telegram/channel_send.rs
@@ -1,10 +1,7 @@
 //! Telegram channel — outbound message sending: text chunking, media uploads, reaction sending,
 //! and attachment dispatch.
 
-use super::attachments::{
-    is_http_url, parse_attachment_markers, parse_path_only_attachment, TelegramAttachment,
-    TelegramAttachmentKind,
-};
+use super::attachments::{is_http_url, TelegramAttachment, TelegramAttachmentKind};
 use super::channel_types::TelegramChannel;
 use super::text::split_message_for_telegram;
 use crate::core::event_bus::{publish_global, DomainEvent};

--- a/src/openhuman/composio/providers/profile.rs
+++ b/src/openhuman/composio/providers/profile.rs
@@ -21,7 +21,7 @@ use super::ProviderUserProfile;
 use crate::openhuman::learning::candidate::{
     self as learning_candidate, CueFamily, EvidenceRef, FacetClass, LearningCandidate,
 };
-use crate::openhuman::memory::store::profile::{self, FacetState, FacetType, UserState};
+use crate::openhuman::memory::store::profile::{self, FacetType};
 use rusqlite::params;
 use serde_json::Value;
 use std::collections::BTreeMap;

--- a/src/openhuman/composio/trigger_history.rs
+++ b/src/openhuman/composio/trigger_history.rs
@@ -6,7 +6,9 @@
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(windows)]
+use std::sync::Mutex;
+use std::sync::{Arc, OnceLock};
 
 use chrono::Utc;
 use fs2::FileExt;

--- a/src/openhuman/learning/cache.rs
+++ b/src/openhuman/learning/cache.rs
@@ -9,7 +9,7 @@ use rusqlite::Connection;
 use std::sync::Arc;
 
 use crate::openhuman::learning::candidate::FacetClass;
-use crate::openhuman::memory::store::profile::{self, FacetState, ProfileFacet, UserState};
+use crate::openhuman::memory::store::profile::{self, ProfileFacet, UserState};
 
 /// Thin wrapper around the `user_profile` table.
 ///

--- a/src/openhuman/learning/stability_detector.rs
+++ b/src/openhuman/learning/stability_detector.rs
@@ -32,7 +32,6 @@
 //! overflow pool holds up to `BUDGET_OVERFLOW` extra Provisional rows.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::core::event_bus;
 use crate::core::event_bus::DomainEvent;

--- a/src/openhuman/memory/store/factories.rs
+++ b/src/openhuman/memory/store/factories.rs
@@ -12,9 +12,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crate::openhuman::config::{
-    EmbeddingRouteConfig, LocalAiConfig, MemoryConfig, StorageProviderConfig,
-};
+use crate::openhuman::config::{EmbeddingRouteConfig, MemoryConfig, StorageProviderConfig};
 use crate::openhuman::embeddings::{
     self, EmbeddingProvider, DEFAULT_CLOUD_EMBEDDING_DIMENSIONS, DEFAULT_CLOUD_EMBEDDING_MODEL,
     DEFAULT_OLLAMA_DIMENSIONS, DEFAULT_OLLAMA_MODEL,

--- a/src/openhuman/memory/tree/chat/mod.rs
+++ b/src/openhuman/memory/tree/chat/mod.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::openhuman::config::{Config, LlmBackend, DEFAULT_CLOUD_LLM_MODEL};
+use crate::openhuman::config::{Config, DEFAULT_CLOUD_LLM_MODEL};
 
 pub mod cloud;
 pub mod local;

--- a/src/openhuman/memory/tree/score/extract/mod.rs
+++ b/src/openhuman/memory/tree/score/extract/mod.rs
@@ -12,7 +12,7 @@ pub mod types;
 
 use std::sync::Arc;
 
-use crate::openhuman::config::{Config, LlmBackend, DEFAULT_CLOUD_LLM_MODEL};
+use crate::openhuman::config::{Config, DEFAULT_CLOUD_LLM_MODEL};
 use crate::openhuman::memory::tree::chat::{build_chat_provider, ChatConsumer};
 
 pub use extractor::{CompositeExtractor, EntityExtractor, RegexEntityExtractor};

--- a/src/openhuman/memory/tree/tree_source/source_file.rs
+++ b/src/openhuman/memory/tree/tree_source/source_file.rs
@@ -32,7 +32,7 @@ use chrono::{DateTime, Utc};
 
 use crate::openhuman::config::Config;
 use crate::openhuman::memory::tree::content_store::raw::raw_source_dir;
-use crate::openhuman::memory::tree::tree_source::types::Tree;
+use crate::openhuman::memory::tree::tree_source::types::{Tree, TreeKind, TreeStatus};
 
 /// Filename of the per-source registry mirror inside `raw/<source_slug>/`.
 pub const SOURCE_FILE_NAME: &str = "_source.md";

--- a/src/openhuman/memory/tree/tree_source/source_file.rs
+++ b/src/openhuman/memory/tree/tree_source/source_file.rs
@@ -32,7 +32,7 @@ use chrono::{DateTime, Utc};
 
 use crate::openhuman::config::Config;
 use crate::openhuman::memory::tree::content_store::raw::raw_source_dir;
-use crate::openhuman::memory::tree::tree_source::types::{Tree, TreeKind, TreeStatus};
+use crate::openhuman::memory::tree::tree_source::types::Tree;
 
 /// Filename of the per-source registry mirror inside `raw/<source_slug>/`.
 pub const SOURCE_FILE_NAME: &str = "_source.md";

--- a/src/openhuman/skills/ops_create.rs
+++ b/src/openhuman/skills/ops_create.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use super::ops_discover::{discover_skills_inner, is_workspace_trusted};
 use super::ops_types::{
-    Skill, SkillFrontmatter, SkillScope, MAX_DESCRIPTION_LEN, MAX_NAME_LEN, RESOURCE_DIRS, SKILL_MD,
+    Skill, SkillScope, MAX_DESCRIPTION_LEN, MAX_NAME_LEN, RESOURCE_DIRS, SKILL_MD,
 };
 
 /// Input for [`create_skill`]. Mirrors the `skills.create` JSON-RPC payload.

--- a/src/openhuman/tools/impl/browser/browser.rs
+++ b/src/openhuman/tools/impl/browser/browser.rs
@@ -15,6 +15,7 @@ mod security;
 #[path = "types.rs"]
 mod types;
 
+#[allow(unused_imports)]
 pub(super) use action_parser::{
     backend_name, is_computer_use_only_action, is_supported_browser_action, parse_browser_action,
     unavailable_action_for_backend_error,


### PR DESCRIPTION
## Summary

- Removes all 12 `unused_imports` compiler warnings produced by `cargo check --lib` across 12 files in the Rust core.
- Fixes are grouped into three categories: removing genuinely dead imports, gating a platform-specific import under `#[cfg(windows)]`, and suppressing intentional test-surface re-exports with `#[allow(unused_imports)]`.
- No logic changed — imports were either unused, test-only, or platform-specific.

## Problem

`cargo check --lib` produced 12 `unused_imports` warnings across core domains (`channels`, `composio`, `learning`, `memory`, `skills`, `tools`). These accumulated during the QuickJS runtime removal and subsequent refactors and create noise that obscures genuine new warnings during development.

## Solution

Three fix strategies applied:

1. **Remove dead imports** — symbols imported but never referenced in production code (and not needed by test submodules): `parse_attachment_markers`, `parse_path_only_attachment`, `FacetState` (×2), `UserState`, `LlmBackend` (×2), `LocalAiConfig`, `TreeKind`, `TreeStatus`, `SkillFrontmatter`, `std::sync::Arc` (in `stability_detector.rs` — test-only).
2. **Platform-gate** — `Mutex` in `composio/trigger_history.rs` moved inside `#[cfg(windows)]` to match its sole usage site.
3. **Suppress intentional re-exports** — `#[allow(unused_imports)]` on `pub use TelegramChannel` (exists for `channel_tests.rs` path module) and `pub(super) use backend_name` (exists for `browser_tests.rs`). Removing these would break the test module import paths.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — N/A: pure import cleanup, no logic changed; existing tests are unaffected and continue to cover the same code paths.
- [x] **Diff coverage ≥ 80%** — N/A: no new lines of executable code introduced; only import statements removed/gated. Coverage gate does not apply to import-only diffs.
- [x] Coverage matrix updated — N/A: no feature rows added, removed, or renamed; this is a build-hygiene cleanup with no behavior change.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature matrix entries affected.
- [x] No new external network dependencies introduced — N/A: no dependencies changed.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surfaces touched; import-only change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no Linear issue; this is a maintainer-initiated cleanup PR.

## Impact

- **Build hygiene only.** Zero runtime behavior change.
- `cargo check --lib` warning count reduced from 12 (targeted) to 0 for the `unused_imports` category.
- The 4 remaining pre-existing warnings (`PermissionsExt`, `unused_mut`, `unused_variables`, `private_interfaces`) are unchanged and in different files/modules; they are not in scope for this PR.

## Related

- Follow-up PR(s)/TODOs: The 4 remaining pre-existing Tauri shell warnings (`unused_imports`, `dead_code`) in `app/src-tauri/` can be addressed in a follow-up.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A — maintainer-initiated cleanup, no Linear issue.
- URL: N/A

### Commit & Branch
- Branch: `fix/rust-unused-import-warnings`
- Commit SHA: `28299f0e669587360bae4d2e70cba73ed4873e42`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed (run by Husky pre-push hook)
- [x] `pnpm typecheck` — passed (run by Husky pre-push hook, 0 errors)
- [x] Focused tests: N/A — no logic changed; test modules using the re-exported symbols (`channel_tests.rs`, `browser_tests.rs`) are covered by existing CI test runs.
- [x] Rust fmt/check (if changed): `cargo check --lib` → 0 targeted warnings; `cargo fmt --check` passed (enforced by pre-push hook and `Type Check / Rust Quality` CI job ✅).
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri/` files modified.

### Validation Blocked
- `command:` N/A — all local validation completed successfully.
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: None. Import-only cleanup.
- User-visible effect: None.

### Parity Contract
- Legacy behavior preserved: All removed imports were unused; no call sites removed.
- Guard/fallback/dispatch parity checks: N/A — no guard/dispatch logic changed.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None.
- Canonical PR: This PR.
- Resolution: N/A.