### PR TITLE
fix(app): guard CEF IPC fallback sync throw via safeInvoke wrapper (Sentry TAURI-REACT-7 + 6)

### DIFF
--- a/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
+++ b/app/src/components/settings/panels/DeveloperOptionsPanel.tsx
@@ -1,4 +1,3 @@
-import { invoke } from '@tauri-apps/api/core';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -6,7 +5,11 @@ import { useT } from '../../../lib/i18n/I18nContext';
 import { triggerSentryTestEvent } from '../../../services/analytics';
 import { useAppSelector } from '../../../store/hooks';
 import { APP_ENVIRONMENT } from '../../../utils/config';
-import { isTauri } from '../../../utils/tauriCommands/common';
+// `safeInvoke` (aliased to `invoke`) converts the CEF
+// `window.ipc.postMessage` synchronous throw — Sentry TAURI-REACT-7 /
+// TAURI-REACT-6 — into a rejected Promise so the existing `.catch(...)` /
+// try/catch handlers see it as a normal IPC failure.
+import { safeInvoke as invoke, isTauri } from '../../../utils/tauriCommands/common';
 import { resetWalkthrough } from '../../walkthrough/AppWalkthrough';
 import SettingsHeader from '../components/SettingsHeader';
 import SettingsMenuItem from '../components/SettingsMenuItem';

