### PR TITLE
docs(install): promote native packages as primary install path (#2620)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,57 @@
 
 > **Local + managed services, upfront:** OpenHuman stores its Memory Tree, Obsidian-style Markdown vault, workspace config, and local runtime state on your machine. The default managed experience still uses OpenHuman-hosted services for account sign-in, model routing, web search proxying, and managed integration/OAuth flows through the Composio connector layer. Choose custom/local settings if you want to bring your own model, search, or Composio credentials; some real-time triggers and hosted features still require the managed backend.
 
-To install or get started, either download from the website over at [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or run
+# Install
+
+Download installers from [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or from the [GitHub Releases](https://github.com/tinyhumansai/openhuman/releases/latest) page. For terminal installs, the native package paths below are preferred — they ride your OS package-manager's signing chain.
+
+### Recommended install (native packages)
+
+These paths verify the artifact through your OS package manager's signing chain (Homebrew bottle hash, signed apt repo, MSI signature).
+
+**macOS (Homebrew tap):**
 
 ```bash
-# Download DMG, EXEs over at https://tinyhumans.ai/openhuman or run in from your terminal
+brew tap tinyhumansai/openhuman
+brew install openhuman
+```
 
-# For macOS or Linux x64
+**Linux (Debian/Ubuntu — signed apt repo):**
+
+```bash
+sudo apt-get install -y --no-install-recommends gnupg2 curl ca-certificates
+curl -fsSL https://tinyhumansai.github.io/openhuman/apt/KEY.gpg \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/openhuman.gpg
+echo "deb [signed-by=/etc/apt/keyrings/openhuman.gpg arch=amd64] \
+  https://tinyhumansai.github.io/openhuman/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/openhuman.list
+sudo apt-get update
+sudo apt-get install -y openhuman
+```
+
+**Linux (Arch — AUR):** the [`openhuman-bin` AUR recipe](./packages/arch/openhuman-bin/) is in the repo. Once published, Arch users can install it with `yay -S openhuman-bin`.
+
+**Windows:** download the signed `.msi` from the [latest release](https://github.com/tinyhumansai/openhuman/releases/latest) and run it.
+
+**Manual `.dmg` / `.deb` / `.AppImage` / `.msi`:** grab the installer for your platform directly from the [latest release page](https://github.com/tinyhumansai/openhuman/releases/latest).
+
+> **Linux:** the AppImage can crash on launch under Wayland (and on Arch-based distros with `sharun: Interpreter not found!`) — see [#2463](https://github.com/tinyhumansai/openhuman/issues/2463) for the cause and env-var workarounds. The `.deb` package above avoids those failure modes on Debian/Ubuntu.
+
+### Alternative: script install (no integrity check)
+
+> **Warning — unverified install.** These scripts are served live from `raw.githubusercontent.com` and do **not** ship a separate signature, so `curl … | bash` and `irm … | iex` have no way to detect tampering of the script bytes. Prefer the **native package** paths above whenever possible. If you must use the script, see "Verified script install" below.
+
+```bash
+# macOS or Linux x64
 curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash
 
-# For Windows
+# Windows (PowerShell)
 irm https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.ps1 | iex
 ```
 
-> **Linux:** the AppImage can crash on launch under Wayland (and on Arch-based distros with `sharun: Interpreter not found!`) — see [#2463](https://github.com/tinyhumansai/openhuman/issues/2463) for the cause and env-var workarounds.
-Arch Linux package maintainers can use the [`openhuman-bin` AUR recipe](./packages/arch/openhuman-bin/);
-once published, Arch users can install it with `yay -S openhuman-bin`.
+### Verified script install (coming soon)
+
+PR2 of [#2620](https://github.com/tinyhumansai/openhuman/issues/2620) will publish `install.sh.asc` / `install.ps1.asc` as release assets and document the `gpg --verify` (and Windows equivalent) flow here, so the script path can be made integrity-checked end-to-end.
 
 # What is OpenHuman?
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 Download installers from [tinyhumans.ai/openhuman](https://tinyhumans.ai/openhuman?utm_source=github&utm_medium=readme) or from the [GitHub Releases](https://github.com/tinyhumansai/openhuman/releases/latest) page. For terminal installs, the native package paths below are preferred — they ride your OS package-manager's signing chain.
 
-### Recommended install (native packages)
+## Recommended install (native packages)
 
 These paths verify the artifact through your OS package manager's signing chain (Homebrew bottle hash, signed apt repo, MSI signature).
 
@@ -94,7 +94,7 @@ sudo apt-get install -y openhuman
 
 > **Linux:** the AppImage can crash on launch under Wayland (and on Arch-based distros with `sharun: Interpreter not found!`) — see [#2463](https://github.com/tinyhumansai/openhuman/issues/2463) for the cause and env-var workarounds. The `.deb` package above avoids those failure modes on Debian/Ubuntu.
 
-### Alternative: script install (no integrity check)
+## Alternative: script install (no integrity check)
 
 > **Warning — unverified install.** These scripts are served live from `raw.githubusercontent.com` and do **not** ship a separate signature, so `curl … | bash` and `irm … | iex` have no way to detect tampering of the script bytes. Prefer the **native package** paths above whenever possible. If you must use the script, see "Verified script install" below.
 
@@ -106,7 +106,7 @@ curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts
 irm https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.ps1 | iex
 ```
 
-### Verified script install (coming soon)
+## Verified script install (coming soon)
 
 PR2 of [#2620](https://github.com/tinyhumansai/openhuman/issues/2620) will publish `install.sh.asc` / `install.ps1.asc` as release assets and document the `gpg --verify` (and Windows equivalent) flow here, so the script path can be made integrity-checked end-to-end.
 


### PR DESCRIPTION
## Summary

- Reorganize `README.md` install section into three subsections.
- **Recommended (native packages)** first — Homebrew tap, signed apt repo, AUR, Windows MSI, manual installer download.
- **Alternative: script install (no integrity check)** demoted with a blockquote warning explaining the bytes ship without a separate signature.
- **Verified script install (coming soon)** stub reserves a stable anchor for PR2 of #2620 (the GPG-signed install scripts + verification docs).

## Problem

Install scripts are served live from `raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.{sh,ps1}` (no GitHub release artifact, no signature, no integrity check). The previous README promoted `curl ... | bash` and `irm ... | iex` as the primary install path. A write-access compromise of `tinyhumansai/openhuman` flips the script bytes directly into every new install. CWE-494 / MITRE ATT&CK T1195.002.

Native packages (Homebrew, signed apt repo, AUR, Windows MSI) already ship via `release-packages.yml` and provide stronger integrity guarantees via OS package-manager signing chains. The fix is editorial — make native packages the default path so most users never run pipe-to-shell, and demote pipe-to-shell with an explicit integrity-warning blockquote.

Identified by audit #2575 (H-1).

## Solution

PR1 of 2 for #2620 (this PR is editorial; PR2 adds the signing job + verified-install snippet):

1. New `# Install` h1 wrapping three h3 subsections.
2. `### Recommended install (native packages)` lists the four package paths verbatim from `.github/workflows/release-packages.yml:202-229` (the literal commands the release pipeline already validates on every release — load-bearing accurate).
3. `### Alternative: script install (no integrity check)` keeps the existing `curl … install.sh | bash` and `irm … install.ps1 | iex` lines verbatim, prepended with a `>` blockquote warning.
4. `### Verified script install (coming soon)` placeholder pointing at #2620 / PR2 / `install.sh.asc` / `install.ps1.asc` so PR2 has a stable anchor.
5. Existing Linux-AppImage Wayland callout retained and re-pointed at "use the `.deb` package above" so the new structure absorbs it cleanly.

Out of scope (documented for follow-up):
- Locale READMEs (`README.de.md`, `README.ja-JP.md`, `README.ko.md`, `README.zh-CN.md`) still promote `curl | bash` and will drift further from English. Better handled as a translator-friendly parity sweep rather than rolled into this security-editorial PR.
- `gitbooks/developing/getting-set-up.md` (L77-126) and `docs/RELEASE-MANUAL-SMOKE.md` (L26) still call `curl | install.sh` the "Primary install command" without any warning. Worth folding into PR2 of #2620.

## Submission Checklist

- [x] N/A: Tests added or updated — README-only editorial change
- [x] **Diff coverage ≥ 80%** — README is not Vitest- or cargo-tracked; coverage gate doesn't apply
- [x] N/A: Coverage matrix updated — documentation change
- [x] N/A: All affected feature IDs from the matrix are listed in `## Related` — install docs are not a matrix-tracked feature
- [x] No new external network dependencies introduced
- [x] N/A: Manual smoke checklist updated — companion-doc drift in `docs/RELEASE-MANUAL-SMOKE.md` flagged as PR2 follow-up
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — partially: PR2 will close #2620 when it lands. This PR is PR1 of 2.

## Impact

- **Security**: reduces the audience exposed to unverified pipe-to-shell by making native packages the default path. CWE-494 mitigation; not fully closed until PR2 ships signed install scripts.
- **Compatibility**: existing `curl | bash` and `irm | iex` commands remain operational verbatim — no breakage of external docs / blog posts that reference them.
- **Documentation**: ~50-line README diff. No code changes.

## Related

- Refs #2620 (PR2 will close it; this is PR1 of 2)
- Parent: #2575
- Follow-up: PR2 of #2620 (release-workflow signing job + verified-install README snippet replacing the stub)
- Follow-up: locale README parity sweep (de / ja-JP / ko / zh-CN)
- Follow-up: `gitbooks/developing/getting-set-up.md` + `docs/RELEASE-MANUAL-SMOKE.md` alignment with the new editorial guidance

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `refactor/2620-readme-native-first`
- Commit SHA: `465bc072`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: repo-root README is not a prettier target (filter is scoped to `openhuman-app` workspace)
- [x] `pnpm typecheck` — N/A: no TypeScript touched
- [x] Focused tests: `git diff --stat README.md` confirms 1 file +43/-7
- [x] Rust fmt/check: N/A
- [x] Tauri fmt/check: N/A

### Validation Blocked
- `command:` `npx prettier --check README.md`
- `error:` registry cache miss (offline)
- `impact:` markdown visually validated against the file's existing h1/h3/blockquote/fenced-code conventions; structure clean

### Behavior Changes
- Intended behavior change: README reader is directed to a verified install path by default; the script install is clearly labeled as no-integrity-check.
- User-visible effect: install section reordered; existing curl/irm one-liners still present.

### Parity Contract
- Legacy behavior preserved: all existing install commands work verbatim.
- Guard/fallback/dispatch parity checks: N/A — documentation change.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this PR (PR1 of 2 for #2620)
- Resolution: N/A — PR2 of #2620 will follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized installation instructions with clear, platform-specific guidance.
  * Enhanced emphasis on verifying package integrity through signature verification.
  * Clarified distinction between secure package manager installations and alternative script-based methods.
  * Added note about upcoming signed script installation option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
