### PR TITLE
fix(onboarding): clarify continue to chat fallback

### DIFF
--- a/app/src/lib/i18n/chunks/en-4.ts
+++ b/app/src/lib/i18n/chunks/en-4.ts
@@ -143,7 +143,7 @@ const en4: TranslationMap = {
   'onboarding.contextGathering.buildingProfile': 'Building your profile...',
   'onboarding.contextGathering.continueToChat': 'Continue to chat',
   'onboarding.contextGathering.errorDesc':
-    "We couldn't build your full profile right now, but that's okay — you can continue and your profile will build over time.",
+    "Your chat is ready. We'll keep building your full profile in the background, so you can continue now and refine it over time.",
   'onboarding.contextGathering.title': 'Context Gathering',
   'openhuman.team_list_teams': 'Team list teams',
   'overlay.ariaAttention': 'Attention message',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -1449,7 +1449,7 @@ const en: TranslationMap = {
   'onboarding.contextGathering.buildingProfile': 'Building your profile...',
   'onboarding.contextGathering.continueToChat': 'Continue to chat',
   'onboarding.contextGathering.errorDesc':
-    "We couldn't build your full profile right now, but that's okay — you can continue and your profile will build over time.",
+    "Your chat is ready. We'll keep building your full profile in the background, so you can continue now and refine it over time.",
   'onboarding.contextGathering.title': 'Context Gathering',
   'openhuman.team_list_teams': 'Team list teams',
   'overlay.ariaAttention': 'Attention message',

--- a/app/src/pages/onboarding/steps/ContextGatheringStep.tsx
+++ b/app/src/pages/onboarding/steps/ContextGatheringStep.tsx
@@ -291,13 +291,15 @@ const ContextGatheringStep = ({
           <h1 className="text-xl font-bold text-stone-900 dark:text-neutral-100">
             {t('onboarding.contextGathering.title')}
           </h1>
-          <p className="text-sm text-stone-600 dark:text-neutral-300 text-center max-w-xs leading-relaxed">
-            {t('onboarding.contextGathering.errorDesc')}
-          </p>
-          <OnboardingNextButton
-            label={t('onboarding.contextGathering.continueToChat')}
-            onClick={continueToChat}
-          />
+          <div className="w-full max-w-sm rounded-xl border border-primary-100 bg-primary-50/80 p-4 dark:border-primary-900/50 dark:bg-primary-950/30">
+            <p className="text-sm text-stone-700 dark:text-neutral-200 text-center leading-relaxed mb-4">
+              {t('onboarding.contextGathering.errorDesc')}
+            </p>
+            <OnboardingNextButton
+              label={t('onboarding.contextGathering.continueToChat')}
+              onClick={continueToChat}
+            />
+          </div>
         </div>
       </div>
     );

--- a/app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx
+++ b/app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx
@@ -237,9 +237,7 @@ describe('ContextGatheringStep', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/we couldn't build your full profile right now/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/your chat is ready/i)).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole('button', { name: /continue to chat/i }));
@@ -270,9 +268,7 @@ describe('ContextGatheringStep', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/we couldn't build your full profile right now/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/your chat is ready/i)).toBeInTheDocument();
     });
 
     expect(screen.getByRole('button', { name: /continue to chat/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Makes the profile-build fallback clearly tell users that chat is ready.
- Highlights the fallback copy and `Continue to chat` CTA in a focused callout.
- Updates existing onboarding tests to assert the new recovery-state copy.

## Problem

- When profile building times out or fails, the fallback copy can read like login is broken.
- Users may miss that `Continue to chat` is available and safe to use.
- This addresses the small UX issue tracked in #2157.

## Solution

- Reworded the fallback from a failure-style message to a ready-state message.
- Wrapped the fallback message and CTA in a subtle primary-tinted panel so the action is more obvious.
- Kept the existing continue behavior unchanged.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — CI coverage is expected to validate this; local coverage was blocked by missing `node_modules` in this checkout and is documented below.
- [x] Coverage matrix updated — N/A: behaviour-only copy/CTA prominence change, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: narrow onboarding fallback UI copy/prominence change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop onboarding UI only.
- No persistence, security, migration, or backend behavior changes.
- Existing fallback navigation behavior is preserved.

## Related

- Closes #2157
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/obvious-continue-chat`
- Commit SHA: `d8a98912951ffe8b306a995d15881d7218503483`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — not run locally; blocked by missing `node_modules`, see below.
- [x] `pnpm typecheck` — not run locally; blocked by missing `node_modules`, see below.
- [x] Focused tests: `pnpm debug unit app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx` — attempted locally, blocked by missing `node_modules`; CI is running the suite.
- [x] Rust fmt/check (if changed): N/A, no Rust changes.
- [x] Tauri fmt/check (if changed): N/A, no Tauri changes.

### Validation Blocked
- `command:` `pnpm debug unit app/src/pages/onboarding/steps/__tests__/ContextGatheringStep.test.tsx`
- `error:` local checkout is missing `node_modules`; pnpm reported: `Local package.json exists, but node_modules missing, did you mean to install?`
- `impact:` focused Vitest validation did not run locally in this clone.

### Behavior Changes
- Intended behavior change: profile-build fallback now frames the state as chat-ready and makes the CTA more prominent.
- User-visible effect: users should more easily understand they can continue into chat while profile enrichment continues later.

### Parity Contract
- Legacy behavior preserved: `Continue to chat` still calls the same `onNext` path; only copy and presentation changed.
- Guard/fallback/dispatch parity checks: existing recoverable-error tests were updated for the new copy.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A
