### PR TITLE
fix(ci): preserve build jobs in release-production when skip_e2e

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -390,7 +390,14 @@ jobs:
   build-desktop:
     name: Build desktop matrix
     needs: [prepare-build, create-release]
-    if: needs.create-release.result == 'success'
+    # `always()` is load-bearing: when `skip_e2e=true` the pretest jobs are
+    # `skipped`, and GitHub propagates that skipped status transitively to any
+    # downstream job lacking an explicit status function — even though we only
+    # `needs` create-release here, the build would otherwise be skipped along
+    # with the pretests. Same pattern below for build-cli-linux / build-docker /
+    # publish-updater-manifest / publish-release / tag-docker-latest /
+    # record-sentry-deploy. See release-staging.yml for the working precedent.
+    if: always() && needs.create-release.result == 'success'
     uses: ./.github/workflows/build-desktop.yml
     secrets: inherit
     with:
@@ -436,7 +443,7 @@ jobs:
   build-docker:
     name: "Docker: build and push"
     needs: [prepare-build, create-release]
-    if: needs.create-release.result == 'success'
+    if: always() && needs.create-release.result == 'success'
     runs-on: ubuntu-latest
     environment: Production
     env:
@@ -507,7 +514,7 @@ jobs:
   build-cli-linux:
     name: "CLI: ${{ matrix.target }}"
     needs: [prepare-build, create-release]
-    if: needs.create-release.result == 'success'
+    if: always() && needs.create-release.result == 'success'
     environment: Production
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -576,7 +583,7 @@ jobs:
   publish-updater-manifest:
     name: Publish updater manifest (latest.json)
     needs: [prepare-build, create-release, build-desktop]
-    if: needs.build-desktop.result == 'success'
+    if: always() && needs.build-desktop.result == 'success'
     runs-on: ubuntu-latest
     environment: Production
     steps:
@@ -609,7 +616,8 @@ jobs:
       - build-docker
       - publish-updater-manifest
     if: >-
-      needs.build-desktop.result == 'success'
+      always()
+      && needs.build-desktop.result == 'success'
       && needs.build-cli-linux.result == 'success'
       && needs.build-docker.result == 'success'
       && needs.publish-updater-manifest.result == 'success'
@@ -708,7 +716,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     needs: [prepare-build, publish-release]
-    if: needs.publish-release.result == 'success'
+    if: always() && needs.publish-release.result == 'success'
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: tinyhumansai/openhuman-core
@@ -744,6 +752,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     needs: [prepare-build, publish-release]
+    if: always() && needs.publish-release.result == 'success'
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SENTRY_URL: ${{ vars.SENTRY_URL }}


### PR DESCRIPTION
## Summary

- Follow-up to #2174. When `skip_e2e=true` on the Release Production workflow, the pretest jobs are skipped — and GitHub Actions then transitively cascades that `skipped` status to every downstream job whose `if:` lacks an explicit status function, even those that only `needs: [prepare-build, create-release]`.
- Result observed in [run 26079423305](https://github.com/tinyhumansai/openhuman/actions/runs/26079423305): `create-release` ran (it had `always()`) and pushed the `v0.53.52` tag + commit, but the entire build matrix (desktop / cli / docker / updater / publish-release / sentry / docker-latest) silently skipped, leaving a broken release attempt with no artifacts.
- Adds `always() && needs.<X>.result == 'success'` to every downstream job, matching the proven pattern from `release-staging.yml`.

## Problem

The `release-production.yml` `skip_e2e` path opened in #2174 looked correct in isolation: pretests are gated on `!inputs.skip_e2e`, and `create-release` was relaxed to accept pretest `success` OR (`skip_e2e` && `skipped`). That part worked.

But GitHub Actions has a documented behavior where a job's default success-check propagates *transitively* — a job with `if: needs.create-release.result == 'success'` is still treated as skipped if any job upstream of `create-release` (i.e. the pretests) was skipped, even though it doesn't `needs:` them directly. The only escape hatch is an explicit `always()` (or `success()`/`failure()`/`cancelled()`) in the `if:`.

The staging workflow already uses `always() && …` everywhere for exactly this reason; production was missing it.

Concrete consequence in production run 26079423305:
- `Prepare build context` ✓
- `Create GitHub release` ✓ (tag `v0.53.52` pushed, draft release created)
- All build jobs: SKIPPED
- `cleanup-failed-release` also did not fire — its condition only catches `failure`/`cancelled`, not `skipped` — so the orphan tag and draft release survived.

## Solution

Gate every job downstream of `create-release` on `always() && needs.<X>.result == 'success'`:

- `build-desktop`
- `build-cli-linux`
- `build-docker`
- `publish-updater-manifest`
- `publish-release`
- `tag-docker-latest`
- `record-sentry-deploy`

This matches `release-staging.yml`'s `always()` usage for `build-desktop` / `build-docker` / `record-sentry-deploy` and ensures the transitive-skipped propagation no longer cancels the build matrix when `skip_e2e=true`.

`cleanup-failed-release` is untouched — its existing condition is the right shape for the `failure`/`cancelled` paths, and a future patch could add a `skipped`-aware branch separately if desired.

## Submission Checklist

- [x] N/A: workflow-only change, no application code under test
- [x] N/A: workflow-only change, no application code on the diff coverage gate
- [x] N/A: behaviour-only change
- [x] N/A: workflow-only change, no feature IDs affected
- [x] N/A: workflow-only change, no runtime dependencies introduced
- [x] N/A: does not touch a release-cut surface tracked by the manual smoke checklist (control-plane CI input only)
- [x] N/A: no linked issue

## Impact

- CI/release pipeline only. No runtime/desktop/CLI impact.
- Fixes the `skip_e2e=true` path of the Release Production workflow so the build matrix actually runs and the draft release receives artifacts before `publish-release` flips it out of draft.
- No change to the default `skip_e2e=false` path — `always()` plus the explicit `success` check is equivalent to the previous behavior when no upstream is skipped.

## Related

- Closes:
- Follow-up PR(s)/TODOs: orphan `v0.53.52` commit on `main` and any leftover draft release/tag from run 26079423305 need manual cleanup (out of scope for this PR).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/release-prod-skip-e2e-cascade
- Commit SHA: de6449f9

### Validation Run
- [x] N/A: workflow-only change, no frontend formatter delta
- [x] N/A: workflow-only change, no TS surface touched
- [x] N/A: Focused tests — workflow-only change
- [x] N/A: Rust fmt/check — no Rust touched
- [x] N/A: Tauri fmt/check — no Tauri touched

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: when `skip_e2e=true` on Release Production, the build matrix actually runs instead of being transitively cascade-skipped by the skipped pretest jobs.
- User-visible effect: Release Production with `skip_e2e=true` now produces a complete release (desktop installers, CLI tarballs, Docker image, updater manifest, published GitHub Release) instead of just an orphan draft.

### Parity Contract
- Legacy behavior preserved: with `skip_e2e=false`, every downstream job's `if:` still evaluates the same way — `always() && needs.<X>.result == 'success'` is equivalent to the previous implicit `success()` when no upstream is skipped.
- Guard/fallback/dispatch parity checks: mirrors the `always() && …` usage in `release-staging.yml` (build-desktop, build-docker, record-sentry-deploy).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved production release workflow robustness to ensure critical build and deployment jobs execute reliably during releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->