### PR TITLE
fix(release): build linux arm64 target artifact

### DIFF
--- a/scripts/release/build-linux-arm64.sh
+++ b/scripts/release/build-linux-arm64.sh
@@ -16,13 +16,16 @@ TARGET="aarch64-unknown-linux-gnu"
 UPLOAD_REPO="${UPLOAD_REPO:-tinyhumansai/openhuman}"
 
 echo "[linux-arm64] Building openhuman-core for $TARGET ..."
-cargo build --release --bin openhuman-core
+if command -v rustup >/dev/null 2>&1; then
+  rustup target add "$TARGET"
+fi
+cargo build --release --bin openhuman-core --target "$TARGET"
 
 TARBALL="openhuman-core-${VERSION}-${TARGET}.tar.gz"
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
-cp target/release/openhuman-core "$WORK/"
+cp "target/${TARGET}/release/openhuman-core" "$WORK/"
 chmod +x "$WORK/openhuman-core"
 tar -czf "$TARBALL" -C "$WORK" openhuman-core
 openssl dgst -sha256 -r "$TARBALL" | awk '{print $1}' > "${TARBALL}.sha256"


### PR DESCRIPTION
## Summary
- make the Linux ARM64 release helper build the explicit aarch64-unknown-linux-gnu target
- install the Rust target when rustup is available
- package the binary from target/aarch64-unknown-linux-gnu/release so the tarball name and contents match

Refs #1599

## Checks
- [x] bash -n scripts/release/build-linux-arm64.sh
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved ARM64 release build process to ensure proper target configuration and correct binary staging for architecture-specific releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->