### PR TITLE
feat(mascot): react to conversation cues

### DIFF
--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ChatEventListeners } from '../../services/chatService';
 import { VISEMES } from './Mascot/visemes';
-import { ACK_FACE_HOLD_MS, pickViseme, useHumanMascot } from './useHumanMascot';
+import {
+  ACK_FACE_HOLD_MS,
+  pickConversationAckFace,
+  pickViseme,
+  useHumanMascot,
+} from './useHumanMascot';
 import { type PlaybackHandle, playBase64Audio } from './voice/audioPlayer';
 import { synthesizeSpeech } from './voice/ttsClient';
 
@@ -133,6 +138,46 @@ describe('pickViseme', () => {
   });
 });
 
+describe('pickConversationAckFace', () => {
+  it('prefers explicit reaction emoji from chat_done', () => {
+    expect(pickConversationAckFace({ full_response: 'Done', reaction_emoji: '✅' })).toBe('happy');
+    expect(pickConversationAckFace({ full_response: 'Done', reaction_emoji: '🤔' })).toBe(
+      'confused'
+    );
+    expect(pickConversationAckFace({ full_response: 'Done', reaction_emoji: '⚠️' })).toBe(
+      'concerned'
+    );
+  });
+
+  it('falls back to deterministic response text cues', () => {
+    expect(
+      pickConversationAckFace({ full_response: 'All set, this is fixed.', reaction_emoji: null })
+    ).toBe('happy');
+    expect(
+      pickConversationAckFace({
+        full_response: 'I need more detail to clarify which workspace you mean.',
+        reaction_emoji: null,
+      })
+    ).toBe('confused');
+    expect(
+      pickConversationAckFace({
+        full_response: 'Sorry, the provider failed and I cannot continue.',
+        reaction_emoji: null,
+      })
+    ).toBe('concerned');
+  });
+
+  it('returns null when there is no strong cue', () => {
+    expect(
+      pickConversationAckFace({ full_response: 'Here is the summary.', reaction_emoji: null })
+    ).toBeNull();
+  });
+
+  it('returns null when the response text is missing', () => {
+    expect(pickConversationAckFace({ reaction_emoji: null })).toBeNull();
+  });
+});
+
 describe('useHumanMascot state machine', () => {
   beforeEach(() => {
     capturedListeners = null;
@@ -224,6 +269,42 @@ describe('useHumanMascot state machine', () => {
       vi.advanceTimersByTime(ACK_FACE_HOLD_MS + 1);
     });
     expect(result.current.face).toBe('idle');
+  });
+
+  it('uses reaction emoji for the post-turn acknowledgement face', () => {
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: false }));
+    act(() => {
+      capturedListeners?.onDone?.(
+        fakeEvent({
+          full_response: 'I need more detail before I can choose.',
+          reaction_emoji: '🤔',
+          rounds_used: 1,
+          total_input_tokens: 1,
+          total_output_tokens: 1,
+        })
+      );
+    });
+    expect(result.current.face).toBe('confused');
+    act(() => {
+      vi.advanceTimersByTime(ACK_FACE_HOLD_MS + 1);
+    });
+    expect(result.current.face).toBe('idle');
+  });
+
+  it('uses response text cues when no reaction emoji is present', () => {
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: false }));
+    act(() => {
+      capturedListeners?.onDone?.(
+        fakeEvent({
+          full_response: 'Sorry, that failed because the provider is unavailable.',
+          reaction_emoji: null,
+          rounds_used: 1,
+          total_input_tokens: 1,
+          total_output_tokens: 1,
+        })
+      );
+    });
+    expect(result.current.face).toBe('concerned');
   });
 
   it('holds concerned briefly on chat_error, then idles', () => {
@@ -507,6 +588,28 @@ describe('useHumanMascot TTS playback', () => {
     const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
     await act(async () => {
       capturedListeners?.onDone?.(fakeDone('hello'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('concerned');
+    act(() => {
+      vi.advanceTimersByTime(ACK_FACE_HOLD_MS + 1);
+    });
+    expect(result.current.face).toBe('idle');
+  });
+
+  it('shows concerned when audio playback cannot start', async () => {
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [{ viseme: 'aa', start_ms: 0, end_ms: 100 }],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('decode failed'));
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('All set, this is fixed.'));
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -76,6 +76,40 @@ export function pickViseme(delta: string): VisemeShape {
   }
 }
 
+type ConversationAckFace = Extract<MascotFace, 'happy' | 'confused' | 'concerned'>;
+type ConversationAckEvent = { full_response?: string | null; reaction_emoji?: string | null };
+
+const HAPPY_REACTION_EMOJIS = new Set(['✅', '🎉', '🙌', '😊', '😄', '👍', '💪']);
+const CONFUSED_REACTION_EMOJIS = new Set(['🤔', '❓', '❔']);
+const CONCERNED_REACTION_EMOJIS = new Set(['⚠️', '⚠', '🚨', '❌', '😕', '😟']);
+
+const CONCERNED_TEXT_RE =
+  /\b(sorry|apolog(?:y|ize|ise)|failed|failure|error|cannot|can't|unable|blocked|problem)\b/i;
+const CONFUSED_TEXT_RE =
+  /\b(not sure|unclear|ambiguous|clarify|which one|need more|can you confirm|maybe)\b/i;
+const HAPPY_TEXT_RE = /\b(done|completed|fixed|success|successful|ready|all set|great|nice)\b/i;
+
+/**
+ * Map conversation-level meaning into the short acknowledgement face that
+ * follows a completed turn. Runtime activity still owns thinking/speaking
+ * states; this only decides the post-turn emotional beat.
+ */
+export function pickConversationAckFace(event: ConversationAckEvent): ConversationAckFace | null {
+  const reaction = event.reaction_emoji?.trim();
+  if (reaction) {
+    if (HAPPY_REACTION_EMOJIS.has(reaction)) return 'happy';
+    if (CONFUSED_REACTION_EMOJIS.has(reaction)) return 'confused';
+    if (CONCERNED_REACTION_EMOJIS.has(reaction)) return 'concerned';
+  }
+
+  const text = event.full_response?.trim() ?? '';
+  if (!text) return null;
+  if (CONCERNED_TEXT_RE.test(text)) return 'concerned';
+  if (CONFUSED_TEXT_RE.test(text)) return 'confused';
+  if (HAPPY_TEXT_RE.test(text)) return 'happy';
+  return null;
+}
+
 export interface UseHumanMascotOptions {
   /** When true, post-stream replies are sent to ElevenLabs and the mouth
    *  follows the returned viseme timeline while the audio plays. */
@@ -99,9 +133,9 @@ export interface UseHumanMascotResult {
  * - `iteration_start` round > 1 or `tool_call` → `confused` (heavy reasoning)
  * - `tool_result success=false` → `concerned` (held briefly)
  * - `text_delta` → `speaking`, pseudo-lipsync from the trailing letter
- * - `chat_done` (no TTS) → `happy` (held briefly), then `idle`
+ * - `chat_done` (no TTS) → message-aware ack face (held briefly), then `idle`
  * - `chat_done` (TTS enabled) → `thinking` while synthesizing → `speaking`
- *   with real visemes → `idle` when the audio ends
+ *   with real visemes → message-aware ack face when the audio ends
  * - `chat_error`, TTS failure → `concerned` (held briefly), then `idle`
  * - `listening` option override → `listening` (highest priority)
  *
@@ -187,13 +221,14 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         lastDeltaAtRef.current = window.performance.now();
       },
       onDone: e => {
+        const ackFace = pickConversationAckFace(e) ?? 'happy';
         if (!speakRef.current || !e.full_response?.trim()) {
           // Soft acknowledgement beat instead of snapping back to idle.
-          holdThenIdle('happy');
+          holdThenIdle(ackFace);
           return;
         }
         // Fire-and-forget — startTtsPlayback owns its cleanup via finally.
-        void startTtsPlayback(e.full_response).catch(() => {});
+        void startTtsPlayback(e.full_response, ackFace).catch(() => {});
       },
       onError: () => {
         // Bump seq to invalidate any in-flight startTtsPlayback awaiters.
@@ -225,7 +260,10 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
     };
   }, []);
 
-  async function startTtsPlayback(text: string): Promise<void> {
+  async function startTtsPlayback(
+    text: string,
+    ackFace: ConversationAckFace = 'happy'
+  ): Promise<void> {
     // Cancel any in-flight playback so its handle.ended callback can't reset
     // state belonging to the new run.
     const prev = playbackRef.current;
@@ -313,6 +351,9 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         // rethrow anything else so real decoder errors aren't masked.
         swallowAudioStop(err);
       }
+    } catch (err) {
+      if (isStillCurrent()) degraded = true;
+      throw err;
     } finally {
       if (isStillCurrent()) {
         playbackRef.current = null;
@@ -320,7 +361,7 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         if (degraded) {
           holdThenIdle('concerned');
         } else {
-          holdThenIdle('happy');
+          holdThenIdle(ackFace);
         }
       }
     }

--- a/gitbooks/features/mascot/README.md
+++ b/gitbooks/features/mascot/README.md
@@ -30,6 +30,8 @@ This is the headline use case and has its own page, see [Meeting Agents](meeting
 
 The mascot has mood states (idle, thinking, listening, talking, surprised, dreaming) and it transitions between them based on what the agent is doing. When you start typing it shifts into a listening pose. When the model is reasoning, it shows that. When a tool call returns something noteworthy, it reacts. When you stop interacting for a while, it drifts into idle.
 
+After a turn finishes, the desktop mascot also reads the conversation-level cue that arrives with the chat result. A success cue produces a short happy acknowledgement, uncertainty produces a confused acknowledgement, and warnings or failed outcomes produce a concerned acknowledgement. If no strong cue is present, it keeps the existing calm post-turn acknowledgement and falls back to idle.
+
 It is meant to feel alive, not animated-on-rails.
 
 ### It remembers you


### PR DESCRIPTION
﻿## Summary

- Adds a deterministic conversation-cue layer for the desktop mascot acknowledgement face after chat turns finish.
- Maps `chat_done.reaction_emoji` and clear response text cues into `happy`, `confused`, or `concerned` beats while preserving existing runtime states for thinking/speaking/listening.
- Keeps synth/playback/decoder failures on the `concerned` recovery path instead of showing a normal acknowledgement.
- Documents the post-turn reaction model in the mascot GitBook page.

## Problem

#1144 asks for the mascot to react to message/conversation meaning instead of only transport phases. The hook already reacts to runtime events; this PR adds the first bounded message-aware layer without introducing animation noise.

## Solution

- Adds `pickConversationAckFace` to classify explicit reaction emoji first, then deterministic response text cues.
- Uses the selected ack face for text-only completion and after successful TTS playback.
- Leaves voice/TTS synth, playback, and decoder failure behavior as `concerned` so recovery states still take priority.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement).
- [x] Diff coverage >= 80% - `useHumanMascot.test.ts` covers emoji, text-cue, neutral fallback, TTS success, synth failure, and playback failure transitions.
- [x] Coverage matrix updated - N/A: existing mascot hook test path already covers this UI behavior; no matrix catalog ID changed.
- [x] All affected feature IDs from the matrix are listed in the PR description under ## Related - N/A.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: deterministic UI reaction logic only.
- [x] Linked issue closed via Closes #NNN in the ## Related section - N/A: partial #1144 implementation, references only.

## Validation

- [x] `pnpm install --offline --frozen-lockfile`
- [x] `pnpm --dir app test -- src/features/human/useHumanMascot.test.ts` - 1 file, 34 tests.
- [x] `pnpm --dir app compile`
- [x] `pnpm --dir app exec prettier --check src/features/human/useHumanMascot.ts src/features/human/useHumanMascot.test.ts`
- [x] `git diff --check`

## Related

- Refs #1144

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/1144-mascot-reactions`
- Commit SHA: `5a4aca728432b2e5327dc84a3b090c7eb714bfde`

### Validation Run
- [x] Frontend targeted test passed: 1 file, 34 tests.
- [x] TypeScript compile passed.
- [x] Prettier check passed on changed TS files.
- [x] Diff whitespace check passed.

### Validation Blocked
- N/A

### Behavior Changes
- Intended behavior change: completed turns can now produce a short `happy`, `confused`, or `concerned` mascot acknowledgement based on conversation cues.
- User-visible effect: mascot post-turn face better matches success, uncertainty, and warning/failure outcomes.

### Parity Contract
- Legacy behavior preserved: no-cue completions still use the existing happy acknowledgement; thinking/speaking/listening/error state priority is unchanged.
- Guard/fallback/dispatch parity checks: TTS degradation still forces `concerned`; unknown reaction cues fall back to prior behavior.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for this scoped #1144 slice.
- Canonical PR: this PR.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mascot now chooses post-turn facial expressions from conversation cues (emoji or result text): happy for success, confused for uncertainty, concerned for warnings/failures; integrates with TTS and falls back to calm/idle when no cue exists. Also shows concerned if audio playback fails, then returns to idle.

* **Tests**
  * Added unit tests for acknowledgement-face selection and post-turn behavior with and without TTS, including audio-failure handling.

* **Documentation**
  * Updated mascot docs to describe conversation-aware post-turn expressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
