### PR TITLE
ci(i18n): add zh-CN desktop bundle guard

### DIFF
--- a/app/src/components/LanguageSelect.tsx
+++ b/app/src/components/LanguageSelect.tsx
@@ -8,7 +8,7 @@ import { setLocale } from '../store/localeSlice';
 const LOCALE_OPTIONS: Array<{ value: Locale; flag: string; label: string }> = [
   { value: 'en', flag: '🇬🇧', label: 'English' },
   { value: 'ko', flag: '🇰🇷', label: '한국어' },
-  { value: 'zh-CN', flag: '🇨🇳', label: '中文' },
+  { value: 'zh-CN', flag: '🇨🇳', label: '简体中文' },
   { value: 'hi', flag: '🇮🇳', label: 'हिन्दी' },
   { value: 'es', flag: '🇪🇸', label: 'Español' },
   { value: 'ar', flag: '🇸🇦', label: 'العربية' },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "rust:check": "pnpm --filter openhuman-app rust:check",
     "typecheck": "pnpm --filter openhuman-app compile",
     "i18n:check": "tsx scripts/i18n-coverage.ts",
+    "i18n:bundle:check": "node scripts/verify-i18n-bundle.mjs",
     "i18n:dump": "tsx scripts/i18n-coverage.ts --no-unused --out tmp/i18n-coverage"
   },
   "devDependencies": {

--- a/scripts/verify-i18n-bundle.mjs
+++ b/scripts/verify-i18n-bundle.mjs
@@ -46,13 +46,13 @@ const requiredMarkers = [
   },
   {
     label: "Simplified Chinese picker label",
-    needles: ["\u4e2d\u6587", "\\u4e2d\\u6587"],
+    needles: ["\u7b80\u4f53\u4e2d\u6587", "\\u7b80\\u4f53\\u4e2d\\u6587"],
   },
 ];
 
-if (!existsSync(distDir)) {
+if (!existsSync(distDir) || !statSync(distDir).isDirectory()) {
   console.error(
-    `verify-i18n-bundle: dist directory does not exist: ${distDir}`,
+    `verify-i18n-bundle: dist directory does not exist or is not a directory: ${distDir}`,
   );
   process.exit(1);
 }

--- a/scripts/verify-i18n-bundle.mjs
+++ b/scripts/verify-i18n-bundle.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+let distDir = resolve(root, "app/dist");
+
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (arg === "--dist") {
+    const value = process.argv[i + 1];
+    if (!value) {
+      console.error("verify-i18n-bundle: --dist requires a path");
+      process.exit(2);
+    }
+    distDir = resolve(process.cwd(), value);
+    i += 1;
+  } else if (arg === "--help" || arg === "-h") {
+    console.log("Usage: node scripts/verify-i18n-bundle.mjs [--dist app/dist]");
+    process.exit(0);
+  } else {
+    console.error(`verify-i18n-bundle: unknown argument: ${arg}`);
+    process.exit(2);
+  }
+}
+
+function listJsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      out.push(...listJsFiles(path));
+    } else if (entry.endsWith(".js")) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+const requiredMarkers = [
+  {
+    label: "zh-CN locale key",
+    needles: ["zh-CN"],
+  },
+  {
+    label: "Simplified Chinese picker label",
+    needles: ["\u4e2d\u6587", "\\u4e2d\\u6587"],
+  },
+];
+
+if (!existsSync(distDir)) {
+  console.error(
+    `verify-i18n-bundle: dist directory does not exist: ${distDir}`,
+  );
+  process.exit(1);
+}
+
+const files = listJsFiles(distDir);
+if (files.length === 0) {
+  console.error(
+    `verify-i18n-bundle: no JavaScript assets found under ${distDir}`,
+  );
+  process.exit(1);
+}
+
+const bundle = files.map((file) => readFileSync(file, "utf8")).join("\n");
+const missing = requiredMarkers.filter(
+  (marker) => !marker.needles.some((needle) => bundle.includes(needle)),
+);
+
+if (missing.length > 0) {
+  console.error(
+    "verify-i18n-bundle: production bundle is missing i18n markers:",
+  );
+  for (const marker of missing) {
+    console.error(`  - ${marker.label}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `verify-i18n-bundle: found ${requiredMarkers.length} required markers in ${files.length} JS assets`,
+);


### PR DESCRIPTION
## Summary
- add a bundle scanner that fails when production JS assets omit the zh-CN locale key or Simplified Chinese picker label
- expose the check as pnpm i18n:bundle:check for release validation after app/dist is built
- keep the guard independent from source-only i18n coverage so release bundles can be checked directly

Refs #2117

## Checks
- [x] node --check scripts/verify-i18n-bundle.mjs
- [x] prettier --check package.json scripts/verify-i18n-bundle.mjs
- [x] pnpm --filter openhuman-app build
- [x] pnpm i18n:bundle:check
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new maintenance script entry for build checks.
* **Style**
  * Updated Chinese locale label in the language selector from "中文" to "简体中文".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->