### PR TITLE
fix(i18n): remove duplicate German mascot GIF keys

### DIFF
--- a/app/src/lib/i18n/chunks/de-5.ts
+++ b/app/src/lib/i18n/chunks/de-5.ts
@@ -531,10 +531,6 @@ const de5: TranslationMap = {
   'settings.mascot.colorGreen': 'Grün',
   'settings.mascot.colorNavy': 'Marine',
   'settings.mascot.colorYellow': 'Gelb',
-  'settings.mascot.customGifError':
-    'GIF konnte nicht geladen werden. Bitte überprüfe die URL und versuche es erneut.',
-  'settings.mascot.customGifHeading': 'Benutzerdefinierter GIF-Avatar',
-  'settings.mascot.customGifLabel': 'URL für benutzerdefinierten GIF-Avatar',
   'settings.mascot.libraryUnavailable': 'OpenHuman Bibliothek nicht verfügbar',
   'settings.mascot.title': 'OpenHuman',
   'settings.developerMenu.composio.title': 'Composio',


### PR DESCRIPTION
## Summary

- Remove 3 duplicate keys in `app/src/lib/i18n/chunks/de-5.ts` that cause `tsc --noEmit` to fail with TS1117 (`An object literal cannot have multiple properties with the same name`).
- `customGifError`, `customGifHeading`, `customGifLabel` each appeared twice (lines 243-246 and 534-537). Kept the first occurrence, removed the duplicates.

## Test plan

- [x] `pnpm typecheck` passes (no more TS1117 errors)
- [x] `pnpm lint` passes (no more `no-dupe-keys` ESLint errors)