### PR TITLE
fix(ci): harden contributor-rewards pull_request_target (#2621)

### DIFF
--- a/.github/workflows/contributor-rewards.yml
+++ b/.github/workflows/contributor-rewards.yml
@@ -1,4 +1,21 @@
 ---
+# Security note: this workflow intentionally uses `pull_request_target` so the
+# `reward user` label can fire on PRs from forks (the plain `pull_request`
+# trigger cannot see labels applied to fork PRs and runs under a read-only
+# GITHUB_TOKEN that cannot post comments / add labels).
+#
+# The job is bounded:
+#   - it never checks out fork code (no `actions/checkout` with `pull_request.head.ref`)
+#   - it never executes arbitrary scripts from the PR
+#   - the only side effects are: posting a templated comment and adding a label
+#   - permissions are minimal (contents:read, issues:write, pull-requests:read)
+#   - all PR/issue user metadata interpolated into search queries or comment
+#     bodies is treated as untrusted and normalized through safeLogin/safeUrl
+#     before use (see the inline script below).
+#
+# Do NOT broaden permissions, add a fork checkout, or remove the input
+# normalization without a security review.
+
 name: Contributor Rewards
 
 on:
@@ -47,6 +64,25 @@ jobs:
             const merchUrl = (process.env.CONTRIBUTOR_REWARD_MERCH_URL || '').trim();
             const customMessage = (process.env.CONTRIBUTOR_REWARD_MESSAGE || '').trim();
 
+            // Treat all PR/issue metadata as untrusted display-only data — this
+            // workflow runs under `pull_request_target` so anything coming from
+            // a fork (login, html_url) crosses a trust boundary. Normalize
+            // before interpolating into search queries or comment bodies.
+            // GitHub usernames are 1-39 chars, alphanumeric + hyphen.
+            const safeLogin = (s) => String(s || '').replace(/[^A-Za-z0-9-]/g, '').slice(0, 39);
+            // Only allow github.com / *.github.com (covers GitHub Enterprise).
+            // Strip query/fragment to defeat comment-body injection via crafted
+            // URLs. Return '' if the URL is unparseable or off-host.
+            const safeUrl = (s) => {
+              try {
+                const u = new URL(String(s || ''));
+                const okHost = u.hostname === 'github.com' || u.hostname.endsWith('.github.com');
+                return okHost ? `${u.origin}${u.pathname}` : '';
+              } catch {
+                return '';
+              }
+            };
+
             const normalize = value => String(value || '').trim().toLowerCase();
             const triggerLabelKey = normalize(triggerLabel);
 
@@ -94,12 +130,19 @@ jobs:
                     return null;
                   }
 
+                  const login = safeLogin(pr.user?.login);
+                  if (!login) {
+                    core.info(`PR #${pr.number} has an unrecognized author login shape; skipping.`);
+                    return null;
+                  }
+                  const htmlUrl = safeUrl(pr.html_url);
+
                   return {
                     kind: 'pull request',
                     number: pr.number,
-                    htmlUrl: pr.html_url,
-                    login: pr.user.login,
-                    userType: pr.user.type,
+                    htmlUrl,
+                    login,
+                    userType: pr.user?.type,
                     reason: 'first merged pull request',
                     manualOverride: false,
                     requireFirstMergedPr: true,
@@ -112,12 +155,19 @@ jobs:
                     return null;
                   }
 
+                  const login = safeLogin(pr.user?.login);
+                  if (!login) {
+                    core.info(`PR #${pr.number} has an unrecognized author login shape; skipping.`);
+                    return null;
+                  }
+                  const htmlUrl = safeUrl(pr.html_url);
+
                   return {
                     kind: 'pull request',
                     number: pr.number,
-                    htmlUrl: pr.html_url,
-                    login: pr.user.login,
-                    userType: pr.user.type,
+                    htmlUrl,
+                    login,
+                    userType: pr.user?.type,
                     reason: `maintainer-applied "${triggerLabel}" label on a pull request`,
                     manualOverride: true,
                     requireFirstMergedPr: false,
@@ -139,12 +189,19 @@ jobs:
                   return null;
                 }
 
