### PR TITLE
fix(i18n): add missing settings.mascot.customGif* keys for de

### DIFF
--- a/app/src/lib/i18n/chunks/de-5.ts
+++ b/app/src/lib/i18n/chunks/de-5.ts
@@ -240,6 +240,10 @@ const de5: TranslationMap = {
   'settings.mascot.active': 'Aktiv',
   'settings.mascot.characterDesc': 'Charakterbeschreibung',
   'settings.mascot.characterHeading': 'Zeichenüberschrift',
+  'settings.mascot.customGifError':
+    'Gib eine HTTPS-.gif-URL, eine Loopback-HTTP-.gif-URL, eine file://-.gif-URL oder einen lokalen .gif-Pfad ein.',
+  'settings.mascot.customGifHeading': 'Eigener GIF-Avatar',
+  'settings.mascot.customGifLabel': 'URL des eigenen GIF-Avatars',
   'settings.mascot.colorDesc': 'Farbbeschreibung',
   'settings.mascot.colorHeading': 'Farbüberschrift',
   'settings.mascot.loadingLibrary': 'OpenHuman-Bibliothek wird geladen…',


### PR DESCRIPTION
## Summary
- The i18n `coverage.test.ts` was failing on German: `settings.mascot.customGifError`, `settings.mascot.customGifHeading`, and `settings.mascot.customGifLabel` were missing from `chunks/de-5.ts`.
- Added German translations matching the English copy in `en.ts`.

## Test plan
- [x] `pnpm debug unit src/lib/i18n/__tests__/coverage.test.ts` — 46/46 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added German translations for mascot customization features, including error messages for invalid custom avatar inputs and labels for custom avatar configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->