### PR TITLE
fix(i18n): remove duplicate German keys unblocking main's Type Check

### DIFF
--- a/app/src/lib/i18n/chunks/de-3.ts
+++ b/app/src/lib/i18n/chunks/de-3.ts
@@ -123,8 +123,6 @@ const de3: TranslationMap = {
   'subconscious.decision.failed': 'Fehlgeschlagen',
   'subconscious.decision.cancelled': 'Abgesagt',
   'subconscious.decision.skipped': 'Übersprungen',
-  'subconscious.providerUnavailableTitle': 'Unterbewusstsein pausiert',
-  'subconscious.providerSettings': 'KI-Einstellungen',
   'actionable.complete': 'Komplett',
   'actionable.dismiss': 'Entlassen',
   'actionable.snooze': 'Schlummern',

--- a/app/src/lib/i18n/chunks/de-5.ts
+++ b/app/src/lib/i18n/chunks/de-5.ts
@@ -523,28 +523,6 @@ const de5: TranslationMap = {
   'settings.mascot.colorYellow': 'Gelb',
   'settings.mascot.libraryUnavailable': 'OpenHuman Bibliothek nicht verfügbar',
   'settings.mascot.title': 'OpenHuman',
-  'settings.developerMenu.mcpServer.title': 'MCP-Server',
-  'settings.developerMenu.mcpServer.desc':
-    'Externe MCP-Clients für die Verbindung zu OpenHuman konfigurieren',
-  'settings.mcpServer.title': 'MCP-Server',
-  'settings.mcpServer.toolsSectionTitle': 'Verfügbare Tools',
-  'settings.mcpServer.toolsSectionDesc':
-    'Tools, die über den MCP-stdio-Server bereitgestellt werden, wenn openhuman-core mcp läuft',
-  'settings.mcpServer.configSectionTitle': 'Client-Konfiguration',
-  'settings.mcpServer.configSectionDesc':
-    'Wähle deinen MCP-Client, um den passenden Konfigurations-Snippet zu erzeugen',
-  'settings.mcpServer.copySnippet': 'In Zwischenablage kopieren',
-  'settings.mcpServer.copied': 'Kopiert!',
-  'settings.mcpServer.openConfigFile': 'Konfigurationsdatei öffnen',
-  'settings.mcpServer.binaryPathNotFound':
-    'OpenHuman-Binary nicht gefunden. Bei Quellbau bitte mit `cargo build --bin openhuman-core` bauen.',
-  'settings.mcpServer.openConfigError': 'Konfigurationsdatei konnte nicht geöffnet werden',
-  'settings.mcpServer.clientClaudeDesktop': 'Claude Desktop',
-  'settings.mcpServer.clientCursor': 'Cursor',
-  'settings.mcpServer.clientCodex': 'Codex',
-  'settings.mcpServer.clientZed': 'Zed',
-  'settings.mcpServer.configFilePath': 'Konfigurationsdatei',
-  'settings.mcpServer.clientSelectorAriaLabel': 'MCP-Client-Auswahl',
 };
 
 export default de5;


### PR DESCRIPTION
## Summary

- `main` has been **red on `Type Check TypeScript`** since the German locale landed (#2378): two German chunks contain duplicate object-literal keys, which TypeScript rejects with **TS1117**.
- This removes the duplicates so the typecheck passes — unblocking the typecheck/e2e checks on **every open PR** (they currently inherit this failure).

## Problem

TypeScript errors on `main` (`pnpm --filter openhuman-app compile`):

- **`de-5.ts`** — the entire `settings.mcpServer.*` block is defined **twice** (18 duplicate keys, incl. `settings.developerMenu.mcpServer.{title,desc}`).
- **`de-3.ts`** — `subconscious.providerUnavailableTitle` and `subconscious.providerSettings` are each defined twice.

`Type Check TypeScript` is not a required status check, so #2378 merged red and `main` has stayed red — failing the typecheck (and the e2e build, which runs `tsc`) on all subsequent PRs.

## Solution

Delete the duplicate occurrences, keeping the **canonical, better-translated** ones:

- `de-5.ts`: drop the second `settings.mcpServer.*` block (L526–547), keeping the first — which also restores the better German (`'Verfügbare Werkzeuge'` over `'Verfügbare Tools'`, `'In die Zwischenablage kopieren'` over `'In Zwischenablage kopieren'`).
- `de-3.ts`: drop the second `providerUnavailableTitle`/`providerSettings`, keeping `'Unterbewusstsein ist pausiert'`.

No keys are lost (each appeared exactly twice). **`pnpm typecheck` passes clean** after this change.

## Submission Checklist

- [x] Tests added or updated — `N/A`: removes duplicate translation keys; behaviour-preserving (each key kept once). Verified via `pnpm --filter openhuman-app compile` (full typecheck) passing.
- [x] **Diff coverage ≥ 80%** — `N/A`: translation-data only (no executable lines).
- [x] Coverage matrix updated — `N/A`: no feature change.
- [x] No new external network dependencies — `N/A`.
- [x] Manual smoke checklist — `N/A`.
- [x] Linked issue closed — `N/A`.

## Impact

- Fixes `main`'s own broken `Type Check TypeScript`; unblocks typecheck + e2e on all open PRs.
- German UI strings unchanged except where the duplicate shadowed the better translation (now corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated German language translations to improve consistency and clarity across the application's user interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->