### PR TITLE
fix(tauri): resolve Linux CEF init panic — root/container + SingletonLock + display-server guards (OPENHUMAN-TAURI-K1)

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -129,7 +129,7 @@ cef = { version = "=146.4.1", default-features = false }
 openhuman_core = { path = "../..", package = "openhuman", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", default-features = false, features = ["signal"] }
+nix = { version = "0.29", default-features = false, features = ["signal", "user"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/app/src-tauri/src/cef_preflight.rs
+++ b/app/src-tauri/src/cef_preflight.rs
@@ -1,11 +1,16 @@
-//! CEF cache-lock preflight check (macOS).
+//! CEF cache-lock preflight check (macOS and Linux).
 //!
 //! When another OpenHuman instance is already running, it holds an exclusive
-//! lock on the CEF user-data-dir at `~/Library/Caches/com.openhuman.app/cef`.
+//! lock on the CEF user-data-dir. On macOS this is
+//! `~/Library/Caches/com.openhuman.app/cef`; on Linux it is the path in
+//! `OPENHUMAN_CEF_CACHE_PATH` (set by `cef_profile::prepare_process_cache_path`
+//! before this module runs), falling back to `$XDG_CACHE_HOME/<id>/cef` or
+//! `$HOME/.cache/<id>/cef` when the env var is absent.
+//!
 //! The vendored `tauri-runtime-cef` crate calls `cef::initialize()` and
 //! asserts the result equals `1`; on lock collision it returns `0` and the
 //! assertion panics with a Rust backtrace and no actionable message
-//! (see issue #864).
+//! (Sentry OPENHUMAN-TAURI-K1 on Linux, issue #864 on macOS).
 //!
 //! This module runs *before* the Tauri builder constructs the runtime.
 //! It detects the lock-holder PID via Chromium's `SingletonLock` symlink and
@@ -72,7 +77,12 @@ impl fmt::Display for CefLockError {
 
 impl std::error::Error for CefLockError {}
 
-/// Resolves the macOS default CEF cache directory and runs the preflight.
+/// Resolves the platform default CEF cache directory and runs the preflight.
+///
+/// Checks `OPENHUMAN_CEF_CACHE_PATH` first (always set by
+/// `cef_profile::prepare_process_cache_path` before this runs). Falls back
+/// to the platform-specific default: `~/Library/Caches/<id>/cef` on macOS,
+/// `$XDG_CACHE_HOME/<id>/cef` or `$HOME/.cache/<id>/cef` on Linux.
 pub fn check_default_cache() -> Result<(), CefLockError> {
     if let Some(configured) = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH") {
         let configured = PathBuf::from(configured);
@@ -84,10 +94,22 @@ pub fn check_default_cache() -> Result<(), CefLockError> {
     }
 
     let home = std::env::var_os("HOME").ok_or(CefLockError::NoHomeDir)?;
-    let cache_path = PathBuf::from(home)
-        .join("Library/Caches")
+    let home = PathBuf::from(home);
+
+    #[cfg(target_os = "macos")]
+    let cache_path = home.join("Library/Caches").join(APP_IDENTIFIER).join("cef");
+
+    // On Linux: $XDG_CACHE_HOME/<id>/cef or $HOME/.cache/<id>/cef.
+    // This matches the fallback path in tauri-runtime-cef's CefRuntime::init
+    // (via `dirs::cache_dir()`).
+    #[cfg(target_os = "linux")]
+    let cache_path = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| home.join(".cache"))
         .join(APP_IDENTIFIER)
         .join("cef");
+
     log::debug!("[cef-preflight] cache_path={}", cache_path.display());
     check_cef_cache_lock(&cache_path)
 }
@@ -308,6 +330,91 @@ mod tests {
             fs::symlink_metadata(tmp.join("SingletonLock")).is_ok(),
             "unparseable lock must NOT be removed"
         );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// `check_default_cache` must use `OPENHUMAN_CEF_CACHE_PATH` when set —
+    /// on both macOS and Linux the profile module always sets this before the
+    /// preflight runs, so the platform-specific fallback paths are irrelevant
+    /// in production, but the configured-path branch must work on all platforms.
+    #[test]
+    fn check_default_cache_uses_configured_env_path() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prior = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH");
+        let tmp = fresh_tmp("default-cache-env");
+
+        std::env::set_var("OPENHUMAN_CEF_CACHE_PATH", &tmp);
+        let result = check_default_cache();
+
+        match prior {
+            Some(v) => std::env::set_var("OPENHUMAN_CEF_CACHE_PATH", v),
+            None => std::env::remove_var("OPENHUMAN_CEF_CACHE_PATH"),
+        }
+
+        assert!(result.is_ok(), "expected Ok with no lock, got {result:?}");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// `check_default_cache` with env-path pointing to a dir holding a live lock
+    /// must return `CefLockError::Held`.
+    #[test]
+    fn check_default_cache_env_path_held_returns_err() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prior = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH");
+        let tmp = fresh_tmp("default-cache-held");
+        let me = std::process::id() as i32;
+        symlink(format!("testhost-{me}"), tmp.join("SingletonLock")).unwrap();
+
+        std::env::set_var("OPENHUMAN_CEF_CACHE_PATH", &tmp);
+        let result = check_default_cache();
+
+        match prior {
+            Some(v) => std::env::set_var("OPENHUMAN_CEF_CACHE_PATH", v),
+            None => std::env::remove_var("OPENHUMAN_CEF_CACHE_PATH"),
+        }
+
+        match result {
+            Err(CefLockError::Held { pid, .. }) => assert_eq!(pid, me),
+            other => panic!("expected Held, got {other:?}"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// On Linux, `check_default_cache` without `OPENHUMAN_CEF_CACHE_PATH` set
+    /// must fall back to `$XDG_CACHE_HOME/<id>/cef` and return Ok when no lock
+    /// is present.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn check_default_cache_linux_xdg_fallback_no_lock() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prior_cache = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH");
+        let prior_xdg = std::env::var_os("XDG_CACHE_HOME");
+        std::env::remove_var("OPENHUMAN_CEF_CACHE_PATH");
+
+        // Redirect XDG_CACHE_HOME to a temp dir we control.
+        let tmp = fresh_tmp("linux-xdg-fallback");
+        std::env::set_var("XDG_CACHE_HOME", &tmp);
+
+        let result = check_default_cache();
+
+        std::env::remove_var("XDG_CACHE_HOME");
+        match prior_cache {
+            Some(v) => std::env::set_var("OPENHUMAN_CEF_CACHE_PATH", v),
+            None => {}
+        }
+        match prior_xdg {
+            Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
+            None => {}
+        }
+
+        // No SingletonLock under tmp/<id>/cef — should be Ok.
+        assert!(result.is_ok(), "expected Ok with no lock, got {result:?}");
         let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/app/src-tauri/src/cef_preflight.rs
+++ b/app/src-tauri/src/cef_preflight.rs
@@ -223,6 +223,12 @@ mod tests {
     use super::*;
     use std::os::unix::fs::symlink;
 
+    // Shared lock for all tests that mutate process-global env vars.
+    // Each test previously had its own local `static ENV_LOCK`, allowing
+    // concurrent test threads to race on OPENHUMAN_CEF_CACHE_PATH /
+    // XDG_CACHE_HOME. A single module-level lock serialises them.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn parse_target_simple() {
         assert_eq!(
@@ -339,7 +345,6 @@ mod tests {
     /// in production, but the configured-path branch must work on all platforms.
     #[test]
     fn check_default_cache_uses_configured_env_path() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let prior = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH");
@@ -361,7 +366,6 @@ mod tests {
     /// must return `CefLockError::Held`.
     #[test]
     fn check_default_cache_env_path_held_returns_err() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let prior = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH");
@@ -390,7 +394,6 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn check_default_cache_linux_xdg_fallback_no_lock() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let prior_cache = std::env::var_os("OPENHUMAN_CEF_CACHE_PATH");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1634,6 +1634,13 @@ fn check_linux_display_server() {}
 
 type CefCommandLineArg = (&'static str, Option<&'static str>);
 
+/// Returns `true` when the process is running as root (UID 0) on Linux.
+/// Testable pure function; takes the uid directly.
+#[cfg(any(target_os = "linux", test))]
+fn linux_is_root_uid(uid: u32) -> bool {
+    uid == 0
+}
+
 fn append_platform_cef_gpu_workarounds(args: &mut Vec<CefCommandLineArg>, os: &str, arch: &str) {
     // Issue #1697: on Arch/Manjaro-family Linux systems, the AppImage can
     // abort during CEF GPU process startup when EGL context creation fails
@@ -1658,6 +1665,28 @@ fn append_platform_cef_gpu_workarounds(args: &mut Vec<CefCommandLineArg>, os: &s
         log::info!(
             "[cef-startup] Intel macOS detected: adding --disable-gpu-compositing (issue #1012)"
         );
+    }
+
+    // Sentry OPENHUMAN-TAURI-K1: `cef::initialize` returns 0 when running as
+    // root (uid 0) on Linux unless `--no-sandbox` is passed as a command-line
+    // argument. The `no_sandbox: 1` field in `cef::Settings` disables the
+    // sub-process sandbox but does NOT satisfy Chromium's separate root-user
+    // check in the browser process — that check requires the CLI flag.
+    //
+    // This hits CI / coder-bot / Docker environments (e.g.
+    // `/root/.hermes/profiles/coder-bot/home`) that run as root inside a
+    // container. Without the flag, `cef_initialize` returns 0 and the vendored
+    // runtime assertion fires (`left: 0, right: 1`).
+    #[cfg(target_os = "linux")]
+    {
+        let uid = nix::unistd::getuid().as_raw();
+        if linux_is_root_uid(uid) {
+            args.push(("--no-sandbox", None));
+            log::info!(
+                "[cef-startup] running as root (uid=0) on Linux: adding --no-sandbox \
+                 (OPENHUMAN-TAURI-K1)"
+            );
+        }
     }
 }
 
@@ -3273,6 +3302,17 @@ mod tests {
     #[test]
     fn linux_display_absent_without_either() {
         assert!(!linux_display_server_present(false, false));
+    }
+
+    #[test]
+    fn linux_root_uid_detected() {
+        assert!(linux_is_root_uid(0));
+    }
+
+    #[test]
+    fn linux_non_root_uid_not_detected() {
+        assert!(!linux_is_root_uid(1000));
+        assert!(!linux_is_root_uid(1));
     }
 
     // -------------------------------------------------------------------------

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1683,7 +1683,7 @@ fn append_platform_cef_gpu_workarounds(args: &mut Vec<CefCommandLineArg>, os: &s
     #[cfg(target_os = "linux")]
     {
         let uid = nix::unistd::getuid().as_raw();
-        if linux_is_root_uid(uid) {
+        if os == "linux" && linux_is_root_uid(uid) {
             args.push(("--no-sandbox", None));
             log::info!(
                 "[cef-startup] running as root (uid=0) on Linux: adding --no-sandbox \

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@
 compile_error!("src-tauri host is desktop-only. Non-desktop targets are not supported.");
 
 mod cdp;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 mod cef_preflight;
 mod cef_profile;
 mod core_process;
@@ -1593,6 +1593,45 @@ fn warn_if_wsl_x11_desktop_launch() {
 #[cfg(not(target_os = "linux"))]
 fn warn_if_wsl_x11_desktop_launch() {}
 
+/// Returns `true` if a display server is available on Linux.
+/// Testable pure function: takes the env-presence booleans directly.
+#[cfg(any(target_os = "linux", test))]
+fn linux_display_server_present(display: bool, wayland_display: bool) -> bool {
+    display || wayland_display
+}
+
+/// Pre-CEF display-server check for Linux (Sentry OPENHUMAN-TAURI-K1).
+///
+/// CEF/Chromium requires X11 (`DISPLAY`) or Wayland (`WAYLAND_DISPLAY`) to
+/// initialise. Without either, `cef_initialize` returns 0 and the vendored
+/// `tauri-runtime-cef` asserts `result == 1` → panic `left: 0, right: 1`.
+/// This is fatal and silent on WSL2 without WSLg and on any headless Linux box.
+/// Detect it here and exit with a clear message before `CefRuntime::init` runs.
+#[cfg(target_os = "linux")]
+fn check_linux_display_server() {
+    if linux_display_server_present(has_non_empty_env("DISPLAY"), has_non_empty_env("WAYLAND_DISPLAY")) {
+        log::debug!(
+            "[cef-preflight] Linux display server present: DISPLAY={:?} WAYLAND_DISPLAY={:?}",
+            std::env::var("DISPLAY").ok(),
+            std::env::var("WAYLAND_DISPLAY").ok()
+        );
+        return;
+    }
+    let msg = "[openhuman] no display server found (DISPLAY and WAYLAND_DISPLAY are both unset).\n\
+               OpenHuman requires an X11 or Wayland display to run.\n\
+               On WSL2: install WSLg or configure X11 forwarding from Windows.\n\
+               Set DISPLAY (e.g. export DISPLAY=:0) or WAYLAND_DISPLAY before launching.";
+    log::error!(
+        "[cef-preflight] Linux display server missing — CEF cannot initialize \
+         (OPENHUMAN-TAURI-K1): DISPLAY and WAYLAND_DISPLAY both unset"
+    );
+    eprintln!("\n{msg}\n");
+    std::process::exit(1);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn check_linux_display_server() {}
+
 type CefCommandLineArg = (&'static str, Option<&'static str>);
 
 fn append_platform_cef_gpu_workarounds(args: &mut Vec<CefCommandLineArg>, os: &str, arch: &str) {
@@ -1812,6 +1851,9 @@ pub fn run() {
     }
 
     warn_if_wsl_x11_desktop_launch();
+    // Exit before CEF if no display server is available — prevents the
+    // `assert_eq!(cef_initialize(…), 1)` panic (OPENHUMAN-TAURI-K1).
+    check_linux_display_server();
 
     // The vendored tauri-cef dev-server proxy builds a reqwest 0.13 client
     // (see vendor/tauri-cef/crates/tauri/src/protocol/tauri.rs) which calls
@@ -1899,7 +1941,12 @@ pub fn run() {
     #[cfg(target_os = "macos")]
     process_recovery::reap_stale_openhuman_processes();
 
-    #[cfg(target_os = "macos")]
+    // CEF cache-lock preflight: if another OpenHuman instance holds the CEF
+    // user-data-dir SingletonLock, `cef_initialize` returns 0 and the vendored
+    // runtime panics (`left: 0, right: 1`). Catch the collision here and exit
+    // cleanly. Stale locks (PID dead) are removed so crashed processes don't
+    // block subsequent launches. macOS: issue #864. Linux: OPENHUMAN-TAURI-K1.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     if let Err(e) = cef_preflight::check_default_cache() {
         eprintln!("\n[openhuman] {e}\n");
         std::process::exit(1);

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1609,7 +1609,10 @@ fn linux_display_server_present(display: bool, wayland_display: bool) -> bool {
 /// Detect it here and exit with a clear message before `CefRuntime::init` runs.
 #[cfg(target_os = "linux")]
 fn check_linux_display_server() {
-    if linux_display_server_present(has_non_empty_env("DISPLAY"), has_non_empty_env("WAYLAND_DISPLAY")) {
+    if linux_display_server_present(
+        has_non_empty_env("DISPLAY"),
+        has_non_empty_env("WAYLAND_DISPLAY"),
+    ) {
         log::debug!(
             "[cef-preflight] Linux display server present: DISPLAY={:?} WAYLAND_DISPLAY={:?}",
             std::env::var("DISPLAY").ok(),

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3252,6 +3252,30 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
+    // Linux display-server pre-flight (Sentry OPENHUMAN-TAURI-K1)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn linux_display_present_with_x11() {
+        assert!(linux_display_server_present(true, false));
+    }
+
+    #[test]
+    fn linux_display_present_with_wayland() {
+        assert!(linux_display_server_present(false, true));
+    }
+
+    #[test]
+    fn linux_display_present_with_both() {
+        assert!(linux_display_server_present(true, true));
+    }
+
+    #[test]
+    fn linux_display_absent_without_either() {
+        assert!(!linux_display_server_present(false, false));
+    }
+
+    // -------------------------------------------------------------------------
     // Platform constants (issue #1012 Sentry tagging)
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fixes fatal Linux startup panic: \`assertion left == right failed\` (left: 0, right: 1) in \`tauri_runtime_cef::CefRuntime::init\`
- Adds \`--no-sandbox\` CLI flag to CEF when running as root (uid=0) — dominant cause per Sentry trace (coder-bot/CI containers)
- Adds display-server pre-flight guard: exits cleanly when \`DISPLAY\` and \`WAYLAND_DISPLAY\` are both unset (WSL2/headless)
- Extends macOS SingletonLock preflight check to Linux (XDG cache path, same \`cef_initialize → 0\` failure mode)

## Problem

Sentry OPENHUMAN-TAURI-K1 reports 55 fatal panics on Linux. The crash is in \`CefRuntime::init\` where \`cef::initialize()\` returns 0 and the vendored runtime asserts it equals 1. The Sentry breadcrumbs show the process runs as root under \`/root/.hermes/profiles/coder-bot/home\` — a CI/container environment. Chromium's browser process silently rejects root unless \`--no-sandbox\` is on the command line; \`Settings.no_sandbox = 1\` only disables sub-process sandboxing.

## Solution

- Detect \`uid == 0\` via \`nix::unistd::getuid()\` in \`append_platform_cef_gpu_workarounds\` (Linux only, cfg-gated) and append \`--no-sandbox\`
- Add \`check_linux_display_server()\` that runs before \`Builder::build\` and exits with a clear message when no display server is present
- Extend \`cef_preflight::check_default_cache\` to Linux: \`OPENHUMAN_CEF_CACHE_PATH\` → \`\$XDG_CACHE_HOME/<id>/cef\` → \`\$HOME/.cache/<id>/cef\` fallback chain matching \`dirs::cache_dir()\`

Windows and macOS are unaffected — all new Linux paths are \`#[cfg(target_os = "linux")]\`.

## Submission Checklist

> If a section does not apply to this change, mark the item as \`N/A\` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via \`diff-cover\`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run \`pnpm test:coverage\` and \`pnpm test:rust\` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: Coverage matrix updated — no new feature rows; this is a bug fix for an existing startup path
- [x] N/A: All affected feature IDs from the matrix are listed — no matrix feature IDs apply to CEF init guards
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated — no release-cut surfaces touched
- [x] Linked issue closed via \`Closes #NNN\` in the \`## Related\` section

## Impact

- Linux only. Resolves fatal crash on startup in root/container environments (CI, coder-bot, Docker).
- No behavioural change for non-root Linux users or macOS/Windows users.
- \`nix\` dependency gains the \`user\` feature (needed for \`getuid()\`).

## Related

- Closes : #2078 
- Mirrors Windows fix from #1723 and macOS SingletonLock fix from #864
- Does NOT address #2094 (NVIDIA+XWayland \`X BadWindow\` — separate crash after CEF init)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field \`N/A\`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: \`fix/sentry-OPENHUMAN-TAURI-K1\`
- Commit SHA: \`26c5b41d\`

### Validation Run
- [x] \`pnpm --filter openhuman-app format:check\`
- [x] \`pnpm typecheck\`
- [x] Focused tests: \`cargo test --manifest-path app/src-tauri/Cargo.toml -- linux cef_preflight\` — 17 passed
- [x] Rust fmt/check (if changed): \`cargo check --manifest-path app/src-tauri/Cargo.toml\` — clean
- [x] Tauri fmt/check (if changed): clean

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended behavior change: CEF on Linux now starts successfully when running as root; exits cleanly with actionable message when no display server is available
- User-visible effect: App launches in CI/container environments instead of panicking with an opaque Rust backtrace

### Parity Contract
- Legacy behavior preserved: non-root Linux, macOS, and Windows paths are unchanged
- Guard/fallback/dispatch parity checks: \`#[cfg(target_os = "linux")]\` gates ensure zero code generation on other platforms

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this one
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added display-server validation on Linux with clear startup messaging when unavailable.
  * Extended CEF cache preflight and platform-specific cache path handling to Linux and macOS, honoring environment override.
  * Improved sandbox handling when running with elevated privileges.

* **Tests**
  * Serialized env-var tests to avoid race conditions and added coverage for new Linux helpers and cache behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->