### PR TITLE
feat(migrations): update schema version to 3 and retire chat-v1 model

### DIFF
--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -25,16 +25,14 @@ pub const MODEL_REASONING_QUICK_V1: &str = "reasoning-quick-v1";
 pub const MODEL_CODING_V1: &str = "coding-v1";
 /// Default model used when no explicit model is configured.
 ///
-/// The orchestrator (user-facing chat agent) reads the user's message and
-/// either replies directly or delegates to a sub-agent via `spawn_subagent`.
-/// We route it through the `chat` workload (`hint:chat`) so the user-facing
-/// `chat_provider` setting in Settings → LLM → Routing actually drives the
-/// main chat turn — and so the orchestrator gets the low-latency `chat` tier
-/// by default (backend maps `hint:chat` to Kimi K2.6 Turbo, tuned for
-/// time-to-first-token; see backend PR #760). Sub-agents that actually
-/// execute tool calls explicitly ride on `hint:agentic`/`hint:coding` via
-/// their `ModelSpec::Hint(...)` declarations — see `builtin_definitions.rs`.
-pub const DEFAULT_MODEL: &str = MODEL_CHAT_V1;
+/// Set to `reasoning-quick-v1` (Kimi K2.6 Turbo on Fireworks — low-latency,
+/// 128k context, tuned for time-to-first-token). `chat-v1` was the previous
+/// value here but was retired from the backend strict model registry; new
+/// session threads that sent `chat-v1` received a 400 error. Existing threads
+/// had it silently remapped to `reasoning-v1` by the backend, but sub-agent
+/// spawns (new threads) failed. Migration 2 → 3 (`retire_chat_v1_model`)
+/// upgrades any persisted `config.toml` that still holds `chat-v1`.
+pub const DEFAULT_MODEL: &str = MODEL_REASONING_QUICK_V1;
 
 /// Top-level configuration (config.toml root).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -225,7 +225,7 @@ fn make_openhuman_backend(config: &Config) -> anyhow::Result<(Box<dyn Provider>,
     // canonical tier names.
     let model = match model.strip_prefix("hint:") {
         Some("reasoning") => crate::openhuman::config::MODEL_REASONING_V1.to_string(),
-        Some("chat") => crate::openhuman::config::MODEL_CHAT_V1.to_string(),
+        Some("chat") => crate::openhuman::config::MODEL_REASONING_QUICK_V1.to_string(),
         Some("agentic") => crate::openhuman::config::MODEL_AGENTIC_V1.to_string(),
         Some("coding") => crate::openhuman::config::MODEL_CODING_V1.to_string(),
         _ => model,

--- a/src/openhuman/migrations/mod.rs
+++ b/src/openhuman/migrations/mod.rs
@@ -24,10 +24,11 @@
 use crate::openhuman::config::Config;
 
 mod phase_out_profile_md;
+mod retire_chat_v1_model;
 mod unify_ai_provider_settings;
 
 /// Current target schema version. Bumped alongside every new migration.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Run any migrations whose `schema_version` gate hasn't yet been
 /// crossed for this workspace.
@@ -136,6 +137,40 @@ pub async fn run_pending(config: &mut Config) {
             Err(err) => {
                 log::warn!(
                     "[migrations] unify_ai_provider_settings failed: {err:#} — \
+                     will retry on next launch"
+                );
+            }
+        }
+    }
+
+    // 2 -> 3: retire `chat-v1` as the default model. The backend removed
+    // `chat-v1` from its strict model registry; sub-agent spawns (new
+    // threads) that sent this literal model ID received a 400. Remap any
+    // persisted `default_model = "chat-v1"` to `"reasoning-quick-v1"`.
+    // Guard on `== 2` so a failed 1→2 migration doesn't skip this step.
+    if config.schema_version == 2 {
+        match retire_chat_v1_model::run(config) {
+            Ok(stats) => {
+                let previous_version = config.schema_version;
+                config.schema_version = 3;
+                if let Err(err) = config.save().await {
+                    config.schema_version = previous_version;
+                    log::warn!(
+                        "[migrations] retire_chat_v1_model ran but config.save failed: \
+                         {err:#} — rolled in-memory schema_version back to {previous_version}, \
+                         will retry on next launch"
+                    );
+                    return;
+                }
+                log::info!(
+                    "[migrations] schema_version bumped to 3 (retire_chat_v1_model \
+                     default_model_remapped={})",
+                    stats.default_model_remapped
+                );
+            }
+            Err(err) => {
+                log::warn!(
+                    "[migrations] retire_chat_v1_model failed: {err:#} — \
                      will retry on next launch"
                 );
             }

--- a/src/openhuman/migrations/mod_tests.rs
+++ b/src/openhuman/migrations/mod_tests.rs
@@ -74,7 +74,7 @@ async fn run_pending_runs_phase_out_when_version_zero() {
     assert_eq!(config.schema_version, 0);
     run_pending(&mut config).await;
 
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
     let session = read_transcript(&path).unwrap();
     assert!(
         !session.messages[0].content.contains("### PROFILE.md"),
@@ -84,8 +84,8 @@ async fn run_pending_runs_phase_out_when_version_zero() {
 
     let on_disk = std::fs::read_to_string(&config.config_path).unwrap();
     assert!(
-        on_disk.contains("schema_version = 2"),
-        "saved config.toml must record schema_version=2, got:\n{on_disk}"
+        on_disk.contains("schema_version = 3"),
+        "saved config.toml must record schema_version=3, got:\n{on_disk}"
     );
 }
 
@@ -98,9 +98,9 @@ async fn run_pending_bumps_version_on_fresh_install() {
     let mut config = config_in(&tmp);
     run_pending(&mut config).await;
 
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
     let on_disk = std::fs::read_to_string(&config.config_path).unwrap();
-    assert!(on_disk.contains("schema_version = 2"));
+    assert!(on_disk.contains("schema_version = 3"));
 }
 
 #[tokio::test]
@@ -132,7 +132,7 @@ async fn run_pending_is_a_no_op_on_second_invocation() {
 
     let mut config = config_in(&tmp);
     run_pending(&mut config).await;
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
 
     // Mutate the config file timestamp marker by reading + comparing
     // before vs after the second invocation.
@@ -141,7 +141,7 @@ async fn run_pending_is_a_no_op_on_second_invocation() {
     run_pending(&mut config).await;
     let after = fs::metadata(&config.config_path).unwrap().modified().ok();
 
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
     assert_eq!(
         before, after,
         "config.toml must not be re-saved on second run"

--- a/src/openhuman/migrations/retire_chat_v1_model.rs
+++ b/src/openhuman/migrations/retire_chat_v1_model.rs
@@ -1,0 +1,111 @@
+//! Migration 2 → 3: retire `chat-v1` as the default model.
+//!
+//! The backend removed `chat-v1` from its strict model registry. New inference
+//! threads (sub-agent spawns) that sent the literal `"chat-v1"` model ID
+//! received a 400 error ("Model 'chat-v1' is not available"), while existing
+//! session threads continued to work because the backend silently remapped
+//! `chat-v1` → `reasoning-v1` for backward compatibility on old threads only.
+//!
+//! This migration upgrades any workspace whose `config.default_model` is still
+//! `"chat-v1"` to `"reasoning-quick-v1"` — the same Kimi K2.6 Turbo backend
+//! model that `chat-v1` was previously aliased to. The code constant
+//! `DEFAULT_MODEL` was updated in the same change.
+//!
+//! ## Behaviour
+//!
+//! - Pure in-memory mutation of `Config`. The caller (`migrations::run_pending`)
+//!   persists the result via `Config::save()` and bumps `schema_version`.
+//! - Idempotent: only remaps when `default_model == Some("chat-v1")`.
+//! - Does not touch any other config fields, API keys, or session files.
+
+use crate::openhuman::config::schema::MODEL_CHAT_V1;
+use crate::openhuman::config::schema::MODEL_REASONING_QUICK_V1;
+use crate::openhuman::config::Config;
+
+/// Counters returned by [`run`] for diagnostics.
+#[derive(Debug, Default, Clone)]
+pub struct MigrationStats {
+    /// `true` when `default_model` was remapped from `chat-v1`.
+    pub default_model_remapped: bool,
+}
+
+/// Run the `chat-v1` retirement migration on the given `Config`.
+///
+/// Synchronous — pure config mutation, no I/O. Caller persists via
+/// `Config::save()` once `schema_version` is also bumped.
+pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
+    let mut stats = MigrationStats::default();
+
+    if config.default_model.as_deref() == Some(MODEL_CHAT_V1) {
+        log::info!(
+            "[migrations][retire-chat-v1] remapping default_model chat-v1 -> {}",
+            MODEL_REASONING_QUICK_V1
+        );
+        config.default_model = Some(MODEL_REASONING_QUICK_V1.to_string());
+        stats.default_model_remapped = true;
+    } else {
+        log::debug!(
+            "[migrations][retire-chat-v1] default_model={:?} — no remap needed",
+            config.default_model
+        );
+    }
+
+    Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::config::Config;
+
+    #[test]
+    fn remaps_chat_v1_to_reasoning_quick_v1() {
+        let mut config = Config::default();
+        config.default_model = Some("chat-v1".to_string());
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(stats.default_model_remapped);
+        assert_eq!(
+            config.default_model.as_deref(),
+            Some("reasoning-quick-v1"),
+            "default_model must be remapped"
+        );
+    }
+
+    #[test]
+    fn leaves_other_model_values_unchanged() {
+        let mut config = Config::default();
+        config.default_model = Some("reasoning-v1".to_string());
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.default_model_remapped);
+        assert_eq!(config.default_model.as_deref(), Some("reasoning-v1"));
+    }
+
+    #[test]
+    fn leaves_none_default_model_unchanged() {
+        let mut config = Config::default();
+        config.default_model = None;
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.default_model_remapped);
+        assert_eq!(config.default_model, None);
+    }
+
+    #[test]
+    fn idempotent_when_already_reasoning_quick_v1() {
+        let mut config = Config::default();
+        config.default_model = Some("reasoning-quick-v1".to_string());
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.default_model_remapped);
+        assert_eq!(
+            config.default_model.as_deref(),
+            Some("reasoning-quick-v1")
+        );
+    }
+}

--- a/src/openhuman/migrations/retire_chat_v1_model.rs
+++ b/src/openhuman/migrations/retire_chat_v1_model.rs
@@ -103,9 +103,6 @@ mod tests {
         let stats = run(&mut config).expect("migration should succeed");
 
         assert!(!stats.default_model_remapped);
-        assert_eq!(
-            config.default_model.as_deref(),
-            Some("reasoning-quick-v1")
-        );
+        assert_eq!(config.default_model.as_deref(), Some("reasoning-quick-v1"));
     }
 }


### PR DESCRIPTION
## Summary

- Retires `chat-v1` as the default model: the backend removed it from its strict model registry, causing new sub-agent spawns (new inference threads) to receive 400 errors
- Updates `DEFAULT_MODEL` constant to `reasoning-quick-v1` (Kimi K2.6 Turbo on Fireworks — same underlying model `chat-v1` previously aliased to)
- Adds schema migration 2 → 3 (`retire_chat_v1_model`) that remaps any persisted `config.default_model = "chat-v1"` to `"reasoning-quick-v1"` on next launch
- Remaps `hint:chat` in the OpenHuman backend provider factory to `reasoning-quick-v1` as well

## Test plan

- [ ] Unit tests in `retire_chat_v1_model.rs`: remap when `chat-v1`, idempotent when already `reasoning-quick-v1`, no-op on `None` and other model values
- [ ] Migration integration tests in `mod_tests.rs`: fresh install and upgrade from v0 all advance to schema_version=3
- [ ] `cargo test` passes
- [ ] Existing workspace with `default_model = "chat-v1"` in `config.toml` is migrated to `reasoning-quick-v1` on launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Default AI model changed from chat-v1 to reasoning-quick-v1
  * Existing configurations using chat-v1 are automatically remapped to reasoning-quick-v1 on next launch
  * Model selection logic updated to reflect the new default
  * Full backward compatibility ensured—no user action required

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->