### PR TITLE
docs: clarify managed backend defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
  
 <p align="center">
- <strong>OpenHuman is your Personal AI super intelligence. Private, Simple and extremely powerful.</strong>
+ <strong>OpenHuman is your Personal AI super intelligence: local memory, managed services where needed, simple and powerful.</strong>
 </p>
 
 
@@ -46,6 +46,8 @@
 
 > **Early Beta**: Under active development. Expect rough edges.
 
+> **Local + managed services, upfront:** OpenHuman stores its Memory Tree, Obsidian-style Markdown vault, workspace config, and local runtime state on your machine. The default managed experience still uses OpenHuman-hosted services for account sign-in, model routing, web search proxying, and managed integration/OAuth flows through the Composio connector layer. Choose custom/local settings if you want to bring your own model, search, or Composio credentials; some real-time triggers and hosted features still require the managed backend.
+
 To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
 
 ```bash
@@ -66,11 +68,11 @@ OpenHuman is an open-source agentic assistant designed to integrate with you in 
 
 - **[118+ third-party integrations](https://tinyhumans.gitbook.io/openhuman/features/integrations) with [auto-fetch](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki/auto-fetch)**: plug into Gmail, Notion, GitHub, Slack, Stripe, Calendar, Drive, Linear, Jira and the rest of your stack with **one-click OAuth**. Every connection is exposed to the agent as a typed tool, and every twenty minutes the core walks each active connection and pulls fresh data into the [memory tree](https://tinyhumans.gitbook.io/openhuman/features/integrations/auto-fetch). No prompts, no polling loops you have to write, so the agent already has tomorrow's context this morning.
 
-  Managed integrations are backend-proxied through OpenHuman's Composio connector layer. If you want to run Composio directly instead of using the managed backend path, configure direct mode with your own Composio API key; real-time trigger webhooks then need to be hosted and wired by you.
+  Managed integrations use OpenHuman's Composio connector layer. OAuth handshakes and integration tool calls are proxied through the managed backend by default. If you want to run Composio directly instead, configure direct mode with your own Composio API key; real-time trigger webhooks then need to be hosted and wired by you.
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: a local-first knowledge base built from your data and your activity. Everything you connect is canonicalized into ≤3k-token Markdown chunks, scored, and folded into hierarchical summary trees stored in **SQLite on your machine**. The same chunks land as `.md` files in an Obsidian-compatible vault you can open, browse and edit, inspired by Karpathy's [obsidian-wiki workflow](https://x.com/karpathy/status/2039805659525644595).
 
-- **Batteries included**: web search, a web-fetch [scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), a full coder toolset (filesystem, git, lint, test, grep), and [native voice](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT in, ElevenLabs TTS out, mascot lip-sync, live Google Meet agent) are wired in by default. [Model routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) sends each task to the right LLM (reasoning, fast, or vision) under one subscription. No "install a plugin to read files" friction. [Optional local AI via Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) for on-device workloads.
+- **Batteries included**: web search, a web-fetch [scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), a full coder toolset (filesystem, git, lint, test, grep), and [native voice](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT in, ElevenLabs TTS out, mascot lip-sync, live Google Meet agent) are wired in by default. By default, [model routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) uses the OpenHuman backend to select and proxy the right LLM for each workload (reasoning, fast, or vision). One subscription includes all models. No "install a plugin to read files" friction. Use [optional local AI via Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) for supported on-device workloads.
 
 - **[Smart token compression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: every tool call, scrape result, email body, and search payload is run through a token compression layer before it touches any LLM Model. HTML is converted to Markdown, long URLs are shortened, and verbose tool output is deduped and summarized via a configurable rule overlay etc... CJK, emoji, and other multi-byte text are preserved grapheme-by-grapheme — never stripped. You get the same information but at a fraction of the tokens. Reducing cost &amp; latency by up to 80%.
 

--- a/app/src/lib/i18n/chunks/en-1.ts
+++ b/app/src/lib/i18n/chunks/en-1.ts
@@ -241,20 +241,21 @@ const en1: TranslationMap = {
   'onboarding.getStarted': 'Get Started',
   'onboarding.runtimeChoice.title': 'How would you like to run OpenHuman?',
   'onboarding.runtimeChoice.subtitle':
-    'Pick the setup that fits you best. You can change this later in Settings.',
+    'Pick how much OpenHuman manages for you. You can change this later in Settings.',
   'onboarding.runtimeChoice.cloud.title': 'Simple',
-  'onboarding.runtimeChoice.cloud.tagline': 'Let OpenHuman manage everything for you.',
-  'onboarding.runtimeChoice.cloud.f1': 'Built-in security',
+  'onboarding.runtimeChoice.cloud.tagline':
+    'Use OpenHuman-hosted sign-in, model routing, search, and managed integrations.',
+  'onboarding.runtimeChoice.cloud.f1': 'Backend-brokered OAuth and model routing',
   'onboarding.runtimeChoice.cloud.f2': 'Token compression to stretch your usage further',
   'onboarding.runtimeChoice.cloud.f3': 'One subscription, every model included',
-  'onboarding.runtimeChoice.cloud.f4': 'No API keys to manage',
-  'onboarding.runtimeChoice.cloud.f5': 'Simple to set up',
+  'onboarding.runtimeChoice.cloud.f4': 'No model, search, or Composio keys to manage',
+  'onboarding.runtimeChoice.cloud.f5': 'Local Memory Tree, managed network services',
   'onboarding.runtimeChoice.custom.title': 'Run Custom',
   'onboarding.runtimeChoice.custom.tagline':
-    "Bring your own keys. Full control of what you're using.",
+    'Bring your own keys. Choose which services OpenHuman should call.',
   'onboarding.runtimeChoice.custom.f1': "You'll need API keys for almost everything",
   'onboarding.runtimeChoice.custom.f2': 'Reuses services you already pay for',
-  'onboarding.runtimeChoice.custom.f3': 'Can be free if you run everything locally',
+  'onboarding.runtimeChoice.custom.f3': 'Keep supported workloads on your machine',
   'onboarding.runtimeChoice.custom.f4': 'More setup, more knobs',
   'onboarding.runtimeChoice.custom.f5': 'Best for power users and developers',
   'onboarding.runtimeChoice.cloud.creditHighlight': '$1 free credit to try it out',
@@ -293,26 +294,26 @@ const en1: TranslationMap = {
   'onboarding.custom.inference.subtitle':
     'Which language model should answer your questions and run your agents?',
   'onboarding.custom.inference.defaultDesc':
-    'OpenHuman routes every workload to a sensible default model. No keys, no setup.',
+    'OpenHuman routes workloads through its managed backend by default. No keys, no setup.',
   'onboarding.custom.inference.configureDesc':
     'Bring your own OpenAI or Anthropic key. We use it for every text-based workload.',
   'onboarding.custom.voice.title': 'Voice',
   'onboarding.custom.voice.subtitle': 'Speech-to-text and text-to-speech for voice mode.',
   'onboarding.custom.voice.defaultDesc':
-    'OpenHuman ships with managed STT/TTS that just works. Nothing to wire up.',
+    'OpenHuman ships with managed STT/TTS providers that may send audio/text to hosted services.',
   'onboarding.custom.voice.configureDesc':
     'Use your own ElevenLabs / OpenAI Whisper / etc. Configure in Settings › Voice.',
   'onboarding.custom.oauth.title': 'Connections (OAuth)',
   'onboarding.custom.oauth.subtitle':
     'Gmail, Slack, Notion, and other connected services that need OAuth.',
   'onboarding.custom.oauth.defaultDesc':
-    'OpenHuman runs a managed Composio workspace. One click to connect each service later.',
+    'OpenHuman brokers OAuth and tool calls through a managed Composio workspace.',
   'onboarding.custom.oauth.configureDesc':
     'Bring your own Composio account / API key. Configure in Settings › Connections.',
   'onboarding.custom.search.title': 'Web Search',
   'onboarding.custom.search.subtitle': 'How OpenHuman searches the web on your behalf.',
   'onboarding.custom.search.defaultDesc':
-    'OpenHuman uses a managed search backend. No keys needed.',
+    'OpenHuman uses a managed search proxy by default. No search API key needed.',
   'onboarding.custom.search.configureDesc':
     'Bring your own search provider key (Tavily, Brave, etc.). Configure in Settings › Tools.',
   'onboarding.custom.memory.title': 'Memory',

--- a/app/src/lib/i18n/chunks/en-3.ts
+++ b/app/src/lib/i18n/chunks/en-3.ts
@@ -87,8 +87,9 @@ const en3: TranslationMap = {
   'backend.cloud': 'Cloud',
   'backend.recommended': 'Recommended',
   'backend.cloudDescription':
-    'Fast, powerful models hosted on our servers. Ready to use immediately.',
-  'backend.privacyNote': 'No personal data, messages, or keys are ever sent to our servers.',
+    'Fast, powerful models routed through the OpenHuman backend. Ready to use immediately.',
+  'backend.privacyNote':
+    'Prompts and selected context may be sent to the configured backend/provider. Use local mode for supported on-device workloads.',
   'backend.local': 'Local',
   'backend.advanced': 'Advanced',
   'backend.localDescription':

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -273,20 +273,21 @@ const en: TranslationMap = {
   // Onboarding: runtime-choice step (Cloud vs Custom)
   'onboarding.runtimeChoice.title': 'How would you like to run OpenHuman?',
   'onboarding.runtimeChoice.subtitle':
-    'Pick the setup that fits you best. You can change this later in Settings.',
+    'Pick how much OpenHuman manages for you. You can change this later in Settings.',
   'onboarding.runtimeChoice.cloud.title': 'Simple',
-  'onboarding.runtimeChoice.cloud.tagline': 'Let OpenHuman manage everything for you.',
-  'onboarding.runtimeChoice.cloud.f1': 'Built-in security',
+  'onboarding.runtimeChoice.cloud.tagline':
+    'Use OpenHuman-hosted sign-in, model routing, search, and managed integrations.',
+  'onboarding.runtimeChoice.cloud.f1': 'Backend-brokered OAuth and model routing',
   'onboarding.runtimeChoice.cloud.f2': 'Token compression to stretch your usage further',
   'onboarding.runtimeChoice.cloud.f3': 'One subscription, every model included',
-  'onboarding.runtimeChoice.cloud.f4': 'No API keys to manage',
-  'onboarding.runtimeChoice.cloud.f5': 'Simple to set up',
+  'onboarding.runtimeChoice.cloud.f4': 'No model, search, or Composio keys to manage',
+  'onboarding.runtimeChoice.cloud.f5': 'Local Memory Tree, managed network services',
   'onboarding.runtimeChoice.custom.title': 'Run Custom',
   'onboarding.runtimeChoice.custom.tagline':
-    "Bring your own keys. Full control of what you're using.",
+    'Bring your own keys. Choose which services OpenHuman should call.',
   'onboarding.runtimeChoice.custom.f1': "You'll need API keys for almost everything",
   'onboarding.runtimeChoice.custom.f2': 'Reuses services you already pay for',
-  'onboarding.runtimeChoice.custom.f3': 'Can be free if you run everything locally',
+  'onboarding.runtimeChoice.custom.f3': 'Keep supported workloads on your machine',
   'onboarding.runtimeChoice.custom.f4': 'More setup, more knobs',
   'onboarding.runtimeChoice.custom.f5': 'Best for power users and developers',
   'onboarding.runtimeChoice.cloud.creditHighlight': '$1 free credit to try it out',
@@ -331,7 +332,7 @@ const en: TranslationMap = {
   'onboarding.custom.inference.subtitle':
     'Which language model should answer your questions and run your agents?',
   'onboarding.custom.inference.defaultDesc':
-    'OpenHuman routes every workload to a sensible default model. No keys, no setup.',
+    'OpenHuman routes workloads through its managed backend by default. No keys, no setup.',
   'onboarding.custom.inference.configureDesc':
     'Bring your own OpenAI or Anthropic key. We use it for every text-based workload.',
 
@@ -339,7 +340,7 @@ const en: TranslationMap = {
   'onboarding.custom.voice.title': 'Voice',
   'onboarding.custom.voice.subtitle': 'Speech-to-text and text-to-speech for voice mode.',
   'onboarding.custom.voice.defaultDesc':
-    'OpenHuman ships with managed STT/TTS that just works. Nothing to wire up.',
+    'OpenHuman ships with managed STT/TTS providers that may send audio/text to hosted services.',
   'onboarding.custom.voice.configureDesc':
     'Use your own ElevenLabs / OpenAI Whisper / etc. Configure in Settings › Voice.',
 
@@ -348,7 +349,7 @@ const en: TranslationMap = {
   'onboarding.custom.oauth.subtitle':
     'Gmail, Slack, Notion, and other connected services that need OAuth.',
   'onboarding.custom.oauth.defaultDesc':
-    'OpenHuman runs a managed Composio workspace. One click to connect each service later.',
+    'OpenHuman brokers OAuth and tool calls through a managed Composio workspace.',
   'onboarding.custom.oauth.configureDesc':
     'Bring your own Composio account / API key. Configure in Settings › Connections.',
 
@@ -356,7 +357,7 @@ const en: TranslationMap = {
   'onboarding.custom.search.title': 'Web Search',
   'onboarding.custom.search.subtitle': 'How OpenHuman searches the web on your behalf.',
   'onboarding.custom.search.defaultDesc':
-    'OpenHuman uses a managed search backend. No keys needed.',
+    'OpenHuman uses a managed search proxy by default. No search API key needed.',
   'onboarding.custom.search.configureDesc':
     'Bring your own search provider key (Tavily, Brave, etc.). Configure in Settings › Tools.',
 
@@ -1019,8 +1020,9 @@ const en: TranslationMap = {
   'backend.cloud': 'Cloud',
   'backend.recommended': 'Recommended',
   'backend.cloudDescription':
-    'Fast, powerful models hosted on our servers. Ready to use immediately.',
-  'backend.privacyNote': 'No personal data, messages, or keys are ever sent to our servers.',
+    'Fast, powerful models routed through the OpenHuman backend. Ready to use immediately.',
+  'backend.privacyNote':
+    'Prompts and selected context may be sent to the configured backend/provider. Use local mode for supported on-device workloads.',
   'backend.local': 'Local',
   'backend.advanced': 'Advanced',
   'backend.localDescription':

--- a/gitbooks/overview/getting-started.md
+++ b/gitbooks/overview/getting-started.md
@@ -35,6 +35,10 @@ The first screen is **"Sign in! Let's Cook"**. Multiple sign-in options are avai
 **No permanent lock-in.** Signing in does not grant OpenHuman ongoing access to anything. All third-party access requires explicit OAuth approval per integration in the steps below.
 {% endhint %}
 
+{% hint style="warning" %}
+**Know what is local and what is managed.** Your Memory Tree database, Markdown vault, workspace config, and local runtime state live on your machine. The default setup still uses OpenHuman-hosted services for sign-in, model routing, managed integration OAuth/tool calls, and web search proxying. Use the custom setup paths if you want to bring your own model, search, or Composio credentials. Some hosted features and real-time integration triggers still require the managed backend.
+{% endhint %}
+
 ## 3. Run your first request
 
 Once Gmail has been ingested (the first auto-fetch tick happens within twenty minutes), try prompts like:


### PR DESCRIPTION
## Summary

- Clarifies the README headline and early-beta note so local storage and managed services are visible before onboarding.
- Updates the integrations/model-routing README bullets to state when OAuth, tool calls, search, and model routing use OpenHuman-hosted paths by default.
- Adds a GitBook onboarding warning that separates local Memory Tree/vault/runtime state from hosted sign-in, routing, and managed Composio flows.
- Tightens English onboarding/backend copy so the default path no longer implies a fully local-only or no-data-to-backend posture.

## Problem

Issue #2422 points out that current public copy can read as more local-only than the product defaults actually are. On current `main`, the README leads with private/simple positioning while later default flows use hosted sign-in, model routing, search proxying, and managed Composio OAuth/tool calls. The onboarding copy also said OpenHuman could manage everything or that no personal data/messages/keys are sent to servers, which is too broad for the managed backend path.

## Solution

This PR keeps the current default product model, but makes the boundary explicit:

- Local by default for Memory Tree, Markdown vault, workspace config, and local runtime state.
- Managed by default for account sign-in, model routing/proxying, web search proxying, and Composio-backed OAuth/tool calls.
- Custom/local setup remains available for users who bring their own model, search, or Composio credentials, with hosted features/triggers called out as still requiring backend infrastructure.

No runtime behavior changes are included.

## Submission Checklist

- [x] N/A: Tests added or updated ? documentation and copy clarification only; existing i18n/onboarding tests were run.
- [x] N/A: Diff coverage >= 80% ? no executable logic changed; focused tests and typecheck were run instead.
- [x] N/A: Coverage matrix updated ? documentation/copy-only change.
- [x] N/A: Affected feature IDs listed ? no coverage matrix feature row changed.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist updated ? no release-cut behavior changed.
- [x] N/A: Linked issue closed via `Closes #NNN` ? #2422 has broader audit/remediation asks; this PR addresses the README/onboarding clarity slice only.

