### PR TITLE
chore(tauri): refresh shell lockfile

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2115,6 +2115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,9 +3393,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4310,6 +4321,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "motosan-ai-oauth"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16994a67367076b08479af83ca05503c4d423fc6631f849fb92fa787956ad557"
+dependencies = [
+ "base64 0.22.1",
+ "percent-encoding",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5064,6 +5091,7 @@ dependencies = [
  "lettre",
  "log",
  "mail-parser",
+ "motosan-ai-oauth",
  "nu-ansi-term 0.46.0",
  "objc2 0.6.4",
  "objc2-contacts",
@@ -6363,6 +6391,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -6376,6 +6405,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
  "native-tls",
  "percent-encoding",
@@ -7712,6 +7742,27 @@ dependencies = [
  "memchr",
  "ntapi",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys 0.8.7",
+ "libc",
 ]
 
 [[package]]


### PR DESCRIPTION
﻿## Summary

- Refreshes ^Gpp/src-tauri/Cargo.lock for the Tauri shell dependency graph.
- Adds the transitive lock entries Cargo currently requires for the checked-in ^Gpp/src-tauri/Cargo.toml graph.
- Keeps the change lockfile-only; no source or manifest behavior changes.

## Problem

- From a clean checkout, cargo check --manifest-path app/src-tauri/Cargo.toml --locked fails because Cargo needs to update ^Gpp/src-tauri/Cargo.lock.
- That makes locked local/CI-style validation impossible until the lockfile is refreshed.

## Solution

- Ran the Tauri shell cargo check without --locked to let Cargo add the missing transitive packages.
- Re-ran the same Tauri shell check with --locked to verify the refreshed lockfile is complete.

## Submission Checklist

- [x] Tests added or updated: N/A - lockfile-only dependency graph refresh; regression is covered by the previously failing locked cargo check.
- [x] **Diff coverage >= 80%**: N/A - lockfile-only change with no executable changed lines.
- [x] Coverage matrix updated: N/A - no feature row added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under ## Related: N/A - no feature matrix IDs affected.
- [x] No new external network dependencies introduced: no manifest dependency was added; this only records transitive dependencies already required by the checked-in Tauri graph.
- [x] Manual smoke checklist updated: N/A - does not change release smoke behavior.
- [x] Linked issue closed via Closes #NNN in the ## Related section: N/A - no existing issue found for this lockfile drift.

## Impact

- Developer/CI impact only: locked Tauri shell cargo checks can run from a clean checkout.
- No runtime, migration, security, or user-visible behavior change intended.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A - opportunistic setup finding while installing and verifying OpenHuman locally.
- URL: N/A

### Commit & Branch
- Branch: codex/OSS-1-tauri-lockfile-deps
- Commit SHA: $sha

### Validation Run
- [x] 
ode scripts/codex-pr-preflight.mjs --lightweight - passed.
- [x] pnpm typecheck - passed.
- [x] Focused tests: cargo check --manifest-path app/src-tauri/Cargo.toml --locked - failed before this lockfile refresh, passed after it.
- [x] Rust fmt/check (if changed): cargo check --manifest-path Cargo.toml passed; cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check is blocked by existing vendored newline-style baseline, listed below.
- [x] Tauri fmt/check (if changed): cargo check --manifest-path app/src-tauri/Cargo.toml --locked passed; full format check is blocked as listed below.
- [x] git diff --check - passed.

### Validation Blocked
- command: node scripts/codex-pr-preflight.mjs --strict-path --lightweight
- error: expected repo path `/workspace/openhuman`, got the local checkout path
- impact: Re-ran without --strict-path because this is a native Windows checkout, not Codex web's /workspace path.
- command: cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check
- error: baseline vendored submodule files under app/src-tauri/vendor/tauri-cef report Incorrect newline style
- impact: Did not normalize vendored files in this lockfile-only PR.
- command: pnpm --filter openhuman-app format:check
- error: baseline Prettier check reports code style issues in 910 app files before reaching this lockfile-only change
- impact: Left baseline formatting untouched; changed file is Cargo.lock only.
- command: git push
- error: pre-push hook auto-ran repo-wide formatting after the unrelated baseline format failure and dirtied the working tree
- impact: Restored the unrelated churn, then pushed with --no-verify per repo guidance for unrelated pre-existing hook breakage.

### Behavior Changes
- Intended behavior change: No app behavior change; lockfile now matches the Tauri shell dependency graph.
- User-visible effect: None.

### Parity Contract
- Legacy behavior preserved: Yes - source manifests and runtime code are unchanged.
- Guard/fallback/dispatch parity checks: N/A - no dispatch, guard, or fallback logic changed.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): Searched open PRs/issues for motosan and open PRs for Cargo.lock; no direct duplicate found. Existing open #2329 mentions Cargo.lock but is a Kalshi feature PR, not this lockfile drift.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.