### PR TITLE
fix(memory): accept flexible document ingest timestamps

### DIFF
--- a/src/openhuman/memory/tree/canonicalize/document.rs
+++ b/src/openhuman/memory/tree/canonicalize/document.rs
@@ -1,12 +1,10 @@
-//! Standalone documents → canonical Markdown.
+﻿//! Standalone documents 鈫?canonical Markdown.
 //!
 //! Document sources are single-record (no grouping): one Notion page, one
-//! Drive doc, one meeting-note file. The canonicaliser adds a small title
-//! header and passes through the body; if the body is already markdown it
-//! is kept verbatim.
+//! Drive doc, one meeting-note file. The canonicaliser trims and passes through the body as canonical Markdown. If the body is already markdown it is kept verbatim, and provider/title metadata stays in front-matter rather than a generated heading.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::{normalize_source_ref, CanonicalisedSource};
 use crate::openhuman::memory::tree::types::{Metadata, SourceKind};
@@ -15,21 +13,53 @@ use crate::openhuman::memory::tree::types::{Metadata, SourceKind};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DocumentInput {
     /// Provider name (e.g. `notion`, `drive`, `meeting_notes`).
+    #[serde(default = "default_provider")]
     pub provider: String,
     /// Document title.
     pub title: String,
     /// Document body (markdown preferred; plain text also accepted).
     pub body: String,
     /// When the document was last modified at the source.
-    #[serde(with = "chrono::serde::ts_milliseconds")]
+    #[serde(
+        default = "default_modified_at",
+        deserialize_with = "deserialize_modified_at"
+    )]
     pub modified_at: DateTime<Utc>,
     /// Optional pointer back to source (URL, file path, Notion page id).
     #[serde(default)]
     pub source_ref: Option<String>,
 }
 
+fn default_provider() -> String {
+    "unknown".to_string()
+}
+
+fn default_modified_at() -> DateTime<Utc> {
+    Utc::now()
+}
+
+fn deserialize_modified_at<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ModifiedAtValue {
+        Milliseconds(i64),
+        Iso8601(String),
+    }
+
+    match ModifiedAtValue::deserialize(deserializer)? {
+        ModifiedAtValue::Milliseconds(value) => DateTime::<Utc>::from_timestamp_millis(value)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid unix timestamp in milliseconds: {value}"))),
+        ModifiedAtValue::Iso8601(value) => chrono::DateTime::parse_from_rfc3339(&value)
+            .map(|parsed| parsed.with_timezone(&Utc))
+            .map_err(|err| serde::de::Error::custom(format!("invalid RFC3339 timestamp: {err}"))),
+    }
+}
+
 /// Canonicalise a single document into a [`CanonicalisedSource`]. Returns
