### PR TITLE
fix: block symlink escapes in path policy

### DIFF
--- a/src/openhuman/security/policy.rs
+++ b/src/openhuman/security/policy.rs
@@ -383,6 +383,17 @@ fn contains_unquoted_char(command: &str, target: char) -> bool {
     false
 }
 
+fn resolve_existing_path_prefix(path: &Path) -> Option<PathBuf> {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return current.canonicalize().ok();
+        }
+
+        current = current.parent()?;
+    }
+}
+
 impl SecurityPolicy {
     /// Classify command risk. Any high-risk segment marks the whole command high.
     pub fn command_risk_level(&self, command: &str) -> CommandRiskLevel {
@@ -718,6 +729,15 @@ impl SecurityPolicy {
             let forbidden_path = Path::new(&forbidden_expanded);
             if expanded_path.starts_with(forbidden_path) {
                 return false;
+            }
+        }
+
+        if self.workspace_only && !path.is_empty() {
+            let candidate = self.workspace_dir.join(&expanded);
+            if let Some(resolved) = resolve_existing_path_prefix(&candidate) {
+                if !self.is_resolved_path_allowed(&resolved) {
+                    return false;
+                }
             }
         }
 

--- a/src/openhuman/security/policy_tests.rs
+++ b/src/openhuman/security/policy_tests.rs
@@ -987,6 +987,40 @@ fn resolved_path_blocks_symlink_escape() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+#[cfg(unix)]
+#[test]
+fn is_path_allowed_blocks_workspace_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let root = std::env::temp_dir().join(format!(
+        "openhuman_test_path_symlink_escape_{}",
+        std::process::id()
+    ));
+    let workspace = root.join("workspace");
+    let outside = root.join("outside_target");
+
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    symlink(&outside, workspace.join("escape_link")).unwrap();
+
+    let policy = SecurityPolicy {
+        workspace_dir: workspace,
+        ..SecurityPolicy::default()
+    };
+
+    assert!(
+        !policy.is_path_allowed("escape_link"),
+        "existing symlink targets outside the workspace must be blocked"
+    );
+    assert!(
+        !policy.is_path_allowed("escape_link/new-file.txt"),
+        "paths beneath symlinked directories outside the workspace must be blocked"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 #[test]
 fn is_path_allowed_blocks_null_bytes() {
     let policy = default_policy();

--- a/src/openhuman/tools/impl/filesystem/file_read.rs
+++ b/src/openhuman/tools/impl/filesystem/file_read.rs
@@ -327,7 +327,8 @@ mod tests {
         // caught before canonicalize — error says "not allowed" rather than
         // "escapes workspace", but the operation is still correctly blocked.
         assert!(
-            result.output().contains("not allowed") || result.output().contains("escapes workspace")
+            result.output().contains("not allowed")
+                || result.output().contains("escapes workspace")
         );
 
         let _ = tokio::fs::remove_dir_all(&root).await;

--- a/src/openhuman/tools/impl/filesystem/file_read.rs
+++ b/src/openhuman/tools/impl/filesystem/file_read.rs
@@ -323,7 +323,12 @@ mod tests {
         let result = tool.execute(json!({"path": "escape.txt"})).await.unwrap();
 
         assert!(result.is_error);
-        assert!(result.output().contains("escapes workspace"));
+        // is_path_allowed now resolves symlinks eagerly, so the block is
+        // caught before canonicalize — error says "not allowed" rather than
+        // "escapes workspace", but the operation is still correctly blocked.
+        assert!(
+            result.output().contains("not allowed") || result.output().contains("escapes workspace")
+        );
 
         let _ = tokio::fs::remove_dir_all(&root).await;
     }

--- a/src/openhuman/tools/impl/filesystem/file_write.rs
+++ b/src/openhuman/tools/impl/filesystem/file_write.rs
@@ -319,7 +319,12 @@ mod tests {
             .unwrap();
 
         assert!(result.is_error);
-        assert!(result.output().contains("escapes workspace"));
+        // is_path_allowed now resolves symlinks eagerly, so the block is
+        // caught before canonicalize — error says "not allowed" rather than
+        // "escapes workspace", but the operation is still correctly blocked.
+        assert!(
+            result.output().contains("not allowed") || result.output().contains("escapes workspace")
+        );
         assert!(!outside.join("hijack.txt").exists());
 
         let _ = tokio::fs::remove_dir_all(&root).await;
@@ -395,9 +400,13 @@ mod tests {
             .unwrap();
 
         assert!(result.is_error, "writing through symlink must be blocked");
+        // is_path_allowed now resolves symlinks eagerly; the block is caught
+        // before the explicit symlink-target check in file_write, so the error
+        // says "not allowed" instead of explicitly mentioning "symlink".
         assert!(
-            result.output().contains("symlink"),
-            "error should mention symlink"
+            result.output().contains("symlink") || result.output().contains("not allowed"),
+            "error should indicate symlink/policy block; got: {}",
+            result.output()
         );
 
         // Verify original file was not modified

--- a/src/openhuman/tools/impl/filesystem/file_write.rs
+++ b/src/openhuman/tools/impl/filesystem/file_write.rs
@@ -323,7 +323,8 @@ mod tests {
         // caught before canonicalize — error says "not allowed" rather than
         // "escapes workspace", but the operation is still correctly blocked.
         assert!(
-            result.output().contains("not allowed") || result.output().contains("escapes workspace")
+            result.output().contains("not allowed")
+                || result.output().contains("escapes workspace")
         );
         assert!(!outside.join("hijack.txt").exists());
 


### PR DESCRIPTION
## Summary

- Harden `SecurityPolicy::is_path_allowed` against workspace symlink escapes.
- Resolve the existing path, or nearest existing parent, for workspace-relative paths before allowing them.
- Add a Unix regression test covering both a symlink path and a not-yet-created child under a symlinked directory.

## Problem

Issue #1927 reports that `is_path_allowed()` validates the path string but does not resolve symlinks. A path such as `escape_link` can look workspace-relative while resolving outside the workspace, leaving callers dependent on remembering a separate `is_resolved_path_allowed()` check.

## Solution

- Add a small helper that canonicalizes the path if it exists, or walks upward to canonicalize the nearest existing parent.
- In workspace-only mode, join relative paths to `workspace_dir` and reject them if the resolved existing prefix is outside the workspace.
- Keep non-existing normal workspace paths allowed so write/create flows still work.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — focused regression test covers the new symlink guard; CI Coverage Gate will report the exact diff coverage.
- [x] Coverage matrix updated — N/A: security policy hardening; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release manual smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Workspace-only file policy now rejects symlink paths that resolve outside the configured workspace even when callers only use `is_path_allowed()`. Normal relative paths and non-existing create targets inside the workspace remain allowed.

No migration or dependency impact.

## Related

- Closes #1927
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/security-policy-symlink-paths`
- Commit SHA: `4a43f9d`

### Validation Run
- [x] `cargo test -p openhuman is_path_allowed_blocks_workspace_symlink_escape --lib`
- [x] `cargo fmt --manifest-path Cargo.toml --all --check`
- [x] Full pre-push hook: `git push -u fork fix/security-policy-symlink-paths` (format, lint, compile, Rust check, command token lint)
- [x] Rust fmt/check (if changed): passed via focused fmt check and pre-push hook.
- [x] Tauri fmt/check (if changed): passed via pre-push hook; no Tauri files changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: reject workspace-relative symlink paths whose existing target/prefix resolves outside the workspace.
- User-visible effect: tool calls that attempt to traverse symlinks out of the workspace are blocked earlier.

### Parity Contract
- Legacy behavior preserved: normal workspace-relative paths, dotfiles in the workspace, and not-yet-created files under real workspace parents remain allowed.
- Guard/fallback/dispatch parity checks: `is_resolved_path_allowed()` remains available for callers that already canonicalize; this PR adds defense in depth to `is_path_allowed()`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced path validation to block attempts to access files outside the configured workspace, including symlink-based escapes and traversal cases.

* **Tests**
  * Added a regression test validating symlink escape prevention.
  * Updated existing file-read/write tests to accept broader error outcomes from earlier path validation while preserving checks that outside files remain unmodified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->