### PR TITLE
test(e2e): add E2E coverage for 15 Composio connector flows

### DIFF
--- a/app/test/e2e/helpers/composio-helpers.ts
+++ b/app/test/e2e/helpers/composio-helpers.ts
@@ -123,9 +123,9 @@ export async function assertModalPhase(
     await browser.pause(400);
   }
 
-  // Soft assertion — log but don't fail; the UI may legitimately not expose
-  // all markers on all platforms.
-  console.log(`${LOG} modal phase "${phase}" not confirmed within timeout — continuing`);
+  throw new Error(
+    `assertModalPhase: phase "${phase}" for "${name}" not confirmed within ${timeout}ms — no marker found in [${markers.join(', ')}]`
+  );
 }
 
 /**
@@ -151,11 +151,12 @@ export async function assertSessionNotNuked(timeout = 20_000): Promise<void> {
  * knobs to trigger the given status code.
  *
  * Supported status codes: 400, 500.
+ * The mock route handlers interpret knob value '400' → HTTP 400 and '500' → HTTP 500.
  */
 export function injectComposioFault(statusCode: 400 | 500): void {
-  const value = String(statusCode === 500 ? '500' : '1');
+  const value = String(statusCode);
   setMockBehavior('composioExecuteFails', value);
-  setMockBehavior('composioDeleteFails', value === '500' ? '1' : value);
-  setMockBehavior('composioSyncFails', '1');
+  setMockBehavior('composioDeleteFails', value);
+  setMockBehavior('composioSyncFails', value);
   console.log(`${LOG} injected composio fault: status=${statusCode}`);
 }

--- a/app/test/e2e/helpers/composio-helpers.ts
+++ b/app/test/e2e/helpers/composio-helpers.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * Shared helpers for Composio connector E2E specs.
+ *
+ * All helpers are platform-agnostic (tauri-driver + Appium Mac2) and
+ * follow the same patterns established in composio-triggers-flow.spec.ts
+ * and the existing shared-flows / element-helpers modules.
+ */
+import { setMockBehavior } from '../mock-server';
+import { textExists, waitForText } from './element-helpers';
+import { navigateToHome, navigateToSkills, waitForHomePage } from './shared-flows';
+
+const LOG = '[ComposioHelpers]';
+
+// ---------------------------------------------------------------------------
+// Seed helpers — set mock behavior knobs before navigation
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed a single Composio connection into the mock backend.
+ *
+ * Sets the `composioConnections` behavior knob with a single entry for the
+ * given toolkit.  Subsequent calls overwrite any previous seed — isolate
+ * specs by calling this in `beforeEach` or at the start of each test.
+ */
+export function seedComposioConnection(
+  toolkit: string,
+  status: 'ACTIVE' | 'FAILED' | 'EXPIRED' | 'CONNECTING',
+  connectionId: string = 'c-e2e'
+): void {
+  setMockBehavior('composioConnections', JSON.stringify([{ id: connectionId, toolkit, status }]));
+}
+
+/**
+ * Seed the list of available Composio toolkits shown on the Skills page.
+ *
+ * Sets the `composioToolkits` behavior knob to the given slugs array.
+ */
+export function seedComposioToolkits(slugs: string[]): void {
+  setMockBehavior('composioToolkits', JSON.stringify(slugs));
+}
+
+// ---------------------------------------------------------------------------
+// Navigation + UI assertion helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigate to /skills and wait until the connector card with the given
+ * display name is visible.
+ *
+ * Throws (via waitForText) if the card is not visible within the timeout.
+ */
+export async function assertConnectorCardVisible(name: string, timeout = 15_000): Promise<void> {
+  await navigateToSkills();
+  await waitForText(name, timeout);
+  console.log(`${LOG} connector card visible: "${name}"`);
+}
+
+/**
+ * Click a connector card by display name, then wait for the modal header
+ * to appear.  The modal header text is either "Connect <name>", "Manage
+ * <name>", or "Reconnect <name>" depending on connection state.
+ *
+ * Returns the modal header text that was found, or null when none of the
+ * candidates appeared within the timeout (so callers that can tolerate a
+ * missing modal don't have to wrap in try/catch).
+ */
+export async function openConnectorModal(name: string, timeout = 15_000): Promise<string | null> {
+  console.log(`${LOG} opening connector modal for "${name}"`);
+  // Click the connector card by name
+  const cardEl = await waitForText(name, timeout);
+  await cardEl.click();
+  await browser.pause(1_500);
+
+  // Wait for any of the standard modal header patterns
+  const candidates = [`Connect ${name}`, `Manage ${name}`, `Reconnect ${name}`];
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const candidate of candidates) {
+      if (await textExists(candidate)) {
+        console.log(`${LOG} modal opened: "${candidate}"`);
+        return candidate;
+      }
+    }
+    await browser.pause(400);
+  }
+
+  console.log(`${LOG} modal for "${name}" did not open within timeout`);
+  return null;
+}
+
+/**
+ * Assert the modal is in a given phase by checking UI markers.
+ *
+ * Phase markers:
+ *   idle       — Connect button present (no active connection)
+ *   connected  — "is connected" or Disconnect button visible
+ *   expired    — "authorization expired" text visible
+ *   error      — error UI present (coral-coloured error block)
+ */
+export async function assertModalPhase(
+  phase: 'idle' | 'connected' | 'expired' | 'error',
+  name: string,
+  timeout = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  const phaseMarkers: Record<string, string[]> = {
+    idle: [`Connect ${name}`, 'Connect'],
+    connected: ['Disconnect', 'is connected'],
+    expired: ['authorization expired', 'Reconnect'],
+    error: ['Something went wrong', 'Authorization failed', 'dismissAll'],
+  };
+
+  const markers = phaseMarkers[phase] ?? [];
+  while (Date.now() < deadline) {
+    for (const marker of markers) {
+      if (await textExists(marker)) {
+        console.log(`${LOG} modal phase "${phase}" confirmed via marker: "${marker}"`);
+        return;
+      }
+    }
+    await browser.pause(400);
+  }
+
+  // Soft assertion — log but don't fail; the UI may legitimately not expose
+  // all markers on all platforms.
+  console.log(`${LOG} modal phase "${phase}" not confirmed within timeout — continuing`);
+}
+
+/**
+ * Assert that the user session is still alive (not logged out) by navigating
+ * to /home and waiting for home page content.
+ *
+ * This is the key guard for the "401 on composio routes must NOT log user
+ * out" class of regressions (#2285, #2286).
+ */
+export async function assertSessionNotNuked(timeout = 20_000): Promise<void> {
+  console.log(`${LOG} asserting session is intact — navigating to /home`);
+  await navigateToHome();
+  const marker = await waitForHomePage(timeout);
+  if (!marker) {
+    throw new Error(`assertSessionNotNuked: Home page not reached — user may have been logged out`);
+  }
+  console.log(`${LOG} session intact, home page marker: "${marker}"`);
+}
+
+/**
+ * Inject a mock HTTP fault on all Composio routes by setting the
+ * composioExecuteFails / composioDeleteFails / composioSyncFails behavior
+ * knobs to trigger the given status code.
+ *
+ * Supported status codes: 400, 500.
+ */
+export function injectComposioFault(statusCode: 400 | 500): void {
+  const value = String(statusCode === 500 ? '500' : '1');
+  setMockBehavior('composioExecuteFails', value);
+  setMockBehavior('composioDeleteFails', value === '500' ? '1' : value);
+  setMockBehavior('composioSyncFails', '1');
+  console.log(`${LOG} injected composio fault: status=${statusCode}`);
+}

--- a/app/test/e2e/helpers/composio-helpers.ts
+++ b/app/test/e2e/helpers/composio-helpers.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Shared helpers for Composio connector E2E specs.
  *
@@ -70,6 +69,7 @@ export async function openConnectorModal(name: string, timeout = 15_000): Promis
   // Click the connector card by name
   const cardEl = await waitForText(name, timeout);
   await cardEl.click();
+  // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
   await browser.pause(1_500);
 
   // Wait for any of the standard modal header patterns
@@ -82,6 +82,7 @@ export async function openConnectorModal(name: string, timeout = 15_000): Promis
         return candidate;
       }
     }
+    // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
     await browser.pause(400);
   }
 
@@ -120,6 +121,7 @@ export async function assertModalPhase(
         return;
       }
     }
+    // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
     await browser.pause(400);
   }
 

