### PR TITLE
feat(composio,agent): async sync + gated-tools surface + UI-only scope elevation + force-delegate capability questions

### DIFF
--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -137,6 +137,50 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
     for ci in connected {
         let _ = writeln!(out, "- **{}** — {}", ci.toolkit, ci.description);
     }
+
+    // Surface pref-gated tools so the agent can honestly answer "do you
+    // support X?" and offer to elevate. The agent CANNOT call these
+    // directly — no parameters schema is exposed and they aren't in its
+    // function list. To make one callable, ask the user for permission
+    // and then call the `composio_enable_scope` meta-tool, which flips
+    // the per-toolkit scope pref. After the next prompt rebuild the
+    // action graduates into the callable list above.
+    let mut has_gated = false;
+    for ci in integrations.iter().filter(|ci| ci.connected) {
+        if !ci.gated_tools.is_empty() {
+            has_gated = true;
+            break;
+        }
+    }
+    if has_gated {
+        out.push_str(
+            "\n### Additional capabilities behind a permission toggle\n\n\
+             These actions exist in the toolkit but are NOT currently in your callable \
+             tool list — the user has not granted the required scope. Do NOT pretend \
+             they're unavailable. If the user asks for one (or you'd otherwise need it), \
+             tell them what it does and offer to flip the required scope on. With explicit \
+             user consent, call `composio_enable_scope(toolkit, scope)` to elevate; the \
+             action becomes callable on your next turn. The user can also flip it manually \
+             in Settings → Integrations → {toolkit} → scope toggles.\n\n",
+        );
+        for ci in integrations.iter().filter(|ci| ci.connected && !ci.gated_tools.is_empty()) {
+            let _ = writeln!(out, "- **{}**:", ci.toolkit);
+            for gt in &ci.gated_tools {
+                let desc = if gt.description.is_empty() {
+                    "(no description)".to_string()
+                } else {
+                    gt.description.clone()
+                };
+                let _ = writeln!(
+                    out,
+                    "  - `{}` — {} (requires `{}` scope)",
+                    gt.name, desc, gt.required_scope
+                );
+            }
+        }
+        out.push('\n');
+    }
+
     out
 }
 
@@ -187,6 +231,7 @@ mod tests {
             toolkit: "gmail".into(),
             description: "Email access.".into(),
             tools: Vec::new(),
+            gated_tools: Vec::new(),
             connected: true,
         }];
         let body = build(&ctx_with(&integrations, &[])).unwrap();
@@ -205,6 +250,7 @@ mod tests {
             toolkit: "notion".into(),
             description: "Pages.".into(),
             tools: Vec::new(),
+            gated_tools: Vec::new(),
             connected: false,
         }];
         let body = build(&ctx_with(&integrations, &[])).unwrap();

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -138,13 +138,14 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
         let _ = writeln!(out, "- **{}** — {}", ci.toolkit, ci.description);
     }
 
-    // Surface pref-gated tools so the agent can honestly answer "do you
-    // support X?" and offer to elevate. The agent CANNOT call these
-    // directly — no parameters schema is exposed and they aren't in its
-    // function list. To make one callable, ask the user for permission
-    // and then call the `composio_enable_scope` meta-tool, which flips
-    // the per-toolkit scope pref. After the next prompt rebuild the
-    // action graduates into the callable list above.
+    // Surface pref-gated tools so the agent can honestly say "I have this
+    // capability but it needs the {scope} toggle in Connections → {toolkit}".
+    // The agent CANNOT call these directly (no parameters schema is exposed)
+    // and CANNOT flip the gating scope itself — there is no agent-callable
+    // scope-elevate tool. The user must toggle the scope in the Connections
+    // UI; after the next prompt rebuild the action graduates into the
+    // callable list above. The per-row `unlock paths` rendered below carry
+    // the exact UI hint the agent should show.
     let mut has_gated = false;
     for ci in integrations.iter().filter(|ci| ci.connected) {
         if !ci.gated_tools.is_empty() {

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -157,11 +157,10 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
             "\n### Additional capabilities behind a permission toggle\n\n\
              These actions exist in the toolkit but are NOT currently in your callable \
              tool list — the user has not granted the required scope. Do NOT pretend \
-             they're unavailable. If the user asks for one (or you'd otherwise need it), \
-             tell them what it does and offer to flip the required scope on. With explicit \
-             user consent, call `composio_enable_scope(toolkit, scope)` to elevate; the \
-             action becomes callable on your next turn. The user can also flip it manually \
-             in Settings → Integrations → {toolkit} → scope toggles.\n\n",
+             they're unavailable. When the user asks for one (or you'd otherwise need \
+             it), tell them what the action does and present ALL of its `unlock paths` \
+             listed below so the user can choose how to enable it. Never drop a path or \
+             rewrite it into your own framing.\n\n",
         );
         for ci in integrations
             .iter()
@@ -179,6 +178,9 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
                     "  - `{}` — {} (requires `{}` scope)",
                     gt.name, desc, gt.required_scope
                 );
+                for path in &gt.unlock_paths {
+                    let _ = writeln!(out, "    - unlock path: {path}");
+                }
             }
         }
         out.push('\n');

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -163,7 +163,10 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
              action becomes callable on your next turn. The user can also flip it manually \
              in Settings → Integrations → {toolkit} → scope toggles.\n\n",
         );
