### PR TITLE
perf(memory): reduce chunker allocations

### DIFF
--- a/src/openhuman/memory/chunker.rs
+++ b/src/openhuman/memory/chunker.rs
@@ -48,27 +48,34 @@ pub fn chunk_markdown(text: &str, max_tokens: usize) -> Vec<Chunk> {
 
     for (heading, body) in sections {
         let heading: Option<Rc<str>> = heading.map(Rc::from);
+        let heading_prefix = heading.as_deref().map(|h| {
+            let mut prefix = String::with_capacity(h.len() + 1);
+            prefix.push_str(h);
+            prefix.push('\n');
+            prefix
+        });
 
-        // Combine heading and body to check initial size.
-        let full = if let Some(ref h) = heading {
-            format!("{h}\n{body}")
-        } else {
-            body.clone()
-        };
+        let full_len = body.len() + heading_prefix.as_ref().map_or(0, String::len);
 
-        if full.len() <= max_chars {
+        if full_len <= max_chars {
             // Section fits entirely in one chunk.
+            let content = if let Some(prefix) = heading_prefix.as_deref() {
+                let mut full = String::with_capacity(full_len);
+                full.push_str(prefix);
+                full.push_str(&body);
+                full.trim().to_string()
+            } else {
+                body.trim().to_string()
+            };
             chunks.push(Chunk {
                 index: chunks.len(),
-                content: full.trim().to_string(),
+                content,
                 heading: heading.clone(),
             });
         } else {
             // Step 2: Section is too large; split into paragraphs.
             let paragraphs = split_on_blank_lines(&body);
-            let mut current = heading
-                .as_deref()
-                .map_or_else(String::new, |h| format!("{h}\n"));
+            let mut current = heading_prefix.clone().unwrap_or_default();
 
             for para in paragraphs {
                 // If adding this paragraph exceeds the limit, emit the current chunk.
@@ -79,9 +86,7 @@ pub fn chunk_markdown(text: &str, max_tokens: usize) -> Vec<Chunk> {
                         heading: heading.clone(),
                     });
                     // Reset with the heading for context preservation.
-                    current = heading
-                        .as_deref()
-                        .map_or_else(String::new, |h| format!("{h}\n"));
+                    reset_chunk_buffer(&mut current, heading_prefix.as_deref());
                 }
 
                 if para.len() > max_chars {
@@ -92,9 +97,7 @@ pub fn chunk_markdown(text: &str, max_tokens: usize) -> Vec<Chunk> {
                             content: current.trim().to_string(),
                             heading: heading.clone(),
                         });
-                        current = heading
-                            .as_deref()
-                            .map_or_else(String::new, |h| format!("{h}\n"));
+                        reset_chunk_buffer(&mut current, heading_prefix.as_deref());
                     }
                     for line_chunk in split_on_lines(&para, max_chars) {
                         chunks.push(Chunk {
@@ -128,6 +131,13 @@ pub fn chunk_markdown(text: &str, max_tokens: usize) -> Vec<Chunk> {
     }
 
     chunks
+}
+
+fn reset_chunk_buffer(current: &mut String, heading_prefix: Option<&str>) {
+    current.clear();
+    if let Some(prefix) = heading_prefix {
+        current.push_str(prefix);
+    }
 }
 
 /// Returns `true` if `line` starts with a valid ATX markdown heading


### PR DESCRIPTION
## Summary

- Avoid materializing a full heading-plus-body string before deciding whether a memory section must be split.
- Reuse a prebuilt heading prefix when emitting split chunks from oversized sections.
- Keep the existing chunk content and heading behavior intact while reducing allocation and copy work in the chunker hot path.

## Problem

- `chunk_markdown` built `format!("{h}\n{body}")` for every headed section before checking size.
- Oversized sections immediately split again, so that full string allocation and copy work was wasted.
- Split sections also rebuilt the same heading prefix each time a chunk buffer was reset.

## Solution

- Compute the candidate section length from the body and optional heading prefix without allocating the full string.
- Build the full string only when the section fits in one chunk.
- Store the heading prefix once per section and reuse it when resetting split buffers.

## Submission Checklist

- [x] Tests added or updated: N/A, performance-only refactor covered by existing chunker unit tests.
- [ ] **Diff coverage >= 80%**: not run locally; focused standalone chunker tests passed.
- [x] Coverage matrix updated: N/A, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`: N/A, no matrix feature ID affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated: N/A, not a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section: N/A, no linked issue.

## Impact

- Performance: reduces allocations and copying during markdown memory chunking, especially for oversized headed sections.
- Compatibility: no intended behavior change; existing chunker tests pass.
- Local benchmark, harness kept outside the repo:
  - before: `chunk_markdown_large` 4513.335 us/round
  - after: `chunk_markdown_large` 3284.451 us/round
  - change: about 27.2% lower runtime on that synthetic large markdown case

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

## Validation Run

- [x] `cargo fmt --check --manifest-path Cargo.toml`
- [x] `git diff --check`
- [x] Standalone touched-module tests: `env CARGO_TARGET_DIR=/tmp/openhuman-chunker-standalone-target cargo test --manifest-path /tmp/openhuman-chunker-bench/Cargo.toml` (24 passed)
- [x] Local benchmark after patch: `env CARGO_TARGET_DIR=/tmp/openhuman-chunker-standalone-target cargo run --release --manifest-path /tmp/openhuman-chunker-bench/Cargo.toml`

## Validation Blocked

- `command:` `cargo test --manifest-path Cargo.toml chunker --lib`
- `error:` stopped locally after roughly two hours; the filtered library test was still compiling the full `openhuman_core` test binary and native/runtime dependencies.
- `impact:` full repo-filtered test was not completed locally; the touched module was validated through its existing 24 unit tests in an isolated harness plus format, diff, and benchmark checks.

## Behavior Changes

- Intended behavior change: none.
- User-visible effect: none expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the memory chunking system's efficiency through optimized handling of section headers and buffer management during text segmentation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->