### PR TITLE
chore(sentry): wire source-map + DIF uploads to self-hosted Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,6 +217,10 @@ OPENHUMAN_SKILLS_WORKING_MEMORY_ENABLED=true
 # `VITE_SENTRY_DSN`. The legacy unprefixed name `OPENHUMAN_SENTRY_DSN` is
 # still accepted as a fallback during the transition.
 OPENHUMAN_CORE_SENTRY_DSN=
+# [optional] Override the Sentry server URL. Defaults to sentry.io if unset.
+# Set to https://sentry.tinyhumans.ai for the self-hosted instance — used by
+# sentry-cli (symbol/release uploads) and the @sentry/vite-plugin.
+SENTRY_URL=
 # [optional] Short git SHA baked into the Sentry release tag
 # (`openhuman@<version>+<sha>`) via `option_env!("OPENHUMAN_BUILD_SHA")`.
 # CI sets this automatically; leave blank locally (release tag falls back

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -398,6 +398,7 @@ jobs:
           # here would tag uploads against a different release than events.
           SENTRY_RELEASE: openhuman@${{ inputs.version }}+${{ inputs.short_sha }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           # SENTRY_PROJECT here is consumed by sentry-vite-plugin during the
           # Vite build that runs inside `cargo tauri build` — it uploads
@@ -489,6 +490,7 @@ jobs:
         shell: bash
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
         run: node scripts/release/verify-sentry-sourcemaps.mjs
 
       # ---- Sentry DIF uploads ------------------------------------------------
@@ -504,6 +506,7 @@ jobs:
         shell: bash
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_TAURI }}
           SENTRY_RELEASE: openhuman@${{ inputs.version }}+${{ inputs.short_sha }}
