### PR TITLE
docs(search): document SearXNG setup

### DIFF
--- a/gitbooks/features/native-tools/README.md
+++ b/gitbooks/features/native-tools/README.md
@@ -25,7 +25,7 @@ A plugin-only model means tools live in different processes, behind RPC, with th
 
 | Family | What it covers |
 | ------ | -------------- |
-| [Web Search](web-search.md) | Search the live web without bringing your own API key. |
+| [Web Search](web-search.md) | Search the live web via the managed proxy, or opt into self-hosted SearXNG. |
 | [Web Scraper](web-scraper.md) | Pull clean text out of any URL - articles, docs, READMEs. |
 | [Coder](coder.md) | Read/write/edit/patch files, glob, grep, git, lint, test. |
 | [Browser & Computer Control](browser-and-computer.md) | Open URLs, screenshot, click, type, move the mouse. |

--- a/gitbooks/features/native-tools/README.md
+++ b/gitbooks/features/native-tools/README.md
@@ -19,7 +19,7 @@ A plugin-only model means tools live in different processes, behind RPC, with th
 * Consistent error handling.
 * Zero install friction.
 * All output passes through [Smart Token Compression](../token-compression.md) for free.
-* Predictable security boundary - filesystem tools respect workspace scoping, network tools go through the OpenHuman proxy.
+* Predictable security boundary - filesystem tools respect workspace scoping, and network tools use the managed OpenHuman proxy by default unless you opt into a self-hosted path such as SearXNG.
 
 ## The toolbelt
 

--- a/gitbooks/features/native-tools/web-search.md
+++ b/gitbooks/features/native-tools/web-search.md
@@ -5,7 +5,7 @@ icon: magnifying-glass
 
 # Web Search
 
-The agent can search the live web on its own. Backed by a server-side proxy (Parallel) so you don't carry a search API key, the tool returns titles, snippets, and URLs ready to follow up on.
+The agent can search the live web on its own. By default this is backed by a server-side proxy (Parallel) so you don't carry a search API key. If you run your own [SearXNG](https://docs.searxng.org/) instance, you can enable `searxng_search` as a private, self-hosted search tool.
 
 ## What it's good for
 
