### PR TITLE
fix(mcp): send streamable HTTP Accept header

### DIFF
--- a/src/openhuman/mcp_client/client.rs
+++ b/src/openhuman/mcp_client/client.rs
@@ -853,9 +853,7 @@ mod tests {
         headers
             .get(ACCEPT)
             .and_then(|value| value.to_str().ok())
-            .map(|value| {
-                value.contains("application/json") && value.contains("text/event-stream")
-            })
+            .map(|value| value.contains("application/json") && value.contains("text/event-stream"))
             .unwrap_or(false)
     }
 
@@ -866,7 +864,10 @@ mod tests {
         Json(body): Json<Value>,
     ) -> Response {
         if method == Method::POST && !has_streamable_http_accept(&headers) {
-            return (StatusCode::NOT_ACCEPTABLE, "missing MCP Accept header".to_string())
+            return (
+                StatusCode::NOT_ACCEPTABLE,
+                "missing MCP Accept header".to_string(),
+            )
                 .into_response();
         }
         let rpc_method = body.get("method").and_then(Value::as_str).unwrap_or("");
@@ -969,7 +970,10 @@ mod tests {
             .filter(|value| value.contains("text/event-stream"))
             .is_none()
         {
-            return (StatusCode::NOT_ACCEPTABLE, "missing SSE Accept header".to_string())
+            return (
+                StatusCode::NOT_ACCEPTABLE,
+                "missing SSE Accept header".to_string(),
+            )
                 .into_response();
         }
         if headers.get(HEADER_SESSION_ID).is_none() {
@@ -1008,7 +1012,10 @@ mod tests {
         Json(body): Json<Value>,
     ) -> Response {
         if !has_streamable_http_accept(&headers) {
-            return (StatusCode::NOT_ACCEPTABLE, "missing MCP Accept header".to_string())
+            return (
+                StatusCode::NOT_ACCEPTABLE,
+                "missing MCP Accept header".to_string(),
+            )
                 .into_response();
         }
         let rpc_method = body.get("method").and_then(Value::as_str).unwrap_or("");

--- a/src/openhuman/mcp_client/client.rs
+++ b/src/openhuman/mcp_client/client.rs
@@ -3,7 +3,7 @@ use crate::openhuman::skills::types::ToolResult;
 use anyhow::Context;
 use base64::Engine;
 use parking_lot::Mutex;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -21,6 +21,7 @@ const HEADER_PROTOCOL_VERSION: &str = "MCP-Protocol-Version";
 const HEADER_SESSION_ID: &str = "Mcp-Session-Id";
 const HEADER_METHOD: &str = "Mcp-Method";
 const HEADER_NAME: &str = "Mcp-Name";
+const MCP_HTTP_ACCEPT: &str = "application/json, text/event-stream";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct McpRemoteTool {
@@ -194,7 +195,8 @@ impl McpHttpClient {
             .apply_auth(
                 self.http
                     .post(&self.endpoint)
-                    .header(CONTENT_TYPE, "application/json"),
+                    .header(CONTENT_TYPE, "application/json")
+                    .header(ACCEPT, MCP_HTTP_ACCEPT),
                 true,
             )
             .body(serde_json::to_vec(&body)?);
@@ -286,6 +288,7 @@ impl McpHttpClient {
             .http
             .post(&self.endpoint)
             .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, MCP_HTTP_ACCEPT)
             .body(serde_json::to_vec(&json!({
                 "jsonrpc": "2.0",
                 "id": self.next_id.fetch_add(1, Ordering::Relaxed),
@@ -332,6 +335,7 @@ impl McpHttpClient {
         let session_id = self.state.lock().session_id.clone();
         let mut request = self
             .apply_auth(self.http.get(&self.endpoint), false)
+            .header(ACCEPT, "text/event-stream")
             .header(HEADER_PROTOCOL_VERSION, protocol_version);
         if let Some(session_id) = session_id {
             request = request.header(HEADER_SESSION_ID, session_id);
@@ -381,7 +385,8 @@ impl McpHttpClient {
         let request = self
             .http
             .post(&self.endpoint)
-            .header(CONTENT_TYPE, "application/json");
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, MCP_HTTP_ACCEPT);
         let request = self.apply_standard_headers(request, false, method, None, &[]);
         let response = request.body(serde_json::to_vec(&body)?).send().await?;
         let status = response.status();
@@ -431,7 +436,8 @@ impl McpHttpClient {
         let request = self
             .http
             .post(&self.endpoint)
-            .header(CONTENT_TYPE, "application/json");
+            .header(CONTENT_TYPE, "application/json")
+            .header(ACCEPT, MCP_HTTP_ACCEPT);
         let request = if options.initialize {
             self.apply_auth(request, true)
         } else {
@@ -843,12 +849,26 @@ mod tests {
         call_count: Arc<AtomicUsize>,
     }
 
+    fn has_streamable_http_accept(headers: &AxumHeaderMap) -> bool {
+        headers
+            .get(ACCEPT)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| {
+                value.contains("application/json") && value.contains("text/event-stream")
+            })
+            .unwrap_or(false)
+    }
+
     async fn mcp_handler(
         State(state): State<TestState>,
         headers: AxumHeaderMap,
         method: Method,
         Json(body): Json<Value>,
     ) -> Response {
+        if method == Method::POST && !has_streamable_http_accept(&headers) {
+            return (StatusCode::NOT_ACCEPTABLE, "missing MCP Accept header".to_string())
+                .into_response();
+        }
         let rpc_method = body.get("method").and_then(Value::as_str).unwrap_or("");
         if method == Method::POST && rpc_method == "initialize" {
             state.init_count.fetch_add(1, AtomicOrdering::SeqCst);
@@ -943,6 +963,15 @@ mod tests {
     }
 
     async fn events_handler(headers: AxumHeaderMap) -> Response {
+        if headers
+            .get(ACCEPT)
+            .and_then(|v| v.to_str().ok())
+            .filter(|value| value.contains("text/event-stream"))
+            .is_none()
+        {
+            return (StatusCode::NOT_ACCEPTABLE, "missing SSE Accept header".to_string())
+                .into_response();
+        }
         if headers.get(HEADER_SESSION_ID).is_none() {
             return (StatusCode::BAD_REQUEST, "no session".to_string()).into_response();
         }
@@ -978,6 +1007,10 @@ mod tests {
         headers: AxumHeaderMap,
         Json(body): Json<Value>,
     ) -> Response {
+        if !has_streamable_http_accept(&headers) {
+            return (StatusCode::NOT_ACCEPTABLE, "missing MCP Accept header".to_string())
+                .into_response();
+        }
         let rpc_method = body.get("method").and_then(Value::as_str).unwrap_or("");
         if rpc_method == "initialize" {
             state.init_count.fetch_add(1, AtomicOrdering::SeqCst);


### PR DESCRIPTION
## Summary

- Adds `Accept: application/json, text/event-stream` to OpenHuman HTTP MCP JSON-RPC requests.
- Adds `Accept: text/event-stream` to MCP event stream GET requests.
- Tightens the existing MCP client tests so local test servers reject missing Accept headers.

## Problem

GitBook's MCP endpoint now rejects clients that do not advertise both JSON and event-stream response support:

```json
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Not Acceptable: Client must accept both application/json and text/event-stream"},"id":null}
```

OpenHuman's shared `McpHttpClient` set `Content-Type: application/json` but did not set `Accept`, so `gitbooks_search` failed with HTTP 406.

## Solution

Set the streamable HTTP-compatible Accept header on all MCP POST paths:

```text
Accept: application/json, text/event-stream
```

and set the event-stream Accept header on MCP event draining:

```text
Accept: text/event-stream
```

## Submission Checklist

- [x] Tests added or updated (happy path + failure / edge case): existing MCP client tests now assert POST and event GET requests include the required Accept headers.
- [x] N/A: Diff coverage >= 80% — local coverage tooling could not be run in this environment; changes are covered by focused MCP client tests in source.
- [x] N/A: Coverage matrix updated — bug fix to existing MCP client transport behavior; no feature row added/removed/renamed.
- [x] N/A: All affected feature IDs from the matrix are listed — no matrix feature row changed.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist updated — internal MCP transport compatibility fix.
- [x] Linked issue closed via `Closes #2251`.

## Impact

- Runtime/platform impact: Rust core MCP HTTP client only.
- Compatibility impact: broadens compatibility with MCP streamable HTTP servers that enforce content negotiation, including GitBook MCP.
- Security impact: no new endpoints or credentials; only request content negotiation headers changed.

## Related

Closes #2251

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/mcp-accept-header`
- Commit SHA: `7256d29`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change.
- [x] `pnpm typecheck` — N/A: Rust-only change.
- [x] Focused tests: attempted `cargo test --manifest-path Cargo.toml mcp_client --lib`; blocked locally, see below.
- [x] Rust fmt/check: attempted `cargo fmt --check`; blocked locally, see below.
- [x] Tauri fmt/check: N/A: no `app/src-tauri` changes.

### Validation Blocked
- `command:` `cargo fmt --check`
- `error:` `error: no such command: fmt`
- `impact:` Local environment has Rust 1.75 without rustfmt installed; formatting should be verified by CI.

- `command:` `cargo test --manifest-path Cargo.toml mcp_client --lib`
- `error:` `failed to parse lock file ... Cargo.lock; lock file version 4 requires -Znext-lockfile-bump`
- `impact:` Local cargo is 1.75 and cannot read the repository's lockfile format; CI/newer cargo should run the focused tests.

### Behavior Changes
- Intended behavior change: MCP HTTP requests now advertise support for both JSON and event-stream responses.
- User-visible effect: `gitbooks_search` / GitBooks MCP calls should no longer fail with HTTP 406 from servers that require streamable HTTP Accept negotiation.

### Parity Contract
- Legacy behavior preserved: request bodies, auth/session headers, session retry behavior, and response parsing are unchanged.
- Guard/fallback/dispatch parity checks: existing test server flows still exercise initialize/list/call/events/retry, now with Accept header assertions.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none known.
- Canonical PR: this PR.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP requests now explicitly advertise support for both JSON and server-sent events, improving streaming reliability and retry behavior.
  * Server interactions are stricter about accept headers; incompatible requests will be rejected (406), resulting in more predictable error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
