### PR TITLE
fix(security): fail closed in pairing.rs::is_authenticated when token is unset (#1919)

### DIFF
--- a/src/openhuman/security/mod.rs
+++ b/src/openhuman/security/mod.rs
@@ -21,7 +21,10 @@ pub use detect::create_sandbox;
 pub use ops as rpc;
 pub use ops::*;
 #[allow(unused_imports)]
-pub use pairing::PairingGuard;
+pub use pairing::{
+    ensure_core_rpc_token_for_bind, is_public_bind, CoreBindTokenError, PairingGuard,
+    CORE_TOKEN_ENV_VAR,
+};
 pub use policy::validate_path_within_root;
 #[allow(unused_imports)]
 pub use policy::AutonomyLevel;

--- a/src/openhuman/security/pairing.rs
+++ b/src/openhuman/security/pairing.rs
@@ -7,8 +7,16 @@
 use parking_lot::Mutex;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
+use std::io::Write as _;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+/// Environment variable for the core JSON-RPC bearer token (see `crate::core::auth`).
+pub const CORE_TOKEN_ENV_VAR: &str = "OPENHUMAN_CORE_TOKEN";
 
 /// Maximum failed pairing attempts before lockout.
 const MAX_PAIR_ATTEMPTS: u32 = 5;
@@ -156,13 +164,31 @@ impl PairingGuard {
     }
 
     /// Check if a bearer token is valid (compares against stored hashes).
+    ///
+    /// Always fails closed on empty/whitespace tokens. When pairing is not required,
+    /// configured tokens are still honored if present; with no tokens configured,
+    /// every request is rejected.
     pub fn is_authenticated(&self, token: &str) -> bool {
-        if !self.require_pairing {
-            return true;
+        if token.trim().is_empty() {
+            log::debug!("[openhuman:pairing] is_authenticated: rejected empty bearer token");
+            return false;
         }
-        let hashed = hash_token(token);
+
         let tokens = self.paired_tokens.lock();
-        tokens.contains(&hashed)
+        if tokens.is_empty() {
+            log::debug!(
+                "[openhuman:pairing] is_authenticated: no paired tokens configured (require_pairing={})",
+                self.require_pairing
+            );
+            return false;
+        }
+
+        let hashed = hash_token(token);
+        let ok = tokens.contains(&hashed);
+        if !ok {
+            log::debug!("[openhuman:pairing] is_authenticated: bearer token not in paired set");
+        }
+        ok
     }
 
     /// Returns true if pairing is satisfied (has at least one token).
@@ -252,9 +278,111 @@ pub fn constant_time_eq(a: &str, b: &str) -> bool {
 /// Check if a host string represents a non-localhost bind address.
 pub fn is_public_bind(host: &str) -> bool {
     !matches!(
-        host,
+        host.trim(),
         "127.0.0.1" | "localhost" | "::1" | "[::1]" | "0:0:0:0:0:0:0:1"
     )
+}
+
+/// Error while resolving or persisting a core RPC token for a bind address.
+#[derive(Debug, thiserror::Error)]
+pub enum CoreBindTokenError {
+    #[error(
+        "{CORE_TOKEN_ENV_VAR} must not be empty when binding on a non-loopback address ({host})"
+    )]
+    EmptyEnvToken { host: String },
+    #[error("failed to persist core RPC token at {path}: {source}")]
+    Persist {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Ensure a non-empty core RPC bearer token exists before binding on `host`.
+///
+/// **Loopback** (`127.0.0.1`, `localhost`, `::1`, …): returns `Ok(None)` when
+/// `env_token` is unset/empty so local dev can rely on other startup paths.
+///
+/// **Non-loopback** (`0.0.0.0`, LAN IPs, …): returns a usable token — either the
+/// trimmed `env_token` or a freshly generated 256-bit value written to
+/// `{workspace_dir}/core.token` (owner-only on Unix), matching the standalone CLI
+/// path in `crate::core::auth::init_rpc_token`.
+pub fn ensure_core_rpc_token_for_bind(
+    host: &str,
+    workspace_dir: &Path,
+    env_token: Option<&str>,
+) -> Result<Option<String>, CoreBindTokenError> {
+    let host = host.trim();
+    if let Some(raw) = env_token {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            log::info!(
+                "[openhuman:pairing] core RPC token supplied via {CORE_TOKEN_ENV_VAR} for bind host={host}"
+            );
+            return Ok(Some(trimmed.to_string()));
+        }
+        if is_public_bind(host) {
+            log::error!(
+                "[openhuman:pairing] {CORE_TOKEN_ENV_VAR} is set but empty on public bind host={host}"
+            );
+            return Err(CoreBindTokenError::EmptyEnvToken {
+                host: host.to_string(),
+            });
+        }
+    }
+
+    if !is_public_bind(host) {
+        log::debug!(
+            "[openhuman:pairing] loopback bind host={host}: no {CORE_TOKEN_ENV_VAR} configured"
+        );
+        return Ok(None);
+    }
+
+    let token = generate_core_rpc_token();
+    let token_path = workspace_dir.join("core.token");
+    write_core_token_file(&token_path, &token).map_err(|source| CoreBindTokenError::Persist {
+        path: token_path.display().to_string(),
+        source,
+    })?;
+    log::warn!(
+        "[openhuman:pairing] Public bind on {host} without {CORE_TOKEN_ENV_VAR}: \
+         generated token at {} — set {CORE_TOKEN_ENV_VAR} explicitly for stable deployments",
+        token_path.display()
+    );
+    Ok(Some(token))
+}
+
+/// Generate a 256-bit core RPC bearer token (lowercase hex, no `zc_` prefix).
+fn generate_core_rpc_token() -> String {
+    use rand::RngExt as _;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Write `token` to `path` with owner-only permissions on Unix (`0o600`).
+fn write_core_token_file(path: &Path, token: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(token.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, token)?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/openhuman/security/pairing_tests.rs
+++ b/src/openhuman/security/pairing_tests.rs
@@ -70,10 +70,29 @@ async fn is_authenticated_with_invalid_token() {
 }
 
 #[test]
-async fn is_authenticated_when_pairing_disabled() {
+async fn empty_token_rejected_when_require_pairing_false() {
     let (guard, _) = PairingGuard::new(false, &[]);
-    assert!(guard.is_authenticated("anything"));
-    assert!(guard.is_authenticated(""));
+    assert!(!guard.is_authenticated(""));
+    assert!(!guard.is_authenticated("   "));
+}
+
+#[test]
+async fn empty_token_rejected_when_require_pairing_true() {
+    let (guard, _) = PairingGuard::new(true, &["zc_valid".into()]);
+    assert!(!guard.is_authenticated(""));
+}
+
+#[test]
+async fn is_authenticated_rejects_unknown_when_pairing_disabled_and_no_tokens() {
+    let (guard, _) = PairingGuard::new(false, &[]);
+    assert!(!guard.is_authenticated("anything"));
+}
+
+#[test]
+async fn is_authenticated_honors_configured_tokens_when_pairing_disabled() {
+    let (guard, _) = PairingGuard::new(false, &["zc_dev".into()]);
+    assert!(guard.is_authenticated("zc_dev"));
+    assert!(!guard.is_authenticated("zc_other"));
 }
 
 #[test]
@@ -144,6 +163,54 @@ async fn zero_zero_is_public() {
 async fn real_ip_is_public() {
     assert!(is_public_bind("192.168.1.100"));
     assert!(is_public_bind("10.0.0.1"));
+}
+
+// ── Core RPC bind token ──────────────────────────────────
+
+#[test]
+async fn public_bind_without_env_token_auto_generates() {
+    let tmp = std::env::temp_dir().join(format!("pairing-bind-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let token = ensure_core_rpc_token_for_bind("0.0.0.0", &tmp, None)
+        .expect("public bind should auto-generate a token")
+        .expect("public bind should return Some(token)");
+    assert_eq!(token.len(), 64);
+    assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    let from_disk = std::fs::read_to_string(tmp.join("core.token")).unwrap();
+    assert_eq!(from_disk, token);
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+async fn public_bind_rejects_explicit_empty_env_token() {
+    let tmp = std::env::temp_dir().join(format!("pairing-bind-empty-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let err = ensure_core_rpc_token_for_bind("0.0.0.0", &tmp, Some("   "))
+        .expect_err("empty env token on public bind must fail");
+    assert!(matches!(err, CoreBindTokenError::EmptyEnvToken { .. }));
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+async fn loopback_bind_without_env_token_returns_none() {
+    let tmp = std::env::temp_dir().join(format!("pairing-bind-loopback-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let token = ensure_core_rpc_token_for_bind("127.0.0.1", &tmp, None).unwrap();
+    assert!(token.is_none());
+    assert!(!tmp.join("core.token").exists());
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+async fn public_bind_uses_nonempty_env_token_without_writing_file() {
+    let tmp = std::env::temp_dir().join(format!("pairing-bind-env-token-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let token = ensure_core_rpc_token_for_bind("0.0.0.0", &tmp, Some("  abc123  "))
+        .unwrap()
+        .expect("env token should be returned");
+    assert_eq!(token, "abc123");
+    assert!(!tmp.join("core.token").exists());
+    std::fs::remove_dir_all(&tmp).ok();
 }
 
 // ── constant_time_eq ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- `PairingGuard::is_authenticated` now **fails closed**: empty/whitespace bearer tokens are always rejected, and requests are rejected when no paired tokens are configured (regardless of `require_pairing`).
- Added `ensure_core_rpc_token_for_bind` for non-loopback binds: uses a non-empty `OPENHUMAN_CORE_TOKEN` when set, otherwise **auto-generates** a 256-bit token and persists it to `{workspace}/core.token` (same behavior as standalone `init_rpc_token` in `core/auth.rs`).
- New unit tests cover empty-token rejection, valid paired tokens, and public-bind auto-generation / empty-env failure.

## Problem

When `OPENHUMAN_CORE_HOST` is non-loopback (e.g. Docker’s `0.0.0.0`) and `OPENHUMAN_CORE_TOKEN` is unset, pairing could be constructed with `require_pairing = false`. `is_authenticated` then returned `true` for **any** token—including empty—exposing the full RPC surface on the LAN.

## Solution

**Auth-check layer (`pairing.rs`):** removed the `if !self.require_pairing { return true; }` bypass. Authentication always requires a non-empty bearer that matches a configured paired-token hash.

**Bind-time token policy:** chose **(b) auto-generate and persist** on public bind without env token (aligned with existing standalone CLI `core.token` flow). Explicit `OPENHUMAN_CORE_TOKEN=""` on a public bind returns `CoreBindTokenError::EmptyEnvToken`.

Coordinates with open PR #2011 (which adds a public-bind warning on `src/core/jsonrpc.rs`). This PR fixes the actual auth bypass in `pairing.rs`; #2011’s warning becomes a defense-in-depth complement. Wiring `ensure_core_rpc_token_for_bind` into server startup can land in a follow-up outside this batch’s owned paths.

## Threat model

- **Attack surface:** any host on the LAN can reach the RPC port when bound to `0.0.0.0`.
- **Capabilities exposed pre-fix:** full tool execution, file system access, credential retrieval (effectively RCE).
- **Mitigation:** fail-closed auth in `is_authenticated` + token enforcement at bind time via `ensure_core_rpc_token_for_bind`.
- **Residual risk after fix:** operator sets `OPENHUMAN_CORE_TOKEN=""` explicitly on a public bind — still rejected with `EmptyEnvToken`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: security-module behavior only; no user-facing feature row change
- [x] All affected feature IDs from the matrix are listed in the PR description under `Related` — N/A: no matrix feature IDs
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A
- [x] Linked issue closed via `Closes #NNN` in the `Related` section

## Impact

- **Security:** closes unauthenticated RPC when pairing guard is used with `require_pairing = false` and no tokens.
- **Runtime:** Docker/cloud operators without `OPENHUMAN_CORE_TOKEN` get an auto-generated `core.token` on public bind (once startup calls `ensure_core_rpc_token_for_bind`).
- **Compatibility:** callers that relied on `is_authenticated("") == true` with no tokens will now be denied (intended).

## Related

- Closes #1919
- Follow-up PR(s)/TODOs: wire `ensure_core_rpc_token_for_bind` from `run_server_inner` (orthogonal to #2011 warning-only PR)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A (GitHub #1919)
- URL: https://github.com/tinyhumansai/openhuman/issues/1919

### Commit & Branch
- Branch: `cursor/a01-1919-pairing-fail-closed`
- Commit SHA: `b86efe2b2d3733897fa8c29b397fe5ad6daee5ca`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A (Rust-only); `cargo fmt --all --check` passed
- [x] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: `cargo test -p openhuman --lib security::pairing` — 34/34 passed
- [x] Rust fmt/check (if changed): `cargo fmt --all --check`; pre-push `pnpm rust:check` passed
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked
- `command:` `pnpm test:rust` (full suite)
- `error:` not run in this session (focused pairing tests + pre-push hook rust:check only)
- `impact:` full regression signal deferred to CI; pairing module fully covered locally

### Behavior Changes
- Intended behavior change: fail-closed bearer validation; public-bind auto-token generation API
- User-visible effect: unauthenticated LAN RPC via pairing guard is blocked; operators may see `core.token` auto-created on public bind once wired

### Parity Contract
- Legacy behavior preserved: loopback bind without env token still returns `None` from `ensure_core_rpc_token_for_bind` (local dev)
- Guard/fallback/dispatch parity checks: `is_authenticated` no longer short-circuits on `require_pairing == false`

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPC token binding functionality with environment variable support.
  * Automatic token generation and secure persistence for public-facing binds.

* **Security Improvements**
  * Authentication now fails securely when bearer tokens are empty or unconfigured.
  * Enhanced token validation through secure hashing and set membership verification.
  * Improved error handling for token binding operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->