### PR TITLE
fix(observability,embeddings): demote Ollama embed user-config rejections (Sentry TAURI-RUST-XS + MA/KM/GX)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -160,6 +160,17 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if is_loopback_unavailable(&lower) {
         return Some(ExpectedErrorKind::LoopbackUnavailable);
     }
+    // Check `is_ollama_user_config_rejection` BEFORE the generic network /
+    // backend-error matchers: the GX "daemon unreachable at localhost" shape
+    // contains a loopback host but no `Connection refused (os error …)`
+    // marker, and the XS / MA / KM 400/404 shapes are pure user-config —
+    // wrong model name, model not pulled, daemon opted-in but not running.
+    // Route them to the dedicated arm so they share the `ProviderUserState`
+    // bucket with the composio / OAuth user-state errors instead of falling
+    // through to capture. See `is_ollama_user_config_rejection`.
+    if is_ollama_user_config_rejection(&lower) {
+        return Some(ExpectedErrorKind::ProviderUserState);
+    }
     if is_network_unreachable_message(&lower) {
         return Some(ExpectedErrorKind::NetworkUnreachable);
     }
@@ -282,6 +293,77 @@ fn is_loopback_unavailable(lower: &str) -> bool {
     lower.contains("connection refused (os error 61)")
         || lower.contains("connection refused (os error 111)")
         || lower.contains("connection refused (os error 10061)")
+}
+
+/// Detect Ollama embed call sites that surface a user-config rejection from
+/// the local Ollama daemon — pure user-state errors the UI already surfaces
+/// (toast / settings page warning) where Sentry has no remediation path.
+///
+/// Three canonical wire shapes are covered, all emitted by
+/// `openhuman::embeddings::ollama::OllamaEmbedding::embed` and the embed
+/// service fallback path:
+///
+/// - **TAURI-RUST-XS** (~376 events on self-hosted Sentry): user pointed the
+///   embedder at a chat / vision model id with a temperature suffix (e.g.
+///   `qwen3-vl:4b@0.7`) which Ollama parses as malformed. Wire shape:
+///   `ollama embed failed with status 400 Bad Request: {"error":"invalid model name"}`.
+/// - **OPENHUMAN-TAURI-MA / -KM** (deferred follow-up from PR #2216): user
+///   configured a model id that the local Ollama daemon hasn't pulled yet.
+///   Wire shape:
+///   `ollama embed failed with status 404 Not Found: {"error":"model \"<id>\" not found, try pulling it first"}`.
+/// - **OPENHUMAN-TAURI-GX**: user opted into Ollama embeddings but the
+///   daemon isn't running on `localhost:11434`, so the embed service falls
+///   back to cloud embeddings for the session. Wire shape:
+///   `ollama embeddings opted-in but daemon unreachable at http://localhost:11434; falling back to cloud embeddings for this session`.
+///
+/// All three are user-config: the user picked the wrong model id, forgot to
+/// pull it, or forgot to start the daemon. The remediation is "fix the
+/// model id in Settings" / "run `ollama pull <id>`" / "start ollama" —
+/// none of which Sentry can do for them.
+///
+/// The classifier is anchored on the `"ollama embed"` prefix
+/// (`"ollama embed failed"` for the 400/404 shapes, `"ollama embeddings opted-in"`
+/// for the daemon-unreachable fallback) so unrelated 400/404 errors elsewhere
+/// in the codebase that happen to contain `"invalid model name"` or
+/// `"not found"` substrings are not silenced.
+///
+/// Routes to [`ExpectedErrorKind::ProviderUserState`] — the same bucket that
+/// holds the composio / gmail / OAuth user-state errors. We deliberately do
+/// **not** introduce a dedicated Ollama enum variant: the demotion semantics
+/// (drop to `info` log, skip Sentry capture) are identical and adding a new
+/// variant for every provider would balloon the enum without changing
+/// behavior.
+fn is_ollama_user_config_rejection(lower: &str) -> bool {
+    // XS — 400-status user-config (invalid model name, including the
+    // temperature-suffix shape `qwen3-vl:4b@0.7` Ollama parses as malformed).
+    if lower.contains("ollama embed failed") && lower.contains("invalid model name") {
+        return true;
+    }
+
+    // MA / KM — 404-status pull-required. The wire shape is JSON-escaped
+    // (`\"<model-id>\" not found`); after lower-casing we still see the
+    // backslash-quoted form. Anchor on `model \"` + `\" not found` so an
+    // unrelated 404 that merely contains `"model"` and `"not found"` is not
+    // swallowed. The `\\"` byte pair in Rust source matches the literal
+    // `\"` sequence in the wire shape.
+    if lower.contains("ollama embed failed")
+        && lower.contains("model \\\"")
+        && lower.contains("\\\" not found")
+    {
+        return true;
+    }
+
+    // GX — daemon-unreachable opt-in state. The wire shape is emitted by
+    // the embed service when the user has opted into Ollama in settings
+    // but the daemon isn't responding, so the service falls back to cloud
+    // embeddings for the session. Anchor on the full prefix to keep the
+    // matcher from colliding with unrelated `"daemon unreachable"`
+    // messages from other domains (e.g. backend connection-health logs).
+    if lower.contains("ollama embeddings opted-in but daemon unreachable at") {
+        return true;
+    }
+
+    false
 }
 
 /// Detect transport-level connection failures that fire before any HTTP status
