### PR TITLE
feat(agents): route prediction-market intents via new markets_agent specialist (#2427)

### DIFF
--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -853,6 +853,26 @@ mod tests {
         );
     }
 
+    /// `tools_agent` must explicitly disallow `polymarket` and `kalshi`
+    /// so the prediction-market venues route ONLY through
+    /// `markets_agent` (`delegate_do_prediction_markets`). Without this
+    /// the wildcard inventory would also surface them as raw tools to
+    /// the generalist, bypassing the venue-aware approval-gate prompt.
+    #[test]
+    fn tools_agent_disallows_prediction_market_tools() {
+        let def = find("tools_agent");
+        assert!(
+            def.disallowed_tools.iter().any(|t| t == "polymarket"),
+            "tools_agent.disallowed_tools must contain `polymarket` so the \
+             venue routes through markets_agent exclusively"
+        );
+        assert!(
+            def.disallowed_tools.iter().any(|t| t == "kalshi"),
+            "tools_agent.disallowed_tools must contain `kalshi` so the \
+             venue routes through markets_agent exclusively"
+        );
+    }
+
     #[test]
     fn orchestrator_subagents_include_skill_creator() {
         use crate::openhuman::agent::harness::definition::SubagentEntry;

--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -84,6 +84,11 @@ pub const BUILTINS: &[BuiltinAgent] = &[
         prompt_fn: super::crypto_agent::prompt::build,
     },
     BuiltinAgent {
+        id: "markets_agent",
+        toml: include_str!("markets_agent/agent.toml"),
+        prompt_fn: super::markets_agent::prompt::build,
+    },
+    BuiltinAgent {
         id: "tools_agent",
         toml: include_str!("tools_agent/agent.toml"),
         prompt_fn: super::tools_agent::prompt::build,
@@ -273,7 +278,7 @@ mod tests {
     fn all_builtins_parse() {
         let defs = load_builtins().expect("built-in TOML must parse");
         assert_eq!(defs.len(), BUILTINS.len());
-        assert_eq!(defs.len(), 17, "expected 17 built-in agents");
+        assert_eq!(defs.len(), 18, "expected 18 built-in agents");
     }
 
     #[test]
@@ -740,6 +745,90 @@ mod tests {
             listed,
             "orchestrator.subagents must list `crypto_agent` so the \
              routing layer can synthesise `delegate_do_crypto`"
+        );
+    }
+
+    #[test]
+    fn markets_agent_has_narrow_prediction_market_tools_and_safety_on() {
+        let def = find("markets_agent");
+        // Hint must be agentic — the agent reasons about market shape vs.
+        // executes across multiple tool calls per turn.
+        assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "agentic"));
+        assert_eq!(def.sandbox_mode, SandboxMode::None);
+        // Financial-side-effect agent — global safety preamble stays ON.
+        assert!(
+            !def.omit_safety_preamble,
+            "markets_agent must keep the global safety preamble — financial-risk gate"
+        );
+        match &def.tools {
+            ToolScope::Named(tools) => {
+                // Prediction-market venues.
+                for required in ["polymarket", "kalshi"] {
+                    assert!(
+                        tools.iter().any(|t| t == required),
+                        "markets_agent needs venue tool `{required}`"
+                    );
+                }
+                // Confirmation gate — MUST be present so the prompt's
+                // "confirm before execute" rule is mechanically enforceable.
+                assert!(
+                    tools.iter().any(|t| t == "ask_user_clarification"),
+                    "markets_agent needs ask_user_clarification to gate write ops"
+                );
+                // Context helpers. Pin the full set so a TOML edit that
+                // silently drops `memory_recall` or `current_time` gets
+                // caught here — the agent's "ground in user preferences"
+                // and "as of <when>" framing depend on these.
+                for required in ["memory_recall", "current_time"] {
+                    assert!(
+                        tools.iter().any(|t| t == required),
+                        "markets_agent needs supporting tool `{required}`"
+                    );
+                }
+                // Hard exclusions — no broad-surface tools, no wallet
+                // primitives (those belong to crypto_agent), no
+                // delegation tools (markets_agent is a worker leaf).
+                for forbidden in [
+                    "shell",
+                    "file_write",
+                    "curl",
+                    "http_request",
+                    "composio_execute",
+                    "composio_list_tools",
+                    "spawn_subagent",
+                    "spawn_worker_thread",
+                    "delegate_to_integrations_agent",
+                    "delegate_run_code",
+                    "delegate_research",
+                    "delegate_plan",
+                    "wallet_execute_prepared",
+                    "wallet_prepare_transfer",
+                    "wallet_prepare_swap",
+                ] {
+                    assert!(
+                        !tools.iter().any(|t| t == forbidden),
+                        "markets_agent must NOT have `{forbidden}` — keeps blast radius bounded"
+                    );
+                }
+            }
+            ToolScope::Wildcard => panic!("markets_agent must have a Named tool scope"),
+        }
+        // Keep iteration cap tight — browse → propose → confirm → execute
+        // is a short loop, not a research crawl.
+        assert!(
+            def.max_iterations <= 10,
+            "markets_agent max_iterations must stay tight (got {})",
+            def.max_iterations
+        );
+        assert!(def.omit_identity);
+        assert!(def.omit_memory_context);
+        assert!(def.omit_skills_catalog);
+        // Delegate name must be the stable, chat-friendly slug — the
+        // orchestrator surfaces it as `delegate_do_prediction_markets`.
+        assert_eq!(
+            def.delegate_name.as_deref(),
+            Some("do_prediction_markets"),
+            "markets_agent must keep its `do_prediction_markets` delegate name stable"
         );
     }
 

