### PR TITLE
fix(docker): lower default build memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,13 @@
 # ==========================================================================
 FROM rust:1.93-bookworm AS builder
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Docker builds often run on small VPS/CI builders. The crate's `ci` profile
+# keeps peak rustc memory lower than `release`; override with
+# `--build-arg CARGO_PROFILE=release` when maximum runtime optimization matters.
+ARG CARGO_PROFILE=ci
+ARG CARGO_BUILD_JOBS=1
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
 # System dependencies required for compilation.
 #
@@ -43,14 +49,15 @@ COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 RUN mkdir -p src && \
     echo 'fn main() {}' > src/main.rs && \
     echo 'pub fn run_core_from_args(_: &[String]) -> anyhow::Result<()> { Ok(()) }' > src/lib.rs && \
-    cargo build --release --bin openhuman-core 2>/dev/null || true && \
+    cargo build --profile "${CARGO_PROFILE}" --bin openhuman-core 2>/dev/null || true && \
     rm -rf src
 
 # Copy actual source and build
 COPY src/ src/
 # Touch main.rs to force rebuild of our code (not deps)
 RUN touch src/main.rs src/lib.rs && \
-    cargo build --release --bin openhuman-core
+    cargo build --profile "${CARGO_PROFILE}" --bin openhuman-core && \
+    cp "target/${CARGO_PROFILE}/openhuman-core" /tmp/openhuman-core
 
 # ==========================================================================
 # Stage 2: Minimal runtime image
@@ -84,7 +91,7 @@ RUN mkdir -p /home/openhuman/.openhuman \
  && chown -R openhuman:openhuman /home/openhuman
 
 # Copy the built binary
-COPY --from=builder /build/target/release/openhuman-core /usr/local/bin/openhuman-core
+COPY --from=builder /tmp/openhuman-core /usr/local/bin/openhuman-core
 
 # Copy the entrypoint script that chowns the workspace volume before dropping
 # privileges.  The script is a separate file so the E2E entrypoint

--- a/gitbooks/features/cloud-deploy.md
+++ b/gitbooks/features/cloud-deploy.md
@@ -603,6 +603,10 @@ To run the same check locally:
 ```bash
 docker build -t openhuman-core:smoke .
 
+# Optional: tune build profile and Cargo parallelism.
+# Keep CARGO_BUILD_JOBS=1 on constrained builders; raise it on larger machines.
+docker build --build-arg CARGO_PROFILE=release --build-arg CARGO_BUILD_JOBS=4 -t openhuman-core:release .
+
 # Token-set path (App Platform):
 docker run -d --name oh-smoke -p 7788:7788 \
   -e OPENHUMAN_CORE_TOKEN=smoke-test-token \


### PR DESCRIPTION
## Summary  - Lowers the default Docker image build profile from `release` to the crate's `ci` profile to reduce peak `rustc` memory. - Sets `CARGO_BUILD_JOBS=1` inside the builder stage so dependency builds do not fan out on small VPS/CI builders. - Copies the built binary from a stable `/tmp/openhuman-core` path so `CARGO_PROFILE` can still be overridden. - Documents `--build-arg CARGO_PROFILE=release` for operators who want the fully optimized build.  ## Problem  Issue #2419 shows `docker build -t openhuman:v11 .` failing in the final `cargo build --release --bin openhuman-core` step. The compiler process exits with `SIGKILL`, which is the typical failure mode when the builder is killed by memory pressure rather than a Rust type or linker error.  ## Solution  - Use `ARG CARGO_PROFILE=ci` by default in the Docker builder stage. The existing `ci` profile inherits release but uses lower optimization and fewer debug artifacts, reducing build memory. - Use `ARG CARGO_BUILD_JOBS=1` and export it as `CARGO_BUILD_JOBS` to cap Cargo parallelism by default. - Keep an escape hatch: `docker build --build-arg CARGO_PROFILE=release ...` restores the old fully optimized profile.  ## Submission Checklist  - [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) - N/A: Dockerfile/docs change; Deploy Smoke CI builds and runs the image. - [x] **Diff coverage >= 80%** - N/A: no Rust/TS executable lines changed. - [x] Coverage matrix updated - N/A: deploy build behavior only, no feature row changed. - [x] All affected feature IDs from the matrix are listed in the PR description under ## Related - N/A: no matrix feature ID changed. - [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)). - [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: cloud deploy docs updated with the build-profile override; release manual steps unchanged. - [x] Linked issue closed via Closes #NNN in the ## Related section.  ## Impact  - Docker builds become more reliable on low-memory builders. - Default Docker image build trades some runtime optimization for build reliability. - Operators can still request the old release profile explicitly with a build arg. - No runtime config, migration, or dependency change.  ## Related  - Closes #2419 - Follow-up PR(s)/TODOs: N/A  ---  ## AI Authored PR Metadata (required for Codex/Linear PRs)  ### Linear Issue - Key: N/A - URL: N/A  ### Commit & Branch - Branch: codex/2419-docker-low-memory-build - Commit SHA: bdb35ef71b6c6e4c2f465c51f90cd232e47156d2  ### Validation Run - [x] `git diff --check` - [x] Docker CLI availability checked: `docker --version` (blocked; see below) - [x] Focused tests: N/A - Dockerfile/docs only; CI Deploy Smoke is the executable validation. - [x] Rust fmt/check (if changed): N/A - [x] Tauri fmt/check (if changed): N/A  ### Validation Blocked - `command:` `docker --version` - `error:` Docker CLI is not installed on this Windows worker (`docker` command not found). - `impact:` local Docker build/smoke could not run; GitHub Deploy Smoke should validate the Dockerfile build and health check.  ### Behavior Changes - Intended behavior change: default Docker builds use the lower-memory `ci` Cargo profile and one Cargo build job. - User-visible effect: `docker build .` is less likely to be killed on memory-constrained machines.  ### Parity Contract - Legacy behavior preserved: fully optimized release builds remain available with `--build-arg CARGO_PROFILE=release`. - Guard/fallback/dispatch parity checks: entrypoint, runtime image, ports, env vars, and health check stay unchanged.  ### Duplicate / Superseded PR Handling - Duplicate PR(s): N/A - Canonical PR: this PR - Resolution (closed/superseded/updated): N/A  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added local testing note: optional second Docker build to produce an optimized release image by tuning Rust build profile and parallelism.

* **Chores**
  * Updated multi-stage Docker build to parameterize Rust compilation, improve caching, and copy the compiled runtime artifact into the final image.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->