### PR TITLE
Add MCP bridge tool allowlists

### DIFF
--- a/src/openhuman/config/schema/tools.rs
+++ b/src/openhuman/config/schema/tools.rs
@@ -255,6 +255,15 @@ pub struct McpServerConfig {
     /// Whether this server should be exposed to the MCP bridge tools.
     #[serde(default = "defaults::default_true")]
     pub enabled: bool,
+    /// Exact remote tool names this server may expose through the generic
+    /// MCP bridge. Empty means all remote tools are allowed unless they
+    /// appear in `disallowed_tools`.
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    /// Exact remote tool names that should always be hidden and blocked.
+    /// This denylist takes precedence over `allowed_tools`.
+    #[serde(default)]
+    pub disallowed_tools: Vec<String>,
     /// Per-request timeout in seconds.
     #[serde(default = "default_mcp_timeout_secs")]
     pub timeout_secs: u64,
@@ -281,6 +290,8 @@ impl Default for McpServerConfig {
             cwd: None,
             description: None,
             enabled: defaults::default_true(),
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
             timeout_secs: default_mcp_timeout_secs(),
             auth: McpAuthConfig::None,
         }

--- a/src/openhuman/mcp_client/registry.rs
+++ b/src/openhuman/mcp_client/registry.rs
@@ -22,10 +22,32 @@ pub struct McpServerDefinition {
     pub endpoint: String,
     pub command: Option<String>,
     pub description: Option<String>,
+    pub allowed_tools: Vec<String>,
+    pub disallowed_tools: Vec<String>,
     pub timeout_secs: u64,
     pub auth: McpAuthConfig,
     pub source: McpRegistrySource,
     client: Arc<McpTransportClient>,
+}
+
+impl McpServerDefinition {
+    pub fn is_tool_allowed(&self, tool: &str) -> bool {
+        let tool = tool.trim();
+        if tool.is_empty() {
+            return false;
+        }
+        if self.disallowed_tools.iter().any(|name| name == tool) {
+            return false;
+        }
+        self.allowed_tools.is_empty() || self.allowed_tools.iter().any(|name| name == tool)
+    }
+
+    pub fn filter_allowed_tools(&self, tools: Vec<McpRemoteTool>) -> Vec<McpRemoteTool> {
+        tools
+            .into_iter()
+            .filter(|tool| self.is_tool_allowed(&tool.name))
+            .collect()
+    }
 }
 
 #[derive(Debug)]
@@ -61,6 +83,8 @@ impl McpServerRegistry {
                 endpoint: config.gitbooks.endpoint.clone(),
                 command: None,
                 description: Some("OpenHuman GitBook documentation MCP server.".into()),
+                allowed_tools: Vec::new(),
+                disallowed_tools: Vec::new(),
                 timeout_secs: config.gitbooks.timeout_secs,
                 auth: McpAuthConfig::None,
                 source: McpRegistrySource::LegacyGitbooks,
@@ -95,7 +119,8 @@ impl McpServerRegistry {
         let server = self
             .get(server)
             .ok_or_else(|| anyhow::anyhow!("unknown MCP server `{server}`"))?;
-        server.client.list_tools().await
+        let tools = server.client.list_tools().await?;
+        Ok(server.filter_allowed_tools(tools))
     }
 
     pub async fn call_tool(
@@ -107,6 +132,13 @@ impl McpServerRegistry {
         let server = self
             .get(server)
             .ok_or_else(|| anyhow::anyhow!("unknown MCP server `{server}`"))?;
+        let tool = tool.trim();
+        if !server.is_tool_allowed(tool) {
+            anyhow::bail!(
+                "MCP tool `{tool}` is not allowed for server `{}`",
+                server.name
+            );
+        }
         server.client.call_tool(tool, arguments).await
     }
 
@@ -153,6 +185,8 @@ impl McpServerRegistry {
             endpoint: endpoint.to_string(),
             command: transport_command(server),
             description: server.description.clone(),
+            allowed_tools: normalize_tool_names(&server.allowed_tools),
+            disallowed_tools: normalize_tool_names(&server.disallowed_tools),
             timeout_secs: server.timeout_secs,
             auth: server.auth.clone(),
             source,
@@ -238,6 +272,17 @@ fn transport_command(server: &McpServerConfig) -> Option<String> {
     }
 }
 
+fn normalize_tool_names(tools: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for tool in tools {
+        let tool = tool.trim();
+        if !tool.is_empty() && !normalized.iter().any(|existing| existing == tool) {
+            normalized.push(tool.to_string());
+        }
+    }
+    normalized
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,6 +307,8 @@ mod tests {
             cwd: None,
             description: Some("Custom docs".into()),
             enabled: true,
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
             timeout_secs: 9,
             auth: crate::openhuman::config::McpAuthConfig::None,
         });
@@ -277,5 +324,83 @@ mod tests {
         config.mcp_client.enabled = false;
         let registry = McpServerRegistry::from_config(&config);
         assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn server_definition_filters_allowed_tools() {
+        let mut config = Config::default();
+        config.gitbooks.enabled = false;
+        config.mcp_client.servers.push(McpServerConfig {
+            name: "docs".into(),
+            endpoint: "https://example.com/mcp".into(),
+            command: String::new(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+            description: None,
+            enabled: true,
+            allowed_tools: vec![" search ".into(), "read".into(), "search".into()],
+            disallowed_tools: vec!["read".into()],
+            timeout_secs: 30,
+            auth: crate::openhuman::config::McpAuthConfig::None,
+        });
+        let registry = McpServerRegistry::from_config(&config);
+        let docs = registry.get("docs").expect("docs");
+
+        let filtered = docs.filter_allowed_tools(vec![
+            remote_tool("search"),
+            remote_tool("read"),
+            remote_tool("write"),
+        ]);
+
+        assert_eq!(
+            docs.allowed_tools,
+            vec!["search".to_string(), "read".to_string()]
+        );
+        assert_eq!(docs.disallowed_tools, vec!["read".to_string()]);
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["search"]
+        );
+    }
+
+    #[tokio::test]
+    async fn call_tool_blocks_disallowed_tool_before_transport() {
+        let mut config = Config::default();
+        config.gitbooks.enabled = false;
+        config.mcp_client.servers.push(McpServerConfig {
+            name: "docs".into(),
+            endpoint: "http://127.0.0.1:9/mcp".into(),
+            command: String::new(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+            description: None,
+            enabled: true,
+            allowed_tools: vec!["search".into()],
+            disallowed_tools: Vec::new(),
+            timeout_secs: 30,
+            auth: crate::openhuman::config::McpAuthConfig::None,
+        });
+        let registry = McpServerRegistry::from_config(&config);
+
+        let err = registry
+            .call_tool("docs", "write", serde_json::json!({}))
+            .await
+            .expect_err("blocked before transport");
+
+        assert!(err.to_string().contains("not allowed for server `docs`"));
+    }
+
+    fn remote_tool(name: &str) -> McpRemoteTool {
+        McpRemoteTool {
+            name: name.into(),
+            title: None,
+            description: None,
+            input_schema: serde_json::json!({"type":"object"}),
+        }
     }
 }

--- a/src/openhuman/tools/impl/network/mcp.rs
+++ b/src/openhuman/tools/impl/network/mcp.rs
@@ -52,6 +52,8 @@ impl Tool for McpListServersTool {
                     "endpoint": server.endpoint,
                     "description": server.description,
                     "timeout_secs": server.timeout_secs,
+                    "allowed_tools": server.allowed_tools,
+                    "disallowed_tools": server.disallowed_tools,
                     "auth": server.auth,
                     "source": server.source,
                 })
@@ -82,6 +84,18 @@ impl Tool for McpListServersTool {
                 ));
                 if let Some(description) = server.description.as_deref() {
                     md.push_str(&format!("\n  - {description}"));
+                }
+                if !server.allowed_tools.is_empty() {
+                    md.push_str(&format!(
+                        "\n  - allowed tools: `{}`",
+                        server.allowed_tools.join("`, `")
+                    ));
+                }
+                if !server.disallowed_tools.is_empty() {
+                    md.push_str(&format!(
+                        "\n  - disallowed tools: `{}`",
+                        server.disallowed_tools.join("`, `")
+                    ));
                 }
             }
             md
@@ -290,6 +304,8 @@ mod tests {
             cwd: None,
             description: Some("Docs MCP".into()),
             enabled: true,
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
             timeout_secs: 30,
             auth: crate::openhuman::config::McpAuthConfig::None,
         });

--- a/src/openhuman/tools/ops_tests.rs
+++ b/src/openhuman/tools/ops_tests.rs
@@ -255,6 +255,8 @@ fn all_tools_registers_generic_mcp_bridge_tools_when_servers_exist() {
             cwd: None,
             description: Some("Example docs MCP".into()),
             enabled: true,
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
             timeout_secs: 30,
             auth: crate::openhuman::config::McpAuthConfig::None,
         });


### PR DESCRIPTION
## Summary
- Add per-server `allowed_tools` / `disallowed_tools` config for the generic MCP bridge.
- Filter `mcp_list_tools` output through the configured allowlist.
- Reject blocked `mcp_call_tool` requests before remote transport dispatch.
- Include allowlist state in `mcp_list_servers` diagnostics.

## Validation
- `cargo fmt --manifest-path Cargo.toml`
- `cargo test --manifest-path Cargo.toml mcp`

Refs #2134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tool-level access control for MCP servers through allow and deny lists. Disallowed tools are blocked from execution and take precedence over allowed tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->