@@ -1276,6 +1358,71 @@ mod tests {
         );
         assert_eq!(
             expected_error_kind("ollama embed failed with status 500"),
+            None
+        );
+    }
+
+    #[test]
+    fn classifies_ollama_user_config_rejections() {
+        // TAURI-RUST-XS (~376 events): user pointed embedder at a chat /
+        // vision model id, sometimes with a temperature suffix like `@0.7`
+        // that Ollama parses as malformed.
+        for raw in [
+            // Canonical XS wire shape from
+            // `OllamaEmbedding::embed` non-2xx path on a 400 Bad Request.
+            r#"ollama embed failed with status 400 Bad Request: {"error":"invalid model name"}"#,
+            // Same shape with a temperature-suffix model id the user pasted
+            // into Settings → Embeddings → Ollama.
+            r#"ollama embed failed with status 400 Bad Request: {"error":"invalid model name: qwen3-vl:4b@0.7"}"#,
+            // OPENHUMAN-TAURI-MA — model not pulled (404 Not Found).
+            r#"ollama embed failed with status 404 Not Found: {"error":"model \"bge-m3\" not found, try pulling it first"}"#,
+            // OPENHUMAN-TAURI-KM — same shape, different model id + `:latest` tag.
+            r#"ollama embed failed with status 404 Not Found: {"error":"model \"nomic-embed-text:latest\" not found, try pulling it first"}"#,
+            // OPENHUMAN-TAURI-GX — daemon-unreachable opt-in state.
+            "ollama embeddings opted-in but daemon unreachable at http://localhost:11434; falling back to cloud embeddings for this session",
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::ProviderUserState),
+                "should classify Ollama user-config rejection: {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_ollama_errors_as_user_config() {
+        // Unrelated 500 — server-side ollama bug must still reach Sentry.
+        assert_eq!(
+            expected_error_kind("ollama embed failed with status 500"),
+            None
+        );
+        // Parse-failure on the response — real bug in either the server
+        // or our deserializer, must still reach Sentry.
+        assert_eq!(
+            expected_error_kind(
+                "ollama embed response parse failed: invalid type: expected sequence"
+            ),
+            None
+        );
+        // Dimension mismatch — real bug (model dims don't match what we
+        // recorded), must still reach Sentry.
+        assert_eq!(
+            expected_error_kind(
+                "ollama embed dimension mismatch at index 0: expected 768, got 1024"
+            ),
+            None
+        );
+        // Unrelated `invalid model name` outside Ollama embed call —
+        // anchor on the `ollama embed` prefix keeps this from being silenced.
+        assert_eq!(
+            expected_error_kind("provider config validation failed: invalid model name"),
+            None
+        );
+        // Unrelated `model "…" not found` text without the `ollama embed`
+        // prefix — anchor keeps this from being silenced even when the
+        // exact MA/KM wire-shape substring appears in another context.
+        assert_eq!(
+            expected_error_kind(r#"provider listing failed: model \"foo\" not found in registry"#),
             None
         );
     }

--- a/src/openhuman/embeddings/ollama_tests.rs
+++ b/src/openhuman/embeddings/ollama_tests.rs
@@ -327,32 +327,60 @@ async fn embed_connection_refused() {
     );
 }
 
