### PR TITLE
docs(linux): add arch linux setup and build instructions

### DIFF
--- a/CONTRIBUTING-BEGINNERS.md
+++ b/CONTRIBUTING-BEGINNERS.md
@@ -26,11 +26,11 @@ For the full contributor reference, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 OpenHuman is a desktop AI assistant app. The codebase has three main parts:
 
-| Part | Tech | What it does |
-|------|------|-------------|
-| `app/` | React + TypeScript | The UI — what you see and click |
-| `app/src-tauri/` | Rust + Tauri | Wraps the UI into a desktop app |
-| `src/` | Rust | The backend brain — logic, memory, RPC |
+| Part             | Tech               | What it does                           |
+| ---------------- | ------------------ | -------------------------------------- |
+| `app/`           | React + TypeScript | The UI — what you see and click        |
+| `app/src-tauri/` | Rust + Tauri       | Wraps the UI into a desktop app        |
+| `src/`           | Rust               | The backend brain — logic, memory, RPC |
 
 **As a beginner**, focus on `app/src/` (React/TypeScript). You don't need to touch Rust to make meaningful contributions.
 
@@ -138,6 +138,106 @@ When the installer opens, select **Desktop development with C++**. Make sure it 
 
 </details>
 
+<details>
+<summary><strong>Linux (Arch) setup</strong></summary>
+
+Install Node.js 24+, pnpm, Rust, and the native build dependencies:
+
+```bash
+# Node.js and npm (Arch ships current Node)
+sudo pacman -S --needed nodejs npm
+
+# pnpm (JavaScript package manager)
+npm install -g pnpm@10.10.0
+
+# Rust via rustup
+sudo pacman -S --needed rustup
+rustup toolchain install 1.93.0 --profile minimal
+rustup component add rustfmt clippy --toolchain 1.93.0
+
+# Build tools required by native Rust crates (whisper-rs, cpal, enigo, etc.)
+sudo pacman -S --needed base-devel cmake pkgconf clang openssl \
+  alsa-lib xdotool libxtst libxi libevdev
+```
+
+For desktop (Tauri/CEF) builds, also install:
+
+```bash
+sudo pacman -S --needed gtk3 webkit2gtk-4.1 libayatana-appindicator \
+  librsvg patchelf nss nspr at-spi2-core libcups libdrm \
+  libxkbcommon libxcomposite libxdamage libxfixes libxrandr \
+  mesa pango cairo libxshmfence
+```
+
+Verify everything is installed:
+
+```bash
+node --version     # should be v24.x.x or higher
+pnpm --version     # should be 10.10.0
+rustc --version    # should be 1.93.0
+cmake --version    # any recent version
+```
+
+> **Node version warning**: The project requires Node 24+. If your Arch `nodejs` package is older, install `nvm` and run `nvm install 24 && nvm use 24`.
+
+</details>
+
+<details>
+<summary><strong>Linux (Ubuntu/Debian) setup</strong></summary>
+
+Install Node.js 24+ via [NodeSource](https://github.com/nodesource/distributions) or `nvm`:
+
+```bash
+# Using nvm (recommended)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+nvm install 24
+nvm use 24
+
+# pnpm
+npm install -g pnpm@10.10.0
+```
+
+Install Rust:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install 1.93.0 --profile minimal
+rustup component add rustfmt clippy --toolchain 1.93.0
+```
+
+Install native build dependencies:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential cmake pkg-config clang libssl-dev libclang-dev \
+  libasound2-dev libxi-dev libxtst-dev libxdo-dev libudev-dev \
+  libstdc++-14-dev
+```
+
+For desktop (Tauri/CEF) builds, also install:
+
+```bash
+sudo apt-get install -y \
+  libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev \
+  patchelf libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+  libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+  libgbm1 libpango-1.0-0 libcairo2 libatspi2.0-0 libxshmfence1 libu2f-udev
+```
+
+Verify everything is installed:
+
+```bash
+node --version     # should be v24.x.x or higher
+pnpm --version     # should be 10.10.0
+rustc --version    # should be 1.93.0
+cmake --version    # any recent version
+```
+
+> **Node version warning**: The project requires Node 24+. If you see `Unsupported engine: wanted >=24.0.0`, run `nvm install 24 && nvm use 24`.
+
+</details>
+
 ---
 
 ## Step 2 — Fork and clone the repo
@@ -223,12 +323,12 @@ For your first contribution, `pnpm dev` is all you need.
 
 ### Recommended first areas for beginners
 
-| Area | Where it lives | Skills needed |
-|------|---------------|---------------|
-| UI components | `app/src/` | React, TypeScript |
-| Styles / design | `app/src/`, `app/tailwind.config.js` | CSS, Tailwind |
-| Documentation | `*.md` files, `gitbooks/` | Writing |
-| Bug fixes (frontend) | `app/src/` | React, TypeScript |
+| Area                 | Where it lives                       | Skills needed     |
+| -------------------- | ------------------------------------ | ----------------- |
+| UI components        | `app/src/`                           | React, TypeScript |
+| Styles / design      | `app/src/`, `app/tailwind.config.js` | CSS, Tailwind     |
+| Documentation        | `*.md` files, `gitbooks/`            | Writing           |
+| Bug fixes (frontend) | `app/src/`                           | React, TypeScript |
 
 **Avoid for now**: anything in `src/` (Rust core) or `app/src-tauri/` (Tauri shell) until you're comfortable with the codebase.
 

--- a/gitbooks/developing/building-rust-core.md
+++ b/gitbooks/developing/building-rust-core.md
@@ -114,7 +114,7 @@ Why these matter:
 - `build-essential` / `base-devel`, `cmake`, `pkg-config` / `pkgconf`: native builds used by transitive Rust dependencies.
 - `clang`, `libclang-dev`: bindgen / C and C++ compilation paths used by native crates.
 - `libssl-dev` / `openssl`: OpenSSL headers needed by some networking dependencies.
-- `libasound2-dev` / `alsa-lib`, `libxi-dev` / `libxi`, `libxtst-dev` / `libxtst`, `libxdo-dev` / `xdotool`, `libudev-dev` / `libevdev`: required by audio/input/device crates pulled into the core build.
+- `libasound2-dev` / `alsa-lib`, `libxi-dev` / `libxi`, `libxtst-dev` / `libxtst`, `libxdo-dev` / `xdotool`, `libudev-dev` (included in Arch `systemd-libs`), `libevdev`: required by audio/input/device crates pulled into the core build.
 
 ### `whisper-rs` + `clang` note
 

--- a/gitbooks/developing/building-rust-core.md
+++ b/gitbooks/developing/building-rust-core.md
@@ -88,7 +88,9 @@ After Xcode CLT is installed, the core should build with the cargo commands abov
 
 ### Core-only package set
 
-Install these packages before running `cargo` on a fresh Ubuntu/Debian machine:
+Install these packages before running `cargo` on a fresh Linux machine.
+
+**Ubuntu / Debian:**
 
 ```bash
 sudo apt-get update
@@ -98,12 +100,21 @@ sudo apt-get install -y \
   libstdc++-14-dev
 ```
 
+**Arch Linux:**
+
+```bash
+sudo pacman -S --needed base-devel cmake pkgconf clang openssl \
+  alsa-lib libxi libxtst xdotool libevdev
+```
+
+> On Arch, `clang` includes `libclang` and `base-devel` includes `gcc` (providing `libstdc++`), so separate `-dev` packages are not needed.
+
 Why these matter:
 
-- `build-essential`, `cmake`, `pkg-config`: native builds used by transitive Rust dependencies.
+- `build-essential` / `base-devel`, `cmake`, `pkg-config` / `pkgconf`: native builds used by transitive Rust dependencies.
 - `clang`, `libclang-dev`: bindgen / C and C++ compilation paths used by native crates.
-- `libssl-dev`: OpenSSL headers needed by some networking dependencies.
-- `libasound2-dev`, `libxi-dev`, `libxtst-dev`, `libxdo-dev`, `libudev-dev`: required by audio/input/device crates pulled into the core build.
+- `libssl-dev` / `openssl`: OpenSSL headers needed by some networking dependencies.
+- `libasound2-dev` / `alsa-lib`, `libxi-dev` / `libxi`, `libxtst-dev` / `libxtst`, `libxdo-dev` / `xdotool`, `libudev-dev` / `libevdev`: required by audio/input/device crates pulled into the core build.
 
 ### `whisper-rs` + `clang` note
 
@@ -118,14 +129,17 @@ This is why the docs call out `libstdc++-14-dev`: `clang` may pick GCC 14 C++ he
 If your distro layout still leaves `libstdc++.so` unresolved for the build, use the same workaround documented in [`AGENTS.md`](../../AGENTS.md):
 
 ```bash
+# Ubuntu/Debian — adjust the GCC version as needed
 sudo ln -sf /usr/lib/gcc/x86_64-linux-gnu/13/libstdc++.so /usr/lib/x86_64-linux-gnu/libstdc++.so
 ```
 
-Adjust the GCC version in that path if your machine installs a different one.
+Arch Linux typically does not need this workaround because `gcc-libs` places `libstdc++.so` on the default library search path.
 
 ### Linux desktop/Tauri package set
 
-If you are building the desktop shell instead of the core-only crate, install the broader Ubuntu dependency set mirrored from [`.github/workflows/build-desktop.yml`](../../.github/workflows/build-desktop.yml):
+If you are building the desktop shell instead of the core-only crate, install the broader dependency set.
+
+**Ubuntu / Debian** (mirrored from [`.github/workflows/build-desktop.yml`](../../.github/workflows/build-desktop.yml)):
 
 ```bash
 sudo apt-get update
@@ -138,7 +152,16 @@ sudo apt-get install -y \
   libgbm1 libpango-1.0-0 libcairo2 libatspi2.0-0 libxshmfence1 libu2f-udev
 ```
 
-Use that desktop list only when you need `app/src-tauri/`; for root-crate work, the smaller core-only list above is the relevant baseline.
+**Arch Linux:**
+
+```bash
+sudo pacman -S --needed gtk3 webkit2gtk-4.1 libayatana-appindicator \
+  librsvg patchelf nss nspr at-spi2-core libcups libdrm \
+  libxkbcommon libxcomposite libxdamage libxfixes libxrandr \
+  mesa pango cairo libxshmfence
+```
+
+Use the desktop lists only when you need `app/src-tauri/`; for root-crate work, the smaller core-only list above is the relevant baseline.
 
 ## 6. Windows prerequisites
 

--- a/gitbooks/developing/getting-set-up.md
+++ b/gitbooks/developing/getting-set-up.md
@@ -35,7 +35,7 @@ rustup component add rustfmt clippy --toolchain 1.93.0
 Arch Linux quick start:
 
 ```bash
-sudo pacman -S --needed nodejs npm rustup cmake base-devel clang \
+sudo pacman -S --needed nodejs npm rustup cmake base-devel clang openssl \
   alsa-lib xdotool libxtst libxi libevdev gtk3 webkit2gtk-4.1 \
   libayatana-appindicator librsvg patchelf nss nspr at-spi2-core \
   libcups libdrm libxkbcommon libxcomposite libxdamage libxfixes \

--- a/gitbooks/developing/getting-set-up.md
+++ b/gitbooks/developing/getting-set-up.md
@@ -32,6 +32,19 @@ rustup toolchain install 1.93.0 --profile minimal
 rustup component add rustfmt clippy --toolchain 1.93.0
 ```
 
+Arch Linux quick start:
+
+```bash
+sudo pacman -S --needed nodejs npm rustup cmake base-devel clang \
+  alsa-lib xdotool libxtst libxi libevdev gtk3 webkit2gtk-4.1 \
+  libayatana-appindicator librsvg patchelf nss nspr at-spi2-core \
+  libcups libdrm libxkbcommon libxcomposite libxdamage libxfixes \
+  libxrandr mesa pango cairo libxshmfence
+npm install -g pnpm@10.10.0
+rustup toolchain install 1.93.0 --profile minimal
+rustup component add rustfmt clippy --toolchain 1.93.0
+```
+
 ## Build from source (local compile)
 
 Run from the repository root:


### PR DESCRIPTION
## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.
* Added an Arch Linux collapsible setup block to `CONTRIBUTING-BEGINNERS.md` detailing packages for both core-only builds and desktop shell builds.
* Updated `gitbooks/developing/building-rust-core.md` with explicit Arch `pacman` dependency maps alongside the existing Debian/Ubuntu instructions.
* Added an Arch Linux system prerequisite quick start to `gitbooks/developing/getting-set-up.md`.
* Standardized formatting on all three updated markdown files using Prettier to match workspace styling guidelines.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.
* New contributors attempting to set up the development environment on Arch Linux or Arch-based systems face friction because onboarding guides only document macOS, Windows, and Ubuntu/Debian. Users had to manually guess or map package names like `libxdo`, `libxi`, `webkit2gtk-4.1`, and `libayatana-appindicator`.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.
* Mapped all Ubuntu/Debian dependencies to their Arch Linux `pacman` equivalents, grouping them clearly into base-build tools and desktop/CEF shell dependencies.
* Integrated the instructions into the existing collapsible layouts of the beginner setup guides.
* Noted details specific to Arch systems, such as why separate header `-dev` packages are not needed and why the manual `libstdc++.so` path symlink workaround for clang/whisper-rs is typically unnecessary.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) (N/A: Documentation-only change)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. (N/A: Documentation-only change)
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) (N/A: Documentation-only change)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` (N/A: Documentation-only change)
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) (N/A: Documentation-only change)
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) (N/A: Documentation-only change)
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section (N/A: No corresponding GitHub Issue exists)


## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.
* Safe documentation changes with zero runtime or compilation impact.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: docs/arch-linux-setup
- Commit SHA: 68634870a84cf91435a39e7380170db8cb4bf9a6

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (Verified formatting locally via Prettier)
- [x] `pnpm typecheck`
- [x] Focused tests:
- [N/A] Rust fmt/check (if changed):
- [N/A] Tauri fmt/check (if changed):


### Behavior Changes
- Intended behavior change: Documentation-only additions for Arch Linux setup steps.
- User-visible effect: None on runtime app.

### Parity Contract
- Legacy behavior preserved: Yes.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved beginner contributor guide layout and clearer project-part overview
  * Added dedicated Linux setup instructions for Arch and Ubuntu/Debian (desktop and core)
  * Expanded Rust core build docs with distribution-specific package lists and rationale
  * Added Ubuntu/Debian workaround for a native library selection issue
  * Added Arch Linux quick-start with pinned toolchain and package/install steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->