### PR TITLE
fix(i18n): add missing German keys for MCP Server settings

### DIFF
--- a/app/src/lib/i18n/chunks/de-3.ts
+++ b/app/src/lib/i18n/chunks/de-3.ts
@@ -104,6 +104,8 @@ const de3: TranslationMap = {
   'subconscious.failed': 'gescheitert',
   'subconscious.tickInterval': 'Tick-Intervall',
   'subconscious.runNow': 'Jetzt ausführen',
+  'subconscious.providerUnavailableTitle': 'Unterbewusstsein pausiert',
+  'subconscious.providerSettings': 'KI-Einstellungen',
   'subconscious.approvalNeeded': 'Genehmigung erforderlich',
   'subconscious.requiresApproval': 'Erfordert eine Genehmigung',
   'subconscious.fixInConnections': 'Fix in Verbindungen',

--- a/app/src/lib/i18n/chunks/de-5.ts
+++ b/app/src/lib/i18n/chunks/de-5.ts
@@ -501,6 +501,28 @@ const de5: TranslationMap = {
   'settings.mascot.colorYellow': 'Gelb',
   'settings.mascot.libraryUnavailable': 'OpenHuman Bibliothek nicht verfügbar',
   'settings.mascot.title': 'OpenHuman',
+  'settings.developerMenu.mcpServer.title': 'MCP-Server',
+  'settings.developerMenu.mcpServer.desc':
+    'Externe MCP-Clients für die Verbindung mit OpenHuman konfigurieren',
+  'settings.mcpServer.title': 'MCP-Server',
+  'settings.mcpServer.toolsSectionTitle': 'Verfügbare Werkzeuge',
+  'settings.mcpServer.toolsSectionDesc':
+    'Werkzeuge, die über den MCP-stdio-Server bereitgestellt werden, wenn openhuman-core mcp läuft',
+  'settings.mcpServer.configSectionTitle': 'Client-Konfiguration',
+  'settings.mcpServer.configSectionDesc':
+    'Wähle deinen MCP-Client aus, um das passende Konfigurations-Snippet zu erzeugen',
+  'settings.mcpServer.copySnippet': 'In die Zwischenablage kopieren',
+  'settings.mcpServer.copied': 'Kopiert!',
+  'settings.mcpServer.openConfigFile': 'Konfigurationsdatei öffnen',
+  'settings.mcpServer.binaryPathNotFound':
+    'OpenHuman-Binary nicht gefunden. Wenn du aus dem Quellcode startest, erstelle sie mit: cargo build --bin openhuman-core',
+  'settings.mcpServer.openConfigError': 'Konfigurationsdatei konnte nicht geöffnet werden',
+  'settings.mcpServer.clientClaudeDesktop': 'Claude Desktop',
+  'settings.mcpServer.clientCursor': 'Cursor',
+  'settings.mcpServer.clientCodex': 'Codex',
+  'settings.mcpServer.clientZed': 'Zed',
+  'settings.mcpServer.configFilePath': 'Konfigurationsdatei',
+  'settings.mcpServer.clientSelectorAriaLabel': 'MCP-Client-Auswahl',
 };
 
 export default de5;


### PR DESCRIPTION
## Summary

The German locale was missing **20 keys** introduced by the MCP Server settings panel (originally added without German translations and uncaught when the German locale itself was added in #2378). This causes `pnpm i18n:check` to fail on `main`, which cascades into:

- `i18n Coverage` workflow
- `Frontend Unit Tests` (2 failures: `I18nContext.test.tsx > keeps the German locale complete against English keys`, `coverage.test.ts > locale de defines every English key`)
- `Frontend Coverage (Vitest)` (same 2 tests fail)
- `Coverage Gate (diff-cover ≥ 80%)` (cancelled because Frontend Coverage failed)

Every open PR is currently red on these checks for this reason — see #2249 for an example.

## Changes

- `app/src/lib/i18n/chunks/de-3.ts`: +2 keys (`subconscious.providerUnavailableTitle`, `subconscious.providerSettings`)
- `app/src/lib/i18n/chunks/de-5.ts`: +18 keys (`settings.developerMenu.mcpServer.{title,desc}`, `settings.mcpServer.*`)

Product names (Claude Desktop, Cursor, Codex, Zed) are intentionally kept in English — they show as "untranslated" in the report but the check passes (untranslated count is informational, not a failure).

## Verification

```
$ pnpm i18n:check
## de  (1947 keys)
  missing:        0
  extra:          0
  drifted chunks: 0
exit: 0

$ pnpm exec vitest run src/lib/i18n/__tests__/I18nContext.test.tsx src/lib/i18n/__tests__/coverage.test.ts
Test Files  2 passed (2)
     Tests  50 passed (50)
```

## Test plan

- [x] `pnpm i18n:check` exits 0
- [x] `I18nContext.test.tsx` German-completeness suite passes
- [x] `coverage.test.ts > locale de defines every English key` passes
- [x] Prettier formatting clean