### PR TITLE
chore(shortcuts): self-assign PR in pnpm review fix

### DIFF
--- a/scripts/shortcuts/review/fix.sh
+++ b/scripts/shortcuts/review/fix.sh
@@ -38,6 +38,10 @@ done
 require "$agent"
 sync_pr "$pr"
 
+if [ "${REVIEW_AUTO_ASSIGN:-1}" = "1" ]; then
+  gh_assign_self_pr "$pr" "$REVIEW_REPO_RESOLVED"
+fi
+
 template="$here/prompts/fix.md"
 if [ ! -f "$template" ]; then
   echo "[review] missing prompt template: $template" >&2


### PR DESCRIPTION
## Summary

- `pnpm review fix <pr>` now assigns the PR to the current GitHub user after `sync_pr`, mirroring `pnpm work`'s existing `WORK_AUTO_ASSIGN` behavior for issues.
- Gated by `REVIEW_AUTO_ASSIGN` (default `1`); set to `0` to opt out.

## Problem

When multiple people pick up open PRs (CodeRabbit follow-ups, conflict resolution, etc.), there's no signal in GitHub for who's actively working a PR. `pnpm work` already self-assigns issues; `pnpm review fix` did not do the same for PRs.

## Solution

Call the existing `gh_assign_self_pr` helper from `scripts/shortcuts/review/lib.sh` right after `sync_pr` in `scripts/shortcuts/review/fix.sh`, gated by `REVIEW_AUTO_ASSIGN=1`. The helper already prints an `[INFO]` line on success and warns-but-continues on failure, so callers don't need extra error handling.

## Submission Checklist

- [x] N/A: shell-only dev shortcut with no runtime behavior; covered by manual invocation
- [x] N/A: shell-only dev shortcut, no Vitest/Rust coverage applicable
- [x] N/A: behaviour-only change to a dev shortcut
- [x] N/A: no feature surface affected
- [x] N/A: no new external network dependencies
- [x] N/A: dev shortcut, not a release-cut surface
- [x] N/A: no linked issue

## Impact

- Dev-shortcut only. No runtime, app, or release impact. Existing users get auto-assignment by default; opt out with `REVIEW_AUTO_ASSIGN=0`.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: chore/review-fix-self-assign
- Commit SHA: c84722d25094a6fe6c81a08b972f881265434f1c

### Validation Run
- [x] N/A: shell-only change, no app code touched
- [x] N/A: shell-only change
- [x] N/A: no tests to run for shell shortcut
- [x] N/A: no Rust touched
- [x] N/A: no Tauri touched

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: `pnpm review fix <pr>` now self-assigns the PR.
- User-visible effect: PR shows current gh user in the Assignees field after running the shortcut.

### Parity Contract
- Legacy behavior preserved: `REVIEW_AUTO_ASSIGN=0` reverts to the previous no-assign behavior.
- Guard/fallback/dispatch parity checks: mirrors `WORK_AUTO_ASSIGN` in `scripts/shortcuts/work/start.sh`.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A