### PR TITLE
docs(cloud): document remote web UI preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ JWT_TOKEN=
 OPENHUMAN_CORE_PORT=7788
 # [optional] Default: http://127.0.0.1:7788/rpc
 OPENHUMAN_CORE_RPC_URL=http://127.0.0.1:7788/rpc
+# [optional] Comma-separated browser origins allowed to call /rpc with the
+# Authorization bearer. Tauri and loopback Vite origins are allowed by default.
+# Set this when serving a private web UI preview from a non-loopback origin.
+# OPENHUMAN_CORE_ALLOWED_ORIGINS=https://openhuman-ui.example.com
 # Core RPC bearer token. Single source of truth for /rpc auth.
 #  - Tauri desktop: set automatically by the shell — leave blank.
 #  - Docker / cloud / VPS: REQUIRED. Generate with `openssl rand -hex 32`.

--- a/gitbooks/features/cloud-deploy.md
+++ b/gitbooks/features/cloud-deploy.md
@@ -31,6 +31,52 @@ in `app/.env.local` and launch.
 
 ---
 
+## Remote UI choices
+
+OpenHuman's supported remote deployment is **core remote, UI local**: run
+`openhuman-core` on a Linux server and point a desktop client at that RPC URL.
+The deployed core does not serve the full React/Tauri UI as a production web
+app yet. Desktop-only features still need the Tauri shell, including tray
+controls, native deep links, CEF account scanners, OS keychain integration, and
+window/screen affordances.
+
+For a browser-accessible UI on a private server today, use the Vite web build as
+a development/preview surface against the remote core:
+
+```bash
+# On the server, run the core with an explicit token.
+export OPENHUMAN_CORE_HOST=0.0.0.0
+export OPENHUMAN_CORE_PORT=7788
+export OPENHUMAN_CORE_TOKEN="$(openssl rand -hex 32)"
+openhuman-core serve
+
+# In another shell on the server, serve the UI only on loopback.
+pnpm --dir app dev -- --host 127.0.0.1 --port 1420
+```
+
+Then tunnel both ports from your workstation:
+
+```bash
+ssh -L 1420:127.0.0.1:1420 -L 7788:127.0.0.1:7788 user@server
+```
+
+Open `http://127.0.0.1:1420`, choose the remote/core option on the first-run
+screen, and enter `http://127.0.0.1:7788/rpc` plus the
+`OPENHUMAN_CORE_TOKEN` value from the server.
+
+If you serve the browser UI from a non-loopback origin, add that exact origin to
+the core's CORS allowlist:
+
+```bash
+export OPENHUMAN_CORE_ALLOWED_ORIGINS="https://openhuman-ui.example.com"
+```
+
+Loopback Vite origins such as `http://127.0.0.1:1420` and
+`http://localhost:1420` are allowed automatically. Public `http://` origins are
+not recommended because every RPC call carries the bearer token.
+
+---
+
 ## Single source of truth for the bearer token
 
 Every `/rpc` call carries `Authorization: Bearer <token>`. The core has two

--- a/gitbooks/features/platform.md
+++ b/gitbooks/features/platform.md
@@ -56,6 +56,21 @@ The shell is a delivery vehicle (windowing, process lifecycle, IPC). All product
 
 ***
 
+## Remote/headless usage
+
+Linux servers can host the Rust core without a desktop session. The production
+shape is a remote `openhuman-core` JSON-RPC service plus a local desktop client
+configured with that core URL and bearer token.
+
+A private browser UI is possible for development/preview by serving the Vite
+frontend and pointing it at the remote core, but it is not a full replacement
+for the desktop shell. Native deep links, tray controls, OS keychain access, CEF
+account scanners, and screen/window integrations still require the Tauri app.
+See [Cloud Deploy](cloud-deploy.md#remote-ui-choices) for the current remote UI
+setup.
+
+***
+
 ## Real-time communication
 
 The desktop app maintains a persistent connection to the OpenHuman backend. Responses stream as they are generated; outputs appear progressively, not after a hang. If the network drops, the app reconnects automatically with progressive backoff.


### PR DESCRIPTION
## Summary

- Added a Cloud Deploy section for the current remote UI path: remote Linux core, local UI/client.
- Documented a private Vite browser-preview workflow via SSH tunnel for users who want a web-accessible UI today.
- Documented `OPENHUMAN_CORE_ALLOWED_ORIGINS` in `.env.example` for non-loopback browser origins.
- Added a Platform note clarifying which features still require the Tauri desktop shell.

## Problem

Issue #2433 asks for a Linux setup that can be installed remotely and accessed through a web UI instead of relying only on desktop usage. The repo already supports a remote `openhuman-core`, but the docs did not clearly explain the current UI choices, the preview web path, or the CORS setting needed when serving the UI from a custom origin.

## Solution

- Treats `openhuman-core` as the supported remote deployment target.
- Gives a concrete loopback + SSH tunnel flow for private browser UI preview.
- Calls out the production limitation that the deployed core does not yet serve the full React/Tauri UI.
- Points non-loopback UI hosts at the existing `OPENHUMAN_CORE_ALLOWED_ORIGINS` guard.

## Submission Checklist

- [x] Tests added or updated: N/A, docs/env example only.
- [x] Diff coverage >= 80%: N/A, no executable code changed.
- [x] Coverage matrix updated: N/A, documentation-only change.
- [x] All affected feature IDs from the matrix are listed in the PR description: N/A.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated: N/A, no release-cut behavior changed.
- [x] Linked issue closed via `Closes #NNN`: N/A, this is a documentation slice for #2433, not the production webserver feature.

## Impact

No runtime behavior changes. Users self-hosting the core get clearer setup guidance and can discover the existing CORS allowlist when using a private browser preview.

## Related

- Refs #2433
- Follow-up PR(s)/TODOs: production browser-hosted UI/server mode remains separate product scope.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/2433-remote-web-docs`
- Commit SHA: `9dfd6f87808b937c01d69b6710524fcda11c5bf9`

### Validation Run
- [x] `git diff --check`
- [x] `rg -n "Remote UI choices|Remote/headless usage|OPENHUMAN_CORE_ALLOWED_ORIGINS" gitbooks/features/cloud-deploy.md gitbooks/features/platform.md .env.example`
- [x] `pnpm --filter openhuman-app format:check`: N/A, docs/env-only change; not run in this isolated worktree.
- [x] `pnpm typecheck`: N/A, docs/env-only change.
- [x] Focused tests: N/A, docs/env-only change.
- [x] Rust fmt/check (if changed): N/A, no Rust changed.
- [x] Tauri fmt/check (if changed): N/A, no Tauri changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: N/A, documentation only.
- User-visible effect: Cloud/headless docs now explain how to access a remote core through a desktop client or private browser preview.

### Parity Contract
- Legacy behavior preserved: Yes, no runtime code changed.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.