### PR TITLE
fix(composio): surface Gmail scope errors as permissions

### DIFF
--- a/src/openhuman/agent/agents/integrations_agent/prompt.md
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.md
@@ -15,13 +15,15 @@ You do **not** have shell, file I/O, or any other capability beyond these permit
 
 1. You already have the toolkit's action tools in your tool list — start there. If you need a schema reminder or a slug you don't see, call `composio_list_tools`.
 2. Call the per-action tool (or `composio_execute` with the slug) using the caller's task as your guide.
-3. If the call fails with an authentication / authorization / connection error, stop and return: **"Connection error, try to authenticate"** — the orchestrator will take over and route the user to settings.
+3. If the call fails with `[composio:error:insufficient_scope]`, `insufficient authentication scopes`, or `missing required permissions`, do **not** call the service disconnected. Say the connected account is missing the permissions needed for the requested action and point the user to Settings → Connections → the toolkit to reconnect or enable the required scope.
+4. If the call fails with a true authentication / authorization / connection error that is **not** a scope or permission error, stop and return: **"Connection error, try to authenticate"** — the orchestrator will take over and route the user to settings.
 
 ## Rules
 
 - **Never fabricate action slugs.** Pull them from `composio_list_tools` or use the per-action tools already in your list.
 - **Respect rate limits** — Composio and upstream providers both throttle. Back off on errors rather than retrying tightly.
-- **Auth errors bubble up.** On any auth / connection failure reply exactly: `Connection error, try to authenticate`. Do not retry, do not attempt to re-authorise yourself — you have no tools for that.
+- **Scope errors are not disconnections.** If Gmail or another connected toolkit returns insufficient scope / missing permissions, report the missing permission plainly and direct the user to Settings → Connections → that toolkit. Never say the toolkit is disconnected for this case.
+- **Auth errors bubble up.** On true auth / connection failures only, reply exactly: `Connection error, try to authenticate`. Do not retry, do not attempt to re-authorise yourself — you have no tools for that.
 - **Be precise** — every action expects a specific argument shape. Validate against the schema before calling.
 - **Report results** — state what action was taken and the outcome, including any cost reported by Composio.
 

--- a/src/openhuman/agent/agents/integrations_agent/prompt.rs
+++ b/src/openhuman/agent/agents/integrations_agent/prompt.rs
@@ -258,6 +258,16 @@ mod tests {
     }
 
     #[test]
