### PR TITLE
fix(cef): auto-disable prewarm webview on Wayland/XWayland to prevent X_ConfigureWindow BadWindow crash

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1450,6 +1450,31 @@ fn setup_tray(app: &AppHandle<AppRuntime>) -> tauri::Result<()> {
 
 const CEF_PREWARM_LABEL: &str = "cef-prewarm";
 
+/// Decide whether to spawn the CEF cold-start prewarm webview.
+///
+/// Testable pure function — callers pass the relevant env values directly.
+///
+/// Decision matrix:
+/// - `env_override` = `Some("0"|"false"|"no"|"off")` → disabled (explicit)
+/// - `env_override` = `Some(<other non-empty string>)` → enabled (explicit opt-in;
+///   overrides even the Wayland guard so ops can re-enable if CEF subprocess
+///   X handling improves)
+/// - `env_override` = `None` (env var unset, default path):
+///   - `wayland_display_set` = `true` → **disabled** — auto-guard against the
+///     fatal `X_ConfigureWindow BadWindow` crash that fires in CEF render
+///     subprocesses on Wayland/XWayland sessions (issue #2463). The main-process
+///     silent X error handler (`install_silent_x_error_handler`) does not reach
+///     CEF subprocesses; until subprocess-level coverage is available, skipping
+///     the prewarm child webview is the safest mitigation.
+///   - `wayland_display_set` = `false` → enabled
+fn cef_prewarm_enabled(env_override: Option<&str>, wayland_display_set: bool) -> bool {
+    if let Some(v) = env_override {
+        let v = v.trim().to_ascii_lowercase();
+        return !(v == "0" || v == "false" || v == "no" || v == "off");
+    }
+    !wayland_display_set
+}
+
 /// Spawn a hidden 1×1 child webview at `about:blank` on the main window so
 /// CEF's child-webview render path is hot before the user clicks an
 /// account. The first `webview_account_open` then skips the cold
@@ -2825,13 +2850,12 @@ pub fn run() {
             // tear it down in the shutdown sequence below. Disable at
             // runtime with `OPENHUMAN_CEF_PREWARM=0` if it regresses.
             {
-                let prewarm_enabled = std::env::var("OPENHUMAN_CEF_PREWARM")
-                    .map(|v| {
-                        let v = v.trim().to_ascii_lowercase();
-                        !(v == "0" || v == "false" || v == "no" || v == "off")
-                    })
-                    .unwrap_or(true);
-                if prewarm_enabled {
+                #[cfg(target_os = "linux")]
+                let wayland_display_set = has_non_empty_env("WAYLAND_DISPLAY");
+                #[cfg(not(target_os = "linux"))]
+                let wayland_display_set = false;
+                let env_override = std::env::var("OPENHUMAN_CEF_PREWARM").ok();
+                if cef_prewarm_enabled(env_override.as_deref(), wayland_display_set) {
                     let app_handle = app.handle().clone();
                     tauri::async_runtime::spawn(async move {
                         // Defer one tick so the main window finishes its
@@ -2841,6 +2865,12 @@ pub fn run() {
                             log::warn!("[cef-prewarm] failed (non-fatal): {e}");
                         }
                     });
+                } else if wayland_display_set && env_override.is_none() {
+                    log::info!(
+                        "[cef-prewarm] auto-disabled: WAYLAND_DISPLAY is set (Wayland/XWayland \
+                         session) — prevents X_ConfigureWindow BadWindow crash in CEF \
+                         subprocesses (issue #2463); set OPENHUMAN_CEF_PREWARM=1 to override"
+                    );
                 } else {
                     log::info!("[cef-prewarm] disabled via OPENHUMAN_CEF_PREWARM");
                 }
@@ -3798,6 +3828,60 @@ mod tests {
     #[test]
     fn platform_arch_is_aarch64_on_apple_silicon_build() {
         assert_eq!(std::env::consts::ARCH, "aarch64");
+    }
+
+    // -------------------------------------------------------------------------
+    // cef_prewarm_enabled (issue #2463 — Wayland/XWayland BadWindow guard)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn prewarm_enabled_by_default_on_non_wayland() {
+        assert!(cef_prewarm_enabled(None, false));
+    }
+
+    #[test]
+    fn prewarm_auto_disabled_on_wayland_when_env_unset() {
+        assert!(!cef_prewarm_enabled(None, true));
+    }
+
+    #[test]
+    fn prewarm_explicit_disable_respected_on_non_wayland() {
+        assert!(!cef_prewarm_enabled(Some("0"), false));
+        assert!(!cef_prewarm_enabled(Some("false"), false));
+        assert!(!cef_prewarm_enabled(Some("no"), false));
+        assert!(!cef_prewarm_enabled(Some("off"), false));
+    }
+
+    #[test]
+    fn prewarm_explicit_disable_respected_on_wayland() {
+        assert!(!cef_prewarm_enabled(Some("0"), true));
+        assert!(!cef_prewarm_enabled(Some("false"), true));
+    }
+
+    #[test]
+    fn prewarm_explicit_enable_overrides_wayland_guard() {
+        // OPENHUMAN_CEF_PREWARM=1 (or any non-disable value) lets ops
+        // force prewarm even on Wayland sessions.
+        assert!(cef_prewarm_enabled(Some("1"), true));
+        assert!(cef_prewarm_enabled(Some("true"), true));
+        assert!(cef_prewarm_enabled(Some("yes"), true));
+        assert!(cef_prewarm_enabled(Some("on"), true));
+    }
+
+    #[test]
+    fn prewarm_disable_flags_are_case_insensitive() {
+        assert!(!cef_prewarm_enabled(Some("FALSE"), false));
+        assert!(!cef_prewarm_enabled(Some("OFF"), true));
+        assert!(!cef_prewarm_enabled(Some("  0  "), false));
+        assert!(!cef_prewarm_enabled(Some("  No  "), true));
+    }
+
+    #[test]
+    fn prewarm_unknown_env_value_treated_as_enable() {
+        // Any string that is not a recognised disable token → treat as enable.
+        assert!(cef_prewarm_enabled(Some("enabled"), false));
+        assert!(cef_prewarm_enabled(Some("yes"), false));
+        assert!(cef_prewarm_enabled(Some(""), false));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `cef_prewarm_enabled(env_override, wayland_display_set)` pure predicate that auto-disables the CEF cold-start prewarm webview when `WAYLAND_DISPLAY` is set and `OPENHUMAN_CEF_PREWARM` is not explicitly configured.
- The prewarm `RunEvent::Ready` block is updated to call the predicate, reading `WAYLAND_DISPLAY` on Linux and logging the reason for disabling (Wayland auto-guard vs. explicit env var).
- Users can opt back in with `OPENHUMAN_CEF_PREWARM=1` if CEF subprocess-level X error handling improves.
- Adds 7 unit tests for the pure predicate covering all branches.

## Root cause

On Wayland/XWayland (e.g. KDE Plasma 6), the CEF cold-start prewarm child webview (`spawn_cef_prewarm`) positions itself at `(-20000, -20000)` off-screen. CEF's render subprocess issues `X_ConfigureWindow` against that child webview's XWindow before XWayland has fully realized it, producing a fatal `BadWindow` error. The main-process silent X error handler (`install_silent_x_error_handler`) does not intercept subprocess errors — each CEF subprocess is a separate process with its own (default, fatal) Xlib error handler.

Setting `OPENHUMAN_CEF_PREWARM=0` fully avoids the crash, confirming the prewarm path is the source.

## Changes

| File | Change |
|---|---|
| `app/src-tauri/src/lib.rs` | Add `cef_prewarm_enabled()` predicate; update `RunEvent::Ready` prewarm block; add 7 unit tests |

## Test plan

- [x] `cargo test --manifest-path app/src-tauri/Cargo.toml -- prewarm` — 10 tests pass (7 new)
- [x] `cargo check --manifest-path app/src-tauri/Cargo.toml` — clean
- [x] `cargo fmt --manifest-path app/src-tauri/Cargo.toml -- --check` — clean

**Hardware tests** (require a Wayland-capable Linux system — not automatable in CI):

- Manual verification on KDE Wayland/XWayland: when `WAYLAND_DISPLAY` is set, the log shows `[cef-prewarm] auto-disabled: WAYLAND_DISPLAY is set` and the window stays up indefinitely.
- On X11 (no `WAYLAND_DISPLAY`): prewarm spawns normally, `[cef-prewarm] hidden warmup webview spawned` is logged.
- With `OPENHUMAN_CEF_PREWARM=1` on Wayland: explicit opt-in is honored, prewarm spawns.

The unit tests for `cef_prewarm_enabled()` cover all three branches (default, explicit disable, explicit enable) including the Wayland guard, providing the regression coverage required by the acceptance criteria.

## Related

Closes #2463