### PR TITLE
fix(security): allow bare date in default autonomy policy

### DIFF
--- a/src/openhuman/config/schema/autonomy.rs
+++ b/src/openhuman/config/schema/autonomy.rs
@@ -60,6 +60,7 @@ fn default_allowed_commands() -> Vec<String> {
         "wc".into(),
         "head".into(),
         "tail".into(),
+        "date".into(),
         "dir".into(),
         "type".into(),
         "where".into(),

--- a/src/openhuman/security/policy.rs
+++ b/src/openhuman/security/policy.rs
@@ -722,6 +722,7 @@ impl SecurityPolicy {
                         || arg == "-c"
                 })
             }
+            "date" => args.is_empty(),
             _ => true,
         }
     }

--- a/src/openhuman/security/policy_tests.rs
+++ b/src/openhuman/security/policy_tests.rs
@@ -129,6 +129,17 @@ fn config_default_policy_includes_windows_read_equivalents() {
 }
 
 #[test]
+fn config_default_policy_allows_prompt_date_command() {
+    let cfg = crate::openhuman::config::AutonomyConfig::default();
+    let p = SecurityPolicy::from_config(&cfg, std::path::Path::new("."));
+
+    assert!(
+        p.is_command_allowed("date"),
+        "agent instructions use `shell date`, so the default runtime policy must allow it"
+    );
+}
+
+#[test]
 fn blocked_commands_basic() {
     let p = default_policy();
     assert!(!p.is_command_allowed("rm -rf /"));


### PR DESCRIPTION
## Summary

- Allows the default runtime autonomy config to run the bare `date` command.
- Keeps `date` argument handling conservative: `date 2026-05-21` remains blocked by command argument safety checks.
- Adds a regression test for config-derived policy parity with the agent instruction that uses `shell date`.

## Problem

- Refs #2486.
- The default `SecurityPolicy` allowlist already included `date`, and the agent harness instructions tell the assistant to use `shell` with `date` for date/time questions.
- `AutonomyConfig::default()` did not include `date`, so runtime policies created from default config could reject that basic read-only workflow.

## Solution

- Add `date` to `default_allowed_commands()` in the autonomy config schema.
- Restrict `date` to no arguments in `SecurityPolicy::is_args_safe()` so allowing bare `date` does not also allow date-setting style arguments.
- Add a targeted regression test for config-derived policy allowing bare `date`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). CI will enforce the merged coverage gate for this Rust-only change.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change. N/A: behavior-only security policy parity fix, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`. N/A: no coverage-matrix feature ID changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)). N/A: no release smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section. N/A: #2486 has broader remaining scope; this PR references but does not close it.

## Impact

- Runtime/security policy impact only.
- Bare `date` becomes allowed under default config-derived policies.
- `date` with arguments remains blocked to avoid widening command execution to system-time mutation forms.

## Related

- Refs #2486
- Follow-up PR(s)/TODOs: remaining #2486 execution feedback and configurable command policy surfaces.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/2486-allow-date-default`
- Commit SHA: `43777cd7`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed.
- [x] `pnpm typecheck` — N/A: no TypeScript files changed.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml config_default_policy_allows_prompt_date_command --lib`; `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml openhuman::security::policy::tests --lib`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --all --check`; `git diff --check`; `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: default config-derived autonomy policy now permits the bare `date` command used by agent instructions.
- User-visible effect: basic date/time shell lookup is no longer blocked under default runtime autonomy config.

### Parity Contract
- Legacy behavior preserved: default `SecurityPolicy` already allowed bare `date`; config-derived policy now matches it.
- Guard/fallback/dispatch parity checks: `date 2026-05-21` remains blocked by argument safety tests.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `date` command is now available by default in autonomy configurations.

* **Bug Fixes**
  * The `date` command is now restricted to execute without additional arguments for enhanced security enforcement.

* **Tests**
  * Added test coverage validating the default `date` command policy behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->