### PR TITLE
fix(security): allow Windows read commands

### DIFF
--- a/src/openhuman/config/schema/autonomy.rs
+++ b/src/openhuman/config/schema/autonomy.rs
@@ -57,6 +57,12 @@ fn default_allowed_commands() -> Vec<String> {
         "wc".into(),
         "head".into(),
         "tail".into(),
+        "date".into(),
+        "dir".into(),
+        "type".into(),
+        "where".into(),
+        "findstr".into(),
+        "more".into(),
     ]
 }
 

--- a/src/openhuman/config/schema/autonomy.rs
+++ b/src/openhuman/config/schema/autonomy.rs
@@ -57,7 +57,6 @@ fn default_allowed_commands() -> Vec<String> {
         "wc".into(),
         "head".into(),
         "tail".into(),
-        "date".into(),
         "dir".into(),
         "type".into(),
         "where".into(),

--- a/src/openhuman/security/policy.rs
+++ b/src/openhuman/security/policy.rs
@@ -120,6 +120,13 @@ impl Default for SecurityPolicy {
                 "head".into(),
                 "tail".into(),
                 "date".into(),
+                // Windows read-only equivalents for the same basic
+                // inspection workflows as ls/cat/grep/which.
+                "dir".into(),
+                "type".into(),
+                "where".into(),
+                "findstr".into(),
+                "more".into(),
             ],
             forbidden_paths: vec![
                 // System directories (blocked even when workspace_only=false)

--- a/src/openhuman/security/policy_tests.rs
+++ b/src/openhuman/security/policy_tests.rs
@@ -100,6 +100,7 @@ fn allowed_commands_include_windows_read_equivalents() {
         "type README.md",
         "where node",
         "findstr pattern file.txt",
+        "more README.md",
     ] {
         assert!(
             p.is_command_allowed(command),
@@ -112,7 +113,19 @@ fn allowed_commands_include_windows_read_equivalents() {
 fn config_default_policy_includes_windows_read_equivalents() {
     let cfg = crate::openhuman::config::AutonomyConfig::default();
     let p = SecurityPolicy::from_config(&cfg, std::path::Path::new("."));
-    assert!(p.is_command_allowed("where node"));
+    for command in [
+        "dir",
+        "type README.md",
+        "where node",
+        "findstr pattern file.txt",
+        "more README.md",
+    ] {
+        assert!(
+            p.is_command_allowed(command),
+            "config-derived policy should allow Windows read-only command: {command}"
+        );
+    }
+    assert!(!p.is_command_allowed("date 2026-05-21"));
 }
 
 #[test]

--- a/src/openhuman/security/policy_tests.rs
+++ b/src/openhuman/security/policy_tests.rs
@@ -93,6 +93,29 @@ fn allowed_commands_basic() {
 }
 
 #[test]
+fn allowed_commands_include_windows_read_equivalents() {
+    let p = default_policy();
+    for command in [
+        "dir",
+        "type README.md",
+        "where node",
+        "findstr pattern file.txt",
+    ] {
+        assert!(
+            p.is_command_allowed(command),
+            "default policy should allow Windows read-only command: {command}"
+        );
+    }
+}
+
+#[test]
+fn config_default_policy_includes_windows_read_equivalents() {
+    let cfg = crate::openhuman::config::AutonomyConfig::default();
+    let p = SecurityPolicy::from_config(&cfg, std::path::Path::new("."));
+    assert!(p.is_command_allowed("where node"));
+}
+
+#[test]
 fn blocked_commands_basic() {
     let p = default_policy();
     assert!(!p.is_command_allowed("rm -rf /"));


### PR DESCRIPTION
## Summary

- Adds Windows read-only command equivalents to the default security policy allowlist: `dir`, `type`, `where`, `findstr`, and `more`.
- Adds the same Windows-safe read commands to `AutonomyConfig::default()` without broadening config-derived policy to allow mutating `date` usage.
- Adds regression tests for default policy and config-derived policy behavior.
- Complements #2382, which covers the Windows child-process env allowlist portion of #2379.

## Problem

- #2379 reports that the tool defaults are POSIX-only on Windows: commands like `ls`, `cat`, `grep`, and `which` do not map to native Windows read/lookup workflows.
- #2382 addresses the env propagation half of the bug, but does not update the policy/config command defaults.
- Without this companion change, Windows users can still be blocked from basic read-only inspection commands even after subprocess env propagation is fixed.

## Solution

- Extend the default `SecurityPolicy` allowlist with native Windows read/lookup equivalents.
- Extend `AutonomyConfig::default_allowed_commands()` with the same Windows read/lookup entries, while leaving `date` out of config defaults because mutating forms can change the system clock.
- Cover both direct default policy and config-derived policy paths in Rust tests, including a guard against config-derived `date 2026-05-21` being allowed.
- Deliberately leaves shell runtime selection unchanged here; switching native Windows shell semantics also touches `node_exec`/`npm_exec` quoting and should be handled as a separate, targeted follow-up if needed.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — CI Coverage Gate passed.
- [x] Coverage matrix updated — N/A: small behavior-only security default change, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: this complements #2382 for #2379 and should not close the issue alone.

## Impact

- Runtime/platform impact: Windows users get native read-only inspection commands admitted by default policy/config.
- Security impact: added commands are read/lookup oriented and parallel existing POSIX defaults (`ls`, `cat`, `grep`, `which`, paged output). Config defaults intentionally do not add `date`.
- No migration or external dependency impact.

## Related

- Closes: N/A: companion PR for #2379; #2382 covers the env propagation half.
- Follow-up PR(s)/TODOs: #2382 should land with this to cover both env and default allowlist facets.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/GH-2379-windows-tool-env`
- Commit SHA: `05e8203aacce2b99d68465d113018863c97c5b09`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed via pre-push hook.
- [x] `pnpm typecheck` — passed via pre-push hook (`pnpm compile`).
- [x] Focused tests:
  - `GGML_NATIVE=OFF pnpm debug rust allowed_commands_include_windows_read_equivalents` — log confirms 1 passed.
  - `GGML_NATIVE=OFF pnpm debug rust config_default_policy_includes_windows_read_equivalents` — log confirms 1 passed.
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --all`
  - `cargo fmt --manifest-path Cargo.toml --all --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): `pnpm rust:check` passed via pre-push hook.
- [x] Additional validation:
  - `git diff --check`
  - `node scripts/codex-pr-preflight.mjs --lightweight`
  - pre-push hook also ran `pnpm lint` and `pnpm lint:commands-tokens` successfully; lint emitted existing warnings only.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: default policies now allow Windows-native read/lookup commands.
- User-visible effect: Windows shell-tool users can perform basic directory listing, file display, command lookup, and text search without custom allowlist config.

### Parity Contract
- Legacy behavior preserved: existing POSIX defaults remain unchanged.
- Guard/fallback/dispatch parity checks: `SecurityPolicy::default()` and `AutonomyConfig::default()` both include the Windows read/lookup command set; config-derived policy does not add `date`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: #2382 for the env propagation portion of #2379.
- Resolution (closed/superseded/updated): this PR is intentionally non-overlapping and complements #2382 by covering the default command allowlist gap.
