### PR TITLE
fix(agent): bound cached resume transcript by max_history_messages

### DIFF
--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -295,11 +295,21 @@ impl Agent {
             cached.push(chat);
         }
 
+        let cached_len_before = cached.len();
+        let bounded = self.bound_cached_transcript_messages(cached);
+        if bounded.len() < cached_len_before {
+            log::warn!(
+                "[agent] seed_resume_from_messages — bounded cached transcript {} → {} (max_history_messages={})",
+                cached_len_before,
+                bounded.len(),
+                self.config.max_history_messages
+            );
+        }
         log::info!(
             "[agent] seed_resume_from_messages — primed cached transcript with {} prior messages",
-            cached.len() - 1
+            bounded.len().saturating_sub(1)
         );
-        self.cached_transcript_messages = Some(cached);
+        self.cached_transcript_messages = Some(bounded);
         Ok(())
     }
 

--- a/src/openhuman/agent/harness/session/tests.rs
+++ b/src/openhuman/agent/harness/session/tests.rs
@@ -731,3 +731,50 @@ fn seed_resume_from_messages_preserves_unmatched_trailing_user() {
     assert_eq!(cached[3].role, "user");
     assert_eq!(cached[3].content, "stranded follow-up");
 }
+
+#[test]
+fn seed_resume_from_messages_respects_history_window_bound() {
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    agent.config.max_history_messages = 4;
+    let prior = vec![
+        ("user".to_string(), "u1".to_string()),
+        ("agent".to_string(), "a1".to_string()),
+        ("user".to_string(), "u2".to_string()),
+        ("agent".to_string(), "a2".to_string()),
+        ("user".to_string(), "u3".to_string()),
+        ("agent".to_string(), "a3".to_string()),
+    ];
+    agent
+        .seed_resume_from_messages(prior, "new turn")
+        .expect("seed");
+
+    let cached = agent
+        .cached_transcript_messages
+        .as_ref()
+        .expect("cache populated");
+    // max_history_messages=4 keeps [system + last 3 messages].
+    assert_eq!(cached.len(), 4);
+    assert_eq!(cached[0].role, "system");
+    assert_eq!(cached[1].content, "a2");
+    assert_eq!(cached[2].content, "u3");
+    assert_eq!(cached[3].content, "a3");
+}
+
+#[test]
+fn bound_cached_transcript_messages_without_system_prefix_keeps_tail() {
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    agent.config.max_history_messages = 3;
+
+    let messages = vec![
+        crate::openhuman::inference::provider::ChatMessage::user("u1"),
+        crate::openhuman::inference::provider::ChatMessage::assistant("a1"),
+        crate::openhuman::inference::provider::ChatMessage::user("u2"),
+        crate::openhuman::inference::provider::ChatMessage::assistant("a2"),
+        crate::openhuman::inference::provider::ChatMessage::user("u3"),
+    ];
+    let bounded = agent.bound_cached_transcript_messages(messages);
+    assert_eq!(bounded.len(), 3);
+    assert_eq!(bounded[0].content, "u2");
+    assert_eq!(bounded[1].content, "a2");
+    assert_eq!(bounded[2].content, "u3");
+}

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -1292,6 +1292,37 @@ impl Agent {
         self.history.extend(other_messages);
     }
 
+    /// Bound a resumed transcript prefix to the agent history window.
+    ///
+    /// Resume paths may load a long prior transcript directly into
+    /// `cached_transcript_messages` (provider-ready `ChatMessage`s), which
+    /// bypasses `self.history`-based trimming/reduction. Keep at most
+    /// `max_history_messages` entries while preserving the leading system
+    /// message when present.
+    pub(super) fn bound_cached_transcript_messages(
+        &self,
+        messages: Vec<ChatMessage>,
+    ) -> Vec<ChatMessage> {
+        let max = self.config.max_history_messages.max(1);
+        if messages.len() <= max {
+            return messages;
+        }
+
+        if matches!(messages.first(), Some(msg) if msg.role == "system") {
+            let keep_tail = max.saturating_sub(1);
+            let start = messages.len().saturating_sub(keep_tail);
+            let mut bounded = Vec::with_capacity(max);
+            bounded.push(messages[0].clone());
+            if keep_tail > 0 {
+                bounded.extend(messages[start..].iter().cloned());
+            }
+            bounded
+        } else {
+            let start = messages.len().saturating_sub(max);
+            messages[start..].to_vec()
+        }
+    }
+
     /// Pre-fetches learned context data from memory (observations, patterns, user profile).
     ///
     /// This is an async, non-blocking operation that populates the context
@@ -1652,11 +1683,18 @@ impl Agent {
                             );
                             return;
                         }
