### PR TITLE
fix(composio): show waiting state before opening browser

### DIFF
--- a/app/src/components/composio/ComposioConnectModal.test.tsx
+++ b/app/src/components/composio/ComposioConnectModal.test.tsx
@@ -292,6 +292,23 @@ describe('<ComposioConnectModal>', () => {
         );
       });
     });
+
+    it('shows the waiting state even when the OS browser opener rejects', async () => {
+      vi.mocked(composioApi.authorize).mockResolvedValue({
+        connectUrl: 'https://hosted.composio.dev/test-token',
+        connectionId: '',
+      });
+      vi.mocked(composioApi.listConnections).mockResolvedValue({ connections: [] });
+      vi.mocked(openUrlModule.openUrl).mockRejectedValueOnce(new Error('opener unavailable'));
+
+      render(<ComposioConnectModal toolkit={mockToolkit} onClose={() => {}} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Connect Gmail/ }));
+
+      expect(await screen.findByRole('button', { name: /Reopen browser/i })).toBeInTheDocument();
+      expect(screen.getByText(/Waiting for Gmail/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Something went wrong/i)).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/app/src/components/composio/ComposioConnectModal.tsx
+++ b/app/src/components/composio/ComposioConnectModal.tsx
@@ -358,9 +358,13 @@ export default function ComposioConnectModal({
         resp.connectionId
       );
       setConnectUrl(resp.connectUrl);
-      await openUrl(resp.connectUrl);
       setPhase('waiting');
       startPolling();
+      try {
+        await openUrl(resp.connectUrl);
+      } catch (openErr) {
+        console.warn('[composio][authorize] failed to open connectUrl:', openErr);
+      }
     } catch (err) {
       console.error(
         '[composio][authorize] failed toolkit=%s slug_check=%s',


### PR DESCRIPTION
## Summary
- move Composio connect modal into waiting/polling state immediately after authorize returns a connectUrl
- keep the Reopen browser fallback visible even if the OS browser opener rejects
- add regression coverage for an opener failure path so the connect click does not collapse into a dead/no-response state

Refs #2354

## Checks
- [x] prettier --check src/components/composio/ComposioConnectModal.tsx src/components/composio/ComposioConnectModal.test.tsx
- [x] pnpm test:unit src/components/composio/ComposioConnectModal.test.tsx
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of the authentication flow by handling browser launch failures gracefully. Users can now manually reopen their browser instead of encountering a complete connection failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->