### PR TITLE
chore(ci): make pretest optional for release-production

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -28,6 +28,16 @@ on:
         default: patch
         type: choice
         options: [patch, minor, major]
+      skip_e2e:
+        description:
+          Skip the entire pretest phase (unit/rust plus E2E) and continue
+          directly to create-release + build matrix. Use only when the
+          required pretest signal is already known (e.g. promoting a
+          staging tag whose pretests already ran green) and you need to
+          unblock a production cut.
+        required: false
+        type: boolean
+        default: false
 permissions:
   contents: write
   packages: write
@@ -308,12 +318,14 @@ jobs:
   pretest-tests:
     name: Pretest — unit + rust
     needs: [prepare-build]
+    if: ${{ !inputs.skip_e2e }}
     uses: ./.github/workflows/test-reusable.yml
     with:
       ref: ${{ needs.prepare-build.outputs.build_ref }}
   pretest-e2e:
     name: Pretest — E2E (all OS, full suite)
     needs: [prepare-build]
+    if: ${{ !inputs.skip_e2e }}
     uses: ./.github/workflows/e2e-reusable.yml
     with:
       ref: ${{ needs.prepare-build.outputs.build_ref }}
@@ -330,7 +342,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     needs: [prepare-build, pretest-tests, pretest-e2e]
-    if: needs.pretest-tests.result == 'success' && needs.pretest-e2e.result == 'success'
+    if: >-
+      always()
+      && needs.prepare-build.result == 'success'
+      && (needs.pretest-tests.result == 'success'
+          || (inputs.skip_e2e && needs.pretest-tests.result == 'skipped'))
+      && (needs.pretest-e2e.result == 'success'
+          || (inputs.skip_e2e && needs.pretest-e2e.result == 'skipped'))
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}
       upload_url: ${{ steps.create.outputs.upload_url }}
@@ -390,6 +408,7 @@ jobs:
       with_release_upload: true
       release_id: ${{ needs.create-release.outputs.release_id }}
       build_sidecar: false
+      skip_pretests: ${{ inputs.skip_e2e }}
 
   # =========================================================================
   # Phase 3b: Build & push Docker image (runs parallel with build-desktop).


### PR DESCRIPTION
## Summary

- Adds a `skip_e2e` `workflow_dispatch` input to `release-production.yml` mirroring the existing input on `release-staging.yml`.
- Gates the `pretest-tests` and `pretest-e2e` jobs on `!inputs.skip_e2e`.
- Relaxes the `create-release` job guard to accept pretest `success` OR (`skip_e2e` && `skipped`).
- Propagates `skip_pretests` to the reusable `build-desktop.yml` so the bypass is logged in the build run.

## Problem

`release-production.yml` always runs the full pretest matrix (unit/rust + E2E across all three OSes) before `create-release`. When promoting a staging tag whose pretests already ran green, this re-runs an expensive matrix unnecessarily, and there is no escape hatch to unblock a production cut when the signal is already known.

`release-staging.yml` already supports this via a `skip_e2e` input — production should match.

## Solution

Mirror staging's `skip_e2e` design verbatim:
- Add the `skip_e2e` `workflow_dispatch` input (boolean, default `false`).
- Gate `pretest-tests` / `pretest-e2e` on `!inputs.skip_e2e`.
- Update `create-release.if` to allow either pretest `success` or (`skip_e2e` && `skipped`).
- Pass `skip_pretests: ${{ inputs.skip_e2e }}` to `build-desktop` so the bypass is metadata-logged in the build run.

The `cleanup-failed-release` condition is intentionally untouched — skipped pretests are neither `failure` nor `cancelled`, so the failure-cleanup branch naturally won't fire on the skip path.

## Submission Checklist

- [x] N/A: workflow-only change, no application code under test
- [x] N/A: workflow-only change, no application code on the diff coverage gate
- [x] N/A: behaviour-only change
- [x] N/A: workflow-only change, no feature IDs affected
- [x] N/A: workflow-only change, no runtime dependencies introduced
- [x] N/A: does not touch a release-cut surface tracked by the manual smoke checklist (control-plane CI input only)
- [x] N/A: no linked issue

## Impact

- CI/release pipeline only. No runtime/desktop/CLI impact.
- Operator-facing: a new optional input on the `Release Production` workflow dispatch UI. Default behaviour (run pretests) is unchanged.
- Safety: when `skip_e2e=true`, the production cut proceeds without the pretest gate — operators must already have a green pretest signal (e.g. a `v*-staging` tag).

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: chore/release-prod-skip-e2e
- Commit SHA: b2bc8349

### Validation Run
- [x] N/A: workflow-only change, no frontend formatter delta
- [x] N/A: workflow-only change, no TS surface touched
- [x] N/A: Focused tests — workflow-only change
- [x] N/A: Rust fmt/check — no Rust touched
- [x] N/A: Tauri fmt/check — no Tauri touched

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: Allow operators to skip the pretest phase of `release-production.yml` via a new `skip_e2e` workflow_dispatch input.
- User-visible effect: New optional input on the Release Production workflow dispatch form; default `false` preserves current behaviour.

### Parity Contract
- Legacy behavior preserved: Default `skip_e2e=false` keeps the existing pretest gate active and the `create-release` predicate strictly equivalent.
- Guard/fallback/dispatch parity checks: `create-release` now accepts pretest `success` OR (`skip_e2e` && `skipped`); mirrors `release-staging.yml` exactly.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A