-                        log::info!(
-                            "[transcript] loaded {} messages for resume",
-                            session.messages.len()
-                        );
-                        self.cached_transcript_messages = Some(session.messages);
+                        let loaded_count = session.messages.len();
+                        log::info!("[transcript] loaded {} messages for resume", loaded_count);
+                        let bounded = self.bound_cached_transcript_messages(session.messages);
+                        if bounded.len() < loaded_count {
+                            log::warn!(
+                                "[transcript] resume prefix trimmed from {} to {} messages (max_history_messages={})",
+                                loaded_count,
+                                bounded.len(),
+                                self.config.max_history_messages
+                            );
+                        }
+                        self.cached_transcript_messages = Some(bounded);
                     }
                     Err(err) => {
                         log::warn!(

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -289,6 +289,34 @@ async fn transcript_roundtrip_work() {
 }
 
 #[tokio::test]
+async fn transcript_resume_is_bounded_by_max_history_messages() {
+    let mut writer = make_agent(None);
+    let mut messages = vec![ChatMessage::system("sys")];
+    for idx in 0..8 {
+        messages.push(ChatMessage::user(format!("u{idx}")));
+        messages.push(ChatMessage::assistant(format!("a{idx}")));
+    }
+    writer.persist_session_transcript(&messages, 0, 0, 0, 0.0, None);
+
+    let mut resumed = make_agent(None);
+    resumed.workspace_dir = writer.workspace_dir.clone();
+    resumed.agent_definition_name = writer.agent_definition_name.clone();
+    resumed.config.max_history_messages = 5;
+    resumed.try_load_session_transcript();
+
+    let cached = resumed
+        .cached_transcript_messages
+        .as_ref()
+        .expect("resume cache should be populated");
+    assert_eq!(cached.len(), 5);
+    assert_eq!(cached[0].role, "system");
+    assert_eq!(cached[1].content, "u6");
+    assert_eq!(cached[2].content, "a6");
+    assert_eq!(cached[3].content, "u7");
+    assert_eq!(cached[4].content, "a7");
+}
+
+#[tokio::test]
 async fn execute_tool_call_blocks_invisible_tool_and_emits_events() {
     let _ = init_global(64);
     let events = Arc::new(AsyncMutex::new(Vec::<DomainEvent>::new()));


### PR DESCRIPTION
## Summary

- Cap the cached transcript prefix at `config.max_history_messages` whenever a resumed session is primed, so resume paths can no longer ship an unbounded message log to the provider on iteration 1.
- Applied at both resume entry points: `seed_resume_from_messages` (cold-boot priming from caller-supplied messages) and `try_load_session_transcript` (transcript-file load).
- Leading `system` message is preserved when present; otherwise the tail `N` messages are kept.
- Added `bound_cached_transcript_messages` helper on `Agent` with three unit tests covering: system-prefix bound on seed, system-prefix bound on transcript load, and the no-system-message tail-keep branch.
- Resume paths now emit a `warn` log when the bound actually trims, so over-long transcripts are visible in diagnostics.

## Problem

Sentry issue [OPENHUMAN-TAURI-QX](https://tinyhumans.sentry.io/issues/7485785653/) — `custom_openai` 400 Bad Request: *"Requested token count exceeds the model's maximum context length of 202752 tokens. You requested a total of 203783 tokens"*. 48 events, first seen 2026-05-15, last 2026-05-17, release `openhuman@0.53.43`.

Root cause: on resume, `cached_transcript_messages` is consumed verbatim on the first iteration of the agent loop (`turn.rs:561`) — only a single new-tail user message is appended. This path **bypasses both** `trim_history` and `reduce_before_call`, so a long persisted transcript blows straight through the model's context window on the very first provider call after a resume.

## Solution

- Introduce `Agent::bound_cached_transcript_messages(Vec<ChatMessage>) -> Vec<ChatMessage>` that caps the slice at `config.max_history_messages` (`.max(1)` floor). When the first message is `system`, it is preserved and the last `max-1` messages are kept; otherwise the last `max` messages are kept.
- Wire the helper at both resume entry points so the bound applies before the cached transcript is handed to the provider.
- Diagnostics: warn-level log when bounding actually trims, plus the existing info log now reports the post-bound count so logs don't overstate what was primed.

**Design notes / tradeoffs:**
- Bound is by **message count**, mirroring the existing `trim_history` semantics — not by token count. A single oversized tool-result message can still in theory exceed context; the autocompactor (`reduce_before_call`) is what handles token-level pressure on subsequent iterations. A token-aware bound for the cached path is a sensible follow-up but was intentionally deferred to keep this change behavior-conservative and Sentry-targeted.
- `ChatMessage` is `role` + `content` only (no structured `tool_calls`), so slicing in the middle is structurally safe at the wire level; same orphan-tool-reference risk that `trim_history` already carries.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — **N/A: behaviour-only change to an existing resume code path; no new feature surface.**
- All affected feature IDs from the matrix are listed in the PR description under `## Related` — **N/A: no matrix rows affected.**
- No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — **N/A: internal agent harness bound; no release-cut surface touched.**
- Linked issue closed via `Closes #NNN` in the `## Related` section — **N/A: Sentry issue OPENHUMAN-TAURI-QX, no GitHub issue tracking item.**

## Impact

- **Runtime/platform**: Rust core only (`src/openhuman/agent/harness/session/`). Affects desktop (Tauri host) and `openhuman-core` CLI equally — both paths share the agent harness. No frontend, no mobile, no web surface touched.
- **Performance**: net positive — resume requests with long transcripts will now fit inside the context window instead of 400ing. Bounding cost is a single `Vec` slice/clone on resume entry; negligible.
- **Security**: none.
- **Migration / compatibility**: no schema, RPC, or persistence changes. Cached transcripts on disk are unaffected — they're just truncated in memory at load time when oversized.
- **Behavioral change for resumed sessions**: a resumed agent that previously sent (and provider-rejected) a 200k+-token transcript will now see only the most recent `max_history_messages` of that transcript on iteration 1. Older context is dropped at the wire layer, mirroring what `trim_history` already does for in-process histories. Logged at `warn` when this actually triggers.

## Related

- Closes: [OPENHUMAN-TAURI-QX](https://tinyhumans.sentry.io/issues/7485785653/?environment=development&environment=production&environment=staging&project=4511287579836416&query=is%3Aunresolved%20assigned%3Anone&referrer=issue-stream&sort=freq)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session transcript history is now properly limited to the configured maximum message count when resuming conversations. This ensures that long prior conversation histories don't unnecessarily consume memory or impact performance during session restoration.

* **Tests**
  * Added tests covering transcript history bounding and session resume behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->