### PR TITLE
fix(tools): preserve Windows process env

### DIFF
--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -40,7 +40,28 @@ const MAX_OUTPUT_BYTES: usize = 1_048_576;
 /// into spawned node processes. `PATH` gets a prepend of the managed bin
 /// dir before being forwarded.
 const SAFE_ENV_VARS: &[&str] = &[
-    "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+    "HOME",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    // Windows process creation and child command lookup need these after env_clear().
+    // PATH is rebuilt separately with the managed Node bin dir prepended.
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "ProgramFiles",
+    "ProgramFiles(x86)",
+    "ProgramW6432",
 ];
 
 /// `node_exec` — execute JavaScript through the resolved Node.js runtime.
@@ -354,5 +375,15 @@ mod tests {
         let ws = std::path::Path::new("/ws");
         let resolved = resolve_script_path(ws, "scripts/run.js").unwrap();
         assert_eq!(resolved, std::path::Path::new("/ws/scripts/run.js"));
+    }
+
+    #[test]
+    fn safe_env_vars_include_windows_process_essentials() {
+        for var in ["SystemRoot", "COMSPEC", "PATHEXT", "TEMP", "USERPROFILE"] {
+            assert!(
+                SAFE_ENV_VARS.contains(&var),
+                "{var} must be forwarded for Windows child processes"
+            );
+        }
     }
 }

--- a/src/openhuman/tools/impl/system/npm_exec.rs
+++ b/src/openhuman/tools/impl/system/npm_exec.rs
@@ -35,7 +35,28 @@ const NPM_TIMEOUT_MAX_SECS: u64 = 1800;
 const MAX_OUTPUT_BYTES: usize = 1_048_576;
 /// Env allow-list — matches the shell / node_exec tools.
 const SAFE_ENV_VARS: &[&str] = &[
-    "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+    "HOME",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    // Windows process creation and child command lookup need these after env_clear().
+    // PATH is rebuilt separately with the managed Node bin dir prepended.
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "ProgramFiles",
+    "ProgramFiles(x86)",
+    "ProgramW6432",
 ];
 
 /// Subcommands we outright refuse to run. These either break the managed
@@ -372,5 +393,15 @@ mod tests {
         let ws = std::path::Path::new("/tmp/ws");
         let got = resolve_cwd(ws, Some("app")).unwrap();
         assert_eq!(got, std::path::PathBuf::from("/tmp/ws/app"));
+    }
+
+    #[test]
+    fn safe_env_vars_include_windows_process_essentials() {
+        for var in ["SystemRoot", "COMSPEC", "PATHEXT", "TEMP", "USERPROFILE"] {
+            assert!(
+                SAFE_ENV_VARS.contains(&var),
+                "{var} must be forwarded for Windows child processes"
+            );
+        }
     }
 }

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -14,7 +14,28 @@ const MAX_OUTPUT_BYTES: usize = 1_048_576;
 /// Environment variables safe to pass to shell commands.
 /// Only functional variables are included — never API keys or secrets.
 const SAFE_ENV_VARS: &[&str] = &[
-    "PATH", "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+    "PATH",
+    "HOME",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    // Windows process creation and child command lookup need these after env_clear().
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "ProgramFiles",
+    "ProgramFiles(x86)",
+    "ProgramW6432",
 ];
 
 /// Shell command execution tool with sandboxing
@@ -614,6 +635,16 @@ mod tests {
             SAFE_ENV_VARS.contains(&"TERM"),
             "TERM must be in safe env vars"
         );
+    }
+
+    #[test]
+    fn shell_safe_env_vars_include_windows_process_essentials() {
+        for var in ["SystemRoot", "COMSPEC", "PATHEXT", "TEMP", "USERPROFILE"] {
+            assert!(
+                SAFE_ENV_VARS.contains(&var),
+                "{var} must be forwarded for Windows child processes"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- forward Windows process essentials through the shell, node_exec, and npm_exec env allowlists after env_clear()
- keep managed Node PATH rebuilding intact while preserving PATHEXT/COMSPEC/SystemRoot and user temp/profile paths
- add regression coverage for the Windows env allowlist entries

Refs #2379

## Testing
- [x] cargo fmt --all --check
- [x] git diff --check
- [x] cargo test windows_process_essentials --lib (fails before tests: whisper-rs-sys cannot find clang.dll/libclang.dll in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows compatibility for system command execution by ensuring all essential Windows environment variables are properly configured for subprocess creation and lookup operations.

* **Tests**
  * Added unit test coverage to verify that required Windows environment variables are present and properly configured in system execution contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->