### PR TITLE
fix(workflow): auto-assign issues and prs

### DIFF
--- a/scripts/deep-work/cli.sh
+++ b/scripts/deep-work/cli.sh
@@ -13,6 +13,7 @@ Full workflow automation for GitHub issues using worktrees and AI agents.
 
 By default `start` auto-assigns the issue to `@me`, and PR creation steps
 auto-assign the created PR to `@me`.
+Set `DEEP_WORK_AUTO_ASSIGN=0` (or `WORK_AUTO_ASSIGN=0`) to opt out.
 
 Commands:
   start <issue-number>           Start full workflow for an issue

--- a/scripts/deep-work/cli.sh
+++ b/scripts/deep-work/cli.sh
@@ -11,6 +11,9 @@ Usage: pnpm deep-work <command> [args...]
 
 Full workflow automation for GitHub issues using worktrees and AI agents.
 
+By default `start` auto-assigns the issue to `@me`, and PR creation steps
+auto-assign the created PR to `@me`.
+
 Commands:
   start <issue-number>           Start full workflow for an issue
   pick                          Smart issue selection + start workflow

--- a/scripts/deep-work/continue.sh
+++ b/scripts/deep-work/continue.sh
@@ -10,6 +10,7 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$here/lib.sh"
 
 issue="${1:-}"
+auto_assign="${DEEP_WORK_AUTO_ASSIGN:-${WORK_AUTO_ASSIGN:-1}}"
 
 # If no issue provided, try to detect from current directory
 if [ -z "$issue" ]; then
@@ -207,6 +208,11 @@ ${body}
               --head "$(gh auth status 2>&1 | grep 'Logged in.*as' | sed 's/.*as //' | cut -d' ' -f1):$branch" \
               --base main \
               --repo "$repo")
+
+            pr_number="${pr_url##*/}"
+            if [ "$auto_assign" = "1" ]; then
+              gh_assign_self_pr "$pr_number" "$repo"
+            fi
 
             echo "[deep-work] 📝 PR created: $pr_url"
           else

--- a/scripts/deep-work/continue.sh
+++ b/scripts/deep-work/continue.sh
@@ -294,4 +294,8 @@ fi
 
 echo ""
 echo "[deep-work] 🎯 Continue session complete!"
-echo "[deep-work] Use 'pnpm deep-work continue $issue' to resume anytime."
+if worktree_exists "$issue"; then
+  echo "[deep-work] Use 'pnpm deep-work continue $issue' to resume anytime."
+else
+  echo "[deep-work] Worktree was cleaned up. Use 'pnpm deep-work start $issue' to begin again."
+fi

--- a/scripts/deep-work/lib.sh
+++ b/scripts/deep-work/lib.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # Source the existing review lib for repo resolution
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$here/../.." && pwd)"
-# shellcheck source=../review/lib.sh
-source "$repo_root/scripts/review/lib.sh"
+# shellcheck source=../shortcuts/review/lib.sh
+source "$repo_root/scripts/shortcuts/review/lib.sh"
 
 # Worktree utilities
 worktree_dir_for_issue() {

--- a/scripts/deep-work/start.sh
+++ b/scripts/deep-work/start.sh
@@ -42,6 +42,7 @@ issue="$1"
 shift
 
 repo=$(resolve_deep_work_repo)
+auto_assign="${DEEP_WORK_AUTO_ASSIGN:-${WORK_AUTO_ASSIGN:-1}}"
 
 echo "[deep-work] 🚀 Starting full workflow for issue #$issue from $repo"
 
@@ -56,6 +57,10 @@ echo "[deep-work] === Step 1: Fetching issue details ==="
 echo "[deep-work] fetching issue #$issue from $repo..."
 issue_json=$(gh issue view "$issue" -R "$repo" \
   --json number,title,body,labels,state,url,assignees)
+
+if [ "$auto_assign" = "1" ]; then
+  gh_assign_self_issue "$issue" "$repo"
+fi
 
 state=$(jq -r '.state' <<<"$issue_json")
 if [ "$state" != "OPEN" ]; then
@@ -303,6 +308,11 @@ pr_url=$(gh pr create \
   --head "$(gh auth status 2>&1 | grep 'Logged in.*as' | sed 's/.*as //' | cut -d' ' -f1):$branch" \
   --base main \
   --repo "$repo")
+
+pr_number="${pr_url##*/}"
+if [ "$auto_assign" = "1" ]; then
+  gh_assign_self_pr "$pr_number" "$repo"
+fi
 
 echo "[deep-work] 📝 draft PR created: $pr_url"
 

--- a/scripts/shortcuts/review/lib.sh
+++ b/scripts/shortcuts/review/lib.sh
@@ -28,6 +28,26 @@ require() {
   done
 }
 
+gh_assign_self_issue() {
+  local issue="$1"
+  local repo="$2"
+  if gh issue edit "$issue" -R "$repo" --add-assignee "@me" >/dev/null 2>&1; then
+    info "assigned issue #$issue to @me"
+  else
+    warn "could not assign issue #$issue to @me; continuing"
+  fi
+}
+
+gh_assign_self_pr() {
+  local pr="$1"
+  local repo="$2"
+  if gh pr edit "$pr" -R "$repo" --add-assignee "@me" >/dev/null 2>&1; then
+    info "assigned PR #$pr to @me"
+  else
+    warn "could not assign PR #$pr to @me; continuing"
+  fi
+}
+
 # Summarize free-form text via a local LLM CLI (expects `-p <prompt>`).
 # Usage: summarize_text <tool> <input>
 # Tools used here: gemini (default for summaries), claude, or any CLI that

--- a/scripts/shortcuts/work/README.md
+++ b/scripts/shortcuts/work/README.md
@@ -35,8 +35,13 @@ and `pnpm work start 1234 …` are equivalent.
    `--agent cursor` or `--agent cursor-agent`, it uses
    `cursor-agent --yolo`.
 
+By default the script also tries to assign the issue to `@me` through GitHub
+as soon as work starts.
+
 ## Config
 
 - `WORK_REPO=owner/name` — override the target repo.
 - `WORK_BRANCH_PREFIX=issue` — branch is `<prefix>/<num>-<slug>`.
+- `WORK_AUTO_ASSIGN=1` — auto-assign the issue to `@me` when work starts. Set
+  to `0` to disable.
 - Requires `git`, `gh`, `jq`, plus the agent CLI (default `claude`).

--- a/scripts/shortcuts/work/cli.sh
+++ b/scripts/shortcuts/work/cli.sh
@@ -37,6 +37,8 @@ Env:
                                  scripts/shortcuts/review.
   WORK_BRANCH_PREFIX=issue       Branch name is <prefix>/<num>-<slug> (default:
                                  issue).
+  WORK_AUTO_ASSIGN=1             Auto-assign the issue to `@me` when work
+                                 starts. Set to `0` to disable.
 EOF
 }
 

