### PR TITLE
docs(installer): print Linux AppImage fallback hint

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -621,9 +621,10 @@ EOF
   echo ""
   echo "OpenHuman is ready."
   echo "Launch: ${app_path}"
-  echo "If the AppImage prints 'Interpreter not found!' or an unshare uid_map"
-  echo "error, try the .deb package on Debian/Ubuntu or report your distro,"
-  echo "kernel, GPU driver, and ${ASSET_NAME}."
+  echo "If the AppImage prints 'Interpreter not found!' or unshare/uid_map errors,"
+  echo "try the .deb package from https://github.com/${REPO}/releases/latest"
+  echo "(Debian/Ubuntu) or report at https://github.com/${REPO}/issues with your"
+  echo "distro, kernel (uname -a), GPU driver (lspci), dmesg excerpt, and asset: ${ASSET_NAME}."
   echo "Uninstall: rm -f \"${app_path}\" \"${desktop_file}\""
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -621,6 +621,9 @@ EOF
   echo ""
   echo "OpenHuman is ready."
   echo "Launch: ${app_path}"
+  echo "If the AppImage prints 'Interpreter not found!' or an unshare uid_map"
+  echo "error, try the .deb package on Debian/Ubuntu or report your distro,"
+  echo "kernel, GPU driver, and ${ASSET_NAME}."
   echo "Uninstall: rm -f \"${app_path}\" \"${desktop_file}\""
 }
 


### PR DESCRIPTION
## Summary
- add a Linux installer post-install hint for AppImage startup failures
- mention the Debian/Ubuntu .deb fallback for Interpreter not found and unshare uid_map errors
- ask reporters for distro, kernel, GPU driver, and exact AppImage asset name

Refs #2380
Refs #2368

## Checks
- [x] bash -n scripts/install.sh
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux installer post-install messaging to help when the AppImage fails to run (e.g., missing interpreter or unshare/uid_map errors). Guidance now suggests trying the .deb package and, if problems persist, filing an issue with distro and kernel info, GPU/driver details, a dmesg excerpt, and the detected installer asset name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->