+    fn build_distinguishes_scope_errors_from_disconnected_auth() {
+        let body = build(&ctx_with(&[], &[])).unwrap();
+        assert!(body.contains("[composio:error:insufficient_scope]"));
+        assert!(body.contains("Scope errors are not disconnections"));
+        assert!(body.contains("Never say the toolkit is disconnected"));
+        assert!(body.contains("Settings"));
+        assert!(body.contains("Connections"));
+    }
+
+    #[test]
     fn build_skips_unconnected_integrations() {
         let integrations = vec![ConnectedIntegration {
             toolkit: "notion".into(),

--- a/src/openhuman/agent/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent/agents/orchestrator/prompt.md
@@ -78,6 +78,7 @@ When the user asks to connect a service (Gmail, Notion, WhatsApp, Calendar, Driv
 - **Never** explain OAuth, Composio, or any backend mechanic by name.
 - Reply with one short bubble pointing to the in-app path: **Settings → Connections → [Service]**. Example: `head to Settings → Connections → Gmail to hook it up, ping me when it's connected`.
 - If the user already said they connected it, call `composio_list_connections` to verify before continuing.
+- Do **not** apply this rule to scope / permission failures such as `[composio:error:insufficient_scope]` or "missing required permissions". For those, say the connection exists but needs additional permissions in **Settings → Connections → [Service]**.
 
 ## Response Style
 

--- a/src/openhuman/agent/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent/agents/orchestrator/prompt.rs
@@ -251,6 +251,16 @@ mod tests {
     }
 
     #[test]
+    fn build_does_not_route_scope_errors_as_disconnected() {
+        let body = build(&ctx_with(&[])).unwrap();
+        assert!(body.contains("[composio:error:insufficient_scope]"));
+        assert!(body.contains("missing required permissions"));
+        assert!(body.contains("connection exists but needs additional permissions"));
+        assert!(body.contains("Settings"));
+        assert!(body.contains("Connections"));
+    }
+
+    #[test]
     fn delegation_guide_uses_compact_collapsed_format() {
         let integrations = vec![ConnectedIntegration {
             toolkit: "gmail".into(),

--- a/src/openhuman/app_state/ops_tests.rs
+++ b/src/openhuman/app_state/ops_tests.rs
@@ -1,6 +1,10 @@
 use super::*;
+use once_cell::sync::Lazy as TestLazy;
+use parking_lot::Mutex as TestMutex;
 use serde_json::json;
 use tempfile::tempdir;
+
+static APP_STATE_CACHE_TEST_LOCK: TestLazy<TestMutex<()>> = TestLazy::new(|| TestMutex::new(()));
 
 #[test]
 fn sanitize_snapshot_user_drops_empty_payloads() {
@@ -137,6 +141,7 @@ fn save_and_reload_stored_app_state_round_trips() {
 
 #[test]
 fn peek_cached_current_user_identity_plucks_known_fields() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
     struct CacheResetGuard;
     impl Drop for CacheResetGuard {
         fn drop(&mut self) {
@@ -164,6 +169,7 @@ fn peek_cached_current_user_identity_plucks_known_fields() {
 
 #[test]
 fn peek_cached_current_user_identity_returns_none_when_only_empty_fields_exist() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
     struct CacheResetGuard;
     impl Drop for CacheResetGuard {
         fn drop(&mut self) {
@@ -196,6 +202,7 @@ impl Drop for SnapshotCacheResetGuard {
 
 #[test]
 fn runtime_snapshot_cache_hit_within_ttl() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
     let _reset = SnapshotCacheResetGuard;
 
     let dummy = build_dummy_runtime_snapshot();
@@ -215,6 +222,7 @@ fn runtime_snapshot_cache_hit_within_ttl() {
 
 #[test]
 fn runtime_snapshot_cache_miss_after_ttl() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
     let _reset = SnapshotCacheResetGuard;
 
     *RUNTIME_SNAPSHOT_CACHE.lock() = Some(CachedRuntimeSnapshot {

--- a/src/openhuman/composio/error_mapping.rs
+++ b/src/openhuman/composio/error_mapping.rs
@@ -120,8 +120,8 @@ fn format_insufficient_scope_message(tool: &str, detail: &str) -> String {
         .to_ascii_lowercase();
     format!(
         "`{tool}` was rejected because the connected {toolkit} account is missing required \
-         permissions ({detail}). Reconnect the integration in Settings → Skills and grant the \
-         scopes requested during OAuth."
+         permissions ({detail}). Reconnect the integration in Settings → Connections → \
+         {toolkit} and grant the scopes requested during OAuth."
     )
 }
 

--- a/src/openhuman/composio/error_mapping_tests.rs
+++ b/src/openhuman/composio/error_mapping_tests.rs
@@ -1,4 +1,6 @@
-use super::{classify_composio_error, remap_transport_error, ComposioErrorClass};
+use super::{
+    classify_composio_error, format_provider_error, remap_transport_error, ComposioErrorClass,
+};
 
 #[test]
 fn classifies_gmail_insufficient_scope() {
@@ -7,6 +9,21 @@ fn classifies_gmail_insufficient_scope() {
         classify_composio_error("GMAIL_FETCH_EMAILS", msg),
         ComposioErrorClass::InsufficientScope
     );
+}
+
+#[test]
+fn formats_gmail_insufficient_scope_as_missing_permissions_not_disconnected() {
+    let mapped = format_provider_error(
+        "GMAIL_SEND_EMAIL",
+        "HTTP 403: Request had insufficient authentication scopes.",
+    );
+    assert!(mapped.contains("[composio:error:insufficient_scope]"));
+    assert!(mapped.contains("connected gmail account is missing required permissions"));
+    assert!(mapped.contains("Settings"));
+    assert!(mapped.contains("Connections"));
+    assert!(mapped.contains("gmail"));
+    assert!(!mapped.contains("not connected"));
+    assert!(!mapped.contains("Settings → Skills"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary  - Keeps Gmail insufficient-scope failures distinct from disconnected/auth failures. - Points missing Gmail permissions to Settings -> Connections -> gmail instead of Settings -> Skills. - Updates integrations/orchestrator prompts so connected-but-missing-scope errors are not collapsed into the generic disconnected flow. - Adds focused regression assertions for prompt wording and Composio error mapping. - Serializes app-state cache tests that mutate global test caches so unrelated CI jobs do not fail nondeterministically.  ## Problem  When Gmail is connected but a send action fails due to missing permissions/scopes, the agent can treat the failure like a disconnected integration and tell the user to reconnect generically. That makes a connected account look broken and hides the real missing-scope issue.  ## Solution  - Format `insufficient_scope` Composio errors as missing permissions on a connected account. - Route the user to Settings -> Connections -> gmail for reconnect/scope grant. - Teach `integrations_agent` to report scope/permission failures plainly instead of returning `Connection error, try to authenticate`. - Teach the orchestrator not to apply the disconnected-service rule to `[composio:error:insufficient_scope]` / missing-permission messages.  ## Submission Checklist  - [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) - [x] **Diff coverage >= 80%** - focused Rust prompt/error-mapping tests added; CI coverage gate will enforce merged diff coverage. - [x] Coverage matrix updated - N/A: connector error/prompt behavior only, no feature row added/removed/renamed - [x] All affected feature IDs from the matrix are listed in the PR description under ## Related - N/A: no matrix feature ID changed - [x] No new external network dependencies introduced (mock/pure prompt and mapping coverage only) - [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: no release-cut smoke surface changed - [x] Linked issue closed via Closes #NNN in the ## Related section  ## Impact  - User-facing copy changes when a connected Gmail account lacks send permissions. - True disconnected/auth failures still use the existing authenticate handoff. - No migration or dependency change.  ## Related  - Closes #2365 - Related tracking issue: #2305 - Follow-up PR(s)/TODOs: N/A  ---  ## AI Authored PR Metadata (required for Codex/Linear PRs)  ### Linear Issue - Key: N/A - URL: N/A  ### Commit & Branch - Branch: codex/2365-gmail-scope-error - Commit SHA: 4156d29a612661e7987cfe1db5c5299972a3bbdb  ### Validation Run - [x] `cargo fmt -- --check` - [x] `git diff --check` - [x] Focused tests attempted locally: `cargo test -p openhuman openhuman::composio::error_mapping::tests --lib` (blocked by missing Windows libclang; see below) - [x] Focused prompt tests attempted locally: `cargo test -p openhuman openhuman::agent::agents::integrations_agent::prompt::tests --lib` (blocked by missing Windows libclang; see below) - [x] Focused app-state cache test attempted locally: `cargo test --lib openhuman::app_state::ops::tests::runtime_snapshot_cache_hit_within_ttl -- --nocapture` (blocked by missing Windows libclang; see below) - [x] Rust fmt/check (if changed): `cargo fmt -- --check` - [x] Tauri fmt/check (if changed): N/A  ### Validation Blocked - command: `cargo test -p openhuman openhuman::composio::error_mapping::tests --lib` - error: Unable to find libclang: could not find `clang.dll`/`libclang.dll`; set `LIBCLANG_PATH` - impact: Local Windows Rust test run blocked before executing tests; CI Linux Rust jobs should validate the added tests.  ### Behavior Changes - Intended behavior change: connected Gmail insufficient-scope failures surface as missing permissions, not as disconnected-account copy. - User-visible effect: users are pointed to Connections to reconnect/grant Gmail scopes instead of being told Gmail is simply disconnected.  ### Parity Contract - Legacy behavior preserved: true auth/connection failures still bubble up as `Connection error, try to authenticate` for the orchestrator settings handoff. - Guard/fallback/dispatch parity checks: Composio error classification prefix remains `[composio:error:insufficient_scope]`.  ### Duplicate / Superseded PR Handling - Duplicate PR(s): N/A - Canonical PR: this PR - Resolution (closed/superseded/updated): N/A  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling to distinguish scope/permission failures from authentication/connection errors.
  * Updated user guidance to direct users to Settings → Connections when additional scopes/permissions are required.
  * Clarified error messaging so users receive accurate instructions for resolving authorization issues.

* **Tests**
  * Added unit tests to verify prompts and error formatting distinguish insufficient-scope cases from disconnected accounts.
  * Serialized cache-related tests to prevent interference from shared test state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->