### PR TITLE
fix(config): guard env overrides during config load

### DIFF
--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -992,7 +992,12 @@ impl Config {
     /// with a [`HashMapEnv`] (see tests) without requiring the
     /// `TEST_ENV_LOCK` or tainting sibling tests.
     pub(crate) fn apply_env_overlay_with<E: EnvLookup + ?Sized>(&mut self, env: &E) {
-        if let Some(model) = env.get_any(&["OPENHUMAN_MODEL", "MODEL"]) {
+        // Only the namespaced `OPENHUMAN_MODEL` is honoured. The bare `MODEL`
+        // env var used to be accepted as an alias but collides with vendor
+        // asset-tag env vars (e.g. Dell OptiPlex sets `MODEL=7080`), which
+        // silently clobbered the LLM model and 400'd every backend call
+        // (Sentry OPENHUMAN-TAURI-J8).
+        if let Some(model) = env.get("OPENHUMAN_MODEL") {
             if !model.is_empty() {
                 self.default_model = Some(model);
             }

--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -998,8 +998,13 @@ impl Config {
         // silently clobbered the LLM model and 400'd every backend call
         // (Sentry OPENHUMAN-TAURI-J8).
         if let Some(model) = env.get("OPENHUMAN_MODEL") {
-            if !model.is_empty() {
-                self.default_model = Some(model);
+            // Trim before checking so `OPENHUMAN_MODEL="   "` (a common
+            // shape from shells that pass through an unset-but-declared
+            // variable) doesn't clobber the configured default with a
+            // non-usable value.
+            let trimmed = model.trim();
+            if !trimmed.is_empty() {
+                self.default_model = Some(trimmed.to_string());
             }
         }
 

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -445,6 +445,18 @@ fn env_overlay_model_only_honours_namespaced_var() {
         cfg.default_model, original,
         "bare MODEL env var must not override default_model"
     );
+
+    // Whitespace-only OPENHUMAN_MODEL must not clobber either. Some
+    // shells/CI runners pass an unset-but-declared env var through as
+    // `"   "`, which `is_empty()` alone wouldn't reject.
+    let env = HashMapEnv::new().with("OPENHUMAN_MODEL", "   ");
+    let mut cfg = Config::default();
+    let original = cfg.default_model.clone();
+    cfg.apply_env_overlay_with(&env);
+    assert_eq!(
+        cfg.default_model, original,
+        "whitespace-only OPENHUMAN_MODEL must not clobber default_model"
+    );
 }
 
 #[test]

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -423,8 +423,9 @@ impl EnvLookup for HashMapEnv {
 }
 
 #[test]
-fn env_overlay_model_prefers_openhuman_over_alias() {
-    // Both set → OPENHUMAN_MODEL wins.
+fn env_overlay_model_only_honours_namespaced_var() {
+    // Both set → OPENHUMAN_MODEL wins; bare MODEL is ignored even when
+    // OPENHUMAN_MODEL is absent.
     let env = HashMapEnv::new()
         .with("OPENHUMAN_MODEL", "specific-v2")
         .with("MODEL", "alias-fallback");
@@ -432,11 +433,18 @@ fn env_overlay_model_prefers_openhuman_over_alias() {
     cfg.apply_env_overlay_with(&env);
     assert_eq!(cfg.default_model.as_deref(), Some("specific-v2"));
 
-    // Only alias set → alias wins.
-    let env = HashMapEnv::new().with("MODEL", "alias-only");
+    // Only bare MODEL set → must NOT clobber default_model. Vendor
+    // asset-tag env vars (e.g. Dell OptiPlex `MODEL=7080`) would otherwise
+    // hijack the LLM model name and 400 every backend call
+    // (Sentry OPENHUMAN-TAURI-J8).
+    let env = HashMapEnv::new().with("MODEL", "7080");
     let mut cfg = Config::default();
+    let original = cfg.default_model.clone();
     cfg.apply_env_overlay_with(&env);
-    assert_eq!(cfg.default_model.as_deref(), Some("alias-only"));
+    assert_eq!(
+        cfg.default_model, original,
+        "bare MODEL env var must not override default_model"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
  - Added guard logic in config loading to apply env overrides only when values are valid and intentional.
  - Prevented empty/invalid env values from clobbering file-based config defaults.
  - Hardened src/openhuman/config/schema/load.rs behavior around override precedence and fallback safety.
  - Expanded src/openhuman/config/schema/load_tests.rs with regression coverage for override edge cases.
  - Reduced risk of silent misconfiguration caused by partial or malformed environment setup.

## Problem
  - Config loading previously allowed risky env override paths where invalid or blank values could override known-good config.
  - This made runtime behavior depend on fragile environment state and could cause hard-to-debug startup/config issues.
  - Reviewers needed a clear, test-backed contract for when env should win vs when loader should keep base config values.

## Solution
  - Added explicit validation/guard checks in the load pipeline before applying env-driven overrides.
  - Kept precedence model intact (env over file) only when env values pass guard conditions.
  - Preserved existing defaults and file values when override inputs are missing/blank/invalid.
  - Added focused tests for:
    - valid override application
    - invalid/empty override rejection
    - fallback to base config behavior
  - Tradeoff: stricter guards may ignore previously accepted-but-bad env inputs, but this is intentional to improve safety and predictability.

## Submission Checklist
  - If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.
  - Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
  - Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.
  - Coverage matrix updated — added/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md` reflect this change (or N/A: behaviour-only change)
  - All affected feature IDs from the matrix are listed in the PR description under ## Related
  - No new external network dependencies introduced (mock backend used per Testing Strategy)
  - Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`)
  - Linked issue closed via Closes #NNN in the ## Related section

## Impact
  - Runtime/platform impact: Rust core config initialization path (desktop core startup/runtime config behavior).
  - Compatibility impact: safer env precedence semantics; invalid override inputs no longer silently override base config.
  - Performance impact: negligible; only lightweight guard checks during config load.
  - Security/reliability impact: lower misconfiguration risk and more deterministic startup behavior.

## Related

- Closes: [OPENHUMAN-TAURI-J8](https://tinyhumans.sentry.io/issues/7482789772/?environment=development&environment=production&environment=staging&project=4511287579836416&query=is%3Aunresolved%20assigned%3Anone&referrer=issue-stream&sort=freq)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable handling tightened: the app now exclusively honors OPENHUMAN_MODEL for overriding the default model (ignores bare MODEL), and ignores whitespace-only OPENHUMAN_MODEL values to avoid accidentally clearing the configured default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->