### PR TITLE
Docs/windows beginner contributing

### DIFF
--- a/CONTRIBUTING-BEGINNERS.md
+++ b/CONTRIBUTING-BEGINNERS.md
@@ -16,6 +16,7 @@ For the full contributor reference, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - [Step 5 — Create your branch](#step-5--create-your-branch)
 - [Step 6 — Make your change and verify it](#step-6--make-your-change-and-verify-it)
 - [Step 7 — Push and open a Pull Request](#step-7--push-and-open-a-pull-request)
+- [Optional — Let an AI coding agent guide you](#optional--let-an-ai-coding-agent-guide-you)
 - [Keeping your fork up to date](#keeping-your-fork-up-to-date)
 - [Troubleshooting common issues](#troubleshooting-common-issues)
 
@@ -291,6 +292,24 @@ git push -u origin your-branch-name
 4. Fill in the PR template completely
 5. Link the issue with `Closes #ISSUE_NUMBER` in the description
 6. Submit
+
+---
+
+## Optional — Let an AI coding agent guide you
+
+If you use Claude Code, Cursor, AmpCode, Codex, or another coding agent, you can paste this prompt after cloning the repo:
+
+```text
+I want to make my first contribution to OpenHuman. First read these upstream docs:
+
+CONTRIBUTING.md: https://raw.githubusercontent.com/tinyhumansai/openhuman/main/CONTRIBUTING.md
+AGENTS.md: https://raw.githubusercontent.com/tinyhumansai/openhuman/main/AGENTS.md
+CLAUDE.md: https://raw.githubusercontent.com/tinyhumansai/openhuman/main/CLAUDE.md
+
+If you can see the cloned repo locally, also read those files directly from the repo. Then guide me step by step: verify my tools, install dependencies, initialize submodules, create a branch, make the smallest safe change for my issue, run the right checks, and prepare a PR. Do not skip failed checks; explain any blocked command with the exact command and error.
+```
+
+The agent should still ask before destructive actions like deleting files, resetting branches, or force-pushing. You are responsible for reviewing the final diff before opening a PR.
 
 ---
 

--- a/CONTRIBUTING-BEGINNERS.md
+++ b/CONTRIBUTING-BEGINNERS.md
@@ -37,7 +37,8 @@ OpenHuman is a desktop AI assistant app. The codebase has three main parts:
 
 ## Step 1 — Install the required tools
 
-### macOS (recommended for beginners)
+<details>
+<summary><strong>macOS setup</strong> (recommended for beginners)</summary>
 
 Install [Homebrew](https://brew.sh) first if you don't have it:
 
@@ -64,7 +65,7 @@ brew install cmake
 xcode-select --install
 ```
 
-### Verify everything is installed
+Verify everything is installed:
 
 ```bash
 node --version     # should be v24.x.x or higher
@@ -74,6 +75,67 @@ cmake --version    # any recent version
 ```
 
 > **Node version warning**: The project requires Node 24+. If you see a warning like `Unsupported engine: wanted >=24.0.0 (current: v22.x.x)`, upgrade Node. Using `nvm`? Run `nvm install 24 && nvm use 24`.
+
+</details>
+
+<details>
+<summary><strong>Windows setup</strong></summary>
+
+Open PowerShell or Windows Terminal.
+
+Install Node.js 24+ with `nvm-windows`:
+
+```powershell
+winget install CoreyButler.NVMforWindows
+```
+
+Close and reopen your terminal, then run:
+
+```powershell
+nvm install 24
+nvm use 24
+node --version     # should be v24.x.x or higher
+```
+
+Install pnpm:
+
+```powershell
+npm install -g pnpm@10.10.0
+pnpm --version     # should be 10.10.0
+```
+
+Install Rust:
+
+```powershell
+winget install Rustlang.Rustup
+```
+
+Close and reopen your terminal, then run:
+
+```powershell
+rustup toolchain install 1.93.0 --profile minimal
+rustup component add rustfmt clippy --toolchain 1.93.0
+rustc --version    # should be 1.93.0
+```
+
+Install CMake:
+
+```powershell
+winget install Kitware.CMake
+cmake --version    # any recent version
+```
+
+Install Visual Studio Build Tools:
+
+```powershell
+winget install Microsoft.VisualStudio.2022.BuildTools
+```
+
+When the installer opens, select **Desktop development with C++**. Make sure it includes the Windows SDK and MSVC v143 build tools.
+
+> **Node version warning**: The project requires Node 24+. If you see a warning like `Unsupported engine: wanted >=24.0.0 (current: v22.x.x)`, run `nvm install 24 && nvm use 24`.
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OpenHuman is an open-source agentic assistant designed to integrate with you in 
 
 ## Contributing from source
 
-New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands. The short path is:
+New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands, or use the copy-paste AI-agent prompt in [`CONTRIBUTING-BEGINNERS.md`](./CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you). The short path is:
 
 1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep, and the platform desktop build prerequisites.
 2. Fork and clone the repo, then run `git submodule update --init --recursive` before `pnpm install` so the vendored Tauri/CEF sources are present.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OpenHuman is an open-source agentic assistant designed to integrate with you in 
 
 ## Contributing from source
 
-New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands, or use the copy-paste AI-agent prompt in [`CONTRIBUTING-BEGINNERS.md`](./CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you). The short path is:
+New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands, or use the copy-paste AI-agent prompt in [`CONTRIBUTING-BEGINNERS.md`](./CONTRIBUTING-BEGINNERS.md#optional-let-an-ai-coding-agent-guide-you). The short path is:
 
 1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep, and the platform desktop build prerequisites.
 2. Fork and clone the repo, then run `git submodule update --init --recursive` before `pnpm install` so the vendored Tauri/CEF sources are present.


### PR DESCRIPTION
## Summary

- Added Windows setup guidance to the beginner contribution guide.
- Converted Step 1 platform setup instructions into collapsible macOS and Windows dropdowns.
- Added a copy-paste AI coding agent prompt for contributors who want guided setup, checks, and PR preparation.
- Linked the new AI-agent prompt from the README contributor section.

## Problem

- `CONTRIBUTING-BEGINNERS.md` only had a macOS-focused tool installation path, leaving Windows beginners to infer
required setup steps from other docs.
- Beginner contributors using AI coding agents did not have a safe copy-paste prompt that points agents to the repo’s
authoritative contribution instructions before running setup or checks.
- The Step 1 setup section was growing harder to scan as platform-specific instructions expanded.

## Solution

- Added separate `<details>` dropdowns for macOS and Windows setup in Step 1.
- Kept the existing macOS commands and added Windows commands for `nvm-windows`, Node.js 24, `pnpm@10.10.0`, Rust
`1.93.0`, CMake, and Visual Studio Build Tools.
- Added an optional AI-agent guidance section that tells agents to read the upstream raw docs first:
  - `CONTRIBUTING.md`
  - `AGENTS.md`
  - `CLAUDE.md`
- Added a short README link to the new beginner-friendly AI-agent prompt.
- Kept the scope documentation-only; no code, build scripts, or workflow logic changed.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] N/A: Tests added or updated — documentation-only change.
- [x] N/A: **Diff coverage ≥ 80%** — documentation-only change with no executable code.
- [x] N/A: Coverage matrix updated — documentation-only change; no feature rows added, removed, or renamed.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no affected
feature IDs.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist updated — does not touch release-cut surfaces.
- [x] N/A: Linked issue closed via `Closes #NNN` — no issue number provided.

## Impact

- Runtime/platform impact: none; documentation-only.
- Performance impact: none.
- Security impact: none.
- Migration impact: none.
- Compatibility impact: improves Windows contributor setup guidance without changing project behavior.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes: N/A — no issue number provided.
- Follow-up PR(s)/TODOs: N/A.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `docs/windows-beginner-contributing`
- Commit SHA:
  - `1113d586` — `docs: add Windows beginner setup guidance`
  - `c69f48bc` — `docs: add AI-agent contributor prompt`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — attempted via `pnpm format:check`, blocked by local environment.
- [ ] `pnpm typecheck` — N/A: documentation-only change.
- [ ] Focused tests: N/A: documentation-only change.
- [ ] Rust fmt/check (if changed): N/A: no Rust changes.
- [ ] Tauri fmt/check (if changed): N/A: no Tauri changes.

### Validation Blocked
- `command:` `pnpm format:check`
- `error:` Local environment uses Node `v22.19.0` while the repo requires Node `>=24.0.0`; `node_modules` are not
installed, so `prettier` is not available.
- `impact:` Formatting check could not complete locally. The change is markdown-only and the diff was manually
reviewed.

### Behavior Changes
- Intended behavior change: N/A — documentation-only change.
- User-visible effect: New contributors can find Windows setup steps and an AI-agent setup prompt more easily.

### Parity Contract
- Legacy behavior preserved: Existing macOS setup guidance remains, now inside a dropdown.
- Guard/fallback/dispatch parity checks: N/A — no runtime behavior changed.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized contributor setup guides with collapsible macOS and Windows sections for easier navigation
  * Added clearer verification prompts during setup and updated onboarding path recommendations
  * Introduced an optional AI-assisted contributor workflow with a ready prompt template and guidance to confirm actions and review diffs before PRs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->