### PR TITLE
feat(mcp): i18n + a11y McpStatusBadge status labels

### DIFF
--- a/app/src/components/channels/mcp/McpStatusBadge.test.tsx
+++ b/app/src/components/channels/mcp/McpStatusBadge.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for McpStatusBadge — renders the i18n'd label and a11y role
+ * for each ServerStatus, and forwards custom className.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import McpStatusBadge from './McpStatusBadge';
+import type { ServerStatus } from './types';
+
+describe('McpStatusBadge', () => {
+  it.each<[ServerStatus, string]>([
+    ['connected', 'Connected'],
+    ['connecting', 'Connecting'],
+    ['disconnected', 'Disconnected'],
+    ['error', 'Error'],
+  ])('renders i18n label for status=%s', (status, expectedLabel) => {
+    render(<McpStatusBadge status={status} />);
+    expect(screen.getByRole('status')).toHaveTextContent(expectedLabel);
+  });
+
+  it('exposes role="status" and aria-live="polite" for assistive tech', () => {
+    render(<McpStatusBadge status="connecting" />);
+    const badge = screen.getByRole('status');
+    expect(badge).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('falls back to the disconnected style for an unknown status value', () => {
+    // ServerStatus is a closed union, but the runtime fallback exists for
+    // forward-compat with possible future Rust-side variants — exercise it.
+    render(<McpStatusBadge status={'spawning' as ServerStatus} />);
+    expect(screen.getByRole('status')).toHaveTextContent('Disconnected');
+  });
+
+  it('appends the optional className without dropping the built-in classes', () => {
+    render(<McpStatusBadge status="connected" className="ml-2 my-custom-class" />);
+    const badge = screen.getByRole('status');
+    expect(badge.className).toContain('my-custom-class');
+    expect(badge.className).toContain('ml-2');
+    // Built-in look-and-feel preserved.
+    expect(badge.className).toContain('rounded-full');
+    expect(badge.className).toContain('bg-sage-500/10');
+  });
+});

--- a/app/src/components/channels/mcp/McpStatusBadge.tsx
+++ b/app/src/components/channels/mcp/McpStatusBadge.tsx
@@ -1,25 +1,28 @@
 /**
  * Status badge for MCP server connection states.
- * Mirrors ChannelStatusBadge but uses ServerStatus values.
+ * Mirrors ChannelStatusBadge but uses ServerStatus values; reuses the
+ * shared `channels.status.*` i18n keys since the label vocabulary is
+ * identical (Connected / Connecting / Disconnected / Error).
  */
+import { useT } from '../../../lib/i18n/I18nContext';
 import type { ServerStatus } from './types';
 
-const STATUS_STYLES: Record<ServerStatus, { label: string; className: string }> = {
+const STATUS_META: Record<ServerStatus, { i18nKey: string; className: string }> = {
   connected: {
-    label: 'Connected',
+    i18nKey: 'channels.status.connected',
     className: 'bg-sage-500/10 text-sage-700 border-sage-500/30 dark:text-sage-300',
   },
   connecting: {
-    label: 'Connecting',
+    i18nKey: 'channels.status.connecting',
     className: 'bg-amber-500/10 text-amber-700 border-amber-500/30 dark:text-amber-300',
   },
   disconnected: {
-    label: 'Disconnected',
+    i18nKey: 'channels.status.disconnected',
     className:
       'bg-stone-100 dark:bg-neutral-800 text-stone-500 dark:text-neutral-400 border-stone-200 dark:border-neutral-700',
   },
   error: {
-    label: 'Error',
+    i18nKey: 'channels.status.error',
     className: 'bg-coral-500/10 text-coral-700 border-coral-500/30 dark:text-coral-300',
   },
 };
@@ -30,11 +33,14 @@ interface McpStatusBadgeProps {
 }
 
 const McpStatusBadge = ({ status, className = '' }: McpStatusBadgeProps) => {
-  const style = STATUS_STYLES[status] ?? STATUS_STYLES.disconnected;
+  const { t } = useT();
+  const meta = STATUS_META[status] ?? STATUS_META.disconnected;
   return (
     <span
-      className={`shrink-0 px-2 py-1 text-[11px] border rounded-full ${style.className} ${className}`}>
-      {style.label}
+      role="status"
+      aria-live="polite"
+      className={`shrink-0 px-2 py-1 text-[11px] border rounded-full ${meta.className} ${className}`}>
+      {t(meta.i18nKey)}
     </span>
   );
 };


### PR DESCRIPTION
## Summary

- Route the 4 hardcoded status labels in `McpStatusBadge.tsx` ('Connected' / 'Connecting' / 'Disconnected' / 'Error') through `useT()` using the existing `channels.status.*` keys. The badge's own docstring says it *"Mirrors ChannelStatusBadge"*; the labels are identical English; reusing the shared key set avoids redundant translation work.
- Add `role="status"` and `aria-live="polite"` so screen readers announce state changes — matches the alpha-banner pattern already used in `McpServersTab`.
- Add a 7-test `McpStatusBadge.test.tsx` covering each `ServerStatus` variant, the a11y attributes, the disconnected fallback for unknown statuses, and className passthrough.

## Problem

`McpStatusBadge.tsx` slipped past the #2577 React i18n sweep because it's an isolated leaf component without a co-located test. Lines 7–25 hardcoded English labels (`label: 'Connected'`, etc.) directly in a `STATUS_STYLES` object, violating the CLAUDE.md rule that *every user-visible string in `app/src/**` must go through `useT()`*. Non-EN users saw English labels on every MCP server connection state.

The same `<span>` had no `role` or `aria-live`, so screen readers wouldn't announce state changes — important for a long-running connection that can transition between `connecting` → `connected` → `error` while the user is on a different part of the page.

## Solution

- Reuse the existing `channels.status.{connected,connecting,disconnected,error}` i18n keys rather than introducing `mcp.status.*` duplicates. The labels are character-identical to the channel status set; the badge's docstring already calls it a "mirror" of `ChannelStatusBadge`. If the MCP vocabulary ever diverges (e.g. adds "spawning" / "handshaking"), the keys can be split then.
- Add `role="status"` + `aria-live="polite"` (matches `McpServersTab`'s alpha banner).
- Co-locate `McpStatusBadge.test.tsx` covering: every status variant renders the right label, a11y attributes present, fallback to "Disconnected" for unknown status values, className passthrough preserves built-in classes.

## Submission Checklist

- [x] Tests added or updated — 7 tests added in new `McpStatusBadge.test.tsx`.
- [x] **Diff coverage ≥ 80%** — All changed lines in `McpStatusBadge.tsx` are exercised by the new test file (`it.each` over all 4 status variants + a11y + fallback + className).
- [x] Coverage matrix updated — **N/A: behaviour-only change** (no new feature; same component, just i18n + a11y).
- [x] All affected feature IDs listed under `## Related` — **N/A: leaf-component fix.**
- [x] No new external network dependencies introduced — N/A.
- [x] Manual smoke checklist updated if release-cut surfaces touched — **N/A: no release-cut surface touched.**
- [x] Linked issue closed via `Closes #NNN` in `## Related` — **N/A: no linked issue.**

## Impact

- Runtime/platform impact: **none** (drop-in component change).
- Performance/security/migration/compatibility: none.
- Localized users will now see translated status labels in their locale; screen reader users will hear connection state changes announced.

## Related

- Closes:
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `feat/mcp-servers-ui-panel`
- Commit SHA: (filled by GitHub after push)

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — `McpStatusBadge.test.tsx` clean; `McpStatusBadge.tsx` inherits CRLF from Windows checkout (CI on Linux passes)
- [x] `pnpm typecheck` — clean
- [x] Focused tests: `pnpm vitest run src/components/channels/mcp/` — 82/82 pass (includes the new file + the pinned `Skills.mcp-coming-soon.test.tsx` confirming no regression)
- [x] Rust fmt/check (if changed): N/A (no Rust touched)
- [x] Tauri fmt/check (if changed): N/A (no Tauri touched)

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Localized status labels + screen-reader announcement of state changes
- User-visible effect: Non-EN users see translated labels; screen readers announce connection state transitions

### Parity Contract
- Legacy behavior preserved: Yes — labels render identically in English; the fallback for unknown statuses still resolves to "Disconnected" style + label
- Guard/fallback/dispatch parity checks: Test covers unknown status fallback to "Disconnected" label + style

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None known
- Canonical PR: This one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the status badge component, verifying proper label rendering across all status types, accessibility attributes, fallback behavior for unknown statuses, and CSS class preservation.

* **Refactor**
  * Status badge component refactored to use internationalization for status labels, replacing hardcoded label mappings with language-aware metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->