### PR TITLE
test(observability): pin SESSION_EXPIRED wire-shape regression tests (#SG)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1662,6 +1662,35 @@ mod tests {
         );
     }
 
+    /// The two sibling `SESSION_EXPIRED:` bail sites in
+    /// `providers::factory::verify_session_active` emit different message
+    /// suffixes but the same sentinel prefix. They route through the same
+    /// classifier as the run_single bail at
+    /// `providers::openhuman_backend::resolve_bearer`, and any matcher
+    /// tweak that breaks the family (e.g. moving from `contains` to a
+    /// stricter prefix/suffix match) would re-leak ALL of them. Pin every
+    /// variant the codebase actually emits so a future regression on the
+    /// matcher is caught for the whole family, not just the SG instance.
+    #[test]
+    fn session_expired_sibling_family_factory_strings_match() {
+        // src/openhuman/inference/provider/factory.rs:247
+        // (verify_session_active — scheduler_gate signed-out path)
+        let custom_providers_variant =
+            "SESSION_EXPIRED: backend session not active — sign in to use custom providers";
+        // src/openhuman/inference/provider/factory.rs:266
+        // (verify_session_active — empty auth-profile JWT path)
+        let no_backend_session_variant =
+            "SESSION_EXPIRED: no backend session — sign in to use OpenHuman";
+
+        for raw in [custom_providers_variant, no_backend_session_variant] {
+            assert_eq!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::SessionExpired),
+                "factory.rs sibling sentinel must classify as SessionExpired: {raw}"
+            );
+        }
+    }
+
     #[test]
     fn does_not_classify_byo_key_provider_401_as_session_expired() {
         // Critical: a BYO-key 401 from OpenAI / Anthropic etc. is an

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1643,6 +1643,25 @@ mod tests {
         }
     }
 
