### PR TITLE
fix(reliable): fail fast on SESSION_EXPIRED in provider retry loop

### DIFF
--- a/src/openhuman/inference/provider/reliable.rs
+++ b/src/openhuman/inference/provider/reliable.rs
@@ -13,6 +13,13 @@ fn is_non_retryable(err: &anyhow::Error) -> bool {
     if is_context_window_exceeded(err) {
         return true;
     }
+    let msg = err.to_string();
+    // Session-expired is a user-auth-state boundary condition, not a
+    // transient provider outage. Retrying just burns attempts and delays
+    // the sign-in prompt.
+    if crate::core::observability::is_session_expired_message(&msg) {
+        return true;
+    }
 
     if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
         if let Some(status) = reqwest_err.status() {
@@ -20,7 +27,6 @@ fn is_non_retryable(err: &anyhow::Error) -> bool {
             return status.is_client_error() && code != 429 && code != 408;
         }
     }
-    let msg = err.to_string();
     for word in msg.split(|c: char| !c.is_ascii_digit()) {
         if let Ok(code) = word.parse::<u16>() {
             if (400..500).contains(&code) {

--- a/src/openhuman/inference/provider/reliable.rs
+++ b/src/openhuman/inference/provider/reliable.rs
@@ -78,6 +78,13 @@ fn is_stream_error_non_retryable(err: &StreamError) -> bool {
             false
         }
         StreamError::Provider(msg) => {
+            // Mirror the non-streaming classifier: session-expired is a
+            // user-auth-state boundary, not a transient provider outage —
+            // fail fast so the streaming caller can prompt sign-in instead
+            // of burning the retry budget.
+            if crate::core::observability::is_session_expired_message(msg) {
+                return true;
+            }
             let lower = msg.to_lowercase();
             lower.contains("invalid api key")
                 || lower.contains("unauthorized")

--- a/src/openhuman/inference/provider/reliable_tests.rs
+++ b/src/openhuman/inference/provider/reliable_tests.rs
@@ -294,6 +294,130 @@ async fn session_expired_aborts_retries() {
     );
 }
 
+/// Streaming-path mock that emits a single configurable `StreamError::Provider`
+/// then ends, and tracks how many times the stream was created (`stream_calls`)
+/// and how many times the consumer polled it (`polls`). The latter is the
+/// signal used by [`session_expired_aborts_retries_streaming`] to prove that
+/// `is_stream_error_non_retryable` broke the retry loop after the first error
+/// instead of polling for further attempts.
+struct StreamingErrorMock {
+    stream_calls: Arc<AtomicUsize>,
+    polls: Arc<AtomicUsize>,
+    error: &'static str,
+}
+
+#[async_trait]
+impl Provider for StreamingErrorMock {
+    async fn chat_with_system(
+        &self,
+        _system_prompt: Option<&str>,
+        _message: &str,
+        _model: &str,
+        _temperature: f64,
+    ) -> anyhow::Result<String> {
+        anyhow::bail!(self.error)
+    }
+
+    async fn chat_with_history(
+        &self,
+        _messages: &[ChatMessage],
+        _model: &str,
+        _temperature: f64,
+    ) -> anyhow::Result<String> {
+        anyhow::bail!(self.error)
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn stream_chat_with_system(
+        &self,
+        _system_prompt: Option<&str>,
+        _message: &str,
+        _model: &str,
+        _temperature: f64,
+        _options: StreamOptions,
+    ) -> futures_util::stream::BoxStream<'static, StreamResult<StreamChunk>> {
+        use futures_util::{stream, StreamExt};
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        let polls = Arc::clone(&self.polls);
+        let error = self.error.to_string();
+        // `unfold` state: `sent` flips to true after the first poll. The
+        // counter bumps on every poll so the test can prove that the retry
+        // loop short-circuited after the first error (polls == 1) rather
+        // than continuing to drain (polls == 2).
+        stream::unfold(false, move |sent| {
+            let polls = Arc::clone(&polls);
+            let error = error.clone();
+            async move {
+                polls.fetch_add(1, Ordering::SeqCst);
+                if sent {
+                    None
+                } else {
+                    Some((Err(StreamError::Provider(error)), true))
+                }
+            }
+        })
+        .boxed()
+    }
+}
+
+#[tokio::test]
+async fn session_expired_aborts_retries_streaming() {
+    use futures_util::StreamExt;
+
+    let stream_calls = Arc::new(AtomicUsize::new(0));
+    let polls = Arc::new(AtomicUsize::new(0));
+    let provider = ReliableProvider::new(
+        vec![(
+            "openhuman".into(),
+            Box::new(StreamingErrorMock {
+                stream_calls: Arc::clone(&stream_calls),
+                polls: Arc::clone(&polls),
+                error: "SESSION_EXPIRED: backend session not active — sign in to resume LLM work",
+            }),
+        )],
+        3,
+        1,
+    );
+
+    let mut stream = provider.stream_chat_with_system(
+        None,
+        "hello",
+        "reasoning-v1",
+        0.0,
+        StreamOptions::new(true),
+    );
+
+    // Drain the consumer-facing stream. ReliableProvider does NOT forward
+    // candidate errors — the consumer only sees a single terminal
+    // "All streaming providers/models failed" once retries are exhausted.
+    let mut terminal: Option<String> = None;
+    while let Some(item) = stream.next().await {
+        if let Err(StreamError::Provider(msg)) = item {
+            terminal = Some(msg);
+        }
+    }
+
+    assert_eq!(
+        stream_calls.load(Ordering::SeqCst),
+        1,
+        "single candidate (one provider, one model) must build exactly one stream"
+    );
+    assert_eq!(
+        polls.load(Ordering::SeqCst),
+        1,
+        "session-expired must abort the streaming retry loop after the first poll; \
+         a second poll means is_stream_error_non_retryable misclassified it"
+    );
+    let terminal = terminal.expect("stream must surface a terminal aggregate error");
+    assert!(
+        terminal.contains("All streaming providers/models failed"),
+        "expected aggregate failure terminal, got: {terminal}"
+    );
+}
+
 #[tokio::test]
 async fn aggregated_error_marks_non_retryable_model_mismatch_with_details() {
     let calls = Arc::new(AtomicUsize::new(0));

--- a/src/openhuman/inference/provider/reliable_tests.rs
+++ b/src/openhuman/inference/provider/reliable_tests.rs
@@ -216,6 +216,9 @@ fn non_retryable_detects_common_patterns() {
     assert!(is_non_retryable(&anyhow::anyhow!(
         "OpenAI Codex stream error: Your input exceeds the context window of this model."
     )));
+    assert!(is_non_retryable(&anyhow::anyhow!(
+        "SESSION_EXPIRED: backend session not active — sign in to resume LLM work"
+    )));
 }
 
 #[tokio::test]
@@ -251,6 +254,44 @@ async fn context_window_error_aborts_retries_and_model_fallbacks() {
     assert!(msg.contains("context window"));
     assert!(msg.contains("skipped"));
     assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn session_expired_aborts_retries() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = ReliableProvider::new(
+        vec![(
+            "openhuman".into(),
+            Box::new(MockProvider {
+                calls: Arc::clone(&calls),
+                fail_until_attempt: usize::MAX,
+                response: "never",
+                error: "SESSION_EXPIRED: backend session not active — sign in to resume LLM work",
+            }),
+        )],
+        3,
+        1,
+    );
+
+    let err = provider
+        .simple_chat("hello", "reasoning-v1", 0.0)
+        .await
+        .expect_err("session-expired should fail fast");
+    let msg = err.to_string();
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "session-expired must skip retry loop"
+    );
+    assert!(
+        msg.contains("non_retryable"),
+        "aggregate should classify SESSION_EXPIRED as non_retryable: {msg}"
+    );
+    assert!(
+        !msg.contains("attempt 2/4"),
+        "aggregate should contain only the first attempt for this provider: {msg}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Treat SESSION_EXPIRED errors as non-retryable in ReliableProvider classification.
- Stop wasting retry budget on auth-state failures that can only be resolved by re-auth/sign-in.
- Reduce noisy aggregate failures like repeated attempt 1/3 ... attempt 3/3 for the same expired-session condition.
- Add regression coverage in reliable_tests.rs to verify session-expired errors short-circuit retries.
- Keep existing retry behavior unchanged for transient upstream failures (429/5xx/timeouts).

## Problem

- The reliable provider layer retried SESSION_EXPIRED as if it were a transient provider/network failure.
- That caused repeated failed attempts with no chance of recovery, slower user feedback, and noisy Sentry events.
- The expected behavior for expired backend session is immediate failure so the app can prompt sign-in/re-auth.

## Solution

- Updated is_non_retryable in src/openhuman/inference/provider/reliable.rs to classify messages matching is_session_expired_message(...) as non-retryable.
- This ensures the retry loop exits after the first failed attempt for expired-session boundaries.

Added tests in src/openhuman/inference/provider/reliable_tests.rs:
- classification test for SESSION_EXPIRED
- end-to-end retry-loop test asserting only one call occurs and aggregate marks non_retryable.

Tradeoff: this relies on canonical session-expired message patterns, but those are already centralized in observability and used across the core.

## Submission Checklist

- Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.
- Coverage matrix updated — added/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md` reflect this change (or N/A: behaviour-only change)
- All affected feature IDs from the matrix are listed in the PR description under ## Related
- No new external network dependencies introduced (mock backend used per Testing Strategy)
- Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`)
- Linked issue closed via Closes #NNN in the ## Related section

## Impact

- Runtime/platform impact: Rust core provider reliability path (desktop app core behavior) only.
- User impact: faster, clearer failure on expired session; fewer redundant retries before sign-in flow is needed.
- Observability impact: reduced noise for this auth-state class; errors are treated as expected non-retryable flow.
- Performance: avoids unnecessary retry delays/work for unrecoverable auth-state failures.
- Security/compatibility: no new permissions, migrations, or external dependencies.

## Related

- Closes: [OPENHUMAN-TAURI-KY](https://tinyhumans.sentry.io/issues/7483016041/?environment=development&environment=production&environment=staging&project=4511287579836416&query=is%3Aunresolved%20assigned%3Anone&referrer=issue-stream&sort=freq)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Session expired" errors are now treated as non-retryable, causing failed requests (both standard and streaming) to abort immediately instead of entering retry/poll loops, improving responsiveness and error clarity.

* **Tests**
  * Added unit and streaming tests to verify immediate abort behavior and proper failure aggregation for session-expired errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->