### PR TITLE
fix(windows): make port/process takeover actually free the port

### DIFF
--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -780,6 +780,13 @@ fn parse_lsof_pid(stdout: &str) -> Option<u32> {
 }
 
 /// Pure parse of `netstat -ano` output for a LISTENING entry on `port`.
+///
+/// Skips kernel-protected PIDs 0 (System Idle Process) and 4 (NT Kernel) —
+/// `HTTP.sys` and kernel-mode socket reservations occasionally surface as
+/// LISTENING under PID 4 even though no user-mode owner exists. Killing
+/// those is impossible and would otherwise abort startup recovery; if the
+/// "owner" is the kernel, callers should fall back to a port reroute
+/// instead of trying to take over.
 #[allow(dead_code)] // exercised only on windows builds
 fn parse_netstat_pid(stdout: &str, port: u16) -> Option<u32> {
     let needle = format!(":{port}");
@@ -792,6 +799,12 @@ fn parse_netstat_pid(stdout: &str, port: u16) -> Option<u32> {
         // Expected: ["TCP", "127.0.0.1:7788", "0.0.0.0:0", "LISTENING", "1234"]
         if parts.len() >= 5 && parts[1].ends_with(&needle) {
             if let Ok(pid) = parts[parts.len() - 1].parse::<u32>() {
+                if pid == 0 || pid == 4 {
+                    log::warn!(
+                        "[core] netstat reports port {port} owned by protected windows pid {pid}; treating as no-owner"
+                    );
+                    continue;
+                }
                 return Some(pid);
             }
         }

--- a/app/src-tauri/src/core_process_tests.rs
+++ b/app/src-tauri/src/core_process_tests.rs
@@ -277,6 +277,146 @@ Active Connections
     assert_eq!(parse_netstat_pid(stdout, 9999), None);
 }
 
+#[test]
+fn parse_netstat_pid_skips_protected_kernel_pids() {
+    // HTTP.sys / driver-level reservations occasionally show as LISTENING
+    // under PID 4 (NT Kernel) or PID 0 (System Idle). Returning those pids
+    // would lead startup recovery to call taskkill on a process that cannot
+    // be signalled from user mode — aborting the entire takeover flow.
+    // The parser must treat these entries as "no owner" so callers fall
+    // back to the port-reroute path instead of trying to kill the kernel.
+    let stdout = "\
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    127.0.0.1:7788         0.0.0.0:0              LISTENING       4
+  TCP    127.0.0.1:7789         0.0.0.0:0              LISTENING       0
+  TCP    127.0.0.1:7790         0.0.0.0:0              LISTENING       1234
+";
+    assert_eq!(parse_netstat_pid(stdout, 7788), None);
+    assert_eq!(parse_netstat_pid(stdout, 7789), None);
+    assert_eq!(parse_netstat_pid(stdout, 7790), Some(1234));
+}
+
+#[test]
+fn parse_netstat_pid_falls_through_protected_to_real_owner_on_dual_stack() {
+    // Real-world dual-stack listener: kernel-reserved entry sits ahead of
+    // the actual user-mode owner on the same port. The parser must keep
+    // scanning past the protected pid and return the genuine owner.
+    let stdout = "\
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    [::]:7788              [::]:0                 LISTENING       4
+  TCP    127.0.0.1:7788         0.0.0.0:0              LISTENING       9999
+";
+    assert_eq!(parse_netstat_pid(stdout, 7788), Some(9999));
+}
+
+// ---------------------------------------------------------------------------
+// Windows end-to-end port-takeover test
+//
+// Spawns a real child process that occupies a TCP port, then walks the same
+// path the Tauri host walks at startup (find_pid_on_port → kill_pid_force →
+// is_port_open) and asserts the port is actually freed. This is the
+// behavior the user reported broken — a unit-only parser test is not enough
+// to catch netstat/taskkill drift on real Windows machines.
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+#[test]
+fn windows_port_takeover_finds_and_kills_listener() {
+    use crate::process_kill::kill_pid_force;
+    use std::net::TcpListener;
+    use std::os::windows::process::CommandExt;
+    use std::time::{Duration, Instant};
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    // Bind in this process first to claim an ephemeral free port the OS
+    // picks for us, capture the port, then drop the listener so the child
+    // can bind to the same port. There is a tiny TOCTOU window here but
+    // ephemeral ports on Windows are not aggressively recycled so it is
+    // robust enough for a single-shot test.
+    let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+    let port = probe.local_addr().expect("probe addr").port();
+    drop(probe);
+
+    // Use PowerShell to spawn a listener that holds the port open for 60s.
+    // PowerShell ships with every supported Windows version.
+    let script = format!(
+        "$l = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, {port}); \
+         $l.Start(); Start-Sleep -Seconds 60; $l.Stop()"
+    );
+    let mut child = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .creation_flags(CREATE_NO_WINDOW)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn powershell listener");
+
+    // Wait until the listener is actually bound (PowerShell startup is slow).
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut bound = false;
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect_timeout(
+            &format!("127.0.0.1:{port}").parse().unwrap(),
+            Duration::from_millis(100),
+        )
+        .is_ok()
+        {
+            bound = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    if !bound {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("child listener never bound to 127.0.0.1:{port}");
+    }
+
+    // Walk the production path: pid lookup via netstat, then force-kill.
+    let pid = super::find_pid_on_port(port).expect("find pid on port via netstat");
+    // The pid we discovered won't be `child.id()` directly — the powershell
+    // process is the listener, and on Windows `child.id()` IS that pid.
+    // Sanity-check they match so a future netstat parser regression is loud.
+    assert_eq!(
+        pid,
+        child.id(),
+        "find_pid_on_port returned pid {pid}, expected child pid {}",
+        child.id()
+    );
+
+    kill_pid_force(pid).expect("force-kill listener");
+
+    // Verify the port is actually free within a reasonable window — this is
+    // the assertion that fails when taskkill mis-reports success or when
+    // /T fails to take down the powershell subtree.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut freed = false;
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect_timeout(
+            &format!("127.0.0.1:{port}").parse().unwrap(),
+            Duration::from_millis(100),
+        )
+        .is_err()
+        {
+            freed = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let _ = child.wait();
+    assert!(freed, "port {port} still bound after kill_pid_force(pid={pid})");
+
+    // Idempotency: kill the same pid again — must be Ok, not Err, because
+    // the process is already gone and recovery code calls force-kill after
+    // a re-validation that may race.
+    kill_pid_force(pid).expect("kill_pid_force on dead pid must be idempotent");
+}
+
 // ---------------------------------------------------------------------------
 // Token generation tests
 // ---------------------------------------------------------------------------

--- a/app/src-tauri/src/core_process_tests.rs
+++ b/app/src-tauri/src/core_process_tests.rs
@@ -377,16 +377,25 @@ fn windows_port_takeover_finds_and_kills_listener() {
     }
 
     // Walk the production path: pid lookup via netstat, then force-kill.
-    let pid = super::find_pid_on_port(port).expect("find pid on port via netstat");
+    let pid = match super::find_pid_on_port(port) {
+        Some(pid) => pid,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("find_pid_on_port returned None for port {port}");
+        }
+    };
     // The pid we discovered won't be `child.id()` directly — the powershell
     // process is the listener, and on Windows `child.id()` IS that pid.
     // Sanity-check they match so a future netstat parser regression is loud.
-    assert_eq!(
-        pid,
-        child.id(),
-        "find_pid_on_port returned pid {pid}, expected child pid {}",
-        child.id()
-    );
+    // Tear down the child *before* panicking so a 60s listener doesn't leak
+    // into the rest of the test suite.
+    if pid != child.id() {
+        let expected = child.id();
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("find_pid_on_port returned pid {pid}, expected child pid {expected}");
+    }
 
     kill_pid_force(pid).expect("force-kill listener");
 

--- a/app/src-tauri/src/core_process_tests.rs
+++ b/app/src-tauri/src/core_process_tests.rs
@@ -409,7 +409,10 @@ fn windows_port_takeover_finds_and_kills_listener() {
     }
 
     let _ = child.wait();
-    assert!(freed, "port {port} still bound after kill_pid_force(pid={pid})");
+    assert!(
+        freed,
+        "port {port} still bound after kill_pid_force(pid={pid})"
+    );
 
     // Idempotency: kill the same pid again — must be Ok, not Err, because
     // the process is already gone and recovery code calls force-kill after

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -210,10 +210,18 @@ pub(crate) fn classify_taskkill_force_status(
         }
         other => {
             let stderr_str = String::from_utf8_lossy(stderr);
-            if stderr_str.contains("not found")
-                || stderr_str.contains("could not be terminated")
-                || stderr_str.contains("ERROR: The process") && stderr_str.contains("not found")
-            {
+            // Only treat the "process is gone" stderr shapes as success.
+            // `could not be terminated` ALONE is *not* enough — it also
+            // appears in access-denied messages like
+            // "could not be terminated. Reason: Access is denied." which
+            // we must surface as a real failure.
+            let stderr_lower = stderr_str.to_ascii_lowercase();
+            let process_gone = stderr_lower.contains("no running instance of the task")
+                || (stderr_lower.contains("could not be terminated")
+                    && stderr_lower.contains("not found"))
+                || (stderr_lower.contains("error: the process")
+                    && stderr_lower.contains("not found"));
+            if process_gone {
                 log::debug!(
                     "[app] taskkill /F /PID {pid}: process already gone (stderr match: {stderr_str:?})"
                 );
@@ -270,9 +278,31 @@ mod windows_tests {
     }
 
     #[test]
-    fn classify_taskkill_force_propagates_real_failure() {
-        // Access-denied or other genuine errors must surface — recovery
-        // depends on knowing when escalation actually failed.
+    fn classify_taskkill_force_treats_no_running_instance_as_success() {
+        // The `/T` (tree) flag emits this shape when the parent is already
+        // gone but child traversal still runs.
+        let stderr = b"ERROR: The process with PID 1234 (child process of PID 999) \
+            could not be terminated.\r\n\
+            Reason: There is no running instance of the task.\r\n";
+        assert!(classify_taskkill_force_status(Some(128), stderr, 1234).is_ok());
+    }
+
+    #[test]
+    fn classify_taskkill_force_propagates_access_denied() {
+        // Access-denied has the SAME "could not be terminated" prefix as
+        // the process-gone case, so the predicate must require additional
+        // tokens before treating it as success. Otherwise we silently mark
+        // a live, unreachable process as killed and recovery proceeds
+        // against a still-bound port.
+        let stderr = b"ERROR: The process with PID 1234 could not be terminated.\r\n\
+            Reason: Access is denied.\r\n";
+        let err = classify_taskkill_force_status(Some(1), stderr, 1234).unwrap_err();
+        assert!(err.contains("code Some(1)"), "got: {err}");
+        assert!(err.contains("Access is denied"), "got: {err}");
+    }
+
+    #[test]
+    fn classify_taskkill_force_propagates_bare_access_denied() {
         let stderr = b"ERROR: Access is denied.\r\n";
         let err = classify_taskkill_force_status(Some(5), stderr, 1234).unwrap_err();
         assert!(err.contains("code Some(5)"), "got: {err}");

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -173,7 +173,9 @@ pub(crate) fn kill_pid_term(pid: u32) -> Result<(), String> {
 #[cfg(windows)]
 pub(crate) fn kill_pid_force(pid: u32) -> Result<(), String> {
     if is_protected_windows_pid(pid) {
-        return Err(format!("refusing to force-kill protected windows pid {pid}"));
+        return Err(format!(
+            "refusing to force-kill protected windows pid {pid}"
+        ));
     }
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
@@ -210,8 +212,7 @@ pub(crate) fn classify_taskkill_force_status(
             let stderr_str = String::from_utf8_lossy(stderr);
             if stderr_str.contains("not found")
                 || stderr_str.contains("could not be terminated")
-                || stderr_str.contains("ERROR: The process")
-                    && stderr_str.contains("not found")
+                || stderr_str.contains("ERROR: The process") && stderr_str.contains("not found")
             {
                 log::debug!(
                     "[app] taskkill /F /PID {pid}: process already gone (stderr match: {stderr_str:?})"

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -150,8 +150,16 @@ fn signaled_at_least_one(status: &std::process::ExitStatus) -> bool {
 /// without `/F` only delivers `WM_CLOSE` to GUI apps. Send the WM_CLOSE first
 /// (best-effort) so console subprocesses can run shutdown handlers; the
 /// follow-up [`kill_pid_force`] does the actual termination.
+///
+/// Refuses to signal the protected system PIDs 0 (System Idle Process) and 4
+/// (NT Kernel & System) — those should never be reachable from
+/// `find_pid_on_port`, but if they slip through the parser they would
+/// otherwise produce a hard taskkill failure that aborts startup recovery.
 #[cfg(windows)]
 pub(crate) fn kill_pid_term(pid: u32) -> Result<(), String> {
+    if is_protected_windows_pid(pid) {
+        return Err(format!("refusing to signal protected windows pid {pid}"));
+    }
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     // Best-effort — ignore non-zero exit (e.g. process is windowless).
@@ -164,15 +172,148 @@ pub(crate) fn kill_pid_term(pid: u32) -> Result<(), String> {
 
 #[cfg(windows)]
 pub(crate) fn kill_pid_force(pid: u32) -> Result<(), String> {
+    if is_protected_windows_pid(pid) {
+        return Err(format!("refusing to force-kill protected windows pid {pid}"));
+    }
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    let status = std::process::Command::new("taskkill")
+    let output = std::process::Command::new("taskkill")
         .args(["/F", "/T", "/PID", &pid.to_string()])
         .creation_flags(CREATE_NO_WINDOW)
-        .status()
+        .output()
         .map_err(|e| format!("taskkill spawn: {e}"))?;
-    if !status.success() {
-        return Err(format!("taskkill exited with {status}"));
+    classify_taskkill_force_status(output.status.code(), &output.stderr, pid)
+}
+
+/// Classify a `taskkill /F /T /PID <pid>` exit. Exit code 128 ("process not
+/// found") means the process already exited between the pid lookup and the
+/// force-kill — the resource is freeing on its own, treat as success. Same
+/// semantics as ESRCH on Unix (`kill_pid_force` returns Ok for that case).
+///
+/// `stderr` is matched as a fallback when exit codes are masked by an
+/// intermediate shell — some Windows hosts/wrappers normalize taskkill exit
+/// codes to 1 but still write the "not found" message to stderr.
+#[cfg(windows)]
+pub(crate) fn classify_taskkill_force_status(
+    code: Option<i32>,
+    stderr: &[u8],
+    pid: u32,
+) -> Result<(), String> {
+    match code {
+        Some(0) => Ok(()),
+        // 128 = "There is no running instance of the task." — process already gone.
+        Some(128) => {
+            log::debug!("[app] taskkill /F /PID {pid}: process already gone (exit 128)");
+            Ok(())
+        }
+        other => {
+            let stderr_str = String::from_utf8_lossy(stderr);
+            if stderr_str.contains("not found")
+                || stderr_str.contains("could not be terminated")
+                || stderr_str.contains("ERROR: The process")
+                    && stderr_str.contains("not found")
+            {
+                log::debug!(
+                    "[app] taskkill /F /PID {pid}: process already gone (stderr match: {stderr_str:?})"
+                );
+                return Ok(());
+            }
+            Err(format!(
+                "taskkill exited with code {other:?} stderr={stderr_str:?}"
+            ))
+        }
     }
-    Ok(())
+}
+
+/// PIDs 0 (System Idle Process) and 4 (NT Kernel & System) are kernel-owned
+/// and cannot be signalled by user-mode processes. They occasionally surface
+/// in `netstat -ano` output for sockets reserved by HTTP.sys or other
+/// kernel-side bindings — guard against ever trying to kill them.
+#[cfg(windows)]
+pub(crate) const fn is_protected_windows_pid(pid: u32) -> bool {
+    pid == 0 || pid == 4
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    #[test]
+    fn is_protected_windows_pid_matches_kernel_pids() {
+        assert!(is_protected_windows_pid(0));
+        assert!(is_protected_windows_pid(4));
+        assert!(!is_protected_windows_pid(1));
+        assert!(!is_protected_windows_pid(8));
+        assert!(!is_protected_windows_pid(1234));
+    }
+
+    #[test]
+    fn classify_taskkill_force_treats_exit_0_as_success() {
+        assert!(classify_taskkill_force_status(Some(0), b"", 1234).is_ok());
+    }
+
+    #[test]
+    fn classify_taskkill_force_treats_exit_128_as_success() {
+        // Exit 128 = "There is no running instance of the task." — process
+        // already gone between the pid lookup and our kill call. The port is
+        // freeing on its own; recovery must NOT bail out here.
+        assert!(classify_taskkill_force_status(Some(128), b"", 1234).is_ok());
+    }
+
+    #[test]
+    fn classify_taskkill_force_treats_not_found_stderr_as_success() {
+        // Some hosts/wrappers normalize exit codes to 1 but still emit the
+        // canonical "not found" message on stderr.
+        let stderr = b"ERROR: The process \"1234\" not found.\r\n";
+        assert!(classify_taskkill_force_status(Some(1), stderr, 1234).is_ok());
+    }
+
+    #[test]
+    fn classify_taskkill_force_propagates_real_failure() {
+        // Access-denied or other genuine errors must surface — recovery
+        // depends on knowing when escalation actually failed.
+        let stderr = b"ERROR: Access is denied.\r\n";
+        let err = classify_taskkill_force_status(Some(5), stderr, 1234).unwrap_err();
+        assert!(err.contains("code Some(5)"), "got: {err}");
+        assert!(err.contains("Access is denied"), "got: {err}");
+    }
+
+    #[test]
+    fn kill_pid_term_refuses_protected_pids() {
+        assert!(kill_pid_term(0).is_err());
+        assert!(kill_pid_term(4).is_err());
+    }
+
+    #[test]
+    fn kill_pid_force_refuses_protected_pids() {
+        assert!(kill_pid_force(0).is_err());
+        assert!(kill_pid_force(4).is_err());
+    }
+
+    /// End-to-end-on-Windows: spawn a real child process, force-kill it, and
+    /// verify it exits. Also covers the "process already gone" case by
+    /// killing the same PID twice — the second call must succeed (this is
+    /// the bug the patch above fixes).
+    #[test]
+    fn kill_pid_force_terminates_real_process_and_is_idempotent() {
+        // `timeout` is a builtin shipped with every Windows install; sleeps
+        // for ~30s which is plenty for the kill round-trip.
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "timeout", "/T", "30", "/NOBREAK"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .stdin(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn child process");
+        let pid = child.id();
+
+        kill_pid_force(pid).expect("force-kill running process");
+
+        // Reap so we don't leave a zombie regardless of test outcome.
+        let _ = child.wait();
+
+        // Second call: same pid is now gone. Must be Ok — this is the
+        // regression we're guarding against.
+        kill_pid_force(pid).expect("force-kill of already-gone pid is success");
+    }
 }

--- a/app/src-tauri/src/process_kill.rs
+++ b/app/src-tauri/src/process_kill.rs
@@ -280,11 +280,13 @@ mod windows_tests {
     #[test]
     fn classify_taskkill_force_treats_no_running_instance_as_success() {
         // The `/T` (tree) flag emits this shape when the parent is already
-        // gone but child traversal still runs.
+        // gone but child traversal still runs. Pass a *non-128* exit code
+        // here so the test actually exercises the stderr-matching branch —
+        // `Some(128)` short-circuits before we ever inspect stderr.
         let stderr = b"ERROR: The process with PID 1234 (child process of PID 999) \
             could not be terminated.\r\n\
             Reason: There is no running instance of the task.\r\n";
-        assert!(classify_taskkill_force_status(Some(128), stderr, 1234).is_ok());
+        assert!(classify_taskkill_force_status(Some(1), stderr, 1234).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Windows-only fix for the stale-listener recovery path in the Tauri shell — startup-time port takeover and force-kill were failing in three distinct ways.
- `kill_pid_force` now treats `taskkill` exit 128 (\"process not found\") as success, matching Unix ESRCH semantics. Previously every race between PID lookup and force-kill aborted recovery.
- `parse_netstat_pid` skips kernel-protected PIDs 0 (System Idle) and 4 (NT Kernel & System), which surface for HTTP.sys / driver-level socket reservations and cannot be signalled from user mode.
- Adds Windows-only unit tests (exit-code classification, protected-PID refusal) and an integration test that spawns a real PowerShell `TcpListener` and walks the full `find_pid_on_port` → `kill_pid_force` flow end to end, including idempotency on an already-gone pid.

## Problem

On Windows, when a previous OpenHuman session left a stale core process bound to the RPC port, startup recovery (`CoreProcessHandle::takeover_stale_listener`) often failed to free the port:

1. `kill_pid_force` used `status().success()` to detect failure. `taskkill /F /T /PID <pid>` returns exit code 128 (\"There is no running instance of the task\") when the process exits between our pid lookup and the kill — a normal race. The Unix branch already handles the equivalent ESRCH as success; the Windows branch was strictly stricter and aborted recovery instead.
2. `parse_netstat_pid` happily returned PID 0 (System Idle Process) or PID 4 (NT Kernel & System) when those showed up as LISTENING on the port. Those PIDs are kernel-owned and `taskkill` will always fail against them, breaking recovery. They can appear when HTTP.sys or another driver has the socket reserved — in that case the right behavior is to fall back to a different port, not to try to kill the kernel.
3. `kill_pid_term` / `kill_pid_force` had no defense in depth against ever receiving these protected PIDs from a future caller.

## Solution

`app/src-tauri/src/process_kill.rs`:
- New `classify_taskkill_force_status(code, stderr, pid)` — exit 0 → Ok, exit 128 → Ok (already gone), stderr containing \"not found\" / \"could not be terminated\" → Ok (for hosts that normalize the exit code), everything else → Err with full diagnostic.
- `kill_pid_force` now uses `.output()` and routes through the classifier so the stderr fallback path is reachable.
- New `is_protected_windows_pid(pid)` — `pid == 0 || pid == 4`. Both `kill_pid_term` and `kill_pid_force` refuse protected PIDs with a descriptive error.

`app/src-tauri/src/core_process.rs`:
- `parse_netstat_pid` skips lines whose PID is 0 or 4 and continues scanning (so a dual-stack listener like `[::]:port` showing under PID 4 ahead of the real `127.0.0.1:port` owner still returns the genuine PID).

Tests:
- Cross-platform parser units: `parse_netstat_pid_skips_protected_kernel_pids`, `parse_netstat_pid_falls_through_protected_to_real_owner_on_dual_stack`.
- Windows-only units (`#[cfg(all(test, windows))]` in `process_kill.rs`): exit 0 / exit 128 / stderr-only \"not found\" / genuine access-denied classifications, refusal of pids 0 and 4 by both kill functions, and a real-process round-trip that spawns a `cmd /C timeout` child, force-kills it, and asserts the same PID can be force-killed again with no error.
- Windows-only end-to-end (`#[cfg(windows)]` in `core_process_tests.rs`): `windows_port_takeover_finds_and_kills_listener` spawns a real PowerShell TCP listener on an ephemeral port, walks the production path (`find_pid_on_port` → `kill_pid_force` → poll `is_port_open`), and asserts the port is actually freed.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: diff-coverage gate — changed code is platform-specific Windows logic gated on `#[cfg(windows)]`; macOS/Linux coverage runs cannot exercise those paths. Cross-platform parser changes are covered by the new `parse_netstat_pid_*` unit tests that run on every host.
- [x] N/A: coverage matrix — behaviour-only change inside an existing lifecycle path; no new user-facing feature row.
- [x] N/A: feature IDs — no matrix entries affected (see above).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: manual smoke checklist — internal lifecycle fix, no release-cut surface affected.
- [x] N/A: linked issue — fix discovered during follow-up debugging of #1130 / Windows lifecycle work; no dedicated issue filed.

## Impact

- **Platform**: Windows-only behavior change inside `app/src-tauri` (the Tauri host). macOS and Linux paths are unchanged.
- **Runtime**: Windows users who hard-quit OpenHuman should now see startup recover from a stale core process reliably instead of aborting with \"taskkill exited with...\".
- **Security**: protected kernel PIDs (0/4) can no longer be passed into `taskkill` from this code path.
- **Performance**: negligible. One extra cheap check per kill call.

## Related

- Follows up on the stale-listener recovery work in #1130.

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/windows-port-kill`
- Commit SHA: `69eea0121ee1da464e25655c0ecb3447e5089b72`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] N/A: `pnpm typecheck` — pre-existing failure on `upstream/main` (missing `qrcode.react`, `@noble/ciphers/*`, `@tauri-apps/plugin-barcode-scanner` deps in iOS-client files I did not touch). Reproduced on a clean `upstream/main` checkout. Used `git push --no-verify` per the CLAUDE.md policy for pre-existing unrelated breakage.
- [x] Focused tests: `cargo test --manifest-path app/src-tauri/Cargo.toml --lib parse_netstat_pid` — 3/3 pass.
- [x] N/A: Rust fmt/check (core) — no core crate changes.
- [x] Tauri fmt/check (changed): `cargo check --manifest-path app/src-tauri/Cargo.toml --tests` — clean.

### Validation Blocked
- `command:` `pnpm typecheck`
- `error:` `Cannot find module 'qrcode.react' / '@noble/ciphers/chacha' / '@noble/ciphers/webcrypto' / '@tauri-apps/plugin-barcode-scanner'`
- `impact:` None — reproduces verbatim on a clean `upstream/main` checkout, files are iOS-client code I did not modify.

### Behavior Changes
- Intended behavior change: Windows port takeover now succeeds in two scenarios that previously aborted recovery (process exits mid-kill; kernel-reserved socket on the port).
- User-visible effect: Windows users no longer see startup hang/abort after a hard quit when the previous core left a stale listener.

### Parity Contract
- Legacy behavior preserved: Unix branches unchanged; Windows `kill_pid_force` still surfaces genuine failures (access denied, spawn failure, unexpected exit codes) — only the \"already gone\" race is reclassified.
- Guard/fallback/dispatch parity checks: `parse_netstat_pid` still returns `Some(pid)` for the same real-listener inputs the existing test covers; the new skip applies only to PIDs 0 and 4.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None
- Canonical PR: This one
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows process termination now safely skips kernel-protected processes, preventing potential system errors
  * Improved port listener recovery to gracefully handle protected kernel-owned processes and fall back to alternative routing

* **Tests**
  * Added comprehensive Windows process handling tests covering protected process scenarios, edge cases, and port cleanup verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->