### PR TITLE
fix(deploy): add .do/deploy.template.yaml so the Deploy-to-DO button works

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,60 @@
+# DigitalOcean "Deploy to DO" one-click button template.
+#
+# The button at cloud.digitalocean.com/apps/new?repo=... looks for this exact
+# filename (.do/deploy.template.yaml) and requires the App Spec to be nested
+# under a top-level `spec:` key. The sibling `.do/app.yaml` keeps the flat
+# format used by `doctl apps create --spec` and the App Platform UI.
+#
+# Keep these two files in sync — both deploy the headless Rust core
+# (`openhuman-core`) from the repo Dockerfile, exposing JSON-RPC on http_port.
+# After deploy:
+#   - /health is publicly reachable (no auth — used for liveness)
+#   - /rpc requires Authorization: Bearer $OPENHUMAN_CORE_TOKEN
+#
+# Operators MUST set OPENHUMAN_CORE_TOKEN to a strong secret in App Platform's
+# environment editor before any client calls /rpc.
+
+spec:
+  name: openhuman-core
+  region: nyc
+
+  services:
+    - name: core
+      dockerfile_path: Dockerfile
+      source_dir: /
+      github:
+        repo: tinyhumansai/openhuman
+        branch: main
+        deploy_on_push: false
+      instance_count: 1
+      instance_size_slug: basic-xs
+      http_port: 7788
+      health_check:
+        http_path: /health
+        initial_delay_seconds: 20
+        period_seconds: 30
+        timeout_seconds: 5
+        success_threshold: 1
+        failure_threshold: 3
+      envs:
+        - key: OPENHUMAN_CORE_HOST
+          scope: RUN_TIME
+          value: "0.0.0.0"
+        - key: OPENHUMAN_CORE_PORT
+          scope: RUN_TIME
+          value: "7788"
+        - key: OPENHUMAN_APP_ENV
+          scope: RUN_TIME
+          value: production
+        - key: BACKEND_URL
+          scope: RUN_TIME
+          value: https://api.tinyhumans.ai
+        - key: RUST_LOG
+          scope: RUN_TIME
+          value: info
+        # Required for clients to authenticate against /rpc. Set to a strong
+        # random value (e.g. `openssl rand -hex 32`) in the App Platform UI.
+        - key: OPENHUMAN_CORE_TOKEN
+          scope: RUN_TIME
+          type: SECRET
+          value: "CHANGE_ME_BEFORE_DEPLOY"


### PR DESCRIPTION
## Summary

- Add `.do/deploy.template.yaml` so the "Deploy to DigitalOcean" button referenced in [gitbooks/developing/cloud-deploy.md](../blob/main/gitbooks/developing/cloud-deploy.md) actually works.
- Keep the existing `.do/app.yaml` (used by `doctl apps create --spec` / App Platform UI) unchanged — the two files now coexist with identical deployment settings.

## Problem

Following the public cloud-deploy guide (https://tinyhumans.gitbook.io/openhuman/features/cloud-deploy) and clicking the **Deploy to DigitalOcean** button currently fails with an error along the lines of *"no DigitalOcean config found in the repo's main tree."*

Root cause: DO's one-click deploy button at `cloud.digitalocean.com/apps/new?repo=...` looks for a file named **`.do/deploy.template.yaml`** (with the App Spec nested under a top-level `spec:` key) — not `.do/app.yaml`. The repo only ships `app.yaml`, which is the flat format used by `doctl` and the manual App Platform UI. The two formats are sibling concepts in DO's docs but only `deploy.template.yaml` powers the button.

Reproduced by clicking the button at the URL above against `tinyhumansai/openhuman@main`.

## Solution

Add `.do/deploy.template.yaml` alongside the existing `app.yaml`:

- Same Dockerfile, region, instance size, `http_port: 7788`, `/health` probe.
- Same env vars including the `OPENHUMAN_CORE_TOKEN` SECRET placeholder.
- App Spec nested under `spec:` as required by the button.
- Header comment documents the relationship to `app.yaml` and the requirement to keep both in sync.

No code paths change. The flat `app.yaml` continues to be authoritative for `doctl apps create --spec .do/app.yaml`.

## Submission Checklist

- [x] Tests added or updated — **N/A: deploy config only, no runtime code touched.**
- [x] **Diff coverage ≥ 80%** — **N/A: no source code changed, only `.do/deploy.template.yaml`.**
- [x] Coverage matrix updated — **N/A: behaviour-only change (no new feature row).**
- [x] All affected feature IDs from the matrix are listed — **N/A: no matrix rows touched.**
- [x] No new external network dependencies introduced — confirmed, only a config file.
- [x] Manual smoke checklist updated — **N/A: does not affect release-cut surfaces.**
- [ ] Linked issue closed via `Closes #NNN` — none filed; happy to file one if maintainers prefer.

## Impact

- **Runtime**: none. Tauri desktop app, Rust core, CLI, and existing `doctl`-based deploys are unaffected.
- **Cloud deploy**: the documented one-click button starts working from `main` immediately on merge. Anyone currently working around it via `doctl` continues to work.
- **Security/compatibility**: `OPENHUMAN_CORE_TOKEN` remains a `SECRET`-scoped placeholder the operator must replace before any `/rpc` traffic — same posture as `app.yaml`.

## Related

- Closes:
- Follow-up PR(s)/TODOs: optionally consolidate to a single source of truth (template-only, with a generated `app.yaml`) in a separate PR if maintainers prefer.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A — community contribution, no Linear ticket.
- URL: N/A

### Commit & Branch
- Branch: `add-do-deploy-template`
- Commit SHA: see PR head

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — **N/A: no app/ files changed.**
- [x] `pnpm typecheck` — **N/A: no TS files changed.**
- [x] Focused tests — **N/A: no testable code changed.**
- [x] Rust fmt/check (if changed) — **N/A: no Rust files changed.**
- [x] Tauri fmt/check (if changed) — **N/A: no Tauri files changed.**

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: the "Deploy to DigitalOcean" button in the public docs now succeeds against `main`.
- User-visible effect: operators following the cloud-deploy guide no longer hit the "no config found" error.

### Parity Contract
- Legacy behavior preserved: yes — `.do/app.yaml` is unchanged; `doctl apps create --spec .do/app.yaml` continues to produce an identical deployment.
- Guard/fallback/dispatch parity checks: N/A — no dispatch logic touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none known.
- Canonical PR: this one.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added DigitalOcean one-click deployment template for simplified app deployment with pre-configured service settings and health checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->