### PR TITLE
docs(README.zh-CN): sync Product Hunt badge + install URL with English

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,11 +11,12 @@
 <p align="center" style="display: inline-block">
  <a href="https://trendshift.io/repositories/23680" target="_blank" style="display: inline-block">
   <img src="https://trendshift.io/api/badge/repositories/23680" alt="tinyhumansai%2Fopenhuman | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+ </a> 
+ &nbsp;
+ <a href="https://www.producthunt.com/products/openhuman?embed=true&amp;utm_source=badge-top-post-badge&amp;utm_medium=badge&amp;utm_campaign=badge-openhuman" target="_blank" rel="noopener noreferrer">
+  <img alt="OpenHuman - An open source AI harness built with the human in mind | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1136902&amp;theme=light&amp;period=daily&amp;t=1778916022823">
  </a>
-</p>
-
-<p align="center" style="display: inline-block">
- <a href="https://www.producthunt.com/products/openhuman?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-openhuman" target="_blank" rel="noopener noreferrer"><img alt="OpenHuman - An open source AI harness built with the human in mind | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1136902&amp;theme=light&amp;t=1778829432446"></a>
+ 
 </p>
 
 <p align="center">
@@ -44,7 +45,7 @@
 要安装或开始使用，请从 [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) 下载，或在终端中运行：
 
 ```bash
-# 从 https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme 下载 DMG、EXE，或在终端中运行
+# 从 https://tinyhumans.ai/openhuman 下载 DMG、EXE，或在终端中运行
 
 # macOS 或 Linux x64
 curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash


### PR DESCRIPTION
## Summary

- After the Simplified Chinese README was added in #1890, two follow-up tweaks to `README.md` (#1895, #1903) were never mirrored into `README.zh-CN.md`.
- Apply both upstream diffs verbatim to `README.zh-CN.md` so the Chinese edition matches the English source.
- `README.ja-JP.md` is already in sync with both changes — no edit needed there.
- Documentation-only — no code, tests, or behaviour change.

## Problem

`README.zh-CN.md` is the user-facing landing page for Chinese-speaking visitors arriving via the language badge / Trendshift / Product Hunt referrals. Two upstream changes drifted away from it:

1. **Product Hunt badge** (#1895, commit `bd5c2ed3`): the English README migrated the embed from `badge-featured` / `featured.svg` to `badge-top-post-badge` / `top-post-badge.svg`, and merged the two separate `<p>` blocks (one for Trendshift, one for Product Hunt) into a single centred row with `&nbsp;` spacing. The Chinese README still shows the older `featured` badge in its own block, so visitors see a stale "OpenHuman is Featured" widget instead of the current "Top Post" widget — and the layout differs between editions.

2. **Install URL** (#1903, commit `df542e72`): the English README dropped `?utm_source=github&utm_medium=readme` from the URL inside the install code block's comment, so the URL shown to users matches what they would actually type. The Chinese README still carries the tracking parameters in the comment, which is both inconsistent and slightly confusing (the prose link above it kept the params; only the in-code comment was simplified).

`README.ja-JP.md` was added later (#2005) and already includes both fixes, so it does not need touching in this PR.

## Solution

Apply the two upstream diffs to `README.zh-CN.md`:

- Replace the `featured` Product Hunt block with the `top-post-badge` markup and collapse the two `<p>` blocks into one, matching `README.md` line 7-16 byte-for-byte (apart from the surrounding Chinese prose).
- Drop `?utm_source=github&utm_medium=readme` from the comment line inside the install code block (line 48), matching `README.md` line 49.

No other content is touched. This is the minimal diff that re-aligns the Chinese edition to the English source as of `main`.

## Submission Checklist

- [x] Tests added or updated — **N/A**: documentation-only change.
- [x] **Diff coverage ≥ 80%** — **N/A**: only `.md` lines changed; `diff-cover` does not score Markdown.
- [x] Coverage matrix updated — **N/A**: behaviour-only, no feature row added/removed/renamed.
- [x] Affected feature IDs listed under `## Related` — **N/A**: documentation correction.
- [x] No new external network dependencies introduced — confirmed, only Markdown copy changes.
- [x] Manual smoke checklist updated if release-cut surfaces are touched — **N/A**: README copy only.
- [x] Linked issue closed via `Closes #NNN` — **N/A**: #1886 (the original request to add a Chinese README) is already fulfilled by the merged #1890; this PR is sync maintenance, not the original delivery. Happy to also close #1886 in a separate comment if maintainers prefer.

## Impact

- **Runtime / platform**: none.
- **Performance / security / migration / compatibility**: none.
- **User-visible**: Chinese-speaking visitors now see the current "Top Post" Product Hunt badge in the same layout as the English README, and the in-code install comment shows a clean URL.

## Related

- Follows: #1895, #1903 (upstream changes that drifted from the Chinese edition).
- Original Chinese README: #1890 (closes the spirit of #1886).
- Follow-up PR(s)/TODOs: none — straightforward sync.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Human-authored PR — fields marked `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `docs/sync-zh-cn-readme-drift`
- Commit SHA: `d535fe13`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — **N/A**: no `app/*` files changed.
- [x] `pnpm typecheck` — **N/A**: no TypeScript changed.
- [x] Focused tests: **N/A**: docs-only change.
- [x] Rust fmt/check (if changed): **N/A**: no `.rs` changed.
- [x] Tauri fmt/check (if changed): **N/A**: no Tauri code changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: None (documentation only).
- User-visible effect: Chinese-speaking visitors see the current Product Hunt badge and a clean install URL, matching the English README.

### Parity Contract
- Legacy behavior preserved: Yes — no code paths touched. Chinese copy preserves all prose; only the two drifted blocks are realigned.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None known.
- Canonical PR: This PR.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Product Hunt badge presentation in Chinese README
  * Simplified installation link with cleaner URL format

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->