### PR TITLE
fix(linux): install silent X error handler to fix BadWindow exit on Wayland

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1622,7 +1622,79 @@ fn append_platform_cef_gpu_workarounds(args: &mut Vec<CefCommandLineArg>, os: &s
     }
 }
 
+/// Linux only: replace Xlib's default error handler with a logging no-op.
+///
+/// Why: on Wayland sessions (GNOME/KDE/Hyprland) running CEF via XWayland,
+/// the CEF browser process issues `XConfigureWindow` against a window the
+/// XWayland server hasn't fully realized yet, and Xlib's *default* error
+/// handler reacts to the resulting `BadWindow` by calling `exit(1)` — which
+/// kills the entire app before the main window ever paints. This reproduces
+/// reliably on Ubuntu 26.04 + GNOME-Wayland with the locally-built AppImage
+/// (issue #2001 item #2 — was punted as "separate display-side concerns"
+/// in PR #2032 but blocks any actual use of the app on a Wayland host).
+///
+/// XSetErrorHandler is a process-global registration; safe to install before
+/// any X display is opened. libX11 is already a runtime dep (verified via
+/// ldd of the compiled OpenHuman binary).
+#[cfg(target_os = "linux")]
+fn install_silent_x_error_handler() {
+    use std::ffi::c_void;
+    use std::os::raw::{c_int, c_uchar, c_ulong};
+    use std::sync::Once;
+
+    #[repr(C)]
+    struct XErrorEvent {
+        type_: c_int,
+        display: *mut c_void,
+        resourceid: c_ulong,
+        serial: c_ulong,
+        error_code: c_uchar,
+        request_code: c_uchar,
+        minor_code: c_uchar,
+    }
+
+    type ErrorHandler = unsafe extern "C" fn(*mut c_void, *mut XErrorEvent) -> c_int;
+    unsafe extern "C" {
+        fn XSetErrorHandler(handler: Option<ErrorHandler>) -> Option<ErrorHandler>;
+    }
+
+    unsafe extern "C" fn silent_handler(_display: *mut c_void, ev: *mut XErrorEvent) -> c_int {
+        if !ev.is_null() {
+            let e = unsafe { &*ev };
+            log::warn!(
+                "[x11] suppressed X protocol error: code={} request={} minor={} resource=0x{:x} serial={}",
+                e.error_code,
+                e.request_code,
+                e.minor_code,
+                e.resourceid,
+                e.serial
+            );
+        } else {
+            log::warn!("[x11] suppressed X protocol error (null event)");
+        }
+        0
+    }
+
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        unsafe {
+            XSetErrorHandler(Some(silent_handler));
+        }
+        log::info!(
+            "[x11] installed silent X error handler to prevent BadWindow exits on Wayland-XWayland (issue #2001 item #2)"
+        );
+    });
+}
+
+#[cfg(not(target_os = "linux"))]
+fn install_silent_x_error_handler() {}
+
 pub fn run() {
+    // Must run before any GTK/CEF code that could trigger X calls — otherwise
+    // Xlib's default handler calls exit(1) on the first BadWindow and we never
+    // reach this line. See helper doc above for the full reasoning.
+    install_silent_x_error_handler();
+
     // ── Install a custom tokio runtime for tauri::async_runtime ─────────
     //
     // Tauri's default async runtime uses tokio multi-thread workers with


### PR DESCRIPTION
## Summary

- Install a process-global `XSetErrorHandler` at the top of `lib.rs::run()` on Linux so non-fatal X protocol errors (e.g. `BadWindow` from `XConfigureWindow` during CEF window setup on XWayland) don't trigger Xlib's default-handler `exit(1)`.
- Linux-only (`cfg(target_os = "linux")`). macOS/Windows are no-ops.

## Problem

On Wayland sessions (GNOME-Wayland, KDE-Wayland, Hyprland — anywhere XWayland is the X server), the CEF browser process issues multiple `XConfigureWindow` calls against windows the XWayland server hasn't fully realized yet. The X server responds with `BadWindow` and Xlib's *default* error handler reacts by calling `exit(1)` — killing the entire app between `[app] RunEvent::Ready` and the actual window paint. Users see no UI; the shell prompt comes back instantly.

Reproduces reliably on Ubuntu 26.04 GNOME-Wayland (verified) and matches the Arch+Hyprland traceback in #2001 item #2 (different compositor, same XWayland → Xlib-default-handler → exit code path). #2032 closed #2001 based only on the NSS fix and explicitly punted this as "separate display-side concerns — see issue follow-ups." This is that follow-up.

## Solution

`install_silent_x_error_handler()` does a one-time FFI call to libX11's `XSetErrorHandler` with a no-op handler that logs each error via `log::warn!("[x11] suppressed X protocol error: code=… request=… …")` and returns 0. Called as the first line of `pub fn run()` so it's installed before any GTK/CEF init that might trigger an X call.

Safe because:

- `XSetErrorHandler` is process-global; can be installed before any X display is opened.
- `libX11` is already a runtime dep of the OpenHuman binary (confirmed via `ldd`) so the FFI extern resolves at link time without a new crate.
- GUI apps that drive complex window state (Chromium, Electron, CEF) all install their own X handlers for the same reason; the CEF *browser* process already does, but the parent Tauri host process keeps the default — which is where the kill comes from.

After this fix, smoke-test on Ubuntu 26.04 GNOME-Wayland (with the AppImage launch regressions from tinyhumansai/tauri-cef PR also applied so the binary actually starts at all) shows ~12 suppressed `BadWindow`s during CEF window setup, the app survives, the window paints, and the user can interact normally.

## Submission Checklist

- [ ] Tests added or updated — `N/A: FFI bootstrap with no behavior to assert beyond "process doesn't exit on X protocol errors". The patch is a one-line install + a logging-no-op handler; the only meaningful "test" is observing the suppressed-error log lines during a real Wayland launch, which can't be exercised in unit tests (no X server available).
- [ ] **Diff coverage ≥ 80%** — `N/A: same as above — the only changed lines are FFI declarations and a `log::warn!` in an Xlib-callback that runs only when the X server returns an error. The change is also gated behind `cfg(target_os = "linux")` and the coverage workflow doesn't currently run a Linux X11 session.`
- [ ] Coverage matrix updated — `N/A: behaviour-only change with no new feature row.`
- [ ] All affected feature IDs listed under Related — `N/A`
- [ ] No new external network dependencies introduced
- [ ] Manual smoke checklist updated — `N/A: Linux launch behavior, not a release-cut surface in the smoke checklist today.`
- [ ] Linked issue closed via `Closes #NNN` — see Related below

## Impact

- Linux runtime only. macOS/Windows no-op via `cfg`. No new crate deps.
- ~60 lines including doc/comments. The actual code is 1 FFI extern + 1 logging handler + 1 `Once` install.
- Closes the only remaining blocker for #2001 to be truly done end-to-end on Wayland-XWayland hosts.

## Related

- Closes #2001 (item #2 — item #1 was closed by #2032)
- Refs #2032

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/x11-silent-error-handler-2001-followup
- Commit SHA: see PR

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passes locally
- [ ] `pnpm typecheck` — N/A: no TypeScript changes
- [x] Focused tests: manual end-to-end smoke (Ubuntu 26.04 GNOME-Wayland) — app launches, BadWindows suppressed, window paints
- [x] Rust fmt/check (if changed): `cargo fmt --check` passes
- [x] Tauri fmt/check (if changed): `cargo fmt --check` on `app/src-tauri/Cargo.toml` passes

### Validation Blocked
- `command:` `git push` pre-push hook (`pnpm lint:commands-tokens`)
- `error:` `lint:commands-tokens requires ripgrep` (ripgrep not installed on the dev box used to push this)
- `impact:` pushed with `--no-verify` per CLAUDE.md guidance ("If a pre-push hook fails on something unrelated to your changes … push with `--no-verify` and call it out in the PR body"). The ripgrep dep is unrelated to this patch.

### Behavior Changes
- Intended behavior change: prevent `exit(1)` from Xlib's default error handler on Linux.
- User-visible effect: the app no longer dies between `RunEvent::Ready` and window paint on Wayland-XWayland.

### Parity Contract
- Legacy behavior preserved: macOS/Windows are unchanged (`cfg(target_os = "linux")` gate). The Linux change is a strict superset — errors that previously killed the process are now logged.
- Guard/fallback/dispatch parity checks: N/A — no dispatch path changes.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability on Linux systems by preventing unexpected crashes from X11 protocol errors when running under Wayland environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->