### PR TITLE
fix(docker): normalize core entrypoint line endings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,5 +38,7 @@ Thumbs.db
 tests/
 scripts/
 # Re-include the Docker entrypoint for the core image (Dockerfile COPYs it).
-# The negation must come after the broad exclusion above to take effect.
+# Re-include the parent directory first so older Docker pattern matchers that
+# prune excluded directories still see the leaf exception below.
+!scripts/
 !scripts/docker-entrypoint-core.sh

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.sh text eol=lf
+*.bash text eol=lf
+Dockerfile text eol=lf
+.dockerignore text eol=lf
+docker-compose*.yml text eol=lf
+*.ps1 text eol=crlf

--- a/.github/workflows/deploy-smoke.yml
+++ b/.github/workflows/deploy-smoke.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - Dockerfile
       - .dockerignore
+      - .gitattributes
       - docker-compose.yml
+      - scripts/docker-entrypoint-core.sh
       - .do/app.yaml
       - gitbooks/developing/cloud-deploy.md
       - .github/workflows/deploy-smoke.yml
@@ -18,7 +20,9 @@ on:
     paths:
       - Dockerfile
       - .dockerignore
+      - .gitattributes
       - docker-compose.yml
+      - scripts/docker-entrypoint-core.sh
       - .do/app.yaml
       - gitbooks/developing/cloud-deploy.md
       - .github/workflows/deploy-smoke.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,11 @@ COPY --from=builder /tmp/openhuman-core /usr/local/bin/openhuman-core
 # privileges.  The script is a separate file so the E2E entrypoint
 # (e2e/docker-entrypoint.sh) is not affected.
 COPY scripts/docker-entrypoint-core.sh /usr/local/bin/docker-entrypoint-core.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint-core.sh
+# Windows checkouts may materialize shell scripts with CRLF line endings when
+# core.autocrlf is enabled.  A CRLF shebang makes Linux report the executable
+# as "no such file or directory" at container startup, so normalize in-image.
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint-core.sh \
+ && chmod +x /usr/local/bin/docker-entrypoint-core.sh
 
 # The entrypoint runs as root so it can chown the mounted volume, then execs
 # gosu to drop to the openhuman user before starting the binary.


### PR DESCRIPTION
## Summary

- Fixes Windows checkout builds where `docker-entrypoint-core.sh` can enter the Docker image with CRLF line endings and fail at container startup.
- Adds `.gitattributes` rules to keep shell/Docker files LF across platforms while preserving PowerShell scripts as CRLF.
- Normalizes the core Docker entrypoint inside the image after `COPY`, so the runtime is protected even if a local checkout is already CRLF.
- Makes `.dockerignore` re-include the `scripts/` parent directory before the entrypoint leaf and widens deploy-smoke triggers to cover the entrypoint and line-ending rules.

## Problem

- #2540 reports `docker compose up -d` on Windows 11 building an image that immediately restarts with:
  `exec /usr/local/bin/docker-entrypoint-core.sh: no such file or directory`.
- The script exists in the repository and Dockerfile copies it, so a missing repository file is not the likely runtime cause.
- Reproduced locally with a CRLF shell script: Linux containers report the same `exec ... no such file or directory` because the shebang becomes `#!/bin/sh\r`.

## Solution

- Add `.gitattributes` to force `*.sh`, Dockerfile, `.dockerignore`, and compose YAML to LF on checkout.
- Add a defensive Dockerfile normalization step: `sed -i 's/\r$//' /usr/local/bin/docker-entrypoint-core.sh` before `chmod +x`.
- Update `.dockerignore` to explicitly re-include `scripts/` before `scripts/docker-entrypoint-core.sh` for older/stricter Docker pattern matchers.
- Update `deploy-smoke.yml` path filters so future entrypoint or line-ending changes run the Docker image smoke tests.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — local Docker regression harness exercised failing CRLF startup and passing normalized startup.
- [x] **Diff coverage ≥ 80%** — N/A: Docker/CI packaging change; no Rust/TS production lines for lcov diff coverage.
- [x] Coverage matrix updated — N/A: packaging/runtime startup fix, no product feature row changed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage matrix feature ID affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: headless Docker deploy is covered by `Deploy Smoke` CI; this PR widens that CI trigger.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Docker self-hosted core image; specifically protects Windows checkouts with `core.autocrlf` enabled.
- Security impact: unchanged; entrypoint still starts as root only to chown the workspace and then drops to `openhuman` via `gosu`.
- Performance/migration impact: negligible one-time `sed` over a tiny entrypoint script during image build.

## Related

- Closes #2540
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/2540-docker-entrypoint-windows`
- Commit SHA: `cac7ce11af027bfe6db041aa82f768e7534f6458`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` via `pnpm format:check`
- [x] `pnpm typecheck` via pre-push `pnpm compile` (`tsc --noEmit`)
- [x] Focused tests:
  - CRLF repro harness before fix: Docker image with CRLF shebang exited `255` with `exec /usr/local/bin/docker-entrypoint-core.sh: no such file or directory`
  - CRLF normalized harness after fix: Docker image using the same `sed -i 's/\r$//'` step exited `0` and printed `crlf-normalized`
  - Build context harness: `docker build --no-cache -t openhuman-entrypoint-context-test -f - .` successfully copied `scripts/docker-entrypoint-core.sh`
  - `git check-attr --all -- scripts/docker-entrypoint-core.sh scripts/install.sh scripts/install.ps1 Dockerfile .dockerignore docker-compose.yml` confirmed LF attrs for shell/Docker files and CRLF for PowerShell.
  - `git diff --check`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path ../Cargo.toml --all --check` via `pnpm format:check`; pre-push `pnpm rust:check` passed with `GGML_NATIVE=OFF`
- [x] Tauri fmt/check (if changed): `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check` via `pnpm format:check`; pre-push `pnpm rust:check` passed with `GGML_NATIVE=OFF`

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Docker images built from Windows checkouts no longer fail to exec the core entrypoint when the source script is CRLF.
- User-visible effect: `docker compose up -d` should start the core container instead of entering an exit-255 restart loop for this entrypoint-line-ending failure.

### Parity Contract
- Legacy behavior preserved: LF checkouts and Linux/macOS builds keep the same entrypoint behavior.
- Guard/fallback/dispatch parity checks: `.gitattributes` prevents future CRLF checkouts; Dockerfile normalization protects already-CRLF local worktrees; deploy-smoke now runs when the entrypoint or line-ending rules change.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved cross-platform compatibility by enforcing consistent line ending behavior for build scripts and Docker configurations.
  * Enhanced Docker build process to ensure proper script execution across different operating systems.
  * Updated deployment automation to monitor relevant configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->