### PR TITLE
Revert "fix(accounts): don't persist activeAccountId across renderer …

### DIFF
--- a/app/src/store/__tests__/accountsSlice.rehydrate.test.ts
+++ b/app/src/store/__tests__/accountsSlice.rehydrate.test.ts
@@ -88,8 +88,7 @@ describe('accountsSlice REHYDRATE — issue #1379', () => {
 
     const after = rehydrate(before);
     expect(after.order).toEqual(['acct-slack', 'acct-discord']);
-    // Issue #2044 — activeAccountId is cleared on rehydrate (see below).
-    expect(after.activeAccountId).toBeNull();
+    expect(after.activeAccountId).toBe('acct-slack');
     expect(after.lastActiveAccountId).toBe('acct-discord');
     expect(after.accounts['acct-slack']?.label).toBe('Work Slack');
     expect(after.accounts['acct-slack']?.provider).toBe('slack');
@@ -107,37 +106,5 @@ describe('accountsSlice REHYDRATE — issue #1379', () => {
     const after = rehydrate(before);
     expect(after.accounts).toEqual({});
     expect(after.order).toEqual([]);
-  });
-});
-
-describe('accountsSlice REHYDRATE — issue #2044 (activeAccountId not persisted)', () => {
-  it('clears a non-null activeAccountId on rehydrate so no webview auto-surfaces', () => {
-    const before = seedState([
-      makeAccount({ id: 'acct-slack', provider: 'slack', status: 'closed' }),
-    ]);
-    before.activeAccountId = 'acct-slack';
-    before.lastActiveAccountId = 'acct-slack';
-
-    const after = rehydrate(before);
-    expect(after.activeAccountId).toBeNull();
-    // MRU pointer is intentionally preserved so the off-screen prewarm
-    // can still warm the same account in the background.
-    expect(after.lastActiveAccountId).toBe('acct-slack');
-  });
-
-  it('leaves activeAccountId null when nothing was persisted', () => {
-    const before = seedState([]);
-    before.activeAccountId = null;
-    const after = rehydrate(before);
-    expect(after.activeAccountId).toBeNull();
-  });
-
-  it('does not touch activeAccountId for REHYDRATE actions on other persist keys', () => {
-    const before = seedState([
-      makeAccount({ id: 'acct-slack', provider: 'slack', status: 'closed' }),
-    ]);
-    before.activeAccountId = 'acct-slack';
-    const after = rehydrate(before, 'notifications');
-    expect(after.activeAccountId).toBe('acct-slack');
   });
 });

--- a/app/src/store/accountsSlice.ts
+++ b/app/src/store/accountsSlice.ts
@@ -168,16 +168,6 @@ const accountsSlice = createSlice({
           acct.lastError = undefined;
         }
       }
-      // Issue #2044 — even though `activeAccountId` is no longer in the
-      // persist whitelist, redux-persist blobs written by older builds
-      // can still carry it. Force-clear on rehydrate so a dev hot reload
-      // / app restart never auto-surfaces a provider webview without an
-      // explicit user click. `lastActiveAccountId` is preserved — it
-      // only drives the off-screen MRU prewarm.
-      if (state.activeAccountId !== null) {
-        log('clearing persisted activeAccountId=%s on rehydrate', state.activeAccountId);
-        state.activeAccountId = null;
-      }
       if (reset.length > 0) {
         log('reset %d transient account status(es) on rehydrate: %o', reset.length, reset);
       }

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -97,19 +97,10 @@ const persistedChannelConnectionsReducer = persistReducer(
 
 // Persist only the account list (not the live message stream / logs which
 // are re-ingested every time we open an account).
-//
-// Issue #2044 — `activeAccountId` is deliberately NOT persisted. It is a
-// per-session UX selection: persisting it caused provider webviews to
-// auto-surface on dev hot reload / app restart without an explicit user
-// click, because `Accounts.tsx` immediately mounts `WebviewHost` for the
-// active account and `WebviewHost` calls `openWebviewAccount` on mount.
-// `lastActiveAccountId` is still persisted so the off-screen MRU prewarm
-// can warm the same account in the background — that webview stays
-// hidden until the user clicks the rail.
 const accountsPersistConfig = {
   key: 'accounts',
   storage,
-  whitelist: ['accounts', 'order', 'lastActiveAccountId'],
+  whitelist: ['accounts', 'order', 'activeAccountId', 'lastActiveAccountId'],
 };
 const persistedAccountsReducer = persistReducer(accountsPersistConfig, accountsReducer);
 


### PR DESCRIPTION
…reloads (#2044) (#2047)"

This reverts commit 0f616e4a62ff21c01a16acee8b7c56e6b1d67197.

## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [ ] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key:
- URL:

### Commit & Branch
- Branch:
- Commit SHA:

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check`
- [ ] `pnpm typecheck`
- [ ] Focused tests:
- [ ] Rust fmt/check (if changed):
- [ ] Tauri fmt/check (if changed):

### Validation Blocked
- `command:`
- `error:`
- `impact:`

### Behavior Changes
- Intended behavior change:
- User-visible effect:

### Parity Contract
- Legacy behavior preserved:
- Guard/fallback/dispatch parity checks:

### Duplicate / Superseded PR Handling
- Duplicate PR(s):
- Canonical PR:
- Resolution (closed/superseded/updated):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account selection persistence: the active account is now properly preserved across app restarts instead of being reset.

* **Tests**
  * Updated rehydration tests to verify active account selection is maintained after app reload while transient account statuses are appropriately reset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->