### PR TITLE
fix(accounts): don't persist activeAccountId across renderer reloads (#2044)

### DIFF
--- a/app/src/store/__tests__/accountsSlice.rehydrate.test.ts
+++ b/app/src/store/__tests__/accountsSlice.rehydrate.test.ts
@@ -88,7 +88,8 @@ describe('accountsSlice REHYDRATE — issue #1379', () => {
 
     const after = rehydrate(before);
     expect(after.order).toEqual(['acct-slack', 'acct-discord']);
-    expect(after.activeAccountId).toBe('acct-slack');
+    // Issue #2044 — activeAccountId is cleared on rehydrate (see below).
+    expect(after.activeAccountId).toBeNull();
     expect(after.lastActiveAccountId).toBe('acct-discord');
     expect(after.accounts['acct-slack']?.label).toBe('Work Slack');
     expect(after.accounts['acct-slack']?.provider).toBe('slack');
@@ -106,5 +107,37 @@ describe('accountsSlice REHYDRATE — issue #1379', () => {
     const after = rehydrate(before);
     expect(after.accounts).toEqual({});
     expect(after.order).toEqual([]);
+  });
+});
+
+describe('accountsSlice REHYDRATE — issue #2044 (activeAccountId not persisted)', () => {
+  it('clears a non-null activeAccountId on rehydrate so no webview auto-surfaces', () => {
+    const before = seedState([
+      makeAccount({ id: 'acct-slack', provider: 'slack', status: 'closed' }),
+    ]);
+    before.activeAccountId = 'acct-slack';
+    before.lastActiveAccountId = 'acct-slack';
+
+    const after = rehydrate(before);
+    expect(after.activeAccountId).toBeNull();
+    // MRU pointer is intentionally preserved so the off-screen prewarm
+    // can still warm the same account in the background.
+    expect(after.lastActiveAccountId).toBe('acct-slack');
+  });
+
+  it('leaves activeAccountId null when nothing was persisted', () => {
+    const before = seedState([]);
+    before.activeAccountId = null;
+    const after = rehydrate(before);
+    expect(after.activeAccountId).toBeNull();
+  });
+
+  it('does not touch activeAccountId for REHYDRATE actions on other persist keys', () => {
+    const before = seedState([
+      makeAccount({ id: 'acct-slack', provider: 'slack', status: 'closed' }),
+    ]);
+    before.activeAccountId = 'acct-slack';
+    const after = rehydrate(before, 'notifications');
+    expect(after.activeAccountId).toBe('acct-slack');
   });
 });

--- a/app/src/store/accountsSlice.ts
+++ b/app/src/store/accountsSlice.ts
@@ -168,6 +168,16 @@ const accountsSlice = createSlice({
           acct.lastError = undefined;
         }
       }
