### PR TITLE
fix(composio): request Gmail read scope for triggers

### DIFF
--- a/app/test/e2e/specs/composio-triggers-flow.spec.ts
+++ b/app/test/e2e/specs/composio-triggers-flow.spec.ts
@@ -25,8 +25,18 @@ import {
   waitForWebView,
   waitForWindowVisible,
 } from '../helpers/element-helpers';
-import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
-import { clearRequestLog, setMockBehavior, startMockServer, stopMockServer } from '../mock-server';
+import {
+  completeOnboardingIfVisible,
+  navigateToSkills,
+  waitForRequest,
+} from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  setMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
 
 const LOG = '[ComposioTriggersE2E]';
 
@@ -77,6 +87,30 @@ describe('Composio trigger toggles (UI + core RPC)', () => {
     const slugs = triggers.map((t: any) => t.slug);
     expect(slugs).toContain('GMAIL_NEW_GMAIL_MESSAGE');
     expect(slugs).toContain('SLACK_NEW_MESSAGE');
+  });
+
+  it('authorize sends Gmail read scope before Gmail trigger setup', async () => {
+    clearRequestLog();
+
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: 'gmail' });
+    expect(out.ok).toBe(true);
+
+    const authorizeReq = await waitForRequest(
+      getRequestLog,
+      'POST',
+      '/agent-integrations/composio/authorize',
+      10_000
+    );
+    if (!authorizeReq) {
+      throw new Error(
+        `Missing /agent-integrations/composio/authorize request.\n` +
+          `Request log:\n${JSON.stringify(getRequestLog(), null, 2)}`
+      );
+    }
+
+    const body = JSON.parse(authorizeReq?.body || '{}');
+    expect(body.toolkit).toBe('gmail');
+    expect(body.oauth_scopes).toContain('https://www.googleapis.com/auth/gmail.readonly');
   });
 
   it('list_triggers starts empty for the seeded user', async () => {

--- a/docs/TEST-COVERAGE-MATRIX.md
+++ b/docs/TEST-COVERAGE-MATRIX.md
@@ -336,7 +336,7 @@ Canonical mapping of every product feature to its test source(s). Drives gap-fil
 | ID     | Feature                               | Layer | Test path(s)                                              | Status | Notes                             |
 | ------ | ------------------------------------- | ----- | --------------------------------------------------------- | ------ | --------------------------------- |
 | 10.2.1 | OAuth / API Token Handling            | WD    | `skill-oauth.spec.ts`                                     | ✅     |                                   |
-| 10.2.2 | Scope Selection (Read/Write/Initiate) | WD    | `gmail-flow.spec.ts`, `skill-oauth.spec.ts`               | 🟡     | Multi-scope matrix not exhaustive |
+| 10.2.2 | Scope Selection (Read/Write/Initiate) | WD    | `gmail-flow.spec.ts`, `skill-oauth.spec.ts`, `composio-triggers-flow.spec.ts` | 🟡     | Multi-scope matrix not exhaustive; Gmail trigger OAuth read scope covered |
 | 10.2.3 | Token Storage & Encryption            | RU    | `src/openhuman/encryption/`, `src/openhuman/credentials/` | ✅     |                                   |
 
 ### 10.3 Message Sync & Ingestion

--- a/gitbooks/features/integrations/triggers.md
+++ b/gitbooks/features/integrations/triggers.md
@@ -27,6 +27,12 @@ A trigger is an external event published by an integration you've connected. Com
 
 The full set comes from the [Composio](https://composio.dev) connector layer that powers [third-party integrations](README.md). When a connection is active, the relevant trigger subscriptions are wired up automatically.
 
+### Gmail OAuth scopes
+
+Gmail trigger subscriptions require message-read access on the connected Google account. Fresh OpenHuman Gmail authorizations request `https://www.googleapis.com/auth/gmail.readonly` so `GMAIL_NEW_GMAIL_MESSAGE` can be enabled and the native Gmail sync path can read the new message metadata.
+
+If an older Gmail connection was created before this scope was requested, reconnect Gmail from Settings before enabling Gmail triggers.
+
 ## Where triggers come from, end to end
 
 ```

--- a/scripts/mock-api/routes/integrations.mjs
+++ b/scripts/mock-api/routes/integrations.mjs
@@ -156,6 +156,29 @@ export function handleIntegrations(ctx) {
   }
 
   if (
+    method === "POST" &&
+    /^\/agent-integrations\/composio\/authorize\/?$/.test(url)
+  ) {
+    const toolkit =
+      typeof parsedBody?.toolkit === "string" ? parsedBody.toolkit.trim() : "";
+    if (!toolkit) {
+      json(res, 400, {
+        success: false,
+        error: "Missing required field: toolkit",
+      });
+      return true;
+    }
+    json(res, 200, {
+      success: true,
+      data: {
+        connectUrl: `https://composio.example/${toolkit}/consent`,
+        connectionId: `conn-${toolkit}-pending`,
+      },
+    });
+    return true;
+  }
+
+  if (
     method === "GET" &&
     /^\/agent-integrations\/composio\/triggers\/available(\?.*)?$/.test(url)
   ) {

--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::openhuman::integrations::IntegrationClient;
 
@@ -30,6 +30,8 @@ const POST_OAUTH_ACTION_RETRY_DELAY: Duration = Duration::from_secs(10);
 /// trailing punctuation or wrapper text from the gateway does not silently
 /// disable the retry.
 const POST_OAUTH_AUTH_ERROR_STRINGS: &[&str] = &["connection error, try to authenticate"];
+const AUTHORIZE_OAUTH_SCOPES_FIELD: &str = "oauth_scopes";
+const GMAIL_REQUIRED_OAUTH_SCOPES: &[&str] = &["https://www.googleapis.com/auth/gmail.readonly"];
 
 /// High-level client for all backend-proxied Composio operations.
 #[derive(Clone)]
@@ -106,6 +108,7 @@ impl ComposioClient {
                 obj.insert(k.clone(), v.clone());
             }
         }
