### PR TITLE
fix(sentry): tag Tauri shell events with cached user uid

### DIFF
--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -276,7 +276,14 @@ impl CoreProcessHandle {
                 }
             }
 
-            for _ in 0..40 {
+            // Readiness budget: 100 iterations × 100ms = 10s. The embedded
+            // core's JSON-RPC controller registry has grown over time and
+            // the previous 4s budget started flaking under CI worker load
+            // (issue: core_process tests intermittently failing with
+            // "core process did not become ready"). 10s is still well
+            // under any user-visible startup expectation and matches the
+            // upper end of observed cold-start times.
+            for _ in 0..100 {
                 if !received_ready {
                     match ready_rx.try_recv() {
                         Ok(ready_signal) => {

--- a/app/src-tauri/src/core_process_tests.rs
+++ b/app/src-tauri/src/core_process_tests.rs
@@ -6,10 +6,16 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 fn env_lock() -> MutexGuard<'static, ()> {
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    // Recover from poison: when one test panics while holding this lock
+    // (e.g. an embedded-core readiness timeout under CI load), every
+    // subsequent test in the suite would otherwise cascade-fail with
+    // "env lock poisoned" — turning one real flake into three. The lock
+    // only serializes process-wide env-var mutation; the inner `()`
+    // carries no state that poisoning could corrupt.
     ENV_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .expect("env lock poisoned")
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 struct EnvGuard {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1915,7 +1915,20 @@ pub fn run() {
             }
             // Strip server_name (hostname) to avoid leaking machine identity.
             event.server_name = None;
-            event.user = None;
+            // Attach the cached account uid so Sentry can count unique users
+            // affected by an issue. We only carry `id` — never email, name,
+            // or IP — so this stays consistent with `send_default_pii: false`.
+            // Since #1061 the core runs in-process inside this shell, so this
+            // is the surface that tags ~all desktop events. Mirrors the
+            // standalone `openhuman-core` binary's filter in `src/main.rs`.
+            // Empty/missing on early-startup events (cache populates after
+            // the first `auth_get_me` RPC); that's expected.
+            event.user = openhuman_core::openhuman::app_state::peek_cached_current_user_identity()
+                .and_then(|identity| identity.id)
+                .map(|id| sentry::User {
+                    id: Some(id),
+                    ..Default::default()
+                });
             Some(event)
         })),
         sample_rate: 1.0,


### PR DESCRIPTION
## Summary
- The Tauri shell's Sentry `before_send` was explicitly setting `event.user = None`, so desktop events landed without a uid attached and Sentry could not count unique users impacted by an issue.
- Since #1061 the sidecar was removed and the core runs in-process inside the shell — this filter is what runs for ~all production desktop events. The standalone `openhuman-core` binary in `src/main.rs` already attaches the uid via `peek_cached_current_user_identity`; the shell now mirrors that.
- Only `id` is carried (no email, name, or IP), consistent with `send_default_pii: false`.

## Test plan
- [ ] `cargo check --manifest-path app/src-tauri/Cargo.toml` ✅ (verified locally)
- [ ] Manual: trigger a Sentry event from the desktop app after login (e.g. `OPENHUMAN_TAURI_SENTRY_TEST=message`) and confirm the event in Sentry shows the user id under "User" and contributes to "users impacted"
- [ ] Manual: trigger a Sentry event before login and confirm `user` is absent (cache not yet populated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced error tracking to attribute crash reports to individual users using a privacy-preserving identifier.
  * Increased startup readiness timeout to reduce intermittent startup flakiness.

* **Tests**
  * Improved test resilience by handling locked resources more gracefully to prevent cascading test failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->