### PR TITLE
fix(installer): let linux arm64 dry-run report unsupported asset

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,6 +141,11 @@ case "${ARCH_RAW}" in
 esac
 
 if [ "${OS}" = "linux" ] && [ "${ARCH}" != "x86_64" ]; then
+  if [ "${DRY_RUN}" = true ]; then
+    log_warn "Linux installer currently supports x86_64 only; no install asset resolved for ${ARCH}."
+    echo "DRY RUN: skipping install for ${OS}/${ARCH} - no compatible asset is published."
+    exit 0
+  fi
   log_err "Linux installer currently supports x86_64 only."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- keep real Linux ARM64 installs blocked until an asset exists
- make --dry-run exit successfully with a clear unsupported-asset message instead of hard-failing at the architecture gate
- align unsupported-platform dry-runs with the later no-compatible-asset resolver behavior

Refs #1599

## Checks
- [x] bash -n scripts/install.sh
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed installer dry-run mode to gracefully handle unsupported system architectures by logging warnings and exiting successfully, while maintaining strict validation for standard installations on incompatible systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->