### PR TITLE
fix(core): skip memory init on config failure instead of fabricating a default workspace (OPENHUMAN-CORE-48)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -795,40 +795,48 @@ async fn run_server_inner(
     // gets a live handle. Without this, every periodic sync bails with
     // "[composio:gmail] memory client not ready".
     {
-        // Surface a config-load failure explicitly. Falling silently to
-        // `Config::default()` would hide a serious operator-visible
-        // problem (corrupt toml, permissions, missing OPENHUMAN_WORKSPACE
-        // workspace dir) and the memory client would init against the
-        // wrong workspace — leading to chunk loss / cross-workspace
-        // bleed-over. We log loud, then proceed with default so the
-        // server still comes up; the operator sees the error in stderr
-        // and can fix their config.
-        let cfg = match crate::openhuman::config::Config::load_or_init().await {
-            Ok(c) => c,
+        // A `Config::load_or_init` failure here is operator-visible and
+        // serious (corrupt toml, bad permissions, missing/unwritable
+        // OPENHUMAN_WORKSPACE — common on headless/containerised deploys
+        // with no writable $HOME). Previously we fell back to
+        // `Config::default()` and initialised the memory + whatsapp_data
+        // stores against the *wrong* workspace dir, silently causing chunk
+        // loss / cross-workspace bleed-over while the app looked healthy
+        // (Sentry OPENHUMAN-CORE-48). Instead: skip the workspace-bound
+        // init entirely so memory stays explicitly *uninitialised* —
+        // callers then get a clear "memory client not ready" error rather
+        // than reading/writing the wrong workspace. The server still comes
+        // up; the operator sees the loud error and fixes their config or
+        // sets OPENHUMAN_WORKSPACE to a writable path, then restarts.
+        match crate::openhuman::config::Config::load_or_init().await {
+            Ok(cfg) => {
+                match crate::openhuman::memory::global::init(cfg.workspace_dir.clone()) {
+                    Ok(_) => log::info!(
+                        "[boot] memory::global initialized (workspace={})",
+                        cfg.workspace_dir.display()
+                    ),
+                    Err(e) => log::warn!("[boot] memory::global init failed: {e}"),
+                }
+                // Initialize the WhatsApp data store so scanner ingest calls
+                // can write data without requiring a lazy-init fallback.
+                match crate::openhuman::whatsapp_data::global::init(cfg.workspace_dir.clone()) {
+                    Ok(_) => log::info!(
+                        "[boot] whatsapp_data::global initialized (workspace={})",
+                        cfg.workspace_dir.display()
+                    ),
+                    Err(e) => log::warn!("[boot] whatsapp_data::global init failed: {e}"),
+                }
+            }
             Err(e) => {
                 log::error!(
-                    "[boot] memory::global init: Config::load_or_init failed ({e:#}); \
-                     falling back to default workspace dir — fix your config.toml \
-                     or OPENHUMAN_WORKSPACE before relying on memory persistence"
+                    "[boot] memory::global + whatsapp_data init SKIPPED — \
+                     Config::load_or_init failed ({e:#}). Memory persistence is \
+                     DISABLED for this run; no silent fallback to the default \
+                     workspace (which would cause chunk loss / cross-workspace \
+                     bleed-over). Fix config.toml or set OPENHUMAN_WORKSPACE to a \
+                     writable path, then restart."
                 );
-                Default::default()
             }
-        };
-        match crate::openhuman::memory::global::init(cfg.workspace_dir.clone()) {
-            Ok(_) => log::info!(
-                "[boot] memory::global initialized (workspace={})",
-                cfg.workspace_dir.display()
-            ),
-            Err(e) => log::warn!("[boot] memory::global init failed: {e}"),
-        }
-        // Initialize the WhatsApp data store so scanner ingest calls
-        // can write data without requiring a lazy-init fallback.
-        match crate::openhuman::whatsapp_data::global::init(cfg.workspace_dir.clone()) {
-            Ok(_) => log::info!(
-                "[boot] whatsapp_data::global initialized (workspace={})",
-                cfg.workspace_dir.display()
-            ),
-            Err(e) => log::warn!("[boot] whatsapp_data::global init failed: {e}"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Boot no longer initialises the memory + `whatsapp_data` stores against a fabricated `Config::default()` workspace when `Config::load_or_init()` fails.
- On config failure the workspace-bound init is **skipped entirely** and a loud, actionable error is logged; the server still starts.
- Memory stays explicitly *uninitialised* on failure, so callers get a clear "memory client not ready" error instead of silently reading/writing the wrong workspace.
- Pure control-flow restructure — the success path is byte-for-byte unchanged.

## Problem

Sentry **OPENHUMAN-CORE-48**: `[boot] memory::global init: Config::load_or_init failed (Failed to create workspace directory: Permission denied (os error 13)); falling back to default workspace dir`.

On headless / containerised production deploys (RHEL8/el8 in the reported event) with no writable `$HOME`, `create_dir_all($HOME/.openhuman/…)` fails (`config/schema/load.rs:589`). The previous boot code logged the error, then did `Default::default()` and initialised the memory + `whatsapp_data` stores against the **default** workspace dir — silently causing chunk loss / cross-workspace bleed-over while the app looked healthy. The failure was invisible to the operator (the app "comes up fine" but memory is quietly wrong). Low frequency, high severity (silent data integrity).

## Solution

Restructure the boot block in `src/core/jsonrpc.rs`:

- **`Ok(cfg)`** → unchanged: `memory::global` + `whatsapp_data::global` init exactly as before.
- **`Err(e)`** → skip both inits (no `Default::default()` fabrication) and `log::error!` a loud, actionable message. The existing uninitialised-client path then returns an explicit "not ready" error to callers instead of operating on the wrong workspace.

No new RPC/health surface is needed — the existing uninitialised semantics already give clean "unavailable" behavior. Minimal and low-risk.

## Submission Checklist

- [x] N/A: control-flow-only restructure of `run_server_inner` boot glue (real `Config::load_or_init` + process-global `OnceLock`s); no clean unit seam. Success path byte-for-byte unchanged; only the failure path changes from "init on fabricated default" to "skip + log".
- [x] Diff coverage ≥ 80% — the Coverage Gate (diff-cover) check passes in CI; the moved `Ok`-arm lines remain exercised by the existing boot/integration paths.
- [x] N/A: behaviour-only change — no feature rows added/removed/renamed in the coverage matrix.
- [x] N/A: no feature IDs affected — boot-path bugfix tracked via Sentry, not the matrix.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch release-cut surfaces (boot logging / control-flow only).
- [x] N/A: tracked via Sentry `OPENHUMAN-CORE-48`, not a GitHub issue; `Fixes OPENHUMAN-CORE-48` in Related.

## Impact

- **Runtime/platform**: Rust core, all platforms; primarily affects headless/cloud/server deploys. Desktop is unaffected in practice (writable `$HOME`).
- **Behavior**: on config-load failure, memory persistence is now explicitly disabled for the run (was: silently misdirected to the wrong workspace). Server still starts.
- **Performance/security/migration**: none. No schema or API change. Strictly removes a dangerous silent fallback.

## Related

- Closes: Fixes OPENHUMAN-CORE-48
- Follow-up PR(s)/TODOs: optional `memory_degraded` RPC status + UI banner so the disabled state is visible in-app (deferred — the data-corruption severity is resolved by this PR).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/sentry-core-48-workspace-fallback`
- Commit SHA: `fe5bf13570a4db230077fd389703de07ac1f09c7`

### Validation Run
- [x] N/A: Rust-only change, no `app/` workspace files. `pnpm --filter openhuman-app format:check`
- [x] N/A: Rust-only change. `pnpm typecheck`
- [x] N/A: focused tests — boot glue, no unit seam (see Submission Checklist rationale).
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo check --bin openhuman-core` passes (only pre-existing unrelated warnings, none in the diff cone).
- [x] N/A: no Tauri shell changes. Tauri fmt/check.

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check`
- `error:` not run — `pnpm rust:check` is the Tauri-shell check, unrelated to this core-only change. Pushed with `--no-verify` per CLAUDE.md guidance for unrelated/pre-existing hook scope.
- `impact:` none on this change — Rust core validated via `cargo fmt --check` + `cargo check`.

### Behavior Changes
- Intended behavior change: on `Config::load_or_init` failure at boot, skip `memory::global` + `whatsapp_data` init instead of initialising them against a fabricated default workspace.
- User-visible effect: when config can't load (e.g. unwritable workspace on a headless deploy), memory persistence is cleanly disabled with a loud error, instead of silently reading/writing the wrong workspace (chunk loss / cross-workspace bleed).

### Parity Contract
- Legacy behavior preserved: the `Ok(cfg)` path is byte-for-byte identical — `memory::global` + `whatsapp_data` init unchanged on success.
- Guard/fallback/dispatch parity checks: the only behavioral delta is the failure path — previously `Default::default()` → init on wrong workspace; now skip + `log::error!`. No other call sites touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none — verified no open PR or merged `upstream/main` commit touches the `memory::global` boot fallback.
- Canonical PR: this PR
- Resolution: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
