### PR TITLE
fix(tauri): skip single-instance plugin when D-Bus session bus is unreachable

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1656,6 +1656,73 @@ fn check_linux_display_server() {
 #[cfg(not(target_os = "linux"))]
 fn check_linux_display_server() {}
 
+/// Pure predicate: given a candidate `DBUS_SESSION_BUS_ADDRESS` value, decide
+/// whether it points to a transport `zbus` can actually open.
+///
+/// `tauri-plugin-single-instance` on Linux calls
+/// `zbus::blocking::connection::Builder::session().unwrap()` in its `setup()`
+/// closure. When `DBUS_SESSION_BUS_ADDRESS` is missing or set to `disabled`
+/// (the literal string WSL2-without-WSLg sets), zbus returns
+/// `Address("unsupported transport 'disabled'")` and the unwrap blows up the
+/// whole process before any window is created (Sentry OPENHUMAN-TAURI-TM).
+///
+/// We treat an address as reachable only when at least one alternative listed
+/// in the env var uses a transport `zbus` ships with: `unix:`, `tcp:`,
+/// `launchd:`, or `autolaunch:`. Anything else (`disabled`, empty, unknown
+/// scheme) is treated as unreachable so we can skip registering the plugin
+/// instead of crashing.
+#[cfg(any(target_os = "linux", test))]
+fn dbus_address_is_supported(addr: &str) -> bool {
+    addr.split(';').any(|entry| {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            return false;
+        }
+        let transport = entry.split(':').next().unwrap_or("").trim();
+        matches!(transport, "unix" | "tcp" | "launchd" | "autolaunch")
+    })
+}
+
+/// Pure predicate: decide whether the Linux D-Bus session bus is reachable
+/// based on the relevant env vars and (optionally) the existence of the
+/// `$XDG_RUNTIME_DIR/bus` socket.
+///
+/// Used to gate registration of `tauri-plugin-single-instance` on Linux so
+/// WSL2-without-WSLg / minimal-container launches don't crash on the plugin's
+/// `unwrap()` (Sentry OPENHUMAN-TAURI-TM).
+#[cfg(any(target_os = "linux", test))]
+fn linux_dbus_session_reachable(
+    dbus_session_bus_address: Option<&str>,
+    xdg_runtime_bus_socket_exists: bool,
+) -> bool {
+    match dbus_session_bus_address {
+        Some(addr) => dbus_address_is_supported(addr),
+        // When the env var is unset, zbus falls back to autolaunch which on
+        // most distros requires `$XDG_RUNTIME_DIR/bus` to exist. Treat its
+        // absence as "no D-Bus".
+        None => xdg_runtime_bus_socket_exists,
+    }
+}
+
+/// Returns `true` when this process can safely register
+/// `tauri-plugin-single-instance` without tripping the
+/// `Address("unsupported transport 'disabled'")` panic on Linux.
+/// Always `true` on non-Linux platforms.
+#[cfg(target_os = "linux")]
+fn can_register_single_instance_plugin() -> bool {
+    let env_addr = std::env::var("DBUS_SESSION_BUS_ADDRESS").ok();
+    let runtime_bus_present = std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .map(|dir| std::path::Path::new(&dir).join("bus").exists())
+        .unwrap_or(false);
+    linux_dbus_session_reachable(env_addr.as_deref(), runtime_bus_present)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn can_register_single_instance_plugin() -> bool {
+    true
+}
+
 type CefCommandLineArg = (&'static str, Option<&'static str>);
 
 /// Returns `true` when the process is running as root (UID 0) on Linux.
@@ -2236,18 +2303,28 @@ pub fn run() {
             }
         });
 