@@ -13,11 +13,39 @@ The agent can search the live web on its own. Backed by a server-side proxy (Par
 * Citation hunting - "find me three sources for Y".
 * Fact-checking before answering - the agent runs a quick search if it isn't confident.
 
+## Self-hosted SearXNG
+
+SearXNG search is opt-in. When enabled, OpenHuman registers `searxng_search` for agents and MCP clients. The tool calls your configured SearXNG `/search?format=json` endpoint and returns normalized `{ title, url, snippet, source }` results.
+
+Enable it in `config.toml`:
+
+```toml
+[searxng]
+enabled = true
+base_url = "http://localhost:8080"
+max_results = 10
+default_language = "en"
+timeout_seconds = 10
+```
+
+Or via environment:
+
+```bash
+OPENHUMAN_SEARXNG_ENABLED=true
+OPENHUMAN_SEARXNG_BASE_URL=http://localhost:8080
+OPENHUMAN_SEARXNG_MAX_RESULTS=10
+OPENHUMAN_SEARXNG_DEFAULT_LANGUAGE=en
+OPENHUMAN_SEARXNG_TIMEOUT_SECONDS=10
+```
+
+Per call, the tool accepts `query`, optional `categories` (`web`, `news`, `images`), optional `language`, and optional `max_results` up to 50. Empty queries, unsupported categories, non-2xx SearXNG responses, and timeout failures return structured tool errors instead of silently falling back to a cloud search provider.
+
 ## How it differs from generic HTTP
 
 A pure `http_request` tool can fetch a URL but can't *find* one. Web Search is the discovery layer: it picks the right URLs for the agent, which then hands them off to the [Web Scraper](web-scraper.md) for the actual reading.
 
 ## See also
 
+* [MCP Server](../../developing/mcp-server.md) - how `searxng_search` appears to MCP clients.
 * [Web Scraper](web-scraper.md) - fetch and clean a specific URL.
 * [Smart Token Compression](../token-compression.md) - search snippets are compressed before they hit the model.

--- a/gitbooks/features/privacy-and-security.md
+++ b/gitbooks/features/privacy-and-security.md
@@ -36,7 +36,7 @@ OpenHuman is designed so that the **memory of your life lives on your machine**.
 |                                    |                                                                                                                                                                            |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **LLM calls**                      | Proxied through the backend under one subscription, then forwarded to the underlying provider (Anthropic / OpenAI / Google / etc.) per the [model router](model-routing/). |
-| **Web search proxy**               | The native [web search tool](native-tools/web-search.md) calls a backend proxy so you don't carry a search API key.                                                                   |
+| **Web search proxy**               | The native [web search tool](native-tools/web-search.md) uses the backend proxy by default so you don't carry a search API key. If you call the optional SearXNG tool, that query goes to your configured SearXNG instance instead. |
 | **Integration OAuth & tool proxy** | Token storage and rate-limited request brokering for [118+ integrations](integrations/README.md).                                                                                 |
 | **TTS streaming**                  | Hosted [text-to-speech](native-tools/voice.md) audio streams. Audio is generated and discarded - not retained.                                                                          |
 


### PR DESCRIPTION
## Summary

- Documented the optional `searxng_search` tool on the user-facing Web Search page.
- Added `config.toml` and environment examples for enabling self-hosted SearXNG search.
- Updated the native tools index and privacy page so web search no longer reads as backend-only.

## Problem

Issue #1842 asks for SearXNG as a native tool. The implementation is already present on `main`, but the feature docs still describe only the managed web-search proxy. Users running a private SearXNG instance would not know how to enable or call the existing tool from the feature docs.

## Solution

- Adds a Self-hosted SearXNG section to `gitbooks/features/native-tools/web-search.md`.
- Links the feature page to the MCP server docs where `searxng_search` is listed for MCP clients.
- Clarifies privacy routing: default search uses the backend proxy; SearXNG queries go to the configured user-owned instance when that optional tool is called.

## Submission Checklist

- [x] Tests added or updated: N/A, docs-only change.
- [x] Diff coverage >= 80%: N/A, no executable code changed.
- [x] Coverage matrix updated: N/A, documentation-only change.
- [x] All affected feature IDs from the matrix are listed in the PR description: N/A.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated: N/A, no release-cut behavior changed.
- [x] Linked issue closed via `Closes #NNN`: N/A, this documents existing #1842 implementation but does not itself add the runtime feature.

## Impact

No runtime behavior changes. Users and MCP clients get a discoverable setup path for the existing self-hosted SearXNG search tool.

## Related

- Refs #1842
- Follow-up PR(s)/TODOs: maintainers can close #1842 separately if the existing runtime implementation plus this user-facing documentation satisfies the request.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/1842-searxng-docs`
- Commit SHA: `7eadfb6ddf0584b90b825874a3e85e0e679ea8fd`

### Validation Run
- [x] `git diff --check`
- [x] `rg -n "SearXNG|searxng_search|OPENHUMAN_SEARXNG|MCP Server" gitbooks/features/native-tools/web-search.md gitbooks/features/native-tools/README.md gitbooks/features/privacy-and-security.md`
- [x] `pnpm --filter openhuman-app format:check`: N/A, docs-only change; not run in this isolated worktree.
- [x] `pnpm typecheck`: N/A, docs-only change.
- [x] Focused tests: N/A, docs-only change.
- [x] Rust fmt/check (if changed): N/A, no Rust changed.
- [x] Tauri fmt/check (if changed): N/A, no Tauri changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: N/A, documentation only.
- User-visible effect: Web Search docs now show how to enable and use the existing SearXNG path.

### Parity Contract
- Legacy behavior preserved: Yes, no runtime code changed.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None found.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Web Search docs with guidance for an optional self-hosted SearXNG setup
  * Clarified that Web Search uses the managed backend proxy by default, with an opt-in self-hosted path
  * Updated tool descriptions and privacy/security guidance to reflect default proxy behavior
  * Documented per-call input constraints, structured error handling, and response behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->