### PR TITLE
fix(deps): bump lettre to 0.11.22 to clear RUSTSEC-2026-0141

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,9 +3669,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "base64 0.22.1",
  "email-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ webpki-roots = "1.0.6"
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
-lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
 mail-parser = "0.11.2"
 async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"] }

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3943,9 +3943,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "base64 0.22.1",
  "email-encoding",


### PR DESCRIPTION
## Summary

- Bumps `lettre` from `0.11.19` (resolved `0.11.21`) to `0.11.22` to clear [RUSTSEC-2026-0141](https://rustsec.org/advisories/RUSTSEC-2026-0141.html) on both `Cargo.lock` and `app/src-tauri/Cargo.lock`.
- The advisory affects only the `boring-tls` backend; OpenHuman builds with `rustls-tls`, so this is not exploitable at runtime — the bump just clears the `cargo-audit` warning the weekly code-review report (#2084) has been surfacing since 2026-05-18.

## Problem

- `cargo-audit` flags `lettre@0.11.21` for RUSTSEC-2026-0141 / [GHSA-4pj9-g833-qx53](https://github.com/lettre/lettre/security/advisories/GHSA-4pj9-g833-qx53): an inverted boolean disabled TLS hostname verification on the `boring-tls` backend across `0.10.1..0.11.21`.
- Fixed upstream in `0.11.22` (released 2026-05-14).
- Both lockfiles (root + `app/src-tauri/`) resolved `lettre` to the vulnerable `0.11.21`.

## Solution

- Root `Cargo.toml`: `lettre = "0.11.19"` -> `lettre = "0.11.22"`.
- `cargo update -p lettre` in both workspaces refreshed the resolved version to `0.11.22`.
- No call-site changes: the two consumer modules (`src/openhuman/audio_toolkit/ops.rs` and `src/openhuman/channels/providers/email_channel.rs`) only use stable surface (`Message`, `SmtpTransport`, `Transport`, `Credentials`, message-builder types). `0.11.20` raised MSRV to 1.85, but OpenHuman targets Rust 1.93 per `rust-toolchain.toml`, so the bump is compatible.

## Submission Checklist

- [x] N/A: Tests added or updated — pure dependency bump with no behavior change; existing `email_channel` and `audio_toolkit` unit tests cover the consumer sites.
- [x] N/A: Diff coverage >= 80% — `Cargo.toml` / `Cargo.lock` changes have no executable lines for `cargo-llvm-cov` to score.
- [x] N/A: Coverage matrix updated — no feature row added/removed/renamed.
- [x] N/A: All affected feature IDs from the matrix are listed — no matrix row affected.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist updated — dependency-only change, no release-cut surface.
- [x] Linked issue closed via `Closes #2274` in `## Related`.

## Impact

- Runtime/platform impact: none in practice — `rustls-tls` backend is unaffected by RUSTSEC-2026-0141. Clears the `cargo-audit` advisory flag in the weekly code-review report.
- Compatibility impact: back-compatible patch-version bump within the same `0.11.x` line.
- Security impact: forward-looking — removes vulnerable version pin so a future build that ever toggles to `boring-tls` would not regress into the advisory.

## Related

- Closes #2274
- Surfaced by: #2084 (weekly code-review report — 2026-05-18)
- Upstream advisory: https://rustsec.org/advisories/RUSTSEC-2026-0141.html
- Upstream changelog: https://github.com/lettre/lettre/blob/v0.11.22/CHANGELOG.md

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/lettre-rustsec-2026-0141`
- Commit SHA: 7d3dbdb0

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust-only dependency change.
- [x] N/A: `pnpm typecheck` — Rust-only dependency change.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib email_channel` (50/50 pass) and `cargo test --manifest-path Cargo.toml --lib audio_toolkit` (10/10 pass).
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo check --manifest-path Cargo.toml` clean (pre-existing warnings only); `cargo clippy --lib --no-deps` no new warnings.
- [x] N/A: Tauri fmt/check — no `app/src-tauri/src/**` changes; only `app/src-tauri/Cargo.lock` updated to refresh the transitive `lettre` pin.

### Validation Blocked
- N/A

### Behavior Changes
- Intended behavior change: none in this codebase (build uses `rustls-tls` feature, not `boring-tls`).
- User-visible effect: weekly code-review report no longer flags `lettre@0.11.21` for RUSTSEC-2026-0141 after merge.

### Parity Contract
- Legacy behavior preserved: `Message`/`SmtpTransport`/`Transport`/`Credentials` and message-builder API surface unchanged in `0.11.22`.
- Guard/fallback/dispatch parity checks: not applicable — dependency-only bump.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none known (searched open and closed PRs touching `lettre`; the only prior hit was #1970 which introduced the dependency).
- Canonical PR: this PR.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the email service library to the latest patch version for improved stability and bug fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->