### PR TITLE
feat(analytics): enable low-rate browser Sentry tracing

### DIFF
--- a/app/src/services/__tests__/analytics.test.ts
+++ b/app/src/services/__tests__/analytics.test.ts
@@ -300,13 +300,16 @@ describe('initSentry beforeSend manual-staging bypass', () => {
 
     const opts = hoisted.init.mock.calls[0][0] as {
       release: string;
-      tracesSampleRate: number;
+      tracesSampler: () => number;
       replaysSessionSampleRate: number;
       replaysOnErrorSampleRate: number;
       integrations: Array<{ name?: string }>;
     };
     expect(opts.release).toBe('openhuman@test+abc');
-    expect(opts.tracesSampleRate).toBe(0.1);
+    hoisted.analyticsEnabled = true;
+    expect(opts.tracesSampler()).toBe(0.1);
+    hoisted.analyticsEnabled = false;
+    expect(opts.tracesSampler()).toBe(0);
     expect(opts.replaysSessionSampleRate).toBe(0);
     expect(opts.replaysOnErrorSampleRate).toBe(0);
     const names = opts.integrations.map(i => i.name).filter(Boolean);

--- a/app/src/services/__tests__/analytics.test.ts
+++ b/app/src/services/__tests__/analytics.test.ts
@@ -300,9 +300,15 @@ describe('initSentry beforeSend manual-staging bypass', () => {
 
     const opts = hoisted.init.mock.calls[0][0] as {
       release: string;
+      tracesSampleRate: number;
+      replaysSessionSampleRate: number;
+      replaysOnErrorSampleRate: number;
       integrations: Array<{ name?: string }>;
     };
     expect(opts.release).toBe('openhuman@test+abc');
+    expect(opts.tracesSampleRate).toBe(0.1);
+    expect(opts.replaysSessionSampleRate).toBe(0);
+    expect(opts.replaysOnErrorSampleRate).toBe(0);
     const names = opts.integrations.map(i => i.name).filter(Boolean);
     expect(names).toContain('HttpContext');
   });

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -101,7 +101,7 @@ export function initSentry(): void {
     // Privacy: disable EVERYTHING that could leak sensitive state.
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
-    tracesSampleRate: 0,
+    tracesSampleRate: 0.1,
     defaultIntegrations: false,
     integrations: [
       Sentry.functionToStringIntegration(),
@@ -189,11 +189,6 @@ export function initSentry(): void {
       }
 
       return event;
-    },
-
-    beforeSendTransaction() {
-      // Block all transactions (performance traces).
-      return null;
     },
 
     // Ignore common non-actionable errors.

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -101,7 +101,7 @@ export function initSentry(): void {
     // Privacy: disable EVERYTHING that could leak sensitive state.
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
-    tracesSampleRate: 0.1,
+    tracesSampler: () => (isAnalyticsEnabled() ? 0.1 : 0),
     defaultIntegrations: false,
     integrations: [
       Sentry.functionToStringIntegration(),


### PR DESCRIPTION
## Summary

- Enable low-rate browser Sentry tracing in the React client, sampled at 10% only when analytics consent is enabled.
- Replace the unconditional transaction block with a consent-aware `tracesSampler` so browser traces are emitted only for opted-in users.
- Keep Session Replay disabled at `0`/`0` and leave error reporting, DSN, release, environment, and `beforeSend` untouched.
- Add a regression assertion covering the Sentry init trace/replay sampling config in the analytics test suite.

## Problem

- The browser Sentry client was configured with `tracesSampleRate: 0` and a `beforeSendTransaction()` hook that returned `null` for every transaction.
- That made browser tracing effectively disabled even when low-rate tracing would be useful for correlating frontend issues.
- After enabling tracing, transaction sampling also needed to stay behind the existing analytics-consent gate because `beforeSend` does not apply to transaction events.

## Solution

- Replace the disabled transaction path with `tracesSampler: () => (isAnalyticsEnabled() ? 0.1 : 0)` in `app/src/services/analytics.ts`.
- Preserve the existing privacy and error-reporting configuration, including replay disabled and the existing `beforeSend` scrubbing path.
- Extend the analytics test to assert replay stays off and trace sampling follows the analytics consent state.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Local full coverage was not run for this narrow app-only change; CI remains the merge gate.
- [x] Coverage matrix updated — `N/A: observability config change only; no matrix row added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature row changed`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: analytics config/test change only`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no linked issue provided`

## Impact

- Runtime/platform impact: desktop renderer / React browser Sentry client only.
- Performance impact: enables 10% frontend transaction sampling only for users who have analytics consent; Session Replay remains disabled.
- Security/privacy impact: no change to DSN, release, environment, `beforeSend`, PII policy, or replay settings.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: `N/A`

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: `N/A`
- URL: `N/A`

### Commit & Branch
- Branch: `sentry-browser-tracing-0.1`
- Commit SHA: `c7beb86a430965fd1511ee5ddc8a59a84bb20a0d`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm exec vitest run src/services/__tests__/analytics.test.ts --config test/vitest.config.ts`
- [x] Rust fmt/check (if changed): `N/A: no root Rust files changed`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri source files changed`

### Validation Blocked
- `command:` `N/A`
- `error:` `N/A`
- `impact:` `N/A`

### Behavior Changes
- Intended behavior change: browser Sentry transactions are sampled at 10% only when analytics consent is enabled, and remain disabled otherwise.
- User-visible effect: frontend traces become available in Sentry for a small sample of opted-in sessions; replay remains off.

### Parity Contract
- Legacy behavior preserved: error capture, DSN/release/environment wiring, replay disabled, and privacy scrubbing remain unchanged.
- Guard/fallback/dispatch parity checks: `beforeSend` event filtering and HTTP context integration are unchanged; transaction sampling now reuses the existing analytics-consent gate.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): `None`
- Canonical PR: `This PR`
- Resolution (closed/superseded/updated): `Updated in place after CodeRabbit review`