--- a/src/openhuman/agent/agents/loader.rs
+++ b/src/openhuman/agent/agents/loader.rs
@@ -832,6 +832,27 @@ mod tests {
         );
     }
 
+    /// Routing: the orchestrator must list `markets_agent` in its
+    /// `subagents` so a `delegate_do_prediction_markets` tool is
+    /// synthesised at agent-build time. Without this entry the
+    /// orchestrator can't route Polymarket / Kalshi requests to the
+    /// specialist and they fall back into the generalist tools_agent
+    /// wildcard.
+    #[test]
+    fn orchestrator_subagents_include_markets_agent() {
+        use crate::openhuman::agent::harness::definition::SubagentEntry;
+        let def = find("orchestrator");
+        let listed = def.subagents.iter().any(|e| match e {
+            SubagentEntry::AgentId(id) => id == "markets_agent",
+            _ => false,
+        });
+        assert!(
+            listed,
+            "orchestrator.subagents must list `markets_agent` so the \
+             routing layer can synthesise `delegate_do_prediction_markets`"
+        );
+    }
+
     #[test]
     fn orchestrator_subagents_include_skill_creator() {
         use crate::openhuman::agent::harness::definition::SubagentEntry;

--- a/src/openhuman/agent/agents/markets_agent/agent.toml
+++ b/src/openhuman/agent/agents/markets_agent/agent.toml
@@ -1,0 +1,46 @@
+id = "markets_agent"
+display_name = "Markets Agent"
+delegate_name = "do_prediction_markets"
+when_to_use = "Prediction-market & event-contract trading specialist — drives Polymarket (CTF Exchange) and Kalshi (KalshiEX) plus other event-contract venues. Use for: market discovery (list/get markets, events, orderbooks); portfolio reads (positions, balance, open orders, fills); and (with explicit user approval) place_order / cancel_order. Always browse before placing; always surface approval gates to the user; refuse trade actions on missing API credentials or unknown ticker shape. Distinct from `crypto_agent`, which owns on-chain wallets + crypto exchange trading."
+temperature = 0.2
+max_iterations = 8
+sandbox_mode = "none"
+
+# Markets agent has a tight single-purpose voice and gets its own safety
+# rules from the prompt body — the global identity/skills boilerplate
+# would dilute them, but the standard safety preamble stays on as a
+# belt-and-suspenders gate on financial-side-effect actions.
+omit_identity = true
+omit_memory_context = true
+omit_safety_preamble = false
+omit_skills_catalog = true
+
+[model]
+hint = "agentic"
+
+[tools]
+# Narrow allowlist. Prediction-market venues only — no shell, no
+# file_write, no broad HTTP, no integration delegation, no wallet
+# primitives. Names line up with the network tool `name()` returns in
+# `src/openhuman/tools/impl/network/{polymarket,kalshi}.rs`. Hyperliquid
+# (#1398 venue 3/3) lands separately; its routing slot (markets_agent vs
+# `crypto_agent`) is decided in that PR's plan since perps may belong
+# with wallet-side trading. Tools that aren't yet registered are silently
+# dropped by the tool filter at spawn time, so this list also describes
+# the agent's *intended* tool surface.
+named = [
+    # Prediction-market venues.
+    "polymarket",
+    "kalshi",
+    # Memory recall lets the agent ground execution in the user's
+    # previously-stated preferences (default venue, account labels)
+    # instead of re-asking every time.
+    "memory_recall",
+    # Confirmation gate — surfaced to the user when a venue tool returns
+    # the approval-required error. The runtime routes the prompt to the
+    # user and blocks until they reply.
+    "ask_user_clarification",
+    # Time grounding for "as of <when>" framing and freshness checks on
+    # quotes / orderbook snapshots before execute.
+    "current_time",
+]

--- a/src/openhuman/agent/agents/markets_agent/mod.rs
+++ b/src/openhuman/agent/agents/markets_agent/mod.rs
@@ -1,0 +1,1 @@
+pub mod prompt;

--- a/src/openhuman/agent/agents/markets_agent/prompt.md
+++ b/src/openhuman/agent/agents/markets_agent/prompt.md
@@ -1,0 +1,74 @@
+# Markets Agent
+
+You are the **Markets Agent** — OpenHuman's specialist for prediction-market and event-contract trading on Polymarket and Kalshi. Every action you take moves real money, so your default posture is **read, simulate, confirm, then execute**.
+
+## What you handle
+
+- Reading markets, events, orderbooks, and ticker metadata on Polymarket (CTF Exchange) and Kalshi (KalshiEX).
+- Reading portfolio state: positions, balance, open orders, fills.
+- Proposing buy / sell on YES or NO legs with explicit side, count, and price.
+- Executing **only the exact order shape** you previously proposed to the user — never a parameter set you invented.
+- Cancelling open orders on user instruction.
+- Pointing the user back to **Settings → Connections** when a venue's API key / secret isn't configured.
+
+## What you do NOT handle
+
+- On-chain wallet operations, swaps, transfers, contract calls — defer to `crypto_agent`.
+- Generic web research, news summaries, regulatory analysis — defer to the researcher.
+- Code writing, file edits, shell access, broad HTTP. You have no shell, no file_write, no curl.
+- Service integrations like Gmail / Notion / Slack — delegate via the orchestrator.
+- Autonomous background trading. You only act on an in-band user instruction with an explicit confirmation.
+
+## Hard rules
+
+1. **No fabrication.** Never invent ticker IDs, condition IDs, market slugs, event identifiers, prices, position counts, order IDs, or tool names. If you don't have it from a tool result or the user, ask. If a tool isn't in your tool list, say so — do not pretend it exists.
+2. **Read before write.** Before proposing any `place_order`, confirm the market exists and is live with `polymarket` / `kalshi` browse actions (`list_markets` / `get_market` / `get_orderbook`). Cross-check side, count, and price against the orderbook so the order is plausibly fillable.
+3. **Approval gate is non-negotiable.** Every write action (`place_order`, `cancel_order`) on Polymarket or Kalshi requires the caller to pass `approved=true`. Before sending that flag, call `ask_user_clarification` with a tight summary: venue, ticker, side (YES/NO), count, price in cents, est. cost. Only proceed on an explicit yes.
+4. **Confirm before execute.** Surface the venue's approval-required error verbatim if it bounces — do not silently retry with `approved=true`. The user, not the agent, owns the green light.
+5. **Stop cleanly on missing setup.** If a venue's credentials are missing (Polymarket CLOB L2 key/secret/passphrase, or Kalshi API key + RSA/HMAC secret), do not retry, do not guess. Say which thing is missing, point to **Settings → Connections**, and stop.
+6. **Price sanity.** Kalshi prices are integer cents in `1..=99`. Polymarket prices are normalised in `0.01..=0.99`. Refuse proposals outside band. If a user types "buy at $1.50", surface the bug and re-ask in the venue's native units.
+7. **Stop cleanly on insufficient balance / liquidity.** If a quote / orderbook lookup shows the requested fill cannot land at the requested price, surface the reason verbatim, suggest the smallest viable adjustment (lower count, different price tier), and wait for the user.
+8. **Never log secrets.** Do not echo API keys, RSA private keys, HMAC secrets, Polymarket L2 passphrases, or signed payload bodies in your replies. Quote the ticker, side, count, price, and any order id the venue returned, nothing more.
+
+## Standard flow
+
+1. **Frame the intent.** Restate the request in one short sentence: which venue, which market (full ticker), which side, what count, at what price, why. If anything is ambiguous (venue choice, ticker, side, count, price), ask once with `ask_user_clarification`.
+2. **Inspect.** `list_markets` / `get_market` / `get_orderbook` to confirm the market exists, is live, and the requested price is consistent with the visible book. For portfolio questions, `get_positions` / `get_balance` / `get_open_orders` / `get_fills`.
+3. **Propose.** Restate the order shape: venue, ticker, side (YES or NO), count, price (in venue-native units), est. cost. Call `ask_user_clarification` with this summary. Show: venue, ticker, side, count, price, est. cost, est. landing time, account label if known.
+4. **Execute.** On explicit confirmation, re-invoke `polymarket` / `kalshi` with `action=place_order`, `approved=true`, and the exact parameters you confirmed. Report back the broadcast result (order id, status) and the venue order link only if the tool returned one — do not synthesise links from the order id.
+5. **On failure.** Show a **sanitized** summary of the tool's error — never echo raw payloads, signed request bodies, full HTTP responses, stack traces, or any field that could embed a secret. Redact long opaque tokens to a short prefix (e.g. `eyJh…XR8`). Then name the likely cause in one line (e.g. "venue rejected — price moved", "insufficient balance"), and stop. Do not auto-retry write operations.
+
+## Output shape
+
+Keep replies tight and grounded.
+
+> checking kalshi for FED-25NOV-Y …
+>
+> market is live; orderbook YES top-of-book 52c × 200, NO 49c × 180.
+>
+> proposed order:
+>
+> - venue: kalshi
+> - ticker: FED-25NOV-Y
+> - side: YES
+> - count: 1
+> - price: 50c
+> - est. cost: $0.50
+>
+> ok to send?
+
+After execution:
+
+> sent. kalshi order id `order_8f2…`, status `resting`.
+
+On a missing prerequisite:
+
+> no kalshi credentials set up yet — head to **Settings → Connections** to add your KalshiEX API key + secret, then ping me back.
+
+On a failed order:
+
+> kalshi rejected — price moved to 53c top-of-book. try 53c, or wait for the book to settle.
+
+## Why this prompt exists
+
+The orchestrator delegates prediction-market work here precisely because generic agents over-assume tool availability and under-confirm financial intent. **Your value is caution, not breadth.** When in doubt, stop and ask.

--- a/src/openhuman/agent/agents/markets_agent/prompt.rs
+++ b/src/openhuman/agent/agents/markets_agent/prompt.rs
@@ -1,0 +1,144 @@
+//! System prompt builder for the `markets_agent` built-in agent.
+//!
+//! Markets Agent is a narrow-scope, write-capable specialist for
+//! prediction-market and event-contract trading on Polymarket and
+//! Kalshi. The body is the archetype's read/propose/confirm/execute
+//! contract, followed by the standard tool + workspace blocks so the
+//! model sees the `polymarket` / `kalshi` schemas the runtime injected.
+//! Identity, skills catalogue and global memory context are omitted —
+//! they would dilute the financial-safety voice the archetype
+//! establishes.
+
+use crate::openhuman::context::prompt::{
+    render_safety, render_tools, render_user_files, render_workspace, PromptContext,
+};
+use anyhow::Result;
+
+const ARCHETYPE: &str = include_str!("prompt.md");
+
+pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
+    tracing::debug!(
+        agent_id = ctx.agent_id,
+        model = ctx.model_name,
+        tool_count = ctx.tools.len(),
+        skill_count = ctx.skills.len(),
+        "[agent_prompt][markets_agent] build_start"
+    );
+
+    let mut out = String::with_capacity(8192);
+    out.push_str(ARCHETYPE.trim_end());
+    out.push_str("\n\n");
+
+    let user_files = render_user_files(ctx)?;
+    let user_files_present = !user_files.trim().is_empty();
+    if user_files_present {
+        out.push_str(user_files.trim_end());
+        out.push_str("\n\n");
+    }
+
+    let tools = render_tools(ctx)?;
+    let tools_present = !tools.trim().is_empty();
+    if tools_present {
+        out.push_str(tools.trim_end());
+        out.push_str("\n\n");
+    }
+
+    let safety = render_safety();
+    out.push_str(safety.trim_end());
+    out.push_str("\n\n");
+
+    let workspace = render_workspace(ctx)?;
+    let workspace_present = !workspace.trim().is_empty();
+    if workspace_present {
+        out.push_str(workspace.trim_end());
+        out.push('\n');
+    }
+
+    tracing::trace!(
+        agent_id = ctx.agent_id,
+        prompt_len = out.len(),
+        user_files_present,
+        tools_present,
+        workspace_present,
+        "[agent_prompt][markets_agent] build_done"
+    );
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::context::prompt::{LearnedContextData, ToolCallFormat};
+    use std::collections::HashSet;
+
+    fn empty_ctx() -> PromptContext<'static> {
+        use std::sync::OnceLock;
+        static EMPTY_VISIBLE: OnceLock<HashSet<String>> = OnceLock::new();
+        PromptContext {
+            workspace_dir: std::path::Path::new("."),
+            model_name: "test",
+            agent_id: "markets_agent",
+            tools: &[],
+            skills: &[],
+            dispatcher_instructions: "",
+            learned: LearnedContextData::default(),
+            visible_tool_names: EMPTY_VISIBLE.get_or_init(HashSet::new),
+            tool_call_format: ToolCallFormat::PFormat,
+            connected_integrations: &[],
+            connected_identities_md: String::new(),
+            include_profile: false,
+            include_memory_md: false,
+            curated_snapshot: None,
+            user_identity: None,
+        }
+    }
+
+    #[test]
+    fn build_returns_nonempty_body() {
+        let body = build(&empty_ctx()).unwrap();
+        assert!(!body.is_empty());
+        assert!(body.contains("Markets Agent"));
+    }
+
+    #[test]
+    fn build_enforces_read_propose_confirm_execute() {
+        let body = build(&empty_ctx()).unwrap();
+        // The four phases must all be visible in the prompt — the agent's
+        // entire safety story rests on them.
+        assert!(
+            body.contains("read, simulate, confirm, then execute")
+                || body.contains("read/propose/confirm/execute"),
+            "prompt must spell out the read→propose→confirm→execute contract"
+        );
+        assert!(
+            body.contains("ask_user_clarification"),
+            "prompt must require explicit user confirmation before execute"
+        );
+        assert!(
+            body.contains("approved=true"),
+            "prompt must require the venue-level approved=true flag for write actions"
+        );
+    }
+
+    #[test]
+    fn build_forbids_fabrication_and_logging_secrets() {
+        let body = build(&empty_ctx()).unwrap();
+        assert!(
+            body.contains("No fabrication"),
+            "prompt must explicitly forbid fabricating ticker / market / price params"
+        );
+        assert!(
+            body.contains("Never log secrets") || body.contains("never log secrets"),
+            "prompt must forbid echoing API keys / signing secrets"
+        );
+    }
+
+    #[test]
+    fn build_distinguishes_from_crypto_agent() {
+        let body = build(&empty_ctx()).unwrap();
+        assert!(
+            body.contains("crypto_agent"),
+            "prompt must point on-chain work to crypto_agent so concerns stay separated"
+        );
+    }
+}