+        merge_required_oauth_scopes(&mut body, toolkit)?;
         self.inner
             .post::<ComposioAuthorizeResponse>("/agent-integrations/composio/authorize", &body)
             .await
@@ -516,6 +519,75 @@ fn is_post_oauth_auth_readiness_error(resp: &ComposioExecuteResponse) -> bool {
     POST_OAUTH_AUTH_ERROR_STRINGS
         .iter()
         .any(|needle| normalized.contains(needle))
+}
+
+fn required_oauth_scopes_for_toolkit(toolkit: &str) -> &'static [&'static str] {
+    match toolkit.trim().to_ascii_lowercase().as_str() {
+        // GMAIL_NEW_GMAIL_MESSAGE and the native Gmail sync path need read access
+        // to messages. Without this hint fresh OAuth handoffs can complete with a
+        // profile-only Google token and trigger enable fails with 403 insufficient
+        // authentication scopes (#2186).
+        "gmail" => GMAIL_REQUIRED_OAUTH_SCOPES,
+        _ => &[],
+    }
+}
+
+fn merge_required_oauth_scopes(body: &mut Value, toolkit: &str) -> anyhow::Result<()> {
+    let required = required_oauth_scopes_for_toolkit(toolkit);
+    if required.is_empty() {
+        return Ok(());
+    }
+
+    let obj = body
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("composio.authorize: internal payload must be an object"))?;
+    match obj.get_mut(AUTHORIZE_OAUTH_SCOPES_FIELD) {
+        Some(existing) => append_missing_oauth_scopes(existing, required)?,
+        None => {
+            obj.insert(AUTHORIZE_OAUTH_SCOPES_FIELD.to_string(), json!(required));
+        }
+    }
+    Ok(())
+}
+
+fn append_missing_oauth_scopes(value: &mut Value, required: &[&str]) -> anyhow::Result<()> {
+    let mut scopes = match value {
+        Value::Null => Vec::new(),
+        Value::String(raw) => raw
+            .split(|ch: char| ch == ',' || ch.is_whitespace())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect(),
+        Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len() + required.len());
+            for item in items {
+                let Some(scope) = item.as_str() else {
+                    anyhow::bail!(
+                        "composio.authorize: {AUTHORIZE_OAUTH_SCOPES_FIELD} entries must be strings"
+                    );
+                };
+                let scope = scope.trim();
+                if !scope.is_empty() {
+                    out.push(scope.to_string());
+                }
+            }
+            out
+        }
+        _ => {
+            anyhow::bail!(
+                "composio.authorize: {AUTHORIZE_OAUTH_SCOPES_FIELD} must be a string or array"
+            );
+        }
+    };
+
+    for scope in required {
+        if !scopes.iter().any(|existing| existing == scope) {
+            scopes.push((*scope).to_string());
+        }
+    }
+    *value = json!(scopes);
+    Ok(())
 }
 
 /// Backend-mode [`ComposioClient`] constructor. **Internal to the