-/// `Ok(None)` if both the title and body are empty — caller treats as nothing
+/// `Ok(None)` if both the title and body are empty; caller treats that as nothing
 /// to ingest.
 pub fn canonicalise(
     source_id: &str,
@@ -42,7 +72,7 @@ pub fn canonicalise(
     }
 
     let mut md = String::new();
-    // No leading `# provider — title` header. Provider / title info
+    // No leading `# provider 鈥?title` header. Provider / title info
     // belongs in the MD front-matter (Phase MD-content).
     md.push_str(doc.body.trim());
     md.push('\n');
@@ -98,7 +128,7 @@ mod tests {
         )
         .unwrap()
         .unwrap();
-        // No leading `# notion — Launch plan` header — that info belongs in front-matter.
+        // No leading `# notion 鈥?Launch plan` header 鈥?that info belongs in front-matter.
         assert!(
             !out.markdown.starts_with("# "),
             "canonical document MD must NOT start with a `# ` header"
@@ -135,4 +165,73 @@ mod tests {
         let out = canonicalise("d1", "alice", &[], input).unwrap().unwrap();
         assert!(out.metadata.source_ref.is_none());
     }
+
+    #[test]
+    fn deserializes_epoch_millis_modified_at() {
+        let raw = serde_json::json!({
+            "provider": "drive",
+            "title": "Spec",
+            "body": "Notes",
+            "modified_at": 1_700_000_000_000i64,
+        });
+
+        let parsed: DocumentInput = serde_json::from_value(raw).unwrap();
+
+        assert_eq!(parsed.provider, "drive");
+        assert_eq!(
+            parsed.modified_at,
+            Utc.timestamp_millis_opt(1_700_000_000_000).unwrap()
+        );
+    }
+
+    #[test]
+    fn deserializes_iso_8601_modified_at() {
+        let raw = serde_json::json!({
+            "provider": "drive",
+            "title": "Spec",
+            "body": "Notes",
+            "modified_at": "2026-05-17T19:30:00Z",
+        });
+
+        let parsed: DocumentInput = serde_json::from_value(raw).unwrap();
+
+        assert_eq!(
+            parsed.modified_at,
+            chrono::DateTime::parse_from_rfc3339("2026-05-17T19:30:00Z")
+                .unwrap()
+                .with_timezone(&Utc)
+        );
+    }
+
+    #[test]
+    fn missing_provider_defaults_to_unknown() {
+        let raw = serde_json::json!({
+            "title": "Spec",
+            "body": "Notes",
+            "modified_at": 1_700_000_000_000i64,
+        });
+
+        let parsed: DocumentInput = serde_json::from_value(raw).unwrap();
+
+        assert_eq!(parsed.provider, "unknown");
+    }
+
+    #[test]
+    fn missing_modified_at_defaults_to_nowish() {
+        let before = Utc::now();
+        let raw = serde_json::json!({
+            "provider": "drive",
+            "title": "Spec",
+            "body": "Notes",
+        });
+
+        let parsed: DocumentInput = serde_json::from_value(raw).unwrap();
+        let after = Utc::now();
+
+        assert!(parsed.modified_at >= before);
+        assert!(parsed.modified_at <= after);
+    }
+
 }
+
+

--- a/src/openhuman/memory/tree/canonicalize/document.rs
+++ b/src/openhuman/memory/tree/canonicalize/document.rs
@@ -1,4 +1,4 @@
-﻿//! Standalone documents 鈫?canonical Markdown.
+﻿//! Standalone documents -> canonical Markdown.
 //!
 //! Document sources are single-record (no grouping): one Notion page, one
 //! Drive doc, one meeting-note file. The canonicaliser trims and passes through the body as canonical Markdown. If the body is already markdown it is kept verbatim, and provider/title metadata stays in front-matter rather than a generated heading.
@@ -72,7 +72,7 @@ pub fn canonicalise(
     }
 
     let mut md = String::new();
-    // No leading `# provider 鈥?title` header. Provider / title info
+    // No leading `# provider - title` header. Provider / title info
     // belongs in the MD front-matter (Phase MD-content).
     md.push_str(doc.body.trim());
     md.push('\n');
@@ -128,7 +128,7 @@ mod tests {
         )
         .unwrap()
         .unwrap();
-        // No leading `# notion 鈥?Launch plan` header 鈥?that info belongs in front-matter.
+        // No leading `# notion - Launch plan` header - that info belongs in front-matter.
         assert!(
             !out.markdown.starts_with("# "),
             "canonical document MD must NOT start with a `# ` header"
@@ -233,5 +233,7 @@ mod tests {
     }
 
 }
+
+
 
 


### PR DESCRIPTION
## Summary

- Accept both epoch-millisecond and RFC3339/ISO-8601 `modified_at` values for document ingest payloads.
- Default `provider` to `"unknown"` and `modified_at` to `Utc::now()` when those fields are omitted, matching the issue's optional-field expectations.
- Add regression tests covering epoch millis, ISO-8601 strings, missing `provider`, and missing `modified_at`.

## Problem

- `DocumentInput` used `chrono::serde::ts_milliseconds`, so document ingest rejected payloads where `modified_at` arrived as an ISO-8601 string.
- The same input path also rejected payloads that omitted `provider` or `modified_at`, even though those fields are expected to be optional by adapters calling ingest.
- This breaks a core memory-ingest path and forces callers to normalize payloads before they can store a single document.

## Solution

- Replace the strict `ts_milliseconds` deserializer with a custom `deserialize_modified_at` helper that accepts either epoch milliseconds or RFC3339 strings.
- Add serde defaults for `provider` and `modified_at` so omitted fields fall back to safe ingest values instead of failing deserialization.
- Keep the canonicalization/output shape unchanged; the patch is scoped to input parsing plus regression tests.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage >= 80%** - local full-repo coverage could not be run from this API-reconstructed workspace; targeted Rust harness validation is included below.
- [x] Coverage matrix updated - N/A: behaviour-only change in an existing Rust ingest path; no feature rows were added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no coverage-matrix feature rows changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) - N/A: Rust-only ingest parser change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust core memory ingest only; no frontend, Tauri shell, or API shape changes.
- Compatibility impact: broadens accepted document ingest payloads without changing stored canonical output.
- Performance/security impact: negligible; the new logic only affects deserialization of a single timestamp field.

## Related

- Closes #2204
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/document-input-ingest-fallbacks`
- Commit SHA: `bb772a21246ab5537bd326592449f7d63aff5415`

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check` - N/A: Rust-only change in an API-reconstructed workspace.
- [ ] `pnpm typecheck` - N/A: Rust-only change in an API-reconstructed workspace.
- [x] Focused tests: `cargo +stable-x86_64-pc-windows-gnu check --tests --manifest-path D:\project\me\githubAutoPR\openhuman-document-harness\Cargo.toml`
- [ ] Rust fmt/check (if changed): blocked from full repo execution; see `Validation Blocked`.
- [ ] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked
- `command:` `cargo +stable-x86_64-pc-windows-gnu test --manifest-path D:\project\me\githubAutoPR\openhuman-document-harness\Cargo.toml`; `pnpm test:rust`
- `error:` `error calling dlltool 'dlltool.exe': program not found`; full root Rust tests are also blocked in this partial workspace by unrelated dependency fetch failures (`whisper-rs-sys`).
- `impact:` Regression tests compile/typecheck against the real `document.rs` implementation, but I could not execute the full harness test binary or the full upstream Rust suite from this local environment.

### Behavior Changes
- Intended behavior change: document ingest now accepts either epoch-millisecond or RFC3339 timestamps, and omitted `provider` / `modified_at` fields no longer fail deserialization.
- User-visible effect: adapters can ingest more real-world document payloads without pre-normalizing timestamps or injecting filler fields.

### Parity Contract
- Legacy behavior preserved: existing epoch-millisecond payloads still deserialize to the same `DateTime<Utc>` values.
- Guard/fallback/dispatch parity checks: canonicalized markdown and metadata output paths are unchanged; only input parsing became more permissive.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none known
- Canonical PR: this PR
- Resolution (closed/superseded/updated): open for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Document timestamps now accept Unix epoch milliseconds or ISO‑8601 strings.
  * Missing fields get sensible defaults: provider defaults to "unknown" and modified timestamp defaults to now.
  * Canonicalization trims body and emits canonical Markdown while populating canonical metadata (single timestamp time range and normalized source reference).

* **Tests**
  * Expanded tests covering timestamp parsing, defaults for missing fields, and canonicalization/metadata assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->