### PR TITLE
feat(agent): cap runtime subagent spawn depth at MAX_SPAWN_DEPTH=3

### DIFF
--- a/gitbooks/developing/architecture/agent-harness.md
+++ b/gitbooks/developing/architecture/agent-harness.md
@@ -199,9 +199,9 @@ Each `AgentDefinition` carries an `agent_tier` field (`chat` / `reasoning` / `wo
 **Enforcement.** Two layers:
 
 1. **Loader-time (static).** [`agents::loader::validate_tier_hierarchy`](../../../src/openhuman/agent/agents/loader.rs) runs over the merged registry (built-ins + workspace TOMLs) and refuses to boot a registry that lists a same-tier or worker-with-subagents entry. Built-in archetypes are checked at compile-test time; user-shipped TOMLs are checked at workspace load.
-2. **Runtime depth gate (dynamic, planned).** Independent of tier, the sub-agent runner *will* cap total spawn chain depth at `MAX_SPAWN_DEPTH = 3` via a task-local counter incremented across `run_subagent`, surfaced as a new `SpawnDepthExceeded` agent error. This makes a user-shipped TOML that drops the tier annotation still unable to recurse past three hops. Tracked as the follow-up to the gap noted in `harness_gap_tests.rs`.
+2. **Runtime depth gate (dynamic).** Independent of tier, the sub-agent runner caps total spawn chain depth at `MAX_SPAWN_DEPTH = 3` via a task-local counter incremented across `run_subagent`, surfaced as a `SpawnDepthExceeded` agent error. This makes a user-shipped TOML that drops the tier annotation still unable to recurse past three hops.
 
-> **Status:** the loader-time tier check and `agent_tier` field are live (this section). The runtime depth-counter task-local is *not yet implemented* — it is the planned defence-in-depth layer described above. Until it lands, depth is bounded only by the static loader contract plus the prompt-level rules in the orchestrator and planner agents.
+> **Status:** the loader-time tier check, `agent_tier` field, and runtime depth-counter task-local are live. Depth is bounded by both the static loader contract and the runtime `MAX_SPAWN_DEPTH = 3` guard.
 
 ### Toolkit-specific specialists
 

--- a/src/openhuman/agent/harness/harness_gap_tests.rs
+++ b/src/openhuman/agent/harness/harness_gap_tests.rs
@@ -11,9 +11,11 @@
 //!    fallback formats).
 //! 6. `DateTimeSection` produces an ISO-8601-like timestamp with a timezone token.
 //! 7. `parse_tool_timeout_secs` default and boundary cases.
+//! 8. Spawn-depth gate (`SpawnDepthExceeded`) is covered in
+//!    `subagent_runner/ops_tests.rs` because it lives at the `run_subagent`
+//!    boundary.
 //!
 //! Items that have NO underlying code and therefore cannot be tested:
-//! - Spawn-depth gate (SpawnDepthExceeded) — no depth counter or variant exists.
 //! - Follow-up resolution ("yes"/"no" disambiguation) — not implemented.
 //! - Silence timer (SilenceTimeout, 600 s) — not implemented.
 //! - `<invoke tool=…>` XML attribute form — the parser does not parse attributes;

--- a/src/openhuman/agent/harness/mod.rs
+++ b/src/openhuman/agent/harness/mod.rs
@@ -34,6 +34,7 @@ pub mod sandbox_context;
 pub(crate) mod self_healing;
 pub mod session;
 pub(crate) mod session_queue;
+pub(crate) mod spawn_depth_context;
 pub mod subagent_runner;
 pub(crate) mod tool_filter;
 mod tool_loop;
@@ -45,6 +46,7 @@ pub use definition::{
 pub use fork_context::{current_parent, with_parent_context, ParentExecutionContext};
 pub use interrupt::{check_interrupt, InterruptFence, InterruptedError};
 pub use sandbox_context::{current_sandbox_mode, with_current_sandbox_mode};
+pub(crate) use spawn_depth_context::{current_spawn_depth, with_spawn_depth, MAX_SPAWN_DEPTH};
 pub use subagent_runner::{run_subagent, SubagentRunError, SubagentRunOptions};
 
 pub(crate) use instructions::build_tool_instructions_filtered;

--- a/src/openhuman/agent/harness/spawn_depth_context.rs
+++ b/src/openhuman/agent/harness/spawn_depth_context.rs
@@ -1,0 +1,66 @@
+//! Task-local spawn-depth tracking for nested sub-agent delegation.
+//!
+//! Loader-time tier validation prevents built-in and workspace agent
+//! definitions from declaring recursive hierarchies, but runtime calls can
+//! still arrive through tools and MCP surfaces. This task-local is the
+//! defence-in-depth layer that caps the active `run_subagent` chain.
+
+/// Maximum number of nested `run_subagent` scopes allowed in one task.
+///
+/// Depth counts sub-agent runs, not the root user-facing agent turn, so the
+/// intended deepest path is `chat -> reasoning -> worker`:
+///
+/// * reasoning sub-agent: depth 1
+/// * worker spawned by reasoning: depth 2
+/// * one final worker handoff: depth 3
+pub const MAX_SPAWN_DEPTH: usize = 3;
+
+tokio::task_local! {
+    /// Current active `run_subagent` nesting depth for this task.
+    static CURRENT_SPAWN_DEPTH: usize;
+}
+
+/// Return the active sub-agent nesting depth for this task.
+///
+/// Direct callers outside [`with_spawn_depth`] are at depth 0.
+pub fn current_spawn_depth() -> usize {
+    CURRENT_SPAWN_DEPTH.try_with(|depth| *depth).unwrap_or(0)
+}
+
+/// Run `future` with a specific active sub-agent depth.
+pub async fn with_spawn_depth<F, R>(depth: usize, future: F) -> R
+where
+    F: std::future::Future<Output = R>,
+{
+    CURRENT_SPAWN_DEPTH.scope(depth, future).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn current_spawn_depth_defaults_to_zero() {
+        assert_eq!(current_spawn_depth(), 0);
+    }
+
+    #[tokio::test]
+    async fn with_spawn_depth_scopes_value_to_future() {
+        let observed = with_spawn_depth(2, async { current_spawn_depth() }).await;
+        assert_eq!(observed, 2);
+        assert_eq!(current_spawn_depth(), 0);
+    }
+
+    #[tokio::test]
+    async fn nested_spawn_depth_scope_restores_outer_value() {
+        with_spawn_depth(1, async {
+            assert_eq!(current_spawn_depth(), 1);
+            with_spawn_depth(2, async {
+                assert_eq!(current_spawn_depth(), 2);
+            })
+            .await;
+            assert_eq!(current_spawn_depth(), 1);
+        })
+        .await;
+    }
+}

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -230,7 +230,7 @@ pub async fn run_subagent(
         .unwrap_or_else(|| format!("sub-{}", uuid::Uuid::new_v4()));
     let started = Instant::now();
     let current_depth = current_spawn_depth();
-    let attempted_depth = current_depth + 1;
+    let attempted_depth = current_depth.saturating_add(1);
 
     if attempted_depth > MAX_SPAWN_DEPTH {
         tracing::warn!(

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -24,7 +24,9 @@ use super::tool_prep::{
 };
 use super::types::{SubagentMode, SubagentRunError, SubagentRunOptions, SubagentRunOutcome};
 use crate::openhuman::agent::harness::definition::{AgentDefinition, PromptSource};
-use crate::openhuman::agent::harness::with_current_sandbox_mode;
+use crate::openhuman::agent::harness::{
+    current_spawn_depth, with_current_sandbox_mode, with_spawn_depth, MAX_SPAWN_DEPTH,
+};
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::context::prompt::{
     render_subagent_system_prompt, PromptContext, PromptTool, SubagentRenderOptions,
@@ -227,10 +229,29 @@ pub async fn run_subagent(
         .clone()
         .unwrap_or_else(|| format!("sub-{}", uuid::Uuid::new_v4()));
     let started = Instant::now();
+    let current_depth = current_spawn_depth();
+    let attempted_depth = current_depth + 1;
+
+    if attempted_depth > MAX_SPAWN_DEPTH {
+        tracing::warn!(
+            agent_id = %definition.id,
+            task_id = %task_id,
+            current_depth,
+            attempted_depth,
+            max_depth = MAX_SPAWN_DEPTH,
+            "[subagent_runner] spawn depth exceeded"
+        );
+        return Err(SubagentRunError::SpawnDepthExceeded {
+            attempted_depth,
+            max_depth: MAX_SPAWN_DEPTH,
+        });
+    }
 
     tracing::info!(
         agent_id = %definition.id,
         task_id = %task_id,
+        spawn_depth = attempted_depth,
+        max_spawn_depth = MAX_SPAWN_DEPTH,
         prompt_chars = task_prompt.chars().count(),
         skill_filter = ?options.skill_filter_override.as_deref().or(definition.skill_filter.as_deref()),
         "[subagent_runner] dispatching"
@@ -241,8 +262,11 @@ pub async fn run_subagent(
     // want to gate on it (e.g. `composio_execute` rejecting
     // Write/Admin slugs under `ReadOnly`) read it via
     // `current_sandbox_mode()`; tools that don't care just ignore it.
-    let mut outcome = with_current_sandbox_mode(definition.sandbox_mode, async {
-        run_typed_mode(definition, task_prompt, &options, &parent, &task_id).await
+    let mut outcome = with_spawn_depth(attempted_depth, async {
+        with_current_sandbox_mode(definition.sandbox_mode, async {
+            run_typed_mode(definition, task_prompt, &options, &parent, &task_id).await
+        })
+        .await
     })
     .await?;
 
@@ -274,6 +298,7 @@ pub async fn run_subagent(
     tracing::info!(
         agent_id = %definition.id,
         task_id = %task_id,
+        spawn_depth = attempted_depth,
         elapsed_ms = outcome.elapsed.as_millis() as u64,
         iterations = outcome.iterations,
         output_chars = outcome.output.chars().count(),

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -262,9 +262,22 @@ pub async fn run_subagent(
     // want to gate on it (e.g. `composio_execute` rejecting
     // Write/Admin slugs under `ReadOnly`) read it via
     // `current_sandbox_mode()`; tools that don't care just ignore it.
+    // Box-pin the inner future so the large `run_typed_mode` state machine
+    // lives on the heap. Two stacked `task_local::scope` wrappers
+    // (`with_spawn_depth` + `with_current_sandbox_mode`) plus the deeply
+    // nested provider/tool loop inside `run_typed_mode` are otherwise large
+    // enough — under `cargo-llvm-cov` instrumentation in particular — to
+    // overflow tokio's 2 MiB per-thread test stack. See #2234 CI failure.
     let mut outcome = with_spawn_depth(attempted_depth, async {
         with_current_sandbox_mode(definition.sandbox_mode, async {
-            run_typed_mode(definition, task_prompt, &options, &parent, &task_id).await
+            Box::pin(run_typed_mode(
+                definition,
+                task_prompt,
+                &options,
+                &parent,
+                &task_id,
+            ))
+            .await
         })
         .await
     })

--- a/src/openhuman/agent/harness/subagent_runner/ops_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops_tests.rs
@@ -598,6 +598,62 @@ async fn runner_errors_outside_parent_context() {
 }
 
 #[tokio::test]
+async fn runner_allows_spawn_at_max_depth() {
+    let provider = ScriptedProvider::new(vec![text_response("ok")]);
+    let parent = make_parent(provider.clone(), vec![]);
+    let def = make_def_named_tools(&[]);
+
+    let outcome = with_parent_context(parent, async {
+        with_spawn_depth(MAX_SPAWN_DEPTH - 1, async {
+            run_subagent(&def, "x", SubagentRunOptions::default()).await
+        })
+        .await
+    })
+    .await
+    .expect("runner should allow the configured maximum depth");
+
+    assert_eq!(outcome.output, "ok");
+    assert_eq!(provider.captured.lock().len(), 1);
+    assert_eq!(
+        current_spawn_depth(),
+        0,
+        "depth task-local must not leak after the run"
+    );
+}
+
+#[tokio::test]
+async fn runner_rejects_spawn_beyond_max_depth() {
+    let provider = ScriptedProvider::new(vec![text_response("should not be called")]);
+    let parent = make_parent(provider.clone(), vec![]);
+    let def = make_def_named_tools(&[]);
+
+    let result = with_parent_context(parent, async {
+        with_spawn_depth(MAX_SPAWN_DEPTH, async {
+            run_subagent(&def, "x", SubagentRunOptions::default()).await
+        })
+        .await
+    })
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(SubagentRunError::SpawnDepthExceeded {
+            attempted_depth,
+            max_depth
+        }) if attempted_depth == MAX_SPAWN_DEPTH + 1 && max_depth == MAX_SPAWN_DEPTH
+    ));
+    assert!(
+        provider.captured.lock().is_empty(),
+        "depth rejection must happen before provider dispatch"
+    );
+    assert_eq!(
+        current_spawn_depth(),
+        0,
+        "depth task-local must not leak after rejection"
+    );
+}
+
+#[tokio::test]
 async fn typed_mode_model_override_pins_exact_model_for_spawn() {
     let provider = ScriptedProvider::new(vec![text_response("ok")]);
     let parent = make_parent(provider.clone(), vec![]);

--- a/src/openhuman/agent/harness/subagent_runner/types.rs
+++ b/src/openhuman/agent/harness/subagent_runner/types.rs
@@ -100,6 +100,12 @@ pub enum SubagentRunError {
     #[error("provider call failed: {0}")]
     Provider(#[from] anyhow::Error),
 
+    #[error("sub-agent spawn depth exceeded: attempted depth {attempted_depth}, max {max_depth}")]
+    SpawnDepthExceeded {
+        attempted_depth: usize,
+        max_depth: usize,
+    },
+
     #[error("sub-agent exceeded maximum iterations ({0})")]
     MaxIterationsExceeded(usize),
 }


### PR DESCRIPTION
## Summary

- Add a task-local `MAX_SPAWN_DEPTH = 3` runtime guard around `run_subagent` so nested sub-agent delegation cannot recurse past the harness contract.
- Introduce `SubagentRunError::SpawnDepthExceeded { attempted_depth, max_depth }` and a new `spawn_depth_context` module holding the task-local counter.
- Update `gitbooks/developing/architecture/agent-harness.md` and `harness_gap_tests.rs` to flip the depth gate from "planned" to "live".
- Add two `tokio::test` cases that pin the boundary: allow at `MAX_SPAWN_DEPTH - 1`, reject at `MAX_SPAWN_DEPTH`, and assert the task-local does not leak out of the scope.

## Problem

The agent harness already validated the spawn hierarchy at loader time via `validate_tier_hierarchy`, but the matching runtime depth gate documented in `gitbooks/developing/architecture/agent-harness.md` was not implemented. `harness_gap_tests.rs` explicitly listed `SpawnDepthExceeded` as an "untestable because no underlying code exists" gap. A workspace TOML that drops the `agent_tier` annotation, or any tool / MCP surface that calls `run_subagent` recursively, could therefore recurse past the intended `chat → reasoning → worker` chain. The static tier check is insufficient on its own as a defence-in-depth layer.

## Solution

- New module `src/openhuman/agent/harness/spawn_depth_context.rs` exposes `MAX_SPAWN_DEPTH = 3`, a `CURRENT_SPAWN_DEPTH` `tokio::task_local!`, `current_spawn_depth()`, and `with_spawn_depth(depth, future)`. The module follows the existing `sandbox_context` pattern so the additive surface is consistent with the rest of the harness.
- `run_subagent` reads `current_spawn_depth()` before any provider work, computes `attempted_depth = current + 1`, and returns the new `SpawnDepthExceeded` variant early if it exceeds `MAX_SPAWN_DEPTH`. On the allowed path it wraps the inner `with_current_sandbox_mode(...)` future inside `with_spawn_depth(attempted_depth, ...)` so the counter naturally increments for every nested `run_subagent` call inside the same tokio task and unwinds when the scope ends.
- Tracing on the dispatch and completion log lines now includes `spawn_depth` so production traces can confirm the gate is engaged.
- Docs and gap-tests note: `agent-harness.md` flips the status from "planned" to "live"; `harness_gap_tests.rs` removes the "no underlying code" entry and points to the new coverage in `ops_tests.rs`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `runner_allows_spawn_at_max_depth` (happy boundary) and `runner_rejects_spawn_beyond_max_depth` (failure boundary) in `src/openhuman/agent/harness/subagent_runner/ops_tests.rs`, plus three task-local unit tests in `spawn_depth_context.rs`.
- [x] **Diff coverage ≥ 80%** — N/A locally: `cargo test` could not run in this environment because `whisper-rs-sys` requires `cmake`, which is not installed on the local machine. The added lines are exercised by the new tests; please rely on CI `cargo-llvm-cov` for the official diff-cover gate.
- [x] Coverage matrix updated — N/A: behaviour-only change inside an existing feature (agent harness spawn safety), no new top-level matrix row added.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix IDs touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — change is core-only and uses the existing in-tree `ScriptedProvider` test double.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: release manual smoke does not exercise sub-agent recursion limits.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no tracked issue, opening as a follow-up to the documented gap in `harness_gap_tests.rs`.

## Impact

- Runtime/platform impact: desktop (in-process core). No frontend or Tauri shell surface changes.
- Performance: one task-local read per `run_subagent` call plus a scoped `task_local!` setter; negligible compared with provider/tool work.
- Security / safety: defence-in-depth against runaway sub-agent recursion that the loader-time tier check cannot see (user TOMLs without `agent_tier`, tools / MCP that call `run_subagent` directly).
- Migration / compatibility: error taxonomy gains one variant on an enum already annotated `#[derive(Error)]`. Existing matchers default-branch on it like any other `SubagentRunError`. No public function signatures changed.

## Related

- Closes:
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/agent-spawn-depth-gate
- Commit SHA: c25d2b9cf

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change.
- [x] `pnpm typecheck` — N/A: Rust-only change.
- [x] Focused tests: attempted `cargo test --manifest-path Cargo.toml runner_` — blocked, see "Validation Blocked".
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml -- --check` passed; `git diff --check` clean.
- [x] Tauri fmt/check (if changed): N/A: Tauri shell untouched.

### Validation Blocked
- `command:` `cargo test --manifest-path Cargo.toml runner_`
- `error:` `whisper-rs-sys` build script panicked with `failed to execute command: No such file or directory (os error 2) — is cmake not installed?`. `cmake` is not installed in this local environment.
- `impact:` Did not run the focused Rust tests locally. CI will exercise them on its `cargo-llvm-cov` job; both new tests are deterministic and use the existing `ScriptedProvider` harness.

### Behavior Changes
- Intended behavior change: `run_subagent` now refuses to dispatch a sub-agent beyond `MAX_SPAWN_DEPTH = 3` nested invocations within the same tokio task, returning `SubagentRunError::SpawnDepthExceeded` early.
- User-visible effect: a runaway agent loop that would previously recurse past three hops now surfaces a typed error to the parent tool-result block instead. Normal chat → reasoning → worker chains are unchanged.

### Parity Contract
- Legacy behavior preserved: depth ≤ 3 keeps the same provider, tool filter, sandbox-mode, and progress-event behavior as before; the new wrapper is the outermost layer and only adds the task-local scope.
- Guard/fallback/dispatch parity checks: existing `with_current_sandbox_mode` scope, sandbox mode propagation, max-iteration handling, and `max_result_chars` truncation are all preserved verbatim — the change only wraps that future in `with_spawn_depth(...)`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced runtime limit on sub-agent nesting (max depth = 3); further delegation is rejected with a clear error.

* **Documentation**
  * Updated enforcement docs to reflect that runtime depth bounding and loader-time tier checks are active.

* **Tests**
  * Added tests verifying allowed and rejected spawn attempts, proper error reporting, and isolation of depth state after runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->