+                const login = safeLogin(issue.user?.login);
+                if (!login) {
+                  core.info(`Issue #${issue.number} has an unrecognized author login shape; skipping.`);
+                  return null;
+                }
+                const htmlUrl = safeUrl(issue.html_url);
+
                 return {
                   kind: 'issue',
                   number: issue.number,
-                  htmlUrl: issue.html_url,
-                  login: issue.user.login,
-                  userType: issue.user.type,
+                  htmlUrl,
+                  login,
+                  userType: issue.user?.type,
                   reason: `maintainer-applied "${triggerLabel}" label on an issue`,
                   manualOverride: true,
                   requireFirstMergedPr: false,


### PR DESCRIPTION
## Summary

- Add a top-of-file YAML comment block documenting why `pull_request_target` is intentional and what's intentionally constrained.
- Introduce `safeLogin` + `safeUrl` helpers inside the inline `actions/github-script` body and apply them at the `targetFromEvent()` trust boundary.
- Drop on empty: events with unexpected user/url shape now skip cleanly instead of producing `@` mentions or invalid search queries.

## Problem

`.github/workflows/contributor-rewards.yml` uses the high-risk `pull_request_target` trigger. Permissions are already minimal (`contents:read`, `issues:write`, `pull-requests:read`) and the workflow doesn't check out fork code, so the realistic injection surface is narrow. Two real gaps remained:

1. **Documentation gap**: no inline justification explaining why the trigger is intentional + bounded. Future contributors expanding permissions had no signal.
2. **Implicit-trust on attacker-controlled fields**: `pr.user.login` is interpolated into a GitHub search query (`author:${login}`) and PR comment bodies; `pr.html_url` into comment bodies. The script trusted GitHub's server-side constraints without normalization at the trust boundary.

Identified by audit #2575 (H-2). CWE-1287.

## Solution

1. Top-of-file YAML comment block (L2-17, above `name:`) documents the trigger choice, what is intentionally narrow (no fork checkout, no script execution, minimal permissions, templated comment + label only), and warns reviewers not to widen the trust boundary without security review.
2. Two pure helpers added inside the `script:` block:
   ```js
   const safeLogin = (s) => String(s || '').replace(/[^A-Za-z0-9-]/g, '').slice(0, 39);
   const safeUrl = (s) => {
     try {
       const u = new URL(String(s || ''));
       const okHost = u.hostname === 'github.com' || u.hostname.endsWith('.github.com');
       return okHost ? `${u.origin}${u.pathname}` : '';
     } catch {
       return '';
     }
   };
   ```
3. `targetFromEvent()` now computes `safeLogin(pr.user?.login)` / `safeLogin(issue.user?.login)` once per branch, bails with `core.info(...) + return null` if empty, and constructs the return object using the validated `login` and `safeUrl(html_url)`. Optional chaining (`pr.user?.login`) is a strictly-safer deviation from the plan: malformed payloads missing the `user` object now hit the drop guard instead of throwing.

Downstream helpers (`markerFor`, `isFirstMergedPullRequest` search, `renderCustomMessage`, `renderDefaultMessage`, summary write) see already-sanitized values without per-call sanitization.

## Submission Checklist

- [x] N/A: Tests added or updated — `actions/github-script` `script:` directive accepts inline JS only. Extracting the script to a standalone `.js` for unit-testing would require switching to `run: node` and lose the typed `github`/`context`/`core` injection — refactor not warranted for ~4 helpers. Manual validation via `workflow_dispatch` dry-run.
- [x] **Diff coverage ≥ 80%** — single YAML file; coverage gate doesn't apply (YAML / inline JS not tracked by Vitest or cargo-llvm-cov).
- [x] N/A: Coverage matrix updated — behaviour-only change to existing CI workflow
- [x] N/A: All affected feature IDs from the matrix are listed in `## Related` — contributor-rewards workflow is not a matrix-tracked feature
- [x] No new external network dependencies introduced
- [x] N/A: Manual smoke checklist updated — contributor-rewards is not a release-cut surface
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Security**: explicit trust-boundary sanitization closes CWE-1287 finding from audit #2575. Defense-in-depth — GitHub's server-side username/URL constraints make the realistic injection narrow today, but the script no longer relies implicitly on that constraint.
- **Operations**: workflow behavior unchanged for valid PR/issue payloads (real GitHub logins all match `[A-Za-z0-9-]{1,39}` already). Malformed payloads (hypothetical future GitHub feature) now skip rather than throw.
- **Maintainability**: top-of-file comment makes future-contributor pushes that try to widen permissions / add fork-checkout steps obvious code-review red flags.

## Related

- Closes #2621
- Parent: #2575

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/2621-pr-target-sanitize`
- Commit SHA: `2d3a2f2c`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: workflow YAML
- [x] `pnpm typecheck` — N/A: no TypeScript touched
- [x] Focused tests: YAML parses via PyYAML (`yaml.safe_load` succeeds, top-level keys: `name`, `on`, `permissions`, `concurrency`, `jobs`)
- [x] Rust fmt/check: N/A
- [x] Tauri fmt/check: N/A

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: malformed PR/issue payloads with missing/odd `user.login` or `html_url` now skip cleanly with an info log.
- User-visible effect: none for real GitHub payloads.

### Parity Contract
- Legacy behavior preserved: yes for all valid GitHub PR/issue payloads.
- Guard/fallback/dispatch parity checks: existing `actorIsBot`, `targetAlreadyRewarded`, `contributorAlreadyRewardedElsewhere` guards unchanged.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the contributor rewards workflow with enhanced validation of author logins and URLs to ensure robust handling of edge cases and malformed GitHub metadata during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
