### PR TITLE
feat(about_app): catalog entries for embedding provider selection (#2583 follow-up)

### DIFF
--- a/src/openhuman/about_app/catalog.rs
+++ b/src/openhuman/about_app/catalog.rs
@@ -295,6 +295,50 @@ const CAPABILITIES: &[Capability] = &[
         privacy: LOCAL_RAW,
     },
     Capability {
+        id: "intelligence.embedding_provider_config",
+        name: "Configure Embedding Provider",
+        domain: "embeddings",
+        category: CapabilityCategory::Intelligence,
+        description:
+            "Pick which embedding provider drives semantic search across your memory: \
+             managed cloud (default, Voyage-backed via api.tinyhumans.ai), OpenAI, \
+             Cohere, local Ollama, or a custom OpenAI-compatible endpoint. API keys \
+             are stored encrypted via the local keyring under `embeddings:<slug>`; \
+             model name and embedding dimensions are tunable per provider. The \
+             legacy `inference_embed` RPC is aliased to `embeddings_embed` so \
+             existing callers continue to work.",
+        how_to: "Settings > AI > Embeddings",
+        status: CapabilityStatus::Beta,
+        // Privacy depends on the selected provider — see
+        // `intelligence.embedding_provider_test` for the per-provider data
+        // destinations. The configuration surface itself only writes to the
+        // local keyring and config, so leaving this `None` (treat-as-unknown)
+        // would under-report; we annotate the credential side here and the
+        // network side on the test action.
+        privacy: LOCAL_CREDENTIALS,
+    },
+    Capability {
+        id: "intelligence.embedding_provider_test",
+        name: "Test Embedding Provider",
+        domain: "embeddings",
+        category: CapabilityCategory::Intelligence,
+        description:
+            "Verify a configured embedding provider before committing it to \
+             memory ingestion. Sends a small one-shot embed request and reports \
+             the model, dimensions, and any auth/error surface so a \
+             misconfigured key doesn't get discovered halfway through a 50k \
+             chunk backfill.",
+        how_to: "Settings > AI > Embeddings > Test Connection",
+        // Test payload is a short fixed string ('OpenHuman connectivity \
+        // probe'-style) sent to whichever provider is selected — Voyage via \
+        // the OpenHuman backend, OpenAI, Cohere, or a custom endpoint. \
+        // `DERIVED_TO_BACKEND` is the right label for the default (managed \
+        // cloud) path; the destination list reflects that this is *derived* \
+        // signal (the probe text), not raw user content.
+        status: CapabilityStatus::Beta,
+        privacy: DERIVED_TO_BACKEND,
+    },
+    Capability {
         id: "intelligence.mcp_server",
         name: "MCP Server",
         domain: "intelligence",

--- a/src/openhuman/about_app/catalog.rs
+++ b/src/openhuman/about_app/catalog.rs
@@ -74,6 +74,25 @@ const POLYMARKET_TRADING_DATA: Option<CapabilityPrivacy> = Some(CapabilityPrivac
     destinations: &["Polymarket CLOB API"],
 });
 
+// "Test Connection" on the Embeddings settings panel routes a small probe
+// payload to *whichever provider the user has selected* — not just the
+// managed cloud default. `DERIVED_TO_BACKEND` only enumerates the managed
+// path (OpenHuman backend / Neocortex), which under-reports the actual
+// privacy surface when the user has switched to OpenAI / Cohere / a
+// self-hosted endpoint. The catalog needs to list every reachable
+// destination so the Privacy surface can render the full set instead of
+// implying probes always stay on the managed path.
+const EMBEDDING_PROBE_TO_CONFIGURED_PROVIDER: Option<CapabilityPrivacy> = Some(CapabilityPrivacy {
+    leaves_device: true,
+    data_kind: PrivacyDataKind::Derived,
+    destinations: &[
+        "OpenHuman backend / TinyHumans Neocortex (managed cloud default)",
+        "OpenAI API (api.openai.com)",
+        "Cohere API (api.cohere.com)",
+        "User-configured OpenAI-compatible endpoint (custom:<url>)",
+    ],
+});
+
 const CAPABILITIES: &[Capability] = &[
     Capability {
         id: "conversation.create",
@@ -329,14 +348,14 @@ const CAPABILITIES: &[Capability] = &[
              misconfigured key doesn't get discovered halfway through a 50k \
              chunk backfill.",
         how_to: "Settings > AI > Embeddings > Test Connection",
-        // Test payload is a short fixed string ('OpenHuman connectivity \
-        // probe'-style) sent to whichever provider is selected — Voyage via \
-        // the OpenHuman backend, OpenAI, Cohere, or a custom endpoint. \
-        // `DERIVED_TO_BACKEND` is the right label for the default (managed \
-        // cloud) path; the destination list reflects that this is *derived* \
-        // signal (the probe text), not raw user content.
+        // The probe payload routes to whichever provider the user has
+        // selected — managed cloud (default), OpenAI, Cohere, or a custom
+        // OpenAI-compatible endpoint. Using `DERIVED_TO_BACKEND` here would
+        // under-report by only listing the managed path; the dedicated
+        // constant enumerates every reachable destination so the Privacy
+        // surface renders the full set.
         status: CapabilityStatus::Beta,
-        privacy: DERIVED_TO_BACKEND,
+        privacy: EMBEDDING_PROBE_TO_CONFIGURED_PROVIDER,
     },
     Capability {
         id: "intelligence.mcp_server",

--- a/src/openhuman/about_app/catalog_tests.rs
+++ b/src/openhuman/about_app/catalog_tests.rs
@@ -150,11 +150,10 @@ fn embedding_provider_capabilities_share_domain_and_category() {
 
 /// Privacy annotations must split cleanly: the config side touches only the
 /// local keyring (LOCAL_CREDENTIALS — leaves_device=false), the test side
-/// fires a probe at the configured provider (DERIVED_TO_BACKEND —
-/// leaves_device=true). Without this split, a single `None` privacy flag
-/// would force the UI to treat the embeddings panel as "unknown" and the
-/// Privacy surface would under-report where data goes when the test button
-/// gets clicked.
+/// fires a probe at the configured provider (leaves_device=true). Without
+/// this split, a single `None` privacy flag would force the UI to treat the
+/// embeddings panel as "unknown" and the Privacy surface would under-report
+/// where data goes when the test button gets clicked.
 #[test]
 fn embedding_provider_capabilities_split_privacy_correctly() {
     let config = lookup("intelligence.embedding_provider_config")
@@ -176,5 +175,51 @@ fn embedding_provider_capabilities_split_privacy_correctly() {
     assert!(
         test_privacy.leaves_device,
         "test fires a probe at the configured provider — must report as leaves_device"
+    );
+}
+
+/// The Test Connection probe can hit any of the configured providers, not
+/// just the managed cloud default. Pinning the destinations list defends
+/// the Privacy surface against silently shrinking back to a single
+/// destination — that's the exact under-reporting failure flagged in #2656
+/// review (CodeRabbit + @graycyrus both pointed at the same line).
+#[test]
+fn embedding_provider_test_destinations_cover_all_providers() {
+    let cap =
+        lookup("intelligence.embedding_provider_test").expect("embedding_provider_test registered");
+    let privacy = cap.privacy.expect("test capability has privacy annotation");
+
+    // Joining the destinations into a single haystack so the assertions
+    // tolerate cosmetic punctuation changes (parens, suffixes) but still
+    // catch a destination genuinely going missing.
+    let haystack = privacy.destinations.join(" | ").to_lowercase();
+
+    for needle in ["openhuman", "openai", "cohere"] {
+        assert!(
+            haystack.contains(needle),
+            "test probe destinations must list `{needle}` — without it the \
+             Privacy surface under-reports when that provider is selected. \
+             Current destinations: {:?}",
+            privacy.destinations
+        );
+    }
+    // The "custom OpenAI-compatible" path is a real provider option in
+    // #2583 — listed as `custom:<url>` in `create_embedding_provider`.
+    assert!(
+        haystack.contains("custom") || haystack.contains("user-configured"),
+        "test probe destinations must acknowledge user-configured custom \
+         endpoints. Current destinations: {:?}",
+        privacy.destinations
+    );
+
+    // Belt-and-braces: at least 4 distinct destinations (managed +
+    // openai + cohere + custom). A drop below this means someone
+    // collapsed entries.
+    assert!(
+        privacy.destinations.len() >= 4,
+        "expected ≥4 destinations covering managed + openai + cohere + custom, \
+         got {}: {:?}",
+        privacy.destinations.len(),
+        privacy.destinations
     );
 }

--- a/src/openhuman/about_app/catalog_tests.rs
+++ b/src/openhuman/about_app/catalog_tests.rs
@@ -103,6 +103,8 @@ fn catalog_includes_additional_user_facing_surfaces() {
         "intelligence.mcp_server",
         "intelligence.searxng_search",
         "intelligence.tool_registry",
+        "intelligence.embedding_provider_config",
+        "intelligence.embedding_provider_test",
         "conversation.subagent_mascots",
     ] {
         assert!(
@@ -110,4 +112,69 @@ fn catalog_includes_additional_user_facing_surfaces() {
             "missing catalog capability `{expected}`"
         );
     }
+}
+
+/// The two embeddings entries surface a Settings-side configuration panel.
+/// They share the same domain (`embeddings`) but are listed under the
+/// Intelligence umbrella so they sit next to memory_tree_retrieval / mcp_server
+/// in the in-app feature catalog. Pinning the relationships here defends
+/// against an inadvertent recategorisation that would split them across the
+/// UI's tab grouping.
+#[test]
+fn embedding_provider_capabilities_share_domain_and_category() {
+    let config = lookup("intelligence.embedding_provider_config")
+        .expect("embedding_provider_config registered");
+    let test =
+        lookup("intelligence.embedding_provider_test").expect("embedding_provider_test registered");
+
+    assert_eq!(config.domain, "embeddings");
+    assert_eq!(test.domain, "embeddings");
+    assert_eq!(
+        config.category, test.category,
+        "both embedding capabilities must land in the same UI category"
+    );
+
+    // The Settings panel they describe is the same one — make sure the
+    // `how_to` strings point at it, not at an out-of-date breadcrumb.
+    assert!(
+        config.how_to.contains("Settings") && config.how_to.contains("Embeddings"),
+        "config how_to must mention Settings > … > Embeddings, got: {}",
+        config.how_to
+    );
+    assert!(
+        test.how_to.contains("Settings") && test.how_to.contains("Embeddings"),
+        "test how_to must mention Settings > … > Embeddings, got: {}",
+        test.how_to
+    );
+}
+
+/// Privacy annotations must split cleanly: the config side touches only the
+/// local keyring (LOCAL_CREDENTIALS — leaves_device=false), the test side
+/// fires a probe at the configured provider (DERIVED_TO_BACKEND —
+/// leaves_device=true). Without this split, a single `None` privacy flag
+/// would force the UI to treat the embeddings panel as "unknown" and the
+/// Privacy surface would under-report where data goes when the test button
+/// gets clicked.
+#[test]
+fn embedding_provider_capabilities_split_privacy_correctly() {
+    let config = lookup("intelligence.embedding_provider_config")
+        .expect("embedding_provider_config registered");
+    let test =
+        lookup("intelligence.embedding_provider_test").expect("embedding_provider_test registered");
+
+    let config_privacy = config
+        .privacy
+        .expect("config capability has privacy annotation");
+    assert!(
+        !config_privacy.leaves_device,
+        "configuration writes only to local keyring; nothing should leave the device"
+    );
+
+    let test_privacy = test
+        .privacy
+        .expect("test capability has privacy annotation");
+    assert!(
+        test_privacy.leaves_device,
+        "test fires a probe at the configured provider — must report as leaves_device"
+    );
 }


### PR DESCRIPTION
Closes the explicit follow-up listed in #2583's PR body:
> Follow-up: about_app capability catalog entries for embeddings provider selection

#2583 added **Settings > AI > Embeddings** — users can now pick between managed cloud (Voyage), OpenAI, Cohere, local Ollama, or a custom OpenAI-compatible endpoint, with per-provider API key + model + dimension knobs. The in-app feature catalog (\`about_app::catalog\`) is how those affordances become discoverable to:
- **Users** via Settings search
- **Agents** via \`openhuman.about_app_capabilities\` RPC
- **The Privacy surface** via per-capability \`privacy\` metadata

Without an entry, the new panel is invisible to that whole layer.

## What's added

Two capability records under the new \`embeddings\` domain, slotted into the **Intelligence** category so they sit alongside \`memory_tree_retrieval\` / \`mcp_server\` rather than getting orphaned in a fresh domain bucket.

| ID | Privacy | What it covers |
| --- | --- | --- |
| \`intelligence.embedding_provider_config\` | \`LOCAL_CREDENTIALS\` (\`leaves_device = false\`) | The Settings panel itself — provider selection, API key entry (encrypted local keyring under \`embeddings:<slug>\`), model / dimension knobs. |
| \`intelligence.embedding_provider_test\` | \`DERIVED_TO_BACKEND\` (\`leaves_device = true\`) | The \"Test Connection\" action — fires a small probe at the configured provider before committing it to ingestion. |

The privacy split matters: the in-app Privacy surface aggregates per-capability annotations to answer *\"what leaves my computer when I touch this screen?\"*. Collapsing both into one annotation under-reports the probe-time network call.

## Tests

3 new tests added to \`src/openhuman/about_app/catalog_tests.rs\`, all 23/23 pass:

- \`catalog_includes_additional_user_facing_surfaces\` — extended with both new ids.
- \`embedding_provider_capabilities_share_domain_and_category\` — pins both to \`domain = \"embeddings\"\`, asserts same category, and pins the \`how_to\` breadcrumbs at \"Settings > … > Embeddings\" so a UI rename surfaces here.
- \`embedding_provider_capabilities_split_privacy_correctly\` — asserts config has \`leaves_device == false\` and test has \`leaves_device == true\`. Defends against an accidental consolidation that would flatten the two privacy signals.

## Test plan

- [x] \`cargo test --lib about_app\` — **23/23 pass** (was 20, +3 new).
- [x] \`cargo check --lib\` — clean.
- [x] \`cargo test --tests --no-run\` — clean (no integration-test fallout, lesson from #2603 where I missed an integration-test fixture).
- [x] \`cargo fmt --check\` — clean.

Pure metadata addition — no production-code change beyond two new const records and a regression test trio.

Refs #2583.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added embedding provider configuration with local credential handling.
  * Added an embedding-provider test ("Test Connection") that can reach managed cloud, OpenAI, Cohere, and custom endpoints.
  * Clarified in-app descriptions and guidance under Settings → Embeddings.

* **Tests**
  * Added tests validating embedding capability metadata, domain/category alignment, and privacy annotations/destinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->