-        for ci in integrations.iter().filter(|ci| ci.connected && !ci.gated_tools.is_empty()) {
+        for ci in integrations
+            .iter()
+            .filter(|ci| ci.connected && !ci.gated_tools.is_empty())
+        {
             let _ = writeln!(out, "- **{}**:", ci.toolkit);
             for gt in &ci.gated_tools {
                 let desc = if gt.description.is_empty() {

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -147,12 +147,19 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
     // callable list above. The per-row `unlock paths` rendered below carry
     // the exact UI hint the agent should show.
     let mut has_gated = false;
+    let mut connected_with_gated = 0usize;
     for ci in integrations.iter().filter(|ci| ci.connected) {
         if !ci.gated_tools.is_empty() {
             has_gated = true;
-            break;
+            connected_with_gated += 1;
         }
     }
+    tracing::debug!(
+        total_integrations = integrations.len(),
+        has_gated,
+        connected_with_gated,
+        "[integrations-prompt] gated-tools scan complete"
+    );
     if has_gated {
         out.push_str(
             "\n### Additional capabilities behind a permission toggle\n\n\

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -91,7 +91,10 @@ fn render_delegation_guide(integrations: &[ConnectedIntegration]) -> String {
     }
     let mut out = String::from(
         "## Connected Integrations\n\n\
-         Delegate tasks for these services with `delegate_to_integrations_agent`, passing the toolkit slug as `toolkit`:\n\n",
+         The following services have an active connection. Their tool implementations \
+         live inside the `integrations_agent` sub-agent — NOT in your own tool list. \
+         Delegate with `delegate_to_integrations_agent`, passing the toolkit slug as \
+         `toolkit`:\n\n",
     );
     for ci in connected {
         // Use the same slug canonicalisation as `collect_orchestrator_tools`
@@ -104,6 +107,37 @@ fn render_delegation_guide(integrations: &[ConnectedIntegration]) -> String {
             ci.toolkit, slug, ci.description
         );
     }
+    // CRITICAL behavioural rule. Without this, the orchestrator answers
+    // "can you do X with {toolkit}?" from its training-data priors about
+    // "what gmail/notion/slack usually does", which is consistently a
+    // SUBSET of the real per-toolkit catalogue (no bulk-delete, no
+    // batch-modify, no admin/destructive actions, etc.). The result is a
+    // confident wrong refusal ("nope, I can't delete emails") even when
+    // the action is in the actual tool list. The `integrations_agent`
+    // has the ground-truth tool catalogue (`tools` + `gated_tools`); only
+    // it can answer "can I do X?" honestly. Force-delegate capability
+    // questions, not just task requests.
+    out.push_str(
+        "\n### Capability questions about connected toolkits\n\n\
+         Your prior knowledge of \"what a toolkit can do\" is UNRELIABLE — the \
+         real per-toolkit catalogue is wider than the common-knowledge summary \
+         (e.g. Gmail exposes bulk delete, batch modify, thread trash, etc.) and \
+         the user may have enabled scopes that expose further destructive actions. \
+         Therefore:\n\n\
+         - If the user asks **\"can you do X with {toolkit}?\"** or \"does \
+         {toolkit} support Y?\" for a connected toolkit above, **DO NOT** answer \
+         from priors. **DELEGATE** to `integrations_agent` first and let it \
+         inspect its live tool list (including `gated_tools` behind permission \
+         toggles) before answering.\n\
+         - If the user requests an **action** on a connected toolkit (delete, \
+         move, send, modify, label, etc.), **DELEGATE immediately**. Do not \
+         pre-emptively refuse with \"I can't do that\" — that's a confabulation \
+         unless `integrations_agent` itself has already reported the action as \
+         unavailable.\n\
+         - The only honest \"no\" comes back from a delegation that found the \
+         action neither in the visible `tools` list nor in the `gated_tools` \
+         (permission-toggle) list of the sub-agent.\n\n",
+    );
     tracing::debug!(
         section_len = out.len(),
         "[delegation-guide] section emitted ({} bytes)",
@@ -172,6 +206,7 @@ mod tests {
             toolkit: "gmail".into(),
             description: "Email access.".into(),
             tools: Vec::new(),
+            gated_tools: Vec::new(),
             connected: true,
         }];
         let body = build(&ctx_with(&integrations)).unwrap();
@@ -192,6 +227,7 @@ mod tests {
             toolkit: "gmail".into(),
             description: "Email access.".into(),
             tools: Vec::new(),
+            gated_tools: Vec::new(),
             connected: true,
         }];
         let body = build(&ctx_with(&integrations)).unwrap();
@@ -213,12 +249,14 @@ mod tests {
                 toolkit: "gmail".into(),
                 description: "Email.".into(),
                 tools: Vec::new(),
+                gated_tools: Vec::new(),
                 connected: true,
             },
             ConnectedIntegration {
                 toolkit: "linear".into(),
                 description: "Tracker.".into(),
                 tools: Vec::new(),
+                gated_tools: Vec::new(),
                 connected: false,
             },
         ];
@@ -233,6 +271,7 @@ mod tests {
             toolkit: "linear".into(),
             description: "Tracker.".into(),
             tools: Vec::new(),
+            gated_tools: Vec::new(),
             connected: false,
         }];
         let body = build(&ctx_with(&integrations)).unwrap();

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -117,15 +117,22 @@ fn render_delegation_guide(integrations: &[ConnectedIntegration]) -> String {
     // has the ground-truth tool catalogue (`tools` + `gated_tools`); only
     // it can answer "can I do X?" honestly. Force-delegate capability
     // questions, not just task requests.
-    out.push_str(
+    // The cross-chat bullet names the canonical header literal verbatim
+    // so the model knows exactly which block to mistrust. Sourced from
+    // CROSS_CHAT_HEADER (single source of truth) — drift would silently
+    // detune the rule.
+    let cross_chat_header_for_prompt =
+        crate::openhuman::agent::memory_loader::CROSS_CHAT_HEADER.trim_end();
+    let _ = write!(
+        out,
         "\n### Capability questions about connected toolkits\n\n\
          Your prior knowledge of \"what a toolkit can do\" is UNRELIABLE — the \
          real per-toolkit catalogue is wider than the common-knowledge summary \
          (e.g. Gmail exposes bulk delete, batch modify, thread trash, etc.) and \
          the user may have enabled scopes that expose further destructive actions. \
          Therefore:\n\n\
-         - If the user asks **\"can you do X with {toolkit}?\"** or \"does \
-         {toolkit} support Y?\" for a connected toolkit above, **DO NOT** answer \
+         - If the user asks **\"can you do X with {{toolkit}}?\"** or \"does \
+         {{toolkit}} support Y?\" for a connected toolkit above, **DO NOT** answer \
          from priors. **DELEGATE** to `integrations_agent` first and let it \
          inspect its live tool list (including `gated_tools` behind permission \
          toggles) before answering.\n\
@@ -138,8 +145,8 @@ fn render_delegation_guide(integrations: &[ConnectedIntegration]) -> String {
          action neither in the visible `tools` list nor in the `gated_tools` \
          (permission-toggle) list of the sub-agent.\n\
          - **Cross-chat context is historical, not authoritative.** If the \
-         `[Cross-chat context — historical]` block contains a past \"I can / \
-         can't do X with {toolkit}\" statement, treat it as a snapshot from an \
+         `{cross_chat_header_for_prompt}` block contains a past \"I can / can't \
+         do X with {{toolkit}}\" statement, treat it as a snapshot from an \
          earlier moment. The tool list, connected integrations, and per-toolkit \
          scope toggles (read / write / admin) can all change between chats — a \
          past refusal may be stale. Verify against the **current** `## Connected \

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -136,7 +136,16 @@ fn render_delegation_guide(integrations: &[ConnectedIntegration]) -> String {
          unavailable.\n\
          - The only honest \"no\" comes back from a delegation that found the \
          action neither in the visible `tools` list nor in the `gated_tools` \
-         (permission-toggle) list of the sub-agent.\n\n",
+         (permission-toggle) list of the sub-agent.\n\
+         - **Cross-chat context is historical, not authoritative.** If the \
+         `[Cross-chat context — historical]` block contains a past \"I can / \
+         can't do X with {toolkit}\" statement, treat it as a snapshot from an \
+         earlier moment. The tool list, connected integrations, and per-toolkit \
+         scope toggles (read / write / admin) can all change between chats — a \
+         past refusal may be stale. Verify against the **current** `## Connected \
+         Integrations` block above and (when in doubt) **DELEGATE** before \
+         quoting any past capability claim. Never echo a stale \"I can't\" \
+         without re-checking.\n\n",
     );
     tracing::debug!(
         section_len = out.len(),

--- a/src/openhuman/agent/agents/welcome/prompt.rs
+++ b/src/openhuman/agent/agents/welcome/prompt.rs
@@ -179,12 +179,14 @@ mod tests {
                 toolkit: "gmail".into(),
                 description: "Email access.".into(),
                 tools: Vec::new(),
+                gated_tools: Vec::new(),
                 connected: true,
             },
             ConnectedIntegration {
                 toolkit: "notion".into(),
                 description: "Pitch during onboarding.".into(),
                 tools: Vec::new(),
+                gated_tools: Vec::new(),
                 connected: false,
             },
         ];

--- a/src/openhuman/agent/harness/memory_context.rs
+++ b/src/openhuman/agent/harness/memory_context.rs
@@ -135,14 +135,12 @@ pub(crate) async fn build_context(
         );
 
         if !cross.is_empty() {
-            // Keep this header in sync with `memory_loader.rs` — the
-            // orchestrator's "Capability questions" section references it
-            // verbatim to teach the model that a past "I can't do X"
-            // statement may be stale (capabilities + scopes can change
-            // between chats).
-            context.push_str(
-                "[Cross-chat context — historical; capabilities may have changed since]\n",
-            );
+            // Use the canonical CROSS_CHAT_HEADER from `memory_loader` so
+            // this fallback recall path emits the same literal as the
+            // primary JSONL path, and the orchestrator prompt's
+            // "Capability questions" section that names this header stays
+            // in sync. See CROSS_CHAT_HEADER's doc for the rationale.
+            context.push_str(crate::openhuman::agent::memory_loader::CROSS_CHAT_HEADER);
             for entry in &cross {
                 let prov = entry
                     .session_id
@@ -358,7 +356,7 @@ mod tests {
 
         let context = build_context(&mem, "what database should I use?", 0.4).await;
         assert!(
-            context.contains("[Cross-chat context"),
+            context.contains(crate::openhuman::agent::memory_loader::CROSS_CHAT_HEADER.trim_end()),
             "expected cross-chat header, got:\n{context}"
         );
         assert!(
@@ -424,7 +422,7 @@ mod tests {
         let mem = MockMemory::new(Vec::new(), Vec::new(), false);
         let context = build_context(&mem, "Postgres", 0.4).await;
         assert!(
-            !context.contains("[Cross-chat context"),
+            !context.contains(crate::openhuman::agent::memory_loader::CROSS_CHAT_HEADER.trim_end()),
             "no cross-chat hits must produce no header, got:\n{context}"
         );
     }

--- a/src/openhuman/agent/harness/memory_context.rs
+++ b/src/openhuman/agent/harness/memory_context.rs
@@ -135,7 +135,14 @@ pub(crate) async fn build_context(
         );
 
         if !cross.is_empty() {
-            context.push_str("[Cross-chat context]\n");
+            // Keep this header in sync with `memory_loader.rs` — the
+            // orchestrator's "Capability questions" section references it
+            // verbatim to teach the model that a past "I can't do X"
+            // statement may be stale (capabilities + scopes can change
+            // between chats).
+            context.push_str(
+                "[Cross-chat context — historical; capabilities may have changed since]\n",
+            );
             for entry in &cross {
                 let prov = entry
                     .session_id
@@ -351,7 +358,7 @@ mod tests {
 
         let context = build_context(&mem, "what database should I use?", 0.4).await;
         assert!(
-            context.contains("[Cross-chat context]"),
+            context.contains("[Cross-chat context"),
             "expected cross-chat header, got:\n{context}"
         );
         assert!(
@@ -417,7 +424,7 @@ mod tests {
         let mem = MockMemory::new(Vec::new(), Vec::new(), false);
         let context = build_context(&mem, "Postgres", 0.4).await;
         assert!(
-            !context.contains("[Cross-chat context]"),
+            !context.contains("[Cross-chat context"),
             "no cross-chat hits must produce no header, got:\n{context}"
         );
     }

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -644,6 +644,12 @@ async fn run_typed_mode(
                     toolkit: cached_integration.toolkit.clone(),
                     description: cached_integration.description.clone(),
                     tools: fresh_actions,
+                    // Inherit the cached gated set: this spawn path only
+                    // refreshes the *visible* (callable) actions from the
+                    // backend; the gated/unlock-hint surface is computed
+                    // by `fetch_connected_integrations_uncached` against
+                    // the user pref and doesn't change per-spawn.
+                    gated_tools: cached_integration.gated_tools.clone(),
                     connected: cached_integration.connected,
                 };
                 let integration = &integration;

--- a/src/openhuman/agent/harness/test_support_test.rs
+++ b/src/openhuman/agent/harness/test_support_test.rs
@@ -1562,6 +1562,7 @@ async fn orchestrator_prompt_drives_composio_call_via_delegation_chain() {
         toolkit: "gmail".into(),
         description: "Email send/fetch via Gmail.".into(),
         tools: Vec::new(),
+        gated_tools: Vec::new(),
         connected: true,
     }];
     let ctx = {

--- a/src/openhuman/agent/memory_loader.rs
+++ b/src/openhuman/agent/memory_loader.rs
@@ -371,7 +371,17 @@ impl MemoryLoader for DefaultMemoryLoader {
             };
             let prov = provenance_tag(&sid);
             if !appended_cross_header {
-                let section = "[Cross-chat context]\n";
+                // The header explicitly labels these snippets as historical so
+                // the model down-weights them when answering capability
+                // questions. The agent's *own* past "I can/can't do X" answers
+                // are FTS-retrievable here and were the original failure mode:
+                // a stale "nope, I can't delete emails" from a chat predating
+                // the user's Admin-scope toggle would be quoted verbatim as
+                // current truth. The orchestrator prompt's "Capability
+                // questions" section cross-references this header — keep the
+                // wording in sync.
+                let section =
+                    "[Cross-chat context — historical; capabilities may have changed since]\n";
                 if context.len() + section.len() > budget {
                     break;
                 }
@@ -594,7 +604,7 @@ mod tests {
             .await
             .expect("loader must succeed");
         assert!(
-            out.contains("[Cross-chat context]"),
+            out.contains("[Cross-chat context"),
             "expected cross-chat header, got:\n{out}"
         );
         assert!(
@@ -669,7 +679,7 @@ mod tests {
             .await
             .expect("loader must succeed");
         assert!(
-            !out.contains("[Cross-chat context]"),
+            !out.contains("[Cross-chat context"),
             "no cross-chat hits must produce no header, got:\n{out}"
         );
     }
@@ -741,7 +751,7 @@ mod tests {
             .expect("loader must succeed");
 
         assert!(
-            out.contains("[Cross-chat context]"),
+            out.contains("[Cross-chat context"),
             "JSONL primary path must emit the cross-chat header, got:\n{out}"
         );
         assert!(

--- a/src/openhuman/agent/memory_loader.rs
+++ b/src/openhuman/agent/memory_loader.rs
@@ -21,6 +21,25 @@ const PRIOR_CONVERSATION_LIMIT: usize = 3;
 /// do not auto-pollute every fresh chat.
 const PRIOR_CONVERSATION_KEY_PREFIX: &str = "high.";
 
+/// Canonical header for the `[Cross-chat context]` block injected on
+/// every turn that has FTS-surfaced hits from other threads.
+///
+/// The "historical" / "capabilities may have changed since" suffix is
+/// deliberate: it tells the model these snippets are snapshots from
+/// earlier moments and that capability claims (e.g. "I can't delete
+/// emails") may be stale because the tool surface or per-toolkit scope
+/// toggles can change between chats.
+///
+/// Single source of truth — all three call sites bind to this constant
+/// so a wording tweak doesn't drift between (a) `memory_loader.rs`'s
+/// primary JSONL path, (b) `harness/memory_context.rs`'s fallback
+/// recall path, and (c) the orchestrator's "Capability questions"
+/// prompt section that names the header verbatim. Tests assert on this
+/// constant too — see `memory_loader::tests` and
+/// `harness::memory_context::tests`.
+pub const CROSS_CHAT_HEADER: &str =
+    "[Cross-chat context — historical; capabilities may have changed since]\n";
+
 #[async_trait]
 pub trait MemoryLoader: Send + Sync {
     async fn load_context(&self, memory: &dyn Memory, user_message: &str)
@@ -373,19 +392,12 @@ impl MemoryLoader for DefaultMemoryLoader {
             if !appended_cross_header {
                 // The header explicitly labels these snippets as historical so
                 // the model down-weights them when answering capability
-                // questions. The agent's *own* past "I can/can't do X" answers
-                // are FTS-retrievable here and were the original failure mode:
-                // a stale "nope, I can't delete emails" from a chat predating
-                // the user's Admin-scope toggle would be quoted verbatim as
-                // current truth. The orchestrator prompt's "Capability
-                // questions" section cross-references this header — keep the
-                // wording in sync.
-                let section =
-                    "[Cross-chat context — historical; capabilities may have changed since]\n";
-                if context.len() + section.len() > budget {
+                // questions — see CROSS_CHAT_HEADER doc for the rationale and
+                // the cross-module wording contract.
+                if context.len() + CROSS_CHAT_HEADER.len() > budget {
                     break;
                 }
-                context.push_str(section);
+                context.push_str(CROSS_CHAT_HEADER);
                 appended_cross_header = true;
             }
             let line = format!("- [{prov}] {snippet}\n");
@@ -604,7 +616,7 @@ mod tests {
             .await
             .expect("loader must succeed");
         assert!(
-            out.contains("[Cross-chat context"),
+            out.contains(CROSS_CHAT_HEADER.trim_end()),
             "expected cross-chat header, got:\n{out}"
         );
         assert!(
@@ -679,7 +691,7 @@ mod tests {
             .await
             .expect("loader must succeed");
         assert!(
-            !out.contains("[Cross-chat context"),
+            !out.contains(CROSS_CHAT_HEADER.trim_end()),
             "no cross-chat hits must produce no header, got:\n{out}"
         );
     }
@@ -751,7 +763,7 @@ mod tests {
             .expect("loader must succeed");
 
         assert!(
-            out.contains("[Cross-chat context"),
+            out.contains(CROSS_CHAT_HEADER.trim_end()),
             "JSONL primary path must emit the cross-chat header, got:\n{out}"
         );
         assert!(

--- a/src/openhuman/agent/prompts/types.rs
+++ b/src/openhuman/agent/prompts/types.rs
@@ -93,17 +93,18 @@ pub struct ConnectedIntegration {
     /// the user has **not** unlocked via their per-toolkit scope preferences.
     /// The prompt renderer surfaces these descriptively (name + one-line +
     /// which scope is missing) so the agent can honestly answer "do you have
-    /// X?" with "yes, but you need to flip the {scope} toggle in Settings →
-    /// Integrations → {toolkit}; I can do that for you" — instead of silently
-    /// claiming the capability doesn't exist (which is what happens when the
-    /// agent has zero awareness of pref-gated actions).
+    /// X?" with "yes, but you need to flip the {scope} toggle in
+    /// Connections → {toolkit}" — instead of silently claiming the
+    /// capability doesn't exist (which is what happens when the agent has
+    /// zero awareness of pref-gated actions).
     ///
     /// The agent CANNOT directly invoke these (no `parameters` schema is
-    /// exposed; the LLM lacks the function definition). The intended flow:
-    /// agent sees a gated tool → asks user permission → calls the
-    /// `composio_enable_scope` meta-tool (with user consent) → on the next
-    /// turn the action graduates from `gated_tools` to `tools` and becomes
-    /// callable.
+    /// exposed; the LLM lacks the function definition) and it cannot flip
+    /// the gating scope itself — there is no agent-callable scope-elevate
+    /// tool. Intended flow: agent sees a gated tool → tells the user what
+    /// it does + names the `unlock_paths` from the data → the user toggles
+    /// the scope in the Connections UI → on the next turn the action
+    /// graduates from `gated_tools` to `tools` and becomes callable.
     pub gated_tools: Vec<GatedIntegrationTool>,
     /// Whether the user has an active OAuth connection for this
     /// toolkit. When `false`, the toolkit is in the backend allowlist
@@ -119,10 +120,10 @@ pub struct ConnectedIntegration {
 ///
 /// Deliberately no `parameters` field: the LLM should NOT be able to construct
 /// a call envelope for a gated tool — it can only describe its existence and
-/// point the user at the unlock path. Once the scope is granted (via the
-/// `composio_enable_scope` meta-tool or a manual UI toggle), the action moves
-/// from `ConnectedIntegration.gated_tools` to `ConnectedIntegration.tools` on
-/// the next prompt rebuild and becomes a real callable function.
+/// point the user at the unlock path. The agent has no scope-elevate tool;
+/// once the user toggles the gating scope in the Connections UI, the action
+/// moves from `ConnectedIntegration.gated_tools` to `ConnectedIntegration.tools`
+/// on the next prompt rebuild and becomes a real callable function.
 #[derive(Debug, Clone)]
 pub struct GatedIntegrationTool {
     /// Action slug, e.g. `"GMAIL_BATCH_DELETE_MESSAGES"`.

--- a/src/openhuman/agent/prompts/types.rs
+++ b/src/openhuman/agent/prompts/types.rs
@@ -134,6 +134,15 @@ pub struct GatedIntegrationTool {
     /// rows are `"admin"` (destructive actions); `"write"` only appears for
     /// users who have explicitly turned write off, which is unusual.
     pub required_scope: String,
+    /// Literal lines the agent should show the user, verbatim, when offering
+    /// to unlock this action — one entry per available path (typically: the
+    /// agent-side meta-tool, and the manual UI toggle). Populated at
+    /// partition time in `composio::ops`. The prompt-side rule is "show
+    /// these to the user, don't substitute your own framing" — keeping the
+    /// text in the data (not in the system prompt) lets us tweak wording
+    /// without invalidating the KV-cache prefix and avoids biasing the
+    /// model toward a memorized template that drops options.
+    pub unlock_paths: Vec<String>,
 }
 
 /// A single action available on a connected integration.

--- a/src/openhuman/agent/prompts/types.rs
+++ b/src/openhuman/agent/prompts/types.rs
@@ -89,12 +89,51 @@ pub struct ConnectedIntegration {
     pub description: String,
     /// Per-action catalogue (only populated when `connected == true`).
     pub tools: Vec<ConnectedIntegrationTool>,
+    /// Per-action catalogue for actions that the toolkit **does** support but
+    /// the user has **not** unlocked via their per-toolkit scope preferences.
+    /// The prompt renderer surfaces these descriptively (name + one-line +
+    /// which scope is missing) so the agent can honestly answer "do you have
+    /// X?" with "yes, but you need to flip the {scope} toggle in Settings →
+    /// Integrations → {toolkit}; I can do that for you" — instead of silently
+    /// claiming the capability doesn't exist (which is what happens when the
+    /// agent has zero awareness of pref-gated actions).
+    ///
+    /// The agent CANNOT directly invoke these (no `parameters` schema is
+    /// exposed; the LLM lacks the function definition). The intended flow:
+    /// agent sees a gated tool → asks user permission → calls the
+    /// `composio_enable_scope` meta-tool (with user consent) → on the next
+    /// turn the action graduates from `gated_tools` to `tools` and becomes
+    /// callable.
+    pub gated_tools: Vec<GatedIntegrationTool>,
     /// Whether the user has an active OAuth connection for this
     /// toolkit. When `false`, the toolkit is in the backend allowlist
     /// but no authorization has been completed yet — `tools` is empty
     /// and the orchestrator must point the user at Settings instead of
     /// attempting to delegate.
     pub connected: bool,
+}
+
+/// A toolkit action that exists in the catalog but is currently hidden from
+/// the agent's callable function list because the user's scope preference
+/// for this toolkit does not allow the action's required scope.
+///
+/// Deliberately no `parameters` field: the LLM should NOT be able to construct
+/// a call envelope for a gated tool — it can only describe its existence and
+/// point the user at the unlock path. Once the scope is granted (via the
+/// `composio_enable_scope` meta-tool or a manual UI toggle), the action moves
+/// from `ConnectedIntegration.gated_tools` to `ConnectedIntegration.tools` on
+/// the next prompt rebuild and becomes a real callable function.
+#[derive(Debug, Clone)]
+pub struct GatedIntegrationTool {
+    /// Action slug, e.g. `"GMAIL_BATCH_DELETE_MESSAGES"`.
+    pub name: String,
+    /// One-line description of the action.
+    pub description: String,
+    /// Which scope the user must enable for this action to become callable.
+    /// Lowercase: `"read"`, `"write"`, `"admin"`. The vast majority of gated
+    /// rows are `"admin"` (destructive actions); `"write"` only appears for
+    /// users who have explicitly turned write off, which is unusual.
+    pub required_scope: String,
 }
 
 /// A single action available on a connected integration.

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -1685,61 +1685,62 @@ async fn fetch_connected_integrations_uncached(
         // each other's actions. `GMAIL_SEND_EMAIL` matches `gmail_`,
         // not just `gmail`, so siblings stay in their own buckets.
         let action_prefix = format!("{}_", slug.to_uppercase());
-        let (tools, gated_tools): (Vec<ConnectedIntegrationTool>, Vec<GatedIntegrationTool>) = if connected {
-            // Apply the same curated-whitelist + user-scope filter the
-            // meta-tool layer uses, so the integrations_agent prompt
-            // only advertises actions the agent is actually allowed to
-            // call. One pref load per toolkit (not per action).
-            //
-            // Actions that the catalog *does* know about but the user's
-            // current scope pref denies are routed into `gated_tools` so
-            // the agent can honestly answer "I have this capability but
-            // it needs your permission" (and call the `composio_enable_scope`
-            // meta-tool to elevate). Without that surface the LLM has no
-            // way to know the gated action exists at all and will tell the
-            // user "I don't support that" — which is technically correct
-            // about its callable surface, but misleading about the toolkit.
-            let pref = super::providers::load_user_scope_or_default(slug).await;
-            let mut visible: Vec<ConnectedIntegrationTool> = Vec::new();
-            let mut gated: Vec<GatedIntegrationTool> = Vec::new();
-            for t in tools_by_toolkit
-                .iter()
-                .filter(|t| t.function.name.starts_with(&action_prefix))
-            {
-                if super::providers::is_action_visible_with_pref(&t.function.name, &pref) {
-                    visible.push(ConnectedIntegrationTool {
-                        name: t.function.name.clone(),
-                        description: t.function.description.clone().unwrap_or_default(),
-                        parameters: t.function.parameters.clone(),
-                    });
-                } else if let Some(required_scope) =
-                    super::providers::curated_scope_for(&t.function.name)
+        let (tools, gated_tools): (Vec<ConnectedIntegrationTool>, Vec<GatedIntegrationTool>) =
+            if connected {
+                // Apply the same curated-whitelist + user-scope filter the
+                // meta-tool layer uses, so the integrations_agent prompt
+                // only advertises actions the agent is actually allowed to
+                // call. One pref load per toolkit (not per action).
+                //
+                // Actions that the catalog *does* know about but the user's
+                // current scope pref denies are routed into `gated_tools` so
+                // the agent can honestly answer "I have this capability but
+                // it needs your permission" (and call the `composio_enable_scope`
+                // meta-tool to elevate). Without that surface the LLM has no
+                // way to know the gated action exists at all and will tell the
+                // user "I don't support that" — which is technically correct
+                // about its callable surface, but misleading about the toolkit.
+                let pref = super::providers::load_user_scope_or_default(slug).await;
+                let mut visible: Vec<ConnectedIntegrationTool> = Vec::new();
+                let mut gated: Vec<GatedIntegrationTool> = Vec::new();
+                for t in tools_by_toolkit
+                    .iter()
+                    .filter(|t| t.function.name.starts_with(&action_prefix))
                 {
-                    // Only surface CURATED actions as `gated` — uncurated
-                    // tools (which fall through to `classify_unknown` and
-                    // happen to land outside the user's pref) are not
-                    // first-class user-facing capabilities, and listing
-                    // them would clutter the prompt with internal slugs.
-                    // Deliberately NO `parameters` field: the LLM should
-                    // not be able to construct a call envelope; it can
-                    // only describe + point at the unlock path.
-                    gated.push(GatedIntegrationTool {
-                        name: t.function.name.clone(),
-                        description: t.function.description.clone().unwrap_or_default(),
-                        required_scope: required_scope.as_str().to_string(),
-                    });
+                    if super::providers::is_action_visible_with_pref(&t.function.name, &pref) {
+                        visible.push(ConnectedIntegrationTool {
+                            name: t.function.name.clone(),
+                            description: t.function.description.clone().unwrap_or_default(),
+                            parameters: t.function.parameters.clone(),
+                        });
+                    } else if let Some(required_scope) =
+                        super::providers::curated_scope_for(&t.function.name)
+                    {
+                        // Only surface CURATED actions as `gated` — uncurated
+                        // tools (which fall through to `classify_unknown` and
+                        // happen to land outside the user's pref) are not
+                        // first-class user-facing capabilities, and listing
+                        // them would clutter the prompt with internal slugs.
+                        // Deliberately NO `parameters` field: the LLM should
+                        // not be able to construct a call envelope; it can
+                        // only describe + point at the unlock path.
+                        gated.push(GatedIntegrationTool {
+                            name: t.function.name.clone(),
+                            description: t.function.description.clone().unwrap_or_default(),
+                            required_scope: required_scope.as_str().to_string(),
+                        });
+                    }
                 }
-            }
-            tracing::debug!(
-                toolkit = %slug,
-                visible = visible.len(),
-                gated = gated.len(),
-                "[composio][scopes] integrations prompt action set"
-            );
-            (visible, gated)
-        } else {
-            (Vec::new(), Vec::new())
-        };
+                tracing::debug!(
+                    toolkit = %slug,
+                    visible = visible.len(),
+                    gated = gated.len(),
+                    "[composio][scopes] integrations prompt action set"
+                );
+                (visible, gated)
+            } else {
+                (Vec::new(), Vec::new())
+            };
 
         integrations.push(ConnectedIntegration {
             toolkit: slug.clone(),

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -1018,28 +1018,79 @@ pub async fn composio_sync(
     tracing::debug!(
         connection_id = %connection_id,
         reason = reason.as_str(),
-        "[composio] rpc sync"
+        "[composio] rpc sync (spawned)"
     );
+    // Validate synchronously — a bad request (unknown connection / no native
+    // provider for toolkit) must surface to the caller via the RPC error
+    // envelope, not silently inside a spawned task.
     let client = resolve_client(config)?;
     let toolkit = resolve_toolkit_for_connection(&client, connection_id).await?;
-
     let provider = get_provider(&toolkit).ok_or_else(|| {
         format!("[composio] no native provider registered for toolkit '{toolkit}'")
     })?;
-
     let _ = client; // see analogous comment above — drop the pre-baked client (#1710).
+
+    // `provider.sync` walks every page of the upstream API and ingests every
+    // message in-band — on a real prod inbox a healthy run can legitimately
+    // exceed the frontend's 30s `composio_sync` RPC `.await` cap (one
+    // healthy periodic tick is already ~100s for 20 pages / 500 messages).
+    // There is no reason for the UI to block on it: per-source progress is
+    // already exposed via the polled `openhuman.memory_sync_status_list` RPC,
+    // which reads `mem_tree_chunks` directly and therefore reflects the
+    // spawned task's per-message ingest in real time. So we spawn the sync
+    // as a background task and return immediately with a "started" envelope.
+    // The periodic scheduler (`composio::periodic`) already runs
+    // `provider.sync` from inside its own `tokio::spawn` loop — same pattern.
     let ctx = ProviderContext {
         config: Arc::new(config.clone()),
         toolkit: toolkit.clone(),
         connection_id: Some(connection_id.to_string()),
     };
+    let started_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let toolkit_for_outcome = toolkit.clone();
+    let connection_id_for_log = connection_id.to_string();
 
-    let outcome = provider.sync(&ctx, reason).await.map_err(|e| {
-        report_composio_op_error("sync", &e);
-        format!("[composio] sync({toolkit}) failed: {e}")
-    })?;
+    tokio::spawn(async move {
+        let toolkit_in_task = ctx.toolkit.clone();
+        match provider.sync(&ctx, reason).await {
+            Ok(out) => {
+                tracing::info!(
+                    toolkit = %toolkit_in_task,
+                    connection_id = %connection_id_for_log,
+                    items_ingested = out.items_ingested,
+                    elapsed_ms = out.elapsed_ms(),
+                    "[composio] background sync ok"
+                );
+            }
+            Err(e) => {
+                report_composio_op_error("sync", &e);
+                tracing::warn!(
+                    toolkit = %toolkit_in_task,
+                    connection_id = %connection_id_for_log,
+                    error = %e,
+                    "[composio] background sync failed"
+                );
+            }
+        }
+    });
 
-    let summary = outcome.summary.clone();
+    let summary = format!("composio: {toolkit_for_outcome} sync started (background)");
+    let outcome = SyncOutcome {
+        toolkit: toolkit_for_outcome,
+        connection_id: Some(connection_id.to_string()),
+        reason: reason.as_str().to_string(),
+        items_ingested: 0,
+        started_at_ms,
+        // Sentinel: still running. Frontend should rely on
+        // `memory_sync_status_list` for progress; `finished_at_ms == 0`
+        // means "spawned, not yet complete".
+        finished_at_ms: 0,
+        summary: summary.clone(),
+        details: serde_json::json!({ "status": "started" }),
+    };
     Ok(RpcOutcome::new(outcome, vec![summary]))
 }
 
@@ -1063,7 +1114,9 @@ fn parse_sync_reason(raw: Option<&str>) -> OpResult<SyncReason> {
 
 // ── Prompt integration discovery ────────────────────────────────────
 
-use crate::openhuman::context::prompt::{ConnectedIntegration, ConnectedIntegrationTool};
+use crate::openhuman::context::prompt::{
+    ConnectedIntegration, ConnectedIntegrationTool, GatedIntegrationTool,
+};
 use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, RwLock};
 use std::time::{Duration, Instant};
@@ -1632,38 +1685,67 @@ async fn fetch_connected_integrations_uncached(
         // each other's actions. `GMAIL_SEND_EMAIL` matches `gmail_`,
         // not just `gmail`, so siblings stay in their own buckets.
         let action_prefix = format!("{}_", slug.to_uppercase());
-        let tools: Vec<ConnectedIntegrationTool> = if connected {
+        let (tools, gated_tools): (Vec<ConnectedIntegrationTool>, Vec<GatedIntegrationTool>) = if connected {
             // Apply the same curated-whitelist + user-scope filter the
             // meta-tool layer uses, so the integrations_agent prompt
             // only advertises actions the agent is actually allowed to
             // call. One pref load per toolkit (not per action).
+            //
+            // Actions that the catalog *does* know about but the user's
+            // current scope pref denies are routed into `gated_tools` so
+            // the agent can honestly answer "I have this capability but
+            // it needs your permission" (and call the `composio_enable_scope`
+            // meta-tool to elevate). Without that surface the LLM has no
+            // way to know the gated action exists at all and will tell the
+            // user "I don't support that" — which is technically correct
+            // about its callable surface, but misleading about the toolkit.
             let pref = super::providers::load_user_scope_or_default(slug).await;
-            let filtered: Vec<&super::types::ComposioToolSchema> = tools_by_toolkit
+            let mut visible: Vec<ConnectedIntegrationTool> = Vec::new();
+            let mut gated: Vec<GatedIntegrationTool> = Vec::new();
+            for t in tools_by_toolkit
                 .iter()
                 .filter(|t| t.function.name.starts_with(&action_prefix))
-                .filter(|t| super::providers::is_action_visible_with_pref(&t.function.name, &pref))
-                .collect();
+            {
+                if super::providers::is_action_visible_with_pref(&t.function.name, &pref) {
+                    visible.push(ConnectedIntegrationTool {
+                        name: t.function.name.clone(),
+                        description: t.function.description.clone().unwrap_or_default(),
+                        parameters: t.function.parameters.clone(),
+                    });
+                } else if let Some(required_scope) =
+                    super::providers::curated_scope_for(&t.function.name)
+                {
+                    // Only surface CURATED actions as `gated` — uncurated
+                    // tools (which fall through to `classify_unknown` and
+                    // happen to land outside the user's pref) are not
+                    // first-class user-facing capabilities, and listing
+                    // them would clutter the prompt with internal slugs.
+                    // Deliberately NO `parameters` field: the LLM should
+                    // not be able to construct a call envelope; it can
+                    // only describe + point at the unlock path.
+                    gated.push(GatedIntegrationTool {
+                        name: t.function.name.clone(),
+                        description: t.function.description.clone().unwrap_or_default(),
+                        required_scope: required_scope.as_str().to_string(),
+                    });
+                }
+            }
             tracing::debug!(
                 toolkit = %slug,
-                kept = filtered.len(),
+                visible = visible.len(),
+                gated = gated.len(),
                 "[composio][scopes] integrations prompt action set"
             );
-            filtered
-                .into_iter()
-                .map(|t| ConnectedIntegrationTool {
-                    name: t.function.name.clone(),
-                    description: t.function.description.clone().unwrap_or_default(),
-                    parameters: t.function.parameters.clone(),
-                })
-                .collect()
+            (visible, gated)
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
 
         integrations.push(ConnectedIntegration {
             toolkit: slug.clone(),
             description: toolkit_description(slug).to_string(),
             tools,
+            gated_tools,
             connected,
         });
     }

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -1695,11 +1695,12 @@ async fn fetch_connected_integrations_uncached(
                 // Actions that the catalog *does* know about but the user's
                 // current scope pref denies are routed into `gated_tools` so
                 // the agent can honestly answer "I have this capability but
-                // it needs your permission" (and call the `composio_enable_scope`
-                // meta-tool to elevate). Without that surface the LLM has no
-                // way to know the gated action exists at all and will tell the
-                // user "I don't support that" — which is technically correct
-                // about its callable surface, but misleading about the toolkit.
+                // it needs the {scope} toggle in Connections → {toolkit}".
+                // The agent cannot flip the scope itself — that's a UI-only
+                // action. Without this gated surface the LLM has no way to
+                // know the gated action exists at all and will tell the user
+                // "I don't support that" — technically correct about its
+                // callable surface, but misleading about the toolkit.
                 let pref = super::providers::load_user_scope_or_default(slug).await;
                 let mut visible: Vec<ConnectedIntegrationTool> = Vec::new();
                 let mut gated: Vec<GatedIntegrationTool> = Vec::new();
@@ -1724,25 +1725,20 @@ async fn fetch_connected_integrations_uncached(
                         // Deliberately NO `parameters` field: the LLM should
                         // not be able to construct a call envelope; it can
                         // only describe + point at the unlock path.
-                        // Ship the unlock paths as data so the agent can show
-                        // the user every option (agent-side meta-tool + manual
-                        // UI toggle) and let them pick — without the system
-                        // prompt having to hardcode a template. Two paths
-                        // today; if a third route exists in future (per-action
-                        // approval modal, time-boxed elevation, etc.) it lands
-                        // here and the prompt renderer picks it up for free.
+                        // Ship the unlock path as data — single path today
+                        // (the Connections UI toggle). The agent does NOT
+                        // have a tool to flip scopes; that capability was
+                        // removed because LLM-mediated scope elevation made
+                        // the safety contract depend on model behavior and
+                        // was a soft gate the model could route around. If
+                        // more unlock paths exist in future (per-action
+                        // approval modal, time-boxed elevation, etc.) they
+                        // land here and the prompt renderer picks them up.
                         let scope_str = required_scope.as_str();
-                        let unlock_paths = vec![
-                            format!(
-                                "ask the user for consent, then call \
-                                 `composio_enable_scope(toolkit=\"{slug}\", \
-                                 scope=\"{scope_str}\")`"
-                            ),
-                            format!(
-                                "the user can toggle it themselves in \
-                                 Settings → Integrations → {slug} → {scope_str} scope"
-                            ),
-                        ];
+                        let unlock_paths = vec![format!(
+                            "the user enables it themselves in \
+                             Connections → {slug} → {scope_str}"
+                        )];
                         gated.push(GatedIntegrationTool {
                             name: t.function.name.clone(),
                             description: t.function.description.clone().unwrap_or_default(),

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -1724,10 +1724,30 @@ async fn fetch_connected_integrations_uncached(
                         // Deliberately NO `parameters` field: the LLM should
                         // not be able to construct a call envelope; it can
                         // only describe + point at the unlock path.
+                        // Ship the unlock paths as data so the agent can show
+                        // the user every option (agent-side meta-tool + manual
+                        // UI toggle) and let them pick — without the system
+                        // prompt having to hardcode a template. Two paths
+                        // today; if a third route exists in future (per-action
+                        // approval modal, time-boxed elevation, etc.) it lands
+                        // here and the prompt renderer picks it up for free.
+                        let scope_str = required_scope.as_str();
+                        let unlock_paths = vec![
+                            format!(
+                                "ask the user for consent, then call \
+                                 `composio_enable_scope(toolkit=\"{slug}\", \
+                                 scope=\"{scope_str}\")`"
+                            ),
+                            format!(
+                                "the user can toggle it themselves in \
+                                 Settings → Integrations → {slug} → {scope_str} scope"
+                            ),
+                        ];
                         gated.push(GatedIntegrationTool {
                             name: t.function.name.clone(),
                             description: t.function.description.clone().unwrap_or_default(),
-                            required_scope: required_scope.as_str().to_string(),
+                            required_scope: scope_str.to_string(),
+                            unlock_paths,
                         });
                     }
                 }

--- a/src/openhuman/composio/ops_test.rs
+++ b/src/openhuman/composio/ops_test.rs
@@ -593,23 +593,54 @@ async fn composio_sync_gmail_via_mock_archives_raw_email_and_updates_outcome() {
 
     assert_eq!(outcome.value.toolkit, "gmail");
     assert_eq!(outcome.value.connection_id.as_deref(), Some("c1"));
-    assert_eq!(outcome.value.items_ingested, 1);
-    assert!(outcome.value.summary.contains("persisted 1 new"));
+    // composio_sync is now spawn-and-return: the immediate envelope is a
+    // "started" sentinel, and the actual ingestion runs on a detached
+    // tokio task. items_ingested == 0 / finished_at_ms == 0 / summary
+    // contains "started" are the contract of that sentinel.
+    assert_eq!(
+        outcome.value.items_ingested, 0,
+        "spawn-and-return: items_ingested on the immediate envelope is a 'started' sentinel, not a final count"
+    );
+    assert_eq!(
+        outcome.value.finished_at_ms, 0,
+        "spawn-and-return: finished_at_ms == 0 means 'task spawned, not yet complete'"
+    );
+    assert!(
+        outcome.value.summary.contains("started"),
+        "expected spawn-and-return summary to mention 'started', got: {}",
+        outcome.value.summary
+    );
 
-    let chunks = list_chunks_rpc(
-        &config,
-        ListChunksRequest {
-            source_kind: Some("email".to_string()),
-            source_id: Some("gmail:pilot-at-example-dot-com".to_string()),
-            limit: Some(10),
-            ..Default::default()
-        },
-    )
-    .await
-    .unwrap()
-    .value
-    .chunks;
-    assert_eq!(chunks.len(), 1, "expected one ingested Gmail chunk");
+    // Poll for the spawned ingest task to drain. The mock backend is
+    // local + in-memory, so this normally lands in well under a second.
+    let chunks = {
+        let mut chunks = Vec::new();
+        for _ in 0..50 {
+            chunks = list_chunks_rpc(
+                &config,
+                ListChunksRequest {
+                    source_kind: Some("email".to_string()),
+                    source_id: Some("gmail:pilot-at-example-dot-com".to_string()),
+                    limit: Some(10),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .value
+            .chunks;
+            if !chunks.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        chunks
+    };
+    assert_eq!(
+        chunks.len(),
+        1,
+        "expected one ingested Gmail chunk after spawned task drains"
+    );
     assert!(
         chunks[0].content.contains("Phoenix launch canary"),
         "chunk content missing mock email subject: {}",

--- a/src/openhuman/composio/ops_test.rs
+++ b/src/openhuman/composio/ops_test.rs
@@ -839,6 +839,7 @@ fn integration(toolkit: &str, connected: bool) -> ConnectedIntegration {
         toolkit: toolkit.to_string(),
         description: String::new(),
         tools: Vec::new(),
+        gated_tools: Vec::new(),
         connected,
     }
 }

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -171,6 +171,25 @@ pub fn is_action_visible_with_pref(slug: &str, pref: &UserScopePref) -> bool {
     }
 }
 
+/// Look up the curated scope for `slug` if it appears in any registered
+/// catalog (native provider's `curated_tools()` first, then the fallback
+/// catalog from [`catalog_for_toolkit`]). Returns `None` for genuinely
+/// uncurated slugs — callers that want a defensible heuristic for those
+/// should fall back to [`classify_unknown`] explicitly.
+///
+/// Sibling of [`is_action_visible_with_pref`]: that one decides "visible?",
+/// this one returns "what scope is required?" so callers (e.g. the
+/// `gated_tools` partition in `composio::ops::fetch_connected_integrations`)
+/// can render a useful unlock hint to the agent without re-doing the
+/// catalog walk.
+pub fn curated_scope_for(slug: &str) -> Option<ToolScope> {
+    let toolkit = toolkit_from_slug(slug)?;
+    let catalog = get_provider(&toolkit)
+        .and_then(|p| p.curated_tools())
+        .or_else(|| catalog_for_toolkit(&toolkit))?;
+    find_curated(catalog, slug).map(|c| c.scope)
+}
+
 pub fn catalog_for_toolkit(toolkit: &str) -> Option<&'static [CuratedTool]> {
     match toolkit.trim().to_ascii_lowercase().as_str() {
         // Native providers

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -190,6 +190,27 @@ pub fn curated_scope_for(slug: &str) -> Option<ToolScope> {
     find_curated(catalog, slug).map(|c| c.scope)
 }
 
+/// Does any curated action for `toolkit` require `scope`?
+///
+/// Used by the agent-callable `composio_enable_scope` meta-tool to
+/// short-circuit no-op flips: if e.g. a toolkit's catalog has zero
+/// Admin-tagged actions, flipping the user's Admin bit graduates
+/// nothing into the callable surface and the tool can return a
+/// "not applicable" message instead of silently mutating prefs.
+///
+/// Walks both the native provider catalog and the fallback
+/// [`catalog_for_toolkit`] so the answer matches what
+/// [`is_action_visible_with_pref`] would gate against.
+pub fn toolkit_has_scope(toolkit: &str, scope: ToolScope) -> bool {
+    let catalog = get_provider(toolkit)
+        .and_then(|p| p.curated_tools())
+        .or_else(|| catalog_for_toolkit(toolkit));
+    match catalog {
+        Some(cat) => cat.iter().any(|t| t.scope == scope),
+        None => false,
+    }
+}
+
 pub fn catalog_for_toolkit(toolkit: &str) -> Option<&'static [CuratedTool]> {
     match toolkit.trim().to_ascii_lowercase().as_str() {
         // Native providers
@@ -300,6 +321,19 @@ mod tests {
         assert_eq!(s, "\"connection_created\"");
         let back: SyncReason = serde_json::from_str(&s).unwrap();
         assert_eq!(back, SyncReason::ConnectionCreated);
+    }
+
+    #[test]
+    fn toolkit_has_scope_distinguishes_gated_from_ungated_scopes() {
+        // gmail catalog includes destructive verbs (delete / trash /
+        // batch_delete), so admin-gating actually unlocks something.
+        assert!(toolkit_has_scope("gmail", ToolScope::Admin));
+        assert!(toolkit_has_scope("gmail", ToolScope::Read));
+        assert!(toolkit_has_scope("gmail", ToolScope::Write));
+        // Case-insensitive toolkit slug → still routes to the catalog.
+        assert!(toolkit_has_scope("GMAIL", ToolScope::Admin));
+        // Unknown toolkit → no catalog → no scope is "gating" anything.
+        assert!(!toolkit_has_scope("nonexistent-toolkit", ToolScope::Admin));
     }
 
     #[test]

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -34,6 +34,7 @@
 
 mod descriptions;
 pub(crate) mod helpers;
+mod scope_lookup;
 pub mod tool_scope;
 mod traits;
 mod types;
@@ -171,46 +172,6 @@ pub fn is_action_visible_with_pref(slug: &str, pref: &UserScopePref) -> bool {
     }
 }
 
-/// Look up the curated scope for `slug` if it appears in any registered
-/// catalog (native provider's `curated_tools()` first, then the fallback
-/// catalog from [`catalog_for_toolkit`]). Returns `None` for genuinely
-/// uncurated slugs — callers that want a defensible heuristic for those
-/// should fall back to [`classify_unknown`] explicitly.
-///
-/// Sibling of [`is_action_visible_with_pref`]: that one decides "visible?",
-/// this one returns "what scope is required?" so callers (e.g. the
-/// `gated_tools` partition in `composio::ops::fetch_connected_integrations`)
-/// can render a useful unlock hint to the agent without re-doing the
-/// catalog walk.
-pub fn curated_scope_for(slug: &str) -> Option<ToolScope> {
-    let toolkit = toolkit_from_slug(slug)?;
-    let catalog = get_provider(&toolkit)
-        .and_then(|p| p.curated_tools())
-        .or_else(|| catalog_for_toolkit(&toolkit))?;
-    find_curated(catalog, slug).map(|c| c.scope)
-}
-
-/// Does any curated action for `toolkit` require `scope`?
-///
-/// Currently unused in production code (added when the now-removed
-/// `composio_enable_scope` meta-tool needed a no-op short-circuit). Kept
-/// because the same probe is useful any time we ask "would flipping the
-/// {scope} bit unlock anything in this toolkit?" — e.g. for a UI hint
-/// that greys out a toggle with no effect.
-///
-/// Walks both the native provider catalog and the fallback
-/// [`catalog_for_toolkit`] so the answer matches what
-/// [`is_action_visible_with_pref`] would gate against.
-pub fn toolkit_has_scope(toolkit: &str, scope: ToolScope) -> bool {
-    let catalog = get_provider(toolkit)
-        .and_then(|p| p.curated_tools())
-        .or_else(|| catalog_for_toolkit(toolkit));
-    match catalog {
-        Some(cat) => cat.iter().any(|t| t.scope == scope),
-        None => false,
-    }
-}
-
 pub fn catalog_for_toolkit(toolkit: &str) -> Option<&'static [CuratedTool]> {
     match toolkit.trim().to_ascii_lowercase().as_str() {
         // Native providers
@@ -252,6 +213,7 @@ pub(crate) use helpers::pick_str;
 pub use registry::{
     all_providers, get_provider, init_default_providers, register_provider, ProviderArc,
 };
+pub use scope_lookup::{curated_scope_for, toolkit_has_scope};
 pub use tool_scope::{classify_unknown, find_curated, toolkit_from_slug, CuratedTool, ToolScope};
 pub use traits::ComposioProvider;
 pub use types::{ProviderContext, ProviderUserProfile, SyncOutcome, SyncReason};
@@ -323,18 +285,8 @@ mod tests {
         assert_eq!(back, SyncReason::ConnectionCreated);
     }
 
-    #[test]
-    fn toolkit_has_scope_distinguishes_gated_from_ungated_scopes() {
-        // gmail catalog includes destructive verbs (delete / trash /
-        // batch_delete), so admin-gating actually unlocks something.
-        assert!(toolkit_has_scope("gmail", ToolScope::Admin));
-        assert!(toolkit_has_scope("gmail", ToolScope::Read));
-        assert!(toolkit_has_scope("gmail", ToolScope::Write));
-        // Case-insensitive toolkit slug → still routes to the catalog.
-        assert!(toolkit_has_scope("GMAIL", ToolScope::Admin));
-        // Unknown toolkit → no catalog → no scope is "gating" anything.
-        assert!(!toolkit_has_scope("nonexistent-toolkit", ToolScope::Admin));
-    }
+    // Note: `toolkit_has_scope` tests now live in `scope_lookup.rs`
+    // alongside the implementation.
 
     #[test]
     fn capability_matrix_distinguishes_native_from_catalog_only_toolkits() {

--- a/src/openhuman/composio/providers/mod.rs
+++ b/src/openhuman/composio/providers/mod.rs
@@ -192,11 +192,11 @@ pub fn curated_scope_for(slug: &str) -> Option<ToolScope> {
 
 /// Does any curated action for `toolkit` require `scope`?
 ///
-/// Used by the agent-callable `composio_enable_scope` meta-tool to
-/// short-circuit no-op flips: if e.g. a toolkit's catalog has zero
-/// Admin-tagged actions, flipping the user's Admin bit graduates
-/// nothing into the callable surface and the tool can return a
-/// "not applicable" message instead of silently mutating prefs.
+/// Currently unused in production code (added when the now-removed
+/// `composio_enable_scope` meta-tool needed a no-op short-circuit). Kept
+/// because the same probe is useful any time we ask "would flipping the
+/// {scope} bit unlock anything in this toolkit?" — e.g. for a UI hint
+/// that greys out a toggle with no effect.
 ///
 /// Walks both the native provider catalog and the fallback
 /// [`catalog_for_toolkit`] so the answer matches what

--- a/src/openhuman/composio/providers/scope_lookup.rs
+++ b/src/openhuman/composio/providers/scope_lookup.rs
@@ -1,0 +1,78 @@
+//! Scope-lookup operational helpers for the curated tool catalogs.
+//!
+//! Lives in a sibling module (extracted from the formerly-thick
+//! `providers/mod.rs`) to keep the module entrypoint export-focused —
+//! matches the project rule "keep mod.rs light; operational logic in
+//! ops.rs / store.rs / types.rs" from CLAUDE.md.
+//!
+//! - [`curated_scope_for`] answers "what scope does this action slug
+//!   require?" — used by `composio::ops` to render `gated_tools`
+//!   unlock hints.
+//! - [`toolkit_has_scope`] answers "does this toolkit have any
+//!   actions at the given scope?" — currently used by tests; intended
+//!   for future UI hints (grey-out a toggle that unlocks nothing).
+//!
+//! Both walk the native provider catalog first, then fall back to the
+//! static `catalog_for_toolkit` map — so the answers match what
+//! [`super::is_action_visible_with_pref`] would gate against.
+
+use super::tool_scope::{find_curated, toolkit_from_slug, ToolScope};
+use super::{catalog_for_toolkit, get_provider};
+
+/// Look up the curated scope for `slug` if it appears in any registered
+/// catalog (native provider's `curated_tools()` first, then the fallback
+/// catalog from [`super::catalog_for_toolkit`]). Returns `None` for
+/// genuinely uncurated slugs — callers that want a defensible heuristic
+/// for those should fall back to [`super::classify_unknown`] explicitly.
+///
+/// Sibling of [`super::is_action_visible_with_pref`]: that one decides
+/// "visible?", this one returns "what scope is required?" so callers
+/// (e.g. the `gated_tools` partition in
+/// `composio::ops::fetch_connected_integrations`) can render a useful
+/// unlock hint to the agent without re-doing the catalog walk.
+pub fn curated_scope_for(slug: &str) -> Option<ToolScope> {
+    let toolkit = toolkit_from_slug(slug)?;
+    let catalog = get_provider(&toolkit)
+        .and_then(|p| p.curated_tools())
+        .or_else(|| catalog_for_toolkit(&toolkit))?;
+    find_curated(catalog, slug).map(|c| c.scope)
+}
+
+/// Does any curated action for `toolkit` require `scope`?
+///
+/// Currently used by this module's tests only (added when the
+/// now-removed `composio_enable_scope` meta-tool needed a no-op
+/// short-circuit). Kept because the same probe is useful any time we
+/// ask "would flipping the {scope} bit unlock anything in this
+/// toolkit?" — e.g. a UI hint that greys out a toggle with no effect.
+///
+/// Walks both the native provider catalog and the fallback
+/// [`super::catalog_for_toolkit`] so the answer matches what
+/// [`super::is_action_visible_with_pref`] would gate against.
+pub fn toolkit_has_scope(toolkit: &str, scope: ToolScope) -> bool {
+    let catalog = get_provider(toolkit)
+        .and_then(|p| p.curated_tools())
+        .or_else(|| catalog_for_toolkit(toolkit));
+    match catalog {
+        Some(cat) => cat.iter().any(|t| t.scope == scope),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toolkit_has_scope_distinguishes_gated_from_ungated_scopes() {
+        // gmail catalog includes destructive verbs (delete / trash /
+        // batch_delete), so admin-gating actually unlocks something.
+        assert!(toolkit_has_scope("gmail", ToolScope::Admin));
+        assert!(toolkit_has_scope("gmail", ToolScope::Read));
+        assert!(toolkit_has_scope("gmail", ToolScope::Write));
+        // Case-insensitive toolkit slug → still routes to the catalog.
+        assert!(toolkit_has_scope("GMAIL", ToolScope::Admin));
+        // Unknown toolkit → no catalog → no scope is "gating" anything.
+        assert!(!toolkit_has_scope("nonexistent-toolkit", ToolScope::Admin));
+    }
+}

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -266,15 +266,24 @@ fn render_tools_markdown(resp: &super::types::ComposioToolsResponse) -> String {
 // translation contract.
 
 /// Format a user-facing error message for a scope-blocked execution.
+///
+/// Embeds the unlock paths in the error itself so the agent can read the
+/// available options straight off the tool response — same policy-in-data
+/// approach as the `gated_tools` surface. Two paths today: the agent-side
+/// meta-tool (with explicit user consent) and the manual UI toggle.
 fn scope_error_message(slug: &str, scope: ToolScope, pref: UserScopePref) -> String {
+    let toolkit = toolkit_from_slug(slug).unwrap_or_default();
+    let scope_str = scope.as_str();
     format!(
-        "composio_execute: action `{slug}` is classified `{}` and is disabled in your \
-         current scope preferences (read={}, write={}, admin={}). Update the toolkit's \
-         scope preference (composio_set_user_scopes) to enable this category.",
-        scope.as_str(),
-        pref.read,
-        pref.write,
-        pref.admin,
+        "composio_execute: action `{slug}` is classified `{scope_str}` and is \
+         disabled in the user's current scope preferences for `{toolkit}` \
+         (read={}, write={}, admin={}). Surface ALL unlock paths to the user \
+         and let them choose — don't drop one or substitute your own framing:\n\
+         - unlock path: ask the user for consent, then call \
+         `composio_enable_scope(toolkit=\"{toolkit}\", scope=\"{scope_str}\")`\n\
+         - unlock path: the user can toggle it themselves in \
+         Settings → Integrations → {toolkit} → {scope_str} scope",
+        pref.read, pref.write, pref.admin,
     )
 }
 
@@ -1052,13 +1061,16 @@ impl Tool for ComposioEnableScopeTool {
          (e.g. `GMAIL_BATCH_DELETE_MESSAGES`, `GMAIL_DELETE_THREAD`) that the \
          user has not pre-enabled. \
          \
-         CRITICAL: ALWAYS ask the user for explicit consent before calling this \
-         tool. Granting a scope persists across sessions and lets future turns \
-         invoke destructive actions without re-prompting. Phrase the request \
-         specifically (\"You're asking me to bulk-delete 200 emails. This needs \
-         Admin scope for Gmail, which I don't have. Want me to enable it now? \
-         You can always revoke in Settings → Integrations → Gmail.\"). Only call \
-         after the user clearly agrees."
+         CRITICAL: ALWAYS ask the user for explicit consent before calling \
+         this tool. Granting a scope persists across sessions and lets future \
+         turns invoke destructive actions without re-prompting. \
+         \
+         When you offer the unlock to the user, surface ALL of the action's \
+         `unlock paths` (listed beside the gated action in the integrations \
+         data) so the user can choose between letting the agent do it or \
+         flipping it themselves in the UI — do not present only the agent \
+         path. Only call this tool after the user clearly picks the agent \
+         path."
     }
     fn parameters_schema(&self) -> Value {
         json!({

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -14,8 +14,9 @@
 //! | `composio_authorize`          | Start an OAuth handoff for a toolkit, returns `connectUrl`  |
 //! | `composio_list_tools`         | Discover available action slugs + their JSON schemas        |
 //! | `composio_execute`            | Run a Composio action with `{tool, arguments}`              |
-//! | `composio_enable_scope`       | Flip a per-toolkit user scope (read/write/admin) — gates    |
-//! |                               | destructive actions; **requires explicit user consent**     |
+//!
+//! Scope elevation (read/write/admin) is deliberately NOT an agent tool;
+//! the user must toggle it themselves in the Connections UI.
 //!
 //! The agent loop is expected to chain `composio_list_tools` →
 //! `composio_execute` when it needs to use a new action. The full schema
@@ -267,22 +268,22 @@ fn render_tools_markdown(resp: &super::types::ComposioToolsResponse) -> String {
 
 /// Format a user-facing error message for a scope-blocked execution.
 ///
-/// Embeds the unlock paths in the error itself so the agent can read the
-/// available options straight off the tool response — same policy-in-data
-/// approach as the `gated_tools` surface. Two paths today: the agent-side
-/// meta-tool (with explicit user consent) and the manual UI toggle.
+/// Embeds the unlock path in the error itself so the agent reads the
+/// instruction straight off the tool response — same policy-in-data
+/// approach as the `gated_tools` surface. Only ONE path: the user
+/// toggles the scope in the Connections UI. The agent has no tool to
+/// flip scopes (see the note above the removed `ComposioEnableScopeTool`
+/// for why) — it can only describe the gate and point at the UI.
 fn scope_error_message(slug: &str, scope: ToolScope, pref: UserScopePref) -> String {
     let toolkit = toolkit_from_slug(slug).unwrap_or_default();
     let scope_str = scope.as_str();
     format!(
         "composio_execute: action `{slug}` is classified `{scope_str}` and is \
          disabled in the user's current scope preferences for `{toolkit}` \
-         (read={}, write={}, admin={}). Surface ALL unlock paths to the user \
-         and let them choose — don't drop one or substitute your own framing:\n\
-         - unlock path: ask the user for consent, then call \
-         `composio_enable_scope(toolkit=\"{toolkit}\", scope=\"{scope_str}\")`\n\
-         - unlock path: the user can toggle it themselves in \
-         Settings → Integrations → {toolkit} → {scope_str} scope",
+         (read={}, write={}, admin={}). Tell the user this action requires the \
+         `{scope_str}` scope and they can enable it themselves in \
+         **Connections → {toolkit} → {scope_str}**. Do not claim you can flip \
+         it — you cannot.",
         pref.read, pref.write, pref.admin,
     )
 }
@@ -860,7 +861,33 @@ impl Tool for ComposioExecuteTool {
             ));
         }
         let arguments = args.get("arguments").cloned();
-        tracing::debug!(tool = %tool, "[composio] tool execute.execute");
+        let connection_id = args
+            .get("connection_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        // INFO-level entry log — visible without bumping log level. Logs
+        // ARG KEYS only by default so traces don't leak email bodies / PII;
+        // the full arg JSON goes through a paired DEBUG log below for deep
+        // debugging. Together these let `grep "[composio][execute]"` show
+        // the full agent→backend audit trail at default verbosity.
+        let arg_keys: Vec<&str> = arguments
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .map(|obj| obj.keys().map(|k| k.as_str()).collect())
+            .unwrap_or_default();
+        tracing::info!(
+            tool = %tool,
+            connection_id = %connection_id,
+            arg_keys = ?arg_keys,
+            "[composio][execute] >> dispatch"
+        );
+        if let Some(ref args_json) = arguments {
+            tracing::debug!(
+                tool = %tool,
+                args = %args_json,
+                "[composio][execute] >> full args (DEBUG)"
+            );
+        }
 
         // Agent-level sandbox gate (issue #685) — applies on top of the
         // user's scope preference below. When the currently-executing
@@ -973,6 +1000,19 @@ impl Tool for ComposioExecuteTool {
         let elapsed_ms = started.elapsed().as_millis() as u64;
         match res {
             Ok(resp) => {
+                tracing::info!(
+                    tool = %tool,
+                    successful = resp.successful,
+                    error = ?resp.error,
+                    elapsed_ms,
+                    cost_usd = resp.cost_usd,
+                    "[composio][execute] << result"
+                );
+                tracing::debug!(
+                    tool = %tool,
+                    response = ?resp,
+                    "[composio][execute] << full response (DEBUG)"
+                );
                 crate::core::event_bus::publish_global(
                     crate::core::event_bus::DomainEvent::ComposioActionExecuted {
                         tool: tool.clone(),
@@ -1003,6 +1043,12 @@ impl Tool for ComposioExecuteTool {
                 Ok(ToolResult::success(body))
             }
             Err(e) => {
+                tracing::warn!(
+                    tool = %tool,
+                    error = %e,
+                    elapsed_ms,
+                    "[composio][execute] << dispatch error"
+                );
                 crate::core::event_bus::publish_global(
                     crate::core::event_bus::DomainEvent::ComposioActionExecuted {
                         tool: tool.clone(),
@@ -1018,211 +1064,20 @@ impl Tool for ComposioExecuteTool {
     }
 }
 
-// ── composio_enable_scope ───────────────────────────────────────────
-
-/// Agent-callable meta-tool: enable one of the per-toolkit user scopes
-/// (`read` / `write` / `admin`). The default user pref is
-/// `{read: true, write: true, admin: false}`, so Admin-scoped actions
-/// (bulk delete, destructive label modifications, etc.) are hidden from
-/// the agent's callable tool list — and from its `gated_tools` prompt
-/// surface — until this tool flips the bit.
-///
-/// **Safety contract (the agent prompt must enforce this):** the LLM
-/// MUST ask the user for explicit consent BEFORE invoking this tool.
-/// Granting Admin scope persists across sessions and lets future agent
-/// turns invoke destructive Composio actions without re-consenting.
-/// The tool itself does not currently surface a UI approval modal — it
-/// trusts the agent to have asked first. (When the wider tool-policy /
-/// approval-gate layer lands more broadly, this tool should be wired
-/// into it as a `destructive` action.)
-pub struct ComposioEnableScopeTool {
-    /// Held as `Arc<Config>` for the same mode-aware reasons as the
-    /// other composio meta-tools; the actual save path resolves the
-    /// memory client itself via the global registry, so no live config
-    /// reload is needed for this verb.
-    _config: Arc<Config>,
-}
-
-impl ComposioEnableScopeTool {
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { _config: config }
-    }
-}
-
-#[async_trait]
-impl Tool for ComposioEnableScopeTool {
-    fn name(&self) -> &str {
-        "composio_enable_scope"
-    }
-    fn description(&self) -> &str {
-        "Enable a per-toolkit user scope (`read` / `write` / `admin`) so the \
-         agent gains access to actions in that scope on the next prompt rebuild. \
-         The most common use is `scope='admin'` to unlock destructive actions \
-         (e.g. `GMAIL_BATCH_DELETE_MESSAGES`, `GMAIL_DELETE_THREAD`) that the \
-         user has not pre-enabled. \
-         \
-         CRITICAL: ALWAYS ask the user for explicit consent before calling \
-         this tool. Granting a scope persists across sessions and lets future \
-         turns invoke destructive actions without re-prompting. \
-         \
-         When you offer the unlock to the user, surface ALL of the action's \
-         `unlock paths` (listed beside the gated action in the integrations \
-         data) so the user can choose between letting the agent do it or \
-         flipping it themselves in the UI — do not present only the agent \
-         path. Only call this tool after the user clearly picks the agent \
-         path."
-    }
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "toolkit": {
-                    "type": "string",
-                    "description": "Toolkit slug, e.g. 'gmail' or 'notion'. \
-                                    Lowercase; must match a connected toolkit."
-                },
-                "scope": {
-                    "type": "string",
-                    "enum": ["read", "write", "admin"],
-                    "description": "Which scope to enable. Defaults to 'admin' \
-                                    (the only scope that's off by default)."
-                }
-            },
-            "required": ["toolkit"],
-            "additionalProperties": false
-        })
-    }
-    fn permission_level(&self) -> PermissionLevel {
-        // Marked as Write rather than Admin so the session sandbox doesn't
-        // unintentionally lock the tool out when running in non-Admin
-        // contexts — the *toolkit*-level Admin gate is the user pref this
-        // tool flips, not the session-level sandbox. The user-consent
-        // requirement is enforced via the prompt contract above.
-        PermissionLevel::Write
-    }
-    fn category(&self) -> ToolCategory {
-        ToolCategory::Skill
-    }
-    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
-        let toolkit = args
-            .get("toolkit")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if toolkit.is_empty() {
-            return Ok(ToolResult::error(
-                "composio_enable_scope: 'toolkit' is required",
-            ));
-        }
-        let scope = args
-            .get("scope")
-            .and_then(|v| v.as_str())
-            .unwrap_or("admin")
-            .trim()
-            .to_ascii_lowercase();
-        if !matches!(scope.as_str(), "read" | "write" | "admin") {
-            return Ok(ToolResult::error(format!(
-                "composio_enable_scope: 'scope' must be one of 'read'|'write'|'admin' (got '{scope}')"
-            )));
-        }
-        tracing::info!(
-            toolkit = %toolkit,
-            scope = %scope,
-            "[composio] tool enable_scope.execute (user-consent assumed enforced by agent prompt)"
-        );
-
-        // Map the validated string back to the typed scope enum so we
-        // can reuse it for both the applicability probe and the merge.
-        let scope_enum = match scope.as_str() {
-            "read" => crate::openhuman::composio::providers::tool_scope::ToolScope::Read,
-            "write" => crate::openhuman::composio::providers::tool_scope::ToolScope::Write,
-            "admin" => crate::openhuman::composio::providers::tool_scope::ToolScope::Admin,
-            _ => unreachable!("validated above"),
-        };
-
-        // Guard 1: applicability. If no curated action for this toolkit
-        // requires the requested scope, flipping the bit graduates nothing
-        // into the callable surface — short-circuit with a clear message
-        // so the agent doesn't burn a turn (and doesn't mislead the user
-        // into thinking a destructive capability just opened up).
-        if !crate::openhuman::composio::providers::toolkit_has_scope(&toolkit, scope_enum) {
-            tracing::info!(
-                toolkit = %toolkit,
-                scope = %scope,
-                "[composio] enable_scope no-op: toolkit has no curated actions at this scope"
-            );
-            return Ok(ToolResult::success(format!(
-                "No-op. Toolkit `{toolkit}` has no curated actions that require `{scope}` \
-                 scope, so enabling it would not unlock anything new. Re-check the user's \
-                 original ask — the capability they want may live on a different toolkit, \
-                 or may not be supported by this integration at all."
-            )));
-        }
-
-        // Resolve the live memory client. The setter writes to the per-toolkit
-        // KV row. Mirrors the `load_or_default` pattern's fallback handling.
-        let memory = match crate::openhuman::memory::global::client_if_ready() {
-            Some(c) => c,
-            None => {
-                return Ok(ToolResult::error(
-                    "composio_enable_scope: memory client is not initialised — \
-                     scope prefs cannot be persisted",
-                ));
-            }
-        };
-
-        // Guard 2: already-enabled short-circuit. Avoid a redundant write +
-        // a misleading "Enabled" message when the bit is already set.
-        let mut pref =
-            crate::openhuman::composio::providers::user_scopes::load(&memory, &toolkit).await;
-        let already_on = match scope.as_str() {
-            "read" => pref.read,
-            "write" => pref.write,
-            "admin" => pref.admin,
-            _ => unreachable!(),
-        };
-        if already_on {
-            tracing::info!(
-                toolkit = %toolkit,
-                scope = %scope,
-                "[composio] enable_scope no-op: already enabled"
-            );
-            return Ok(ToolResult::success(format!(
-                "No-op. `{scope}` scope is already enabled for `{toolkit}` \
-                 (current pref: read={} write={} admin={}). The matching actions \
-                 should already be in your callable tool list — if a specific \
-                 capability is still missing, the toolkit may simply not expose it.",
-                pref.read, pref.write, pref.admin
-            )));
-        }
-
-        // Load → merge requested bit → save. We deliberately do NOT touch
-        // the other two flags — flipping admin on does not change the
-        // user's read/write choices.
-        match scope.as_str() {
-            "read" => pref.read = true,
-            "write" => pref.write = true,
-            "admin" => pref.admin = true,
-            _ => unreachable!(),
-        }
-        if let Err(e) =
-            crate::openhuman::composio::providers::user_scopes::save(&memory, &toolkit, pref).await
-        {
-            return Ok(ToolResult::error(format!(
-                "composio_enable_scope: save failed for toolkit={toolkit} scope={scope}: {e}"
-            )));
-        }
-
-        let out = format!(
-            "OK. Enabled `{scope}` scope for `{toolkit}`. Effective on the next \
-             prompt rebuild (typically the next turn). New pref: \
-             read={} write={} admin={}.",
-            pref.read, pref.write, pref.admin
-        );
-        Ok(ToolResult::success(out))
-    }
-}
+// NOTE: A `composio_enable_scope` agent-callable meta-tool used to live
+// here. It was removed deliberately: scope elevation is a
+// security-sensitive, cross-session state change that unlocks
+// destructive actions, and putting that flip behind LLM-mediated
+// "user consent" both (a) made the safety contract depend on model
+// behavior — the weakest place for it — and (b) was a soft gate the
+// model could route around (e.g. trash-via-label). The user must
+// toggle scopes themselves in **Connections → {toolkit} → {scope}
+// row**; the agent only describes the gated capability and points at
+// that UI path.
+//
+// Two surfaces name this policy; keep them in sync:
+//   - `GatedIntegrationTool.unlock_paths` populated in `composio::ops`
+//   - `scope_error_message` returned from `composio_execute` blocks
 
 // ── Bulk registration helper ────────────────────────────────────────
 
@@ -1256,13 +1111,10 @@ pub fn all_composio_agent_tools(config: &crate::openhuman::config::Config) -> Ve
         Box::new(ComposioListConnectionsTool::new(config_arc.clone())),
         Box::new(ComposioAuthorizeTool::new(config_arc.clone())),
         Box::new(ComposioListToolsTool::new(config_arc.clone())),
-        Box::new(ComposioExecuteTool::new(config_arc.clone())),
-        // Pref-elevation meta-tool — the LLM-visible companion to the
-        // `ConnectedIntegration.gated_tools` surface. With explicit user
-        // consent, the agent calls this to flip a per-toolkit scope bit
-        // (typically `admin`); the corresponding gated actions graduate
-        // into the callable tool list on the next prompt rebuild.
-        Box::new(ComposioEnableScopeTool::new(config_arc)),
+        Box::new(ComposioExecuteTool::new(config_arc)),
+        // Pref-elevation is intentionally NOT an agent-callable tool;
+        // the user must flip it themselves in the Connections UI.
+        // See the long comment above the (removed) ComposioEnableScopeTool.
     ];
     tracing::debug!(count = tools.len(), "[composio] agent tools registered");
     tools

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -1120,6 +1120,34 @@ impl Tool for ComposioEnableScopeTool {
             "[composio] tool enable_scope.execute (user-consent assumed enforced by agent prompt)"
         );
 
+        // Map the validated string back to the typed scope enum so we
+        // can reuse it for both the applicability probe and the merge.
+        let scope_enum = match scope.as_str() {
+            "read" => crate::openhuman::composio::providers::tool_scope::ToolScope::Read,
+            "write" => crate::openhuman::composio::providers::tool_scope::ToolScope::Write,
+            "admin" => crate::openhuman::composio::providers::tool_scope::ToolScope::Admin,
+            _ => unreachable!("validated above"),
+        };
+
+        // Guard 1: applicability. If no curated action for this toolkit
+        // requires the requested scope, flipping the bit graduates nothing
+        // into the callable surface — short-circuit with a clear message
+        // so the agent doesn't burn a turn (and doesn't mislead the user
+        // into thinking a destructive capability just opened up).
+        if !crate::openhuman::composio::providers::toolkit_has_scope(&toolkit, scope_enum) {
+            tracing::info!(
+                toolkit = %toolkit,
+                scope = %scope,
+                "[composio] enable_scope no-op: toolkit has no curated actions at this scope"
+            );
+            return Ok(ToolResult::success(format!(
+                "No-op. Toolkit `{toolkit}` has no curated actions that require `{scope}` \
+                 scope, so enabling it would not unlock anything new. Re-check the user's \
+                 original ask — the capability they want may live on a different toolkit, \
+                 or may not be supported by this integration at all."
+            )));
+        }
+
         // Resolve the live memory client. The setter writes to the per-toolkit
         // KV row. Mirrors the `load_or_default` pattern's fallback handling.
         let memory = match crate::openhuman::memory::global::client_if_ready() {
@@ -1132,11 +1160,34 @@ impl Tool for ComposioEnableScopeTool {
             }
         };
 
+        // Guard 2: already-enabled short-circuit. Avoid a redundant write +
+        // a misleading "Enabled" message when the bit is already set.
+        let mut pref =
+            crate::openhuman::composio::providers::user_scopes::load(&memory, &toolkit).await;
+        let already_on = match scope.as_str() {
+            "read" => pref.read,
+            "write" => pref.write,
+            "admin" => pref.admin,
+            _ => unreachable!(),
+        };
+        if already_on {
+            tracing::info!(
+                toolkit = %toolkit,
+                scope = %scope,
+                "[composio] enable_scope no-op: already enabled"
+            );
+            return Ok(ToolResult::success(format!(
+                "No-op. `{scope}` scope is already enabled for `{toolkit}` \
+                 (current pref: read={} write={} admin={}). The matching actions \
+                 should already be in your callable tool list — if a specific \
+                 capability is still missing, the toolkit may simply not expose it.",
+                pref.read, pref.write, pref.admin
+            )));
+        }
+
         // Load → merge requested bit → save. We deliberately do NOT touch
         // the other two flags — flipping admin on does not change the
         // user's read/write choices.
-        let mut pref =
-            crate::openhuman::composio::providers::user_scopes::load(&memory, &toolkit).await;
         match scope.as_str() {
             "read" => pref.read = true,
             "write" => pref.write = true,

--- a/src/openhuman/composio/tools.rs
+++ b/src/openhuman/composio/tools.rs
@@ -14,6 +14,8 @@
 //! | `composio_authorize`          | Start an OAuth handoff for a toolkit, returns `connectUrl`  |
 //! | `composio_list_tools`         | Discover available action slugs + their JSON schemas        |
 //! | `composio_execute`            | Run a Composio action with `{tool, arguments}`              |
+//! | `composio_enable_scope`       | Flip a per-toolkit user scope (read/write/admin) — gates    |
+//! |                               | destructive actions; **requires explicit user consent**     |
 //!
 //! The agent loop is expected to chain `composio_list_tools` →
 //! `composio_execute` when it needs to use a new action. The full schema
@@ -1007,6 +1009,158 @@ impl Tool for ComposioExecuteTool {
     }
 }
 
+// ── composio_enable_scope ───────────────────────────────────────────
+
+/// Agent-callable meta-tool: enable one of the per-toolkit user scopes
+/// (`read` / `write` / `admin`). The default user pref is
+/// `{read: true, write: true, admin: false}`, so Admin-scoped actions
+/// (bulk delete, destructive label modifications, etc.) are hidden from
+/// the agent's callable tool list — and from its `gated_tools` prompt
+/// surface — until this tool flips the bit.
+///
+/// **Safety contract (the agent prompt must enforce this):** the LLM
+/// MUST ask the user for explicit consent BEFORE invoking this tool.
+/// Granting Admin scope persists across sessions and lets future agent
+/// turns invoke destructive Composio actions without re-consenting.
+/// The tool itself does not currently surface a UI approval modal — it
+/// trusts the agent to have asked first. (When the wider tool-policy /
+/// approval-gate layer lands more broadly, this tool should be wired
+/// into it as a `destructive` action.)
+pub struct ComposioEnableScopeTool {
+    /// Held as `Arc<Config>` for the same mode-aware reasons as the
+    /// other composio meta-tools; the actual save path resolves the
+    /// memory client itself via the global registry, so no live config
+    /// reload is needed for this verb.
+    _config: Arc<Config>,
+}
+
+impl ComposioEnableScopeTool {
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { _config: config }
+    }
+}
+
+#[async_trait]
+impl Tool for ComposioEnableScopeTool {
+    fn name(&self) -> &str {
+        "composio_enable_scope"
+    }
+    fn description(&self) -> &str {
+        "Enable a per-toolkit user scope (`read` / `write` / `admin`) so the \
+         agent gains access to actions in that scope on the next prompt rebuild. \
+         The most common use is `scope='admin'` to unlock destructive actions \
+         (e.g. `GMAIL_BATCH_DELETE_MESSAGES`, `GMAIL_DELETE_THREAD`) that the \
+         user has not pre-enabled. \
+         \
+         CRITICAL: ALWAYS ask the user for explicit consent before calling this \
+         tool. Granting a scope persists across sessions and lets future turns \
+         invoke destructive actions without re-prompting. Phrase the request \
+         specifically (\"You're asking me to bulk-delete 200 emails. This needs \
+         Admin scope for Gmail, which I don't have. Want me to enable it now? \
+         You can always revoke in Settings → Integrations → Gmail.\"). Only call \
+         after the user clearly agrees."
+    }
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "toolkit": {
+                    "type": "string",
+                    "description": "Toolkit slug, e.g. 'gmail' or 'notion'. \
+                                    Lowercase; must match a connected toolkit."
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": ["read", "write", "admin"],
+                    "description": "Which scope to enable. Defaults to 'admin' \
+                                    (the only scope that's off by default)."
+                }
+            },
+            "required": ["toolkit"],
+            "additionalProperties": false
+        })
+    }
+    fn permission_level(&self) -> PermissionLevel {
+        // Marked as Write rather than Admin so the session sandbox doesn't
+        // unintentionally lock the tool out when running in non-Admin
+        // contexts — the *toolkit*-level Admin gate is the user pref this
+        // tool flips, not the session-level sandbox. The user-consent
+        // requirement is enforced via the prompt contract above.
+        PermissionLevel::Write
+    }
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Skill
+    }
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let toolkit = args
+            .get("toolkit")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if toolkit.is_empty() {
+            return Ok(ToolResult::error(
+                "composio_enable_scope: 'toolkit' is required",
+            ));
+        }
+        let scope = args
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .unwrap_or("admin")
+            .trim()
+            .to_ascii_lowercase();
+        if !matches!(scope.as_str(), "read" | "write" | "admin") {
+            return Ok(ToolResult::error(format!(
+                "composio_enable_scope: 'scope' must be one of 'read'|'write'|'admin' (got '{scope}')"
+            )));
+        }
+        tracing::info!(
+            toolkit = %toolkit,
+            scope = %scope,
+            "[composio] tool enable_scope.execute (user-consent assumed enforced by agent prompt)"
+        );
+
+        // Resolve the live memory client. The setter writes to the per-toolkit
+        // KV row. Mirrors the `load_or_default` pattern's fallback handling.
+        let memory = match crate::openhuman::memory::global::client_if_ready() {
+            Some(c) => c,
+            None => {
+                return Ok(ToolResult::error(
+                    "composio_enable_scope: memory client is not initialised — \
+                     scope prefs cannot be persisted",
+                ));
+            }
+        };
+
+        // Load → merge requested bit → save. We deliberately do NOT touch
+        // the other two flags — flipping admin on does not change the
+        // user's read/write choices.
+        let mut pref =
+            crate::openhuman::composio::providers::user_scopes::load(&memory, &toolkit).await;
+        match scope.as_str() {
+            "read" => pref.read = true,
+            "write" => pref.write = true,
+            "admin" => pref.admin = true,
+            _ => unreachable!(),
+        }
+        if let Err(e) =
+            crate::openhuman::composio::providers::user_scopes::save(&memory, &toolkit, pref).await
+        {
+            return Ok(ToolResult::error(format!(
+                "composio_enable_scope: save failed for toolkit={toolkit} scope={scope}: {e}"
+            )));
+        }
+
+        let out = format!(
+            "OK. Enabled `{scope}` scope for `{toolkit}`. Effective on the next \
+             prompt rebuild (typically the next turn). New pref: \
+             read={} write={} admin={}.",
+            pref.read, pref.write, pref.admin
+        );
+        Ok(ToolResult::success(out))
+    }
+}
+
 // ── Bulk registration helper ────────────────────────────────────────
 
 /// Build the full set of composio agent tools when the integrations
@@ -1039,7 +1193,13 @@ pub fn all_composio_agent_tools(config: &crate::openhuman::config::Config) -> Ve
         Box::new(ComposioListConnectionsTool::new(config_arc.clone())),
         Box::new(ComposioAuthorizeTool::new(config_arc.clone())),
         Box::new(ComposioListToolsTool::new(config_arc.clone())),
-        Box::new(ComposioExecuteTool::new(config_arc)),
+        Box::new(ComposioExecuteTool::new(config_arc.clone())),
+        // Pref-elevation meta-tool — the LLM-visible companion to the
+        // `ConnectedIntegration.gated_tools` surface. With explicit user
+        // consent, the agent calls this to flip a per-toolkit scope bit
+        // (typically `admin`); the corresponding gated actions graduate
+        // into the callable tool list on the next prompt rebuild.
+        Box::new(ComposioEnableScopeTool::new(config_arc)),
     ];
     tracing::debug!(count = tools.len(), "[composio] agent tools registered");
     tools

--- a/src/openhuman/composio/tools_tests.rs
+++ b/src/openhuman/composio/tools_tests.rs
@@ -212,9 +212,11 @@ fn agent_tools_register_when_backend_signed_in() {
     let tools = all_composio_agent_tools(&config);
     assert_eq!(
         tools.len(),
-        6,
-        "backend session present → all 6 generic composio agent tools should register \
-         (list_toolkits, list_connections, authorize, list_tools, execute, enable_scope)"
+        5,
+        "backend session present → all 5 generic composio agent tools should register \
+         (list_toolkits, list_connections, authorize, list_tools, execute). Scope \
+         elevation is intentionally NOT exposed as an agent tool — the user must \
+         flip scopes themselves in the Connections UI."
     );
 }
 
@@ -225,7 +227,8 @@ fn agent_tools_register_when_direct_mode_with_stored_key_and_no_backend_session(
     // tools registered because the gate hard-bound to
     // `build_composio_client` (backend-only). With the mode-aware probe
     // in place this now correctly returns the full generic tool set
-    // (originally 5; grew to 6 with `composio_enable_scope`).
+    // (5 tools: list_toolkits, list_connections, authorize, list_tools,
+    // execute). Scope elevation is not an agent tool — UI-only.
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut config = crate::openhuman::config::Config::default();
     config.config_path = tmp.path().join("config.toml");
@@ -236,9 +239,9 @@ fn agent_tools_register_when_direct_mode_with_stored_key_and_no_backend_session(
     let tools = all_composio_agent_tools(&config);
     assert_eq!(
         tools.len(),
-        6,
+        5,
         "direct mode with stored API key (no backend session) must still register \
-         all 6 generic composio agent tools — the pre-Option-C bug returned 0 here"
+         all 5 generic composio agent tools — the pre-Option-C bug returned 0 here"
     );
 }
 

--- a/src/openhuman/composio/tools_tests.rs
+++ b/src/openhuman/composio/tools_tests.rs
@@ -212,8 +212,9 @@ fn agent_tools_register_when_backend_signed_in() {
     let tools = all_composio_agent_tools(&config);
     assert_eq!(
         tools.len(),
-        5,
-        "backend session present → all 5 generic composio agent tools should register"
+        6,
+        "backend session present → all 6 generic composio agent tools should register \
+         (list_toolkits, list_connections, authorize, list_tools, execute, enable_scope)"
     );
 }
 
@@ -223,7 +224,8 @@ fn agent_tools_register_when_direct_mode_with_stored_key_and_no_backend_session(
     // user with a working personal Composio API key was getting `0`
     // tools registered because the gate hard-bound to
     // `build_composio_client` (backend-only). With the mode-aware probe
-    // in place this now correctly returns the full 5 generic tools.
+    // in place this now correctly returns the full generic tool set
+    // (originally 5; grew to 6 with `composio_enable_scope`).
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut config = crate::openhuman::config::Config::default();
     config.config_path = tmp.path().join("config.toml");
@@ -234,9 +236,9 @@ fn agent_tools_register_when_direct_mode_with_stored_key_and_no_backend_session(
     let tools = all_composio_agent_tools(&config);
     assert_eq!(
         tools.len(),
-        5,
+        6,
         "direct mode with stored API key (no backend session) must still register \
-         all 5 generic composio agent tools — the pre-Option-C bug returned 0 here"
+         all 6 generic composio agent tools — the pre-Option-C bug returned 0 here"
     );
 }
 

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -320,6 +320,7 @@ mod tests {
             toolkit: toolkit.into(),
             description: description.into(),
             tools: vec![],
+            gated_tools: vec![],
             connected: true,
         }
     }
@@ -462,6 +463,7 @@ mod tests {
                 toolkit: "github".into(),
                 description: "GitHub access.".into(),
                 tools: vec![],
+                gated_tools: vec![],
                 connected: false, // not connected — must not appear in the enum
             },
             integration("notion", "Read and write pages."),
@@ -535,6 +537,7 @@ mod tests {
                 toolkit: "Brand.New".into(),
                 description: "   ".into(),
                 tools: vec![],
+                gated_tools: vec![],
                 connected: true,
             },
             integration("gmail", "Email."),


### PR DESCRIPTION
## Summary

- **`composio_sync` is now fire-and-forget**: the RPC validates synchronously (connection_id / toolkit / provider), then `tokio::spawn(provider.sync)` and returns `{status: "started", ...}` immediately. UI is no longer pinned for the 30 s frontend RPC cap while the provider walks an entire prod inbox in-band. Per-source progress already flows via the existing `openhuman.memory_sync_status_list` poll (reads `mem_tree_chunks` directly so the spawned task is reflected in real time).
- **Gated-tools surface for the integrations agent**: `ConnectedIntegration` gains `gated_tools: Vec<GatedIntegrationTool>` (no `parameters` field — LLM can't construct a call envelope for one). `fetch_connected_integrations` now partitions a toolkit's actions into visible/callable vs gated-by-pref. The `integrations_agent` prompt renders an *"Additional capabilities behind a permission toggle"* section so the agent can answer *"do you support X?"* with "yes but admin scope is off — want me to enable it?" instead of confabulating *"no I can't"*.
- **New `composio_enable_scope` meta-tool**: agent-callable (registered in `all_composio_agent_tools`), takes `(toolkit, scope?)`, flips the per-toolkit `composio-user-scopes` KV row. Strong *"ALWAYS ask the user for explicit consent first"* wording in the description.
- **Orchestrator force-delegates capability questions** to `integrations_agent` rather than answering from training-data priors (which were systematically wrong — confidently claimed Gmail had no bulk-delete when the toolkit ships `GMAIL_BATCH_DELETE_MESSAGES`).

## Problem

Observed in production-mode use over a long debugging session:

1. **`composio_sync` consistently shows "sync failed" in the UI** ~30 s in, but the server-side sync is healthy and continues. The frontend RPC `.await` cap is too tight for a real prod inbox — `provider.sync` walks all pages in-band and ingests every message synchronously inside the RPC handler. There is no good reason for the UI to block on it; per-source progress is already polled separately.
2. **Agent flatly denies capabilities the toolkit has** — user asks *"can you delete spam?"*, agent replies *"nope, I can't delete or trash emails through the Gmail integration"*. Wrong: Gmail's Composio catalog ships `GMAIL_BATCH_DELETE_MESSAGES`, `GMAIL_DELETE_THREAD`, `GMAIL_MOVE_TO_TRASH`, etc. Two root causes — (a) admin-scoped tools are filtered out of the agent's tool list by default user pref (`{read:true, write:true, admin:false}`) AND filtered out of the prompt-side `tools:` field, so the agent has zero awareness they exist; (b) for the orchestrator agent, even when admin is on, the orchestrator's training-data prior about toolkit capabilities is unreliable — it answers *"can you do X?"* from priors rather than delegating to the agent that actually has the tool list.

## Solution

| Concern | File(s) | What |
|---|---|---|
| Sync hang | `composio/ops.rs:1012` | `tokio::spawn(provider.sync(...))` + return `SyncOutcome{status:"started", finished_at_ms:0, ...}` immediately. Validation (resolve client, lookup provider, lookup toolkit) stays synchronous so bad-request errors surface via the RPC envelope. |
| Agent unaware of gated capabilities | `agent/prompts/types.rs`, `composio/providers/mod.rs`, `composio/ops.rs`, `integrations_agent/prompt.rs` | New `GatedIntegrationTool` (no `parameters` field — descriptive only). New `curated_scope_for(slug)` helper. Producer (`fetch_connected_integrations_uncached`) partitions into `tools` + `gated_tools`. Integrations-agent prompt renders a *"behind a permission toggle"* section, including instructions on how to call `composio_enable_scope` with user consent. |
| Elevation path | `composio/tools.rs` | New `ComposioEnableScopeTool` (struct, `impl Tool`, registered in `all_composio_agent_tools`). |
| Orchestrator confabulation | `orchestrator/prompt.rs` | New *"Capability questions about connected toolkits"* subsection in the delegation guide that forbids prior-based refusals for connected toolkits and tells the orchestrator the only honest "no" comes back from a delegation that found the action neither in visible `tools` nor `gated_tools`. |
| Plumbing | `welcome/prompt.rs`, `harness/subagent_runner/ops.rs`, `harness/test_support_test.rs`, `composio/ops_test.rs`, `tools/orchestrator_tools.rs` | Update existing `ConnectedIntegration { ... }` literal sites to populate the new `gated_tools` field (defaults to `Vec::new()`). |

Design choices worth flagging for reviewers:

- **Why a separate `gated_tools` field instead of inlining**: the `parameters: None` distinction is load-bearing — without it the LLM can construct call envelopes for tools it can't actually invoke. Splitting at the type level enforces that the prompt-render path produces descriptive-only output for gated entries.
- **Why `ComposioEnableScopeTool` is a separate meta-tool rather than auto-elevation**: granting Admin scope persists across sessions. Self-elevation without explicit user consent is a security boundary regression. The tool relies on the prompt contract today (*"ALWAYS ask the user for explicit consent first"*) and is the right shape to wire into the wider tool-policy / approval-gate layer (#2149 / #2166 area) when that lands.
- **Why force-delegate capability questions vs. push tool data into the orchestrator prompt**: orchestrator prompt-size is already a concern and most user questions about toolkits don't need a sub-agent round-trip. But for *"can you do X?"* / *"does Y support Z?"*, the orchestrator's training-data prior is systematically a subset of the real catalog. One sub-agent hop is cheap; a confidently wrong refusal is not.

## Submission Checklist

- [x] N/A: tests deferred to a follow-up commit — see *Validation Blocked* below. The behavioural change is verified by partition-log evidence on a live workspace (`[composio][scopes] integrations prompt action set toolkit=googledrive visible=14 gated=6`, etc.) but unit-test additions for the partition logic, `composio_enable_scope.execute()`, and the orchestrator prompt-render change are pending. The PR is opened as DRAFT for this reason.
- [x] N/A: diff coverage gate will not pass on this commit alone — same reason. Will land tests in follow-up before un-drafting.
- [x] N/A: no behaviour-only feature ID change — the new `gated_tools` surface is an additive extension of the existing `composio.connected_integrations` capability; no new top-level feature row required.
- [x] N/A: no matrix-tracked feature IDs touched (changes are agent-prompt / Composio infrastructure).
- [x] No new external network dependencies — `composio_enable_scope` writes to the existing per-toolkit KV; `composio_sync` change is purely scheduling.
- [x] N/A: no release-cut surface touched (no manual smoke checklist change needed).
- [x] N/A: no linked issue — the changes were derived from a long-running production-mode debugging session, not a tracked ticket. Happy to file follow-up issues if reviewers prefer.

## Impact

**Runtime / platform**: desktop, all platforms. No platform branches added or changed.

**Performance**: net positive. `composio_sync` no longer pins the UI thread; the orchestrator delegation cost (one extra sub-agent round-trip for capability questions) is bounded and only fires on questions that today produce confidently wrong refusals.

**Migration / compatibility**: schema-level — adding `gated_tools` to `ConnectedIntegration` is an additive Rust struct field; every internal constructor was updated to `Vec::new()` so behaviour is identical when no curated entries are pref-blocked. Backward-compatible.

**Security**: `composio_enable_scope` is the only privilege-changing surface added. Documented requirement: agent must ask for explicit user consent before invocation. No silent self-elevation. Wider tool-policy / approval-gate integration recommended as a follow-up.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - Unit tests for the `gated_tools` partition, `ComposioEnableScopeTool.execute()`, and the orchestrator force-delegate prompt section.
  - Wire `composio_enable_scope` into the tool-policy / approval-gate layer (#2149 / #2166 area) so the user-consent contract is enforced at runtime, not only via prompt instruction.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `feat/composio-agent-ux`
- Commit SHA: `0e5b042e`

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` not run — Windows working tree has the documented ~600-file CRLF/LF drift; `format:check` would rewrite unrelated files. Pre-push hook bypassed via `--no-verify` per the same documented pattern.
- [x] N/A: `pnpm typecheck` not run — no TypeScript surface changed in this PR (Rust core only).
- [x] Focused tests: existing prompt-builder tests in `integrations_agent/prompt.rs`, `orchestrator/prompt.rs`, `welcome/prompt.rs` were updated to populate the new `gated_tools` field on `ConnectedIntegration` literals; existing `composio/ops_test.rs` and `tools/orchestrator_tools.rs` test helpers similarly updated.
- [x] Rust fmt/check: `cargo check` ran implicitly via `pnpm dev:app:win` rebuild — 0 errors. `cargo fmt` not explicitly run; will run in the follow-up that adds tests.
- [x] N/A: Tauri fmt/check — no `app/src-tauri/` Rust changes in this PR.

### Validation Blocked
- `command:` `cargo fmt` and unit-test additions for the new partition + meta-tool paths
- `error:` n/a — not blocked technically; bundled with the test-coverage follow-up before un-drafting.
- `impact:` PR is opened as DRAFT; reviewer feedback welcome on the architectural direction (esp. the `gated_tools` / `enable_scope` shape) before I invest in the test suite.

### Behavior Changes
- Intended behavior change:
  1. `composio_sync` RPC returns `{status:"started"}` immediately instead of awaiting full provider sync.
  2. Integrations agent now sees + describes pref-gated toolkit actions and knows the elevation procedure.
  3. New `composio_enable_scope` meta-tool flips per-toolkit user scopes (with prompt-enforced user-consent contract).
  4. Orchestrator delegates capability questions about connected toolkits to `integrations_agent` instead of confabulating from priors.
- User-visible effect:
  - *"Memory Sources"* UI no longer shows *"sync failed"* within 30 s — shows progress updating in real time via the existing poll.
  - Asking the agent *"can you bulk-delete spam from Gmail?"* produces a real answer (yes, with the relevant tool slugs and an optional `composio_enable_scope` prompt) rather than a confidently wrong *"no"*.

### Parity Contract
- Legacy behavior preserved:
  - `composio_sync` still returns a `SyncOutcome` (now with `status:"started"` / `finished_at_ms:0` as sentinels for "spawned").
  - All existing `ConnectedIntegration` consumers still receive populated `tools`; the new `gated_tools` is additive and starts empty whenever no curated entries are pref-blocked.
  - The orchestrator's existing delegation tools (`delegate_to_integrations_agent`, etc.) are unchanged; the new subsection only adds behavioural guidance, no new tools.
- Guard/fallback/dispatch parity checks: prompt-builder tests for `welcome`, `orchestrator`, `integrations_agent` were updated to populate the new field; they still assert the same prompt-text invariants as before (`## Connected Integrations`, `delegate_to_integrations_agent`, per-toolkit bullets).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: n/a

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows permission‑gated integration capabilities in a dedicated "Additional capabilities behind a permission toggle" section, listing each restricted action, description (or “(no description)”), required scope, and unlock guidance.

* **Improvements**
  * Sync operations now start quickly and continue in the background, returning an immediate "started" result.
  * Clearer messaging distinguishing available vs locked tools with explicit UI unlock instructions.
  * Cross‑chat context header now warns capabilities may be historical.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->