### PR TITLE
ci(docs): trigger Tiny KB refresh on gitbooks/** push to main

### DIFF
--- a/.github/workflows/refresh-tiny-kb.yml
+++ b/.github/workflows/refresh-tiny-kb.yml
@@ -1,0 +1,53 @@
+name: Refresh Tiny knowledge base
+
+# Trigger Tiny (the Discord support bot at tinyhumansai/support-automation)
+# to re-ingest the gitbooks corpus whenever the docs change on main.
+#
+# Setup: in this repo's Settings → Secrets and variables → Actions, add
+#   - TINY_WEBHOOK_URL    e.g. https://tiny-support.fly.dev/refresh-kb
+#   - TINY_WEBHOOK_SECRET matches the REFRESH_WEBHOOK_SECRET env on the bot
+#
+# If either secret is missing, the workflow skips silently — useful while
+# the bot isn't deployed yet.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gitbooks/**'
+
+# Don't queue concurrent refreshes — if two PRs merge back-to-back,
+# the latest one wins and the older invocation is cancelled.
+concurrency:
+  group: refresh-tiny-kb
+  cancel-in-progress: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # Skip cleanly when the bot isn't configured yet so this PR can
+    # merge before Tiny is deployed.
+    if: vars.TINY_WEBHOOK_URL != '' || secrets.TINY_WEBHOOK_URL != ''
+    steps:
+      - name: POST to Tiny refresh endpoint
+        env:
+          TINY_WEBHOOK_URL: ${{ secrets.TINY_WEBHOOK_URL }}
+          TINY_WEBHOOK_SECRET: ${{ secrets.TINY_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$TINY_WEBHOOK_URL" ] || [ -z "$TINY_WEBHOOK_SECRET" ]; then
+            echo "TINY_WEBHOOK_URL or TINY_WEBHOOK_SECRET unset — skipping refresh."
+            exit 0
+          fi
+          echo "Triggering Tiny refresh on docs change..."
+          # 30s connect + total timeout caps us under any sensible
+          # platform request budget. `--fail-with-body` surfaces non-2xx
+          # responses with the JSON the bot returned for easier triage.
+          curl --silent --show-error --fail-with-body \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -X POST "$TINY_WEBHOOK_URL" \
+            -H "Authorization: Bearer $TINY_WEBHOOK_SECRET" \
+            -H "Content-Type: application/json" \
+            -d '{"source":"github-action","repo":"${{ github.repository }}","sha":"${{ github.sha }}"}'
+          echo ""
+          echo "Refresh request sent."


### PR DESCRIPTION
Tracks tinyhumansai/backend#813.

Adds a GitHub Action that POSTs to the Tiny support bot (\`tinyhumansai/support-automation\`) whenever a PR merges to main with \`gitbooks/**\` changes. The bot re-ingests the corpus and atomically swaps its BM25 index — typically within 2-3 seconds of merge.

## Flow

\`\`\`
PR merges to main with gitbooks/** changes
                    │
                    ▼
.github/workflows/refresh-tiny-kb.yml   (this PR)
                    │
                    ▼
POST \${TINY_WEBHOOK_URL}    Bearer \${TINY_WEBHOOK_SECRET}
                    │
                    ▼
support-automation bot:
   POST /refresh-kb → fetchGitbookCorpus →
   computeCorpusDiff → LiveRetriever.replace
                    │
                    ▼
   logs:  tiny.kb.refresh.applied
          { summary: "+3 added, ~2 modified", totalChunks: 87 }
\`\`\`

## Setup checklist (after merge)

In this repo's **Settings → Secrets and variables → Actions**, add:
- \`TINY_WEBHOOK_URL\` — e.g. \`https://tiny-support.fly.dev/refresh-kb\`
- \`TINY_WEBHOOK_SECRET\` — random string, matches \`REFRESH_WEBHOOK_SECRET\` on the bot

Until both secrets are configured, the workflow **skips silently** — so this PR can merge before the bot is deployed.

## Design notes

- **Path filter** (\`paths: ['gitbooks/**']\`) — only docs changes trigger. Code/test PRs are untouched.
- **Concurrency cancel-in-progress** — a burst of doc PRs collapses to one refresh.
- **10s connect / 30s total timeout** — fail fast if the bot is down. The bot keeps the old index on failure, so a missed refresh just means slightly stale memory.
- **\`--fail-with-body\`** — surfaces non-2xx responses with the bot's JSON for triage.
- POST body carries \`{ source, repo, sha }\` so the bot's logs correlate refreshes to triggering commits.

## Bot side

The endpoint, atomic swap, and tests landed in [tinyhumansai/support-automation tinyhumansai/openhuman#7](https://github.com/tinyhumansai/support-automation/pull/7). 298 tests passing, full coverage on the new modules.

## Push note

This PR was pushed with \`--no-verify\` because the pre-push hook flagged pre-existing TypeScript / Rust issues on \`main\` that are unrelated to this 53-line YAML-only change. Per the contributor rule in \`CLAUDE.md\` (\"If a pre-push hook fails on something unrelated to your changes ... push with --no-verify and call it out in the PR body\").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated documentation refresh workflow has been configured to trigger on relevant content updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->