### PR TITLE
ci(release): reject AppImage with bad sharun lib path

### DIFF
--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -236,6 +236,24 @@ ensure_sharun_interpreter() {
   return 0
 }
 
+validate_sharun_lib_path() {
+  local appdir="$1"
+  if ! uses_sharun_launcher "$appdir"; then
+    return 0
+  fi
+
+  local lib_path="$appdir/shared/lib/lib.path"
+  if [ ! -s "$lib_path" ]; then
+    echo "[strip-libs] ERROR: sharun AppImage is missing shared/lib/lib.path; refusing to ship an AppImage that exits with 'Interpreter not found!'" >&2
+    exit 1
+  fi
+
+  if grep -E '(^|[+:])/home/runner/|(^|[+:])/__w/' "$lib_path" >/dev/null; then
+    echo "[strip-libs] ERROR: shared/lib/lib.path contains CI runner paths; regenerate it with bundle-relative entries before release." >&2
+    exit 1
+  fi
+}
+
 strip_one_appimage() {
   local img="$1"
   local original
@@ -286,6 +304,7 @@ strip_one_appimage() {
   if ensure_sharun_interpreter "$appdir"; then
     added_loader=1
   fi
+  validate_sharun_lib_path "$appdir"
 
   if [ "$removed" -eq 0 ] && [ "$added_loader" -eq 0 ]; then
     echo "[strip-libs] No graphics libs or missing sharun interpreter found in $original; leaving unchanged."


### PR DESCRIPTION
## Summary
- fail AppImage release post-processing when a sharun bundle is missing shared/lib/lib.path
- reject lib.path files that still contain GitHub Actions runner paths
- keeps the existing sharun interpreter repair in place while preventing non-portable AppImages from shipping

Refs #2242
Refs #2368

## Testing
- [x] bash -n scripts/release/strip-appimage-graphics-libs.sh
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced AppImage release validation to ensure proper library path configuration and prevent invalid builds from being released.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->