## Impact

Documentation and English UI copy only. The user-visible effect is clearer expectation-setting during README review and onboarding/settings screens. No desktop, core, Tauri, CLI, API, performance, migration, or compatibility behavior changes.

## Related

- Closes: N/A
- Related: #2422
- Follow-up PR(s)/TODOs: OAuth surface audit, BYOK/local-default posture review, and stale local-path cleanup remain separate #2422 follow-up slices.

## Validation Run

- [x] `pnpm i18n:check`
- [x] `pnpm --dir app exec vitest run --config test/vitest.config.ts src/lib/i18n/__tests__/coverage.test.ts src/lib/i18n/__tests__/I18nContext.test.tsx src/pages/onboarding/__tests__/OnboardingLayout.test.tsx src/pages/onboarding/pages/__tests__/ContextPage.test.tsx` ? 4 files / 53 tests passed
- [x] `pnpm typecheck`
- [x] `app/node_modules/.bin/prettier.CMD --check src/lib/i18n/en.ts src/lib/i18n/chunks/en-1.ts src/lib/i18n/chunks/en-3.ts`
- [x] `git diff HEAD --check`

## Validation Blocked

- `command:` `git push fork HEAD:refs/heads/codex/2422-readme-backend-clarity` without `--no-verify`
- `error:` pre-push hook runs broader repository checks; `cargo check --manifest-path app/src-tauri/Cargo.toml` failed because `app/src-tauri/vendor/tauri-cef/crates/tauri/Cargo.toml` is missing in this worktree, and `lint:commands-tokens` fails on existing command-token guard output outside this diff.
- `impact:` unrelated to this docs/copy change; branch was pushed with `--no-verify` after the focused validation above passed.

## Behavior Changes

- Intended behavior change: none.
- User-visible effect: clearer managed-backend and local-state wording in README, GitBook onboarding, and English onboarding/settings copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified “Upfront” messaging: what is stored locally (memory, Markdown vault, workspace config, runtime state) versus default managed services (sign-in, model routing, OAuth/tool calls, web search proxying).
  * Revised onboarding/runtime copy and feature bullets (Simple vs Run Custom), including optional local AI support and “under one subscription” model-routing phrasing.
  * Noted that some voice, OAuth, and search flows may route data via hosted brokers and updated cloud privacy guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->