### PR TITLE
docs(e2e): add desktop deep-link smoke

### DIFF
--- a/gitbooks/developing/e2e-testing.md
+++ b/gitbooks/developing/e2e-testing.md
@@ -119,6 +119,19 @@ Use `waitForTestId(testId)` and `clickTestId(testId)` from `element-helpers.ts` 
 - **tauri-driver**: `browser.execute(window.__simulateDeepLink(url))` (primary), `xdg-open` (fallback)
 - **Appium Mac2**: `macos: deepLink` extension command (primary), `open -a ...` (fallback)
 
+For release candidates, also run one manual secondary-instance smoke on Linux
+or macOS when touching CEF preflight, single-instance, or deep-link startup
+code:
+
+1. Launch OpenHuman normally and leave it running.
+2. Trigger `openhuman://auth?token=e2e-token&key=auth` through the OS opener.
+3. Confirm the already-running window receives the callback and does not start
+   a second full CEF instance.
+4. Confirm the secondary process exits cleanly without a CEF cache-lock error.
+
+This catches the class of regressions where a secondary process exits during
+CEF cache preflight before Tauri's deep-link forwarding path is installed.
+
 ### Writing cross-platform specs
 
 1. **Use helpers** from `element-helpers.ts`, never use raw `XCUIElementType*` selectors in specs


### PR DESCRIPTION
## Summary
- document a manual Linux/macOS secondary-instance deep-link smoke test
- cover openhuman://auth forwarding while an app instance is already running
- call out the CEF cache-preflight failure mode this catches

Refs #2359

## Testing
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added manual test checklist for release candidates covering secondary-instance smoke testing
  * Includes verification scenarios for deep link authentication, proper window handling, CEF instance management, and clean process exit without cache-lock errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->