--- a/src/openhuman/composio/client_tests.rs
+++ b/src/openhuman/composio/client_tests.rs
@@ -213,25 +213,66 @@ async fn list_connections_parses_connection_array() {
 
 #[tokio::test]
 async fn authorize_posts_toolkit_and_returns_connect_url() {
+    let app =
+        Router::new().route(
+            "/agent-integrations/composio/authorize",
+            post(|Json(body): Json<Value>| async move {
+                // Echo toolkit back so we know our POST body made it.
+                let tk = body["toolkit"].as_str().unwrap_or("").to_string();
+                let scopes = body["oauth_scopes"]
+                    .as_array()
+                    .expect("gmail authorize should include oauth_scopes");
+                assert!(scopes.iter().any(|scope| scope.as_str()
+                    == Some("https://www.googleapis.com/auth/gmail.readonly")));
+                Json(json!({
+                    "success": true,
+                    "data": {
+                        "connectUrl": format!("https://composio.example/{tk}/consent"),
+                        "connectionId": "conn-abc"
+                    }
+                }))
+            }),
+        );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client.authorize("gmail", None).await.unwrap();
+    assert!(resp.connect_url.contains("gmail"));
+    assert_eq!(resp.connection_id, "conn-abc");
+}
+
+#[tokio::test]
+async fn authorize_merges_gmail_required_oauth_scopes_with_extra_params() {
     let app = Router::new().route(
         "/agent-integrations/composio/authorize",
         post(|Json(body): Json<Value>| async move {
-            // Echo toolkit back so we know our POST body made it.
-            let tk = body["toolkit"].as_str().unwrap_or("").to_string();
+            assert_eq!(body["toolkit"].as_str(), Some("gmail"));
+            assert_eq!(body["prompt"].as_str(), Some("consent"));
+            let scopes: Vec<&str> = body["oauth_scopes"]
+                .as_array()
+                .expect("oauth_scopes should be an array")
+                .iter()
+                .map(|item| item.as_str().expect("scope should be a string"))
+                .collect();
+            assert!(scopes.contains(&"openid"));
+            assert!(scopes.contains(&"https://www.googleapis.com/auth/gmail.readonly"));
             Json(json!({
                 "success": true,
                 "data": {
-                    "connectUrl": format!("https://composio.example/{tk}/consent"),
-                    "connectionId": "conn-abc"
+                    "connectUrl": "https://composio.example/gmail/consent",
+                    "connectionId": "conn-gmail"
                 }
             }))
         }),
     );
     let base = start_mock_backend(app).await;
     let client = build_client_for(base);
-    let resp = client.authorize("gmail", None).await.unwrap();
+    let extra = serde_json::json!({
+        "prompt": "consent",
+        "oauth_scopes": ["openid"]
+    });
+    let resp = client.authorize("gmail", Some(extra)).await.unwrap();
     assert!(resp.connect_url.contains("gmail"));
-    assert_eq!(resp.connection_id, "conn-abc");
+    assert_eq!(resp.connection_id, "conn-gmail");
 }
 
 #[tokio::test]
@@ -242,6 +283,7 @@ async fn authorize_forwards_extra_params_and_returns_connect_url() {
             // Assert extra_params are forwarded alongside toolkit.
             assert_eq!(body["toolkit"].as_str(), Some("whatsapp"));
             assert_eq!(body["waba_id"].as_str(), Some("waba-123"));
+            assert!(body.get("oauth_scopes").is_none());
             Json(json!({
                 "success": true,
                 "data": {

--- a/src/openhuman/composio/schemas.rs
+++ b/src/openhuman/composio/schemas.rs
@@ -215,7 +215,9 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     ty: TypeSchema::Json,
                     comment: "Optional JSON object of additional auth fields forwarded to Composio \
                               (e.g. {\"waba_id\": \"...\") for toolkits that require them). \
-                              Reserved keys (toolkit, toolkit_version, auth, client_id) are rejected.",
+                              The core may also add toolkit-specific OAuth scope hints such as \
+                              Gmail's oauth_scopes value. Reserved keys (toolkit, toolkit_version, \
+                              auth, client_id) are rejected.",
                     required: false,
                 },
             ],


### PR DESCRIPTION
## Summary

- Adds the Gmail readonly OAuth scope hint to backend-proxied `composio_authorize` requests.
- Merges the required Gmail scope with caller-provided `oauth_scopes` without affecting non-Gmail toolkits.
- Adds focused Rust unit coverage plus WDIO coverage that asserts Gmail authorize sends the read scope before trigger setup.
- Documents the Gmail trigger scope requirement and updates the coverage matrix.

## Problem

- Fresh Gmail OAuth connections can be created without a Gmail message-read scope.
- Enabling `GMAIL_NEW_GMAIL_MESSAGE` then fails with Google's `403 PERMISSION_DENIED: Request had insufficient authentication scopes`.

## Solution

- `ComposioClient::authorize` now augments Gmail authorize payloads with `https://www.googleapis.com/auth/gmail.readonly`.
- Existing `oauth_scopes` extras are normalized and deduped so toolkit-specific params still pass through.
- The mock backend now handles `/agent-integrations/composio/authorize`, validates `toolkit`, and allows the Composio trigger E2E spec to assert the outbound authorize body.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** — CI coverage gate will verify this; local coverage run was blocked by native Rust dependency setup noted below.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces: N/A, scoped OAuth payload behavior and docs only
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop/core Gmail authorization now requests read access needed by Gmail triggers and native Gmail sync metadata reads.
- Existing older Gmail connections still need reconnecting to gain the new scope.
- Non-Gmail toolkit authorize payloads remain unchanged unless the caller already passes `oauth_scopes`.

## Related

- Feature ID: 10.2.2
- Closes: Fixes #2186
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/2186-gmail-scopes-forkbase`
- Commit SHA: `6b54ddd9dfc4bf2e1572a875cff66851eebc7ded`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`: CI gate rerun pending; focused Prettier check run locally via `pnpm dlx prettier@3.8.1 --no-config ... --object-wrap collapse --check app/test/e2e/specs/composio-triggers-flow.spec.ts`.
- [x] `pnpm typecheck`: CI gate rerun pending.
- [x] Focused tests: mock Composio authorize route smoke via Node (`mock composio authorize route ok`, including missing-toolkit 400)
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --all`; `git diff --check`
- [x] Tauri fmt/check (if changed): N/A
- [x] Mergeability: `git merge --no-commit --no-ff origin/main` completed without conflicts, then aborted

### Validation Blocked
- `command:` `cargo test --lib authorize_ -- --nocapture`
- `error:` Windows build is blocked by `whisper-rs-sys`: missing `libclang.dll`; with `WHISPER_DONT_GENERATE_BINDINGS=1`, pre-generated bindings fail with `E0080` layout assertions.
- `impact:` Focused Rust tests could not be run on this Windows host; CI Linux should exercise the added unit coverage.
- `command:` `pnpm --dir app exec prettier --write test/e2e/specs/composio-triggers-flow.spec.ts ../scripts/mock-api/routes/integrations.mjs`
- `error:` local workspace has no `node_modules`, so project-local `prettier` was not available; formatted the touched spec with temporary `pnpm dlx prettier@3.8.1` using matching options.
- `impact:` full repo format/typecheck still relies on CI.

### Behavior Changes
- Intended behavior change: Gmail authorization includes the message-read OAuth scope needed by Gmail trigger enablement.
- User-visible effect: Fresh Gmail reconnects should be able to enable `GMAIL_NEW_GMAIL_MESSAGE` without insufficient-scope failures.

### Parity Contract
- Legacy behavior preserved: WhatsApp and other non-Gmail authorize payloads are unchanged; extra params still pass through.
- Guard/fallback/dispatch parity checks: Added tests for Gmail default scope, Gmail scope merge, non-Gmail no-scope behavior, E2E request body assertion, and mock missing-toolkit rejection.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for #2186 before opening this PR
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gmail trigger subscriptions now ensure required Gmail OAuth scopes are included during authorization (merged with any provided scopes).

* **Documentation**
  * Added guidance on Gmail OAuth scopes for trigger subscriptions and instructions to reconnect existing Gmail connections in Settings.

* **Tests**
  * Expanded end-to-end and unit tests for Gmail trigger authorization and OAuth scope merging/forwarding; mock API behavior updated to simulate Composio authorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->