### PR TITLE
fix(agent): handle config rejection in streaming_chat path

### DIFF
--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -490,6 +490,13 @@ impl OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::is_provider_config_rejection_http(status, self.name.as_str(), &error) {
+                super::log_provider_config_rejection(
+                    "responses_api",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                    );
             } else if super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),
@@ -851,6 +858,13 @@ impl OpenAiCompatibleProvider {
                 );
             } else if super::is_provider_access_policy_denied_http_403(status, &body) {
                 super::log_provider_access_policy_denied_http_403(
+                    "streaming_chat",
+                    self.name.as_str(),
+                    Some(native_request.model.as_str()),
+                    status,
+                );
+            } else if super::is_provider_config_rejection_http(status, self.name.as_str(), &body) {
+                super::log_provider_config_rejection(
                     "streaming_chat",
                     self.name.as_str(),
                     Some(native_request.model.as_str()),
@@ -1348,6 +1362,13 @@ impl Provider for OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::is_provider_config_rejection_http(status, self.name.as_str(), &error) {
+                super::log_provider_config_rejection(
+                    "chat_completions",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                );
             } else if super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),
@@ -1797,6 +1818,13 @@ impl Provider for OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::is_provider_config_rejection_http(status, self.name.as_str(), &error) {
+                super::log_provider_config_rejection(
+                    "native_chat",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                );
             } else if super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),
@@ -1947,6 +1975,17 @@ impl Provider for OpenAiCompatibleProvider {
                     );
                 } else if super::is_provider_access_policy_denied_http_403(status, &raw_error) {
                     super::log_provider_access_policy_denied_http_403(
+                        "stream_chat",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                    );
+                } else if super::is_provider_config_rejection_http(
+                    status,
+                    provider_name.as_str(),
+                    &raw_error,
+                ) {
+                    super::log_provider_config_rejection(
                         "stream_chat",
                         provider_name.as_str(),
                         Some(model_owned.as_str()),

--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -496,7 +496,7 @@ impl OpenAiCompatibleProvider {
                     self.name.as_str(),
                     Some(model),
                     status,
-                    );
+                );
             } else if super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -406,12 +406,8 @@ async fn streaming_chat_config_rejection_propagates_error_without_sentry_report(
     ));
     let _sentry_guard = sentry::HubSwitchGuard::new(sentry_hub);
 
