### PR TITLE
docs: fix markdown-lint warnings in README.md, README.ja-JP.md, README.ko.md

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -88,7 +88,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 OpenHuman は、数分であなたのことを理解する初めてのエージェントハーネスです。[Karpathy 氏の LLM ナレッジベース](https://x.com/karpathy/status/2039805659525644595)にインスパイアされました。ほとんどのエージェントは冷えた状態から始まります。Hermes はあなたの作業を見て学習し、OpenClaw はプラグインがコンテキストを運び込むのを待ちます。いずれにせよ、エージェントがあなたのスタックを十分理解して本当に役立つようになるまで、数日から数週間を費やすことになります。
 
 <p align="center">
- <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" /> />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram">
 </p>
 
 > OpenHuman はあなたのすべてのドキュメント、メール、チャットを要約・圧縮し、エージェントがあなたについてすべてを覚えていられるメモリーグラフを作成します。

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -47,7 +47,7 @@
 
 インストールや利用開始は、ウェブサイト [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) からダウンロードするか、以下のコマンドを実行してください。
 
-```
+```bash
 # DMG や EXE は https://tinyhumans.ai/openhuman からダウンロードするか、ターミナルから実行してください
 
 # macOS または Linux x64 の場合
@@ -88,7 +88,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 OpenHuman は、数分であなたのことを理解する初めてのエージェントハーネスです。[Karpathy 氏の LLM ナレッジベース](https://x.com/karpathy/status/2039805659525644595)にインスパイアされました。ほとんどのエージェントは冷えた状態から始まります。Hermes はあなたの作業を見て学習し、OpenClaw はプラグインがコンテキストを運び込むのを待ちます。いずれにせよ、エージェントがあなたのスタックを十分理解して本当に役立つようになるまで、数日から数週間を費やすことになります。
 
 <p align="center">
- <img src="./gitbooks/.gitbook/assets/image (1).png" />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" /> />
 </p>
 
 > OpenHuman はあなたのすべてのドキュメント、メール、チャットを要約・圧縮し、エージェントがあなたについてすべてを覚えていられるメモリーグラフを作成します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -89,7 +89,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 OpenHuman은 몇 분 만에 당신을 알게 되는 최초의 에이전트 하네스입니다. [Karpathy의 LLM 지식 베이스](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다. 대부분의 에이전트는 아무런 정보 없이 시작합니다. Hermes는 당신의 작업을 지켜보며 학습하고, OpenClaw는 플러그인이 컨텍스트를 가져오기를 기다립니다. 어느 쪽이든 에이전트가 당신의 스택에 대해 충분히 알고 정말 유용해지기까지는 며칠 또는 몇 주가 걸립니다.
 
 <p align="center">
- <img src="./gitbooks/.gitbook/assets/image (1).png" />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" />
 </p>
 
 > OpenHuman은 당신의 모든 문서, 이메일 및 채팅을 요약하고 압축합니다. 그리고 에이전트가 당신에 대한 모든 것을 기억할 수 있도록 메모리 그래프를 생성합니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -89,7 +89,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 OpenHuman은 몇 분 만에 당신을 알게 되는 최초의 에이전트 하네스입니다. [Karpathy의 LLM 지식 베이스](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다. 대부분의 에이전트는 아무런 정보 없이 시작합니다. Hermes는 당신의 작업을 지켜보며 학습하고, OpenClaw는 플러그인이 컨텍스트를 가져오기를 기다립니다. 어느 쪽이든 에이전트가 당신의 스택에 대해 충분히 알고 정말 유용해지기까지는 며칠 또는 몇 주가 걸립니다.
 
 <p align="center">
- <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram">
 </p>
 
 > OpenHuman은 당신의 모든 문서, 이메일 및 채팅을 요약하고 압축합니다. 그리고 에이전트가 당신에 대한 모든 것을 기억할 수 있도록 메모리 그래프를 생성합니다.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
 
-```bash 
+```bash
 # Download DMG, EXEs over at https://tinyhumans.ai/openhuman or run in from your terminal
 
 # For macOS or Linux x64

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
 
-```
+```bash 
 # Download DMG, EXEs over at https://tinyhumans.ai/openhuman or run in from your terminal
 
 # For macOS or Linux x64
@@ -88,7 +88,7 @@ Deeper docs: [Architecture](https://tinyhumans.gitbook.io/openhuman/developing/a
 OpenHuman is the first agent harness that gets to know you in minutes. Inspired by [Karpathy's LLM Knowledgebase](https://x.com/karpathy/status/2039805659525644595). Most agents start cold. Hermes learns by watching you work; OpenClaw waits for plugins to ferry context in. Either way, you spend days or weeks before the agent knows enough about your stack to be genuinely useful.
 
 <p align="center">
- <img src="./gitbooks/.gitbook/assets/image (1).png" />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" />
 </p>
 
 > OpenHuman summarizes and compresses all your documents, emails & chats; and creates a memory graph that lets your agent remember everything about you.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Deeper docs: [Architecture](https://tinyhumans.gitbook.io/openhuman/developing/a
 OpenHuman is the first agent harness that gets to know you in minutes. Inspired by [Karpathy's LLM Knowledgebase](https://x.com/karpathy/status/2039805659525644595). Most agents start cold. Hermes learns by watching you work; OpenClaw waits for plugins to ferry context in. Either way, you spend days or weeks before the agent knows enough about your stack to be genuinely useful.
 
 <p align="center">
- <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram">
 </p>
 
 > OpenHuman summarizes and compresses all your documents, emails & chats; and creates a memory graph that lets your agent remember everything about you.


### PR DESCRIPTION
Fixes #2161

## Summary

Three locale README files (`README.md`, `README.ja-JP.md`, `README.ko.md`) still had
two markdown-lint findings that were already fixed in `README.de.md` (PR #2160,
commit f97728b) and `README.zh-CN.md`. This PR applies the same fixes to the
remaining three files.

## Problem

### Finding 1 — Fenced code block missing language hint

Before (broken):
```
┌─────────────────────────────────────────┐
│  ```                                    │
│  # Download DMG, EXEs...                │
│  curl -fsSL .../install.sh | bash       │
│  ```                                    │
│                                         │
│  ❌ MD040: no language specified        │
└─────────────────────────────────────────┘
```

After (fixed):
```
┌─────────────────────────────────────────┐
│  ```bash                                │
│  # Download DMG, EXEs...                │
│  curl -fsSL .../install.sh | bash       │
│  ```                                    │
│                                         │
│  ✅ MD040: language hint present        │
└─────────────────────────────────────────┘
```

### Finding 2 — Context-diagram `<img>` tag missing `alt` attribute

Before (broken):
```
┌─────────────────────────────────────────────────────────┐
│  <img src="./gitbooks/.gitbook/assets/image (1).png" /> │
│                                                         │
│  ❌ MD045: missing alt attribute                        │
│  ❌ Accessibility: screen readers cannot describe image │
└─────────────────────────────────────────────────────────┘
```

After (fixed):
```
┌───────────────────────────────────────────────────────────────────┐
│  <img src="./gitbooks/.gitbook/assets/image (1).png"              │
│       alt="OpenHuman context diagram" />                          │
│                                                                   │
│  ✅ MD045: alt attribute present                                  │
│  ✅ Accessibility: screen readers can describe image              │
└───────────────────────────────────────────────────────────────────┘
```

## Changes Made

### README.md
- Line 50: Changed ` ``` ` → ` ```bash `
- Line 91: Added `alt="OpenHuman context diagram"` to `<img>` tag

### README.ja-JP.md
- Line 50: Changed ` ``` ` → ` ```bash `
- Line 91: Added `alt="OpenHuman context diagram"` to `<img>` tag

### README.ko.md
- Line 51: Changed ` ``` ` → ` ```bash `
- Line 92: Added `alt="OpenHuman context diagram"` to `<img>` tag

## Files Changed

| File | Fix 1 (bash fence) | Fix 2 (alt attribute) |
|------|-------------------|----------------------|
| `README.md` | ✅ | ✅ |
| `README.ja-JP.md` | ✅ | ✅ |
| `README.ko.md` | ✅ | ✅ |

## Diff Overview

```
  README.md
- ```
+ ```bash

- <img src="./gitbooks/.gitbook/assets/image (1).png" />
+ <img src="./gitbooks/.gitbook/assets/image (1).png" alt="OpenHuman context diagram" />

  README.ja-JP.md  (same 2 changes)
  README.ko.md     (same 2 changes)
```

## Validation
- Docs-only change — no code modified
- No logic, UI, or behavior changes
- Follows exact same pattern used in `README.de.md` and `README.zh-CN.md`
- `pnpm format:check` passes for markdown-only changes

## References
- Issue: #2161
- Related PR: #2160 (German README — where the fix pattern was first applied)
- Raised by: @fflitzrrr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized installation code blocks to explicitly use Bash syntax highlighting across README files for clearer terminal instructions.
  * Added/updated alt text and adjusted image markup/formatting for context diagrams to improve accessibility and consistent rendering across translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->