--- a/app/test/e2e/specs/connector-airtable.spec.ts
+++ b/app/test/e2e/specs/connector-airtable.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Airtable (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Airtable Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-airtable.spec.ts
+++ b/app/test/e2e/specs/connector-airtable.spec.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * E2E: Airtable (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorAirtableE2E]';
+const CONNECTOR_NAME = 'Airtable';
+const TOOLKIT_SLUG = 'airtable';
+const AUTH_TOKEN = 'e2e-connector-airtable-token';
+
+describe('Airtable Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-airtable-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-airtable-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-airtable-1',
+      action: 'AIRTABLE_LIST_BASES',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-airtable-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-airtable-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-airtable-1',
+      action: 'AIRTABLE_LIST_BASES',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-airtable-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-airtable-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-airtable.spec.ts
+++ b/app/test/e2e/specs/connector-airtable.spec.ts
@@ -93,6 +93,9 @@ describe('Airtable Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Airtable Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -155,7 +159,8 @@ describe('Airtable Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-asana.spec.ts
+++ b/app/test/e2e/specs/connector-asana.spec.ts
@@ -93,6 +93,9 @@ describe('Asana Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Asana Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -153,7 +157,8 @@ describe('Asana Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-asana.spec.ts
+++ b/app/test/e2e/specs/connector-asana.spec.ts
@@ -1,0 +1,159 @@
+// @ts-nocheck
+/**
+ * E2E: Asana (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorAsanaE2E]';
+const CONNECTOR_NAME = 'Asana';
+const TOOLKIT_SLUG = 'asana';
+const AUTH_TOKEN = 'e2e-connector-asana-token';
+
+describe('Asana Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-asana-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-asana-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-asana-1',
+      action: 'ASANA_LIST_TASKS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-asana-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-asana-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-asana-1',
+      action: 'ASANA_LIST_TASKS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-asana-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-asana-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-asana.spec.ts
+++ b/app/test/e2e/specs/connector-asana.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Asana (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Asana Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-clickup.spec.ts
+++ b/app/test/e2e/specs/connector-clickup.spec.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * E2E: ClickUp (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorClickUpE2E]';
+const CONNECTOR_NAME = 'ClickUp';
+const TOOLKIT_SLUG = 'clickup';
+const AUTH_TOKEN = 'e2e-connector-clickup-token';
+
+describe('ClickUp Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-clickup-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-clickup-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-clickup-1',
+      action: 'CLICKUP_LIST_TASKS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-clickup-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-clickup-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-clickup-1',
+      action: 'CLICKUP_LIST_TASKS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-clickup-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-clickup-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-clickup.spec.ts
+++ b/app/test/e2e/specs/connector-clickup.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: ClickUp (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('ClickUp Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-clickup.spec.ts
+++ b/app/test/e2e/specs/connector-clickup.spec.ts
@@ -93,6 +93,9 @@ describe('ClickUp Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('ClickUp Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -155,7 +159,8 @@ describe('ClickUp Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-confluence.spec.ts
+++ b/app/test/e2e/specs/connector-confluence.spec.ts
@@ -93,6 +93,9 @@ describe('Confluence Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Confluence Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -155,7 +159,8 @@ describe('Confluence Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-confluence.spec.ts
+++ b/app/test/e2e/specs/connector-confluence.spec.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * E2E: Confluence (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorConfluenceE2E]';
+const CONNECTOR_NAME = 'Confluence';
+const TOOLKIT_SLUG = 'confluence';
+const AUTH_TOKEN = 'e2e-connector-confluence-token';
+
+describe('Confluence Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-confluence-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-confluence-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-confluence-1',
+      action: 'CONFLUENCE_LIST_PAGES',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-confluence-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-confluence-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-confluence-1',
+      action: 'CONFLUENCE_LIST_PAGES',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-confluence-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-confluence-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-confluence.spec.ts
+++ b/app/test/e2e/specs/connector-confluence.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Confluence (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Confluence Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-discord-composio.spec.ts
+++ b/app/test/e2e/specs/connector-discord-composio.spec.ts
@@ -1,0 +1,188 @@
+// @ts-nocheck
+/**
+ * E2E: Discord (Composio) connector flow.
+ *
+ * Critical regression (#2285): clicking the Discord connector card must NOT
+ * log the user out, even if the card click triggers a failed auth attempt.
+ * `assertSessionNotNuked` is called at every test boundary.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorDiscordComposioE2E]';
+const CONNECTOR_NAME = 'Discord';
+const TOOLKIT_SLUG = 'discord';
+const AUTH_TOKEN = 'e2e-connector-discord-composio-token';
+
+describe('Discord (Composio) connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-discord-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-discord-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('clicking the Discord card does NOT log user out (#2285 regression)', async function () {
+    this.timeout(60_000);
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+
+    // Click the card — regardless of what happens (modal opens, error, etc.)
+    // the session must survive
+    const cardEl = await waitForText(CONNECTOR_NAME, 10_000);
+    try {
+      await cardEl.click();
+      await browser.pause(2_000);
+    } catch (err) {
+      console.log(`${LOG} card click threw: ${err} — still asserting session`);
+    }
+
+    // This is the critical regression check
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: Discord card click did NOT log user out (#2285)`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+    await assertSessionNotNuked();
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-discord-1',
+      action: 'DISCORD_LIST_SERVERS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-discord-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-discord-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-discord-1',
+      action: 'DISCORD_LIST_SERVERS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-discord-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-discord-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-discord-composio.spec.ts
+++ b/app/test/e2e/specs/connector-discord-composio.spec.ts
@@ -119,6 +119,9 @@ describe('Discord (Composio) connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -133,7 +136,8 @@ describe('Discord (Composio) connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: execute routed`);
   });
@@ -159,7 +163,7 @@ describe('Discord (Composio) connector flow', () => {
     console.log(`${LOG} PASS: expired auth does not log user out`);
   });
 
-  it('unrelated 401 on composio route does not nuke session', async function () {
+  it('unrelated 4xx on composio route does not nuke session', async function () {
     this.timeout(60_000);
     injectComposioFault(400);
     await callOpenhumanRpc('openhuman.composio_execute', {
@@ -182,7 +186,8 @@ describe('Discord (Composio) connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-discord-composio.spec.ts
+++ b/app/test/e2e/specs/connector-discord-composio.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Discord (Composio) connector flow.
  *
@@ -78,6 +77,7 @@ describe('Discord (Composio) connector flow', () => {
     const cardEl = await waitForText(CONNECTOR_NAME, 10_000);
     try {
       await cardEl.click();
+      // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
       await browser.pause(2_000);
     } catch (err) {
       console.log(`${LOG} card click threw: ${err} — still asserting session`);
@@ -137,7 +137,7 @@ describe('Discord (Composio) connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: execute routed`);
   });

--- a/app/test/e2e/specs/connector-github.spec.ts
+++ b/app/test/e2e/specs/connector-github.spec.ts
@@ -1,0 +1,230 @@
+// @ts-nocheck
+/**
+ * E2E: GitHub Composio connector flow.
+ *
+ * Covers the standard connector lifecycle (card visibility, connect, connected
+ * state, RPC routing, execute, error/expired states, disconnect) plus a
+ * trigger-catalog assertion specific to GitHub.
+ *
+ * All backend calls are served by the mock server — no live GitHub account
+ * is required.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  setMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorGithubE2E]';
+const CONNECTOR_NAME = 'GitHub';
+const TOOLKIT_SLUG = 'github';
+const AUTH_TOKEN = 'e2e-connector-github-token';
+
+describe('GitHub Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-github-1');
+    setMockBehavior(
+      'composioAvailableTriggers',
+      JSON.stringify([{ slug: 'GITHUB_COMMIT_EVENT', scope: 'static' }])
+    );
+    setMockBehavior('composioActiveTriggers', JSON.stringify([]));
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-github-1');
+    setMockBehavior(
+      'composioAvailableTriggers',
+      JSON.stringify([{ slug: 'GITHUB_COMMIT_EVENT', scope: 'static' }])
+    );
+    setMockBehavior('composioActiveTriggers', JSON.stringify([]));
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-github-1');
+    clearRequestLog();
+
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+
+    const log = getRequestLog();
+    const authReq = log.find(
+      r => r.method === 'POST' && r.url.includes('/agent-integrations/composio/authorize')
+    );
+    expect(authReq).toBeDefined();
+    const body = JSON.parse(authReq?.body || '{}');
+    expect(body.toolkit).toBe(TOOLKIT_SLUG);
+    console.log(`${LOG} PASS: auth/connect RPC routes correctly`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-github-1');
+
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    // sync may not be a top-level RPC; if the method is unknown the mock
+    // returns ok=false — that is expected for unimplemented methods but the
+    // HTTP call must not crash the session.
+    const log = getRequestLog();
+    const syncReq = log.find(r => r.url.includes('/composio/sync'));
+    if (syncReq) {
+      console.log(`${LOG} PASS: composio_sync routed to mock (status ${syncReq.statusCode})`);
+    } else {
+      console.log(`${LOG} INFO: composio_sync did not hit /composio/sync — RPC may be batched`);
+    }
+    // Session must remain alive regardless
+    await assertSessionNotNuked();
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-github-1',
+      action: 'GITHUB_LIST_REPOS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) {
+      expect(execReq.method).toBe('POST');
+      console.log(`${LOG} PASS: composio_execute routed to mock`);
+    } else {
+      console.log(`${LOG} INFO: composio_execute not observed in request log — checking RPC ok`);
+      // The RPC itself may succeed via an alternate path
+    }
+  });
+
+  it('trigger catalog lists available GitHub triggers', async function () {
+    this.timeout(30_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_available_triggers', {
+      toolkit: TOOLKIT_SLUG,
+      connection_id: 'c-github-1',
+    });
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const triggers = (result as { triggers?: unknown[] })?.triggers ?? [];
+    const slugs = (triggers as { slug?: string }[]).map(t => t.slug);
+    expect(slugs).toContain('GITHUB_COMMIT_EVENT');
+    console.log(`${LOG} PASS: trigger catalog contains GITHUB_COMMIT_EVENT`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-github-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    // App must remain responsive — skills page should not be blank
+    const alive = await textExists(CONNECTOR_NAME);
+    expect(alive).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed connection does not show blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-github-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) {
+      await assertModalPhase('expired', CONNECTOR_NAME);
+    } else {
+      console.log(`${LOG} modal not opened for expired state — asserting session only`);
+    }
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    // Inject a fault that returns 400 on execute (simulates a scoped 4xx)
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-github-1',
+      action: 'GITHUB_LIST_REPOS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class composio error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-github-1');
+    clearRequestLog();
+
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-github-1' });
+    // delete may succeed or return unknown method — check HTTP layer
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) {
+      console.log(`${LOG} PASS: disconnect routed DELETE to mock`);
+    } else {
+      console.log(`${LOG} INFO: disconnect call not observed at HTTP layer`);
+    }
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-github.spec.ts
+++ b/app/test/e2e/specs/connector-github.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: GitHub Composio connector flow.
  *
@@ -124,7 +123,7 @@ describe('GitHub Composio connector flow', () => {
     const log = getRequestLog();
     const syncReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
     expect(syncReq).toBeDefined();
-    console.log(`${LOG} PASS: composio_sync routed to mock (status ${syncReq.statusCode})`);
+    console.log(`${LOG} PASS: composio_sync routed to mock (status ${syncReq?.statusCode})`);
     // Session must remain alive regardless
     await assertSessionNotNuked();
   });
@@ -141,7 +140,7 @@ describe('GitHub Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: composio_execute routed to mock`);
   });
 

--- a/app/test/e2e/specs/connector-github.spec.ts
+++ b/app/test/e2e/specs/connector-github.spec.ts
@@ -121,16 +121,10 @@ describe('GitHub Composio connector flow', () => {
     clearRequestLog();
 
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
-    // sync may not be a top-level RPC; if the method is unknown the mock
-    // returns ok=false — that is expected for unimplemented methods but the
-    // HTTP call must not crash the session.
     const log = getRequestLog();
-    const syncReq = log.find(r => r.url.includes('/composio/sync'));
-    if (syncReq) {
-      console.log(`${LOG} PASS: composio_sync routed to mock (status ${syncReq.statusCode})`);
-    } else {
-      console.log(`${LOG} INFO: composio_sync did not hit /composio/sync — RPC may be batched`);
-    }
+    const syncReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
+    console.log(`${LOG} PASS: composio_sync routed to mock (status ${syncReq.statusCode})`);
     // Session must remain alive regardless
     await assertSessionNotNuked();
   });
@@ -146,13 +140,9 @@ describe('GitHub Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) {
-      expect(execReq.method).toBe('POST');
-      console.log(`${LOG} PASS: composio_execute routed to mock`);
-    } else {
-      console.log(`${LOG} INFO: composio_execute not observed in request log — checking RPC ok`);
-      // The RPC itself may succeed via an alternate path
-    }
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: composio_execute routed to mock`);
   });
 
   it('trigger catalog lists available GitHub triggers', async function () {
@@ -215,16 +205,12 @@ describe('GitHub Composio connector flow', () => {
     clearRequestLog();
 
     await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-github-1' });
-    // delete may succeed or return unknown method — check HTTP layer
     const log = getRequestLog();
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) {
-      console.log(`${LOG} PASS: disconnect routed DELETE to mock`);
-    } else {
-      console.log(`${LOG} INFO: disconnect call not observed at HTTP layer`);
-    }
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE to mock`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-gmail-composio.spec.ts
+++ b/app/test/e2e/specs/connector-gmail-composio.spec.ts
@@ -104,10 +104,9 @@ describe('Gmail (Composio) connector flow', () => {
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
     const log = getRequestLog();
-    const syncReq = log.find(r => r.url.includes('/composio/sync'));
-    if (syncReq) {
-      console.log(`${LOG} PASS: composio_sync routed (status ${syncReq.statusCode})`);
-    }
+    const syncReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
+    console.log(`${LOG} PASS: composio_sync routed (status ${syncReq.statusCode})`);
     await assertSessionNotNuked();
   });
 
@@ -121,10 +120,9 @@ describe('Gmail (Composio) connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) {
-      expect(execReq.method).toBe('POST');
-      console.log(`${LOG} PASS: composio_execute routed`);
-    }
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: composio_execute routed`);
   });
 
   it('GMAIL_FETCH_EMAILS returning 400 shows user-friendly error, not blank screen (#1296)', async function () {
@@ -201,9 +199,8 @@ describe('Gmail (Composio) connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) {
-      console.log(`${LOG} PASS: disconnect routed DELETE`);
-    }
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-gmail-composio.spec.ts
+++ b/app/test/e2e/specs/connector-gmail-composio.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Gmail (Composio) connector flow.
  *
@@ -106,7 +105,7 @@ describe('Gmail (Composio) connector flow', () => {
     const log = getRequestLog();
     const syncReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
     expect(syncReq).toBeDefined();
-    console.log(`${LOG} PASS: composio_sync routed (status ${syncReq.statusCode})`);
+    console.log(`${LOG} PASS: composio_sync routed (status ${syncReq?.statusCode})`);
     await assertSessionNotNuked();
   });
 
@@ -121,7 +120,7 @@ describe('Gmail (Composio) connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: composio_execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-gmail-composio.spec.ts
+++ b/app/test/e2e/specs/connector-gmail-composio.spec.ts
@@ -1,0 +1,209 @@
+// @ts-nocheck
+/**
+ * E2E: Gmail (Composio) connector flow.
+ *
+ * Covers the standard lifecycle plus a regression test for
+ * GMAIL_FETCH_EMAILS returning 400 (#1296) — the app must show a
+ * user-friendly error, not crash or blank screen.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  setMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorGmailComposioE2E]';
+const CONNECTOR_NAME = 'Gmail';
+const TOOLKIT_SLUG = 'gmail';
+const AUTH_TOKEN = 'e2e-connector-gmail-composio-token';
+
+describe('Gmail (Composio) connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gmail-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gmail-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(
+      r => r.method === 'POST' && r.url.includes('/agent-integrations/composio/authorize')
+    );
+    expect(authReq).toBeDefined();
+    const body = JSON.parse(authReq?.body || '{}');
+    expect(body.toolkit).toBe(TOOLKIT_SLUG);
+    console.log(`${LOG} PASS: auth/connect routed correctly`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gmail-1');
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const log = getRequestLog();
+    const syncReq = log.find(r => r.url.includes('/composio/sync'));
+    if (syncReq) {
+      console.log(`${LOG} PASS: composio_sync routed (status ${syncReq.statusCode})`);
+    }
+    await assertSessionNotNuked();
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gmail-1',
+      action: 'GMAIL_FETCH_EMAILS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) {
+      expect(execReq.method).toBe('POST');
+      console.log(`${LOG} PASS: composio_execute routed`);
+    }
+  });
+
+  it('GMAIL_FETCH_EMAILS returning 400 shows user-friendly error, not blank screen (#1296)', async function () {
+    this.timeout(60_000);
+    // Inject a 400 response on execute
+    setMockBehavior('composioExecuteFails', '1');
+    clearRequestLog();
+
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gmail-1',
+      action: 'GMAIL_FETCH_EMAILS',
+      params: {},
+    });
+
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) {
+      // The mock returns 400 — the RPC layer should surface a safe error, not crash
+      console.log(`${LOG} execute returned status: ${execReq.statusCode}`);
+    }
+
+    // Critical: app must remain responsive — session not nuked
+    await assertSessionNotNuked();
+
+    // Navigate to skills; the page must not be blank
+    await navigateToSkills();
+    const gmailVisible = await textExists(CONNECTOR_NAME);
+    expect(gmailVisible).toBe(true);
+    console.log(`${LOG} PASS: 400 on GMAIL_FETCH_EMAILS does not blank the screen`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-gmail-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const alive = await textExists(CONNECTOR_NAME);
+    expect(alive).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gmail-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) {
+      await assertModalPhase('expired', CONNECTOR_NAME);
+    }
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gmail-1',
+      action: 'GMAIL_FETCH_EMAILS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gmail-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-gmail-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) {
+      console.log(`${LOG} PASS: disconnect routed DELETE`);
+    }
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-google-calendar.spec.ts
+++ b/app/test/e2e/specs/connector-google-calendar.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Google Calendar (Composio) connector flow.
  */
@@ -114,7 +113,7 @@ describe('Google Calendar Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-google-calendar.spec.ts
+++ b/app/test/e2e/specs/connector-google-calendar.spec.ts
@@ -1,0 +1,168 @@
+// @ts-nocheck
+/**
+ * E2E: Google Calendar (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorGoogleCalendarE2E]';
+const CONNECTOR_NAME = 'Google Calendar';
+const TOOLKIT_SLUG = 'googlecalendar';
+const AUTH_TOKEN = 'e2e-connector-googlecalendar-token';
+
+describe('Google Calendar Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gcal-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gcal-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(
+      r => r.method === 'POST' && r.url.includes('/agent-integrations/composio/authorize')
+    );
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed correctly`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gcal-1');
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gcal-1',
+      action: 'GOOGLECALENDAR_LIST_EVENTS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) {
+      expect(execReq.method).toBe('POST');
+    }
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-gcal-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gcal-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) {
+      await assertModalPhase('expired', CONNECTOR_NAME);
+    }
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gcal-1',
+      action: 'GOOGLECALENDAR_LIST_EVENTS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gcal-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-gcal-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) {
+      console.log(`${LOG} PASS: disconnect routed DELETE`);
+    }
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-google-calendar.spec.ts
+++ b/app/test/e2e/specs/connector-google-calendar.spec.ts
@@ -96,6 +96,9 @@ describe('Google Calendar Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -110,9 +113,8 @@ describe('Google Calendar Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) {
-      expect(execReq.method).toBe('POST');
-    }
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -160,9 +162,8 @@ describe('Google Calendar Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) {
-      console.log(`${LOG} PASS: disconnect routed DELETE`);
-    }
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-google-drive.spec.ts
+++ b/app/test/e2e/specs/connector-google-drive.spec.ts
@@ -93,6 +93,9 @@ describe('Google Drive Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Google Drive Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -153,7 +157,8 @@ describe('Google Drive Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-google-drive.spec.ts
+++ b/app/test/e2e/specs/connector-google-drive.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Google Drive (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Google Drive Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-google-drive.spec.ts
+++ b/app/test/e2e/specs/connector-google-drive.spec.ts
@@ -1,0 +1,159 @@
+// @ts-nocheck
+/**
+ * E2E: Google Drive (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorGoogleDriveE2E]';
+const CONNECTOR_NAME = 'Google Drive';
+const TOOLKIT_SLUG = 'googledrive';
+const AUTH_TOKEN = 'e2e-connector-googledrive-token';
+
+describe('Google Drive Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gdrive-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gdrive-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gdrive-1',
+      action: 'GOOGLEDRIVE_LIST_FILES',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-gdrive-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gdrive-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gdrive-1',
+      action: 'GOOGLEDRIVE_LIST_FILES',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gdrive-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-gdrive-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-google-sheets.spec.ts
+++ b/app/test/e2e/specs/connector-google-sheets.spec.ts
@@ -93,6 +93,9 @@ describe('Google Sheets Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Google Sheets Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -155,7 +159,8 @@ describe('Google Sheets Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-google-sheets.spec.ts
+++ b/app/test/e2e/specs/connector-google-sheets.spec.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * E2E: Google Sheets (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorGoogleSheetsE2E]';
+const CONNECTOR_NAME = 'Google Sheets';
+const TOOLKIT_SLUG = 'googlesheets';
+const AUTH_TOKEN = 'e2e-connector-googlesheets-token';
+
+describe('Google Sheets Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gsheets-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gsheets-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gsheets-1',
+      action: 'GOOGLESHEETS_LIST_SPREADSHEETS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-gsheets-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gsheets-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-gsheets-1',
+      action: 'GOOGLESHEETS_LIST_SPREADSHEETS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-gsheets-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-gsheets-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-google-sheets.spec.ts
+++ b/app/test/e2e/specs/connector-google-sheets.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Google Sheets (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Google Sheets Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-jira.spec.ts
+++ b/app/test/e2e/specs/connector-jira.spec.ts
@@ -77,10 +77,7 @@ describe('Jira Composio connector flow', () => {
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
     const modal = await openConnectorModal(CONNECTOR_NAME);
-    if (!modal) {
-      console.log(`${LOG} modal not opened — skipping subdomain field check`);
-      return;
-    }
+    expect(modal).toBeTruthy();
     // The Jira connect modal should render a subdomain input per toolkitRequiredFields.ts
     // It uses data-testid="composio-required-subdomain"
     const hasSubdomainInput = await browser
@@ -95,12 +92,8 @@ describe('Jira Composio connector flow', () => {
         );
       })
       .catch(() => false);
-    // We assert softly — the UI may not be reachable on all hosts
-    if (hasSubdomainInput) {
-      console.log(`${LOG} PASS: subdomain input field visible in Jira modal`);
-    } else {
-      console.log(`${LOG} INFO: subdomain field not detected — skipping hard assert`);
-    }
+    expect(hasSubdomainInput).toBe(true);
+    console.log(`${LOG} PASS: subdomain input field visible in Jira modal`);
     // Close modal by pressing Escape
     await browser.keys(['Escape']).catch(() => {});
     await assertSessionNotNuked();
@@ -141,6 +134,9 @@ describe('Jira Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -155,7 +151,8 @@ describe('Jira Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -201,7 +198,8 @@ describe('Jira Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-jira.spec.ts
+++ b/app/test/e2e/specs/connector-jira.spec.ts
@@ -1,0 +1,207 @@
+// @ts-nocheck
+/**
+ * E2E: Jira (Composio) connector flow.
+ *
+ * Includes an extra test verifying the subdomain required-field validation:
+ * the Connect button must be disabled (or show an inline error) when no
+ * valid Atlassian subdomain is entered.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  setMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorJiraE2E]';
+const CONNECTOR_NAME = 'Jira';
+const TOOLKIT_SLUG = 'jira';
+const AUTH_TOKEN = 'e2e-connector-jira-token';
+
+describe('Jira Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-jira-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-jira-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('connect modal renders subdomain input field for Jira', async function () {
+    this.timeout(60_000);
+    // Seed as idle (no active connection) so we see the connect flow
+    seedComposioConnection(TOOLKIT_SLUG, 'CONNECTING', 'c-jira-idle');
+    setMockBehavior('composioConnections', JSON.stringify([]));
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (!modal) {
+      console.log(`${LOG} modal not opened — skipping subdomain field check`);
+      return;
+    }
+    // The Jira connect modal should render a subdomain input per toolkitRequiredFields.ts
+    // It uses data-testid="composio-required-subdomain"
+    const hasSubdomainInput = await browser
+      .execute(() => {
+        return (
+          document.querySelector('[data-testid="composio-required-subdomain"]') !== null ||
+          document.querySelector('input[placeholder*="subdomain"]') !== null ||
+          // fallback: any .atlassian.net suffix label
+          Array.from(document.querySelectorAll('*')).some(el =>
+            (el.textContent ?? '').includes('.atlassian.net')
+          )
+        );
+      })
+      .catch(() => false);
+    // We assert softly — the UI may not be reachable on all hosts
+    if (hasSubdomainInput) {
+      console.log(`${LOG} PASS: subdomain input field visible in Jira modal`);
+    } else {
+      console.log(`${LOG} INFO: subdomain field not detected — skipping hard assert`);
+    }
+    // Close modal by pressing Escape
+    await browser.keys(['Escape']).catch(() => {});
+    await assertSessionNotNuked();
+  });
+
+  it('auth/connect flow with subdomain extra_params routes correctly', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', {
+      toolkit: TOOLKIT_SLUG,
+      extra_params: { subdomain: 'myteam' },
+    });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    const body = JSON.parse(authReq?.body || '{}');
+    expect(body.toolkit).toBe(TOOLKIT_SLUG);
+    console.log(`${LOG} PASS: authorize with subdomain extra_params routed correctly`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-jira-1');
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-jira-1',
+      action: 'JIRA_LIST_ISSUES',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-jira-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-jira-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-jira-1',
+      action: 'JIRA_LIST_ISSUES',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-jira-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-jira-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-jira.spec.ts
+++ b/app/test/e2e/specs/connector-jira.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Jira (Composio) connector flow.
  *
@@ -80,6 +79,7 @@ describe('Jira Composio connector flow', () => {
     expect(modal).toBeTruthy();
     // The Jira connect modal should render a subdomain input per toolkitRequiredFields.ts
     // It uses data-testid="composio-required-subdomain"
+    // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
     const hasSubdomainInput = await browser
       .execute(() => {
         return (
@@ -95,6 +95,7 @@ describe('Jira Composio connector flow', () => {
     expect(hasSubdomainInput).toBe(true);
     console.log(`${LOG} PASS: subdomain input field visible in Jira modal`);
     // Close modal by pressing Escape
+    // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
     await browser.keys(['Escape']).catch(() => {});
     await assertSessionNotNuked();
   });
@@ -152,7 +153,7 @@ describe('Jira Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-notion.spec.ts
+++ b/app/test/e2e/specs/connector-notion.spec.ts
@@ -1,0 +1,159 @@
+// @ts-nocheck
+/**
+ * E2E: Notion (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorNotionE2E]';
+const CONNECTOR_NAME = 'Notion';
+const TOOLKIT_SLUG = 'notion';
+const AUTH_TOKEN = 'e2e-connector-notion-token';
+
+describe('Notion Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-notion-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-notion-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-notion-1',
+      action: 'NOTION_LIST_PAGES',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-notion-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-notion-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-notion-1',
+      action: 'NOTION_LIST_PAGES',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-notion-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-notion-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-notion.spec.ts
+++ b/app/test/e2e/specs/connector-notion.spec.ts
@@ -93,6 +93,9 @@ describe('Notion Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Notion Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -153,7 +157,8 @@ describe('Notion Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-notion.spec.ts
+++ b/app/test/e2e/specs/connector-notion.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Notion (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Notion Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-session-guard.spec.ts
+++ b/app/test/e2e/specs/connector-session-guard.spec.ts
@@ -1,0 +1,189 @@
+// @ts-nocheck
+/**
+ * E2E: Cross-cutting session guard for Composio connector routes.
+ *
+ * Regression coverage for:
+ *   #2286 — a 401 on any /agent-integrations/composio/* route must NOT clear
+ *             the user session / log the user out.
+ *   #2285 — clicking a connector card in a degraded state must NOT log user out.
+ *
+ * These tests exercise the fault-injection paths against multiple toolkits
+ * and multiple error scenarios to ensure the session-guard holds broadly, not
+ * just for a single connector.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertSessionNotNuked,
+  injectComposioFault,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import { waitForWebView, waitForWindowVisible } from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  resetMockBehavior,
+  setMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorSessionGuardE2E]';
+const AUTH_TOKEN = 'e2e-connector-session-guard-token';
+
+// Toolkits tested in the cross-cutting sweep
+const GUARD_TOOLKITS = ['github', 'gmail', 'slack', 'notion', 'discord'];
+
+describe('Composio connector session guard (cross-cutting, #2286)', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits(GUARD_TOOLKITS);
+    // Seed all toolkits as ACTIVE
+    setMockBehavior(
+      'composioConnections',
+      JSON.stringify(
+        GUARD_TOOLKITS.map((slug, i) => ({ id: `c-guard-${i}`, toolkit: slug, status: 'ACTIVE' }))
+      )
+    );
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits(GUARD_TOOLKITS);
+    setMockBehavior(
+      'composioConnections',
+      JSON.stringify(
+        GUARD_TOOLKITS.map((slug, i) => ({ id: `c-guard-${i}`, toolkit: slug, status: 'ACTIVE' }))
+      )
+    );
+  });
+
+  it('400 on composio/execute does NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+
+    // Fire execute against every guard toolkit
+    for (const slug of GUARD_TOOLKITS) {
+      clearRequestLog();
+      await callOpenhumanRpc('openhuman.composio_execute', {
+        connection_id: `c-guard-${GUARD_TOOLKITS.indexOf(slug)}`,
+        action: `${slug.toUpperCase()}_TEST_ACTION`,
+        params: {},
+      });
+    }
+
+    // Session must survive all of these
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 400 on execute does not log user out for any toolkit`);
+  });
+
+  it('500 on composio/execute does NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    injectComposioFault(500);
+
+    for (const slug of GUARD_TOOLKITS) {
+      clearRequestLog();
+      await callOpenhumanRpc('openhuman.composio_execute', {
+        connection_id: `c-guard-${GUARD_TOOLKITS.indexOf(slug)}`,
+        action: `${slug.toUpperCase()}_TEST_ACTION`,
+        params: {},
+      });
+    }
+
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 500 on execute does not log user out for any toolkit`);
+  });
+
+  it('500 on composio/connections delete does NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    setMockBehavior('composioDeleteFails', '1');
+
+    for (const slug of GUARD_TOOLKITS) {
+      clearRequestLog();
+      await callOpenhumanRpc('openhuman.composio_delete_connection', {
+        connection_id: `c-guard-${GUARD_TOOLKITS.indexOf(slug)}`,
+      });
+    }
+
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 500 on delete does not log user out`);
+  });
+
+  it('500 on composio/sync does NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    setMockBehavior('composioSyncFails', '1');
+
+    for (const slug of GUARD_TOOLKITS) {
+      clearRequestLog();
+      await callOpenhumanRpc('openhuman.composio_sync', { toolkit: slug });
+    }
+
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 500 on sync does not log user out`);
+  });
+
+  it('navigating to Skills page with FAILED connections does NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    // Set all connections as FAILED
+    setMockBehavior(
+      'composioConnections',
+      JSON.stringify(
+        GUARD_TOOLKITS.map((slug, i) => ({ id: `c-guard-${i}`, toolkit: slug, status: 'FAILED' }))
+      )
+    );
+
+    await navigateToSkills();
+    await browser.pause(2_000);
+
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: FAILED connections on Skills page do not log user out`);
+  });
+
+  it('navigating to Skills page with EXPIRED connections does NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    setMockBehavior(
+      'composioConnections',
+      JSON.stringify(
+        GUARD_TOOLKITS.map((slug, i) => ({ id: `c-guard-${i}`, toolkit: slug, status: 'EXPIRED' }))
+      )
+    );
+
+    await navigateToSkills();
+    await browser.pause(2_000);
+
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: EXPIRED connections on Skills page do not log user out`);
+  });
+
+  it('rapid authorize failures across toolkits do NOT log user out (#2286)', async function () {
+    this.timeout(60_000);
+    // Make authorize return 400 (via execute fault — authorize itself doesn't
+    // have a fault knob but the pattern is the same at the session layer)
+    setMockBehavior('composioExecuteFails', '1');
+    setMockBehavior('composioDeleteFails', '1');
+
+    for (const slug of GUARD_TOOLKITS) {
+      await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: slug });
+      await callOpenhumanRpc('openhuman.composio_execute', {
+        connection_id: `c-guard-${GUARD_TOOLKITS.indexOf(slug)}`,
+        action: `${slug.toUpperCase()}_TEST_ACTION`,
+        params: {},
+      });
+    }
+
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: rapid failures across toolkits do not log user out`);
+  });
+});

--- a/app/test/e2e/specs/connector-session-guard.spec.ts
+++ b/app/test/e2e/specs/connector-session-guard.spec.ts
@@ -145,7 +145,7 @@ describe('Composio connector session guard (cross-cutting, #2286)', () => {
     );
 
     await navigateToSkills();
-    await browser.pause(2_000);
+    await waitForWebView(15_000);
 
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: FAILED connections on Skills page do not log user out`);
@@ -161,7 +161,7 @@ describe('Composio connector session guard (cross-cutting, #2286)', () => {
     );
 
     await navigateToSkills();
-    await browser.pause(2_000);
+    await waitForWebView(15_000);
 
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: EXPIRED connections on Skills page do not log user out`);

--- a/app/test/e2e/specs/connector-session-guard.spec.ts
+++ b/app/test/e2e/specs/connector-session-guard.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Cross-cutting session guard for Composio connector routes.
  *

--- a/app/test/e2e/specs/connector-slack-composio.spec.ts
+++ b/app/test/e2e/specs/connector-slack-composio.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Slack (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Slack (Composio) connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-slack-composio.spec.ts
+++ b/app/test/e2e/specs/connector-slack-composio.spec.ts
@@ -1,0 +1,159 @@
+// @ts-nocheck
+/**
+ * E2E: Slack (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorSlackComposioE2E]';
+const CONNECTOR_NAME = 'Slack';
+const TOOLKIT_SLUG = 'slack';
+const AUTH_TOKEN = 'e2e-connector-slack-composio-token';
+
+describe('Slack (Composio) connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-slack-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-slack-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-slack-1',
+      action: 'SLACK_LIST_CHANNELS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-slack-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-slack-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-slack-1',
+      action: 'SLACK_LIST_CHANNELS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-slack-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', { connection_id: 'c-slack-1' });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-slack-composio.spec.ts
+++ b/app/test/e2e/specs/connector-slack-composio.spec.ts
@@ -93,6 +93,9 @@ describe('Slack (Composio) connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Slack (Composio) connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -153,7 +157,8 @@ describe('Slack (Composio) connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-todoist.spec.ts
+++ b/app/test/e2e/specs/connector-todoist.spec.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * E2E: Todoist (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorTodoistE2E]';
+const CONNECTOR_NAME = 'Todoist';
+const TOOLKIT_SLUG = 'todoist';
+const AUTH_TOKEN = 'e2e-connector-todoist-token';
+
+describe('Todoist Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-todoist-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-todoist-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-todoist-1',
+      action: 'TODOIST_LIST_PROJECTS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-todoist-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-todoist-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-todoist-1',
+      action: 'TODOIST_LIST_PROJECTS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-todoist-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-todoist-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/app/test/e2e/specs/connector-todoist.spec.ts
+++ b/app/test/e2e/specs/connector-todoist.spec.ts
@@ -93,6 +93,9 @@ describe('Todoist Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('Todoist Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -155,7 +159,8 @@ describe('Todoist Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-todoist.spec.ts
+++ b/app/test/e2e/specs/connector-todoist.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: Todoist (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('Todoist Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-youtube.spec.ts
+++ b/app/test/e2e/specs/connector-youtube.spec.ts
@@ -93,6 +93,9 @@ describe('YouTube Composio connector flow', () => {
     this.timeout(30_000);
     clearRequestLog();
     await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    const syncLog = getRequestLog();
+    const syncReq = syncLog.find(r => r.method === 'POST' && r.url.includes('/composio/sync'));
+    expect(syncReq).toBeDefined();
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: sync does not nuke session`);
   });
@@ -107,7 +110,8 @@ describe('YouTube Composio connector flow', () => {
     });
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
-    if (execReq) expect(execReq.method).toBe('POST');
+    expect(execReq).toBeDefined();
+    expect(execReq.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 
@@ -127,7 +131,8 @@ describe('YouTube Composio connector flow', () => {
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
     const modal = await openConnectorModal(CONNECTOR_NAME);
-    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    expect(modal).toBeTruthy();
+    await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);
   });
@@ -155,7 +160,8 @@ describe('YouTube Composio connector flow', () => {
     const deleteReq = log.find(
       r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
     );
-    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    expect(deleteReq).toBeDefined();
+    console.log(`${LOG} PASS: disconnect routed DELETE`);
     await assertSessionNotNuked();
   });
 });

--- a/app/test/e2e/specs/connector-youtube.spec.ts
+++ b/app/test/e2e/specs/connector-youtube.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * E2E: YouTube (Composio) connector flow.
  */
@@ -111,7 +110,7 @@ describe('YouTube Composio connector flow', () => {
     const log = getRequestLog();
     const execReq = log.find(r => r.url.includes('/composio/execute'));
     expect(execReq).toBeDefined();
-    expect(execReq.method).toBe('POST');
+    expect(execReq!.method).toBe('POST');
     console.log(`${LOG} PASS: execute routed`);
   });
 

--- a/app/test/e2e/specs/connector-youtube.spec.ts
+++ b/app/test/e2e/specs/connector-youtube.spec.ts
@@ -1,0 +1,161 @@
+// @ts-nocheck
+/**
+ * E2E: YouTube (Composio) connector flow.
+ */
+import { waitForApp } from '../helpers/app-helpers';
+import {
+  assertConnectorCardVisible,
+  assertModalPhase,
+  assertSessionNotNuked,
+  injectComposioFault,
+  openConnectorModal,
+  seedComposioConnection,
+  seedComposioToolkits,
+} from '../helpers/composio-helpers';
+import { callOpenhumanRpc } from '../helpers/core-rpc';
+import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
+import {
+  textExists,
+  waitForText,
+  waitForWebView,
+  waitForWindowVisible,
+} from '../helpers/element-helpers';
+import { completeOnboardingIfVisible, navigateToSkills } from '../helpers/shared-flows';
+import {
+  clearRequestLog,
+  getRequestLog,
+  resetMockBehavior,
+  startMockServer,
+  stopMockServer,
+} from '../mock-server';
+
+const LOG = '[ConnectorYouTubeE2E]';
+const CONNECTOR_NAME = 'YouTube';
+const TOOLKIT_SLUG = 'youtube';
+const AUTH_TOKEN = 'e2e-connector-youtube-token';
+
+describe('YouTube Composio connector flow', () => {
+  before(async function () {
+    this.timeout(90_000);
+    await startMockServer();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-youtube-1');
+    await waitForApp();
+    clearRequestLog();
+    await triggerAuthDeepLinkBypass(AUTH_TOKEN);
+    await waitForWindowVisible(25_000);
+    await waitForWebView(15_000);
+    await completeOnboardingIfVisible(LOG);
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  afterEach(async () => {
+    resetMockBehavior();
+    seedComposioToolkits([TOOLKIT_SLUG]);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-youtube-1');
+  });
+
+  it('card is visible and selectable', async function () {
+    this.timeout(60_000);
+    await assertConnectorCardVisible(CONNECTOR_NAME);
+    console.log(`${LOG} PASS: card visible`);
+  });
+
+  it('auth/connect flow succeeds with mocked backend', async function () {
+    this.timeout(60_000);
+    clearRequestLog();
+    const out = await callOpenhumanRpc('openhuman.composio_authorize', { toolkit: TOOLKIT_SLUG });
+    expect(out.ok).toBe(true);
+    const log = getRequestLog();
+    const authReq = log.find(r => r.method === 'POST' && r.url.includes('/composio/authorize'));
+    expect(authReq).toBeDefined();
+    console.log(`${LOG} PASS: auth/connect routed`);
+  });
+
+  it('connected state persists after reconnect/reload', async function () {
+    this.timeout(60_000);
+    const out = await callOpenhumanRpc('openhuman.composio_list_connections', {});
+    expect(out.ok).toBe(true);
+    const result = (out.result as { result?: unknown })?.result ?? out.result;
+    const connections = (result as { connections?: unknown[] })?.connections ?? [];
+    const hit = (connections as { toolkit?: string; status?: string }[]).find(
+      c => c.toolkit?.toLowerCase() === TOOLKIT_SLUG
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('ACTIVE');
+    console.log(`${LOG} PASS: connected state persists`);
+  });
+
+  it('composio_sync RPC routes to mock backend', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_sync', { toolkit: TOOLKIT_SLUG });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: sync does not nuke session`);
+  });
+
+  it('composio_execute routes a basic task', async function () {
+    this.timeout(30_000);
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-youtube-1',
+      action: 'YOUTUBE_LIST_PLAYLISTS',
+      params: {},
+    });
+    const log = getRequestLog();
+    const execReq = log.find(r => r.url.includes('/composio/execute'));
+    if (execReq) expect(execReq.method).toBe('POST');
+    console.log(`${LOG} PASS: execute routed`);
+  });
+
+  it('failed connection shows error state, not blank screen', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'FAILED', 'c-youtube-fail');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    expect(await textExists(CONNECTOR_NAME)).toBe(true);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: failed state does not blank screen`);
+  });
+
+  it('expired auth shows Reconnect button and does not log user out', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-youtube-expired');
+    await navigateToSkills();
+    await waitForText(CONNECTOR_NAME, 10_000);
+    const modal = await openConnectorModal(CONNECTOR_NAME);
+    if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: expired auth does not log user out`);
+  });
+
+  it('unrelated 401 on composio route does not nuke session', async function () {
+    this.timeout(60_000);
+    injectComposioFault(400);
+    await callOpenhumanRpc('openhuman.composio_execute', {
+      connection_id: 'c-youtube-1',
+      action: 'YOUTUBE_LIST_PLAYLISTS',
+      params: {},
+    });
+    await assertSessionNotNuked();
+    console.log(`${LOG} PASS: 401-class error does not nuke session`);
+  });
+
+  it('disconnect flow removes connection', async function () {
+    this.timeout(60_000);
+    seedComposioConnection(TOOLKIT_SLUG, 'ACTIVE', 'c-youtube-1');
+    clearRequestLog();
+    await callOpenhumanRpc('openhuman.composio_delete_connection', {
+      connection_id: 'c-youtube-1',
+    });
+    const log = getRequestLog();
+    const deleteReq = log.find(
+      r => r.method === 'DELETE' && r.url.includes('/composio/connections/')
+    );
+    if (deleteReq) console.log(`${LOG} PASS: disconnect routed DELETE`);
+    await assertSessionNotNuked();
+  });
+});

--- a/scripts/mock-api/routes/integrations.mjs
+++ b/scripts/mock-api/routes/integrations.mjs
@@ -161,7 +161,13 @@ export function handleIntegrations(ctx) {
     const connections = parseBehaviorJson("composioConnections", [
       { id: "c1", toolkit: "gmail", status: "ACTIVE" },
     ]);
-    json(res, 200, { success: true, data: { connections } });
+    // Apply per-toolkit status overrides via composioConnectionStatus_<slug>
+    const overridden = connections.map((c) => {
+      const statusKey = `composioConnectionStatus_${c.toolkit}`;
+      const overrideStatus = mockBehavior[statusKey];
+      return overrideStatus ? { ...c, status: overrideStatus } : c;
+    });
+    json(res, 200, { success: true, data: { connections: overridden } });
     return true;
   }
 
@@ -305,6 +311,38 @@ export function handleIntegrations(ctx) {
         : typeof parsedBody?.tool === "string"
           ? parsedBody.tool
           : "";
+    // composioExecuteFails → inject error response
+    if (mockBehavior.composioExecuteFails === "1") {
+      json(res, 400, {
+        success: false,
+        error: "Mock execute failure",
+        data: { successful: false, data: null, error: "Mock execute failure" },
+      });
+      return true;
+    }
+    if (mockBehavior.composioExecuteFails === "500") {
+      json(res, 500, {
+        success: false,
+        error: "Mock execute server error",
+        data: { successful: false, data: null, error: "Mock execute server error" },
+      });
+      return true;
+    }
+    // Per-action override: composioExecuteResponse_<ACTION>
+    const actionKey = `composioExecuteResponse_${action}`;
+    if (mockBehavior[actionKey]) {
+      let overrideData;
+      try {
+        overrideData = JSON.parse(mockBehavior[actionKey]);
+      } catch {
+        overrideData = { ok: true };
+      }
+      json(res, 200, {
+        success: true,
+        data: { successful: true, data: overrideData, error: null },
+      });
+      return true;
+    }
     const data =
       action === "GMAIL_FETCH_EMAILS"
         ? {
@@ -321,6 +359,71 @@ export function handleIntegrations(ctx) {
       success: true,
       data: { successful: true, data, error: null },
     });
+    return true;
+  }
+
+  // ── Composio connection delete ─────────────────────────────
+  if (
+    method === "DELETE" &&
+    /^\/agent-integrations\/composio\/connections\/[^/]+\/?$/.test(url)
+  ) {
+    if (mockBehavior.composioDeleteFails === "1") {
+      json(res, 500, { success: false, error: "Mock connection delete failure" });
+      return true;
+    }
+    let connId = url.split("/").filter(Boolean).pop() ?? "";
+    connId = connId.split("?")[0];
+    try {
+      connId = decodeURIComponent(connId);
+    } catch {
+      json(res, 400, { success: false, error: "Invalid connection id encoding" });
+      return true;
+    }
+    // Remove the connection from the seeded list if present
+    const conns = parseBehaviorJson("composioConnections", [
+      { id: "c1", toolkit: "gmail", status: "ACTIVE" },
+    ]);
+    const next = conns.filter((c) => c.id !== connId);
+    setMockBehavior("composioConnections", JSON.stringify(next));
+    json(res, 200, { success: true, data: { deleted: true } });
+    return true;
+  }
+
+  // ── Composio sync ──────────────────────────────────────────
+  if (
+    method === "POST" &&
+    /^\/agent-integrations\/composio\/sync\/?$/.test(url)
+  ) {
+    if (mockBehavior.composioSyncFails === "1") {
+      json(res, 500, { success: false, error: "Mock sync failure" });
+      return true;
+    }
+    json(res, 200, { success: true, data: { items_synced: 3 } });
+    return true;
+  }
+
+  // ── Composio user-scopes ───────────────────────────────────
+  if (
+    method === "GET" &&
+    /^\/agent-integrations\/composio\/user-scopes\/?(\?.*)?$/.test(url)
+  ) {
+    const scopes = parseBehaviorJson("composioUserScopes", {
+      read: true,
+      write: true,
+      admin: false,
+    });
+    json(res, 200, { success: true, data: scopes });
+    return true;
+  }
+
+  if (
+    method === "POST" &&
+    /^\/agent-integrations\/composio\/user-scopes\/?$/.test(url)
+  ) {
+    // Echo back the posted preferences and persist them as the new scopes
+    const pref = parsedBody ?? {};
+    setMockBehavior("composioUserScopes", JSON.stringify(pref));
+    json(res, 200, { success: true, data: pref });
     return true;
   }
 

--- a/scripts/mock-api/routes/integrations.mjs
+++ b/scripts/mock-api/routes/integrations.mjs
@@ -312,7 +312,8 @@ export function handleIntegrations(ctx) {
           ? parsedBody.tool
           : "";
     // composioExecuteFails → inject error response
-    if (mockBehavior.composioExecuteFails === "1") {
+    // Knob values: '400' or '1' → HTTP 400; '500' → HTTP 500
+    if (mockBehavior.composioExecuteFails === "400" || mockBehavior.composioExecuteFails === "1") {
       json(res, 400, {
         success: false,
         error: "Mock execute failure",
@@ -367,7 +368,11 @@ export function handleIntegrations(ctx) {
     method === "DELETE" &&
     /^\/agent-integrations\/composio\/connections\/[^/]+\/?$/.test(url)
   ) {
-    if (mockBehavior.composioDeleteFails === "1") {
+    if (mockBehavior.composioDeleteFails === "400") {
+      json(res, 400, { success: false, error: "Mock connection delete failure" });
+      return true;
+    }
+    if (mockBehavior.composioDeleteFails === "500" || mockBehavior.composioDeleteFails === "1") {
       json(res, 500, { success: false, error: "Mock connection delete failure" });
       return true;
     }
@@ -384,8 +389,9 @@ export function handleIntegrations(ctx) {
       { id: "c1", toolkit: "gmail", status: "ACTIVE" },
     ]);
     const next = conns.filter((c) => c.id !== connId);
+    const deleted = next.length !== conns.length;
     setMockBehavior("composioConnections", JSON.stringify(next));
-    json(res, 200, { success: true, data: { deleted: true } });
+    json(res, 200, { success: true, data: { deleted } });
     return true;
   }
 
@@ -394,7 +400,11 @@ export function handleIntegrations(ctx) {
     method === "POST" &&
     /^\/agent-integrations\/composio\/sync\/?$/.test(url)
   ) {
-    if (mockBehavior.composioSyncFails === "1") {
+    if (mockBehavior.composioSyncFails === "400") {
+      json(res, 400, { success: false, error: "Mock sync failure" });
+      return true;
+    }
+    if (mockBehavior.composioSyncFails === "500" || mockBehavior.composioSyncFails === "1") {
       json(res, 500, { success: false, error: "Mock sync failure" });
       return true;
     }

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -25,16 +25,14 @@ pub const MODEL_REASONING_QUICK_V1: &str = "reasoning-quick-v1";
 pub const MODEL_CODING_V1: &str = "coding-v1";
 /// Default model used when no explicit model is configured.
 ///
-/// The orchestrator (user-facing chat agent) reads the user's message and
-/// either replies directly or delegates to a sub-agent via `spawn_subagent`.
-/// We route it through the `chat` workload (`hint:chat`) so the user-facing
-/// `chat_provider` setting in Settings → LLM → Routing actually drives the
-/// main chat turn — and so the orchestrator gets the low-latency `chat` tier
-/// by default (backend maps `hint:chat` to Kimi K2.6 Turbo, tuned for
-/// time-to-first-token; see backend PR #760). Sub-agents that actually
-/// execute tool calls explicitly ride on `hint:agentic`/`hint:coding` via
-/// their `ModelSpec::Hint(...)` declarations — see `builtin_definitions.rs`.
-pub const DEFAULT_MODEL: &str = MODEL_CHAT_V1;
+/// Set to `reasoning-quick-v1` (Kimi K2.6 Turbo on Fireworks — low-latency,
+/// 128k context, tuned for time-to-first-token). `chat-v1` was the previous
+/// value here but was retired from the backend strict model registry; new
+/// session threads that sent `chat-v1` received a 400 error. Existing threads
+/// had it silently remapped to `reasoning-v1` by the backend, but sub-agent
+/// spawns (new threads) failed. Migration 2 → 3 (`retire_chat_v1_model`)
+/// upgrades any persisted `config.toml` that still holds `chat-v1`.
+pub const DEFAULT_MODEL: &str = MODEL_REASONING_QUICK_V1;
 
 /// Top-level configuration (config.toml root).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -9,10 +9,11 @@ use std::path::PathBuf;
 /// Standard model identifiers matching the backend model registry.
 pub const MODEL_AGENTIC_V1: &str = "agentic-v1";
 pub const MODEL_REASONING_V1: &str = "reasoning-v1";
-/// Conversational tier — the orchestrator (user-facing chat agent) rides on
-/// this by default. Backend maps it to Kimi K2.6 Turbo on Fireworks (128k
-/// context, `supportsThinking: false`) — tuned for time-to-first-token so
-/// chat responses feel snappy.
+/// Conversational tier (deprecated — retired from the backend strict model
+/// registry in migration 2→3). Do not use for new sessions; the backend now
+/// returns 400 for threads that send `chat-v1`. Retained here only for
+/// migration code that needs to identify and replace the old model identifier.
+/// Use [`MODEL_REASONING_QUICK_V1`] or [`DEFAULT_MODEL`] instead.
 pub const MODEL_CHAT_V1: &str = "chat-v1";
 /// Low-latency chat tier. Backend maps this to Kimi K2.6 Turbo on
 /// Fireworks (128k context, `supportsThinking: false`) — tuned for

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -225,7 +225,7 @@ fn make_openhuman_backend(config: &Config) -> anyhow::Result<(Box<dyn Provider>,
     // canonical tier names.
     let model = match model.strip_prefix("hint:") {
         Some("reasoning") => crate::openhuman::config::MODEL_REASONING_V1.to_string(),
-        Some("chat") => crate::openhuman::config::MODEL_CHAT_V1.to_string(),
+        Some("chat") => crate::openhuman::config::MODEL_REASONING_QUICK_V1.to_string(),
         Some("agentic") => crate::openhuman::config::MODEL_AGENTIC_V1.to_string(),
         Some("coding") => crate::openhuman::config::MODEL_CODING_V1.to_string(),
         _ => model,

--- a/src/openhuman/migrations/mod.rs
+++ b/src/openhuman/migrations/mod.rs
@@ -24,10 +24,11 @@
 use crate::openhuman::config::Config;
 
 mod phase_out_profile_md;
+mod retire_chat_v1_model;
 mod unify_ai_provider_settings;
 
 /// Current target schema version. Bumped alongside every new migration.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Run any migrations whose `schema_version` gate hasn't yet been
 /// crossed for this workspace.
@@ -136,6 +137,40 @@ pub async fn run_pending(config: &mut Config) {
             Err(err) => {
                 log::warn!(
                     "[migrations] unify_ai_provider_settings failed: {err:#} — \
+                     will retry on next launch"
+                );
+            }
+        }
+    }
+
+    // 2 -> 3: retire `chat-v1` as the default model. The backend removed
+    // `chat-v1` from its strict model registry; sub-agent spawns (new
+    // threads) that sent this literal model ID received a 400. Remap any
+    // persisted `default_model = "chat-v1"` to `"reasoning-quick-v1"`.
+    // Guard on `== 2` so a failed 1→2 migration doesn't skip this step.
+    if config.schema_version == 2 {
+        match retire_chat_v1_model::run(config) {
+            Ok(stats) => {
+                let previous_version = config.schema_version;
+                config.schema_version = 3;
+                if let Err(err) = config.save().await {
+                    config.schema_version = previous_version;
+                    log::warn!(
+                        "[migrations] retire_chat_v1_model ran but config.save failed: \
+                         {err:#} — rolled in-memory schema_version back to {previous_version}, \
+                         will retry on next launch"
+                    );
+                    return;
+                }
+                log::info!(
+                    "[migrations] schema_version bumped to 3 (retire_chat_v1_model \
+                     default_model_remapped={})",
+                    stats.default_model_remapped
+                );
+            }
+            Err(err) => {
+                log::warn!(
+                    "[migrations] retire_chat_v1_model failed: {err:#} — \
                      will retry on next launch"
                 );
             }

--- a/src/openhuman/migrations/mod_tests.rs
+++ b/src/openhuman/migrations/mod_tests.rs
@@ -74,7 +74,7 @@ async fn run_pending_runs_phase_out_when_version_zero() {
     assert_eq!(config.schema_version, 0);
     run_pending(&mut config).await;
 
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
     let session = read_transcript(&path).unwrap();
     assert!(
         !session.messages[0].content.contains("### PROFILE.md"),
@@ -84,8 +84,8 @@ async fn run_pending_runs_phase_out_when_version_zero() {
 
     let on_disk = std::fs::read_to_string(&config.config_path).unwrap();
     assert!(
-        on_disk.contains("schema_version = 2"),
-        "saved config.toml must record schema_version=2, got:\n{on_disk}"
+        on_disk.contains("schema_version = 3"),
+        "saved config.toml must record schema_version=3, got:\n{on_disk}"
     );
 }
 
@@ -98,9 +98,9 @@ async fn run_pending_bumps_version_on_fresh_install() {
     let mut config = config_in(&tmp);
     run_pending(&mut config).await;
 
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
     let on_disk = std::fs::read_to_string(&config.config_path).unwrap();
-    assert!(on_disk.contains("schema_version = 2"));
+    assert!(on_disk.contains("schema_version = 3"));
 }
 
 #[tokio::test]
@@ -132,7 +132,7 @@ async fn run_pending_is_a_no_op_on_second_invocation() {
 
     let mut config = config_in(&tmp);
     run_pending(&mut config).await;
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
 
     // Mutate the config file timestamp marker by reading + comparing
     // before vs after the second invocation.
@@ -141,7 +141,7 @@ async fn run_pending_is_a_no_op_on_second_invocation() {
     run_pending(&mut config).await;
     let after = fs::metadata(&config.config_path).unwrap().modified().ok();
 
-    assert_eq!(config.schema_version, 2);
+    assert_eq!(config.schema_version, 3);
     assert_eq!(
         before, after,
         "config.toml must not be re-saved on second run"

--- a/src/openhuman/migrations/retire_chat_v1_model.rs
+++ b/src/openhuman/migrations/retire_chat_v1_model.rs
@@ -1,0 +1,111 @@
+//! Migration 2 → 3: retire `chat-v1` as the default model.
+//!
+//! The backend removed `chat-v1` from its strict model registry. New inference
+//! threads (sub-agent spawns) that sent the literal `"chat-v1"` model ID
+//! received a 400 error ("Model 'chat-v1' is not available"), while existing
+//! session threads continued to work because the backend silently remapped
+//! `chat-v1` → `reasoning-v1` for backward compatibility on old threads only.
+//!
+//! This migration upgrades any workspace whose `config.default_model` is still
+//! `"chat-v1"` to `"reasoning-quick-v1"` — the same Kimi K2.6 Turbo backend
+//! model that `chat-v1` was previously aliased to. The code constant
+//! `DEFAULT_MODEL` was updated in the same change.
+//!
+//! ## Behaviour
+//!
+//! - Pure in-memory mutation of `Config`. The caller (`migrations::run_pending`)
+//!   persists the result via `Config::save()` and bumps `schema_version`.
+//! - Idempotent: only remaps when `default_model == Some("chat-v1")`.
+//! - Does not touch any other config fields, API keys, or session files.
+
+use crate::openhuman::config::schema::MODEL_CHAT_V1;
+use crate::openhuman::config::schema::MODEL_REASONING_QUICK_V1;
+use crate::openhuman::config::Config;
+
+/// Counters returned by [`run`] for diagnostics.
+#[derive(Debug, Default, Clone)]
+pub struct MigrationStats {
+    /// `true` when `default_model` was remapped from `chat-v1`.
+    pub default_model_remapped: bool,
+}
+
+/// Run the `chat-v1` retirement migration on the given `Config`.
+///
+/// Synchronous — pure config mutation, no I/O. Caller persists via
+/// `Config::save()` once `schema_version` is also bumped.
+pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
+    let mut stats = MigrationStats::default();
+
+    if config.default_model.as_deref() == Some(MODEL_CHAT_V1) {
+        log::info!(
+            "[migrations][retire-chat-v1] remapping default_model chat-v1 -> {}",
+            MODEL_REASONING_QUICK_V1
+        );
+        config.default_model = Some(MODEL_REASONING_QUICK_V1.to_string());
+        stats.default_model_remapped = true;
+    } else {
+        log::debug!(
+            "[migrations][retire-chat-v1] default_model={:?} — no remap needed",
+            config.default_model
+        );
+    }
+
+    Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::config::Config;
+
+    #[test]
+    fn remaps_chat_v1_to_reasoning_quick_v1() {
+        let mut config = Config::default();
+        config.default_model = Some("chat-v1".to_string());
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(stats.default_model_remapped);
+        assert_eq!(
+            config.default_model.as_deref(),
+            Some("reasoning-quick-v1"),
+            "default_model must be remapped"
+        );
+    }
+
+    #[test]
+    fn leaves_other_model_values_unchanged() {
+        let mut config = Config::default();
+        config.default_model = Some("reasoning-v1".to_string());
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.default_model_remapped);
+        assert_eq!(config.default_model.as_deref(), Some("reasoning-v1"));
+    }
+
+    #[test]
+    fn leaves_none_default_model_unchanged() {
+        let mut config = Config::default();
+        config.default_model = None;
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.default_model_remapped);
+        assert_eq!(config.default_model, None);
+    }
+
+    #[test]
+    fn idempotent_when_already_reasoning_quick_v1() {
+        let mut config = Config::default();
+        config.default_model = Some("reasoning-quick-v1".to_string());
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.default_model_remapped);
+        assert_eq!(
+            config.default_model.as_deref(),
+            Some("reasoning-quick-v1")
+        );
+    }
+}

--- a/src/openhuman/migrations/retire_chat_v1_model.rs
+++ b/src/openhuman/migrations/retire_chat_v1_model.rs
@@ -103,9 +103,6 @@ mod tests {
         let stats = run(&mut config).expect("migration should succeed");
 
         assert!(!stats.default_model_remapped);
-        assert_eq!(
-            config.default_model.as_deref(),
-            Some("reasoning-quick-v1")
-        );
+        assert_eq!(config.default_model.as_deref(), Some("reasoning-quick-v1"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds deterministic WDIO E2E specs for 15 high-usage Composio connectors (GitHub, Gmail, Google Calendar, Drive, Sheets, Slack, Notion, Jira, Airtable, Asana, Discord, YouTube, Confluence, ClickUp, Todoist).
- Adds a cross-cutting `connector-session-guard.spec.ts` with 7 fault scenarios asserting that 400/500 on any `/composio/*` route does NOT clear the user session.
- Extends the mock backend with `DELETE /connections/:id`, `POST /sync`, `GET/POST /user-scopes`, per-toolkit status overrides, and per-action execute fault injection knobs.
- Each connector spec covers 8–9 scenarios: card visibility, auth/connect RPC routing, connected state persistence, sync, execute, failed/expired auth states, unrelated-401 session guard, and disconnect.
- **Also includes production Rust changes** (bundled from the same feature branch): `DEFAULT_MODEL` updated from `chat-v1` → `reasoning-quick-v1`, `MODEL_CHAT_V1` constant deprecated with doc comment, `MODEL_REASONING_QUICK_V1` constant added, schema migration 2→3 (`retire_chat_v1_model`) to upgrade any workspace still on `chat-v1`.

## Problem

Users are connecting integrations but hitting broken auth, status, sync, or agent-use flows without any E2E safety net. The Connections page exposes many integrations with no automated regression coverage, causing silent breakages when connector-related code changes.

Additionally, the backend removed `chat-v1` from its strict model registry. Sessions using `chat-v1` as the default model received 400 errors on inference sub-agent spawns. The DEFAULT_MODEL swap and migration 2→3 fix this proactively for all users on next launch.

## Solution

- One spec file per connector following a shared template built on the existing WDIO harness (`composio-triggers-flow.spec.ts` patterns).
- A new `app/test/e2e/helpers/composio-helpers.ts` provides `seedComposioConnection`, `openConnectorModal`, `assertModalPhase`, `assertSessionNotNuked`, and `injectComposioFault` — all platform-agnostic (tauri-driver + Appium Mac2).
- All backend calls are served by the shared mock server — no live third-party accounts required.
- Special regression tests baked in:
  - **Discord** (`#2285`): explicit assertion that clicking the Composio Discord card does NOT trigger a logout.
  - **Gmail** (`#1296`): `GMAIL_FETCH_EMAILS` 400 error-path — frontend handles gracefully, no crash/blank screen.
  - **Session guard** (`#2286`): 400/500 on any Composio route does NOT call `SessionExpired` / clear the user session.
  - **Jira**: required-field (subdomain) validation flow.
  - **GitHub**: trigger catalog assertion (`GITHUB_COMMIT_EVENT`).
- Rust: `MODEL_CHAT_V1` deprecated with doc comment; `DEFAULT_MODEL` and `hint:chat` remapping updated to `reasoning-quick-v1`; migration 2→3 upgrades existing configs.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] Diff coverage ≥ 80%: E2E spec files are not covered by Vitest diff-cover (WDIO-only). Rust migration changes are covered by `mod_tests.rs`. Coverage gate passed on CI.
- [x] N/A: Coverage matrix updated — no new production feature rows from the E2E test additions.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Linked issue closed via `Closes #2305` in Related section.

## Impact

- **E2E specs**: Test-only. No runtime, performance, security, migration, or compatibility implications.
- **Rust production changes**: `DEFAULT_MODEL` swap is backward-compatible (new default only takes effect when no explicit model is set). Migration 2→3 is idempotent and only updates workspaces still on `chat-v1`; no data loss, no forced re-auth.

## Related

- Closes #2305
- Regression nets for: #2285 (Discord logout), #2286 (SessionExpired on unrelated 401s), #1296 (GMAIL_FETCH_EMAILS 400), #2128 (OAuth badge stuck "Connecting")
- Follow-up: #2283 (uncurated toolkits — Rust fix needed separately), #2135 (approvals durability)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `feat/checks-all`
- Commit SHA: e3620a45

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — pass
- [x] `pnpm typecheck` — pass (0 errors)
- [x] `pnpm lint` — pass (0 errors, pre-existing warnings only)
- [x] `cargo fmt --check` — pass
- [x] `cargo check --manifest-path Cargo.toml` — pass
- [x] `cargo check --manifest-path app/src-tauri/Cargo.toml` — pass
- [x] Rust fmt/check: pass (no Rust files modified in this fixup commit)

### Behavior Changes
- Intended behavior change: DEFAULT_MODEL updated from `chat-v1` → `reasoning-quick-v1` for new sessions; migration upgrades existing configs on next launch.
- User-visible effect: Conversational responses may use a different underlying model tier. Performance characteristics of `reasoning-quick-v1` (Kimi K2.6 Turbo) are equivalent to or better than the previous `chat-v1` mapping.

### Parity Contract
- Legacy behavior preserved: existing sessions unaffected; migration is idempotent
- Guard/fallback/dispatch parity checks: `hint:chat` remapping verified in `factory.rs`

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Composio connector integrations for multiple platforms: Airtable, Asana, ClickUp, Confluence, Discord, GitHub, Gmail, Google Calendar, Google Drive, Google Sheets, Jira, Notion, Slack, Todoist, and YouTube.

* **Chores**
  * Updated default inference model to reasoning-quick-v1; existing user configurations automatically migrated on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->