### PR TITLE
fix(auth): refresh RPC cache before deep-link session store

### DIFF
--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -33,6 +33,13 @@ const waitForOAuthAuthReadiness = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ ready: true as const })
 );
 
+const coreRpcCache = vi.hoisted(() => ({
+  clearCoreRpcUrlCache: vi.fn(),
+  clearCoreRpcTokenCache: vi.fn(),
+}));
+
+vi.mock('../../services/coreRpcClient', () => coreRpcCache);
+
 vi.mock('../oauthAppVersionGate', async importOriginal => {
   const actual = await importOriginal<typeof import('../oauthAppVersionGate')>();
   return {
@@ -59,6 +66,8 @@ describe('desktopDeepLinkListener', () => {
     waitForOAuthAuthReadiness.mockResolvedValue({ ready: true });
     vi.mocked(storeSession).mockReset();
     vi.mocked(storeSession).mockResolvedValue(undefined);
+    coreRpcCache.clearCoreRpcUrlCache.mockClear();
+    coreRpcCache.clearCoreRpcTokenCache.mockClear();
     windowControls.show.mockClear();
     windowControls.unminimize.mockClear();
     windowControls.setFocus.mockClear();
@@ -172,6 +181,8 @@ describe('desktopDeepLinkListener', () => {
     await waitForAuthSettled();
 
     expect(storeSession).toHaveBeenCalledWith('abc', {});
+    expect(coreRpcCache.clearCoreRpcUrlCache).toHaveBeenCalledTimes(1);
+    expect(coreRpcCache.clearCoreRpcTokenCache).toHaveBeenCalledTimes(1);
     expect(getDeepLinkAuthState().isProcessing).toBe(false);
   });
 

--- a/app/src/utils/desktopDeepLinkListener.ts
+++ b/app/src/utils/desktopDeepLinkListener.ts
@@ -4,6 +4,7 @@ import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 import { patchCoreStateSnapshot } from '../lib/coreState/store';
 import { consumeLoginToken } from '../services/api/authApi';
+import { clearCoreRpcTokenCache, clearCoreRpcUrlCache } from '../services/coreRpcClient';
 import {
   beginDeepLinkAuthProcessing,
   completeDeepLinkAuthProcessing,
@@ -76,6 +77,8 @@ const focusMainWindow = async () => {
 };
 
 const applySessionToken = async (sessionToken: string): Promise<void> => {
+  clearCoreRpcUrlCache();
+  clearCoreRpcTokenCache();
   await storeSession(sessionToken, {});
   patchCoreStateSnapshot({ snapshot: { sessionToken } });
   window.dispatchEvent(new CustomEvent(SESSION_TOKEN_UPDATED_EVENT, { detail: { sessionToken } }));


### PR DESCRIPTION
## Summary
- clear cached core RPC URL/token immediately before storing an OAuth deep-link session token
- ensures remote-core selections saved during boot are used for auth_store_session instead of a stale local sidecar cache
- extends the deep-link listener regression test to cover cache invalidation before session storage

Fixes #2377

## Testing
- [x] app: prettier --check src/utils/desktopDeepLinkListener.ts src/utils/__tests__/desktopDeepLinkListener.test.ts
- [x] app: pnpm test:unit src/utils/__tests__/desktopDeepLinkListener.test.ts
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the desktop deep-link login process by ensuring cached authentication data is properly cleared when a new session is established, preventing potential issues with stale cached information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->