### PR TITLE
fix(release): rewrite sharun lib.path CI runner paths to bundle-relative

### DIFF
--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -236,6 +236,69 @@ ensure_sharun_interpreter() {
   return 0
 }
 
+rewrite_sharun_lib_path() {
+  local appdir="$1"
+  if ! uses_sharun_launcher "$appdir"; then
+    return 1
+  fi
+
+  local lib_path="$appdir/shared/lib/lib.path"
+  [ -s "$lib_path" ] || return 1
+
+  if ! grep -E '(^|[+:])/home/runner/|(^|[+:])/__w/' "$lib_path" >/dev/null; then
+    return 1
+  fi
+
+  echo "[strip-libs]   rewriting CI runner paths in shared/lib/lib.path"
+
+  local raw
+  raw="$(cat "$lib_path")"
+
+  local -a entries=()
+  local entry
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    entries+=("$entry")
+  done < <(printf '%s' "$raw" | tr '+:' '\n\n')
+
+  local -a cleaned=()
+  local rel seen_set=""
+  for entry in "${entries[@]}"; do
+    case "$entry" in
+      /home/runner/*|/__w/*)
+        rel="${entry##*/squashfs-root/}"
+        if [ "$rel" = "$entry" ]; then
+          rel="${entry##*/data/}"
+          [ "$rel" != "$entry" ] || continue
+        fi
+        ;;
+      /*)
+        continue
+        ;;
+      *)
+        rel="$entry"
+        ;;
+    esac
+
+    [ -d "$appdir/$rel" ] || continue
+
+    case "+${seen_set}+" in
+      *"+${rel}+"*) continue ;;
+    esac
+    seen_set="${seen_set}+${rel}"
+    cleaned+=("$rel")
+  done
+
+  if [ "${#cleaned[@]}" -eq 0 ]; then
+    cleaned=("shared/lib")
+  fi
+
+  local joined
+  joined="$(IFS='+'; echo "${cleaned[*]}")"
+  printf '%s' "$joined" > "$lib_path"
+  echo "[strip-libs]   lib.path rewritten to: $joined"
+}
+
 validate_sharun_lib_path() {
   local appdir="$1"
   if ! uses_sharun_launcher "$appdir"; then
@@ -276,6 +339,7 @@ strip_one_appimage() {
   local appdir="$workdir/squashfs-root"
   local removed=0
   local added_loader=0
+  local rewrote_libpath=0
   local lib_roots=()
   for candidate in \
     "$appdir/usr/lib" \
@@ -304,9 +368,12 @@ strip_one_appimage() {
   if ensure_sharun_interpreter "$appdir"; then
     added_loader=1
   fi
+  if rewrite_sharun_lib_path "$appdir"; then
+    rewrote_libpath=1
+  fi
   validate_sharun_lib_path "$appdir"
 
-  if [ "$removed" -eq 0 ] && [ "$added_loader" -eq 0 ]; then
+  if [ "$removed" -eq 0 ] && [ "$added_loader" -eq 0 ] && [ "$rewrote_libpath" -eq 0 ]; then
     echo "[strip-libs] No graphics libs or missing sharun interpreter found in $original; leaving unchanged."
     rm -rf "$workdir"
     return


### PR DESCRIPTION
## Summary

- The sharun bundler (`quick-sharun.sh`) writes absolute CI runner paths into `shared/lib/lib.path` inside the AppImage during bundling
- The validation added in #2385 correctly rejects these but never rewrites them, causing the "Strip host graphics libs from AppImage" step to fail
- Adds `rewrite_sharun_lib_path()` that runs before validation: splits lib.path entries, strips CI prefixes to recover bundle-relative paths, deduplicates, verifies each directory exists inside the extracted AppImage, and writes back a clean `+`-delimited lib.path

## Problem

- Staging build fails at the "Strip host graphics libs from AppImage" step with: `shared/lib/lib.path contains CI runner paths; regenerate it with bundle-relative entries before release.`
- The sharun bundler bakes absolute CI paths (e.g. `/home/runner/work/openhuman/...`) into lib.path, and the validation gate from #2385 catches this but provides no fix

## Solution

- Added `rewrite_sharun_lib_path()` in `scripts/release/strip-appimage-graphics-libs.sh` that converts absolute CI paths to bundle-relative paths before validation runs
- Splits entries on `+`/`:` delimiters, strips CI prefixes using `squashfs-root/` or `data/` as anchors, deduplicates, validates dirs exist in extracted AppImage
- Falls back to `shared/lib` if no entries survive
- Tracks rewrite in the modified count so the AppImage is repacked even when no graphics libs were stripped

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — N/A: shell script fix exercised by the release pipeline; no unit test framework for bash scripts
- [x] **Diff coverage ≥ 80%** — N/A: change is to a bash script, not covered by Vitest/cargo-llvm-cov
- [x] Coverage matrix updated — N/A: no feature change, build-pipeline fix only
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: build infrastructure
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: fixes existing release pipeline step
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no tracked issue, fixing CI failure directly

## Impact

- Desktop/Linux only — affects AppImage bundling in the release pipeline
- No runtime behavior change; the rewrite produces the same bundle-relative paths the bundler should have written

## Related

- Fixes staging build failure: https://github.com/tinyhumansai/openhuman/actions/runs/26388848507/job/77673549919
- Follow-up: upstream fix in quick-sharun.sh to generate relative paths natively