-    let builder = builder
-        // Single-instance guard — MUST be the first plugin registered so the
-        // secondary-process exit path triggers before any other plugin setup
-        // (and before `Builder::build()` reaches `CefRuntime::init`). Without
-        // this, launching a second instance races into CEF init while the
-        // primary still holds the cache lock; `cef::initialize` returns 0 and
-        // the vendored runtime asserts (Sentry OPENHUMAN-TAURI-A — 442 events
-        // across Win10/11 + Linux, all releases). The callback receives the
-        // secondary's argv/cwd; we forward deep-link args and focus the main
-        // window. Deep-link payloads stay handled by `tauri-plugin-deep-link`
-        // — we just need to wake the primary so it observes them.
-        .plugin(tauri_plugin_single_instance::init(
+    // Single-instance guard — MUST be the first plugin registered so the
+    // secondary-process exit path triggers before any other plugin setup
+    // (and before `Builder::build()` reaches `CefRuntime::init`). Without
+    // this, launching a second instance races into CEF init while the
+    // primary still holds the cache lock; `cef::initialize` returns 0 and
+    // the vendored runtime asserts (Sentry OPENHUMAN-TAURI-A — 442 events
+    // across Win10/11 + Linux, all releases). The callback receives the
+    // secondary's argv/cwd; we forward deep-link args and focus the main
+    // window. Deep-link payloads stay handled by `tauri-plugin-deep-link`
+    // — we just need to wake the primary so it observes them.
+    //
+    // On Linux the plugin's `setup()` calls
+    // `zbus::blocking::connection::Builder::session().unwrap()`, which panics
+    // with `Address("unsupported transport 'disabled'")` when the D-Bus
+    // session bus is unreachable (WSL2-without-WSLg, minimal containers, root
+    // launches without `$XDG_RUNTIME_DIR/bus`) — Sentry OPENHUMAN-TAURI-TM.
+    // Probe for a usable session bus first and skip the plugin if absent;
+    // single-instance enforcement is best-effort in those environments
+    // anyway, and a graceful skip is strictly better than crashing at
+    // startup.
+    let builder = if can_register_single_instance_plugin() {
+        builder.plugin(tauri_plugin_single_instance::init(
             |app: &AppHandle<AppRuntime>, args, cwd| {
                 // Don't log raw argv/cwd: deep-link callbacks (OAuth codes,
                 // magic links) can carry auth tokens that would otherwise leak
@@ -2262,6 +2339,17 @@ pub fn run() {
                 }
             },
         ))
+    } else {
+        log::warn!(
+            "[single-instance] D-Bus session bus unreachable (DBUS_SESSION_BUS_ADDRESS={:?}, \
+             XDG_RUNTIME_DIR={:?}); skipping tauri-plugin-single-instance to avoid \
+             OPENHUMAN-TAURI-TM panic. Multiple OpenHuman instances will not be deduplicated.",
+            std::env::var("DBUS_SESSION_BUS_ADDRESS").ok(),
+            std::env::var("XDG_RUNTIME_DIR").ok()
+        );
+        builder
+    };
+    let builder = builder
         // Explicitly disable `open_js_links_on_click`: tauri-plugin-opener
         // defaults to injecting `init-iife.js` into *every* webview — a
         // global click listener that invokes `plugin:opener|open_url` via
@@ -3425,6 +3513,75 @@ mod tests {
     fn linux_non_root_uid_not_detected() {
         assert!(!linux_is_root_uid(1000));
         assert!(!linux_is_root_uid(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Linux D-Bus session-bus probe (Sentry OPENHUMAN-TAURI-TM)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn dbus_address_unix_is_supported() {
+        assert!(dbus_address_is_supported(
+            "unix:path=/run/user/1000/bus"
+        ));
+        assert!(dbus_address_is_supported(
+            "unix:abstract=/tmp/dbus-abc"
+        ));
+    }
+
+    #[test]
+    fn dbus_address_tcp_and_launchd_supported() {
+        assert!(dbus_address_is_supported("tcp:host=localhost,port=1234"));
+        assert!(dbus_address_is_supported("launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET"));
+        assert!(dbus_address_is_supported("autolaunch:"));
+    }
+
+    #[test]
+    fn dbus_address_disabled_is_unsupported() {
+        // The literal value WSL2-without-WSLg sets — root cause of the panic.
+        assert!(!dbus_address_is_supported("disabled"));
+        assert!(!dbus_address_is_supported(""));
+        assert!(!dbus_address_is_supported("   "));
+    }
+
+    #[test]
+    fn dbus_address_unknown_transport_is_unsupported() {
+        assert!(!dbus_address_is_supported("nonce-tcp:host=localhost"));
+        assert!(!dbus_address_is_supported("bogus:"));
+    }
+
+    #[test]
+    fn dbus_address_picks_first_supported_in_list() {
+        // zbus walks the semicolon-separated list and uses the first reachable
+        // transport, so one good entry is enough.
+        assert!(dbus_address_is_supported(
+            "disabled;unix:path=/run/user/1000/bus"
+        ));
+        assert!(dbus_address_is_supported(
+            "bogus:;tcp:host=localhost,port=55"
+        ));
+        assert!(!dbus_address_is_supported("disabled;bogus:"));
+    }
+
+    #[test]
+    fn dbus_reachable_when_env_addr_is_supported() {
+        assert!(linux_dbus_session_reachable(
+            Some("unix:path=/run/user/1000/bus"),
+            false,
+        ));
+    }
+
+    #[test]
+    fn dbus_unreachable_when_env_addr_disabled() {
+        // Even if the socket exists, an explicit `disabled` value means the
+        // session bus is intentionally turned off and zbus will reject it.
+        assert!(!linux_dbus_session_reachable(Some("disabled"), true));
+    }
+
+    #[test]
+    fn dbus_falls_back_to_runtime_socket_when_env_unset() {
+        assert!(linux_dbus_session_reachable(None, true));
+        assert!(!linux_dbus_session_reachable(None, false));
     }
 
     // -------------------------------------------------------------------------

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3521,18 +3521,16 @@ mod tests {
 
     #[test]
     fn dbus_address_unix_is_supported() {
-        assert!(dbus_address_is_supported(
-            "unix:path=/run/user/1000/bus"
-        ));
-        assert!(dbus_address_is_supported(
-            "unix:abstract=/tmp/dbus-abc"
-        ));
+        assert!(dbus_address_is_supported("unix:path=/run/user/1000/bus"));
+        assert!(dbus_address_is_supported("unix:abstract=/tmp/dbus-abc"));
     }
 
     #[test]
     fn dbus_address_tcp_and_launchd_supported() {
         assert!(dbus_address_is_supported("tcp:host=localhost,port=1234"));
-        assert!(dbus_address_is_supported("launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET"));
+        assert!(dbus_address_is_supported(
+            "launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET"
+        ));
         assert!(dbus_address_is_supported("autolaunch:"));
     }
 


### PR DESCRIPTION
## Summary

- Probe Linux D-Bus session-bus reachability at startup and skip registration of `tauri-plugin-single-instance` when the bus is unreachable, instead of letting the plugin crash the app on `.unwrap()`.
- Adds two pure predicates (`dbus_address_is_supported`, `linux_dbus_session_reachable`) and a Linux-gated wrapper `can_register_single_instance_plugin()` in `app/src-tauri/src/lib.rs`.
- Existing plugin-ordering invariant preserved: when D-Bus is available, `tauri-plugin-single-instance` is still registered as the first plugin.
- Adds 8 unit tests covering every branch of the predicate (supported transports, `disabled`, empty/whitespace, unknown schemes, semicolon-separated lists, `$XDG_RUNTIME_DIR/bus` fallback).
- Emits a clear `log::warn!` documenting the skip and naming the Sentry tag so the degradation is traceable in production logs.

## Problem

Sentry issue **OPENHUMAN-TAURI-TM** (6 fatal events on `Linux 5.15.167.4-microsoft-standard-WSL2`, release `openhuman@0.53.43`) reports:

`panic: called Result::unwrap() on an Err value:
Address("unsupported transport 'disabled'")
at tauri::plugin::TauriPlugin<R,C>::initialize
← tauri::app::Builder<R>::build
← openhuman::run`


Upstream `tauri-plugin-single-instance` (pinned at rev `c6561ab6` in `Cargo.toml`) calls `zbus::blocking::connection::Builder::session().unwrap()` inside its `setup()` closure on Linux. When `DBUS_SESSION_BUS_ADDRESS=disabled` — the literal value WSL2-without-WSLg, minimal containers, and some root logins export — zbus rejects the address with `Error::Address("unsupported transport 'disabled'")`, the unwrap panics, and the whole app dies before any window is created.

The Sentry status was already toggled to "resolved" but the underlying code was never patched. We can't patch the upstream `.unwrap()` directly without forking the plugin, so the fix has to live in our own startup path.

## Solution

Detect the broken-D-Bus condition in our own code *before* the plugin's `setup()` runs, and skip registering the plugin when the probe says the session bus is unreachable.

**Probe logic** (`app/src-tauri/src/lib.rs`):

1. `dbus_address_is_supported(addr: &str) -> bool` — pure predicate. Walks the semicolon-separated `DBUS_SESSION_BUS_ADDRESS` list and accepts the entry only if its transport prefix is one zbus actually opens: `unix:`, `tcp:`, `launchd:`, `autolaunch:`. Rejects `disabled`, empty, whitespace, and unknown schemes.
2. `linux_dbus_session_reachable(env_addr, runtime_bus_socket_exists) -> bool` — pure predicate. Uses the env-var check when set, falls back to checking that `$XDG_RUNTIME_DIR/bus` exists when unset (which is where zbus auto-launches into).
3. `can_register_single_instance_plugin()` — Linux reads the env + socket and runs the probe; non-Linux always returns `true` so macOS/Windows behaviour is byte-identical to before.

**Plugin registration** is changed from an unconditional `.plugin(...)` to an `if can_register_single_instance_plugin() { … } else { log::warn!(...); builder }` reassignment. When the plugin IS registered, it remains the first plugin in the chain (the OPENHUMAN-TAURI-A ordering invariant is preserved). When it's skipped, a structured warning logs both env vars and tags the Sentry issue ID.

**Design decisions / tradeoffs:**

- *Conservative transport allowlist*: a false-positive ("reachable" when it isn't) is the only way the fix could fail to prevent the panic, so the list is restricted to transports zbus is guaranteed to handle. A false-negative ("unreachable" when zbus could have connected) just causes the plugin to be skipped — no crash, only loss of dedup enforcement on an exotic transport.
- *Skip vs. fallback*: on a system without D-Bus, single-instance enforcement via this plugin is fundamentally impossible. A graceful skip + warn is strictly better than crashing at startup. Users on WSL2 without WSLg get a working app; the dedup feature simply does not apply.
- *No upstream fork*: avoids the maintenance burden of vendoring `tauri-plugin-single-instance`. The probe lives entirely in our code and can be removed when we bump to a plugin version that handles `Err(Error::Address)` gracefully.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 8 unit tests in `tests` mod covering supported transports, the literal `disabled` value, empty/whitespace, unknown schemes, semicolon-separated alternation, and the `$XDG_RUNTIME_DIR/bus` fallback path.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: behaviour-only change to Tauri shell startup path; no new user-facing feature row required in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md).
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix rows touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure env-var + filesystem probe, no network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no user-visible UI surface changes; behaviour change only on a broken-environment failure path.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — references Sentry issue **OPENHUMAN-TAURI-TM** (no corresponding GitHub issue filed).

## Impact

- **Platforms**: Linux-only behaviour change. macOS and Windows code paths are identical to before this PR (`can_register_single_instance_plugin()` returns `true` unconditionally via `#[cfg(not(target_os = "linux"))]`).
- **Working Linux environments** (every normal desktop, WSL2 + WSLg, CI runners): no behaviour change. Single-instance plugin still registered as the first plugin, OPENHUMAN-TAURI-A race mitigation intact.
- **Broken Linux environments** (WSL2 without WSLg, minimal containers, root logins without `$XDG_RUNTIME_DIR/bus`): app now launches successfully with a `[single-instance] D-Bus session bus unreachable …` warning instead of panicking at startup. Single-instance enforcement is degraded — a second `OpenHuman` launch in these environments will spawn a separate process instead of focusing the existing window. This is acceptable: D-Bus is the only mechanism the plugin uses to detect duplicates on Linux, so in its absence the feature simply cannot work, and a working app without dedup is strictly better than no app at all.
- **Performance**: negligible. The probe runs once at startup and consists of two env-var reads plus one `Path::exists()` syscall.
- **Security**: no surface change. We don't open any new sockets, file descriptors, or IPC endpoints; we only read existing env vars and check whether a socket file exists.
- **Migration / compatibility**: none. No on-disk schema, no RPC method, no config key changes. Removing this fix in a future plugin upgrade is a simple revert.
- **Observability**: skip path emits a structured `log::warn!` with both `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` values, plus the Sentry tag `OPENHUMAN-TAURI-TM`, so production logs trivially distinguish "skipped because broken env" from "plugin failed for some other reason".

## Related

- Closes: [OPENHUMAN-TAURI-TM](https://tinyhumans.sentry.io/issues/7486215348/?environment=development&environment=production&environment=staging&project=4511287579836416&query=is%3Aunresolved%20assigned%3Anone&referrer=issue-stream&sort=freq)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability on Linux systems by adding detection logic to gracefully handle single-instance functionality initialization when certain session services are unavailable; the app now logs diagnostic information in these cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->