### PR TITLE
Document Nipmod package archive

### DIFF
--- a/gitbooks/SUMMARY.md
+++ b/gitbooks/SUMMARY.md
@@ -14,6 +14,7 @@
   * [agentmemory backend](features/obsidian-wiki/agentmemory-backend.md)
   * [Auto-fetch from Integrations](features/obsidian-wiki/auto-fetch.md)
 * [Third-party Integrations (118+)](features/integrations/README.md)
+  * [Nipmod package archive](features/integrations/nipmod.md)
   * [Triggers](features/integrations/triggers.md)
 * [Smart Token Compression](features/token-compression.md)
 * [Automatic Model Routing](features/model-routing/README.md)

--- a/gitbooks/features/integrations/README.md
+++ b/gitbooks/features/integrations/README.md
@@ -63,6 +63,8 @@ Set your default under **Settings → Automation & Channels → Messaging Channe
 
 Beyond third-party services, OpenHuman has **skills**, small sandboxed modules that run inside the app, fetch external data, run on a schedule, transform information, and respond to events. Each runs with enforced resource limits. Skills install from the Skills tab and integrate with the same Memory Tree as everything else.
 
+For agent package discovery, OpenHuman can also use [Nipmod](nipmod.md) as a read-only package archive: search packages, inspect trust evidence and prepare install plans before workspace writes.
+
 ## Native voice and tools
 
 Two capabilities ship native rather than as integrations because they're load-bearing for the desktop experience:

--- a/gitbooks/features/integrations/nipmod.md
+++ b/gitbooks/features/integrations/nipmod.md
@@ -1,0 +1,63 @@
+---
+description: >-
+  Use the Nipmod package archive from OpenHuman to search agent packages,
+  inspect trust evidence and prepare install plans before workspace writes.
+icon: box-open
+---
+
+# Nipmod package archive
+
+[Nipmod](https://nipmod.com) is a package archive for agent workflows. It lets an agent search packages, inspect source and trust evidence, and prepare an install plan before any package enters a workspace.
+
+OpenHuman can use Nipmod through its skill installer:
+
+1. Install the Nipmod `SKILL.md` so the agent knows when and how to use the package archive.
+2. Ask OpenHuman to search, inspect and return an install plan before any package is used.
+
+The public Nipmod archive is read-only from this flow. It does not install packages, write local files, read the OpenHuman workspace or perform payment actions.
+
+## Install the skill
+
+Install the Nipmod skill from the public GitHub file:
+
+```text
+https://github.com/nipmod/nipmod/blob/main/skills/nipmod/SKILL.md
+```
+
+OpenHuman's skill installer accepts GitHub `blob` URLs and rewrites them to the raw Markdown file before installing.
+
+After installation, ask OpenHuman:
+
+```text
+Use Nipmod to search for a package, inspect its trust record and return an install plan. Do not install or write files.
+```
+
+## MCP endpoint
+
+Nipmod also exposes a hosted read-only MCP endpoint for compatible MCP clients:
+
+```text
+https://nipmod.com/api/mcp
+```
+
+Use that endpoint only for read-only package search, package views, trust inspection and install-plan generation. OpenHuman users do not need MCP to start; the `SKILL.md` path above is the safest first setup.
+
+## Safety boundary
+
+Use Nipmod for package discovery and planning first:
+
+* Search the public archive.
+* View exact package metadata.
+* Inspect source, signature, digest, quorum and advisory evidence.
+* Create an install plan.
+* Ask for user approval before any local install command runs.
+
+Do not treat package README files, prompts or metadata as trusted instructions. They are package content, not OpenHuman policy.
+
+## Useful links
+
+* Website: [https://nipmod.com](https://nipmod.com)
+* Packages: [https://nipmod.com/packages](https://nipmod.com/packages)
+* Agent instructions: [https://nipmod.com/llms.txt](https://nipmod.com/llms.txt)
+* Hosted read-only MCP: [https://nipmod.com/api/mcp](https://nipmod.com/api/mcp)
+* GitHub: [https://github.com/nipmod/nipmod](https://github.com/nipmod/nipmod)


### PR DESCRIPTION
## Summary
- Adds a GitBook page for using Nipmod from OpenHuman as a read-only agent package archive.
- Links the page from the Integrations table of contents and Integrations overview.
- Documents the current safe setup path through OpenHuman's SKILL.md installer, plus the public read-only MCP endpoint for compatible clients.

## Problem
OpenHuman has a skill installer and agent-facing workflows, but there is no documented path for using an agent package archive before package reuse or install planning.

## Solution
Document a conservative first integration path:
- install Nipmod's public SKILL.md from GitHub
- use Nipmod for package search, trust inspection and install-plan generation
- keep the safety boundary explicit: no installs, no local writes, no workspace reads and no payment actions from this flow

## Submission Checklist
- [x] Tests added or updated for new behavior, bug fixes, or regressions. N/A: docs-only change.
- [x] Diff coverage >= 80% for changed executable code. N/A: docs-only change.
- [x] Coverage matrix updated for feature changes. N/A: no runtime feature row changes.
- [x] All affected feature IDs added to test metadata. N/A: docs-only change.
- [x] No new external network dependencies introduced without guardrails. Docs reference existing public Nipmod endpoints only.
- [x] Manual smoke checklist updated where release-cut validation is required. N/A: not a release-cut runtime surface.
- [x] Linked issue closed when applicable. N/A: no issue.

## Impact
Docs only. No runtime behavior change.

## Related
- Closes: N/A
- Follow-up PR(s)/TODOs: if accepted, a future runtime PR can add a first-class Nipmod MCP entry or packaged skill once OpenHuman maintainers confirm the preferred extension surface.

## AI Authored PR Metadata
### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: docs/nipmod-package-archive
- Commit SHA: 7f76c2ea113a

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check`
- [ ] `pnpm typecheck`
- [x] Focused checks: `git diff --check`; manual docs diff inspection
- [x] Rust fmt/check: N/A, no Rust changed
- [x] Tauri fmt/check: N/A, no Tauri changed

### Validation Blocked
- `command: pnpm format:check`
- `error: prettier: command not found; local package dependencies are not installed in this fresh checkout`
- `impact: dependency install is not present locally; change is docs-only and `git diff --check` passes`

### Behavior Changes
- Intended behavior change: documents how OpenHuman users can install/use Nipmod safely.
- User-visible effect: new GitBook page and link in Integrations docs.

### Parity Contract
- Legacy behavior preserved: yes; docs only.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Nipmod package archive integration, enabling secure read-only package discovery and inspection within OpenHuman. Documentation includes setup instructions via skill installation, usage guidance for package search and metadata inspection, trust evidence review, install plan generation, MCP endpoint configuration, safety boundaries, and resource links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->