### PR TITLE
fix: add provider/model failover to streaming LLM calls

### DIFF
--- a/src/openhuman/inference/provider/reliable.rs
+++ b/src/openhuman/inference/provider/reliable.rs
@@ -1,5 +1,5 @@
 use super::traits::{
-    ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamOptions, StreamResult,
+    ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamError, StreamOptions, StreamResult,
 };
 use super::Provider;
 use async_trait::async_trait;
@@ -57,6 +57,32 @@ fn is_non_retryable(err: &anyhow::Error) -> bool {
             || msg_lower.contains("unsupported")
             || msg_lower.contains("does not exist")
             || msg_lower.contains("invalid"))
+}
+
+/// Classify a StreamError without losing type information.
+/// Inspects the inner reqwest::Error status directly for Http variants.
+fn is_stream_error_non_retryable(err: &StreamError) -> bool {
+    match err {
+        StreamError::Http(reqwest_err) => {
+            if let Some(status) = reqwest_err.status() {
+                let code = status.as_u16();
+                // Client errors except 429 (rate limit) and 408 (timeout) are non-retryable
+                return status.is_client_error() && code != 429 && code != 408;
+            }
+            false
+        }
+        StreamError::Provider(msg) => {
+            let lower = msg.to_lowercase();
+            lower.contains("invalid api key")
+                || lower.contains("unauthorized")
+                || lower.contains("forbidden")
+                || lower.contains("model")
+                    && (lower.contains("not found") || lower.contains("unsupported"))
+        }
+        // JSON/SSE parse errors and IO errors are generally non-retryable
+        StreamError::Json(_) | StreamError::InvalidSse(_) => true,
+        StreamError::Io(_) => false,
+    }
 }
 
 fn is_context_window_exceeded(err: &anyhow::Error) -> bool {
@@ -924,63 +950,126 @@ impl Provider for ReliableProvider {
         temperature: f64,
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
-        // Try each provider/model combination for streaming
-        // For streaming, we use the first provider that supports it and has streaming enabled
-        for (provider_name, provider) in &self.providers {
-            if !provider.supports_streaming() || !options.enabled {
-                continue;
-            }
-
-            // Clone provider data for the stream
-            let provider_clone = provider_name.clone();
-
-            // Try the first model in the chain for streaming
-            let current_model = match self.model_chain(model).first() {
-                Some(m) => m.to_string(),
-                None => model.to_string(),
-            };
-
-            // For streaming, we attempt once and propagate errors
-            // The caller can retry the entire request if needed
-            let stream = provider.stream_chat_with_system(
-                system_prompt,
-                message,
-                &current_model,
-                temperature,
-                options,
-            );
-
-            // Use a channel to bridge the stream with logging
-            let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamChunk>>(100);
-
-            tokio::spawn(async move {
-                let mut stream = stream;
-                while let Some(chunk) = stream.next().await {
-                    if let Err(ref e) = chunk {
-                        tracing::warn!(
-                            provider = provider_clone,
-                            model = current_model,
-                            "Streaming error: {e}"
-                        );
-                    }
-                    if tx.send(chunk).await.is_err() {
-                        break; // Receiver dropped
-                    }
-                }
-            });
-
-            // Convert channel receiver to stream
-            return stream::unfold(rx, |mut rx| async move {
-                rx.recv().await.map(|chunk| (chunk, rx))
+        if !options.enabled {
+            return stream::once(async move {
+                Err(super::traits::StreamError::Provider(
+                    "Streaming disabled".to_string(),
+                ))
             })
             .boxed();
         }
 
-        // No streaming support available
-        stream::once(async move {
-            Err(super::traits::StreamError::Provider(
-                "No provider supports streaming".to_string(),
-            ))
+        // Collect streaming-capable providers
+        let streaming_providers: Vec<_> = self
+            .providers
+            .iter()
+            .filter(|(_, p)| p.supports_streaming())
+            .collect();
+
+        if streaming_providers.is_empty() {
+            return stream::once(async move {
+                Err(super::traits::StreamError::Provider(
+                    "No provider supports streaming".to_string(),
+                ))
+            })
+            .boxed();
+        }
+
+        // Build model chain and provider info for the spawned task
+        let models = self.model_chain(model);
+        let model_chain: Vec<String> = models.into_iter().map(|m| m.to_string()).collect();
+        let base_backoff_ms = self.base_backoff_ms;
+
+        // Collect provider streams lazily inside the task — we need owned data
+        // Provider trait is object-safe, so we call stream_chat_with_system per attempt
+        // We need to pre-create all possible streams since Provider is behind &self
+        // Instead, collect the streams for each provider+model combo upfront
+        let mut candidate_streams: Vec<(
+            String,
+            String,
+            stream::BoxStream<'static, StreamResult<StreamChunk>>,
+        )> = Vec::new();
+        for current_model in &model_chain {
+            for (provider_name, provider) in &streaming_providers {
+                let s = provider.stream_chat_with_system(
+                    system_prompt,
+                    message,
+                    current_model,
+                    temperature,
+                    options,
+                );
+                candidate_streams.push(((*provider_name).clone(), current_model.clone(), s));
+            }
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamChunk>>(100);
+        let max_retries = self.max_retries;
+
+        tokio::spawn(async move {
+            for (provider_name, current_model, mut candidate_stream) in candidate_streams {
+                let mut backoff_ms = base_backoff_ms;
+                let mut attempts = 0u32;
+
+                loop {
+                    match candidate_stream.next().await {
+                        Some(Ok(chunk)) => {
+                            // First chunk succeeded — commit to this stream
+                            if tx.send(Ok(chunk)).await.is_err() {
+                                return;
+                            }
+                            // Forward remaining chunks
+                            while let Some(chunk) = candidate_stream.next().await {
+                                if tx.send(chunk).await.is_err() {
+                                    return;
+                                }
+                            }
+                            return; // Done successfully
+                        }
+                        Some(Err(ref e)) => {
+                            let non_retryable = is_stream_error_non_retryable(e);
+
+                            tracing::warn!(
+                                provider = provider_name,
+                                model = current_model,
+                                attempt = attempts + 1,
+                                error = %e,
+                                "Streaming failed{}", if non_retryable { " (non-retryable)" } else { "" }
+                            );
+
+                            if non_retryable || attempts >= max_retries {
+                                break; // Move to next candidate
+                            }
+
+                            attempts += 1;
+                            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                            backoff_ms = (backoff_ms.saturating_mul(2)).min(10_000);
+                            // Continue inner loop — stream may yield more items
+                        }
+                        None => {
+                            // Stream exhausted without success
+                            if attempts == 0 {
+                                tracing::warn!(
+                                    provider = provider_name,
+                                    model = current_model,
+                                    "Stream returned empty"
+                                );
+                            }
+                            break; // Move to next candidate
+                        }
+                    }
+                }
+            }
+
+            // All providers/models exhausted
+            let _ = tx
+                .send(Err(super::traits::StreamError::Provider(
+                    "All streaming providers/models failed".to_string(),
+                )))
+                .await;
+        });
+
+        stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|chunk| (chunk, rx))
         })
         .boxed()
     }


### PR DESCRIPTION
## Summary

`stream_chat_with_system()` in `ReliableProvider` only tried the first streaming-capable provider with the first model in the chain. Any transient error (rate limit, timeout, 503) propagated immediately — while non-streaming methods (`chat_with_system`, `chat`, `chat_with_tools`) had full retry + provider failover + model fallback.

## Changes

- Pre-create streams for all provider+model candidates (full model chain × all streaming providers)
- Iterate candidates in a spawned task; commit to the first stream that yields a successful first chunk
- On transient failure, apply exponential backoff then try next candidate
- On non-retryable error, skip backoff and move to next candidate immediately
- If all candidates exhausted, emit a single `StreamError::Provider` with clear message

## Testing

- All 53 `reliable::tests` pass
- All 201 `providers` tests pass
- `cargo check` clean (no new warnings)

Closes #1931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability with robust failover across multiple providers and models.
  * Better classification of streaming errors to distinguish retryable vs non-retryable failures.
  * Added exponential backoff for retry attempts to increase resilience and recovery.
  * Returns immediate, clear error when streaming is disabled or no providers support streaming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->