+      // Issue #2044 — even though `activeAccountId` is no longer in the
+      // persist whitelist, redux-persist blobs written by older builds
+      // can still carry it. Force-clear on rehydrate so a dev hot reload
+      // / app restart never auto-surfaces a provider webview without an
+      // explicit user click. `lastActiveAccountId` is preserved — it
+      // only drives the off-screen MRU prewarm.
+      if (state.activeAccountId !== null) {
+        log('clearing persisted activeAccountId=%s on rehydrate', state.activeAccountId);
+        state.activeAccountId = null;
+      }
       if (reset.length > 0) {
         log('reset %d transient account status(es) on rehydrate: %o', reset.length, reset);
       }

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -90,10 +90,19 @@ const persistedChannelConnectionsReducer = persistReducer(
 
 // Persist only the account list (not the live message stream / logs which
 // are re-ingested every time we open an account).
+//
+// Issue #2044 — `activeAccountId` is deliberately NOT persisted. It is a
+// per-session UX selection: persisting it caused provider webviews to
+// auto-surface on dev hot reload / app restart without an explicit user
+// click, because `Accounts.tsx` immediately mounts `WebviewHost` for the
+// active account and `WebviewHost` calls `openWebviewAccount` on mount.
+// `lastActiveAccountId` is still persisted so the off-screen MRU prewarm
+// can warm the same account in the background — that webview stays
+// hidden until the user clicks the rail.
 const accountsPersistConfig = {
   key: 'accounts',
   storage,
-  whitelist: ['accounts', 'order', 'activeAccountId', 'lastActiveAccountId'],
+  whitelist: ['accounts', 'order', 'lastActiveAccountId'],
 };
 const persistedAccountsReducer = persistReducer(accountsPersistConfig, accountsReducer);
 


### PR DESCRIPTION
## Summary

- Provider webviews no longer auto-surface on dev hot reload / app restart without a fresh user click.
- `accountsPersistConfig` no longer whitelists `activeAccountId` — selection is now per-session.
- `REHYDRATE` extraReducer force-clears any `activeAccountId` it sees in legacy persisted blobs.
- `lastActiveAccountId` is still persisted; it only drives the off-screen MRU prewarm, which stays hidden until clicked.

## Problem

In `pnpm dev:app`, provider webviews could show up on startup or after a Vite HMR reload without the user clicking an account. `accountsPersistConfig` whitelisted `activeAccountId`, so the previous session's selection rehydrated; `Accounts.tsx` then immediately mounted `<WebviewHost />` for that account, and `WebviewHost`'s mount effect calls `openWebviewAccount` — surfacing the native CEF child webview "out of nowhere." Same path triggers in production after app restart.

## Solution

Treat `activeAccountId` as ephemeral UI state, not durable account state:

1. `app/src/store/index.ts` — drop `activeAccountId` from the accounts persist whitelist. Keeps `accounts`, `order`, and `lastActiveAccountId` (used by MRU prewarm) persisted.
2. `app/src/store/accountsSlice.ts` — extend the existing `REHYDRATE` extraReducer (issue #1379) to force-clear `activeAccountId` on rehydrate, so blobs written by older builds (which still include the field) don't leak through after upgrade.

`lastActiveAccountId` stays persisted on purpose: the MRU prewarm spawns the CEF subview off-screen at 1×1 and only reveals it on user click via `webview_account_open`'s warm-reopen branch — matching the issue's "hidden prewarm helpers should stay hidden."

No HMR-time Tauri-side teardown is needed: `WebviewHost`'s effect cleanup already calls `hideWebviewAccount(accountId)` on unmount, and with this fix no `WebviewHost` mounts in the first place on a fresh renderer session unless the user clicks.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case)
- [x] **Diff coverage ≥ 80%** — all 3 changed-line locations (one-line whitelist edit, REHYDRATE clear block, 3 new tests) are covered by `accountsSlice.rehydrate.test.ts`.
- [ ] Coverage matrix updated — N/A: behaviour fix, no new feature row.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced
- [ ] Manual smoke checklist updated if this touches release-cut surfaces — N/A: bug fix in existing accounts surface.
- [x] Linked issue closed via `Closes #2044`

## Impact

- **Desktop only** (`app/src/store/`). No Rust / Tauri shell changes.
- **User-visible**: after an app restart or dev HMR reload, the Accounts route lands on the agent pane instead of the previously-selected provider webview. An explicit rail click is required to surface a webview. Prewarm behavior unchanged.
- **No migration**: `activeAccountId` is just dropped on next rehydrate; `lastActiveAccountId` (which the prewarm reads) is unaffected.

## Related

- Closes: #2044
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `issue/2044-dev-hot-reload-can-surface-provider-webv`
- Commit SHA: `2e69eb02e0daca04490be0f4de11b31428ed9fc5`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — ran `pnpm format` (Prettier + cargo fmt) clean.
- [x] `pnpm typecheck` — passes.
- [x] Focused tests: `pnpm test src/store src/hooks/__tests__/usePrewarmMostRecentAccount.test.tsx src/components/accounts` — 226 passed.
- [ ] Rust fmt/check (if changed): N/A — no Rust changes.
- [ ] Tauri fmt/check (if changed): N/A — no Tauri shell changes.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: `activeAccountId` is no longer persisted across renderer sessions; `REHYDRATE` clears any stale value from older builds' blobs.
- User-visible effect: After app restart / dev hot reload, the Accounts route lands on the agent pane until the user explicitly clicks an account rail icon. No provider webview surfaces without a fresh click.

### Parity Contract
- Legacy behavior preserved: `lastActiveAccountId` persistence (MRU prewarm input), all reducer behaviour for live selection within a session, and the existing #1379 transient-status reset on rehydrate are all unchanged.
- Guard/fallback/dispatch parity checks: `Accounts.tsx` already falls back to the agent pane (`AGENT_ID`) when `activeAccountId` is null — that branch is now exercised on every cold boot.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account selection to reset on app restart instead of persisting from previous sessions.

* **Tests**
  * Enhanced test coverage for account state initialization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->