### PR TITLE
Fix/embeddings OpenAI expected error reporting

### DIFF
--- a/src/openhuman/embeddings/openai.rs
+++ b/src/openhuman/embeddings/openai.rs
@@ -129,7 +129,11 @@ impl EmbeddingProvider for OpenAiEmbedding {
                 "[openai] embed error: status={status}, body={text}"
             );
             let message = format!("Embedding API error {status}: {text}");
-            crate::core::observability::report_error(
+            // Route through the expected-error classifier so user-state
+            // conditions (budget exhausted / insufficient credits, missing
+            // API key, transient upstream HTTP) are demoted to info/warn
+            // breadcrumbs instead of spawning Sentry error events. 
+            crate::core::observability::report_error_or_expected(
                 message.as_str(),
                 "embeddings",
                 "openai_embed",

--- a/src/openhuman/embeddings/openai.rs
+++ b/src/openhuman/embeddings/openai.rs
@@ -132,7 +132,7 @@ impl EmbeddingProvider for OpenAiEmbedding {
             // Route through the expected-error classifier so user-state
             // conditions (budget exhausted / insufficient credits, missing
             // API key, transient upstream HTTP) are demoted to info/warn
-            // breadcrumbs instead of spawning Sentry error events. 
+            // breadcrumbs instead of spawning Sentry error events.
             crate::core::observability::report_error_or_expected(
                 message.as_str(),
                 "embeddings",

--- a/src/openhuman/embeddings/openai_tests.rs
+++ b/src/openhuman/embeddings/openai_tests.rs
@@ -225,6 +225,32 @@ async fn embed_server_error() {
 }
 
 #[tokio::test]
+async fn embed_budget_exhausted_400_still_errors() {
+    // OPENHUMAN-TAURI-JM: the backend returns HTTP 400 with a budget-exhausted
+    // body when the user is out of credits. The provider must still surface
+    // an `Err` to the caller (so the calling pipeline can short-circuit), but
+    // the diagnostic emit site must route through `report_error_or_expected`
+    // so the message is classified as `BudgetExhausted` and demoted rather
+    // than spawning a Sentry error event for every embed call.
+    let app = Router::new().route(
+        "/v1/embeddings",
+        post(|| async {
+            (
+                StatusCode::BAD_REQUEST,
+                r#"{"success":false,"error":"Budget exceeded — add credits to continue"}"#,
+            )
+        }),
+    );
+    let url = start_mock(app).await;
+    let p = OpenAiEmbedding::new(&url, "k", "m", 1);
+
+    let err = p.embed(&["hi"]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("400"), "status: {msg}");
+    assert!(msg.contains("Budget exceeded"), "body: {msg}");
+}
+
+#[tokio::test]
 async fn embed_missing_data_field() {
     let app = Router::new().route(
         "/v1/embeddings",


### PR DESCRIPTION
## Summary

- Demote the budget-exhausted HTTP 400 response from the OpenAI-compatible embedding provider to a breadcrumb at the call site instead of unconditionally emitting a Sentry error event.
- Route openai_embed non-2xx reports through report_error_or_expected so the existing ExpectedErrorKind::BudgetExhausted classifier runs at emit time.
- Caller behavior unchanged: the provider still returns Err so the embedding pipeline short-circuits exactly as before; only the Sentry signal changes.
- Add a regression test that exercises the budget-exhausted 400 path end-to-end through a mocked /v1/embeddings endpoint.

## Problem

OPENHUMAN-TAURI-JM — 136 events on openhuman@0.53.43+2b64ea8ac567 with the message:

Embedding API error 400 Bad Request: {"success":false,"error":"Budget exceeded — add credits to continue"}

This is a deterministic user-state condition (the user is out of credits) that the UI already surfaces as an actionable toast — Sentry has no remediation path, and one event fires per failed embed call across the entire memory-embedding pipeline. The phrasing was already recognized by is_budget_exhausted_message and bucketed as ExpectedErrorKind::BudgetExhausted, and PR #1633 added the is_budget_event before_send filter as defense-in-depth — but:

- The embedding call site at ../src/openhuman/embeddings/openai.rs called report_error directly (skipping the classifier), so the Sentry event was still synthesized before being dropped at before_send.
- Pre-#1633 releases (v0.53.43, which is what every event on this issue is tagged with) have no before_send filter at all, so the events flowed straight to Sentry.
- Other embedding/inference call sites already use report_error_or_expected; this one was an outlier.

## Solution

src/openhuman/embeddings/openai.rs — Switch the non-2xx diagnostic emit from report_error → report_error_or_expected. The classifier inspects the formatted message, matches the budget-exhausted phrase ("budget exceeded", "add credits", "insufficient balance"), and demotes to tracing::info! with kind = "budget" — no Sentry event is created. Other expected variants (API-key-missing, transient upstream HTTP, network-unreachable) are handled by the same classifier as a free bonus.

src/openhuman/embeddings/openai_tests.rs — Add embed_budget_exhausted_400_still_errors, which spins up a mock returning HTTP 400 with the canonical backend body and asserts the propagated error preserves both the status code and the "Budget exceeded" phrase so upstream short-circuit logic can still pattern-match on it.

## Design notes

- Kept the change scoped to the openai-compatible provider; ollama.rs was deliberately left alone because Ollama runs locally and does not proxy through the OpenHuman billing backend, so it cannot produce a budget-exhausted body.
- The fix is intentionally at the call site rather than expanding the before_send filter — emitting then dropping is wasteful (event allocation, scope tagging, sentry hub work) and the demotion path is the documented pattern for every other expected-error site in the codebase.

## Submission Checklist

If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.

- done Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — new embed_budget_exhausted_400_still_errors exercises the budget-exhausted 400 failure path; existing embed_server_error covers the generic non-2xx fallthrough.
- not done Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by ../.github/workflows/coverage.yml. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.
- done Coverage matrix updated — N/A: behaviour-only change (no user-visible feature row added/removed/renamed; the observability classification is internal-only).
- done All affected feature IDs from the matrix are listed in the PR description under ## Related — N/A: no feature row impact, see above.
- done No new external network dependencies introduced (mock backend used per Testing Strategy) — new test uses the existing in-process axum::Router mock pattern shared by every other test in this file.
- done Manual smoke checklist updated if this touches release-cut surfaces (../docs/RELEASE-MANUAL-SMOKE.md) — N/A: observability-only change, no user-visible surface.
- not done Linked issue closed via Closes #NNN in the ## Related section — see ## Related below.

## Impact

- Platform: Desktop only (the only host that links openhuman-core and emits to the openhuman-tauri Sentry project). No frontend, mobile, web, or CLI behavior change.
- Runtime: Negligible — one extra string-match pass over the formatted error message before the Sentry capture decision. Hot path is unchanged on the success branch.
- User-visible: None. The provider still returns Err with the same message; the embed pipeline short-circuits identically. UI continues to render the existing budget-exhausted toast.
- Sentry signal: OPENHUMAN-TAURI-JM should stop accruing new events on builds containing this fix (combined with the v0.53.44+ before_send filter, current v0.53.43 deployments will tail off as users update).
- Security / migration / compatibility: None. No schema, RPC, persistence, or wire-format change.

## Related

- Closes: [OPENHUMAN-TAURI-JM](https://tinyhumans.sentry.io/issues/7482816929/?environment=development&environment=production&environment=staging&project=4511287579836416&query=is%3Aunresolved%20assigned%3Anone&referrer=issue-stream&sort=freq)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OpenAI embedding API responses, properly distinguishing between expected user-state conditions and unexpected errors in observability reporting.

* **Tests**
  * Added test coverage for budget exhaustion scenarios in embeddings API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->