### PR TITLE
Protect dictation websocket auth

### DIFF
--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -22,7 +22,6 @@
 //! - `GET /auth/telegram` — external browser callback (carries its own token)
 //! - `GET /schema`        — read-only schema discovery
 //! - `GET /events`        — SSE stream; browser `EventSource` cannot set headers
-//! - `GET /ws/dictation`  — WebSocket upgrade; browser WS API cannot set headers
 //! - `OPTIONS *`          — CORS preflight (handled by outer CORS middleware)
 //!
 //! Endpoints that accept the bearer either via header **or** `?token=…` query
@@ -30,6 +29,9 @@
 //! - `GET /events/webhooks` — webhook SSE; browser `EventSource` cannot set
 //!   headers, so the FE forwards the bearer as a query param. Validated
 //!   against the same in-process RPC token — no separate secret.
+//! - `GET /ws/dictation` — dictation WebSocket upgrade; browser WebSocket APIs
+//!   cannot attach arbitrary headers, so browser clients must forward the same
+//!   core bearer as `?token=…`.
 //!
 //! Executable surfaces:
 //! - `POST /rpc` requires the per-launch core bearer token.
@@ -62,14 +64,7 @@ static RPC_TOKEN: OnceLock<String> = OnceLock::new();
 /// other routes are read-only, streaming, or WebSocket upgrades whose clients
 /// (browser `EventSource`, browser `WebSocket`) cannot set `Authorization`
 /// headers via standard APIs.
-const PUBLIC_PATHS: &[&str] = &[
-    "/",
-    "/health",
-    "/auth/telegram",
-    "/schema",
-    "/events",
-    "/ws/dictation",
-];
+const PUBLIC_PATHS: &[&str] = &["/", "/health", "/auth/telegram", "/schema", "/events"];
 
 /// Paths that may authenticate via `?token=…` in the URL when no
 /// `Authorization` header is present.
@@ -84,7 +79,7 @@ const PUBLIC_PATHS: &[&str] = &[
 /// Add new entries here only for SSE / WebSocket routes whose clients cannot
 /// send headers and that carry per-user data. The follow-up approvals stream
 /// (#1339) is the next planned addition.
-const QUERY_TOKEN_PATHS: &[&str] = &["/events/webhooks"];
+const QUERY_TOKEN_PATHS: &[&str] = &["/events/webhooks", "/ws/dictation"];
 
 /// The environment variable the Tauri shell sets before spawning the core.
 ///

--- a/src/openhuman/inference/http/tests.rs
+++ b/src/openhuman/inference/http/tests.rs
@@ -88,6 +88,49 @@ async fn test_models_no_bearer_returns_401() {
     );
 }
 
+/// Requests to `GET /ws/dictation` without either a bearer or `?token=…`
+/// must be rejected with `401 Unauthorized`.
+#[tokio::test]
+async fn test_dictation_ws_no_credentials_returns_401() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/ws/dictation")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = dispatch(req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "GET /ws/dictation without credentials must return 401"
+    );
+}
+
+/// Browser WebSocket clients cannot attach `Authorization` headers on upgrade,
+/// so `GET /ws/dictation?token=…` must pass auth and fail only on the missing
+/// upgrade headers.
+#[tokio::test]
+async fn test_dictation_ws_query_token_not_rejected_as_auth_error() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("/ws/dictation?token={TEST_RPC_TOKEN}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = dispatch(req).await;
+    let status = resp.status();
+    assert_ne!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "401 must not fire when dictation query token is present"
+    );
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "403 must not fire when dictation query token is present"
+    );
+}
+
 /// A request with a bearer token must not be rejected as 401/403. The actual
 /// response code depends on whether a live inference backend is running; the
 /// test only asserts that auth passed.

--- a/src/openhuman/inference/voice/streaming.rs
+++ b/src/openhuman/inference/voice/streaming.rs
@@ -16,11 +16,11 @@
 //! # Security notes
 //!
 //! ## Authentication
-//! `GET /ws/dictation` is intentionally exempt from Bearer-token authentication because
-//! the browser WebSocket API cannot set arbitrary request headers on upgrade. The correct
-//! auth mechanism is a separate maintainer decision; see `src/core/auth.rs` for the
-//! documented exemption. Do NOT add a Bearer-header check here — it will not work from
-//! browsers and the design decision is tracked in issue #1924.
+//! `GET /ws/dictation` is gated by the core auth middleware before upgrade.
+//! Native callers may use `Authorization: Bearer <core token>`; browser callers
+//! must forward the same token as `?token=…` because the WebSocket API cannot
+//! attach arbitrary request headers on upgrade. Keep auth at the HTTP boundary
+//! (`src/core/auth.rs`) so this handler only runs for authenticated upgrades.
 //!
 //! ## Memory cap
 //! The full-audio accumulation buffer (`full_audio_buf`) is bounded by

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -5695,7 +5695,7 @@ async fn public_paths_accessible_without_token() {
     // Paths that bypass auth but return non-2xx for unrelated reasons
     // (missing required query params, no WebSocket upgrade headers, etc.).
     // The invariant is that the auth middleware does NOT reject them with 401.
-    for path in ["/auth/telegram", "/events", "/ws/dictation"] {
+    for path in ["/auth/telegram", "/events"] {
         let resp = client
             .get(format!("{base}{path}"))
             .send()


### PR DESCRIPTION
## Summary

- What changed and why.
- Keep this to 3-6 bullets focused on user-visible or architecture-impacting changes.

## Problem

- What issue or risk this PR addresses.
- Include context needed for reviewers to evaluate correctness quickly.

## Solution

- How the implementation solves the problem.
- Note important design decisions and tradeoffs.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [ ] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any.
- Performance, security, migration, or compatibility implications.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key:
- URL:

### Commit & Branch
- Branch:
- Commit SHA:

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check`
- [ ] `pnpm typecheck`
- [ ] Focused tests:
- [ ] Rust fmt/check (if changed):
- [ ] Tauri fmt/check (if changed):

### Validation Blocked
- `command:`
- `error:`
- `impact:`

### Behavior Changes
- Intended behavior change:
- User-visible effect:

### Parity Contract
- Legacy behavior preserved:
- Guard/fallback/dispatch parity checks:

### Duplicate / Superseded PR Handling
- Duplicate PR(s):
- Canonical PR:
- Resolution (closed/superseded/updated):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication requirement for WebSocket dictation endpoint. Clients must provide bearer token via `?token=…` query parameter.

* **Tests**
  * Added integration tests verifying WebSocket authentication validation.

* **Documentation**
  * Updated authentication documentation for WebSocket dictation endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->