### PR TITLE
docs(linux): add AppImage failure notes

### DIFF
--- a/gitbooks/features/platform.md
+++ b/gitbooks/features/platform.md
@@ -19,6 +19,23 @@ OpenHuman is a native desktop application, not a browser extension, not an Elect
 | **Windows** | x64, ARM64           | `.msi` installer           |
 | **Linux**   | x64                  | AppImage, `.deb`           |
 
+### Linux AppImage notes
+
+The Linux AppImage is built for x64 desktops and is the default asset selected
+by the curl installer. On newer distributions, especially builds that tighten
+unprivileged user namespaces or AppArmor defaults, AppImage startup can fail
+before OpenHuman reaches its own crash reporter. Known symptoms include:
+
+- `unshare: write failed /proc/self/uid_map: Operation not permitted`
+- `Interpreter not found!`
+- `cannot execute binary file`
+
+When that happens, prefer the `.deb` package on Debian/Ubuntu systems. For
+Fedora, openSUSE, and other non-Debian distributions, include the distro
+version, kernel version, GPU/driver stack, and the exact AppImage filename when
+reporting the issue so maintainers can distinguish host restrictions from a
+badly packaged AppImage runtime.
+
 ***
 
 ## Why native matters


### PR DESCRIPTION
## Summary
- document known Linux AppImage startup symptoms such as unshare uid_map failures, Interpreter not found, and cannot execute binary file
- point Debian/Ubuntu users to the .deb package when AppImage startup is blocked by host restrictions
- list diagnostics maintainers need for Fedora/openSUSE/non-Debian reports

Refs #2368
Refs #2380
Refs #2231

## Checks
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Linux AppImage documentation including platform specifications (x64-targeted, default asset for curl installer), common startup failure scenarios with root causes (namespace/permission issues, missing interpreter, execution errors), recommended troubleshooting steps (fallback to .deb on Debian/Ubuntu systems), and required diagnostic information for issue reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->