### PR TITLE
Fix provider model testing and add MCP coming soon placeholder

### DIFF
--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -30,6 +30,7 @@ import {
   saveAISettings,
   setCloudProviderKey,
   setOpenAICompatEndpointKey,
+  testProviderModel,
 } from '../../../services/api/aiSettingsApi';
 import {
   creditsApi,
@@ -206,6 +207,14 @@ const EMPTY_SETTINGS: AISettings = { cloudProviders: [], routing: EMPTY_ROUTING 
 
 function maskKeyLabel(hasKey: boolean): string {
   return hasKey ? '•••• configured' : 'Not configured';
+}
+
+function slugifyCustomProviderName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /**
@@ -1633,6 +1642,12 @@ function humanizeModelId(id: string): string {
   return id.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
+function appendTemperatureToProviderString(provider: string, temperature: number | null): string {
+  if (temperature == null || !Number.isFinite(temperature)) return provider;
+  const rounded = Math.round(temperature * 100) / 100;
+  return `${provider}@${String(rounded)}`;
+}
+
 const CustomRoutingDialog = ({
   workload,
   initial,
@@ -1672,6 +1687,10 @@ const CustomRoutingDialog = ({
   const [cloudModelsLoading, setCloudModelsLoading] = useState(false);
   const [cloudModelsError, setCloudModelsError] = useState<string | null>(null);
   const [modelsKey, setModelsKey] = useState(0);
+  const [testBusy, setTestBusy] = useState(false);
+  const [testReply, setTestReply] = useState<string | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [testStartedAt, setTestStartedAt] = useState<string | null>(null);
   // Optional temperature override for this workload. `null` = use provider/global default;
   // a finite number means "send `temperature: X` upstream for this workload only".
   const [temperature, setTemperature] = useState<number | null>(
@@ -1724,6 +1743,26 @@ const CustomRoutingDialog = ({
   }, [selectedSlug, modelsKey]);
 
   const canSave = source !== null && model.trim().length > 0;
+  const canTest = canSave && !cloudModelsLoading;
+
+  useEffect(() => {
+    setTestReply(null);
+    setTestError(null);
+    setTestStartedAt(null);
+  }, [source, model, temperature]);
+
+  const currentProviderString =
+    source == null
+      ? null
+      : source.kind === 'cloud'
+        ? appendTemperatureToProviderString(
+            `${source.providerSlug}:${model.trim()}`,
+            temperature == null || !Number.isFinite(temperature) ? null : temperature
+          )
+        : appendTemperatureToProviderString(
+            `ollama:${model.trim()}`,
+            temperature == null || !Number.isFinite(temperature) ? null : temperature
+          );
 
   const handleSave = () => {
     if (!source || !canSave) return;
@@ -1737,6 +1776,22 @@ const CustomRoutingDialog = ({
       });
     } else {
       onSubmit({ kind: 'local', model: model.trim(), temperature: temp });
+    }
+  };
+
+  const handleTest = async () => {
+    if (!currentProviderString || !canTest) return;
+    setTestBusy(true);
+    setTestReply(null);
+    setTestError(null);
+    setTestStartedAt(new Date().toLocaleTimeString());
+    try {
+      const result = await testProviderModel(workload.id, currentProviderString, 'Hello world');
+      setTestReply(result.reply);
+    } catch (err) {
+      setTestError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTestBusy(false);
     }
   };
 
@@ -1932,6 +1987,51 @@ const CustomRoutingDialog = ({
                 Lower = more deterministic. Leave unchecked to use the provider default.
               </p>
             </div>
+
+            {(testBusy || testReply || testError || testStartedAt) && (
+              <div
+                role={testError ? 'alert' : 'status'}
+                className={`rounded-lg border px-3 py-2 text-xs ${
+                  testError
+                    ? 'border-coral-200 dark:border-coral-500/30 bg-coral-50 dark:bg-coral-500/10 text-coral-700 dark:text-coral-300'
+                    : testBusy
+                      ? 'border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 text-amber-800 dark:text-amber-200'
+                    : 'border-sage-200 dark:border-sage-500/30 bg-sage-50 dark:bg-sage-500/10 text-sage-800 dark:text-sage-200'
+                }`}>
+                <div className="font-semibold">
+                  {testError ? 'Test failed' : testBusy ? 'Testing model…' : 'Model response'}
+                </div>
+                <div className="mt-1 space-y-1">
+                  <div className="font-mono text-[11px] text-current/80">
+                    Provider: {currentProviderString ?? '—'}
+                  </div>
+                  <div className="font-mono text-[11px] text-current/80">Prompt: Hello world</div>
+                  {testStartedAt && (
+                    <div className="font-mono text-[11px] text-current/80">
+                      Started: {testStartedAt}
+                    </div>
+                  )}
+                </div>
+                {testBusy ? (
+                  <div className="mt-2 rounded-md border border-current/15 bg-white/50 px-3 py-2 text-[12px] dark:bg-black/10">
+                    Waiting for response from the selected model…
+                  </div>
+                ) : testError ? (
+                  <div className="mt-2 rounded-md border border-current/15 bg-white/50 px-3 py-2 font-mono text-[11px] whitespace-pre-wrap break-words dark:bg-black/10">
+                    {testError}
+                  </div>
+                ) : (
+                  <div className="mt-3 space-y-1.5">
+                    <div className="text-[11px] font-semibold uppercase tracking-wide text-current/80">
+                      Response
+                    </div>
+                    <div className="rounded-md border border-current/15 bg-white/70 px-3 py-3 text-[13px] leading-relaxed text-stone-900 whitespace-pre-wrap break-words dark:bg-black/10 dark:text-neutral-100">
+                      {testReply}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
 
@@ -1941,6 +2041,13 @@ const CustomRoutingDialog = ({
             onClick={onClose}
             className="rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-4 py-2 text-sm font-medium text-stone-700 dark:text-neutral-200 hover:bg-stone-50 dark:hover:bg-neutral-800/60 dark:bg-neutral-800/60 dark:hover:bg-neutral-800/60">
             {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleTest()}
+            disabled={!canTest || testBusy}
+            className="rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-4 py-2 text-sm font-medium text-stone-700 dark:text-neutral-200 hover:bg-stone-50 dark:hover:bg-neutral-800/60 disabled:cursor-not-allowed disabled:opacity-50">
+            {testBusy ? 'Testing…' : 'Test'}
           </button>
           <button
             type="button"
@@ -2605,6 +2712,18 @@ const AIPanel = ({ embedded = false }: AIPanelProps = {}) => {
                   runtime_enabled: true,
                   opt_in_confirmed: true,
                 });
+              } else if (isLocalRuntime && slug === 'lmstudio') {
+                // LM Studio's dedicated local-runtime path reads
+                // `config.local_ai.provider/base_url/chat_model_id`, not a
+                // generic cloud-provider entry. Persist the provider eagerly
+                // so model tests and local-runtime inference hit the same path
+                // as the rest of the app.
+                await openhumanUpdateLocalAiSettings({
+                  base_url: endpoint,
+                  provider: 'lm_studio',
+                  runtime_enabled: true,
+                  opt_in_confirmed: true,
+                });
               }
 
               // Live verification: flush the new cloud_providers list to disk
@@ -2670,21 +2789,33 @@ const CloudProviderEditor = ({
   onClearKey: (slug: string) => Promise<void> | void;
 }) => {
   const { t } = useT();
-  const defaultSlug: string =
-    initial?.slug ??
-    (['openai', 'anthropic', 'openrouter', 'orcarouter', 'custom'] as const).find(
-      s => !existingSlugs.includes(s)
-    ) ??
-    'custom';
-  const [slug, setSlug] = useState<string>(defaultSlug);
-  const [label, setLabel] = useState<string>(
-    initial?.label ?? BUILTIN_PROVIDER_META[defaultSlug]?.label ?? defaultSlug
-  );
-  const [endpoint, setEndpoint] = useState(initial?.endpoint ?? defaultEndpointFor(defaultSlug));
+  const [label, setLabel] = useState<string>(initial?.label ?? '');
+  const [endpoint, setEndpoint] = useState(initial?.endpoint ?? '');
   const [apiKey, setApiKey] = useState('');
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const isOpenHuman = slug === 'openhuman';
+  const slug = initial?.slug ?? slugifyCustomProviderName(label);
+  const hasReservedSlugCollision =
+    !initial &&
+    [
+      'cloud',
+      'openhuman',
+      'pid',
+      'openai',
+      'anthropic',
+      'openrouter',
+      'orcarouter',
+      'custom',
+      'ollama',
+      'lmstudio',
+    ].includes(slug);
+  const slugError = !slug
+    ? 'Enter a provider name to generate a slug.'
+    : existingSlugs.includes(slug)
+      ? 'That provider name is already in use.'
+      : hasReservedSlugCollision
+        ? 'Choose a different provider name.'
+        : null;
   const hasExistingKey = (initial?.maskedKey ?? '').startsWith('••••');
 
   return (
@@ -2703,74 +2834,59 @@ const CloudProviderEditor = ({
         </div>
         <div className="space-y-3 px-4 py-3">
           <div>
-            <label className="text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
-              Provider slug
-            </label>
-            <select
-              value={slug}
-              onChange={e => {
-                const next = e.target.value;
-                setSlug(next);
-                setLabel(BUILTIN_PROVIDER_META[next]?.label ?? next);
-                if (!initial) {
-                  setEndpoint(defaultEndpointFor(next));
-                }
-              }}
-              disabled={!!initial}
-              className="mt-1 w-full rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-3 py-2 text-sm text-stone-900 dark:text-neutral-100 disabled:opacity-60 focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200">
-              {(['openai', 'anthropic', 'openrouter', 'orcarouter', 'custom'] as const)
-                .filter(s => s === slug || !existingSlugs.includes(s))
-                .map(s => (
-                  <option key={s} value={s}>
-                    {BUILTIN_PROVIDER_META[s]?.label ?? s}
-                  </option>
-                ))}
-            </select>
-          </div>
-          <div>
-            <label className="text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
-              Display label
+            <label
+              htmlFor="cloud-provider-name"
+              className="text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
+              Name
             </label>
             <input
+              id="cloud-provider-name"
               value={label}
               onChange={e => setLabel(e.target.value)}
               className="mt-1 w-full rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-3 py-2 text-sm text-stone-900 dark:text-neutral-100 placeholder:text-stone-400 dark:placeholder:text-neutral-500 dark:text-neutral-500 dark:placeholder:text-neutral-500 focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
               placeholder="My Provider"
             />
+            <div className="mt-1 text-[11px] text-stone-500 dark:text-neutral-400">
+              Slug: <span className="font-mono text-stone-700 dark:text-neutral-200">{slug || '—'}</span>
+            </div>
+            {slugError ? (
+              <div className="mt-1 text-[11px] text-coral-600 dark:text-coral-300">{slugError}</div>
+            ) : null}
           </div>
           <div>
-            <label className="text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
-              Endpoint
+            <label
+              htmlFor="cloud-provider-openai-url"
+              className="text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
+              OpenAI URL
             </label>
             <input
+              id="cloud-provider-openai-url"
               value={endpoint}
               onChange={e => setEndpoint(e.target.value)}
-              disabled={isOpenHuman}
               className="mt-1 w-full rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-3 py-2 font-mono text-xs text-stone-900 dark:text-neutral-100 placeholder:text-stone-400 dark:placeholder:text-neutral-500 dark:text-neutral-500 dark:placeholder:text-neutral-500 disabled:opacity-60 focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
-              placeholder="https://api.example.com/v1"
+              placeholder="https://api.openai.com/v1"
             />
           </div>
-          {!isOpenHuman && (
-            <div>
-              <label className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
-                <span>API key</span>
-                {hasExistingKey && (
-                  <button
-                    onClick={() => void onClearKey(slug)}
-                    className="text-[10px] font-medium normal-case text-coral-600 dark:text-coral-300 hover:text-coral-700 dark:text-coral-300">
-                    {t('settings.ai.clearStoredKey')}
-                  </button>
-                )}
-              </label>
-              <input
-                type="password"
-                value={apiKey}
-                onChange={e => setApiKey(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-3 py-2 font-mono text-xs text-stone-900 dark:text-neutral-100 placeholder:text-stone-400 dark:placeholder:text-neutral-500 dark:text-neutral-500 dark:placeholder:text-neutral-500 focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
-                placeholder={hasExistingKey ? 'Leave blank to keep existing key' : 'sk-...'}
-              />
-            </div>
-          )}
+          <div>
+            <label className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-wide text-stone-500 dark:text-neutral-400">
+              <span>API key</span>
+              {hasExistingKey && (
+                <button
+                  onClick={() => void onClearKey(slug)}
+                  className="text-[10px] font-medium normal-case text-coral-600 dark:text-coral-300 hover:text-coral-700 dark:text-coral-300">
+                  {t('settings.ai.clearStoredKey')}
+                </button>
+              )}
+            </label>
+            <input
+              aria-label="API key"
+              type="password"
+              value={apiKey}
+              onChange={e => setApiKey(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-3 py-2 font-mono text-xs text-stone-900 dark:text-neutral-100 placeholder:text-stone-400 dark:placeholder:text-neutral-500 dark:text-neutral-500 dark:placeholder:text-neutral-500 focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
+              placeholder={hasExistingKey ? 'Leave blank to keep existing key' : 'sk-...'}
+            />
+          </div>
           {submitError ? <ProviderSetupErrorNotice error={submitError} /> : null}
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-stone-200 dark:border-neutral-800 px-4 py-3">
@@ -2785,13 +2901,16 @@ const CloudProviderEditor = ({
               setSaving(true);
               setSubmitError(null);
               try {
+                if (slugError) {
+                  throw new Error(slugError);
+                }
                 await onSubmit(
                   {
                     id: initial?.id ?? '',
                     slug,
                     label: label.trim() || slug,
                     endpoint: endpoint.trim(),
-                    authStyle: initial?.authStyle ?? authStyleForSlug(slug),
+                    authStyle: initial?.authStyle ?? 'bearer',
                     maskedKey: maskKeyLabel(hasExistingKey || apiKey.length > 0),
                   },
                   apiKey.trim()
@@ -2810,7 +2929,7 @@ const CloudProviderEditor = ({
                 setSaving(false);
               }
             }}
-            disabled={saving || !endpoint.trim()}
+            disabled={saving || !endpoint.trim() || Boolean(slugError)}
             className="rounded-lg bg-primary-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-600 disabled:opacity-50">
             {saving
               ? t('settings.ai.saving')

--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -1836,8 +1836,9 @@ const CustomRoutingDialog = ({
       if (testRequestIdRef.current !== requestId) return;
       setTestError(err instanceof Error ? err.message : String(err));
     } finally {
-      if (testRequestIdRef.current !== requestId) return;
-      setTestBusy(false);
+      if (testRequestIdRef.current === requestId) {
+        setTestBusy(false);
+      }
     }
   };
 

--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -1745,11 +1745,11 @@ const CustomRoutingDialog = ({
   const canSave = source !== null && model.trim().length > 0;
   const canTest = canSave && !cloudModelsLoading;
 
-  useEffect(() => {
+  const resetTestState = () => {
     setTestReply(null);
     setTestError(null);
     setTestStartedAt(null);
-  }, [source, model, temperature]);
+  };
 
   const currentProviderString =
     source == null
@@ -1847,6 +1847,7 @@ const CustomRoutingDialog = ({
                   const colonIdx = e.target.value.indexOf(':');
                   const kind = e.target.value.slice(0, colonIdx);
                   const slug = e.target.value.slice(colonIdx + 1);
+                  resetTestState();
                   if (kind === 'local') {
                     setSource({ kind: 'local' });
                     setModel(localModels[0]?.id ?? '');
@@ -1872,7 +1873,10 @@ const CustomRoutingDialog = ({
               {source?.kind === 'local' ? (
                 <select
                   value={model}
-                  onChange={e => setModel(e.target.value)}
+                  onChange={e => {
+                    resetTestState();
+                    setModel(e.target.value);
+                  }}
                   className="rounded-lg border border-stone-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm text-stone-900 dark:text-neutral-100 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
                   {localModels.map(m => (
                     <option key={m.id} value={m.id}>
@@ -1905,7 +1909,10 @@ const CustomRoutingDialog = ({
                   <input
                     type="text"
                     value={model}
-                    onChange={e => setModel(e.target.value)}
+                    onChange={e => {
+                      resetTestState();
+                      setModel(e.target.value);
+                    }}
                     placeholder={selectedCloud ? `${selectedCloud.slug} model id` : 'model-id'}
                     className="w-full rounded-lg border border-stone-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm font-mono text-stone-900 dark:text-neutral-100 placeholder-stone-400 dark:placeholder-neutral-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
                   />
@@ -1913,7 +1920,10 @@ const CustomRoutingDialog = ({
               ) : cloudModels.length > 0 ? (
                 <select
                   value={model}
-                  onChange={e => setModel(e.target.value)}
+                  onChange={e => {
+                    resetTestState();
+                    setModel(e.target.value);
+                  }}
                   className="rounded-lg border border-stone-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm text-stone-900 dark:text-neutral-100 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
                   {!model && <option value="">Select a model…</option>}
                   {/* Keep existing value selectable even if the provider no longer lists it */}
@@ -1930,7 +1940,10 @@ const CustomRoutingDialog = ({
                 <input
                   type="text"
                   value={model}
-                  onChange={e => setModel(e.target.value)}
+                  onChange={e => {
+                    resetTestState();
+                    setModel(e.target.value);
+                  }}
                   placeholder={selectedCloud ? `${selectedCloud.slug} model id` : 'model-id'}
                   className="rounded-lg border border-stone-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm font-mono text-stone-900 dark:text-neutral-100 placeholder-stone-400 dark:placeholder-neutral-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
                 />
@@ -1945,7 +1958,10 @@ const CustomRoutingDialog = ({
                   <input
                     type="checkbox"
                     checked={temperature != null}
-                    onChange={e => setTemperature(e.target.checked ? 0.7 : null)}
+                    onChange={e => {
+                      resetTestState();
+                      setTemperature(e.target.checked ? 0.7 : null);
+                    }}
                     className="h-3.5 w-3.5 rounded border-stone-300 dark:border-neutral-700 text-primary-500 focus:ring-primary-500"
                   />
                   Temperature override
@@ -1965,7 +1981,10 @@ const CustomRoutingDialog = ({
                     max={2}
                     step={0.05}
                     value={temperature}
-                    onChange={e => setTemperature(Number(e.target.value))}
+                    onChange={e => {
+                      resetTestState();
+                      setTemperature(Number(e.target.value));
+                    }}
                     className="flex-1 accent-primary-500"
                   />
                   <input
@@ -1977,7 +1996,10 @@ const CustomRoutingDialog = ({
                     value={temperature}
                     onChange={e => {
                       const v = Number(e.target.value);
-                      if (Number.isFinite(v)) setTemperature(Math.max(0, Math.min(2, v)));
+                      if (Number.isFinite(v)) {
+                        resetTestState();
+                        setTemperature(Math.max(0, Math.min(2, v)));
+                      }
                     }}
                     className="w-16 rounded-lg border border-stone-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-xs font-mono text-stone-900 dark:text-neutral-100 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
                   />

--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -1996,7 +1996,7 @@ const CustomRoutingDialog = ({
                     ? 'border-coral-200 dark:border-coral-500/30 bg-coral-50 dark:bg-coral-500/10 text-coral-700 dark:text-coral-300'
                     : testBusy
                       ? 'border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 text-amber-800 dark:text-amber-200'
-                    : 'border-sage-200 dark:border-sage-500/30 bg-sage-50 dark:bg-sage-500/10 text-sage-800 dark:text-sage-200'
+                      : 'border-sage-200 dark:border-sage-500/30 bg-sage-50 dark:bg-sage-500/10 text-sage-800 dark:text-sage-200'
                 }`}>
                 <div className="font-semibold">
                   {testError ? 'Test failed' : testBusy ? 'Testing model…' : 'Model response'}
@@ -2847,7 +2847,8 @@ const CloudProviderEditor = ({
               placeholder="My Provider"
             />
             <div className="mt-1 text-[11px] text-stone-500 dark:text-neutral-400">
-              Slug: <span className="font-mono text-stone-700 dark:text-neutral-200">{slug || '—'}</span>
+              Slug:{' '}
+              <span className="font-mono text-stone-700 dark:text-neutral-200">{slug || '—'}</span>
             </div>
             {slugError ? (
               <div className="mt-1 text-[11px] text-coral-600 dark:text-coral-300">{slugError}</div>

--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -848,12 +848,11 @@ describe('AIPanel', () => {
     };
     vi.mocked(loadAISettings).mockResolvedValue(settingsWithOpenAI);
     vi.mocked(listProviderModels).mockResolvedValue([{ id: 'gpt-4o' }]);
-    let resolveTest: ((value: { reply: string }) => void) | null = null;
-    vi.mocked(testProviderModel).mockReturnValue(
-      new Promise(resolve => {
-        resolveTest = resolve;
-      })
-    );
+    let resolveTest: (value: { reply: string }) => void = () => {};
+    const pendingTest = new Promise<{ reply: string }>(resolve => {
+      resolveTest = resolve;
+    });
+    vi.mocked(testProviderModel).mockReturnValue(pendingTest);
 
     renderWithProviders(<AIPanel />);
 
@@ -869,7 +868,7 @@ describe('AIPanel', () => {
     expect(within(dialog).getByText(/Provider: openai:gpt-4o/i)).toBeInTheDocument();
     expect(within(dialog).getByText(/Prompt: Hello world/i)).toBeInTheDocument();
 
-    resolveTest?.({ reply: 'Hello from gpt-4o.' });
+    resolveTest({ reply: 'Hello from gpt-4o.' });
     expect(await within(dialog).findByText('Model response')).toBeInTheDocument();
   });
 

--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -11,6 +11,7 @@ import {
   saveAISettings,
   setCloudProviderKey,
   setOpenAICompatEndpointKey,
+  testProviderModel,
 } from '../../../../services/api/aiSettingsApi';
 import { creditsApi } from '../../../../services/api/creditsApi';
 import { renderWithProviders } from '../../../../test/test-utils';
@@ -40,6 +41,7 @@ vi.mock('../../../../services/api/aiSettingsApi', () => ({
   saveAISettings: vi.fn(),
   loadLocalProviderSnapshot: vi.fn(),
   setOpenAICompatEndpointKey: vi.fn(),
+  testProviderModel: vi.fn(),
   clearOpenAICompatEndpointKey: vi.fn().mockResolvedValue(undefined),
   setCloudProviderKey: vi.fn(),
   clearCloudProviderKey: vi.fn().mockResolvedValue(undefined),
@@ -203,6 +205,7 @@ describe('AIPanel', () => {
     vi.mocked(setOpenAICompatEndpointKey).mockResolvedValue(undefined);
     vi.mocked(clearOpenAICompatEndpointKey).mockResolvedValue(undefined);
     vi.mocked(setCloudProviderKey).mockResolvedValue(undefined);
+    vi.mocked(testProviderModel).mockResolvedValue({ reply: 'Hello from the selected model.' });
     vi.mocked(listProviderModels).mockResolvedValue([]);
     vi.mocked(openhumanHeartbeatSettingsGet).mockResolvedValue({
       result: { settings: baseHeartbeatSettings },
@@ -431,6 +434,8 @@ describe('AIPanel', () => {
 
     // The full CloudProviderEditor should appear (has "Add cloud provider" heading).
     await waitFor(() => expect(screen.getByText(/Add cloud provider/i)).toBeInTheDocument());
+    expect(screen.getByLabelText(/^Name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/OpenAI URL/i)).toBeInTheDocument();
     // The simple ProviderKeyDialog should NOT appear.
     expect(screen.queryByRole('dialog', { name: /Connect Custom/i })).not.toBeInTheDocument();
   });
@@ -586,18 +591,48 @@ describe('AIPanel', () => {
 
     fireEvent.click(screen.getByRole('switch', { name: /Connect Custom/i }));
     await waitFor(() => expect(screen.getByText(/Add cloud provider/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/^Name$/i), { target: { value: 'Team Gateway' } });
+    fireEvent.change(screen.getByLabelText(/OpenAI URL/i), {
+      target: { value: 'https://api.openai.com/v1' },
+    });
     fireEvent.change(screen.getByPlaceholderText('sk-...'), { target: { value: 'sk-test-key' } });
     fireEvent.click(screen.getByRole('button', { name: /Add provider/i }));
 
     const alert = await screen.findByRole('alert');
     expect(
       within(alert).getByText(
-        'Could not reach OpenAI: Provider teapot says no. Try another endpoint.'
+        'Could not reach Team Gateway: Provider teapot says no. Try another endpoint.'
       )
     ).toBeInTheDocument();
     expect(within(alert).getByText('Technical details')).toBeInTheDocument();
     expect(within(alert).getByText(/provider returned 418/)).toBeInTheDocument();
-    expect(screen.queryByRole('switch', { name: /Disconnect OpenAI/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('switch', { name: /Disconnect Team Gateway/i })).not.toBeInTheDocument();
+  });
+
+  it('derives the custom provider slug from the entered name', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+
+    renderWithProviders(<AIPanel />);
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: /Connect Custom/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: /Connect Custom/i }));
+    await waitFor(() => expect(screen.getByText(/Add cloud provider/i)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/^Name$/i), { target: { value: 'My Team Gateway' } });
+    expect(screen.getByText(/Slug:/i)).toHaveTextContent('Slug: my-team-gateway');
+
+    fireEvent.change(screen.getByLabelText(/OpenAI URL/i), {
+      target: { value: 'https://gateway.example.com/v1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('sk-...'), { target: { value: 'sk-team-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /Add provider/i }));
+
+    await waitFor(() =>
+      expect(vi.mocked(setCloudProviderKey)).toHaveBeenCalledWith('my-team-gateway', 'sk-team-key')
+    );
+    await waitFor(() => expect(vi.mocked(listProviderModels)).toHaveBeenCalledWith('my-team-gateway'));
   });
 
   // ─── local runtime: Ollama endpoint URL dialog ──────────────────────────────
@@ -664,6 +699,30 @@ describe('AIPanel', () => {
     });
   });
 
+  it('LM Studio save persists the local_ai provider and endpoint', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+    renderWithProviders(<AIPanel />);
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: /Connect LM Studio/i })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole('switch', { name: /Connect LM Studio/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Connect LM Studio/i });
+
+    fireEvent.change(within(dialog).getByLabelText(/Endpoint URL/i), {
+      target: { value: 'http://127.0.0.1:1234/v1' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => expect(openhumanUpdateLocalAiSettingsMock).toHaveBeenCalled());
+    const [arg] = vi.mocked(openhumanUpdateLocalAiSettingsMock).mock.calls[0];
+    expect(arg).toMatchObject({
+      base_url: 'http://127.0.0.1:1234/v1',
+      provider: 'lm_studio',
+      runtime_enabled: true,
+      opt_in_confirmed: true,
+    });
+  });
+
   // ─── Custom routing dialog: per-workload temperature override ───────────────
 
   it('Custom routing dialog saves the routing change immediately from the modal', async () => {
@@ -722,6 +781,126 @@ describe('AIPanel', () => {
       model: 'gpt-4o',
       temperature: 0.2,
     });
+  });
+
+  it('Custom routing dialog can test the selected cloud model and show its reply', async () => {
+    const settingsWithOpenAI = {
+      cloudProviders: [
+        {
+          id: 'p_openai_1',
+          slug: 'openai',
+          label: 'OpenAI',
+          endpoint: 'https://api.openai.com/v1',
+          auth_style: 'bearer' as const,
+          has_api_key: true,
+        },
+      ],
+      routing: {
+        ...baseSettings.routing,
+        reasoning: { kind: 'cloud' as const, providerSlug: 'openai', model: 'gpt-4o' },
+      },
+    };
+    vi.mocked(loadAISettings).mockResolvedValue(settingsWithOpenAI);
+    vi.mocked(listProviderModels).mockResolvedValue([{ id: 'gpt-4o' }, { id: 'gpt-4o-mini' }]);
+    vi.mocked(testProviderModel).mockResolvedValue({ reply: 'Hello from gpt-4o.' });
+
+    renderWithProviders(<AIPanel />);
+
+    const reasoningRow = await screen.findByText(/Main chat agent/i);
+    const rowEl = reasoningRow.closest('div.flex.items-center.justify-between');
+    expect(rowEl).not.toBeNull();
+    fireEvent.click(within(rowEl as HTMLElement).getByRole('button', { name: /Custom/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /Custom routing/i });
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Test$/i }));
+
+    await waitFor(() =>
+      expect(vi.mocked(testProviderModel)).toHaveBeenCalledWith(
+        'reasoning',
+        'openai:gpt-4o',
+        'Hello world'
+      )
+    );
+    expect(await within(dialog).findByText('Model response')).toBeInTheDocument();
+    expect(within(dialog).getByText('Hello from gpt-4o.')).toBeInTheDocument();
+  });
+
+  it('Custom routing dialog shows in-flight test status immediately', async () => {
+    const settingsWithOpenAI = {
+      cloudProviders: [
+        {
+          id: 'p_openai_1',
+          slug: 'openai',
+          label: 'OpenAI',
+          endpoint: 'https://api.openai.com/v1',
+          auth_style: 'bearer' as const,
+          has_api_key: true,
+        },
+      ],
+      routing: {
+        ...baseSettings.routing,
+        reasoning: { kind: 'cloud' as const, providerSlug: 'openai', model: 'gpt-4o' },
+      },
+    };
+    vi.mocked(loadAISettings).mockResolvedValue(settingsWithOpenAI);
+    vi.mocked(listProviderModels).mockResolvedValue([{ id: 'gpt-4o' }]);
+    let resolveTest: ((value: { reply: string }) => void) | null = null;
+    vi.mocked(testProviderModel).mockReturnValue(
+      new Promise(resolve => {
+        resolveTest = resolve;
+      })
+    );
+
+    renderWithProviders(<AIPanel />);
+
+    const reasoningRow = await screen.findByText(/Main chat agent/i);
+    const rowEl = reasoningRow.closest('div.flex.items-center.justify-between');
+    expect(rowEl).not.toBeNull();
+    fireEvent.click(within(rowEl as HTMLElement).getByRole('button', { name: /Custom/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /Custom routing/i });
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Test$/i }));
+
+    expect(await within(dialog).findByText('Testing model…')).toBeInTheDocument();
+    expect(within(dialog).getByText(/Provider: openai:gpt-4o/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/Prompt: Hello world/i)).toBeInTheDocument();
+
+    resolveTest?.({ reply: 'Hello from gpt-4o.' });
+    expect(await within(dialog).findByText('Model response')).toBeInTheDocument();
+  });
+
+  it('Custom routing dialog shows test errors inline', async () => {
+    const settingsWithOpenAI = {
+      cloudProviders: [
+        {
+          id: 'p_openai_1',
+          slug: 'openai',
+          label: 'OpenAI',
+          endpoint: 'https://api.openai.com/v1',
+          auth_style: 'bearer' as const,
+          has_api_key: true,
+        },
+      ],
+      routing: {
+        ...baseSettings.routing,
+        reasoning: { kind: 'cloud' as const, providerSlug: 'openai', model: 'gpt-4o' },
+      },
+    };
+    vi.mocked(loadAISettings).mockResolvedValue(settingsWithOpenAI);
+    vi.mocked(listProviderModels).mockResolvedValue([{ id: 'gpt-4o' }]);
+    vi.mocked(testProviderModel).mockRejectedValue(new Error('401 invalid api key'));
+
+    renderWithProviders(<AIPanel />);
+
+    const reasoningRow = await screen.findByText(/Main chat agent/i);
+    const rowEl = reasoningRow.closest('div.flex.items-center.justify-between');
+    expect(rowEl).not.toBeNull();
+    fireEvent.click(within(rowEl as HTMLElement).getByRole('button', { name: /Custom/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /Custom routing/i });
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Test$/i }));
+
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('401 invalid api key');
   });
 
   it('renders background loop diagnostics with newest spend row and budget math', async () => {

--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -606,7 +606,9 @@ describe('AIPanel', () => {
     ).toBeInTheDocument();
     expect(within(alert).getByText('Technical details')).toBeInTheDocument();
     expect(within(alert).getByText(/provider returned 418/)).toBeInTheDocument();
-    expect(screen.queryByRole('switch', { name: /Disconnect Team Gateway/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('switch', { name: /Disconnect Team Gateway/i })
+    ).not.toBeInTheDocument();
   });
 
   it('derives the custom provider slug from the entered name', async () => {
@@ -632,7 +634,9 @@ describe('AIPanel', () => {
     await waitFor(() =>
       expect(vi.mocked(setCloudProviderKey)).toHaveBeenCalledWith('my-team-gateway', 'sk-team-key')
     );
-    await waitFor(() => expect(vi.mocked(listProviderModels)).toHaveBeenCalledWith('my-team-gateway'));
+    await waitFor(() =>
+      expect(vi.mocked(listProviderModels)).toHaveBeenCalledWith('my-team-gateway')
+    );
   });
 
   // ─── local runtime: Ollama endpoint URL dialog ──────────────────────────────

--- a/app/src/lib/i18n/chunks/ar-1.ts
+++ b/app/src/lib/i18n/chunks/ar-1.ts
@@ -50,6 +50,7 @@ const ar1: TranslationMap = {
   'common.showLess': 'عرض أقل',
   'common.submit': 'إرسال',
   'common.continue': 'متابعة',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'عام',
   'settings.featuresAndAI': 'الميزات والذكاء الاصطناعي',
   'settings.billingAndRewards': 'الفوترة والمكافآت',
@@ -428,6 +429,9 @@ const ar1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/bn-1.ts
+++ b/app/src/lib/i18n/chunks/bn-1.ts
@@ -50,6 +50,7 @@ const bn1: TranslationMap = {
   'common.showLess': 'কম দেখুন',
   'common.submit': 'জমা দিন',
   'common.continue': 'চালিয়ে যান',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'সাধারণ',
   'settings.featuresAndAI': 'ফিচার ও AI',
   'settings.billingAndRewards': 'বিলিং ও পুরস্কার',
@@ -437,6 +438,9 @@ const bn1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/de-1.ts
+++ b/app/src/lib/i18n/chunks/de-1.ts
@@ -50,6 +50,7 @@ const de1: TranslationMap = {
   'common.showLess': 'Weniger anzeigen',
   'common.submit': 'Senden',
   'common.continue': 'Weiter',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'Allgemein',
   'settings.featuresAndAI': 'Funktionen und KI',
   'settings.billingAndRewards': 'Abrechnung und Prämien',
@@ -449,6 +450,9 @@ const de1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/es-1.ts
+++ b/app/src/lib/i18n/chunks/es-1.ts
@@ -50,6 +50,7 @@ const es1: TranslationMap = {
   'common.showLess': 'Ver menos',
   'common.submit': 'Enviar',
   'common.continue': 'Continuar',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'General',
   'settings.featuresAndAI': 'Funciones e IA',
   'settings.billingAndRewards': 'Facturación y recompensas',
@@ -449,6 +450,9 @@ const es1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/fr-1.ts
+++ b/app/src/lib/i18n/chunks/fr-1.ts
@@ -50,6 +50,7 @@ const fr1: TranslationMap = {
   'common.showLess': 'Afficher moins',
   'common.submit': 'Envoyer',
   'common.continue': 'Continuer',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'Général',
   'settings.featuresAndAI': 'Fonctionnalités & IA',
   'settings.billingAndRewards': 'Facturation & Récompenses',
@@ -451,6 +452,9 @@ const fr1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/hi-1.ts
+++ b/app/src/lib/i18n/chunks/hi-1.ts
@@ -50,6 +50,7 @@ const hi1: TranslationMap = {
   'common.showLess': 'कम दिखाएं',
   'common.submit': 'सबमिट करें',
   'common.continue': 'जारी रखें',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'सामान्य',
   'settings.featuresAndAI': 'फीचर्स और AI',
   'settings.billingAndRewards': 'बिलिंग और रिवॉर्ड',
@@ -434,6 +435,9 @@ const hi1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/id-1.ts
+++ b/app/src/lib/i18n/chunks/id-1.ts
@@ -50,6 +50,7 @@ const id1: TranslationMap = {
   'common.showLess': 'Tampilkan sedikit',
   'common.submit': 'Kirim',
   'common.continue': 'Lanjutkan',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'Umum',
   'settings.featuresAndAI': 'Fitur & AI',
   'settings.billingAndRewards': 'Tagihan & Hadiah',
@@ -440,6 +441,9 @@ const id1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/it-1.ts
+++ b/app/src/lib/i18n/chunks/it-1.ts
@@ -50,6 +50,7 @@ const it1: TranslationMap = {
   'common.showLess': 'Mostra meno',
   'common.submit': 'Invia',
   'common.continue': 'Continua',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'Generale',
   'settings.featuresAndAI': 'Funzionalità e AI',
   'settings.billingAndRewards': 'Fatturazione e premi',
@@ -444,6 +445,9 @@ const it1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/ko-1.ts
+++ b/app/src/lib/i18n/chunks/ko-1.ts
@@ -50,6 +50,7 @@ const ko1: TranslationMap = {
   'common.showLess': '간단히 보기',
   'common.submit': '제출',
   'common.continue': '계속',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': '일반',
   'settings.featuresAndAI': '기능 및 AI',
   'settings.billingAndRewards': '결제 및 보상',
@@ -425,6 +426,9 @@ const ko1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/pt-1.ts
+++ b/app/src/lib/i18n/chunks/pt-1.ts
@@ -50,6 +50,7 @@ const pt1: TranslationMap = {
   'common.showLess': 'Mostrar menos',
   'common.submit': 'Enviar',
   'common.continue': 'Continuar',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'Geral',
   'settings.featuresAndAI': 'Recursos e IA',
   'settings.billingAndRewards': 'Cobrança e Recompensas',
@@ -449,6 +450,9 @@ const pt1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/ru-1.ts
+++ b/app/src/lib/i18n/chunks/ru-1.ts
@@ -50,6 +50,7 @@ const ru1: TranslationMap = {
   'common.showLess': 'Показать меньше',
   'common.submit': 'Отправить',
   'common.continue': 'Продолжить',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': 'Общие',
   'settings.featuresAndAI': 'Функции и AI',
   'settings.billingAndRewards': 'Оплата и награды',
@@ -439,6 +440,9 @@ const ru1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/chunks/zh-CN-1.ts
+++ b/app/src/lib/i18n/chunks/zh-CN-1.ts
@@ -50,6 +50,7 @@ const zhCN1: TranslationMap = {
   'common.showLess': '收起',
   'common.submit': '提交',
   'common.continue': '继续',
+  'common.comingSoon': 'Coming Soon',
   'settings.general': '通用',
   'settings.featuresAndAI': '功能与 AI',
   'settings.billingAndRewards': '账单与奖励',
@@ -421,6 +422,9 @@ const zhCN1: TranslationMap = {
   'skills.tabs.composio': 'Composio',
   'skills.tabs.channels': 'Channels',
   'skills.tabs.mcp': 'MCP Servers',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.about.connection': 'Connection',
   'settings.about.connectionMode': 'Mode',
   'settings.about.connectionModeLocal': 'Local',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -52,6 +52,7 @@ const en: TranslationMap = {
   'common.showLess': 'Show less',
   'common.submit': 'Submit',
   'common.continue': 'Continue',
+  'common.comingSoon': 'Coming Soon',
 
   // Settings Home
   'settings.general': 'General',
@@ -1817,6 +1818,9 @@ const en: TranslationMap = {
   'settings.ai.openAiCompat.setKey': 'Set key',
   'settings.ai.openAiCompat.title': 'OpenAI-compatible endpoint',
   'settings.ai.providerLabel': 'Provider',
+  'skills.mcpComingSoon.title': 'MCP Servers',
+  'skills.mcpComingSoon.description':
+    'MCP server management is coming soon. This tab will be the home for discovering, connecting, and monitoring your MCP server integrations.',
   'settings.ai.routing': 'Routing',
   'settings.ai.routingCustom': 'Custom routing',
   'settings.ai.routingDefault': 'Default',

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -300,12 +300,10 @@ function McpComingSoonPanel() {
           />
         </svg>
       </div>
-      <h3 className="text-base font-semibold text-stone-900 dark:text-neutral-100">
-        MCP Servers
-      </h3>
+      <h3 className="text-base font-semibold text-stone-900 dark:text-neutral-100">MCP Servers</h3>
       <p className="mt-2 max-w-md text-sm leading-relaxed text-stone-500 dark:text-neutral-400">
-        MCP server management is coming soon. This tab will be the home for discovering,
-        connecting, and monitoring your MCP server integrations.
+        MCP server management is coming soon. This tab will be the home for discovering, connecting,
+        and monitoring your MCP server integrations.
       </p>
       <span className="mt-4 inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-500/10 px-3 py-1 text-xs font-medium text-primary-600 dark:text-primary-400">
         Coming Soon

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -284,6 +284,7 @@ function ChannelTile({ def, status, icon, testId, onOpen }: ChannelTileProps) {
 }
 
 function McpComingSoonPanel() {
+  const { t } = useT();
   return (
     <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-stone-300 dark:border-neutral-700 bg-stone-50/80 dark:bg-neutral-900/80 px-6 py-16 text-center">
       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary-50 dark:bg-primary-500/10">
@@ -300,13 +301,14 @@ function McpComingSoonPanel() {
           />
         </svg>
       </div>
-      <h3 className="text-base font-semibold text-stone-900 dark:text-neutral-100">MCP Servers</h3>
+      <h3 className="text-base font-semibold text-stone-900 dark:text-neutral-100">
+        {t('skills.mcpComingSoon.title')}
+      </h3>
       <p className="mt-2 max-w-md text-sm leading-relaxed text-stone-500 dark:text-neutral-400">
-        MCP server management is coming soon. This tab will be the home for discovering, connecting,
-        and monitoring your MCP server integrations.
+        {t('skills.mcpComingSoon.description')}
       </p>
       <span className="mt-4 inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-500/10 px-3 py-1 text-xs font-medium text-primary-600 dark:text-primary-400">
-        Coming Soon
+        {t('common.comingSoon')}
       </span>
     </div>
   );

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import ChannelSetupModal from '../components/channels/ChannelSetupModal';
-import McpServersTab from '../components/channels/mcp/McpServersTab';
 import ComposioConnectModal from '../components/composio/ComposioConnectModal';
 import {
   composioToolkitMeta,
@@ -281,6 +280,37 @@ function ChannelTile({ def, status, icon, testId, onOpen }: ChannelTileProps) {
         </span>
       </div>
     </button>
+  );
+}
+
+function McpComingSoonPanel() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-stone-300 dark:border-neutral-700 bg-stone-50/80 dark:bg-neutral-900/80 px-6 py-16 text-center">
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary-50 dark:bg-primary-500/10">
+        <svg
+          className="h-7 w-7 text-primary-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 7.5h10.5m-10.5 4.5h10.5m-10.5 4.5h6m-9.75 3h13.5A2.25 2.25 0 0 0 19.5 17.25V6.75A2.25 2.25 0 0 0 17.25 4.5H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5A2.25 2.25 0 0 0 6.75 19.5Z"
+          />
+        </svg>
+      </div>
+      <h3 className="text-base font-semibold text-stone-900 dark:text-neutral-100">
+        MCP Servers
+      </h3>
+      <p className="mt-2 max-w-md text-sm leading-relaxed text-stone-500 dark:text-neutral-400">
+        MCP server management is coming soon. This tab will be the home for discovering,
+        connecting, and monitoring your MCP server integrations.
+      </p>
+      <span className="mt-4 inline-flex items-center rounded-full bg-primary-50 dark:bg-primary-500/10 px-3 py-1 text-xs font-medium text-primary-600 dark:text-primary-400">
+        Coming Soon
+      </span>
+    </div>
   );
 }
 
@@ -1035,7 +1065,7 @@ export default function Skills() {
                         {t('channels.mcp.description')}
                       </p>
                     </div>
-                    <McpServersTab />
+                    <McpComingSoonPanel />
                   </div>
                 )}
               </>

--- a/app/src/pages/__tests__/Skills.mcp-coming-soon.test.tsx
+++ b/app/src/pages/__tests__/Skills.mcp-coming-soon.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import '../../test/mockDefaultSkillStatusHooks';
+import { renderWithProviders } from '../../test/test-utils';
+import Skills from '../Skills';
+
+vi.mock('../../hooks/useChannelDefinitions', () => ({
+  useChannelDefinitions: () => ({ definitions: [], loading: false, error: null }),
+}));
+
+vi.mock('../../services/api/skillsApi', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api/skillsApi')>(
+    '../../services/api/skillsApi'
+  );
+  return {
+    ...actual,
+    skillsApi: { ...actual.skillsApi, listSkills: vi.fn().mockResolvedValue([]) },
+  };
+});
+
+vi.mock('../../lib/composio/hooks', () => ({
+  useComposioIntegrations: () => ({
+    toolkits: [],
+    connectionByToolkit: new Map(),
+    refresh: vi.fn(),
+    loading: false,
+    error: null,
+  }),
+  useAgentReadyComposioToolkits: () => ({
+    agentReady: new Set<string>(),
+    loading: true,
+    error: null,
+  }),
+}));
+
+describe('Skills page — MCP tab', () => {
+  it('shows a coming soon placeholder for MCP server management', () => {
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'MCP Servers' }));
+
+    expect(screen.getAllByRole('heading', { name: 'MCP Servers' })).toHaveLength(2);
+    expect(screen.getByText(/MCP server management is coming soon/i)).toBeInTheDocument();
+    expect(screen.getByText('Coming Soon')).toBeInTheDocument();
+  });
+});

--- a/app/src/services/api/__tests__/aiSettingsApi.test.ts
+++ b/app/src/services/api/__tests__/aiSettingsApi.test.ts
@@ -25,6 +25,7 @@ import {
   setCloudProviderKey,
   setLocalRuntimeEnabled,
   setOpenAICompatEndpointKey,
+  testProviderModel,
 } from '../aiSettingsApi';
 
 // ─── Mock declarations (must be hoisted before imports) ───────────────────────
@@ -806,6 +807,35 @@ describe('listProviderModels', () => {
     const models = await listProviderModels('openai');
 
     expect(models).toEqual([]);
+  });
+});
+
+describe('testProviderModel', () => {
+  beforeEach(() => {
+    mockCallCoreRpc.mockReset();
+    mockIsTauri.mockReturnValue(true);
+  });
+
+  it('dispatches openhuman.inference_test_provider_model and returns the reply', async () => {
+    mockCallCoreRpc.mockResolvedValue({ result: { reply: 'Hello from model' } });
+
+    const result = await testProviderModel('reasoning', 'openai:gpt-4o');
+
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.inference_test_provider_model',
+      params: { workload: 'reasoning', provider: 'openai:gpt-4o', prompt: 'Hello world' },
+      timeoutMs: 120000,
+    });
+    expect(result).toEqual({ reply: 'Hello from model' });
+  });
+
+  it('throws when not running in Tauri', async () => {
+    mockIsTauri.mockReturnValue(false);
+
+    await expect(testProviderModel('reasoning', 'openai:gpt-4o')).rejects.toThrow(
+      'Model testing is only available in the desktop app.'
+    );
+    expect(mockCallCoreRpc).not.toHaveBeenCalled();
   });
 });
 

--- a/app/src/services/api/aiSettingsApi.ts
+++ b/app/src/services/api/aiSettingsApi.ts
@@ -113,6 +113,12 @@ export interface ModelInfo {
   context_window?: number | null;
 }
 
+export interface ProviderModelTestResult {
+  reply: string;
+}
+
+const PROVIDER_MODEL_TEST_TIMEOUT_MS = 120_000;
+
 /** Single in-memory snapshot the AI panel renders against. */
 export interface AISettings {
   cloudProviders: CloudProviderView[];
@@ -369,6 +375,22 @@ export async function listProviderModels(providerId: string): Promise<ModelInfo[
     params: { provider_id: providerId },
   });
   return res?.result?.models ?? [];
+}
+
+export async function testProviderModel(
+  workload: WorkloadId,
+  provider: string,
+  prompt = 'Hello world'
+): Promise<ProviderModelTestResult> {
+  if (!isTauri()) {
+    throw new Error('Model testing is only available in the desktop app.');
+  }
+  const res = await callCoreRpc<{ result: ProviderModelTestResult }>({
+    method: 'openhuman.inference_test_provider_model',
+    params: { workload, provider, prompt },
+    timeoutMs: PROVIDER_MODEL_TEST_TIMEOUT_MS,
+  });
+  return res?.result ?? { reply: '' };
 }
 
 // ─── Local provider façade (Ollama install / detect / model manage) ───────

--- a/app/src/services/api/aiSettingsApi.ts
+++ b/app/src/services/api/aiSettingsApi.ts
@@ -390,7 +390,12 @@ export async function testProviderModel(
     params: { workload, provider, prompt },
     timeoutMs: PROVIDER_MODEL_TEST_TIMEOUT_MS,
   });
-  return res?.result ?? { reply: '' };
+  if (!res?.result) {
+    throw new Error(
+      `Model test RPC returned no result for ${workload} via ${provider} (openhuman.inference_test_provider_model).`
+    );
+  }
+  return res.result;
 }
 
 // ─── Local provider façade (Ollama install / detect / model manage) ───────

--- a/src/openhuman/inference/local/lm_studio.rs
+++ b/src/openhuman/inference/local/lm_studio.rs
@@ -187,6 +187,26 @@ pub(crate) struct LmStudioChatChoice {
 pub(crate) struct LmStudioChatResponseMessage {
     #[serde(default)]
     pub content: Option<String>,
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
+}
+
+impl LmStudioChatResponseMessage {
+    pub(crate) fn effective_content(&self) -> String {
+        self.content
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .or_else(|| {
+                self.reasoning_content
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToString::to_string)
+            })
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -227,5 +247,14 @@ mod tests {
             normalize_lm_studio_base_url("http://127.0.0.1:1234/v1/models").as_deref(),
             Some("http://127.0.0.1:1234/v1")
         );
+    }
+
+    #[test]
+    fn effective_content_falls_back_to_reasoning_content() {
+        let msg = LmStudioChatResponseMessage {
+            content: Some("".into()),
+            reasoning_content: Some("thinking text".into()),
+        };
+        assert_eq!(msg.effective_content(), "thinking text");
     }
 }

--- a/src/openhuman/inference/local/lm_studio.rs
+++ b/src/openhuman/inference/local/lm_studio.rs
@@ -195,15 +195,15 @@ impl LmStudioChatResponseMessage {
     pub(crate) fn effective_content(&self) -> String {
         self.content
             .as_deref()
-            .map(str::trim)
+            .map(crate::openhuman::inference::provider::compatible_parse::strip_think_tags)
+            .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
-            .map(ToString::to_string)
             .or_else(|| {
                 self.reasoning_content
                     .as_deref()
-                    .map(str::trim)
+                    .map(crate::openhuman::inference::provider::compatible_parse::strip_think_tags)
+                    .map(|value| value.trim().to_string())
                     .filter(|value| !value.is_empty())
-                    .map(ToString::to_string)
             })
             .unwrap_or_default()
     }
@@ -256,5 +256,14 @@ mod tests {
             reasoning_content: Some("thinking text".into()),
         };
         assert_eq!(msg.effective_content(), "thinking text");
+    }
+
+    #[test]
+    fn effective_content_strips_think_tags() {
+        let msg = LmStudioChatResponseMessage {
+            content: Some("<think>hidden</think>Visible reply".into()),
+            reasoning_content: None,
+        };
+        assert_eq!(msg.effective_content(), "Visible reply");
     }
 }

--- a/src/openhuman/inference/local/lm_studio.rs
+++ b/src/openhuman/inference/local/lm_studio.rs
@@ -225,7 +225,11 @@ impl LmStudioChatResponseMessage {
             return reasoning;
         }
 
-        tracing::trace!(source = "none", output_chars = 0, "[lm-studio] effective content empty");
+        tracing::trace!(
+            source = "none",
+            output_chars = 0,
+            "[lm-studio] effective content empty"
+        );
         String::new()
     }
 }

--- a/src/openhuman/inference/local/service/lm_studio.rs
+++ b/src/openhuman/inference/local/service/lm_studio.rs
@@ -225,10 +225,8 @@ impl LocalAiService {
         let reply = payload
             .choices
             .first()
-            .and_then(|choice| choice.message.content.as_deref())
-            .unwrap_or_default()
-            .trim()
-            .to_string();
+            .map(|choice| choice.message.effective_content())
+            .unwrap_or_default();
 
         if reply.is_empty() && !allow_empty {
             return Err("lm studio returned empty content".to_string());

--- a/src/openhuman/inference/local/service/public_infer_tests.rs
+++ b/src/openhuman/inference/local/service/public_infer_tests.rs
@@ -261,10 +261,12 @@ async fn lm_studio_chat_with_history_falls_back_to_reasoning_content() {
     let reply = service
         .chat_with_history(
             &config,
-            vec![crate::openhuman::inference::local::ollama::OllamaChatMessage {
-                role: "user".to_string(),
-                content: "hi".to_string(),
-            }],
+            vec![
+                crate::openhuman::inference::local::ollama::OllamaChatMessage {
+                    role: "user".to_string(),
+                    content: "hi".to_string(),
+                },
+            ],
             None,
         )
         .await

--- a/src/openhuman/inference/local/service/public_infer_tests.rs
+++ b/src/openhuman/inference/local/service/public_infer_tests.rs
@@ -237,6 +237,43 @@ async fn lm_studio_chat_with_history_returns_response() {
 }
 
 #[tokio::test]
+async fn lm_studio_chat_with_history_falls_back_to_reasoning_content() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(|Json(_body): Json<serde_json::Value>| async move {
+            Json(json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "reasoning-only reply"
+                    }
+                }]
+            }))
+        }),
+    );
+    let base = spawn_mock(app).await;
+    let config = lm_studio_config(&base);
+    let service = ready_service(&config);
+
+    let reply = service
+        .chat_with_history(
+            &config,
+            vec![crate::openhuman::inference::local::ollama::OllamaChatMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            None,
+        )
+        .await
+        .expect("lm studio reasoning fallback");
+
+    assert_eq!(reply, "reasoning-only reply");
+}
+
+#[tokio::test]
 async fn lm_studio_prompt_errors_on_non_success_status() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 

--- a/src/openhuman/inference/ops.rs
+++ b/src/openhuman/inference/ops.rs
@@ -13,6 +13,11 @@ use tracing::{debug, error};
 
 const LOG_PREFIX: &str = "[inference::ops]";
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InferenceTestProviderModelResult {
+    pub reply: String,
+}
+
 pub async fn inference_status(config: &Config) -> Result<RpcOutcome<LocalAiStatus>, String> {
     debug!("{LOG_PREFIX} status:start");
     let result = local_runtime::rpc::local_ai_status(config).await;
@@ -119,6 +124,88 @@ pub async fn inference_chat(
     match &result {
         Ok(outcome) => debug!(output_len = outcome.value.len(), "{LOG_PREFIX} chat:ok"),
         Err(err) => error!(error = %err, "{LOG_PREFIX} chat:error"),
+    }
+    result
+}
+
+pub async fn inference_test_provider_model(
+    config: &Config,
+    workload: &str,
+    provider: &str,
+    prompt: &str,
+) -> Result<RpcOutcome<InferenceTestProviderModelResult>, String> {
+    debug!(
+        workload,
+        provider,
+        prompt_len = prompt.len(),
+        "{LOG_PREFIX} test_provider_model:start"
+    );
+    let result = if provider.trim().starts_with("lmstudio:") || provider.trim().starts_with("ollama:") {
+        let mut effective = config.clone();
+        let (local_kind, raw_model) = provider
+            .split_once(':')
+            .ok_or_else(|| "invalid local provider string".to_string())?;
+        let (model, temperature_override) = match raw_model.rsplit_once('@') {
+            Some((head, tail)) => match tail.trim().parse::<f64>() {
+                Ok(temp) if !head.trim().is_empty() => (head.trim().to_string(), Some(temp)),
+                _ => (raw_model.trim().to_string(), None),
+            },
+            None => (raw_model.trim().to_string(), None),
+        };
+        if model.is_empty() {
+            return Err("model must not be empty".to_string());
+        }
+        if let Some(temp) = temperature_override {
+            effective.default_temperature = temp;
+        }
+        if local_kind == "lmstudio" {
+            effective.local_ai.provider = "lm_studio".to_string();
+            if let Some(entry) = config.cloud_providers.iter().find(|e| e.slug == "lmstudio") {
+                effective.local_ai.base_url = Some(entry.endpoint.clone());
+            }
+        } else {
+            effective.local_ai.provider = "ollama".to_string();
+            if let Some(entry) = config.cloud_providers.iter().find(|e| e.slug == "ollama") {
+                effective.local_ai.base_url =
+                    Some(entry.endpoint.trim_end_matches("/").trim_end_matches("/v1").to_string());
+            }
+        }
+        effective.local_ai.chat_model_id = model;
+        let messages = vec![LocalAiChatMessage {
+            role: "user".to_string(),
+            content: prompt.to_string(),
+        }];
+        local_runtime::rpc::local_ai_chat(&effective, messages, None)
+            .await
+            .map(|outcome| {
+                RpcOutcome::single_log(
+                    InferenceTestProviderModelResult { reply: outcome.value },
+                    "provider model test completed",
+                )
+            })
+    } else {
+        let (chat_provider, model) =
+            crate::openhuman::inference::provider::factory::create_chat_provider_from_string(
+                workload, provider, config,
+            )
+            .map_err(|e| e.to_string())?;
+        chat_provider
+            .simple_chat(prompt, &model, config.default_temperature)
+            .await
+            .map_err(|e| e.to_string())
+            .map(|reply| {
+                RpcOutcome::single_log(
+                    InferenceTestProviderModelResult { reply },
+                    "provider model test completed",
+                )
+            })
+    };
+    match &result {
+        Ok(outcome) => debug!(
+            output_len = outcome.value.reply.len(),
+            "{LOG_PREFIX} test_provider_model:ok"
+        ),
+        Err(err) => error!(error = %err, "{LOG_PREFIX} test_provider_model:error"),
     }
     result
 }

--- a/src/openhuman/inference/ops.rs
+++ b/src/openhuman/inference/ops.rs
@@ -140,66 +140,74 @@ pub async fn inference_test_provider_model(
         prompt_len = prompt.len(),
         "{LOG_PREFIX} test_provider_model:start"
     );
-    let result = if provider.trim().starts_with("lmstudio:") || provider.trim().starts_with("ollama:") {
-        let mut effective = config.clone();
-        let (local_kind, raw_model) = provider
-            .split_once(':')
-            .ok_or_else(|| "invalid local provider string".to_string())?;
-        let (model, temperature_override) = match raw_model.rsplit_once('@') {
-            Some((head, tail)) => match tail.trim().parse::<f64>() {
-                Ok(temp) if !head.trim().is_empty() => (head.trim().to_string(), Some(temp)),
-                _ => (raw_model.trim().to_string(), None),
-            },
-            None => (raw_model.trim().to_string(), None),
-        };
-        if model.is_empty() {
-            return Err("model must not be empty".to_string());
-        }
-        if let Some(temp) = temperature_override {
-            effective.default_temperature = temp;
-        }
-        if local_kind == "lmstudio" {
-            effective.local_ai.provider = "lm_studio".to_string();
-            if let Some(entry) = config.cloud_providers.iter().find(|e| e.slug == "lmstudio") {
-                effective.local_ai.base_url = Some(entry.endpoint.clone());
+    let result =
+        if provider.trim().starts_with("lmstudio:") || provider.trim().starts_with("ollama:") {
+            let mut effective = config.clone();
+            let (local_kind, raw_model) = provider
+                .split_once(':')
+                .ok_or_else(|| "invalid local provider string".to_string())?;
+            let (model, temperature_override) = match raw_model.rsplit_once('@') {
+                Some((head, tail)) => match tail.trim().parse::<f64>() {
+                    Ok(temp) if !head.trim().is_empty() => (head.trim().to_string(), Some(temp)),
+                    _ => (raw_model.trim().to_string(), None),
+                },
+                None => (raw_model.trim().to_string(), None),
+            };
+            if model.is_empty() {
+                return Err("model must not be empty".to_string());
             }
+            if let Some(temp) = temperature_override {
+                effective.default_temperature = temp;
+            }
+            if local_kind == "lmstudio" {
+                effective.local_ai.provider = "lm_studio".to_string();
+                if let Some(entry) = config.cloud_providers.iter().find(|e| e.slug == "lmstudio") {
+                    effective.local_ai.base_url = Some(entry.endpoint.clone());
+                }
+            } else {
+                effective.local_ai.provider = "ollama".to_string();
+                if let Some(entry) = config.cloud_providers.iter().find(|e| e.slug == "ollama") {
+                    effective.local_ai.base_url = Some(
+                        entry
+                            .endpoint
+                            .trim_end_matches("/")
+                            .trim_end_matches("/v1")
+                            .to_string(),
+                    );
+                }
+            }
+            effective.local_ai.chat_model_id = model;
+            let messages = vec![LocalAiChatMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+            }];
+            local_runtime::rpc::local_ai_chat(&effective, messages, None)
+                .await
+                .map(|outcome| {
+                    RpcOutcome::single_log(
+                        InferenceTestProviderModelResult {
+                            reply: outcome.value,
+                        },
+                        "provider model test completed",
+                    )
+                })
         } else {
-            effective.local_ai.provider = "ollama".to_string();
-            if let Some(entry) = config.cloud_providers.iter().find(|e| e.slug == "ollama") {
-                effective.local_ai.base_url =
-                    Some(entry.endpoint.trim_end_matches("/").trim_end_matches("/v1").to_string());
-            }
-        }
-        effective.local_ai.chat_model_id = model;
-        let messages = vec![LocalAiChatMessage {
-            role: "user".to_string(),
-            content: prompt.to_string(),
-        }];
-        local_runtime::rpc::local_ai_chat(&effective, messages, None)
-            .await
-            .map(|outcome| {
-                RpcOutcome::single_log(
-                    InferenceTestProviderModelResult { reply: outcome.value },
-                    "provider model test completed",
+            let (chat_provider, model) =
+                crate::openhuman::inference::provider::factory::create_chat_provider_from_string(
+                    workload, provider, config,
                 )
-            })
-    } else {
-        let (chat_provider, model) =
-            crate::openhuman::inference::provider::factory::create_chat_provider_from_string(
-                workload, provider, config,
-            )
-            .map_err(|e| e.to_string())?;
-        chat_provider
-            .simple_chat(prompt, &model, config.default_temperature)
-            .await
-            .map_err(|e| e.to_string())
-            .map(|reply| {
-                RpcOutcome::single_log(
-                    InferenceTestProviderModelResult { reply },
-                    "provider model test completed",
-                )
-            })
-    };
+                .map_err(|e| e.to_string())?;
+            chat_provider
+                .simple_chat(prompt, &model, config.default_temperature)
+                .await
+                .map_err(|e| e.to_string())
+                .map(|reply| {
+                    RpcOutcome::single_log(
+                        InferenceTestProviderModelResult { reply },
+                        "provider model test completed",
+                    )
+                })
+        };
     match &result {
         Ok(outcome) => debug!(
             output_len = outcome.value.reply.len(),

--- a/src/openhuman/inference/ops_tests.rs
+++ b/src/openhuman/inference/ops_tests.rs
@@ -64,6 +64,15 @@ async fn inference_chat_rejects_empty_messages() {
 }
 
 #[tokio::test]
+async fn inference_test_provider_model_uses_local_runtime_branch_for_lmstudio_prefix() {
+    let (config, _tmp) = disabled_config();
+    let err = inference_test_provider_model(&config, "reasoning", "lmstudio:test-model", "Hello")
+        .await
+        .expect_err("lmstudio local test should fail when local ai is disabled");
+    assert!(err.contains("local ai is disabled"));
+}
+
+#[tokio::test]
 async fn inference_should_react_short_circuits_for_empty_message() {
     let (config, _tmp) = disabled_config();
     let outcome = inference_should_react(&config, "   ", "web")

--- a/src/openhuman/inference/schemas.rs
+++ b/src/openhuman/inference/schemas.rs
@@ -45,6 +45,13 @@ struct InferenceChatParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct InferenceTestProviderModelParams {
+    workload: String,
+    provider: String,
+    prompt: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct InferenceShouldReactParams {
     message: String,
     channel_type: String,
@@ -147,6 +154,7 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("vision_prompt"),
         schemas("embed"),
         schemas("chat"),
+        schemas("test_provider_model"),
         schemas("should_react"),
         schemas("analyze_sentiment"),
     ]
@@ -225,6 +233,10 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("chat"),
             handler: handle_inference_chat,
+        },
+        RegisteredController {
+            schema: schemas("test_provider_model"),
+            handler: handle_inference_test_provider_model,
         },
         RegisteredController {
             schema: schemas("should_react"),
@@ -431,6 +443,17 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     required: true,
                 },
                 optional_u64("max_tokens", "Optional max output tokens."),
+            ],
+            outputs: vec![json_output("reply", "Assistant reply text.")],
+        },
+        "test_provider_model" => ControllerSchema {
+            namespace: "inference",
+            function: "test_provider_model",
+            description: "Run a one-off Hello-world style test against an explicit provider:model binding without saving routing changes.",
+            inputs: vec![
+                required_string("workload", "Workload id context (chat, reasoning, coding, etc.)."),
+                required_string("provider", "Explicit provider string like 'openai:gpt-4o' or 'ollama:llama3.1:8b'."),
+                optional_string("prompt", "Optional prompt text to send; defaults to 'Hello world'."),
             ],
             outputs: vec![json_output("reply", "Assistant reply text.")],
         },
@@ -800,6 +823,22 @@ fn handle_inference_chat(params: Map<String, Value>) -> ControllerFuture {
         to_json(
             crate::openhuman::inference::rpc::inference_chat(&config, messages, p.max_tokens)
                 .await?,
+        )
+    })
+}
+
+fn handle_inference_test_provider_model(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let p = deserialize_params::<InferenceTestProviderModelParams>(params)?;
+        let config = config_rpc::load_config_with_timeout().await?;
+        to_json(
+            crate::openhuman::inference::rpc::inference_test_provider_model(
+                &config,
+                &p.workload,
+                &p.provider,
+                p.prompt.as_deref().unwrap_or("Hello world"),
+            )
+            .await?,
         )
     })
 }


### PR DESCRIPTION
## Summary

- Added a coming-soon placeholder for the Skills page MCP Servers tab so the tab stays visible without exposing unfinished management UI.
- Simplified the custom cloud-provider editor to use name-derived slugs plus OpenAI-compatible URL/API key fields instead of asking users for a raw provider slug.
- Added model-test UX in AI routing and a dedicated `openhuman.inference_test_provider_model` RPC for one-off provider/model probes.
- Fixed LM Studio inference/test handling so reasoning-only responses surface correctly and slow model-test calls use an extended RPC timeout.

## Problem

- The Skills page still exposed an unfinished MCP Servers management surface.
- The custom provider modal asked users for an internal provider slug, which does not map cleanly to how OpenAI-compatible providers are configured.
- Model-test flows were incomplete: there was no in-modal test action, LM Studio requests could return blank because reasoning-only payloads were dropped, and the test RPC shape/timeout handling was inconsistent across layers.

## Solution

- Replaced the Skills MCP tab body with a dedicated coming-soon panel and added a page-level regression test.
- Reworked the custom provider editor to derive the internal slug from the entered provider name, validate collisions, and keep the user-facing fields to name, URL, and API key.
- Added a `Test` action in custom routing, backed by a new inference RPC that exercises an explicit provider/model binding without persisting routing changes.
- Fixed inference-layer response handling by returning a typed `{ reply }` payload from the RPC, routing LM Studio through the local-runtime path, falling back to `reasoning_content` when `content` is empty, and removing the overly aggressive `max_tokens: 128` cap from provider tests.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (N/A: behavior-only/UI/runtime fixes, no matrix rows added or renamed)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` (N/A: no feature ID additions/removals were required for this change)
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) (N/A: no release-cut smoke checklist changes required)
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section (N/A: no issue number was provided for this branch)

## Impact

- Desktop app: Skills and AI settings flows change visibly.
- Core inference: provider-model test RPC and LM Studio response handling are now aligned with the inference-layer contract.
- Compatibility: OpenAI-compatible providers and LM Studio model tests should behave more predictably, especially when the upstream returns reasoning-only text.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs:
  - Consider removing or hiding the unused MCP management implementation until the feature is reintroduced.
  - Consider broadening reasoning-content fallback coverage across any remaining OpenAI-compatible local-runtime adapters.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `codex/production-changes`
- Commit SHA: `73b3008ae`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests:
  - `pnpm debug unit src/services/api/__tests__/aiSettingsApi.test.ts`
  - `pnpm debug unit src/components/settings/panels/__tests__/AIPanel.test.tsx`
  - `pnpm debug unit src/pages/__tests__/Skills.mcp-coming-soon.test.tsx`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path ../Cargo.toml --all --check` (via pre-push)
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed):
  - `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check` (via pre-push)
  - `cargo check --manifest-path app/src-tauri/Cargo.toml` (via pre-push / `pnpm rust:check`)

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: MCP tab now shows a coming-soon state; provider test flow is now user-visible and returns typed reply payloads; custom provider editor no longer asks for a manual slug.
- User-visible effect: users can test provider/model pairs inline, LM Studio responses show up instead of blank output, and the MCP tab no longer exposes unfinished controls.

### Parity Contract
- Legacy behavior preserved: existing OpenAI-compatible provider routing remains in place; local-runtime test calls now use the same LM Studio/Ollama path the rest of the app uses.
- Guard/fallback/dispatch parity checks: preserved explicit provider-string dispatch, added typed `{ reply }` inference RPC response, and added LM Studio `reasoning_content` fallback instead of changing upstream payload assumptions.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Test" button to validate custom AI provider/model setups before saving
  * Enabled LM Studio local-runtime support in the desktop app AI settings
  * MCP Servers tab now shows a "Coming Soon" placeholder

* **Improvements**
  * Cloud provider editor validates names and generates unique slugs to prevent collisions
  * LM Studio responses now fall back to reasoning content when primary content is empty

* **Tests**
  * Expanded test coverage for provider testing, LM Studio flow, and MCP UI

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->