-    let provider = OpenAiCompatibleProvider::new(
-        "custom_openai",
-        &mock_server.uri(),
-        None,
-        AuthStyle::None,
-    );
+    let provider =
+        OpenAiCompatibleProvider::new("custom_openai", &mock_server.uri(), None, AuthStyle::None);
     let request = NativeChatRequest {
         model: "kimi-k2".to_string(),
         messages: vec![NativeMessage {

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use sentry::test::TestTransport;
+use std::sync::Arc;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn make_provider(name: &str, url: &str, key: Option<&str>) -> OpenAiCompatibleProvider {
     OpenAiCompatibleProvider::new(name, url, key, AuthStyle::Bearer)
@@ -372,6 +376,73 @@ async fn chat_via_responses_requires_non_system_message() {
     assert!(err
         .to_string()
         .contains("requires at least one non-system message"));
+}
+
+#[tokio::test]
+async fn streaming_chat_config_rejection_propagates_error_without_sentry_report() {
+    // Representative guardrail for the new provider-config-rejection
+    // suppression branches in compatible.rs: streaming_chat should still
+    // return an error, but it must not call report_error/Sentry for this
+    // deterministic user-config state.
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_string("invalid temperature: only 1 is allowed for this model"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let transport = TestTransport::new();
+    let sentry_options = sentry::ClientOptions {
+        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
+        transport: Some(Arc::new(transport.clone())),
+        ..Default::default()
+    };
+    let sentry_hub = Arc::new(sentry::Hub::new(
+        Some(Arc::new(sentry_options.into())),
+        Arc::new(Default::default()),
+    ));
+    let _sentry_guard = sentry::HubSwitchGuard::new(sentry_hub);
+
+    let provider = OpenAiCompatibleProvider::new(
+        "custom_openai",
+        &mock_server.uri(),
+        None,
+        AuthStyle::None,
+    );
+    let request = NativeChatRequest {
+        model: "kimi-k2".to_string(),
+        messages: vec![NativeMessage {
+            role: "user".to_string(),
+            content: Some("hello".to_string()),
+            tool_call_id: None,
+            tool_calls: None,
+        }],
+        temperature: Some(0.7),
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        thread_id: None,
+        stream_options: Some(super::compatible_types::OpenAiStreamOptions {
+            include_usage: true,
+        }),
+    };
+    let (delta_tx, _delta_rx) = tokio::sync::mpsc::channel(8);
+
+    let err = provider
+        .stream_native_chat(None, &request, &delta_tx, 0)
+        .await
+        .expect_err("400 provider config-rejection must still propagate as Err");
+    assert!(
+        err.to_string().contains("streaming API error"),
+        "err: {err}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "provider config-rejection must not be reported to Sentry"
+    );
 }
 
 // ----------------------------------------------------------


### PR DESCRIPTION
## Summary

- In `OpenAiCompatibleProvider`, route HTTP errors that match a known *provider-config rejection* (e.g. invalid/unauthorized API key, disabled model, billing block) to `log_provider_config_rejection` instead of `observability::report_error`.
- Applies the new branch consistently across all five request paths in the provider: `responses_api`, `streaming_chat`, `chat_completions`, `native_chat`, and `stream_chat`.
- Suppresses the recurring Sentry issue `OPENHUMAN-TAURI-NJ`, which was being driven by user-config rejections being misclassified as provider bugs.
- No behavior change for genuine provider failures — those still flow through `should_report_provider_http_failure` → `report_error` as before.
- Second commit is a tiny formatting touch-up to the same file.

## Problem

- `OpenAiCompatibleProvider` was funneling every non-401/429 HTTP error into `observability::report_error`, including HTTP responses that are *expected* when the user's provider config is wrong (bad key, wrong base URL, unsupported model, account suspended, etc.).
- Result: Sentry issue `OPENHUMAN-TAURI-NJ` accumulated a high-volume stream of "errors" that were actually user-actionable config problems, not bugs. Real provider regressions got buried in the noise.
- The condition was already detectable — `is_provider_config_rejection_http` exists in the parent module — but only one arm (or none, depending on the path) was consulting it. The five request entry points had drifted out of sync.

## Solution

- Add a new `else if super::is_provider_config_rejection_http(status, self.name.as_str(), &error_body)` branch to each of the five request paths in `compatible.rs`, sitting between the auth/rate-limit handling and the generic `should_report_provider_http_failure` fallback.
- On match, call `super::log_provider_config_rejection(<arm_name>, provider, model, status)` so the rejection is recorded as a structured log line (with the originating arm as the first argument, e.g. `"responses_api"`, `"streaming_chat"`, …) instead of being uploaded to Sentry.
- All five arms now share the same classification ladder: auth → rate-limit → **config rejection** → generic reportable failure. This keeps the Sentry signal clean and makes the per-arm log prefix useful for triage.
- Tradeoff: rejections no longer surface in Sentry. That is the intent — they belong in logs/UX, not in the bug tracker — but it does mean we rely on the logger for visibility going forward.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- Coverage matrix updated — `N/A: error-classification refinement, no feature row added/removed/renamed.`
- All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix row touched.`
- No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: routing fix on an existing error path; no new smoke step.`
- Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime/platform**: desktop (Tauri host + in-process core). Affects every code path that talks to an OpenAI-compatible provider — i.e. all five request shapes in `OpenAiCompatibleProvider`. No mobile/web/CLI surface touched directly.
- **Performance**: negligible — one extra `match` arm + helper call on the error path. Hot path (success) is unchanged.
- **Security**: no change. `log_provider_config_rejection` follows the same redaction rules as the existing log helpers; no new fields, no PII leakage.
- **Observability**: Sentry volume on `OPENHUMAN-TAURI-NJ` should drop materially. In exchange, expect a corresponding rise in structured `[inference][config_rejection]` log lines, tagged with the originating arm so triage can tell which request shape tripped.
- **Migration / compatibility**: none. Provider trait signatures unchanged; RPC surface unchanged.

## Related

- Sentry: [OPENHUMAN-TAURI-NJ](https://tinyhumans.sentry.io/issues/7483254354/?environment=development&environment=production&environment=staging&project=4511287579836416&query=is%3Aunresolved%20assigned%3Anone&referrer=issue-stream&sort=freq)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and logging for provider configuration rejection HTTP responses to better surface and distinguish configuration-related failures.
* **Tests**
  * Added a test ensuring streaming requests propagate provider config rejection errors and do not report events to error-monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->