### PR TITLE
fix(e2e): dismiss BootCheckGate picker with current heading text

### DIFF
--- a/app/test/e2e/helpers/app-helpers.ts
+++ b/app/test/e2e/helpers/app-helpers.ts
@@ -19,7 +19,7 @@ import { isTauriDriver } from './platform';
  * we usually just need to give the React root a beat to mount. Specs that
  * need a stricter guarantee should call `waitForAppReady` directly.
  *
- * Also dismisses the first-run `BootCheckGate` "Choose core mode" modal
+ * Also dismisses the first-run `BootCheckGate` "Select a Runtime" modal
  * if it's up — every spec needs the real app behind it, and the picker
  * intercepts every click / deep-link otherwise. (The picker only renders
  * when persisted `coreMode.kind === 'unset'`; on a fresh CEF profile —
@@ -45,8 +45,14 @@ export async function waitForApp(): Promise<void> {
   await dismissBootCheckGate();
 }
 
+// Heading text rendered by the BootCheckGate picker phase. These are the
+// English values for `bootCheck.chooseCoreMode` and `bootCheck.connectToCore`
+// in `app/src/lib/i18n/en.ts` — the desktop CEF build renders the first one.
+// Kept in sync with that source; if the i18n strings change, update here too.
+const BOOT_CHECK_GATE_PICKER_HEADING_REGEX = /Select a Runtime|Connect to Your Runtime/;
+
 /**
- * Dismiss the `BootCheckGate` first-run "Choose core mode" picker if it is
+ * Dismiss the `BootCheckGate` first-run "Select a Runtime" picker if it is
  * currently rendered. No-op if the picker is absent (subsequent invocations
  * within a session, or builds where coreMode is already persisted).
  *
@@ -54,7 +60,10 @@ export async function waitForApp(): Promise<void> {
  * intercepts every click in the WebView. Without dismissing it, every
  * mega-flow sub-test would deep-link an app the user can't actually
  * interact with, no `/consume` request would ever fire, and the first
- * `waitForMockRequest` would time out.
+ * `waitForMockRequest` would time out. The OAuth auth-readiness gate added
+ * in #2247 also blocks `consume_login_token` until `openhuman_core_mode` is
+ * persisted, which only happens after the user (or this helper) confirms
+ * the picker.
  *
  * "Local" is pre-selected on desktop builds, so a single Continue click is
  * enough — no need to fill cloud URL/token.
@@ -65,19 +74,25 @@ export async function dismissBootCheckGate(timeout: number = 5_000): Promise<voi
   while (Date.now() < deadline) {
     let onPicker = false;
     try {
-      onPicker = await browser.execute(() => {
+      onPicker = await browser.execute(picker => {
+        const re = new RegExp(picker);
         const headings = Array.from(document.querySelectorAll('h2'));
-        return headings.some(h =>
-          /Choose core mode|Connect to your core/.test(h.textContent ?? '')
-        );
-      });
+        return headings.some(h => re.test(h.textContent ?? ''));
+      }, BOOT_CHECK_GATE_PICKER_HEADING_REGEX.source);
     } catch {
       // session not yet ready — keep polling
       await browser.pause(200);
       continue;
     }
 
-    if (!onPicker) return;
+    if (!onPicker) {
+      // Picker not visible right now. It may still be mid-mount (BootCheckGate
+      // renders inside the provider chain so its first paint can land a beat
+      // after `#root` first gains children), so keep polling until the
+      // deadline rather than declaring "no picker" on the first sample.
+      await browser.pause(200);
+      continue;
+    }
 
     let clicked = false;
     try {
@@ -97,11 +112,12 @@ export async function dismissBootCheckGate(timeout: number = 5_000): Promise<voi
       const dismissDeadline = Date.now() + 5_000;
       while (Date.now() < dismissDeadline) {
         try {
-          const stillThere = await browser.execute(() =>
-            Array.from(document.querySelectorAll('h2')).some(h =>
-              /Choose core mode|Connect to your core/.test(h.textContent ?? '')
-            )
-          );
+          const stillThere = await browser.execute(picker => {
+            const re = new RegExp(picker);
+            return Array.from(document.querySelectorAll('h2')).some(h =>
+              re.test(h.textContent ?? '')
+            );
+          }, BOOT_CHECK_GATE_PICKER_HEADING_REGEX.source);
           if (!stillThere) return;
         } catch {
           // ignore


### PR DESCRIPTION
## Summary

- Update `dismissBootCheckGate` to match the current i18n heading text rendered by `BootCheckGate` ("Select a Runtime" / "Connect to Your Runtime"), not the stale "Choose core mode" / "Connect to your core" strings the regex was still pinned to.
- Centralise the regex in a single constant and stop returning early on the first poll when the picker is not visible yet (BootCheckGate's first paint can land a beat after `#root` first gains children; the 5s deadline already bounds the wait).

## Problem

The `e2e / E2E (Linux / Appium Chromium)` job on #2247 is failing because four deep-link-consume mega-flow scenarios time out at 30s waiting for the new OAuth auth-readiness gate to lift:

```
Mega flow — login + Gmail OAuth + Composio in one session login: consume deep link triggers /consume + /auth/me on the mock
Mega flow — login + Gmail OAuth + Composio in one session bypass login: key=auth deep link skips /consume but still fetches /auth/me
Mega flow — login + Gmail OAuth + Composio in one session Gmail OAuth: success deep link is consumed without crashing the session
Mega flow — login + Gmail OAuth + Composio in one session Composio: enable_trigger via RPC mutates the active-triggers list
```

The new `waitForOAuthAuthReadiness` gate (added in #2247) hard-depends on `localStorage.openhuman_core_mode` being set before it lets `consume_login_token` through. That key is only persisted when `BootCheckGate`'s "Continue" button is clicked. In E2E, `dismissBootCheckGate()` is supposed to auto-click that on every spec startup, but its regex still matched the legacy heading text:

```ts
/Choose core mode|Connect to your core/
```

The current i18n values in `app/src/lib/i18n/en.ts:1071-1072` are:

```
'bootCheck.chooseCoreMode': 'Select a Runtime',
'bootCheck.connectToCore':  'Connect to Your Runtime',
```

So the helper never detected the picker, never clicked Continue, never persisted the mode, and the readiness gate timed out.

Pre-#2247 the same mismatch existed but was harmless — the deep-link handler called `consumeLoginToken` immediately and didn't care that the picker was still hovering above the WebView. #2247 surfaces the latent bug.

## Solution

- Replace the inline regex with a single `BOOT_CHECK_GATE_PICKER_HEADING_REGEX` constant matching `/Select a Runtime|Connect to Your Runtime/` (mirrors the desktop and web i18n strings).
- Remove the early-return when `onPicker` is false on the first sample; instead, pause-and-retry until the deadline so we tolerate React's first-paint timing.
- Pass the regex source through `browser.execute` so both the "is picker up" and "did modal unmount" checks stay in sync.
- Refresh the docstrings to reference the current picker name and explain the dependency the gate in #2247 introduced.

No production code changes — this is purely the E2E test harness.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `N/A: test harness helper, not a feature; exercised end-to-end by the mega-flow spec the helper supports.`
- [x] **Diff coverage ≥ 80%** — `N/A: changes are in app/test/e2e/helpers/, excluded from coverage gate.`
- [x] Coverage matrix updated — `N/A: no production behaviour change.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: test-only change.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: unblocks the open #2247 PR; no separate issue.`

## Impact

Unblocks the failing `e2e / E2E (Linux / Appium Chromium)` job on #2247 and any future PR whose tests depend on the picker being dismissed (login-flow, runtime-picker-login, logout-relogin-onboarding, etc.). On non-fresh CEF profiles where the mode is already persisted, the helper still returns within the same 5s budget without clicking anything.

## Related

- Unblocks #2247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test helper reliability by improving modal detection logic to be more resilient to timing variations and reducing early exit conditions.
  * Updated test documentation to clarify bootstrap modal handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->