-// OPENHUMAN-TAURI-{GP,MA,KM,GX} wire shapes — currently routed through
-// `report_error_or_expected` (Sentry classifier ladder) by this PR. The ladder
-// matches GP (LocalAiCapabilityUnavailable) today; MA/KM/GX still fall through
-// to capture because `observability::expected_error_kind` has no matcher arm
-// for "ollama model not found" / "ollama daemon unreachable". Those matcher
-// arms are blocked behind PR #2063 + #2188 merging (both touch
-// `src/core/observability.rs`) and will land in the follow-up classifier
-// batch. Tests below lock the CURRENT state so the follow-up flips them.
+// OPENHUMAN-TAURI-{GP,MA,KM,GX} + TAURI-RUST-XS wire shapes — routed through
+// `report_error_or_expected` (Sentry classifier ladder) and demoted to
+// `ProviderUserState` / `LocalAiCapabilityUnavailable` by the
+// `is_ollama_user_config_rejection` matcher in `src/core/observability.rs`.
+// GP catches the RAM-tier disable shape; XS/MA/KM/GX cover the four Ollama
+// user-config rejection shapes (400 invalid-model-name, 404 model-not-found
+// ×2, daemon-unreachable opt-in state).
 
 #[test]
-fn ma_wire_shape_current_state_unclassified() {
-    let msg = r#"ollama embed failed with status 404 Not Found: {"error":"model \"bge-m3\" not found, try pulling it first"}"#;
+fn xs_wire_shape_classifies_as_provider_user_state() {
+    // TAURI-RUST-XS (~376 events on self-hosted Sentry): user pointed
+    // embedder at a chat / vision model with a temperature suffix
+    // (`qwen3-vl:4b@0.7`) Ollama parses as malformed.
+    let msg = r#"ollama embed failed with status 400 Bad Request: {"error":"invalid model name"}"#;
     assert_eq!(
         crate::core::observability::expected_error_kind(msg),
-        None,
-        "MA — matcher arm pending follow-up classifier batch (post #2063 + #2188 merge)"
+        Some(crate::core::observability::ExpectedErrorKind::ProviderUserState),
+        "XS — invalid model name 400 is pure user-config, must demote"
     );
 }
 
 #[test]
-fn km_wire_shape_current_state_unclassified() {
+fn xs_temperature_suffix_model_classifies_as_provider_user_state() {
+    // Same XS shape with the temperature-suffix model id embedded in the
+    // body. Real wire shape from the field report.
+    let msg = r#"ollama embed failed with status 400 Bad Request: {"error":"invalid model name: qwen3-vl:4b@0.7"}"#;
+    assert_eq!(
+        crate::core::observability::expected_error_kind(msg),
+        Some(crate::core::observability::ExpectedErrorKind::ProviderUserState),
+        "XS — temperature-suffix model id must also demote"
+    );
+}
+
+#[test]
+fn ma_wire_shape_classifies_as_provider_user_state() {
+    // OPENHUMAN-TAURI-MA: user configured an Ollama model id that the
+    // local daemon hasn't pulled yet.
+    let msg = r#"ollama embed failed with status 404 Not Found: {"error":"model \"bge-m3\" not found, try pulling it first"}"#;
+    assert_eq!(
+        crate::core::observability::expected_error_kind(msg),
+        Some(crate::core::observability::ExpectedErrorKind::ProviderUserState),
+        "MA — model-not-found 404 is pure user-state (pull required), must demote"
+    );
+}
+
+#[test]
+fn km_wire_shape_classifies_as_provider_user_state() {
+    // OPENHUMAN-TAURI-KM: same wire shape as MA with a different model
+    // id + `:latest` tag.
     let msg = r#"ollama embed failed with status 404 Not Found: {"error":"model \"nomic-embed-text:latest\" not found, try pulling it first"}"#;
     assert_eq!(
         crate::core::observability::expected_error_kind(msg),
-        None,
-        "KM — matcher arm pending follow-up classifier batch"
+        Some(crate::core::observability::ExpectedErrorKind::ProviderUserState),
+        "KM — pull-required 404 must demote"
     );
 }
 
@@ -363,17 +391,30 @@ fn gp_wire_shape_classifies() {
     assert_eq!(
         crate::core::observability::expected_error_kind(msg),
         Some(crate::core::observability::ExpectedErrorKind::LocalAiCapabilityUnavailable),
-        "GP — LocalAiCapabilityUnavailable matcher must catch this; closed by this PR"
+        "GP — LocalAiCapabilityUnavailable matcher must catch this"
     );
 }
 
 #[test]
-fn gx_wire_shape_current_state_unclassified() {
+fn gx_wire_shape_classifies_as_provider_user_state() {
+    // OPENHUMAN-TAURI-GX: user opted into Ollama embeddings in Settings
+    // but the daemon isn't running on localhost:11434.
     let msg = "ollama embeddings opted-in but daemon unreachable at http://localhost:11434; falling back to cloud embeddings for this session";
     assert_eq!(
         crate::core::observability::expected_error_kind(msg),
+        Some(crate::core::observability::ExpectedErrorKind::ProviderUserState),
+        "GX — daemon-unreachable opt-in state is pure user-config (start daemon)"
+    );
+}
+
+#[test]
+fn ollama_500_wire_shape_stays_unexpected() {
+    // Server-side ollama bug — must still reach Sentry.
+    let msg = "ollama embed failed with status 500 Internal Server Error: model crashed";
+    assert_eq!(
+        crate::core::observability::expected_error_kind(msg),
         None,
-        "GX — matcher arm pending follow-up classifier batch"
+        "real ollama server errors must still reach Sentry"
     );
 }
 
@@ -384,6 +425,19 @@ fn ollama_parse_error_wire_shape_stays_unexpected() {
         crate::core::observability::expected_error_kind(msg),
         None,
         "real parse bugs must still reach Sentry"
+    );
+}
+
+#[test]
+fn ollama_dimension_mismatch_stays_unexpected() {
+    // Dimension mismatch — real bug (model dims don't match what we
+    // recorded for the provider in Settings), must still reach Sentry
+    // so we can investigate the desync.
+    let msg = "ollama embed dimension mismatch at index 0: expected 768, got 1024";
+    assert_eq!(
+        crate::core::observability::expected_error_kind(msg),
+        None,
+        "dimension-mismatch shape must still reach Sentry"
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds `is_ollama_user_config_rejection` matcher to the Sentry classifier ladder in `src/core/observability.rs`, routing four Ollama-embed user-config wire shapes (XS, MA, KM, GX) to the existing `ExpectedErrorKind::ProviderUserState` bucket.
- Closes self-hosted Sentry **TAURI-RUST-XS** (~376 events): user pointed the embedder at a chat / vision model id with a temperature suffix Ollama parses as malformed (`qwen3-vl:4b@0.7`).
- Retires the deferred MA / KM / GX follow-up gap from PR #2216 (Lane K). That PR routed the embed call site through `report_error_or_expected` but explicitly left the matcher arm open pending PR #2063 + #2188 merging; both gating PRs landed 2026-05-19/20 and this PR closes the gap.
- Flips the three pinning tests in `src/openhuman/embeddings/ollama_tests.rs` that locked the prior unclassified state, and adds two new positive XS cases plus dimension-mismatch / 500-server-error negatives.

## Problem

Self-hosted Sentry is collecting `~376` events for `TAURI-RUST-XS` with the canonical body:

```
ollama embed failed with status 400 Bad Request: {"error":"invalid model name"}
```

These come from users who configured the embedding provider with a chat / vision model id (sometimes with a temperature suffix like `qwen3-vl:4b@0.7`) that Ollama parses as malformed. The UI already surfaces an actionable error in the Settings → Embeddings page; Sentry has no remediation path because the request was malformed by the user's input, not by our code.

Three sibling wire shapes — `OPENHUMAN-TAURI-MA`, `OPENHUMAN-TAURI-KM`, `OPENHUMAN-TAURI-GX` — share the same "user-config rejection" semantics but escape capture today because the classifier ladder has no arm for them. PR #2216 (Lane K, merged 2026-05-20) routed the call sites through `report_error_or_expected` but explicitly deferred adding the matcher arm to a follow-up gated on PR #2063 + #2188 merging. Both gating PRs merged 2026-05-19/20 and the follow-up was never opened — this PR closes that gap.

The three existing pinning tests at `src/openhuman/embeddings/ollama_tests.rs:339-378` (named `*_current_state_unclassified`) lock the current escape-to-Sentry state with comments pointing at this exact follow-up.

## Solution

Add a single matcher `is_ollama_user_config_rejection(lower: &str) -> bool` to `src/core/observability.rs` that anchors on the `ollama embed failed` / `ollama embeddings opted-in` prefixes plus one of three body anchors:

1. `"invalid model name"` (XS — 400 Bad Request)
2. `"model \"…\" not found"` (MA / KM — 404 Not Found, pull-required)
3. `"opted-in but daemon unreachable at"` (GX — daemon not running)

Wire the matcher into `expected_error_kind` **after** `is_loopback_unavailable` and **before** `is_network_unreachable_message`. The GX wire shape contains `localhost:` (a loopback host) but no `Connection refused (os error N)` marker, so it would otherwise fall through the loopback arm. Inserting before the network-unreachable arm gives the Ollama prefix anchors first dibs.

Route the matches to the existing `ExpectedErrorKind::ProviderUserState` variant (the same bucket holding the composio / gmail / OAuth user-state errors) rather than introducing a new variant. The demotion semantics (drop to `info` log, skip Sentry capture) are identical and adding a per-provider variant would balloon the enum without changing behavior.

No call-site changes — PR #2216 already routed `src/openhuman/embeddings/ollama.rs:247-279` through `report_error_or_expected`. Verified the route is still in place on this branch.

Tests:

- `src/core/observability.rs::tests::classifies_ollama_user_config_rejections` — five positive wire shapes (XS canonical, XS with temperature-suffix model, MA, KM, GX).
- `src/core/observability.rs::tests::does_not_classify_unrelated_ollama_errors_as_user_config` — four negatives (500 server error, parse failure, dimension mismatch, unrelated `model "…" not found` without the `ollama embed` prefix).
- `src/openhuman/embeddings/ollama_tests.rs` — three flipped pinning tests (`{ma,km,gx}_wire_shape_classifies_as_provider_user_state`), two new XS positives, two new negatives (`ollama_500_wire_shape_stays_unexpected`, `ollama_dimension_mismatch_stays_unexpected`). The GP test (`LocalAiCapabilityUnavailable`) and parse-error escape test are retained verbatim.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: **Diff coverage ≥ 80%** — behavior-only classifier hygiene; every changed line in `is_ollama_user_config_rejection` and the wiring is exercised by the new positive + negative unit tests in both `observability::tests` and `embeddings::ollama::tests`.
- [x] N/A: Coverage matrix updated — behavior-only change to an existing Sentry-noise-suppression code path; no new user-facing feature row to add.
- [x] N/A: All affected feature IDs from the matrix are listed — no matrix rows touched.
- [x] No new external network dependencies introduced (no network calls in this PR; all tests are pure-function classifier checks)
- [x] N/A: Manual smoke checklist updated — no release-cut surface touched; this is a pure observability-classifier change with no user-visible behavior.
- [x] N/A: Linked issue closed via `Closes #NNN` — Sentry-only triage; the `Sentry-Issue:` headers in `## Related` provide the trail.

## Impact

- **Runtime**: Desktop (macOS / Windows / Linux). No iOS / mobile / web / CLI surface touched.
- **User-visible behavior**: Zero. The UI already surfaces these errors via toast and the Settings → Embeddings warning; this PR only changes what Sentry sees (drops `info` breadcrumb instead of an error event).
- **Performance**: Negligible. Three additional `lower.contains(...)` substring checks per classification, all short-circuited on the `ollama embed` / `ollama embeddings opted-in` prefix.
- **Security**: No new attack surface. The matcher operates on already-redacted error messages from `report_error_or_expected`.
- **Migration / compatibility**: None. Adds matcher arms only; no enum variants, no public API changes.
- **Sentry impact**: Closes TAURI-RUST-XS (~376 events) plus retires the deferred MA/KM/GX gap. Once this PR ships, the next release should see those wire shapes stop reaching Sentry. Post-merge cleanup will flip TAURI-RUST-XS to `resolved` and bookmark MA/KM/GX for the 7-day regression-watch window.

## Related

- Sentry-Issue: TAURI-RUST-XS
- Sentry-Issue: OPENHUMAN-TAURI-MA
- Sentry-Issue: OPENHUMAN-TAURI-KM
- Sentry-Issue: OPENHUMAN-TAURI-GX
- Follows up on PR #2216 (Lane K) which routed the call site through `report_error_or_expected` but explicitly deferred the matcher arm pending PR #2063 + #2188 merging (both merged 2026-05-19/20).
- Precedent: PR #2481 demoted `[composio-direct]` 401 / Invalid API key with the same `ProviderUserState` bucket strategy.

### CI note — pre-existing main FE failure

Three frontend jobs (`Frontend Coverage`, `Frontend Unit Tests`, `i18n Coverage`) are red on `upstream/main` since 2026-05-21 due to PR #2378 (German locale missing 20 MCP-Server keys). This PR touches **zero frontend files** (Rust-only: `src/core/observability.rs` + `src/openhuman/embeddings/ollama_tests.rs`) and inherits the failure. PR #2481 merged through the same state — please apply the same precedent here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A — Sentry-only triage, no Linear ticket

### Commit & Branch
- Branch: `fix/sentry-xs-ollama-classifier-arm`
- Commit SHA: `b4bd3da26a342fb4a4051083442db93424668987`

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files touched
- [x] N/A: `pnpm typecheck` — no frontend files touched
- [x] Focused tests: `cargo test --lib core::observability` (88 passed) + `cargo test --lib openhuman::embeddings::ollama` (36 passed)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --manifest-path Cargo.toml` clean (pre-existing warnings only); `cargo clippy --lib` no new warnings on changed code
- [x] N/A: Tauri fmt/check (if changed): no Tauri files touched

### Validation Blocked
- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes
- Intended behavior change: Stop reporting four wire shapes of Ollama embed user-config rejections (XS / MA / KM / GX) to Sentry; demote to `info` breadcrumb instead.
- User-visible effect: None. The Settings → Embeddings page and toast notifications already surface the actionable error to the user; this PR only changes what reaches the observability backend.

### Parity Contract
- Legacy behavior preserved: All other ollama embed failures (500 server errors, parse failures, dimension mismatches, transport-layer connect failures) continue to reach Sentry. Anchored matcher on the `ollama embed` prefix prevents collisions with unrelated 400/404 error envelopes elsewhere in the codebase.
- Guard/fallback/dispatch parity checks: Unit tests cover the substring-anchor isolation (`does_not_classify_unrelated_ollama_errors_as_user_config`). The matcher routes to the existing `ProviderUserState` variant — `report_expected_message` already has the correct demotion path for that variant.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None
- Canonical PR: This is the canonical follow-up for the deferred matcher arm noted in PR #2216
- Resolution: New work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error detection and classification for Ollama embedding services, including invalid model names, unavailable models, and unreachable daemon states.

* **Tests**
  * Extended test coverage for Ollama error classification to ensure accurate differentiation between user configuration issues and system errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->