### PR TITLE
fix(tauri): hide macOS app on close button

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1148,6 +1148,14 @@ fn set_main_window_hidden(hide: bool) {
 }
 
 fn show_main_window(app: &AppHandle<AppRuntime>) -> Result<(), String> {
+    // On macOS the close handler hides the whole NSApplication via
+    // `AppHandle::hide()` so the CEF host and browser surface are dismissed
+    // together. Unhide the application before touching the main window, then
+    // continue with the normal show/focus sequence below.
+    #[cfg(target_os = "macos")]
+    app.show()
+        .map_err(|err| format!("failed to show application: {err}"))?;
+
     // On Windows: surface the OS top-level Chrome_WidgetWin_1 frame BEFORE
     // any Tauri lookups. After our close handler's SW_HIDE the runtime
     // briefly drops the `WebviewWindow` record for "main" (CEF treats the
@@ -2761,10 +2769,10 @@ pub fn run() {
             // window from tray click: main window not found`
             // (OPENHUMAN-TAURI-2X — 21 events, Windows only).
             //
-            // macOS uses `window.hide()` because the vendored CEF runtime
-            // routes that through `set_application_visibility(false)` at the
-            // NSApplication level (`tauri-runtime-cef/src/lib.rs:588`), which
-            // hides the CEF browser surface together with the host window.
+            // macOS uses app-level hide because the vendored CEF runtime only
+            // routes `AppHandle::hide()` through `set_application_visibility(false)`
+            // at the NSApplication level. `WebviewWindow::hide()` targets the
+            // CEF window proxy and can leave the visible app window behind.
             // Windows is handled in the separate arm below — see issue #1607.
             //
             // Linux is left out: `setup_tray` early-returns on Linux because
@@ -2780,8 +2788,8 @@ pub fn run() {
                     "[window] close requested on main window — hiding instead of destroying"
                 );
                 api.prevent_close();
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    let _ = window.hide();
+                if let Err(err) = app_handle.hide() {
+                    log::warn!("[macos] failed to hide application on main window close: {err}");
                 }
             }
             // Windows: full hide-to-tray.


### PR DESCRIPTION
## Summary
- Use app-level hide on macOS close requests so the red close button dismisses the visible CEF-backed app window instead of only targeting the webview proxy.
- Unhide the macOS app before the existing `show_main_window` focus/reopen sequence so Dock/tray/reopen can restore it.
- Leave Windows/Linux close behavior unchanged.

Refs #2049

## Verification
- `git submodule update --init --recursive app/src-tauri/vendor/tauri-cef app/src-tauri/vendor/tauri-plugin-notification`
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF CARGO_TARGET_DIR=/Users/lee/Documents/Claude/Projects/10\ Work\ OS/projects/openhuman/app/src-tauri/target rustup run 1.93.0 cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check`
- `RUSTC=$(rustup which --toolchain 1.93.0 rustc) GGML_NATIVE=OFF CARGO_TARGET_DIR=/Users/lee/Documents/Claude/Projects/10\ Work\ OS/projects/openhuman/app/src-tauri/target rustup run 1.93.0 cargo check --manifest-path app/src-tauri/Cargo.toml`
- `git diff --check`

## Notes
- The Tauri/CEF check initially hit local disk pressure while building CEF in this temporary worktree; rerunning with the existing OpenHuman Tauri target directory completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS window display behavior to ensure proper application visibility when showing the main window.
  * Fixed macOS window close behavior to properly manage the application state and lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->