--- a/scripts/shortcuts/work/start.sh
+++ b/scripts/shortcuts/work/start.sh
@@ -61,10 +61,15 @@ if [ -z "$repo" ]; then
   repo=$(REVIEW_REPO= resolve_repo)
 fi
 branch_prefix="${WORK_BRANCH_PREFIX:-issue}"
+auto_assign="${WORK_AUTO_ASSIGN:-1}"
 
 echo "[work] fetching issue #$issue from $repo..."
 issue_json=$(gh issue view "$issue" -R "$repo" \
   --json number,title,body,labels,state,url,assignees)
+
+if [ "$auto_assign" = "1" ]; then
+  gh_assign_self_issue "$issue" "$repo"
+fi
 
 state=$(jq -r '.state' <<<"$issue_json")
 if [ "$state" != "OPEN" ]; then


### PR DESCRIPTION
## Summary

- Auto-assign picked-up issues to `@me` in `pnpm work` by default.
- Auto-assign created PRs to `@me` in the `pnpm deep-work` flow.
- Add shared GitHub assignment helpers in the review shortcut library.
- Fix `deep-work` to source the shared helper from `scripts/shortcuts/review/lib.sh`.
- Document the new auto-assignment behavior and opt-out env vars in shortcut help text.

## Problem

- Starting work and opening PRs required manual self-assignment, which is easy to forget in the scripted workflow.
- The `deep-work` scripts referenced the wrong shared helper path, which prevents reliable reuse of shared GitHub workflow helpers.

## Solution

- Add `gh_assign_self_issue` and `gh_assign_self_pr` helpers to the shared review shortcut library.
- Call issue auto-assignment from `pnpm work` and `pnpm deep-work start`, with `WORK_AUTO_ASSIGN=0` or `DEEP_WORK_AUTO_ASSIGN=0` as opt-outs.
- Call PR auto-assignment immediately after `gh pr create` in the `deep-work` creation paths.
- Update the work and deep-work help/docs so the default behavior is visible to contributors.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) N/A: shell workflow change validated with syntax and CLI smoke checks instead of unit tests.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. N/A: no application/runtime code changed; coverage suites were not run for shell/docs-only changes.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) N/A: behavior-only developer workflow change.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` N/A: no feature-matrix IDs apply to shortcut scripts.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) N/A: does not touch release-cut product surfaces.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section N/A: no linked issue was provided for this workflow-only change.

## Impact

- Affects contributor and agent GitHub workflow automation only.
- No runtime, desktop, or Rust core behavior changes.
- Issue/PR assignment failures are non-fatal and logged as warnings, so existing flows continue when permissions or repo settings block assignment.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/auto-assign-workflow`
- Commit SHA: `dffe024f`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` N/A: shell/docs-only change; not a meaningful validator for touched files.
- [x] `pnpm typecheck` N/A: shell/docs-only change; targeted validation was `bash -n` plus CLI help smoke checks.
- [x] Focused tests: `bash -n scripts/shortcuts/review/lib.sh scripts/shortcuts/work/cli.sh scripts/shortcuts/work/start.sh scripts/deep-work/lib.sh scripts/deep-work/cli.sh scripts/deep-work/start.sh scripts/deep-work/continue.sh`; `pnpm work --help`; `pnpm deep-work --help`
- [x] Rust fmt/check (if changed): N/A: no Rust files changed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked
- `command:` `pnpm --filter openhuman-app format:check`; `pnpm typecheck`
- `error:` Not run because the change only touched shell/docs workflow files; these commands do not validate the changed surface.
- `impact:` PR relies on targeted shell syntax and CLI smoke validation instead of app/Rust build validation.

### Behavior Changes
- Intended behavior change: work-start and deep-work PR flows now try to assign the current GitHub user to the issue/PR by default.
- User-visible effect: contributors using these scripts should see themselves assigned automatically, with opt-out env vars available.

### Parity Contract
- Legacy behavior preserved: branch creation, issue fetching, PR creation, and agent handoff continue unchanged when assignment succeeds or fails.
- Guard/fallback/dispatch parity checks: assignment calls warn and continue on failure so the existing workflow still completes.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): new PR opened for `codex/auto-assign-workflow`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issues and pull requests now auto-assign to the current user when starting or continuing work sessions.
  * Auto-assignment is configurable via DEEP_WORK_AUTO_ASSIGN and WORK_AUTO_ASSIGN (enabled by default).

* **Documentation**
  * CLI help and README updated to document the auto-assign behavior and configuration.
  * End-of-session guidance improved (explicit next-step wording, including “Merge when approved” and resume/restart instructions).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->