### PR TITLE
fix(subagent): dedup tool specs before sending to provider

### DIFF
--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -839,6 +839,35 @@ async fn run_typed_mode(
         allowed_names.insert(tool.name().to_string());
     }
 
+    // Dedup by tool name before the specs reach the provider. `allowed_names`
+    // is a set (already unique), but `filtered_specs` is a Vec assembled from
+    // `parent.all_tool_specs` indices + dynamic tools, so a delegation tool
+    // shadowing a same-named skill/integration tool (common for the wide-set
+    // `tools_agent`) leaves two specs with the same name. Strict providers then
+    // reject the request with `400 "Tool names must be unique."` The main-agent
+    // path dedups via `session::builder::dedup_visible_tool_specs`; this separate
+    // sub-agent assembly must do the same.
+    {
+        let mut seen: HashSet<String> = HashSet::with_capacity(filtered_specs.len());
+        let mut dropped: Vec<String> = Vec::new();
+        filtered_specs.retain(|spec| {
+            if seen.insert(spec.name.clone()) {
+                true
+            } else {
+                dropped.push(spec.name.clone());
+                false
+            }
+        });
+        if !dropped.is_empty() {
+            tracing::warn!(
+                agent_id = %definition.id,
+                "[subagent_runner] dropped {} duplicate tool spec(s) before sending to provider: {:?}",
+                dropped.len(),
+                dropped
+            );
+        }
+    }
+
     tracing::debug!(
         agent_id = %definition.id,
         model = %model,

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -326,6 +326,44 @@ pub async fn run_subagent(
 // Typed mode — narrow prompt, filtered tools, cheaper model
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Deduplicate assembled tool specs by name, keeping the first occurrence.
+///
+/// The sub-agent's `filtered_specs` is a `Vec` assembled from
+/// `parent.all_tool_specs` indices plus dynamic tools, so a delegation tool can
+/// shadow a same-named skill/integration tool (common for the wide-set
+/// `tools_agent`), leaving two specs with the same name. Strict providers reject
+/// such a request with `400 "Tool names must be unique."` The main-agent path
+/// dedups via [`session::builder::dedup_visible_tool_specs`]; this separate
+/// sub-agent assembly must do the same.
+///
+/// First occurrence wins so registration-order semantics are preserved (tool
+/// dispatch still resolves by name). Dropped duplicates are logged at `debug`
+/// (diagnostic instrumentation, per the repo Rust logging guideline).
+///
+/// Extracted as a free function so the regression suite can exercise the dedup
+/// without standing up the full `run_typed_mode` plumbing.
+fn dedup_tool_specs_by_name(agent_id: &str, specs: Vec<ToolSpec>) -> Vec<ToolSpec> {
+    let mut seen: HashSet<String> = HashSet::with_capacity(specs.len());
+    let mut deduped: Vec<ToolSpec> = Vec::with_capacity(specs.len());
+    let mut dropped: Vec<String> = Vec::new();
+    for spec in specs {
+        if seen.insert(spec.name.clone()) {
+            deduped.push(spec);
+        } else {
+            dropped.push(spec.name);
+        }
+    }
+    if !dropped.is_empty() {
+        tracing::debug!(
+            agent_id = %agent_id,
+            "[subagent_runner] dropped {} duplicate tool spec(s) before sending to provider: {:?}",
+            dropped.len(),
+            dropped
+        );
+    }
+    deduped
+}
+
 /// Execute a sub-agent in "Typed" mode.
 ///
 /// This mode builds a brand-new, minimized system prompt specifically for the
@@ -839,34 +877,9 @@ async fn run_typed_mode(
         allowed_names.insert(tool.name().to_string());
     }
 
-    // Dedup by tool name before the specs reach the provider. `allowed_names`
-    // is a set (already unique), but `filtered_specs` is a Vec assembled from
-    // `parent.all_tool_specs` indices + dynamic tools, so a delegation tool
-    // shadowing a same-named skill/integration tool (common for the wide-set
-    // `tools_agent`) leaves two specs with the same name. Strict providers then
-    // reject the request with `400 "Tool names must be unique."` The main-agent
-    // path dedups via `session::builder::dedup_visible_tool_specs`; this separate
-    // sub-agent assembly must do the same.
-    {
-        let mut seen: HashSet<String> = HashSet::with_capacity(filtered_specs.len());
-        let mut dropped: Vec<String> = Vec::new();
-        filtered_specs.retain(|spec| {
-            if seen.insert(spec.name.clone()) {
-                true
-            } else {
-                dropped.push(spec.name.clone());
-                false
-            }
-        });
-        if !dropped.is_empty() {
-            tracing::warn!(
-                agent_id = %definition.id,
-                "[subagent_runner] dropped {} duplicate tool spec(s) before sending to provider: {:?}",
-                dropped.len(),
-                dropped
-            );
-        }
-    }
+    // Dedup by tool name before the specs reach the provider (see
+    // `dedup_tool_specs_by_name` for why duplicates appear here).
+    let filtered_specs = dedup_tool_specs_by_name(&definition.id, filtered_specs);
 
     tracing::debug!(
         agent_id = %definition.id,
@@ -1708,6 +1721,10 @@ pub(crate) fn user_is_signed_in_to_composio(config: &crate::openhuman::config::C
 #[cfg(test)]
 #[path = "ops_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "ops_dedup_tests.rs"]
+mod dedup_tests;
 
 #[cfg(test)]
 #[path = "ops_truncation_tests.rs"]

--- a/src/openhuman/agent/harness/subagent_runner/ops_dedup_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops_dedup_tests.rs
@@ -1,0 +1,71 @@
+//! Focused unit tests for [`super::dedup_tool_specs_by_name`].
+//!
+//! Mirrors `session::builder::dedup_visible_tool_specs` coverage: the
+//! sub-agent assembly path must drop same-named duplicate tool specs
+//! (first occurrence wins) before they reach a strict provider that
+//! 400s on `"Tool names must be unique."`
+
+use super::*;
+use serde_json::json;
+
+fn spec(name: &str) -> ToolSpec {
+    ToolSpec {
+        name: name.to_string(),
+        description: format!("description for {name}"),
+        parameters: json!({}),
+    }
+}
+
+#[test]
+fn drops_duplicates_first_wins() {
+    // Real-world collision: a delegation tool (e.g. `tools_agent`) shadows a
+    // same-named skill/integration tool. Keep the *first* occurrence so
+    // registration-order semantics hold (dispatch still resolves by name).
+    let specs = vec![
+        spec("research"), // skill
+        spec("plan"),
+        spec("research"), // delegate, dropped
+        spec("run_code"),
+        spec("plan"), // dropped
+    ];
+
+    let deduped = dedup_tool_specs_by_name("test-agent", specs);
+
+    let names: Vec<&str> = deduped.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["research", "plan", "run_code"]);
+}
+
+#[test]
+fn passes_through_when_no_duplicates() {
+    let specs = vec![spec("a"), spec("b"), spec("c")];
+    let deduped = dedup_tool_specs_by_name("test-agent", specs);
+    let names: Vec<&str> = deduped.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn handles_empty_input() {
+    let deduped = dedup_tool_specs_by_name("test-agent", Vec::<ToolSpec>::new());
+    assert!(deduped.is_empty());
+}
+
+#[test]
+fn preserves_full_spec_content_for_kept_entries() {
+    // Description + parameters must survive intact — the LLM uses both for
+    // tool-call decisions, and the kept entry must be the *first* one.
+    let mut first = spec("alpha");
+    first.description = "first alpha — should win".to_string();
+    first.parameters = json!({"type": "object", "required": ["x"]});
+
+    let mut dup = spec("alpha");
+    dup.description = "second alpha — should be dropped".to_string();
+
+    let deduped = dedup_tool_specs_by_name("test-agent", vec![first, dup]);
+
+    assert_eq!(deduped.len(), 1);
+    assert_eq!(deduped[0].description, "first alpha — should win");
+    assert_eq!(
+        deduped[0].parameters,
+        json!({"type": "object", "required": ["x"]})
+    );
+}


### PR DESCRIPTION
## Summary

- Sub-agent delegations (`plan`, `run_code`, `delegate_tools_agent`, …) sent tool-spec lists containing **duplicate tool names** to the provider, which strict backends reject with `400 "Tool names must be unique."`
- The orchestrator/main-agent path already dedups tool specs; the **sub-agent assembly path did not**. This adds the same name-dedup there.
- Restores `delegate_tools_agent` (and any wide-tool-set sub-agent) which previously failed on **every** call.

## Problem

`subagent_runner::ops` builds `filtered_specs: Vec<ToolSpec>` from the parent's allowed tool indices plus dynamic tools, then sends it to the provider. Crucially:

- `allowed_names` (the dispatch allowlist) is a `HashSet` → already unique.
- `filtered_specs` (the list sent to the provider) is a `Vec` built independently → it can contain **two specs with the same name** (e.g. a delegation tool such as `research` / `run_code` shadowing a same-named skill/integration tool — exactly the collision documented in `session::builder::dedup_visible_tool_specs`).

The widest-tool-set sub-agent, `tools_agent` (all connected integrations), reliably hits the collision, so `delegate_tools_agent` returned `400 "Tool names must be unique."` on every invocation. The main agent is unaffected because it dedups at `session/runtime.rs` via `dedup_visible_tool_specs`; the sub-agent path simply never had the equivalent step.

## Solution

After `filtered_specs` is fully assembled (parent specs + dynamic tools), dedup it by name — keep the first occurrence, drop later duplicates — mirroring `dedup_visible_tool_specs`. The logic lives in a pure `dedup_tool_specs_by_name` helper (so it is unit-testable without standing up `run_typed_mode`), and emits a parity log line at `debug`: `[subagent_runner] dropped N duplicate tool spec(s) before sending to provider: [...]` (alongside the orchestrator's existing `[agent] dropped N …`).

`allowed_names` is already unique, so tool resolution/dispatch is unchanged; only the provider-facing spec list is deduped. Verified on a live core: the new dedup log fires on the `tools_agent` path and the `400 Tool names must be unique` error no longer occurs (the delegation now completes instead of failing at the wire).

## Submission Checklist

- [x] Tests added or updated — focused unit tests added in `subagent_runner/ops_dedup_tests.rs` (first-occurrence-wins, pass-through, empty input, content preservation), mirroring `dedup_visible_tool_specs` coverage.
- [x] **Diff coverage ≥ 80%** — the dedup logic was extracted into a pure `dedup_tool_specs_by_name` helper that is fully exercised by the new unit tests; the only changed line not covered is the one-line call site in `run_typed_mode`.
- [x] Coverage matrix updated — `N/A`: behaviour-only bug fix, no feature row added/removed/renamed.
- [x] All affected feature IDs listed under `## Related` — `N/A`: no matrix feature touched.
- [x] No new external network dependencies introduced — `N/A`: none added.
- [x] Manual smoke checklist updated — `N/A`: does not touch a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` — `N/A`: no tracking issue filed for this bug.

## Impact

- **Desktop/CLI/all runtimes:** any sub-agent whose assembled tool set contains a name collision (most reliably `tools_agent`) would fail its delegation with `400 Tool names must be unique`; this fixes that.
- No migration, security, or compatibility implications. Tool dispatch is unchanged (the allowlist was already unique); only duplicate **specs** sent to the provider are dropped.

## Related

- Closes: `N/A` (no issue filed)
- Follow-up PR(s)/TODOs: none (the focused unit test is included in this PR).

---

## AI Authored PR Metadata

### Linear Issue
- Key: `N/A`
- URL: `N/A`

### Commit & Branch
- Branch: `fix/subagent-dedup-tool-specs`
- Commit SHA: `b281391d`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — `N/A`: Rust-only change, no `app/` files touched.
- [x] `pnpm typecheck` — `N/A`: Rust-only change.
- [x] Focused tests: `cargo test --lib subagent_runner::ops::dedup_tests` — 4 passed (drops_duplicates_first_wins, passes_through_when_no_duplicates, handles_empty_input, preserves_full_spec_content_for_kept_entries).
- [x] Rust fmt/check: `cargo fmt --check` and `cargo clippy --lib` clean; lib builds and tests pass. Branch synced with latest `upstream/main`.
- [x] Tauri fmt/check: `N/A`: no `app/src-tauri` files touched.

### Behavior Changes
- Intended behavior change: sub-agent provider requests are now name-unique.
- User-visible effect: `delegate_tools_agent` (and other wide-tool-set delegations) stop failing with `400 Tool names must be unique`.

### Parity Contract
- Legacy behavior preserved: tool dispatch/resolution unchanged (`allowed_names` already unique).
- Guard/fallback/dispatch parity: sub-agent path now matches the main-agent dedup contract (`dedup_visible_tool_specs`).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: `N/A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented provider errors by deduplicating tool specifications with the same name; first occurrence is retained and duplicates are dropped with a debug warning listing removed names.
* **Tests**
  * Added unit tests to verify deduplication behavior, order preservation, empty-input handling, and retention of retained tool details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
