### PR TITLE
fix(tauri): retry main-window lookup on Windows after SW_SHOW (#3A)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1168,6 +1168,59 @@ fn set_main_window_hidden(hide: bool) {
     );
 }
 
+/// Look up the main `WebviewWindow`, optionally waiting briefly on Windows
+/// for the Tauri runtime to re-track the window after SW_SHOW.
+///
+/// Why this exists (OPENHUMAN-TAURI-3A): on Windows the close button routes
+/// through [`set_main_window_hidden`] which uses raw-HWND `SW_HIDE`. CEF
+/// treats the hidden host as gone and the Tauri runtime drops its
+/// `WebviewWindow` record for `"main"` until the next event-loop tick after
+/// SW_SHOW restores visibility. A tray "Show window" callback that runs
+/// `set_main_window_hidden(false)` and then immediately calls
+/// `app.get_webview_window("main")` can race the re-track step and observe
+/// `None` even though the OS window is visible — Sentry sees a
+/// `[tray] failed to show main window from menu: main window not found`
+/// warn even though, from the user's perspective, the window came back.
+///
+/// Bounded retry budget: up to 5 lookups with 10 ms between attempts (≤ 50 ms
+/// worst case). The tray menu is closed during this window, so the small
+/// blocking delay is invisible. After the budget expires the original
+/// error path still triggers, preserving the signal if the runtime never
+/// re-tracks (which would indicate a real lifecycle bug, not a race).
+///
+/// Non-Windows platforms use a single lookup — the close-to-tray flow that
+/// produces the race is Windows-specific (the macOS close button routes
+/// through `app.hide()` per PR #2049, and Linux/X11 keeps the
+/// `WebviewWindow` record across `WM_DELETE_WINDOW` handling).
+fn get_main_webview_window_with_retry(
+    app: &AppHandle<AppRuntime>,
+) -> Option<tauri::WebviewWindow<AppRuntime>> {
+    #[cfg(target_os = "windows")]
+    {
+        const ATTEMPTS: usize = 5;
+        const BACKOFF: std::time::Duration = std::time::Duration::from_millis(10);
+        for attempt in 0..ATTEMPTS {
+            if let Some(window) = app.get_webview_window("main") {
+                if attempt > 0 {
+                    log::debug!(
+                        "[show_main_window] runtime re-tracked main window after {} retries",
+                        attempt
+                    );
+                }
+                return Some(window);
+            }
+            if attempt + 1 < ATTEMPTS {
+                std::thread::sleep(BACKOFF);
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        app.get_webview_window("main")
+    }
+}
+
 fn show_main_window(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     // On Windows: surface the OS top-level Chrome_WidgetWin_1 frame BEFORE
     // any Tauri lookups. After our close handler's SW_HIDE the runtime
@@ -1176,7 +1229,10 @@ fn show_main_window(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     // and the early `?` below would abort before SW_SHOW fires (#1607).
     // EnumWindows + SW_SHOW operates directly on the OS HWND that
     // survived independently, and the runtime re-tracks the window once
-    // it's visible again.
+    // it's visible again — but re-tracking lands on the next event-loop
+    // tick, not synchronously with SW_SHOW. `get_main_webview_window_with_retry`
+    // bounds the wait to ~50 ms total so the tray callback can pick up the
+    // re-tracked window without re-emitting OPENHUMAN-TAURI-3A.
     #[cfg(target_os = "windows")]
     {
         set_main_window_hidden(false);
@@ -1185,8 +1241,7 @@ fn show_main_window(app: &AppHandle<AppRuntime>) -> Result<(), String> {
             let _ = webview.set_focus();
         }
     }
-    let window = app
-        .get_webview_window("main")
+    let window = get_main_webview_window_with_retry(app)
         .ok_or_else(|| "main window not found".to_string())?;
     window
         .show()


### PR DESCRIPTION
## Summary

- Wraps the `app.get_webview_window(\"main\")` lookup in `show_main_window` with a 5×10ms bounded retry on Windows so the tray callback doesn't observe `None` during the brief window where the Tauri runtime hasn't re-tracked the main `WebviewWindow` record after `SW_SHOW`.
- Closes OPENHUMAN-TAURI-3A (~15 events) — the Sentry warn `[tray] failed to show main window from menu: main window not found` fires while the OS window has already come back visible, so the user sees the window restore but Sentry sees noise and the post-show polish chain (`unminimize`, Tauri-level `set_focus`, CEF `set_focus`) is skipped.
- Pure Windows-cfg-gated helper. macOS / Linux paths unchanged — the race is specific to the `SW_HIDE` close-to-tray flow on Windows.

## Problem

On Windows, the app's close button doesn't destroy the main window — it routes through [`set_main_window_hidden(true)`](../app/src-tauri/src/lib.rs#L1111) which uses Win32 `EnumWindows` + `SW_HIDE` on the `Chrome_WidgetWin_1` HWND so the user can restore from the tray (PR #1583). CEF treats the hidden host as gone, so the Tauri runtime drops its `WebviewWindow` record for `\"main\"` while the window is in the SW_HIDE state.

When the user clicks the tray menu's *Show window* item (or left-clicks the tray icon), [`show_main_window`](../app/src-tauri/src/lib.rs#L1171) runs the Windows branch:

1. `set_main_window_hidden(false)` issues `SW_SHOW` on the raw HWND — the OS window becomes visible immediately.
2. `app.get_webview(\"main\")` + `webview.show()` nudges the runtime to re-track.
3. `app.get_webview_window(\"main\")` synchronously expects a `Some(_)` back.

Step 3 races step 2 because the runtime re-tracks the window on the *next event-loop tick*, not synchronously with `SW_SHOW`. The lookup returns `None`, the `?` propagates `\"main window not found\"`, and the tray callback emits:

```
[tray] failed to show main window from menu: main window not found
```

User effect today: the SW_SHOW already worked, so the window IS visible — but the post-show polish chain (Tauri-level `window.show()`, `unminimize()`, `set_focus()`, CEF `set_focus()` for keyboard routing) is skipped, and Sentry pages on what looks like a fatal tray failure even though the user got what they wanted.

15 occurrences observed on Windows 10/11 since 2026-05-09 (release 0.53.22 → 0.54.x), spread across at least one Foshan (CN), one Hyderabad (IN), and several US users. The CEF runtime + SW_HIDE close-to-tray code has not been touched on main since the issue was first seen, so the race is still live in 0.54.x.

## Solution

Introduce `get_main_webview_window_with_retry(app)` next to `show_main_window`:

```rust
fn get_main_webview_window_with_retry(
    app: &AppHandle<AppRuntime>,
) -> Option<tauri::WebviewWindow<AppRuntime>> {
    #[cfg(target_os = \"windows\")]
    {
        const ATTEMPTS: usize = 5;
        const BACKOFF: std::time::Duration = std::time::Duration::from_millis(10);
        for attempt in 0..ATTEMPTS {
            if let Some(window) = app.get_webview_window(\"main\") {
                if attempt > 0 {
                    log::debug!(
                        \"[show_main_window] runtime re-tracked main window after {} retries\",
                        attempt
                    );
                }
                return Some(window);
            }
            if attempt + 1 < ATTEMPTS {
                std::thread::sleep(BACKOFF);
            }
        }
        None
    }
    #[cfg(not(target_os = \"windows\"))]
    {
        app.get_webview_window(\"main\")
    }
}
```

`show_main_window` swaps the single-call lookup for `get_main_webview_window_with_retry(app)`. Worst case: 50 ms of `std::thread::sleep` on the tray callback thread. The tray menu is already closed by the time the user clicks an item, so the small delay is invisible — the user sees `SW_SHOW` (window appears) immediately, and the focus/unminimize polish lands one tick late.

Hard cap at 5 attempts preserves the original error path if the runtime never re-tracks — that would be a real lifecycle bug worth a Sentry event, not a race worth papering over.

Non-Windows platforms route through the single-call path because:
- **macOS** close button routes through `app.hide()` (PR #2049) — the `WebviewWindow` record stays intact.
- **Linux/X11** keeps the `WebviewWindow` record across `WM_DELETE_WINDOW` — the close handler just hides without dropping the host.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] N/A: pure platform-cfg-gated retry helper around an existing Tauri API call. Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — the race is a runtime timing bug between SW_SHOW (raw HWND) and Tauri's event-loop re-track step, not a unit-testable code path. Validation plan in the *Impact* section below.
- [x] N/A: only added rustdoc + a Windows-cfg-gated branch + a one-line call-site swap. **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml).
- [x] N/A: behaviour-only change, no feature row impact. Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)).
- [x] N/A: classifier-adjacent fix; no release-cut surface (tray show-from-menu was already in the release smoke). Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)).
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Runtime**: on Windows, the tray *Show window* / tray icon left-click callback can now block its caller for up to 50 ms in the race window. The tray menu is closed by the time we reach this code path; no user-visible latency. macOS and Linux unchanged.
- **Performance**: negligible — 5×10ms is the worst case and only fires when the race triggers (which is exactly the case the current code paths emit a warn for). The fast path (window already re-tracked) is a single `get_webview_window` call as before.
- **Security**: no new attack surface; helper is private, single-purpose, and doesn't reach beyond `app.get_webview_window`.
- **Migration**: none.
- **Compatibility**: forward-compatible. If/when Tauri synchronously re-tracks the window after a host-visibility change (or our SW_SHOW path stops dropping the record at all), the retry loop short-circuits on the first attempt and the helper degrades to a no-op overhead.
- **Validation plan** (no unit test added — see Submission Checklist above):
  - CI runs `cargo check --manifest-path app/src-tauri/Cargo.toml` and `cargo clippy --manifest-path app/src-tauri/Cargo.toml -- -D warnings` on Windows. Both pass locally on macOS; CI Windows runner exercises the cfg-gated body.
  - Manual smoke on Windows: launch dev:app, close to tray, right-click tray → *Show window*, verify focus + unminimize land and no `[tray] failed to show main window from menu: main window not found` lands in stderr. Repeat with left-click tray icon. (I can't smoke this locally on macOS — flagging honestly.)

## Related

- Closes OPENHUMAN-TAURI-3A
- Related context: PR #1583 (`feat(tauri): hide main window to tray on Windows close`) introduced the SW_HIDE flow; PR #1607 (`fix(tauri): retry main-window lookup`) hardened against the same record-drop on a different code path; PR #2049 (`fix(shell): use app-level hide on macOS close button`) is why this PR is Windows-only.
- Follow-up PR(s)/TODOs: if/when Tauri's re-track step lands synchronously with the host-visibility transition, this helper becomes vestigial and can be deleted. Tracked informally.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A (Sentry-driven triage; no Linear ticket)
- URL: N/A

### Commit & Branch
- Branch: fix/sentry-3a-tray-window-race
- Commit SHA: ca240f93 (tip)

### Agent
- Claude Code (Opus 4.7, 1M context) running locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved main window display reliability by fixing a race condition on Windows that could prevent the window from appearing correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->