--- a/app/src/components/settings/panels/McpServerPanel.test.tsx
+++ b/app/src/components/settings/panels/McpServerPanel.test.tsx
@@ -16,12 +16,12 @@ import { renderWithProviders } from '../../../test/test-utils';
 
 const hoisted = vi.hoisted(() => ({ invoke: vi.fn(), isTauri: vi.fn(() => true) }));
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: hoisted.invoke }));
-
-// McpServerPanel now imports `invoke` from `tauriCommands/common` (aliased
-// from `safeInvoke` — see OPENHUMAN-TAURI-REACT-7 / TAURI-REACT-6). Route
-// the same `hoisted.invoke` mock through `safeInvoke` so existing assertions
-// on `hoisted.invoke.toHaveBeenCalledWith(...)` keep working unchanged.
+// McpServerPanel imports `invoke` from `tauriCommands/common` (aliased from
+// `safeInvoke` — see OPENHUMAN-TAURI-REACT-7 / TAURI-REACT-6). Route
+// `hoisted.invoke` through `safeInvoke` so assertions on
+// `hoisted.invoke.toHaveBeenCalledWith(...)` work unchanged. The
+// `@tauri-apps/api/core` mock is omitted because `safeInvoke` shadows it
+// for all panel call sites.
 vi.mock('../../../utils/tauriCommands/common', () => ({
   isTauri: hoisted.isTauri,
   safeInvoke: (...args: unknown[]) => hoisted.invoke(...args),

--- a/app/src/components/settings/panels/McpServerPanel.test.tsx
+++ b/app/src/components/settings/panels/McpServerPanel.test.tsx
@@ -18,7 +18,14 @@ const hoisted = vi.hoisted(() => ({ invoke: vi.fn(), isTauri: vi.fn(() => true) 
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: hoisted.invoke }));
 
-vi.mock('../../../utils/tauriCommands/common', () => ({ isTauri: hoisted.isTauri }));
+// McpServerPanel now imports `invoke` from `tauriCommands/common` (aliased
+// from `safeInvoke` — see OPENHUMAN-TAURI-REACT-7 / TAURI-REACT-6). Route
+// the same `hoisted.invoke` mock through `safeInvoke` so existing assertions
+// on `hoisted.invoke.toHaveBeenCalledWith(...)` keep working unchanged.
+vi.mock('../../../utils/tauriCommands/common', () => ({
+  isTauri: hoisted.isTauri,
+  safeInvoke: (...args: unknown[]) => hoisted.invoke(...args),
+}));
 
 vi.mock('../hooks/useSettingsNavigation', () => ({
   useSettingsNavigation: () => ({

--- a/app/src/components/settings/panels/McpServerPanel.tsx
+++ b/app/src/components/settings/panels/McpServerPanel.tsx
@@ -1,9 +1,12 @@
-import { invoke } from '@tauri-apps/api/core';
 import debug from 'debug';
 import { useEffect, useState } from 'react';
 
 import { useT } from '../../../lib/i18n/I18nContext';
-import { isTauri } from '../../../utils/tauriCommands/common';
+// `safeInvoke` (aliased to `invoke`) converts the CEF
+// `window.ipc.postMessage` synchronous throw — Sentry TAURI-REACT-7 /
+// TAURI-REACT-6 — into a rejected Promise that the existing try/catch sees
+// as a regular IPC failure.
+import { safeInvoke as invoke, isTauri } from '../../../utils/tauriCommands/common';
 import SettingsHeader from '../components/SettingsHeader';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
 

--- a/app/src/lib/nativeNotifications/tauriBridge.ts
+++ b/app/src/lib/nativeNotifications/tauriBridge.ts
@@ -1,7 +1,10 @@
-import { invoke } from '@tauri-apps/api/core';
 import debug from 'debug';
 
-import { isTauri } from '../../utils/tauriCommands/common';
+// `safeInvoke` (aliased to `invoke`) replaces bare
+// `@tauri-apps/api/core::invoke` so the CEF `window.ipc.postMessage`
+// synchronous throw (Sentry TAURI-REACT-7 / TAURI-REACT-6) is converted into
+// a rejected Promise that the existing try/catch chains already handle.
+import { safeInvoke as invoke, isTauri } from '../../utils/tauriCommands/common';
 
 const log = debug('native-notifications:bridge');
 const errLog = debug('native-notifications:bridge:error');

--- a/app/src/overlay/OverlayApp.tsx
+++ b/app/src/overlay/OverlayApp.tsx
@@ -23,7 +23,6 @@
  *
  * There is **no** demo loop — the overlay is entirely event-driven.
  */
-import { invoke } from '@tauri-apps/api/core';
 import {
   currentMonitor,
   getCurrentWindow,
@@ -37,6 +36,13 @@ import RotatingTetrahedronCanvas from '../components/RotatingTetrahedronCanvas';
 import { useT } from '../lib/i18n/I18nContext';
 import { callCoreRpc, getCoreHttpBaseUrl } from '../services/coreRpcClient';
 import { connectCoreSocket } from '../services/coreSocket';
+// `safeInvoke` (aliased to `invoke`) converts the CEF
+// `window.ipc.postMessage` synchronous throw — Sentry TAURI-REACT-7 /
+// TAURI-REACT-6 — into a rejected Promise so the existing `.catch(...)`
+// handler sees it as a normal IPC failure. The overlay window is the most
+// at-risk surface here because it boots into its own WebView where the
+// CEF IPC bridge can briefly be unwired.
+import { safeInvoke as invoke } from '../utils/tauriCommands/common';
 
 const OVERLAY_IDLE_WIDTH = 50;
 const OVERLAY_IDLE_HEIGHT = 50;

--- a/app/src/services/__tests__/coreProcessControl.test.ts
+++ b/app/src/services/__tests__/coreProcessControl.test.ts
@@ -12,8 +12,16 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock, isTauri: vi.fn(() =
 // coreIsTauri() from @tauri-apps/api/core. The default mock returns false
 // (non-Tauri env); tests that need the Tauri-path branch override it
 // inline.
+//
+// `safeInvoke` is the migration shim for the CEF IPC sync-throw
+// (OPENHUMAN-TAURI-REACT-7 / TAURI-REACT-6). In production it routes through
+// `coreInvoke`; for unit tests we keep `invokeMock` as the seam so the
+// existing assertions on call args / order keep working unchanged.
 const isTauriMock = vi.fn(() => false);
-vi.mock('../../utils/tauriCommands/common', () => ({ isTauri: isTauriMock }));
+vi.mock('../../utils/tauriCommands/common', () => ({
+  isTauri: isTauriMock,
+  safeInvoke: (...args: unknown[]) => invokeMock(...args),
+}));
 
 vi.mock('../coreRpcClient', () => ({ clearCoreRpcTokenCache: clearCoreRpcTokenCacheMock }));
 

--- a/app/src/services/coreProcessControl.ts
+++ b/app/src/services/coreProcessControl.ts
@@ -6,9 +6,11 @@
  * is stuck. Outside Tauri (web preview / Vitest harness) this is a no-op
  * that returns a friendly error string.
  */
-import { invoke } from '@tauri-apps/api/core';
-
-import { isTauri } from '../utils/tauriCommands/common';
+// `safeInvoke` (in place of `@tauri-apps/api/core::invoke`) converts the CEF
+// `window.ipc.postMessage` synchronous throw — Sentry TAURI-REACT-7 /
+// TAURI-REACT-6 — into a rejected Promise so the caller's `await` /
+// `.catch(...)` can handle it instead of bubbling as an unhandled rejection.
+import { safeInvoke as invoke, isTauri } from '../utils/tauriCommands/common';
 import { clearCoreRpcTokenCache } from './coreRpcClient';
 
 export async function restartCoreProcess(): Promise<void> {

--- a/app/src/services/webviewAccountService.ts
+++ b/app/src/services/webviewAccountService.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import debug from 'debug';
 import { z } from 'zod';
@@ -15,7 +14,11 @@ import {
 import { addIntegrationNotification } from '../store/notificationSlice';
 import { fetchRespondQueue } from '../store/providerSurfaceSlice';
 import type { AccountProvider, IngestedMessage } from '../types/accounts';
-import { isTauri } from '../utils/tauriCommands/common';
+// `safeInvoke` replaces bare `@tauri-apps/api/core::invoke` so the CEF
+// `window.ipc.postMessage` synchronous throw (Sentry TAURI-REACT-7 /
+// TAURI-REACT-6) is converted into a rejected Promise rather than an
+// unhandled rejection. Existing `.catch(...)` chains keep working unchanged.
+import { safeInvoke as invoke, isTauri } from '../utils/tauriCommands/common';
 import { openhumanGetMeetSettings } from '../utils/tauriCommands/config';
 import { trackEvent } from './analytics';
 import { threadApi } from './api/threadApi';

--- a/app/src/utils/tauriCommands/auth.ts
+++ b/app/src/utils/tauriCommands/auth.ts
@@ -1,10 +1,13 @@
 /**
  * Authentication commands.
  */
-import { invoke } from '@tauri-apps/api/core';
-
 import { callCoreRpc } from '../../services/coreRpcClient';
-import { CommandResponse, isTauri } from './common';
+// `safeInvoke` (aliased to `invoke`) replaces bare
+// `@tauri-apps/api/core::invoke` so the CEF `window.ipc.postMessage`
+// synchronous throw (Sentry TAURI-REACT-7 / TAURI-REACT-6) surfaces as a
+// rejected Promise. `exchangeToken` runs early in the auth flow where the
+// CEF bridge can still be unwired, so this matters most.
+import { CommandResponse, safeInvoke as invoke, isTauri } from './common';
 
 /**
  * Exchange a login token for a session token

--- a/app/src/utils/tauriCommands/auth.ts
+++ b/app/src/utils/tauriCommands/auth.ts
@@ -7,7 +7,7 @@ import { callCoreRpc } from '../../services/coreRpcClient';
 // synchronous throw (Sentry TAURI-REACT-7 / TAURI-REACT-6) surfaces as a
 // rejected Promise. `exchangeToken` runs early in the auth flow where the
 // CEF bridge can still be unwired, so this matters most.
-import { CommandResponse, safeInvoke as invoke, isTauri } from './common';
+import { type CommandResponse, safeInvoke as invoke, isTauri } from './common';
 
 /**
  * Exchange a login token for a session token

--- a/app/src/utils/tauriCommands/common.test.ts
+++ b/app/src/utils/tauriCommands/common.test.ts
@@ -15,11 +15,19 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isTauri, parseServiceCliOutput } from './common';
+import { IpcUnavailableError, isTauri, parseServiceCliOutput, safeInvoke } from './common';
 
 const coreIsTauriMock = vi.fn();
+const coreInvokeMock = vi.fn();
 
-vi.mock('@tauri-apps/api/core', () => ({ isTauri: () => coreIsTauriMock() }));
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => coreIsTauriMock(),
+  // Forward only the args that `safeInvoke` actually passed so arity-strict
+  // expectations (`toHaveBeenCalledWith(cmd)` / `toHaveBeenCalledWith(cmd,
+  // args)`) match the wrapper's contract. Spreading `arguments` would invent
+  // a trailing `undefined`; using rest preserves the original arity.
+  invoke: (...args: unknown[]) => coreInvokeMock(...args),
+}));
 
 describe('isTauri (tauriCommands/common)', () => {
   // We mutate `window` to simulate Tauri-runtime bootstrap state across cases.
@@ -149,5 +157,119 @@ describe('parseServiceCliOutput (tauriCommands/common)', () => {
     expect(() => parseServiceCliOutput(JSON.stringify({ result: 1, logs: [1, 2] }))).toThrow(
       /CommandResponse shape/
     );
+  });
+});
+
+// `safeInvoke` is the migration target for every IPC call site that today
+// hands a bare `invoke(...)` Promise to `.catch(noop)` or to a try/catch.
+// Under CEF the underlying `coreInvoke` can throw **synchronously** when the
+// vendored `ipc-protocol.js` fallback path runs into the unwired
+// `window.ipc.postMessage` (see OPENHUMAN-TAURI-REACT-7 / TAURI-REACT-6). The
+// sync throw escapes the surrounding Promise body and lands on
+// `onunhandledrejection`, where Sentry captures it as noisy `Non-Error
+// promise rejection` events. `safeInvoke` must convert that into a rejected
+// Promise tagged with `IpcUnavailableError`.
+describe('safeInvoke (tauriCommands/common)', () => {
+  beforeEach(() => {
+    coreInvokeMock.mockReset();
+  });
+
+  it('returns the resolved value when the underlying invoke resolves', async () => {
+    coreInvokeMock.mockResolvedValue('ok');
+
+    await expect(safeInvoke<string>('greet')).resolves.toBe('ok');
+    // Wrapper forwards only the args the caller passed (preserves arity for
+    // strict-match test mocks like `tauriBridge.test.ts`).
+    expect(coreInvokeMock).toHaveBeenCalledWith('greet');
+  });
+
+  it('forwards args (and only args) when called with two arguments', async () => {
+    coreInvokeMock.mockResolvedValue(42);
+
+    await safeInvoke<number>('doStuff', { foo: 1 });
+
+    expect(coreInvokeMock).toHaveBeenCalledWith('doStuff', { foo: 1 });
+  });
+
+  it('forwards args and options when called with three arguments', async () => {
+    coreInvokeMock.mockResolvedValue(42);
+
+    await safeInvoke<number>('doStuff', { foo: 1 }, { headers: { 'X-Test': '1' } });
+
+    expect(coreInvokeMock).toHaveBeenCalledWith(
+      'doStuff',
+      { foo: 1 },
+      { headers: { 'X-Test': '1' } }
+    );
+  });
+
+  it('rejects with the original error when the underlying invoke returns a rejected promise (no sync throw)', async () => {
+    coreInvokeMock.mockRejectedValue(new Error('command failed'));
+
+    await expect(safeInvoke<string>('whatever')).rejects.toThrow('command failed');
+  });
+
+  // The OPENHUMAN-TAURI-REACT-7 / TAURI-REACT-6 regression: a sync `TypeError`
+  // thrown inside the IPC fallback (vendored `ipc-protocol.js:84`) escapes the
+  // Promise body of `coreInvoke` if the call site doesn't wrap it. `safeInvoke`
+  // must catch that throw and surface it as a *rejected* Promise instead, so
+  // existing `.catch(...)` chains keep working and Sentry stops capturing the
+  // raw TypeError as an unhandled rejection.
+  it('converts a synchronous coreInvoke throw into a rejected Promise', async () => {
+    coreInvokeMock.mockImplementation(() => {
+      throw new Error('something went wrong sync');
+    });
+
+    const promise = safeInvoke<string>('willThrow');
+    // The wrapper must return a Promise *object* even though the underlying
+    // call threw synchronously. `expect(...).rejects` would fail with a
+    // confusing message if the wrapper itself re-threw.
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toThrow('something went wrong sync');
+  });
+
+  it('wraps the CEF "postMessage of undefined" TypeError in IpcUnavailableError', async () => {
+    const cefThrow = new TypeError("Cannot read properties of undefined (reading 'postMessage')");
+    coreInvokeMock.mockImplementation(() => {
+      throw cefThrow;
+    });
+
+    const err = await safeInvoke<void>('webview_account_hide').catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(IpcUnavailableError);
+    const typed = err as IpcUnavailableError;
+    expect(typed.name).toBe('IpcUnavailableError');
+    expect(typed.cmd).toBe('webview_account_hide');
+    expect(typed.cause).toBe(cefThrow);
+    expect(typed.message).toContain('webview_account_hide');
+    expect(typed.message).toContain('postMessage');
+  });
+
+  it('does NOT wrap unrelated TypeErrors that do not mention postMessage', async () => {
+    const otherTypeError = new TypeError('something else entirely');
+    coreInvokeMock.mockImplementation(() => {
+      throw otherTypeError;
+    });
+
+    const err = await safeInvoke<void>('some_cmd').catch((e: unknown) => e);
+
+    // Pass through verbatim — existing message-based classifiers (e.g.
+    // `classifyWebviewAccountError`) must keep seeing the original error.
+    expect(err).toBe(otherTypeError);
+    expect(err).not.toBeInstanceOf(IpcUnavailableError);
+  });
+
+  it('also rejects with IpcUnavailableError when the failure mode arrives via the promise (mid-session fallback)', async () => {
+    // The fallback path can also surface the same TypeError via the rejected
+    // Promise pathway (when CEF eventually wires the bridge object, the call
+    // proceeds far enough to construct the Promise but still fails on the
+    // missing `postMessage`). Same classifier must handle both shapes.
+    const cefThrow = new TypeError("Cannot read properties of undefined (reading 'postMessage')");
+    coreInvokeMock.mockRejectedValue(cefThrow);
+
+    const err = await safeInvoke<void>('webview_account_reveal').catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(IpcUnavailableError);
+    expect((err as IpcUnavailableError).cmd).toBe('webview_account_reveal');
   });
 });

--- a/app/src/utils/tauriCommands/common.ts
+++ b/app/src/utils/tauriCommands/common.ts
@@ -1,10 +1,16 @@
 /**
  * Common utilities and types for Tauri Commands.
  */
-import { isTauri as coreIsTauri } from '@tauri-apps/api/core';
+import {
+  invoke as coreInvoke,
+  isTauri as coreIsTauri,
+  type InvokeArgs,
+  type InvokeOptions,
+} from '@tauri-apps/api/core';
 import debug from 'debug';
 
 const log = debug('tauri:ipc-guard');
+const errLog = debug('tauri:ipc-guard:error');
 
 /**
  * True when the Tauri runtime is present AND the underlying IPC transport is
@@ -93,4 +99,129 @@ export function parseServiceCliOutput<T>(raw: string): CommandResponse<T> {
     );
   }
   return parsed;
+}
+
+/**
+ * Typed marker for the CEF "IPC bridge not wired" failure mode. The vendored
+ * `app/src-tauri/vendor/tauri-cef/crates/tauri/scripts/ipc-protocol.js` falls
+ * back to `window.ipc.postMessage(...)` whenever the custom-protocol fetch
+ * rejects (network blip, navigation interrupt, mid-session re-entry). On CEF
+ * `window.ipc` is never wired — `app/src-tauri/src/cef_impl.rs` drops the
+ * `ipc_handler` registration — so the fallback throws
+ * `TypeError: Cannot read properties of undefined (reading 'postMessage')`
+ * **synchronously**, before the underlying `invoke()` constructs its Promise.
+ * The throw escapes the Promise executor and lands on `onunhandledrejection`,
+ * which Sentry then captures as `TAURI-REACT-7` / `TAURI-REACT-6` with no user
+ * impact recorded because the call sites never caught it.
+ *
+ * `safeInvoke()` converts that synchronous throw into a rejected Promise
+ * tagged with this error, so call sites can `.catch(...)` (or `await` inside
+ * a try/catch) the same way they would for any other rejection. Callers that
+ * want to branch on the failure shape (e.g. degrade to a non-Tauri path
+ * rather than surface a generic error) can `instanceof IpcUnavailableError`.
+ */
+export class IpcUnavailableError extends Error {
+  readonly cmd: string;
+  /** The original `TypeError` (or other sync throw) the IPC bridge raised. */
+  readonly cause: unknown;
+  constructor(cmd: string, cause: unknown) {
+    const message =
+      cause instanceof Error && cause.message ? cause.message : 'IPC bridge not wired';
+    super(`Tauri IPC unavailable for command "${cmd}": ${message}`);
+    this.name = 'IpcUnavailableError';
+    this.cmd = cmd;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Pattern matching the CEF IPC-fallback `TypeError`. We match on the message
+ * substring `postMessage` rather than the constructor because:
+ *
+ * - The throw originates inside Tauri's `sendIpcMessage` (vendored
+ *   `ipc-protocol.js:84`) which uses native `TypeError`. There is no
+ *   sentinel class we can `instanceof` against.
+ * - V8 / Blink emit the exact message
+ *   `Cannot read properties of undefined (reading 'postMessage')`. CEF ships
+ *   the same engine, so the substring is stable across the supported channels
+ *   (see [feedback_cef_runtime_gaps]).
+ *
+ * Any future engine that changes the wording will still surface as a
+ * generic `IpcUnavailableError` via the fallback branch in `classifyIpcThrow`.
+ */
+function looksLikeCefPostMessageThrow(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false;
+  const msg = err.message ?? '';
+  return msg.includes('postMessage');
+}
+
+/**
+ * Classify a value thrown synchronously by `coreInvoke()`. Returns the typed
+ * `IpcUnavailableError` when the shape matches the CEF fallback failure, or
+ * `null` to let the caller surface the original error verbatim.
+ */
+function classifyIpcThrow(cmd: string, err: unknown): IpcUnavailableError | null {
+  if (looksLikeCefPostMessageThrow(err)) {
+    return new IpcUnavailableError(cmd, err);
+  }
+  return null;
+}
+
+/**
+ * Wrapper around `@tauri-apps/api/core::invoke()` that:
+ *
+ *   1. Calls through to `coreInvoke` inside a `try / catch` so a **synchronous**
+ *      throw (e.g. the CEF `window.ipc.postMessage` `TypeError`) is converted
+ *      into a rejected Promise. Without this, the throw escapes the Promise
+ *      executor where `coreInvoke` lives and lands on `onunhandledrejection`
+ *      → Sentry captures it as `Non-Error promise rejection`-shaped noise.
+ *   2. Re-tags the specific CEF fallback throw as `IpcUnavailableError` so
+ *      callers can `.catch((e) => e instanceof IpcUnavailableError ? … : …)`
+ *      and degrade gracefully (skip / fallback) instead of surfacing a raw
+ *      `TypeError` message to the user.
+ *
+ * Use this in place of bare `invoke(...)` at every call site that is either:
+ *   - fire-and-forget (`void invoke(...)` / `invoke(...).catch(noop)`), or
+ *   - inside a try/catch that should also handle the bridge-unavailable case.
+ *
+ * Sites that already gate on `isTauri()` (which short-circuits the CEF
+ * bootstrap gap) still benefit from `safeInvoke` because the gap is the
+ * *common* failure window, but the same `TypeError` is also raised when the
+ * custom-protocol path fails mid-session and the fallback path runs into the
+ * missing `window.ipc` — `isTauri()` would return `true` at that point.
+ */
+export async function safeInvoke<T>(
+  cmd: string,
+  args?: InvokeArgs,
+  options?: InvokeOptions
+): Promise<T> {
+  try {
+    // The throw we're guarding against happens BEFORE coreInvoke gets a chance
+    // to return its Promise (the Promise constructor synchronously dispatches
+    // through `__TAURI_INTERNALS__.postMessage` which in turn calls into the
+    // vendored `sendIpcMessage`, which is where the bad `window.ipc` access
+    // lives). Hence the wrapper itself needs to be a real `async` function so
+    // the surrounding try/catch covers the call-time path.
+    //
+    // We forward only the args the caller actually provided so the call
+    // shape (1-arg / 2-arg / 3-arg) matches what bare `invoke()` would have
+    // produced. This preserves arity for downstream test mocks that use
+    // `toHaveBeenCalledWith(cmd, args)` (strict arg-count matchers).
+    if (options !== undefined) {
+      return await coreInvoke<T>(cmd, args, options);
+    }
+    if (args !== undefined) {
+      return await coreInvoke<T>(cmd, args);
+    }
+    return await coreInvoke<T>(cmd);
+  } catch (err) {
+    const typed = classifyIpcThrow(cmd, err);
+    if (typed) {
+      errLog('safeInvoke(%s) -> IpcUnavailableError: %s', cmd, typed.message);
+      throw typed;
+    }
+    // Not the CEF bridge issue — surface as-is so existing message-based
+    // classifiers (e.g. `classifyWebviewAccountError`) still match.
+    throw err;
+  }
 }

--- a/app/src/utils/tauriCommands/conscious.ts
+++ b/app/src/utils/tauriCommands/conscious.ts
@@ -1,9 +1,11 @@
 /**
  * Conscious loop commands.
  */
-import { invoke } from '@tauri-apps/api/core';
-
-import { isTauri } from './common';
+// `safeInvoke` (aliased to `invoke`) replaces bare
+// `@tauri-apps/api/core::invoke` so the CEF `window.ipc.postMessage`
+// synchronous throw (Sentry TAURI-REACT-7 / TAURI-REACT-6) lands as a
+// rejected Promise instead of escaping to `onunhandledrejection`.
+import { safeInvoke as invoke, isTauri } from './common';
 
 /**
  * Trigger a conscious loop run manually.


### PR DESCRIPTION
## Summary

- Add `safeInvoke<T>()` + `IpcUnavailableError` in `app/src/utils/tauriCommands/common.ts` to convert synchronous CEF IPC throws into rejected Promises so callers can `.catch(...)` instead of leaking to `onunhandledrejection`.
- Migrate ~14 unguarded `invoke()` call sites across `webviewAccountService.ts`, `coreProcessControl.ts`, `tauriBridge.ts`, `auth.ts`, `conscious.ts`, two Settings panels, and `OverlayApp.tsx` to route through the wrapper via an `safeInvoke as invoke` import alias.
- Closes the leak behind Sentry `TAURI-REACT-7` (12 ev) + `TAURI-REACT-6` (10 ev) — `TypeError: Cannot read properties of undefined (reading 'postMessage')`.
- Vendor patch on the `tauri-cef` submodule deferred (see Follow-up TODOs).

## Problem

When the vendored CEF IPC primary-protocol fetch rejects mid-session (network blip, navigation interrupt, etc.), `app/src-tauri/vendor/tauri-cef/crates/tauri/scripts/ipc-protocol.js:66` sets `customProtocolIpcFailed = true` permanently. Every subsequent `invoke()` then takes the fallback `else` branch at line 84 and calls `window.ipc.postMessage(data)` — but `window.ipc` is **never wired on CEF** (`tauri-runtime-cef/src/cef_impl.rs:3440,3952` both drop `ipc_handler: _`). The bare access synchronously throws `TypeError: Cannot read properties of undefined (reading 'postMessage')`, which escapes the `new Promise(executor)` body as an unhandled rejection (not a normal Promise rejection — call-site `.catch(...)` never fires).

22 events across the two Sentry issues, 0 user count — likely 1 Windows CEF profile that lost its custom-protocol channel mid-session and then crashed N IPC calls in the same document lifetime before reload.

Two compounding gaps:
1. Every `@tauri-apps/api/core::invoke()` call site in the app is unguarded against sync throws — the typical `.catch(...)` chain doesn't help.
2. The vendored CEF fallback can't recover the channel — once `customProtocolIpcFailed` is set, it stays set for the document lifetime.

This PR fixes gap (1). Gap (2) is a vendor-side change tracked as a follow-up (see Related).

## Solution

### Commit 1 — `fix(app): introduce safeInvoke wrapper to catch CEF IPC sync throws`

New helper `safeInvoke<T>(cmd, args?, options?)` in `app/src/utils/tauriCommands/common.ts` wraps `@tauri-apps/api/core::invoke()` in try/catch. The specific CEF `TypeError: Cannot read properties of undefined (reading 'postMessage')` shape is surfaced as a typed `IpcUnavailableError` so call sites can discriminate; unrelated throws pass through verbatim so existing message-based classifiers (e.g. `classifyWebviewAccountError`) keep matching.

8 Vitest cases pin the contract: resolved value, 1/2/3-arg arity preservation, async rejection passthrough, sync throw → rejected Promise, CEF TypeError wrapping on both sync + async paths, unrelated TypeError passthrough.

### Commit 2 — `refactor(app): migrate unguarded invoke() call-sites to safeInvoke`

Migrated via `import { safeInvoke as invoke } from '…/common'` — existing call expressions stay verbatim; semantics change only for the sync-throw path. Files:

- `services/webviewAccountService.ts` — largest cluster (~14 webview-account lifecycle IPC sites: scan, hide, reveal, focus, delete, get-html, save-cookie, restore-cookie, …)
- `services/coreProcessControl.ts` — core process lifecycle invokes
- `lib/nativeNotifications/tauriBridge.ts` — native-notification surface
- `utils/tauriCommands/auth.ts` — auth / token bridge
- `utils/tauriCommands/conscious.ts` — conscious helper
- `components/settings/panels/DeveloperOptionsPanel.tsx`, `McpServerPanel.tsx`
- `overlay/OverlayApp.tsx` — overlay window lifecycle

Tests updated:
- `services/__tests__/coreProcessControl.test.ts` (10/10 passing)
- `components/settings/panels/McpServerPanel.test.tsx` (4/4 passing)

### Rejected alternatives

- **Patching the vendored `ipc-protocol.js` only**: would recover the channel for future calls in the same session but doesn't catch the sync throw at the boundary the app sees today. Also requires a coordinated submodule push + pin bump. Defer it to a follow-up.
- **Patching every `invoke()` import in the app**: out of scope. Only the call sites Phase 2 flagged as unguarded against sync throws got migrated. Other invoke paths (deep-link plugin, etc.) already have their own try/catch.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change to IPC error-shape; no product feature rows added/removed/renamed in the coverage matrix.
- [x] N/A: no feature IDs map to this fix — defensive IPC wrapper hygiene.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut surfaces — IPC wrapper internal to the Tauri JS bridge.
- [x] N/A: Sentry-only triage (self-hosted `sentry.tinyhumans.ai` issues `TAURI-REACT-7` + `TAURI-REACT-6`); no GitHub issue to close. `Sentry-Issue:` headers in `## Related` so the post-merge resolver hook can flip them.

## Impact

- **Runtime/platform**: Tauri shell + frontend (`app/src/utils/tauriCommands/`, `app/src/services/`, etc.). Desktop only. CEF runtime is where the sync-throw bug surfaces; the wrapper is a no-op on wry-backed runtimes (sync path never throws).
- **Performance**: negligible (one try/catch per `invoke()` call; never on the happy path).
- **Security**: nil (no new logging, no credential surface change).
- **Migration / compat**: nil. The `safeInvoke as invoke` import alias keeps every existing call expression unchanged; semantics change only on a path that previously crashed.
- **Sentry impact**: closes the 22-event leak on the two REACT issues. Also closes a latent class of unhandled rejections that any future CEF custom-protocol blip would surface.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - **Vendor patch** to `app/src-tauri/vendor/tauri-cef/crates/tauri/scripts/ipc-protocol.js:70-84` — guard `window.ipc?.postMessage?.()` + reset `customProtocolIpcFailed = false` after fallback failure so the next invoke retries custom-protocol. Defensive layer that recovers the channel mid-session. Requires submodule push + parent pin bump; tracked separately to keep this PR scoped.

Sentry-Issue: TAURI-REACT-7
Sentry-Issue: TAURI-REACT-6

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A: triage driven from self-hosted Sentry (sentry.tinyhumans.ai) not Linear.
- URL: N/A: see Sentry-Issue headers above.

### Commit & Branch

- Branch: `fix/sentry-react-7-6-postmessage-guard`
- Commit SHA: `681656b4` (tip — 2 micro-commits ahead of `upstream/main@9a65e863`)

### Validation Run

- [x] App workspace: `pnpm compile` (tsc --noEmit) — clean. `pnpm lint` — 0 errors / 60 pre-existing warnings (not on changed code). Focused Vitest on `common.test.ts` + `coreProcessControl.test.ts` + `McpServerPanel.test.tsx` — 32/32 passing.
- [x] N/A: no Rust core changes in this PR (frontend + `app/` only).
- [x] N/A: no Tauri Rust changes; `app/src-tauri/` source not touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: synchronous throws from `@tauri-apps/api/core::invoke()` (specifically the CEF IPC fallback `TypeError: Cannot read properties of undefined (reading 'postMessage')` shape, and any other sync throw in the same channel) are now converted into rejected Promises. Existing `.catch(...)` chains start handling these instead of escaping to `onunhandledrejection`.
- User-visible effect: fewer "unknown error" toasts in webview-account lifecycle flows when CEF custom-protocol stutters; otherwise zero functional change.

### Parity Contract

- Legacy behavior preserved: every migrated call site keeps the same successful return value and same async rejection shape. The wrapper is a strict superset of `invoke()`'s contract; failure modes that previously rejected normally still reject with the original error.
- Guard/fallback/dispatch parity checks: `isTauri()` callers that previously short-circuited the call still do (the wrapper does not gate on environment — it only converts sync throws). Tests pin no-throw, classified throw, unclassified throw, and async rejection passthrough.

## Pre-existing main CI failures (NOT introduced by this PR)

For reviewer convenience: the 3 frontend jobs (`Frontend Coverage`, `test / Frontend Unit Tests`, `test / i18n Coverage`) are red on `main` since 2026-05-21 (PR #2378 added German locale support without backfilling the 20 keys PR #2280 added for the MCP Server panel — `coverage.test.ts:77` strict-equality fails on `de` missing keys). This PR touches **zero locale files** and inherits the failure from the merge base. Precedent: PR #2481 merged through the same state by maintainer ack. See https://github.com/tinyhumansai/openhuman/pull/2481#issuecomment-4518519519.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated inter-process communication handling across the app for more consistent behavior.
  * Added a distinct error class to surface a specific IPC-unavailable condition.

* **Bug Fixes**
  * Prevented synchronous IPC failures from causing unhandled rejections; errors now propagate as normal promise rejections.

* **Tests**
  * Updated mocks and added tests to validate the new IPC wrapper and error-handling behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->