### PR TITLE
harden: restrict docker compose container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,18 @@ services:
     image: openhuman-core:local
     container_name: openhuman-core
     restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
     ports:
       - "${OPENHUMAN_CORE_PORT:-7788}:7788"
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       # Bind to 0.0.0.0 inside the container so port-forwarding works regardless
       # of what `.env` says. The Dockerfile already sets this default, but make
@@ -33,9 +41,13 @@ services:
       OPENHUMAN_CORE_HOST: 0.0.0.0
       OPENHUMAN_CORE_PORT: "7788"
       OPENHUMAN_WORKSPACE: /home/openhuman/.openhuman
+      XDG_CACHE_HOME: /home/openhuman/.openhuman/cache
+      TMPDIR: /tmp
       RUST_LOG: ${RUST_LOG:-info}
     volumes:
       - openhuman-workspace:/home/openhuman/.openhuman
+    mem_limit: ${OPENHUMAN_CORE_MEM_LIMIT:-4g}
+    cpus: ${OPENHUMAN_CORE_CPUS:-2.0}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:7788/health"]
       interval: 30s


### PR DESCRIPTION
## Summary

- Harden the self-hosted `openhuman-core` Docker Compose service.
- Run the container with a read-only root filesystem, no new privileges, and all Linux capabilities dropped.
- Add tmp/cache write locations and configurable CPU/memory limits.
- Make `.env` optional for config validation while keeping documented env-based deployment behavior.

## Problem

Issue #1930 reports that `docker-compose.yml` launches the core container with Docker's broad default privilege surface. A compromised process would retain default Linux capabilities and a writable root filesystem, increasing blast radius for self-hosted deployments.

## Solution

- Add `read_only: true`, `security_opt: no-new-privileges:true`, `cap_drop: [ALL]`, and a tmpfs-backed `/tmp`.
- Keep persistent writes under the existing `/home/openhuman/.openhuman` named volume and point `XDG_CACHE_HOME` there.
- Add configurable defaults for memory and CPU limits through `OPENHUMAN_CORE_MEM_LIMIT` and `OPENHUMAN_CORE_CPUS`.
- Use optional `.env` loading so `docker compose config` and CI-style validation can run before a local `.env` is created.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — N/A: Docker Compose configuration-only hardening; validated with `docker compose config`.
- [x] **Diff coverage ≥ 80%** — N/A: configuration-only change, no executable source lines.
- [x] Coverage matrix updated — N/A: deployment hardening; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no desktop release manual smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Self-hosted Compose deployments get a smaller container privilege surface by default. The workspace volume remains writable, `/tmp` remains available via tmpfs, and memory/CPU defaults can be overridden with environment variables.

No application runtime API or data migration impact.

## Related

- Closes #1930
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `harden/docker-compose-security`
- Commit SHA: `942362f`

### Validation Run
- [x] `docker --version`
- [x] `docker compose version`
- [x] `docker compose config`
- [x] `git diff --check -- docker-compose.yml`
- [x] Full pre-push hook: `git push -u fork harden/docker-compose-security` (format, lint, compile, Rust check, command token lint)
- [x] Rust fmt/check (if changed): passed via pre-push hook; no Rust files changed.
- [x] Tauri fmt/check (if changed): passed via pre-push hook; no Tauri files changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Compose-launched core containers run with read-only rootfs, no-new-privileges, dropped capabilities, tmpfs `/tmp`, and default CPU/memory limits.
- User-visible effect: self-hosted operators can still override resource limits with env vars; `.env` remains supported but is no longer required for config validation.

### Parity Contract
- Legacy behavior preserved: port, image/build path, workspace volume, healthcheck, and default core env values remain the same.
- Guard/fallback/dispatch parity checks: writable paths are preserved through the workspace volume and `/tmp` tmpfs.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened container security with additional hardening measures
  * Refined environment variable configuration for improved runtime behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->