### PR TITLE
fix(billing): hide budget-complete prompt for free zero-budget plans

### DIFF
--- a/app/src/hooks/useUsageState.test.ts
+++ b/app/src/hooks/useUsageState.test.ts
@@ -114,7 +114,7 @@ describe('useUsageState', () => {
     mockLoadAISettings.mockResolvedValue(ALL_OPENHUMAN_AI_SETTINGS);
   });
 
-  it('does not treat free users with zero recurring budget as exhausted', async () => {
+  it('does not show the completed-budget message for free users with zero recurring budget', async () => {
     const { useUsageState } = await import('./useUsageState');
     mockGetCurrentPlan.mockResolvedValue(freePlan());
     mockGetTeamUsage.mockResolvedValue(buildUsage());
@@ -127,7 +127,7 @@ describe('useUsageState', () => {
 
     expect(result.current.isFreeTier).toBe(true);
     expect(result.current.isBudgetExhausted).toBe(false);
-    expect(result.current.shouldShowBudgetCompletedMessage).toBe(true);
+    expect(result.current.shouldShowBudgetCompletedMessage).toBe(false);
     expect(result.current.isAtLimit).toBe(false);
     expect(result.current.usagePct).toBe(0);
   });

--- a/app/src/hooks/useUsageState.ts
+++ b/app/src/hooks/useUsageState.ts
@@ -165,12 +165,10 @@ export function useUsageState(): UsageState {
     ? teamUsage.cycleBudgetUsd > 0.01 && teamUsage.remainingUsd <= 0.01
     : false;
 
-  // Some users have no included recurring budget at all. They still need the
-  // completed-budget warning in chat even though they are not in an exhausted
-  // paid cycle — but only when their chat actually flows through OpenHuman.
-  const rawShouldShowBudgetCompletedMessage = teamUsage
-    ? rawBudgetExhausted || (teamUsage.cycleBudgetUsd <= 0.01 && teamUsage.remainingUsd <= 0.01)
-    : false;
+  // Only show the completed-budget warning for an actually exhausted
+  // recurring budget. Free plans with no recurring budget should not look like
+  // they have exhausted a paid/included cycle (#2129).
+  const rawShouldShowBudgetCompletedMessage = rawBudgetExhausted;
 
   const isBudgetExhausted = !isFullyRoutedAway && rawBudgetExhausted;
   const shouldShowBudgetCompletedMessage =


### PR DESCRIPTION
## Summary

- Hide the completed-budget prompt for FREE users who have no recurring budget.
- Keep the warning for users who have an actual recurring budget and exhaust it.
- Update the `useUsageState` regression test for the FREE zero-budget case reported in #2129.

## Problem

FREE plan users with `cycleBudgetUsd=0` and `remainingUsd=0` were treated as if they should see the completed-budget/payment prompt. That made a zero-recurring-budget FREE state look like an exhausted paid or included budget cycle, which matches the user-visible complaint in #2129.

## Solution

`useUsageState()` now derives `shouldShowBudgetCompletedMessage` from the existing recurring-budget exhaustion check only. This keeps paid/included-budget exhaustion behavior unchanged while preventing FREE zero-budget users from seeing the budget-complete prompt.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: Coverage matrix updated — behaviour-only hook change, no feature row added/removed/renamed in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix feature row applies
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — hook-only billing banner state change
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Runtime impact is limited to frontend billing/banner state. FREE users with no recurring budget no longer see the budget-complete prompt solely because both budget fields are zero. Users with a positive recurring budget still see the existing completed-budget warning after exhaustion.

## Related

- Closes: Fixes #2129
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/GH-2129-free-plan-budget-banner`
- Commit SHA: `178f217d7461838b284a44f089694c9033b0ba20`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — attempted; Prettier passed, Rust fmt blocked by missing `cargo` (see Validation Blocked)
- [x] `pnpm typecheck`
- [x] Focused tests:
  - `pnpm --dir app exec vitest run src/hooks/useUsageState.test.ts --config test/vitest.config.ts`
  - `pnpm --dir app exec vitest run src/hooks/useUsageState.test.ts src/pages/__tests__/Conversations.render.test.tsx --config test/vitest.config.ts`
- [x] Rust fmt/check (if changed): N/A, no Rust files changed
- [x] Tauri fmt/check (if changed): N/A, no Tauri files changed

Additional validation:

- Red check: `pnpm --dir app exec vitest run src/hooks/useUsageState.test.ts --config test/vitest.config.ts` failed before the production change with `expected true to be false` for `shouldShowBudgetCompletedMessage`.
- `pnpm --dir app exec prettier --check src/hooks/useUsageState.ts src/hooks/useUsageState.test.ts`
- `pnpm lint` (passed with existing repo-wide warnings)
- `pnpm test:coverage` (297 test files passed, 2873 tests passed)
- `node scripts/codex-pr-preflight.mjs --strict-path --lightweight` (blocked on expected Codex path; see Validation Blocked)

### Validation Blocked
- `command:` `node scripts/codex-pr-preflight.mjs --strict-path --lightweight`
- `error:` `[FAIL] expected repo path :: expected /workspace/openhuman, got /Users/sungjh/.config/superpowers/worktrees/openhuman/fix-free-plan-budget-banner`
- `impact:` Local desktop worktree path differs from the Codex web path expected by the strict preflight. Required files, branch naming, remote, and changed-file readability checks passed.

- `command:` `pnpm --filter openhuman-app format:check`
- `error:` `sh: cargo: command not found`
- `impact:` Prettier completed successfully before the Rust fmt substep. This PR changes only TypeScript files; `pnpm --dir app exec prettier --check src/hooks/useUsageState.ts src/hooks/useUsageState.test.ts` passed.

### Behavior Changes
- Intended behavior change: FREE users with zero recurring budget no longer see the completed-budget prompt solely because both usage budget values are zero.
- User-visible effect: the payment/budget-complete banner is suppressed for that FREE zero-budget state.

### Parity Contract
- Legacy behavior preserved: paid/included recurring budget exhaustion still sets `isBudgetExhausted` and `shouldShowBudgetCompletedMessage`; routed-away chat workload suppression remains unchanged.
- Guard/fallback/dispatch parity checks: existing hook tests cover paid exhaustion, remaining-credit zero-budget behavior, routed-away suppression, and conservative missing-settings behavior.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for `#2129`, `FREE PLAN`, `asking for payment`, `completed budget`, or `budgetComplete`.
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the budget completed message to display only when a recurring budget is exhausted, removing incorrect display for users with low remaining balances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->