### PR TITLE
fix(channels): show channel selector error state

### DIFF
--- a/app/src/components/channels/ChannelSelector.tsx
+++ b/app/src/components/channels/ChannelSelector.tsx
@@ -52,6 +52,7 @@ const ChannelSelector = ({
           const bestStatus = channelModes
             ? (Object.values(channelModes).find(c => c?.status === 'connected')?.status ??
               Object.values(channelModes).find(c => c?.status === 'connecting')?.status ??
+              Object.values(channelModes).find(c => c?.status === 'error')?.status ??
               'disconnected')
             : 'disconnected';
 

--- a/app/src/components/channels/__tests__/ChannelSelector.test.tsx
+++ b/app/src/components/channels/__tests__/ChannelSelector.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { FALLBACK_DEFINITIONS } from '../../../lib/channels/definitions';
@@ -45,5 +45,56 @@ describe('ChannelSelector', () => {
     );
 
     expect(screen.getByText(/No active route/)).toBeInTheDocument();
+  });
+
+  it('shows error status when a channel has a failed auth mode', () => {
+    renderWithProviders(
+      <ChannelSelector
+        definitions={FALLBACK_DEFINITIONS}
+        selectedChannel="telegram"
+        onSelectChannel={onSelect}
+      />,
+      {
+        preloadedState: {
+          channelConnections: {
+            schemaVersion: 1,
+            migrationCompleted: true,
+            defaultMessagingChannel: 'telegram',
+            connections: {
+              telegram: {
+                managed_dm: undefined,
+                oauth: undefined,
+                bot_token: {
+                  channel: 'telegram',
+                  authMode: 'bot_token',
+                  status: 'error',
+                  selectedDefault: false,
+                  lastError: 'Invalid bot token',
+                  capabilities: [],
+                  updatedAt: '2026-05-19T00:00:00.000Z',
+                },
+                api_key: undefined,
+              },
+              discord: {
+                managed_dm: undefined,
+                oauth: undefined,
+                bot_token: undefined,
+                api_key: undefined,
+              },
+              web: {
+                managed_dm: undefined,
+                oauth: undefined,
+                bot_token: undefined,
+                api_key: undefined,
+              },
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      within(screen.getByRole('button', { name: /Telegram/ })).getByText('Error')
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the channel selector status aggregation so channel-level errors are surfaced instead of falling through to `Disconnected`.

Fixes #2141

## What changed

- Added regression coverage for a channel with an auth mode in `error` state.
- Updated `ChannelSelector` status priority to check `error` before falling back to `disconnected`.
- Preserved the existing `connected` and `connecting` priority.

## Why

The channel detail panels can store failed auth attempts as `error`, but the selector only checked for `connected` and `connecting`. That made failed Telegram or Discord setup look inactive instead of broken in the top-level channel selector.

## Files changed

- `app/src/components/channels/ChannelSelector.tsx`
- `app/src/components/channels/__tests__/ChannelSelector.test.tsx`

## Validation

- [x] RED: `pnpm --dir app exec vitest run src/components/channels/__tests__/ChannelSelector.test.tsx --config test/vitest.config.ts` failed before the implementation because the Telegram tab rendered `Disconnected` instead of `Error`.
- [x] GREEN: `pnpm --dir app exec vitest run src/components/channels/__tests__/ChannelSelector.test.tsx --config test/vitest.config.ts` passed after the fix: 4 tests.
- [x] `node scripts/codex-pr-preflight.mjs --lightweight` passed.
- [x] `PATH="$HOME/.cargo/bin:$PATH" pnpm --filter openhuman-app format:check` passed.
- [x] `pnpm typecheck` passed.
- [x] `pnpm lint` passed with existing warnings.
- [x] `pnpm --dir app run lint:commands-tokens` passed.
- [x] `PATH="$HOME/.cargo/bin:$PATH" pnpm rust:check` passed with existing warnings after initializing the repository submodules.
- [x] `git diff --check` passed.
- [x] `pnpm pr:checklist /tmp/openhuman-2141-pr.md` passed locally before PR creation.

## AI Authored PR Metadata

### Linear Issue
- [x] N/A - GitHub issue #2141: https://github.com/tinyhumansai/openhuman/issues/2141

### Commit & Branch
- [x] Branch: `codex/GH-2141-channel-selector-error-status`
- [x] Commit SHA: `4226f225e213c528c582f65769021df93b1dfd90`

### Validation Run
- [x] Format check: `PATH="$HOME/.cargo/bin:$PATH" pnpm --filter openhuman-app format:check`
- [x] Typecheck: `pnpm typecheck`
- [x] Lint: `pnpm lint`
- [x] Focused test: `pnpm --dir app exec vitest run src/components/channels/__tests__/ChannelSelector.test.tsx --config test/vitest.config.ts`
- [x] Rust check: `PATH="$HOME/.cargo/bin:$PATH" pnpm rust:check`
- [x] Command token lint: `pnpm --dir app run lint:commands-tokens`

### Validation Blocked
- [x] N/A - no validation command remained blocked. Local shell needed `$HOME/.cargo/bin` in `PATH` for Rust commands and needed `git submodule update --init --recursive app/src-tauri/vendor/tauri-cef app/src-tauri/vendor/tauri-plugin-notification` before `pnpm rust:check`. The local Node version produced the repo's engine warning (`wanted >=24.0.0`, current `v22.22.0`) but did not block the listed commands.

### Behavior Changes
- [x] Intended behavior change: channel selector status priority is now `connected`, then `connecting`, then `error`, then `disconnected`.
- [x] Scope boundary: #2128 OAuth pending-state scoping is not changed.

### Duplicate / Superseded PR Handling
- [x] Duplicate PRs: none found by searching `2141 in:body,title ChannelSelector error Disconnected`.

## AI assistance disclosure

I used OpenAI Codex to inspect the issue and code path, draft the regression test and fix, then reviewed the final diff and ran the listed validation commands locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel status now correctly displays "Error" state when a channel's authentication is in an error state, improving visibility of authentication issues.

* **Tests**
  * Added test case verifying proper error status display for channels with authentication failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->