### PR TITLE
fix(auth-profiles): tolerate legacy kind values on load

### DIFF
--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -316,7 +316,27 @@ impl AuthProfilesStore {
                 migrated = true;
             }
 
-            let kind = parse_profile_kind(&p.kind)?;
+            let kind = match parse_profile_kind(&p.kind) {
+                Ok(k) => k,
+                Err(e) => {
+                    // A single profile with an unrecognized `kind` (e.g. a legacy value
+                    // like "OAuth" written before the kebab-case rename, or "api_key"
+                    // written by an older code path) must not poison the whole store —
+                    // otherwise every reader fails the entire load and the user is
+                    // locked out of *all* their auth profiles. Drop just this entry,
+                    // matching the decrypt-failure recovery pattern above; the next
+                    // login re-encodes the kind correctly.
+                    log::warn!(
+                        "[auth] dropping profile with unrecognized kind={:?} provider={}: {e}. \
+                         This usually means the profile was written by an older version of \
+                         OpenHuman. Re-authenticate to restore the session.",
+                        p.kind,
+                        p.provider
+                    );
+                    dropped_ids.push(id.clone());
+                    continue;
+                }
+            };
             let token_set = match kind {
                 AuthProfileKind::OAuth => {
                     let access = access_token.ok_or_else(|| {

--- a/src/openhuman/credentials/profiles_tests.rs
+++ b/src/openhuman/credentials/profiles_tests.rs
@@ -216,6 +216,84 @@ fn load_drops_profiles_whose_decryption_fails_under_rotated_key() {
     assert!(!loaded2.profiles.contains_key(&profile_id));
 }
 
+/// A persisted profile whose `kind` string is something the current code
+/// doesn't recognise (e.g. legacy "OAuth" written before the kebab-case
+/// rename, or "api_key" written by an older code path) must not poison
+/// the whole load — otherwise *every* profile becomes unreadable and the
+/// user is locked out of all sessions. Drop just the bad entry, matching
+/// the decrypt-failure recovery pattern.
+#[test]
+fn load_drops_profiles_with_unrecognized_kind_instead_of_failing_load() {
+    let tmp = TempDir::new().unwrap();
+    let store = AuthProfilesStore::new(tmp.path(), false);
+
+    // Seed one valid profile so we can verify the rest of the store survives.
+    let good = AuthProfile::new_token("openai", "good", "tok-good".into());
+    let good_id = good.id.clone();
+    store.upsert_profile(good, true).unwrap();
+
+    // Inject two profiles with kinds the current parser rejects:
+    //   - "api_key": observed in Sentry issue #123 (370 events over 14d)
+    //   - "OAuth"  : observed in Sentry issue #2605 (258 events) — the
+    //                pre-kebab-case serialized form
+    let path = store.path().to_path_buf();
+    let mut data: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    data["profiles"]["legacy:apikey"] = serde_json::json!({
+        "provider": "legacy",
+        "profile_name": "apikey",
+        "kind": "api_key",
+        "token": "raw-token",
+        "metadata": {},
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+    });
+    data["profiles"]["legacy:oauth"] = serde_json::json!({
+        "provider": "legacy",
+        "profile_name": "oauth",
+        "kind": "OAuth",
+        "access_token": "raw-access",
+        "metadata": {},
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+    });
+    data["active_profiles"]["legacy"] = serde_json::Value::String("legacy:apikey".to_string());
+    std::fs::write(&path, serde_json::to_string_pretty(&data).unwrap()).unwrap();
+
+    // The load must succeed — the only failure mode prior to the fix was
+    // bailing the entire load on the first unrecognized kind.
+    let loaded = store
+        .load()
+        .expect("load must succeed by dropping profiles with unrecognized kinds");
+
+    assert!(
+        loaded.profiles.contains_key(&good_id),
+        "the valid profile must survive"
+    );
+    assert!(
+        !loaded.profiles.contains_key("legacy:apikey"),
+        "profile with kind=api_key must be dropped"
+    );
+    assert!(
+        !loaded.profiles.contains_key("legacy:oauth"),
+        "profile with kind=OAuth (legacy casing) must be dropped"
+    );
+    assert!(
+        !loaded
+            .active_profiles
+            .values()
+            .any(|v| v == "legacy:apikey"),
+        "active_profiles pointer to a dropped profile must be cleared"
+    );
+
+    // Subsequent load: file was rewritten without the bad profiles.
+    let reread: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert!(reread["profiles"].get("legacy:apikey").is_none());
+    assert!(reread["profiles"].get("legacy:oauth").is_none());
+    assert!(reread["profiles"].get(&good_id).is_some());
+}
+
 #[test]
 fn remove_nonexistent_profile_returns_false() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- `AuthProfilesStore::load_locked` no longer bails the entire load when a single persisted profile has a `kind` value that the current parser can't interpret (e.g. legacy `"OAuth"` written before the kebab-case rename, or `"api_key"` from an older code path).
- Instead the bad row is logged at `warn`, pushed into the existing `dropped_ids` set, and purged from `auth-profiles.json` (along with any stale `active_profiles` pointer) on the same load — matching the established decrypt-failure recovery pattern in the same function.
- Reduces blast radius from "every provider is broken until the user manually deletes `auth-profiles.json`" to "one provider needs a fresh login; everything else keeps working."
- Eliminates the per-poll Sentry spam from affected users (≈630 events / 14d across the two issues below) and stops the symptom from re-firing on subsequent loads.
- Added `load_drops_profiles_with_unrecognized_kind_instead_of_failing_load` reproducing both real-world Sentry payloads (`"api_key"` and legacy `"OAuth"`) and asserting in-memory drop + on-disk purge + cleared active-pointer.

## Problem

- Sentry issue **TAURI-RUST-123** — `Unsupported auth profile kind: api_key` (370 events / 14d).
- Sentry issue **TAURI-RUST-2605** — `Unsupported auth profile kind: OAuth` (258 events / 14d).
- Both surface from the same line in `src/openhuman/credentials/profiles.rs`:
  ```rust
  let kind = parse_profile_kind(&p.kind)?;
  ```
  `parse_profile_kind` only accepts `"oauth"` / `"token"`. When any persisted row has a different string (legacy variant-name serialization, older code path writing `"api_key"`), the `?` propagates the error out of `load_locked`, which means every caller of `AuthProfilesStore::load()` — `set_active_profile`, `update_profile`, `app_state_snapshot` polls, `inference_status` polls, every credential read — fails for that user.
- The Tauri shell polls `app_state_snapshot` / `inference_status` roughly once per second, so a single bad row produces hundreds of identical Sentry events per session and locks the user out of *all* their providers, not just the one with the malformed kind. The only user-facing recovery path was "manually delete `auth-profiles.json`," which also wipes every working profile.

## Solution

- Replace the `?` with a `match` that, on `Err`, logs the unrecognized `kind` + `provider` at `warn`, pushes the id into `dropped_ids`, and `continue`s — the same shape already used for decrypt failures at lines 287–300 of the same function.
- No new infrastructure: the existing post-loop block at lines 378–395 already removes `dropped_ids` from `persisted.profiles`, clears any `active_profiles` entry that pointed at them, bumps `updated_at`, and rewrites the file under the lock that's already held. So the bad row is purged on this load and can't keep retriggering on subsequent loads.
- `parse_profile_kind` itself is unchanged — the public/private API surface, struct shapes, serde reprs, and trait impls are all untouched. The only behavioural delta is that `load_locked` now degrades gracefully on one malformed row instead of failing closed on all of them.
- Tradeoff: a user whose row was malformed has to re-authenticate that one provider. This is strictly better than the prior "all providers unusable until the file is deleted" failure mode, and the new `log::warn!` plus a single Sentry breadcrumb tells the user exactly what happened.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — added `load_drops_profiles_with_unrecognized_kind_instead_of_failing_load` covering both real Sentry payloads (`"api_key"` + legacy `"OAuth"`); existing `store_roundtrip_with_encryption` / `corrupt_store_is_quarantined_and_reset` / `load_drops_profiles_whose_decryption_fails_under_rotated_key` continue to cover the happy and adjacent-failure paths.
- [x] **Diff coverage ≥ 80%** — every changed line in `profiles.rs` (the new `match` arm) is exercised by the new test, which asserts both the in-memory and on-disk outcome. Verified locally via `cargo test --lib openhuman::credentials::profiles` (34/34 pass).
- [x] Coverage matrix updated — `N/A: behaviour-only fix to an existing code path; no new/removed/renamed feature rows.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix rows touched (see above).`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — purely local filesystem behaviour; no new crates, no new network calls.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: internal load-path resilience fix, no UI/release-cut surface changes.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no GitHub issue filed; links to Sentry issues TAURI-RUST-123 and TAURI-RUST-2605 included instead.`


## Impact

- **Platform**: desktop only (Windows / macOS / Linux). The change is in the Rust core (`openhuman` lib crate) loaded in-process by the Tauri shell; the mobile/web/CLI surfaces don't read this store.
- **Runtime**: `O(1)` extra `match` on the load hot path, no extra I/O for healthy stores; on stores with bad rows, one additional `write_persisted_locked` per load — already paid by the existing decrypt-failure recovery, so no new write semantics.
- **Performance**: negligible; the load is a one-shot per session-state poll and the file is small.
- **Security**: the dropped row's tokens were unusable already (no valid kind to interpret them under) — purging them is strictly safer than leaving them parked on disk. No PII, secrets, or token values are logged; only `kind` (the unrecognized string) and `provider` (the slug) appear in the warn line.
- **Migration / compatibility**: backward-compatible. Reads any pre-existing `auth-profiles.json` (including malformed legacy rows), writes a clean current-schema version on next save. No schema version bump needed; no manual user action beyond re-authenticating the affected provider.
- **Failure modes removed**: per-poll error spam to Sentry from affected users; locked-out-of-all-providers state caused by a single malformed row.

## Related

- Sentry: [TAURI-RUST-1S — `Unsupported auth profile kind: api_key`](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/123/) (370 events / 14d)
- Sentry: [TAURI-RUST-24A — `Unsupported auth profile kind: OAuth`](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/2605/) (258 events / 14d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential store resilience by gracefully handling unrecognized profile entries. The system now skips invalid profiles instead of failing the entire load operation, allowing other profiles to load successfully. Invalid entries are automatically removed during the load process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->