### PR TITLE
fix(cloud): accept 405 from remote core probe

### DIFF
--- a/app/src/components/BootCheckGate/BootCheckGate.tsx
+++ b/app/src/components/BootCheckGate/BootCheckGate.tsx
@@ -173,6 +173,11 @@ function ModePicker({ onConfirm }: PickerProps) {
         setTestStatus({ kind: 'auth' });
         return;
       }
+      if (response.status === 405) {
+        log('[boot-check] picker — test reached /rpc but method was rejected');
+        setTestStatus({ kind: 'ok' });
+        return;
+      }
       if (!response.ok) {
         log('[boot-check] picker — test failed: HTTP %d', response.status);
         setTestStatus({ kind: 'unreachable', reason: `HTTP ${response.status} from /rpc` });

--- a/app/src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx
+++ b/app/src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx
@@ -274,6 +274,24 @@ describe('BootCheckGate — picker test connection', () => {
     );
   });
 
+  it('shows Connected when /rpc returns 405 Method Not Allowed', async () => {
+    mockTestCoreRpcConnection.mockResolvedValue({
+      ok: false,
+      status: 405,
+      statusText: 'Method Not Allowed',
+      text: async () => 'Method Not Allowed',
+    } as unknown as Response);
+
+    renderGate();
+    fillCloudInputs('https://example.trycloudflare.com/rpc', 'tok-abc');
+    fireEvent.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('test-status-ok')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('test-status-unreachable')).not.toBeInTheDocument();
+  });
+
   it('shows Auth failed on a 401 response', async () => {
     mockTestCoreRpcConnection.mockResolvedValue({
       ok: false,

--- a/app/src/lib/i18n/chunks/de-3.ts
+++ b/app/src/lib/i18n/chunks/de-3.ts
@@ -104,6 +104,8 @@ const de3: TranslationMap = {
   'subconscious.failed': 'gescheitert',
   'subconscious.tickInterval': 'Tick-Intervall',
   'subconscious.runNow': 'Jetzt ausführen',
+  'subconscious.providerUnavailableTitle': 'Subconscious ist pausiert',
+  'subconscious.providerSettings': 'KI-Einstellungen',
   'subconscious.approvalNeeded': 'Genehmigung erforderlich',
   'subconscious.requiresApproval': 'Erfordert eine Genehmigung',
   'subconscious.fixInConnections': 'Fix in Verbindungen',

--- a/app/src/lib/i18n/chunks/de-5.ts
+++ b/app/src/lib/i18n/chunks/de-5.ts
@@ -501,6 +501,28 @@ const de5: TranslationMap = {
   'settings.mascot.colorYellow': 'Gelb',
   'settings.mascot.libraryUnavailable': 'OpenHuman Bibliothek nicht verfügbar',
   'settings.mascot.title': 'OpenHuman',
+  'settings.developerMenu.mcpServer.title': 'MCP-Server',
+  'settings.developerMenu.mcpServer.desc':
+    'Konfiguriere externe MCP-Clients für die Verbindung mit OpenHuman',
+  'settings.mcpServer.title': 'MCP-Server',
+  'settings.mcpServer.toolsSectionTitle': 'Verfügbare Tools',
+  'settings.mcpServer.toolsSectionDesc':
+    'Tools, die über den MCP-stdio-Server verfügbar sind, wenn openhuman-core mcp ausgeführt wird',
+  'settings.mcpServer.configSectionTitle': 'Client-Konfiguration',
+  'settings.mcpServer.configSectionDesc':
+    'Wähle deinen MCP-Client aus, um den passenden Konfigurationsausschnitt zu erzeugen',
+  'settings.mcpServer.copySnippet': 'In Zwischenablage kopieren',
+  'settings.mcpServer.copied': 'Kopiert!',
+  'settings.mcpServer.openConfigFile': 'Konfigurationsdatei öffnen',
+  'settings.mcpServer.binaryPathNotFound':
+    'OpenHuman-Binärdatei nicht gefunden. Wenn du aus dem Quellcode arbeitest, baue sie mit: cargo build --bin openhuman-core',
+  'settings.mcpServer.openConfigError': 'Konfigurationsdatei konnte nicht geöffnet werden',
+  'settings.mcpServer.clientClaudeDesktop': 'Claude Desktop',
+  'settings.mcpServer.clientCursor': 'Cursor',
+  'settings.mcpServer.clientCodex': 'Codex',
+  'settings.mcpServer.clientZed': 'Zed',
+  'settings.mcpServer.configFilePath': 'Konfigurationsdatei',
+  'settings.mcpServer.clientSelectorAriaLabel': 'MCP-Client-Auswahl',
 };
 
 export default de5;


### PR DESCRIPTION
## Summary  - Treat HTTP 405 from the BootCheckGate cloud-mode `/rpc` probe as a reachable core instead of an unreachable endpoint. - Keep 401/403 classified as auth failures and other non-2xx responses as unreachable. - Add BootCheckGate coverage for a Cloudflare/self-hosted-style 405 response.  ## Problem  The remote-core picker used by BootCheckGate calls the shared `testCoreRpcConnection()` probe, but unlike the Welcome advanced RPC panel it treated `405 Method Not Allowed` as a hard connection failure. For self-hosted cores behind Cloudflare Tunnel, the request can reach `/rpc` and still surface 405, causing the picker to show an unreachable state even though the endpoint is present.  ## Solution  Align BootCheckGate with the existing Welcome-page behavior: a 405 from `/rpc` proves the tunnel/server path reached the core endpoint, so the test connection can show `Connected`. Auth errors remain distinct, and server/network failures still block the connection test.  ## Submission Checklist  - [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) - [x] **Diff coverage ≥ 80%** - focused BootCheckGate test covers the new 405 branch. - [x] Coverage matrix updated - N/A: remote-core probe classification only; no feature matrix row changed. - [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no matrix feature ID changed. - [x] No new external network dependencies introduced. - [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: no release-cut smoke flow changed. - [x] Linked issue closed via `Closes #NNN` in the `## Related` section.  ## Validation  - [x] Prettier check on changed files.`n- [x] i18n coverage: German locale now has no missing keys. - [x] Focused tests: `vitest run src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx --config test/vitest.config.ts` - 34 tests passed. - [x] `git diff --check`.  ## Related  - Closes #2467  ---  ## AI Authored PR Metadata (required for Codex/Linear PRs)  ### Linear Issue - Key: N/A - URL: N/A  ### Commit & Branch - Branch: `codex/2467-cloudflare-405` - Commit SHA: `ce2072b2`  ### Validation Run - [x] `pnpm --dir app exec prettier --check app/src/components/BootCheckGate/BootCheckGate.tsx app/src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx` - passed via installed workspace dependency binary. - [x] `vitest run src/components/BootCheckGate/__tests__/BootCheckGate.test.tsx --config test/vitest.config.ts` - 1 file / 34 tests passed. - [x] `git diff --check` - passed.`n- [x] `tsx scripts/i18n-coverage.ts --locale de --no-unused` - passed.  ### Validation Blocked - N/A  ### Behavior Changes - Intended behavior change: BootCheckGate's cloud connection test now treats HTTP 405 from `/rpc` as proof that the remote core endpoint is reachable. - User-visible effect: Cloudflare Tunnel/self-hosted remote-core users are no longer shown an unreachable error solely because `/rpc` replies 405 during the probe.  ### Parity Contract - Legacy behavior preserved: 401/403 still show auth failure; network errors and other non-2xx/non-405 responses still show unreachable. - Guard/fallback/dispatch parity checks: Welcome already accepted 405; BootCheckGate now matches that behavior.  ### Duplicate / Superseded PR Handling - Duplicate PR(s): none found for #2467. - Canonical PR: this PR. - Resolution: N/A.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud connection check now treats a specific server response as reachable, improving connection detection in the connection tester.

* **Tests**
  * Added test coverage verifying the connection flow recognizes that response as successful.

* **Localization**
  * Added German translations for provider/connection messaging and MCP-server configuration UI strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->