### PR TITLE
fix(channels): surface channel error status in selector

### DIFF
--- a/app/src/components/channels/ChannelSelector.tsx
+++ b/app/src/components/channels/ChannelSelector.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { resolvePreferredAuthModeForChannel } from '../../lib/channels/routing';
 import { useT } from '../../lib/i18n/I18nContext';
 import { useAppSelector } from '../../store/hooks';
-import type { ChannelDefinition, ChannelType } from '../../types/channels';
+import type { ChannelConnectionStatus, ChannelDefinition, ChannelType } from '../../types/channels';
 import ChannelStatusBadge from './ChannelStatusBadge';
 
 interface ChannelSelectorProps {
@@ -13,6 +13,12 @@ interface ChannelSelectorProps {
 }
 
 const CHANNEL_ICONS: Record<string, string> = { telegram: '✈️', discord: '🎮', web: '🌐' };
+const CHANNEL_STATUS_PRIORITY: ChannelConnectionStatus[] = [
+  'connected',
+  'connecting',
+  'error',
+  'disconnected',
+];
 
 const ChannelSelector = ({
   definitions,
@@ -49,11 +55,13 @@ const ChannelSelector = ({
 
           // Determine best connection status for this channel.
           const channelModes = channelConnections.connections[channelId];
-          const bestStatus = channelModes
-            ? (Object.values(channelModes).find(c => c?.status === 'connected')?.status ??
-              Object.values(channelModes).find(c => c?.status === 'connecting')?.status ??
-              'disconnected')
-            : 'disconnected';
+          const modeStatuses = channelModes
+            ? Object.values(channelModes)
+                .map(connection => connection?.status)
+                .filter((status): status is ChannelConnectionStatus => Boolean(status))
+            : [];
+          const bestStatus =
+            CHANNEL_STATUS_PRIORITY.find(status => modeStatuses.includes(status)) ?? 'disconnected';
 
           return (
             <button

--- a/app/src/components/channels/__tests__/ChannelSelector.test.tsx
+++ b/app/src/components/channels/__tests__/ChannelSelector.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { FALLBACK_DEFINITIONS } from '../../../lib/channels/definitions';
-import { renderWithProviders } from '../../../test/test-utils';
+import { setChannelConnectionStatus } from '../../../store/channelConnectionsSlice';
+import { createTestStore, renderWithProviders } from '../../../test/test-utils';
 import ChannelSelector from '../ChannelSelector';
 
 describe('ChannelSelector', () => {
@@ -45,5 +46,30 @@ describe('ChannelSelector', () => {
     );
 
     expect(screen.getByText(/No active route/)).toBeInTheDocument();
+  });
+
+  it('surfaces channel errors when no mode is connected or connecting', () => {
+    const store = createTestStore();
+    store.dispatch(
+      setChannelConnectionStatus({
+        channel: 'telegram',
+        authMode: 'bot_token',
+        status: 'error',
+        lastError: 'Invalid token',
+      })
+    );
+
+    renderWithProviders(
+      <ChannelSelector
+        definitions={FALLBACK_DEFINITIONS}
+        selectedChannel="telegram"
+        onSelectChannel={onSelect}
+      />,
+      { store }
+    );
+
+    const telegramTab = screen.getByRole('button', { name: /telegram/i });
+    expect(within(telegramTab).getByText('Error')).toBeInTheDocument();
+    expect(within(telegramTab).queryByText('Disconnected')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Surface `error` channel connection states in the Channels selector instead of falling back to `Disconnected`
- Keep `connected` and `connecting` ahead of `error` so healthy/in-progress modes still win
- Add a regression test covering an errored Telegram auth mode with no connected/connecting modes

Closes #2141

## Test Plan
- `PATH="/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:$PATH" pnpm debug unit src/components/channels/__tests__/ChannelSelector.test.tsx`
- `PATH="/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:$PATH" pnpm --filter openhuman-app format:check`
- `PATH="/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:$PATH" pnpm --filter openhuman-app compile`

## Notes
- Used Node 24 because the default local `node v16.13.1` cannot run this repo's Corepack/pnpm (`URL.canParse` is unavailable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of channel connection status detection by prioritizing connection states more intelligently across multiple connections.

* **Tests**
  * Added test coverage for error state handling in channel connections to ensure proper error label visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->