+    /// OPENHUMAN-TAURI-SG (33 events, escalating, release `0.53.43+2b64ea8…`):
+    /// pre-#1763 leak of the `resolve_bearer` sentinel through
+    /// `agent.run_single`. PR #1763 (1fb0bef5) wired the `SessionExpired`
+    /// arm and the existing `classifies_session_expired_messages` test
+    /// covers the same byte string — this test pins the *Sentry-event
+    /// verbatim* shape (taken from the OPENHUMAN-TAURI-SG event payload)
+    /// so a future tweak to `is_session_expired_message` cannot regress
+    /// this exact wire form without a red test.
+    #[test]
+    fn session_expired_sg_wire_shape_matches() {
+        let msg = "SESSION_EXPIRED: backend session not active — sign in to resume LLM work";
+        assert_eq!(
+            expected_error_kind(msg),
+            Some(ExpectedErrorKind::SessionExpired),
+            "OPENHUMAN-TAURI-SG wire shape must classify as SessionExpired — \
+             a regression here re-leaks 33+ events/cycle to Sentry"
+        );
+    }
+
     #[test]
     fn does_not_classify_byo_key_provider_401_as_session_expired() {
         // Critical: a BYO-key 401 from OpenAI / Anthropic etc. is an


### PR DESCRIPTION
## Summary

- Add two regression tests pinning the SESSION_EXPIRED classifier coverage for `OPENHUMAN-TAURI-SG`'s verbatim wire shape and the two sibling bail variants in `providers::factory::verify_session_active`.
- No production-code change. The agent-layer fix that closes SG already shipped in PR #1763 (1fb0bef5); these tests stop a future matcher tweak from re-opening the leak.

## Problem

`OPENHUMAN-TAURI-SG` (33 events, escalating, all on release `0.53.43+2b64ea8…`) leaked the `SESSION_EXPIRED: backend session not active — sign in to resume LLM work` sentinel — raised at `src/openhuman/inference/provider/openhuman_backend.rs:55` (`resolve_bearer`) — through `agent.run_single` (`src/openhuman/agent/harness/session/runtime.rs:528`) before PR #1763 wired the `ExpectedErrorKind::SessionExpired` arm in `src/core/observability.rs`. Lane C's KICKOFF Step 1 diagnostic test confirmed the post-#1763 classifier already matches the SG byte string verbatim; the existing `classifies_session_expired_messages` test (`src/core/observability.rs:1594`) covers the same string but does not anchor it to the Sentry-event payload as a pinned regression case. Lane C Step 2A grep across `agent/`, `cron/`, `scheduler_gate/`, `inference/` found no direct `report_error!` / `capture_message` bypass — every `SESSION_EXPIRED` emitter routes through `report_error_or_expected` on `main`. The 33 events are pre-fix-release noise on `0.53.43` (does not contain `1fb0bef5`) and will phase out as staging/production binaries roll past `v0.53.48-staging+` (which does contain the fix).

Two sibling sentinel sites at `src/openhuman/inference/provider/factory.rs:247` and `:266` (`verify_session_active`) emit related but distinct `SESSION_EXPIRED:` messages. They share the `is_session_expired_message` `msg.contains("SESSION_EXPIRED")` branch with the SG sentinel — a single matcher tweak (e.g. tightening from `contains` to a prefix/suffix anchor) would silently re-leak all three. None of the three sibling strings had its own pinned test before this PR.

## Solution

Two new tests in `src/core/observability::tests`, kept tight and family-scoped:

- `session_expired_sg_wire_shape_matches` — single-case test asserting the exact byte string lifted from the `OPENHUMAN-TAURI-SG` Sentry-event payload classifies as `ExpectedErrorKind::SessionExpired`. Anchored to the Sentry payload so a future matcher tweak can't regress this specific wire form without a red test (and an explicit message linking the regression cost: "re-leaks 33+ events/cycle to Sentry").
- `session_expired_sibling_family_factory_strings_match` — pins both `factory.rs:247` and `factory.rs:266` variants. Same arm, different suffix bytes — any matcher narrowing that catches one but misses another would surface here.

No change to `is_session_expired_message`, `expected_error_kind`, or any caller. Scope deliberately narrow per KICKOFF: do not generalize the matcher beyond what is needed (per #1719 CR — broadening risks BYO-key 401 false-positives).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — two new `#[test]` fns pinning three distinct verbatim wire strings; existing `does_not_classify_byo_key_provider_401_as_session_expired` and `does_not_classify_unrelated_messages_as_session_expired` cover the negative path.
- [x] N/A: **Diff coverage ≥ 80%** — diff is test-only (`+48` lines, all inside `#[cfg(test)] mod tests`); diff-cover treats new test code as covered-by-itself.
- [x] N/A: Coverage matrix updated — no feature row added/removed/renamed; this PR only adds regression assertions over an already-shipped fix (PR #1763).
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — see prior item; no matrix delta.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure in-process classifier assertions, no I/O.
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces — test-only; no user-visible surface changed.
- [x] N/A: Linked issue closed via `Closes #NNN` in the `## Related` section — Sentry-only PR (no GH issue), mirrors PRs #1719 / #1798 / #1795. Sentry ID closed via `Closes OPENHUMAN-TAURI-SG` under `## Related`.

## Impact

- Runtime/platform: none — `#[cfg(test)]` only, no binary diff in `openhuman-core` or `app/src-tauri`.
- Performance: none.
- Security / migration / compatibility: none. The matcher rule itself is unchanged.
- Pre-existing repo clippy state (e.g. `clippy::useless_vec`, `clippy::field_reassign_with_default`, `clippy::duplicate_mod`) is unrelated to this PR and predates the branch tip — flagged on `upstream/main` directly.

## Related

Closes OPENHUMAN-TAURI-SG

Sentry-Issue: OPENHUMAN-TAURI-SG

Context PRs:
- #1719 — first SESSION_EXPIRED demote (dispatch site)
- #1763 — `SessionExpired` arm at agent layer (the actual fix; this PR adds tests around it)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A — Sentry-only PR, no Linear issue.
- URL: N/A

### Commit & Branch
- Branch: `fix/sentry-session-expired-leak-sg`
- Commit SHA: `5aed9756` (head)

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust-only change, no `app/` files touched.
- [x] N/A: `pnpm typecheck` — Rust-only change.
- [x] Focused tests: `cargo test --lib core::observability::tests` (57 passed, 0 failed) and `cargo test --lib core::observability::tests::session_expired` (both new tests green).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check` clean.
- [x] N/A: Tauri fmt/check (if changed) — no `app/src-tauri/` change.

### Validation Blocked
- `command:` `cargo clippy --lib --tests -- -D warnings`
- `error:` 501 pre-existing clippy errors across unrelated files (e.g. `src/openhuman/tokenjuice/text/process.rs` `clippy::useless_vec`, `src/openhuman/inference/provider/compatible_dump.rs` `clippy::duplicate_mod`, `src/core/observability.rs:2193,2199` `clippy::field_reassign_with_default`). None introduced by this branch; all reproduce on `upstream/main` (7741c581).
- `impact:` none — added test code is clippy-clean.

### Behavior Changes
- Intended behavior change: none — test-only PR.
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: yes — no production code touched.
- Guard/fallback/dispatch parity checks: existing positive and negative SessionExpired tests continue to pass (BYO-key 401 still classified `None`, unrelated 401 / 500 still classified `None`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for session expiration message classification, adding tests to verify proper handling of session-expired message variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->