@@ -533,6 +536,7 @@ jobs:
         shell: bash
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_CORE }}
           SENTRY_RELEASE: openhuman@${{ inputs.version }}+${{ inputs.short_sha }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -727,6 +727,7 @@ jobs:
     needs: [prepare-build, publish-release]
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_URL: ${{ vars.SENTRY_URL }}
     steps:
       - name: Install sentry-cli
         if: env.SENTRY_AUTH_TOKEN != ''
@@ -736,6 +737,7 @@ jobs:
         if: env.SENTRY_AUTH_TOKEN != ''
         shell: bash
         env:
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           # Marker lives on the React project's release; events from all
           # surfaces share the same `openhuman@<version>+<short_sha>` release

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -317,6 +317,7 @@ jobs:
     needs: [prepare-build, build-desktop, build-docker]
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_URL: ${{ vars.SENTRY_URL }}
     steps:
       - name: Install sentry-cli
         if: env.SENTRY_AUTH_TOKEN != ''
@@ -326,6 +327,7 @@ jobs:
         if: env.SENTRY_AUTH_TOKEN != ''
         shell: bash
         env:
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           # Marker lives on the React project's release; events from all
           # surfaces share the same `openhuman@<version>+<short_sha>` release

--- a/app/.env.example
+++ b/app/.env.example
@@ -55,6 +55,7 @@ VITE_BUILD_SHA=
 # `@sentry/vite-plugin`. Leave blank locally; the plugin skips when
 # `SENTRY_AUTH_TOKEN` is empty.
 # SENTRY_AUTH_TOKEN=
+# SENTRY_URL=  # https://sentry.tinyhumans.ai for self-hosted; defaults to sentry.io
 # SENTRY_ORG=
 # SENTRY_PROJECT=
 # SENTRY_RELEASE=

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -41,6 +41,10 @@ function maybeSentryPlugin(): PluginOption | null {
   if (!authToken) return null;
   return sentryVitePlugin({
     authToken,
+    // Self-hosted Sentry — without `url`, the plugin defaults to sentry.io
+    // and silently no-ops the upload. Falls back to sentry.io if unset for
+    // local builds against the SaaS instance.
+    url: process.env.SENTRY_URL,
     org: process.env.SENTRY_ORG,
     project: process.env.SENTRY_PROJECT,
     release: {


### PR DESCRIPTION
## Summary

- Pass `url: process.env.SENTRY_URL` to `@sentry/vite-plugin` so frontend source-map uploads target the configured Sentry server instead of silently defaulting to `sentry.io`.
- Add `SENTRY_URL` to every workflow env block where `sentry-cli` or `@sentry/vite-plugin` runs (`build-desktop.yml` for Vite build / verify / Tauri DIF / core DIF; `release-staging.yml` and `release-production.yml` for `record-sentry-deploy`).
- Document `SENTRY_URL` in `.env.example` and `app/.env.example`.

## Problem

The newly self-hosted Sentry at `sentry.tinyhumans.ai` was reachable for runtime events (the DSN carries the host), but **release artifacts were still going to `sentry.io`**:

- `@sentry/vite-plugin` defaults to `sentry.io` when neither the `url` option nor `SENTRY_URL` env var is set. It logs a generic auth warning and exits 0, so the `verify-sentry-sourcemaps.mjs` guard catches the no-op for React, but the failure mode is opaque.
- `sentry-cli debug-files upload` and `sentry-cli releases deploys ... new` also default to `sentry.io` without `SENTRY_URL`, meaning Tauri / core DIF uploads and the staging/production deploy markers would post into the wrong instance — without any error.

The result: production crashes would land in the self-hosted instance un-symbolicated, while symbols and deploy markers piled up in an unrelated SaaS org.

## Solution

- **Vite plugin**: read `SENTRY_URL` from env at plugin construction time. Unset = fall back to `sentry.io` (preserves SaaS-targeted local builds).
- **Workflows**: thread `SENTRY_URL` into the same env blocks that already export `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT`. Existing `if: env.SENTRY_AUTH_TOKEN != ''` gates are unchanged.
- **Env examples**: surface the knob next to the existing Sentry config so contributors discover it.

GitHub repository configuration (out-of-band, not in this diff):

- `SENTRY_URL` = `https://sentry.tinyhumans.ai` set as a repo-level variable and in the Production + staging environments.
- `SENTRY_PROJECT_CORE` / `_TAURI` / `_REACT` updated to `core-rust` / `tauri-rust` / `tauri-react` to match the new projects.
- `OPENHUMAN_CORE_SENTRY_DSN`, `OPENHUMAN_TAURI_SENTRY_DSN`, `OPENHUMAN_REACT_SENTRY_DSN` (and staging `VITE_SENTRY_DSN`) reissued from the new projects.
- `SENTRY_AUTH_TOKEN` secret rotated to a self-hosted token with the scopes `sentry-cli` and `@sentry/vite-plugin` require (`project:admin`, `project:releases`, `org:read`, …).

## Submission Checklist

- [x] N/A: pure CI/build wiring change — no runtime behaviour to unit-test; verified via `verify-sentry-sourcemaps.mjs` on the next desktop build.
- [x] N/A: no application code lines touched, only workflow env and a one-line vite-plugin option — diff-cover gate doesn't apply.
- [x] N/A: behaviour-only change (no new/removed features) — coverage matrix unchanged.
- [x] N/A: no feature IDs affected.
- [x] N/A: no new network dependency — `sentry.tinyhumans.ai` was already reachable via the DSN at runtime; this PR only redirects the upload path.
- [x] N/A: doesn't touch release-cut UX; release pipeline keeps the same step ordering and gates.
- [x] N/A: no linked issue (operational follow-up to setting up the self-hosted Sentry server).

## Impact

- **Release pipeline**: source-map and DIF uploads now flow to `sentry.tinyhumans.ai` instead of `sentry.io`. Staging/production deploy markers likewise.
- **Local builds**: unchanged — `SENTRY_AUTH_TOKEN` empty ⇒ plugin still skips.
- **Runtime crash reporting**: unchanged in this diff (DSNs already pointed at the self-hosted host); but now matching DIFs are uploaded so events will be symbolicated.

## Related

- Closes:
- Follow-up PR(s)/TODOs: optionally retire the repo-level `OPENHUMAN_SENTRY_DSN` legacy fallback once all branches are confirmed using the `OPENHUMAN_CORE_SENTRY_DSN` name.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `chore/wire-self-hosted-sentry`
- Commit SHA: `d9eb634dfd986d24cbd6ab18b821fca88063053f`

### Validation Run
- [x] N/A: no test surface — CI wiring change verified by next desktop build pipeline.
- [x] N/A: no TS source code touched (only vite config option + env examples).
- [x] Focused tests: N/A
- [x] N/A: no Rust changes.
- [x] N/A: no Tauri shell Rust changes.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: redirect Sentry release-artifact uploads from `sentry.io` to the self-hosted server.
- User-visible effect: none directly; downstream effect is symbolicated crash reports in the right Sentry instance.

### Parity Contract
- Legacy behavior preserved: unset `SENTRY_URL` falls back to `sentry.io` (preserving SaaS behaviour for any caller that hasn't migrated).
- Guard/fallback/dispatch parity checks: existing `if: env.SENTRY_AUTH_TOKEN != ''` skip gates retained; `verify-sentry-sourcemaps.mjs` regression guard still runs.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Sentry server URLs, enabling self-hosted Sentry deployments. Users can now configure the optional `SENTRY_URL` environment variable to specify their own Sentry server instead of using the default SaaS endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- re-trigger checklist after [x] edit -->