--- a/src/openhuman/agent/agents/mod.rs
+++ b/src/openhuman/agent/agents/mod.rs
@@ -10,6 +10,7 @@ pub mod critic;
 pub mod crypto_agent;
 pub mod help;
 pub mod integrations_agent;
+pub mod markets_agent;
 pub mod morning_briefing;
 pub mod orchestrator;
 pub mod planner;

--- a/src/openhuman/agent/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent/agents/orchestrator/agent.toml
@@ -58,6 +58,14 @@ subagents = [
     # the agent enforces a strict read → simulate → confirm → execute
     # contract that the generic delegation surface does not.
     "crypto_agent",
+    # Prediction-market & event-contract specialist (#2427). Synthesised
+    # into a `delegate_do_prediction_markets` tool at agent-build time.
+    # Route any Polymarket / Kalshi (and future event-contract venue)
+    # market browse, portfolio read, or order request here. The
+    # `tools_agent` wildcard explicitly disallows `polymarket` / `kalshi`
+    # so there is exactly one canonical route — through this delegate —
+    # which keeps the venue-specific approval-gate prompt in scope.
+    "markets_agent",
     # NOTE: `summarizer` used to be listed here for the runtime-only
     # oversized-tool-result hook. That path is currently disabled
     # (`context.summarizer_payload_threshold_tokens = 0`) after recursive

--- a/src/openhuman/agent/agents/tools_agent/agent.toml
+++ b/src/openhuman/agent/agents/tools_agent/agent.toml
@@ -9,6 +9,14 @@ omit_memory_context = true
 omit_safety_preamble = false
 omit_skills_catalog = true
 
+# Prediction-market venues (#2427) own their own specialist
+# (`markets_agent` → `delegate_do_prediction_markets`) with a venue-aware
+# approval-gate prompt. Disallow them here so the generalist's wildcard
+# inventory doesn't surface a second, weaker route to the same
+# capability. `tools_agent` retains every other built-in tool through
+# the wildcard.
+disallowed_tools = ["polymarket", "kalshi"]
+
 [model]
 hint = "agentic"
 
@@ -17,5 +25,7 @@ hint = "agentic"
 # surface. Composio meta-tools and dynamic `<TOOLKIT>_*` action tools
 # are stripped at runtime (see `filter_non_composio_indices` in the
 # subagent runner), so the LLM never sees integration-specific tools
-# here; those belong to `integrations_agent`.
+# here; those belong to `integrations_agent`. Trading venues are also
+# stripped via `disallowed_tools` above so they route through
+# `markets_agent` exclusively.
 wildcard = {}

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -410,6 +410,44 @@ mod tests {
         assert_eq!(names, vec!["research", "delegate_archivist"]);
     }
 
+    /// An AgentId entry whose target carries a `delegate_name` override
+    /// must surface that override as the synthesised tool name — the
+    /// orchestrator LLM sees `do_prediction_markets`, not
+    /// `delegate_markets_agent`. Mirrors the existing
+    /// `crypto_agent → do_crypto` precedent (#1397) for the new
+    /// `markets_agent → do_prediction_markets` slot from #2427.
+    #[test]
+    fn markets_agent_subagent_synthesises_do_prediction_markets_delegate() {
+        let mut orch = def("orchestrator", "test", None);
+        orch.subagents = vec![SubagentEntry::AgentId("markets_agent".into())];
+        let mut reg = registry_with_targets();
+        reg.insert(def(
+            "markets_agent",
+            "Prediction-market & event-contract trading specialist — drives Polymarket and Kalshi.",
+            Some("do_prediction_markets"),
+        ));
+        let tools = collect_orchestrator_tools(&orch, &reg, &[]);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(
+            names,
+            vec!["do_prediction_markets"],
+            "markets_agent subagent entry must synthesise a tool named after its \
+             `delegate_name` override (`do_prediction_markets`), not the default \
+             `delegate_markets_agent`"
+        );
+        // Description must come from the target's `when_to_use` blurb so
+        // the orchestrator's LLM has venue-specific routing signal.
+        let tool = tools
+            .iter()
+            .find(|t| t.name() == "do_prediction_markets")
+            .unwrap();
+        assert!(
+            tool.description().contains("Polymarket") || tool.description().contains("Kalshi"),
+            "synthesised tool description must surface the venue blurb so the LLM \
+             can route prediction-market intents to it"
+        );
+    }
+
     /// An AgentId entry that points at an id not present in the registry
     /// should be logged and silently skipped, rather than panicking or
     /// aborting tool assembly. The orchestrator still builds.


### PR DESCRIPTION
## Summary

- Closes the agent routing gap that made #2145 (Polymarket) and #2329 (Kalshi) tools register at the RPC layer but stay invisible to the chat agent.
- Adds a new `markets_agent` built-in specialist for prediction-market and event-contract trading (Polymarket + Kalshi) — modelled on `crypto_agent`, with its own read → browse → propose → confirm → execute safety contract.
- Wires `markets_agent` into the orchestrator's `subagents` so a `delegate_do_prediction_markets` tool is auto-synthesised; venue intents now route deterministically.
- Disallows `polymarket` / `kalshi` on `tools_agent`'s wildcard so each capability has exactly one canonical route — through the venue-aware approval-gate prompt.
- All-Rust change: zero touch to RPC controllers, tool implementations, backend, or frontend.

## Problem

On a staging build of `feat/1398-kalshi` (commit `e68fa585`), the chat orchestrator replied to `use kalshi tool to list markets` with *"I don't have a kalshi tool available right now. The connected integrations I can work with are github, gmail, and slack."* Same response for `polymarket` despite #2145 having shipped that capability. Trace of the runtime delegation surface confirmed exactly 9 `delegate_*` tools visible to the orchestrator, none of which advertise prediction-market venues — `delegate_tools_agent.when_to_use` describes only "shell, file I/O, HTTP, web search, memory", so the LLM never picks it for trading intents, falls back to inspecting Composio connections, and reports "not connected."

`KalshiTool` and `PolymarketTool` are both in the tools registry (`src/openhuman/tools/ops.rs:541-558`) and silently sit inside `tools_agent`'s wildcard inventory (`ToolScope::Wildcard => true` at `tool_prep.rs:165`). The capabilities exist — the **routing layer can't find them**, so every dollar of trading work shipped on #2145 / #2329 is functionally unreachable from chat. Hyperliquid (#1398 venue 3/3) would inherit the same gap.

## Solution

Mirror the `crypto_agent` precedent (`src/openhuman/agent/agents/crypto_agent/`). New specialist `markets_agent`:

- `delegate_name = "do_prediction_markets"` → orchestrator surfaces it as `delegate_do_prediction_markets` alongside `delegate_do_crypto`.
- Named tool allowlist: `["polymarket", "kalshi", "memory_recall", "ask_user_clarification", "current_time"]`. Hyperliquid (perps) is intentionally deferred — its routing slot (markets_agent vs crypto_agent) is decided in venue 3/3's plan.
- Prompt enforces a read → browse → propose → confirm → execute contract anchored on the venue-level `approved=true` flag. Refuses on missing creds, unknown ticker shape, prices out of band (1–99c on Kalshi, 0.01–0.99 on Polymarket). Never echoes API keys / signing secrets.
- Hard exclusions in the loader test: no `shell` / `file_write` / `curl` / `composio_*` / `spawn_*` / `delegate_*` / `wallet_*` — keeps blast radius bounded to the same shape as `crypto_agent`.

Orchestrator wiring: one new entry in `orchestrator/agent.toml` subagents list (between `crypto_agent` and the skills wildcard) with a comment explaining the route. `collect_orchestrator_tools` (`tools/orchestrator_tools.rs`) auto-emits the delegation tool — no code change there beyond a new synthesis test.

Single canonical route: `tools_agent` gains `disallowed_tools = ["polymarket", "kalshi"]`. The wildcard inventory still grants the generalist every other built-in tool, but the prediction-market venues are explicitly stripped so they route ONLY through `delegate_do_prediction_markets`. Without this guard the orchestrator's LLM would see two competing paths to the same capability, only one of which carries the safety preamble.

### Alternatives considered + rejected

- **Extend `crypto_agent`** to include polymarket/kalshi — conflates wallet-signing safety contract with USD market-buy contract; weakens routing signal as the blurb grows multi-topic. Crypto wallet RPCs and prediction-market REST/CLOB calls have different failure modes.
- **Tweak `tools_agent.when_to_use`** to mention prediction markets — wildcard means every future registry tool becomes implicitly trade-routable; no venue-specific safety preamble owned by the generalist.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are exercised by 4 new prompt unit tests (`markets_agent::prompt::tests::*`), 3 new loader tests (`markets_agent_has_narrow_*`, `orchestrator_subagents_include_markets_agent`, `tools_agent_disallows_prediction_market_tools`), the existing `all_builtins_parse` count assertion (17 → 18), and 1 new `orchestrator_tools` synthesis test (`markets_agent_subagent_synthesises_do_prediction_markets_delegate`). 50 / 50 pass locally — see Validation Run below.
- [x] N/A: Coverage matrix updated — this is a routing-layer change with no new user-facing feature ID; no rows added or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix rows touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure agent-definition wiring, no HTTP / external services added.
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`) — Rust-only change, no release-cut surface modified; recommend a one-line addition to the smoke matrix in a follow-up once the markets_agent has run through a live trading flow on staging.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `Closes #2427`.

## Impact

- **Runtime**: desktop only (Tauri shell hosts the in-process core per #1061). No mobile/web/CLI surface change.
- **Security**: prediction-market venues continue to enforce their own credential guard + approval gate; this PR just routes intents to a specialist whose prompt makes the gate mechanically enforceable (`ask_user_clarification` is in the allowlist, prompt requires it before `approved=true`).
- **Performance**: one extra delegation tool (10 instead of 9) in the orchestrator's function-calling schema; trivial token impact.
- **Compatibility**: net-new agent registration. Existing chat flows that already worked (composio integrations, crypto agent, planner, etc.) are untouched. `tools_agent` users that previously accessed `polymarket` / `kalshi` via the wildcard would be re-routed — but no callers existed (the LLM never picked that path, as the bug report shows).
- **Migration**: none. Agent definitions are baked into the binary at compile time.

## Related

- Closes #2427
- Refs #1398 — Trading integrations (Polymarket + Kalshi + Hyperliquid)
- Refs #2145 — Polymarket merged; this PR makes the tool reachable from chat
- Refs #2329 — Kalshi in review; this PR makes the tool reachable from chat once #2329 merges (markets_agent silently drops missing tools, so it works regardless of merge order)
- Follow-up PR(s)/TODOs:
  - Venue 3/3 (Hyperliquid) plan must decide whether perps route through `markets_agent` or `crypto_agent`'s exchange-trading surface; the slot in `markets_agent`'s allowlist is reserved but not pre-allocated.
  - Optional: live staging smoke once the markets_agent has carried a few orders, then add a `docs/RELEASE-MANUAL-SMOKE.md` row.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/2427-markets-agent-routing`
- Commit SHA: `6702d725` (tip; 4 GPG-signed commits off `upstream/main @ bf6f25e6`)

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no TypeScript / app changes in this PR; pure Rust + agent definition TOML + prompt markdown.
- [x] `pnpm typecheck` — N/A: same reason as above.
- [x] Focused tests:
  - `cargo test --lib agent::agents::loader` → **35 passed, 0 failed** in 0.04s (includes new `markets_agent_has_narrow_prediction_market_tools_and_safety_on`, `orchestrator_subagents_include_markets_agent`, `tools_agent_disallows_prediction_market_tools`).
  - `cargo test --lib tools::orchestrator_tools` → **11 passed, 0 failed** in 0.00s (includes new `markets_agent_subagent_synthesises_do_prediction_markets_delegate`).
  - `cargo test --lib agent::agents::markets_agent` → **4 passed, 0 failed** in 0.00s (prompt body unit tests).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` clean (pre-existing warns in `secrets.rs`, `webview_accounts/ops.rs`, `mcp_clients/connections.rs` are unrelated and identical to the upstream/main set).
- [x] Tauri fmt/check (if changed): N/A — Tauri shell untouched.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: orchestrator's chat agent now routes "list / trade Polymarket / Kalshi" intents to a new specialist (`markets_agent` via `delegate_do_prediction_markets`) instead of falling back to "you don't have that integration." Both venues' approval gates are unchanged at the tool layer; the prompt makes them mechanically enforceable.
- User-visible effect: chat prompts targeting Polymarket / Kalshi now produce real tool dispatch (cred-guard error if API creds missing, approval-required error if `approved=true` missing, real venue calls otherwise) instead of the misleading "no kalshi available" reply. Polymarket's gap from #2145 closes alongside Kalshi.

### Parity Contract
- Legacy behavior preserved: `crypto_agent` route is unchanged (test `crypto_agent_has_narrow_wallet_market_tools_and_safety_on` still passes); `tools_agent` retains every tool except the two explicitly disallowed venues; orchestrator's existing 9 delegations remain — `delegate_do_prediction_markets` is additive, not a replacement.
- Guard/fallback/dispatch parity checks: the `crypto_agent → do_crypto` synthesis pattern is preserved (test `collects_agentid_entries_and_collapses_skills_wildcard` covers it); the new `markets_agent → do_prediction_markets` synthesis mirrors that pattern verbatim (new test asserts identical shape). Hard exclusions list on `markets_agent` matches `crypto_agent`'s exclusion list (no shell / curl / wallet primitives / spawn / delegate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Markets Agent specialized for prediction market trading on Polymarket and Kalshi exchanges.
  * Includes built-in safety constraints with user confirmation required before executing market trades.
  * Market trading operations now route through the dedicated Markets Agent for specialized handling and venue-specific approval gating.
  * Agent validates market conditions and enforces strict operational limits to prevent errors and unauthorized trades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->