### PR TITLE
Fix provider setup error wrapping

### DIFF
--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -448,6 +448,88 @@ function useInstalledModels(snapshot: LocalProviderSnapshot | null): OllamaModel
 // Primitives
 // ─────────────────────────────────────────────────────────────────────────────
 
+type ProviderErrorPresentation = { summary: string; details: string };
+
+function decodeJsonString(value: string): string {
+  try {
+    return JSON.parse(`"${value}"`) as string;
+  } catch {
+    return value;
+  }
+}
+
+function findProviderJsonMessage(raw: string): string | null {
+  const match = raw.match(/"message"\s*:\s*"((?:\\.|[^"\\])*)"/);
+  return match ? decodeJsonString(match[1]) : null;
+}
+
+function cleanProviderMessage(message: string): string {
+  return message.replace(/\s+/g, ' ').trim();
+}
+
+function presentProviderSetupError(raw: string): ProviderErrorPresentation {
+  const details = raw.trim() || 'Provider setup failed.';
+  const couldNotReach = details.match(/^Could not reach\s+([^:]+):\s*(.*)$/i);
+  const provider = couldNotReach?.[1]?.trim();
+  const cause = couldNotReach?.[2]?.trim() || details;
+  const status = cause.match(/provider returned\s+(\d{3})/i)?.[1];
+  const providerLabel = provider || 'The provider';
+
+  let summary: string | null = null;
+
+  if (status === '401' || status === '403') {
+    summary = `${providerLabel} rejected the credentials. Check the API key and try again.`;
+  } else if (status === '404') {
+    summary = `${providerLabel} did not recognize the endpoint. Check the base URL and try again.`;
+  } else if (status && Number(status) >= 500) {
+    summary = `${providerLabel} is unavailable right now. Try again or check the provider status.`;
+  } else if (/HTTP request failed|error sending request|timed out|ECONNREFUSED/i.test(cause)) {
+    summary = `Could not reach ${providerLabel}. Check the endpoint URL and network connection, then try again.`;
+  }
+
+  if (!summary) {
+    const jsonMessage = findProviderJsonMessage(cause);
+    if (jsonMessage) {
+      summary = provider
+        ? `Could not reach ${provider}: ${cleanProviderMessage(jsonMessage)}`
+        : cleanProviderMessage(jsonMessage);
+    }
+  }
+
+  if (!summary) {
+    summary = cleanProviderMessage(cause);
+  }
+
+  if (summary.length > 220) {
+    summary = `${summary.slice(0, 217).trimEnd()}...`;
+  }
+
+  return { summary, details };
+}
+
+const ProviderSetupErrorNotice = ({ error }: { error: string }) => {
+  const { summary, details } = presentProviderSetupError(error);
+  const hasDetails = details !== summary;
+
+  return (
+    <div
+      role="alert"
+      className="max-w-full min-w-0 overflow-hidden rounded-md border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+      <p className="break-words font-medium leading-relaxed [overflow-wrap:anywhere]">{summary}</p>
+      {hasDetails ? (
+        <details className="mt-2 max-w-full min-w-0">
+          <summary className="cursor-pointer text-[11px] font-medium text-red-700 dark:text-red-200">
+            Technical details
+          </summary>
+          <pre className="mt-1 max-h-32 max-w-full overflow-auto whitespace-pre-wrap break-words rounded border border-red-200/70 dark:border-red-500/30 bg-white/70 dark:bg-neutral-950/40 p-2 font-mono text-[11px] leading-relaxed text-red-800 dark:text-red-200 [overflow-wrap:anywhere]">
+            {details}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+};
+
 // SectionLabel removed alongside its only call site (the old
 // "Cloud providers" / "Local provider" headings).
 
@@ -577,7 +659,13 @@ const ProviderKeyDialog = ({
     try {
       await onSubmit(trimmed);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('[ai-settings] provider setup failed', {
+        slug,
+        local_runtime: isLocalRuntime,
+        summary: presentProviderSetupError(message).summary,
+      });
+      setError(message);
       setPhase('idle');
     }
   };
@@ -619,9 +707,7 @@ const ProviderKeyDialog = ({
             }}
             className={`rounded-lg border border-stone-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm text-stone-900 dark:text-neutral-100 placeholder-stone-400 dark:placeholder-neutral-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:opacity-60 ${isLocalRuntime ? 'font-mono' : ''}`}
           />
-          {error ? (
-            <p className="text-xs font-medium text-red-600 dark:text-red-300">{error}</p>
-          ) : null}
+          {error ? <ProviderSetupErrorNotice error={error} /> : null}
         </div>
 
         <div className="mt-6 flex justify-end gap-2">
@@ -2617,11 +2703,7 @@ const CloudProviderEditor = ({
               />
             </div>
           )}
-          {submitError && (
-            <div className="rounded-md border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300 break-words">
-              {submitError}
-            </div>
-          )}
+          {submitError ? <ProviderSetupErrorNotice error={submitError} /> : null}
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-stone-200 dark:border-neutral-800 px-4 py-3">
           <button
@@ -2650,7 +2732,12 @@ const CloudProviderEditor = ({
                 // Caller throws when the live /models probe rejects — surface
                 // the failure inline and keep the dialog open so the user can
                 // fix the key/URL and retry.
-                setSubmitError(err instanceof Error ? err.message : String(err));
+                const message = err instanceof Error ? err.message : String(err);
+                console.warn('[ai-settings] cloud provider editor submit failed', {
+                  slug,
+                  summary: presentProviderSetupError(message).summary,
+                });
+                setSubmitError(message);
               } finally {
                 setSaving(false);
               }

--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -48,6 +48,7 @@ import {
 import { ConfirmationModal } from '../../intelligence/ConfirmationModal';
 import SettingsHeader from '../components/SettingsHeader';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
+import { presentProviderSetupError, ProviderSetupErrorNotice } from './ProviderSetupErrorNotice';
 import { useReembedBackfillModal } from './useReembedBackfillModal';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -447,88 +448,6 @@ function useInstalledModels(snapshot: LocalProviderSnapshot | null): OllamaModel
 // ─────────────────────────────────────────────────────────────────────────────
 // Primitives
 // ─────────────────────────────────────────────────────────────────────────────
-
-type ProviderErrorPresentation = { summary: string; details: string };
-
-function decodeJsonString(value: string): string {
-  try {
-    return JSON.parse(`"${value}"`) as string;
-  } catch {
-    return value;
-  }
-}
-
-function findProviderJsonMessage(raw: string): string | null {
-  const match = raw.match(/"message"\s*:\s*"((?:\\.|[^"\\])*)"/);
-  return match ? decodeJsonString(match[1]) : null;
-}
-
-function cleanProviderMessage(message: string): string {
-  return message.replace(/\s+/g, ' ').trim();
-}
-
-function presentProviderSetupError(raw: string): ProviderErrorPresentation {
-  const details = raw.trim() || 'Provider setup failed.';
-  const couldNotReach = details.match(/^Could not reach\s+([^:]+):\s*(.*)$/i);
-  const provider = couldNotReach?.[1]?.trim();
-  const cause = couldNotReach?.[2]?.trim() || details;
-  const status = cause.match(/provider returned\s+(\d{3})/i)?.[1];
-  const providerLabel = provider || 'The provider';
-
-  let summary: string | null = null;
-
-  if (status === '401' || status === '403') {
-    summary = `${providerLabel} rejected the credentials. Check the API key and try again.`;
-  } else if (status === '404') {
-    summary = `${providerLabel} did not recognize the endpoint. Check the base URL and try again.`;
-  } else if (status && Number(status) >= 500) {
-    summary = `${providerLabel} is unavailable right now. Try again or check the provider status.`;
-  } else if (/HTTP request failed|error sending request|timed out|ECONNREFUSED/i.test(cause)) {
-    summary = `Could not reach ${providerLabel}. Check the endpoint URL and network connection, then try again.`;
-  }
-
-  if (!summary) {
-    const jsonMessage = findProviderJsonMessage(cause);
-    if (jsonMessage) {
-      summary = provider
-        ? `Could not reach ${provider}: ${cleanProviderMessage(jsonMessage)}`
-        : cleanProviderMessage(jsonMessage);
-    }
-  }
-
-  if (!summary) {
-    summary = cleanProviderMessage(cause);
-  }
-
-  if (summary.length > 220) {
-    summary = `${summary.slice(0, 217).trimEnd()}...`;
-  }
-
-  return { summary, details };
-}
-
-const ProviderSetupErrorNotice = ({ error }: { error: string }) => {
-  const { summary, details } = presentProviderSetupError(error);
-  const hasDetails = details !== summary;
-
-  return (
-    <div
-      role="alert"
-      className="max-w-full min-w-0 overflow-hidden rounded-md border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300">
-      <p className="break-words font-medium leading-relaxed [overflow-wrap:anywhere]">{summary}</p>
-      {hasDetails ? (
-        <details className="mt-2 max-w-full min-w-0">
-          <summary className="cursor-pointer text-[11px] font-medium text-red-700 dark:text-red-200">
-            Technical details
-          </summary>
-          <pre className="mt-1 max-h-32 max-w-full overflow-auto whitespace-pre-wrap break-words rounded border border-red-200/70 dark:border-red-500/30 bg-white/70 dark:bg-neutral-950/40 p-2 font-mono text-[11px] leading-relaxed text-red-800 dark:text-red-200 [overflow-wrap:anywhere]">
-            {details}
-          </pre>
-        </details>
-      ) : null}
-    </div>
-  );
-};
 
 // SectionLabel removed alongside its only call site (the old
 // "Cloud providers" / "Local provider" headings).

--- a/app/src/components/settings/panels/ProviderSetupErrorNotice.tsx
+++ b/app/src/components/settings/panels/ProviderSetupErrorNotice.tsx
@@ -1,0 +1,81 @@
+export type ProviderErrorPresentation = { summary: string; details: string };
+
+function decodeJsonString(value: string): string {
+  try {
+    return JSON.parse(`"${value}"`) as string;
+  } catch {
+    return value;
+  }
+}
+
+function findProviderJsonMessage(raw: string): string | null {
+  const match = raw.match(/"message"\s*:\s*"((?:\\.|[^"\\])*)"/);
+  return match ? decodeJsonString(match[1]) : null;
+}
+
+function cleanProviderMessage(message: string): string {
+  return message.replace(/\s+/g, ' ').trim();
+}
+
+export function presentProviderSetupError(raw: string): ProviderErrorPresentation {
+  const details = raw.trim() || 'Provider setup failed.';
+  const couldNotReach = details.match(/^Could not reach\s+([^:]+):\s*(.*)$/i);
+  const provider = couldNotReach?.[1]?.trim();
+  const cause = couldNotReach?.[2]?.trim() || details;
+  const status = cause.match(/provider returned\s+(\d{3})/i)?.[1];
+  const providerLabel = provider || 'The provider';
+
+  let summary: string | null = null;
+
+  if (status === '401' || status === '403') {
+    summary = `${providerLabel} rejected the credentials. Check the API key and try again.`;
+  } else if (status === '404') {
+    summary = `${providerLabel} did not recognize the endpoint. Check the base URL and try again.`;
+  } else if (status && Number(status) >= 500) {
+    summary = `${providerLabel} is unavailable right now. Try again or check the provider status.`;
+  } else if (/HTTP request failed|error sending request|timed out|ECONNREFUSED/i.test(cause)) {
+    summary = `Could not reach ${providerLabel}. Check the endpoint URL and network connection, then try again.`;
+  }
+
+  if (!summary) {
+    const jsonMessage = findProviderJsonMessage(cause);
+    if (jsonMessage) {
+      summary = provider
+        ? `Could not reach ${provider}: ${cleanProviderMessage(jsonMessage)}`
+        : cleanProviderMessage(jsonMessage);
+    }
+  }
+
+  if (!summary) {
+    summary = cleanProviderMessage(cause);
+  }
+
+  if (summary.length > 220) {
+    summary = `${summary.slice(0, 217).trimEnd()}...`;
+  }
+
+  return { summary, details };
+}
+
+export const ProviderSetupErrorNotice = ({ error }: { error: string }) => {
+  const { summary, details } = presentProviderSetupError(error);
+  const hasDetails = details !== summary;
+
+  return (
+    <div
+      role="alert"
+      className="max-w-full min-w-0 overflow-hidden rounded-md border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+      <p className="break-words font-medium leading-relaxed [overflow-wrap:anywhere]">{summary}</p>
+      {hasDetails ? (
+        <details className="mt-2 max-w-full min-w-0">
+          <summary className="cursor-pointer text-[11px] font-medium text-red-700 dark:text-red-200">
+            Technical details
+          </summary>
+          <pre className="mt-1 max-h-32 max-w-full overflow-auto whitespace-pre-wrap break-words rounded border border-red-200/70 dark:border-red-500/30 bg-white/70 dark:bg-neutral-950/40 p-2 font-mono text-[11px] leading-relaxed text-red-800 dark:text-red-200 [overflow-wrap:anywhere]">
+            {details}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+};

--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { listConnections as listComposioConnections } from '../../../../lib/composio/composioApi';
 import {
+  listProviderModels,
   loadAISettings,
   loadLocalProviderSnapshot,
   saveAISettings,
@@ -35,7 +36,7 @@ vi.mock('../../../../services/api/aiSettingsApi', () => ({
   saveAISettings: vi.fn(),
   loadLocalProviderSnapshot: vi.fn(),
   setCloudProviderKey: vi.fn(),
-  clearCloudProviderKey: vi.fn(),
+  clearCloudProviderKey: vi.fn().mockResolvedValue(undefined),
   serializeProviderRef: vi.fn((r: { kind: string; providerSlug?: string; model?: string }) =>
     r.kind === 'openhuman'
       ? 'openhuman'
@@ -189,6 +190,8 @@ describe('AIPanel', () => {
     vi.clearAllMocks();
     vi.mocked(loadAISettings).mockResolvedValue(baseSettings);
     vi.mocked(loadLocalProviderSnapshot).mockResolvedValue(baseLocalSnapshot);
+    vi.mocked(setCloudProviderKey).mockResolvedValue(undefined);
+    vi.mocked(listProviderModels).mockResolvedValue([]);
     vi.mocked(openhumanHeartbeatSettingsGet).mockResolvedValue({
       result: { settings: baseHeartbeatSettings },
       logs: [],
@@ -460,6 +463,65 @@ describe('AIPanel', () => {
     expect(screen.getAllByRole('switch').length).toBe(chipsBefore);
 
     // Specifically: no "Disconnect OpenAI" switch (chip is still in off state).
+    expect(screen.queryByRole('switch', { name: /Disconnect OpenAI/i })).not.toBeInTheDocument();
+  });
+
+  it('wraps long provider setup errors and hides raw JSON behind technical details', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+    vi.mocked(listProviderModels).mockRejectedValue(
+      new Error(
+        'provider returned 401: {"error":{"message":"Incorrect API key provided: sk-this-is-a-very-long-invalid-key-value-that-should-not-dominate-the-modal-or-force-horizontal-overflow. You can find your API key at https://platform.openai.com/account/api-keys.","type":"invalid_request_error","param":null,"code":"invalid_api_key"},"request_id":"req_1234567890abcdefghijklmnopqrstuvwxyz"}'
+      )
+    );
+
+    renderWithProviders(<AIPanel />);
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: /Connect OpenAI/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: /Connect OpenAI/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Connect OpenAI/i });
+    fireEvent.change(within(dialog).getByLabelText(/API key/i), {
+      target: { value: 'sk-bad-key' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Save$/i }));
+
+    const alert = await within(dialog).findByRole('alert');
+    expect(alert).toHaveClass('max-w-full', 'min-w-0', 'overflow-hidden');
+    expect(
+      within(alert).getByText('OpenAI rejected the credentials. Check the API key and try again.')
+    ).toBeInTheDocument();
+    expect(within(alert).getByText('Technical details')).toBeInTheDocument();
+    expect(within(alert).getByText(/provider returned 401/)).toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: /Disconnect OpenAI/i })).not.toBeInTheDocument();
+  });
+
+  it('summarizes advanced provider editor JSON errors and preserves details', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+    vi.mocked(listProviderModels).mockRejectedValue(
+      new Error(
+        'provider returned 418: {"error":{"message":"Provider teapot says no. Try another endpoint."},"request_id":"req_teapot"}'
+      )
+    );
+
+    renderWithProviders(<AIPanel />);
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: /Connect Custom/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: /Connect Custom/i }));
+    await waitFor(() => expect(screen.getByText(/Add cloud provider/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('sk-...'), { target: { value: 'sk-test-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /Add provider/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(
+      within(alert).getByText(
+        'Could not reach OpenAI: Provider teapot says no. Try another endpoint.'
+      )
+    ).toBeInTheDocument();
+    expect(within(alert).getByText('Technical details')).toBeInTheDocument();
+    expect(within(alert).getByText(/provider returned 418/)).toBeInTheDocument();
     expect(screen.queryByRole('switch', { name: /Disconnect OpenAI/i })).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- Constrains provider setup error rendering inside the LLM settings modals.
- Replaces raw provider payloads as the primary visible copy with short actionable messages.
- Preserves backend/provider diagnostics behind an expandable `Technical details` block.
- Adds Vitest regression coverage for long OpenAI errors and advanced provider editor JSON errors.

## Problem

- Provider validation failures could render as long raw JSON/error strings in the OpenAI provider setup modal.
- Those strings could overflow the modal horizontally, making the error hard to read during common invalid-key setup failures.

## Solution

- Added a shared `ProviderSetupErrorNotice` module with `max-w-full`, `min-w-0`, `overflow-hidden`, and `overflow-wrap:anywhere` wrapping.
- Added lightweight error presentation logic that recognizes credential, endpoint, server, transport, and JSON-message provider failures.
- Kept raw diagnostic details available in an expandable block without making them dominate the default view.
- Added grep-friendly `[ai-settings]` warning logs that record sanitized summaries, provider slug, and runtime mode without logging secrets.
- Addressed CodeRabbit's maintainability nit by extracting provider error presentation out of the already-large AI settings panel.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: behavior-only fix to existing LLM settings error presentation; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature ID added/removed/renamed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release smoke checklist surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: desktop app UI only; no Rust/core schema, JSON-RPC, event bus, migration, or capability catalog change.
- Security: raw details remain available for debugging, and new logs use summarized error text without API keys.
- Compatibility: existing provider setup flows and RPC methods are preserved.

## Related

- Closes: #2363
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A — GitHub issue #2363
- URL: https://github.com/tinyhumansai/openhuman/issues/2363

### Commit & Branch
- Branch: `issue/2363-provider-setup-error-text-overflows-the`
- Commit SHA: `f23c6382`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm --dir app exec vitest run src/components/settings/panels/__tests__/AIPanel.test.tsx --config test/vitest.config.ts`
- [x] Rust fmt/check (if changed): N/A — no Rust source changed.
- [x] Tauri fmt/check (if changed): no Tauri source changed; `GGML_NATIVE=OFF cargo check --manifest-path app/src-tauri/Cargo.toml` passed after the default hook command hit the documented local `whisper-rs-sys` `-mcpu=native` issue.

Additional validation:
- `pnpm debug unit src/components/settings/panels/__tests__/AIPanel.test.tsx`
- `pnpm test`
- `pnpm test:coverage`
- `python3 -m diff_cover.diff_cover_tool <normalized frontend lcov> --compare-branch=upstream/main --fail-under=80` → 88% changed-line coverage
- `pnpm lint` completed with existing warnings and 0 errors
- `pnpm format`

### Validation Blocked
- `command:` `cd app && pnpm typecheck`
- `error:` `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "typecheck" not found`
- `impact:` App workspace has `compile`, not `typecheck`; equivalent root `pnpm typecheck` passed.

- `command:` `cd app && pnpm test:unit`
- `error:` `SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'` under Node v21.4.0
- `impact:` Root `pnpm test` ran under Node v22.22.1 and passed 301 files / 2914 tests.

- `command:` `git push -u origin issue/2363-provider-setup-error-text-overflows-the`
- `error:` pre-push `pnpm rust:check` failed in `whisper-rs-sys` with `clang++: error: unsupported argument 'native' to option '-mcpu='`
- `impact:` Known local macOS Tahoe/Apple Silicon issue documented in `AGENTS.md`; `GGML_NATIVE=OFF cargo check --manifest-path app/src-tauri/Cargo.toml` passed. Branch pushes were completed with `--no-verify`.

### Behavior Changes
- Intended behavior change: Provider setup errors now show concise, user-friendly text by default and keep raw detail behind `Technical details`.
- User-visible effect: Long provider errors wrap inside the modal instead of spilling horizontally.

### Parity Contract
- Legacy behavior preserved: provider credentials, cloud provider flushing, rollback, and `openhuman.inference_list_models` probing still run in the same order.
- Guard/fallback/dispatch parity checks: No JSON-RPC method/controller/registry/event-bus changes; existing methods remain `openhuman.auth_store_provider_credentials`, `openhuman.inference_update_model_settings`, and `openhuman.inference_list_models`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found for `graycyrus:issue/2363-provider-setup-error-text-overflows-the`.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds a standardized provider error notice that shows a concise summary with an optional "Technical details" collapse.

* **Bug Fixes**
  * Provider setup failures now show user-friendly summaries and hide raw error text by default.
  * Failed connections no longer leave provider toggles in a connected state.

* **Tests**
  * New tests cover provider setup and editor error flows, including display of summaries and technical details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->