### PR TITLE
fix(settings): blur recovery phrase by default

### DIFF
--- a/app/src/components/settings/panels/RecoveryPhrasePanel.test.tsx
+++ b/app/src/components/settings/panels/RecoveryPhrasePanel.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RecoveryPhrasePanel from './RecoveryPhrasePanel';
+
+const navigateBackMock = vi.fn();
+
+vi.mock('../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack: navigateBackMock,
+    breadcrumbs: [],
+  }),
+}));
+
+vi.mock('../../../lib/i18n/I18nContext', () => ({
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../../providers/CoreStateProvider', () => ({
+  useCoreState: () => ({
+    snapshot: { currentUser: { id: 'test-user', publicKey: 'test-pubkey' } },
+    setEncryptionKey: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/SettingsHeader', () => ({
+  default: ({ title, description }: { title: string; description?: string }) => (
+    <div data-testid="settings-header">
+      {title} - {description}
+    </div>
+  ),
+}));
+
+vi.mock('../../../features/wallet/setupLocalWalletFromMnemonic', () => ({
+  persistLocalWalletFromMnemonic: vi.fn(),
+}));
+
+describe('<RecoveryPhrasePanel />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initially hides the recovery phrase and reveals it when clicking the reveal button', () => {
+    render(<RecoveryPhrasePanel />);
+
+    const copyButton = screen.getByText('mnemonic.copyToClipboard').closest('button')!;
+    expect(copyButton).toBeDisabled();
+
+    const revealButton = screen.getByLabelText('mnemonic.revealPhrase');
+    expect(revealButton).toBeInTheDocument();
+    
+    fireEvent.click(revealButton);
+
+    expect(screen.queryByLabelText('mnemonic.revealPhrase')).not.toBeInTheDocument();
+    expect(copyButton).not.toBeDisabled();
+  });
+});

--- a/app/src/components/settings/panels/RecoveryPhrasePanel.test.tsx
+++ b/app/src/components/settings/panels/RecoveryPhrasePanel.test.tsx
@@ -6,15 +6,10 @@ import RecoveryPhrasePanel from './RecoveryPhrasePanel';
 const navigateBackMock = vi.fn();
 
 vi.mock('../hooks/useSettingsNavigation', () => ({
-  useSettingsNavigation: () => ({
-    navigateBack: navigateBackMock,
-    breadcrumbs: [],
-  }),
+  useSettingsNavigation: () => ({ navigateBack: navigateBackMock, breadcrumbs: [] }),
 }));
 
-vi.mock('../../../lib/i18n/I18nContext', () => ({
-  useT: () => ({ t: (key: string) => key }),
-}));
+vi.mock('../../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (key: string) => key }) }));
 
 vi.mock('../../../providers/CoreStateProvider', () => ({
   useCoreState: () => ({
@@ -48,7 +43,7 @@ describe('<RecoveryPhrasePanel />', () => {
 
     const revealButton = screen.getByLabelText('mnemonic.revealPhrase');
     expect(revealButton).toBeInTheDocument();
-    
+
     fireEvent.click(revealButton);
 
     expect(screen.queryByLabelText('mnemonic.revealPhrase')).not.toBeInTheDocument();

--- a/app/src/components/settings/panels/RecoveryPhrasePanel.tsx
+++ b/app/src/components/settings/panels/RecoveryPhrasePanel.tsx
@@ -27,6 +27,7 @@ const RecoveryPhrasePanel = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [revealed, setRevealed] = useState(false);
 
   const mnemonic = useMemo(() => generateMnemonicPhrase(), []);
   const words = useMemo(() => mnemonic.split(' '), [mnemonic]);
@@ -255,8 +256,14 @@ const RecoveryPhrasePanel = () => {
                     </div>
                   </div>
 
-                  <div className="bg-stone-50 dark:bg-neutral-800/60 rounded-2xl p-4 mb-4 border border-stone-200 dark:border-neutral-800">
-                    <div className="grid grid-cols-3 gap-2">
+                  <div className="bg-stone-50 dark:bg-neutral-800/60 rounded-2xl p-4 mb-4 border border-stone-200 dark:border-neutral-800 relative">
+                    <div
+                      className="grid grid-cols-3 gap-2 transition-all duration-300"
+                      style={{
+                        filter: revealed ? 'none' : 'blur(8px)',
+                        userSelect: revealed ? 'auto' : 'none',
+                        pointerEvents: revealed ? 'auto' : 'none',
+                      }}>
                       {words.map((word, index) => (
                         <div
                           key={index}
@@ -268,11 +275,33 @@ const RecoveryPhrasePanel = () => {
                         </div>
                       ))}
                     </div>
+                    {!revealed && (
+                      <button
+                        type="button"
+                        onClick={() => setRevealed(true)}
+                        aria-label="Reveal recovery phrase"
+                        className="absolute inset-0 flex items-center justify-center cursor-pointer bg-transparent">
+                        <svg
+                          className="w-7 h-7 text-stone-900 dark:text-white transition-opacity duration-200 hover:opacity-70"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={1.5}>
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"
+                          />
+                          <line x1="1" y1="1" x2="23" y2="23" />
+                        </svg>
+                      </button>
+                    )}
                   </div>
 
                   <button
                     onClick={handleCopy}
-                    className="w-full flex items-center justify-center gap-2 border border-stone-200 dark:border-neutral-800 hover:border-stone-300 dark:border-neutral-700 dark:hover:border-neutral-700 font-medium py-2.5 text-sm rounded-xl text-stone-700 dark:text-neutral-200 transition-all duration-200 mb-3">
+                    disabled={!revealed}
+                    className="w-full flex items-center justify-center gap-2 border border-stone-200 dark:border-neutral-800 hover:border-stone-300 dark:border-neutral-700 dark:hover:border-neutral-700 font-medium py-2.5 text-sm rounded-xl text-stone-700 dark:text-neutral-200 transition-all duration-200 mb-3 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-stone-200 dark:disabled:hover:border-neutral-800">
                     {copied ? (
                       <>
                         <svg

--- a/app/src/components/settings/panels/RecoveryPhrasePanel.tsx
+++ b/app/src/components/settings/panels/RecoveryPhrasePanel.tsx
@@ -279,7 +279,7 @@ const RecoveryPhrasePanel = () => {
                       <button
                         type="button"
                         onClick={() => setRevealed(true)}
-                        aria-label="Reveal recovery phrase"
+                        aria-label={t('mnemonic.revealPhrase')}
                         className="absolute inset-0 flex items-center justify-center cursor-pointer bg-transparent">
                         <svg
                           className="w-7 h-7 text-stone-900 dark:text-white transition-opacity duration-200 hover:opacity-70"

--- a/app/src/lib/i18n/chunks/ar-1.ts
+++ b/app/src/lib/i18n/chunks/ar-1.ts
@@ -359,6 +359,7 @@ const ar1: TranslationMap = {
     'لا تشارك عبارة الاسترداد أبدًا. أي شخص يمتلك هذه الكلمات يمكنه الوصول إلى حسابك.',
   'mnemonic.copied': 'تم نسخ عبارة الاسترداد إلى الحافظة',
   'mnemonic.reveal': 'الكشف عن العبارة',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'عبارة الاسترداد مخفية',
   'privacy.title': 'الخصوصية والأمان',
   'privacy.description': 'تقرير شفافية البيانات المُرسَلة إلى الخدمات الخارجية.',

--- a/app/src/lib/i18n/chunks/bn-1.ts
+++ b/app/src/lib/i18n/chunks/bn-1.ts
@@ -366,6 +366,7 @@ const bn1: TranslationMap = {
     'আপনার রিকভারি ফ্রেজ কখনো শেয়ার করবেন না। এই শব্দগুলো দিয়ে যে কেউ আপনার অ্যাকাউন্টে প্রবেশ করতে পারবে।',
   'mnemonic.copied': 'রিকভারি ফ্রেজ ক্লিপবোর্ডে কপি হয়েছে',
   'mnemonic.reveal': 'ফ্রেজ দেখুন',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'রিকভারি ফ্রেজ লুকানো আছে',
   'privacy.title': 'গোপনীয়তা ও নিরাপত্তা',
   'privacy.description': 'বাহ্যিক সার্ভিসে পাঠানো ডেটার স্বচ্ছতা রিপোর্ট।',

--- a/app/src/lib/i18n/chunks/de-1.ts
+++ b/app/src/lib/i18n/chunks/de-1.ts
@@ -412,6 +412,7 @@ const de1: TranslationMap = {
     'Gib niemals deine Wiederherstellungsphrase weiter. Jeder mit diesen Wörtern kann auf dein Konto zugreifen.',
   'mnemonic.copied': 'Wiederherstellungsphrase in die Zwischenablage kopiert',
   'mnemonic.reveal': 'Satz enthüllen',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'Die Wiederherstellungsphrase ist ausgeblendet',
   'privacy.title': 'Datenschutz und Sicherheit',
   'privacy.description': 'Transparenzbericht der an externe Dienste gesendeten Daten.',

--- a/app/src/lib/i18n/chunks/en-1.ts
+++ b/app/src/lib/i18n/chunks/en-1.ts
@@ -881,6 +881,7 @@ const en1: TranslationMap = {
     'Never share your recovery phrase. Anyone with these words can access your account.',
   'mnemonic.copied': 'Recovery phrase copied to clipboard',
   'mnemonic.reveal': 'Reveal phrase',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'Recovery phrase is hidden',
   'privacy.title': 'Privacy & Security',
   'privacy.description': 'Transparency report of data sent to external services.',

--- a/app/src/lib/i18n/chunks/es-1.ts
+++ b/app/src/lib/i18n/chunks/es-1.ts
@@ -374,6 +374,7 @@ const es1: TranslationMap = {
     'Nunca compartas tu frase de recuperación. Cualquiera con estas palabras puede acceder a tu cuenta.',
   'mnemonic.copied': 'Frase de recuperación copiada al portapapeles',
   'mnemonic.reveal': 'Mostrar frase',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'La frase de recuperación está oculta',
   'privacy.title': 'Privacidad y seguridad',
   'privacy.description': 'Informe de transparencia de datos enviados a servicios externos.',

--- a/app/src/lib/i18n/chunks/fr-1.ts
+++ b/app/src/lib/i18n/chunks/fr-1.ts
@@ -375,6 +375,7 @@ const fr1: TranslationMap = {
     'Ne partage jamais ta phrase de récupération. Toute personne disposant de ces mots peut accéder à ton compte.',
   'mnemonic.copied': 'Phrase de récupération copiée dans le presse-papiers',
   'mnemonic.reveal': 'Afficher la phrase',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'La phrase de récupération est masquée',
   'privacy.title': 'Confidentialité & Sécurité',
   'privacy.description': 'Rapport de transparence sur les données envoyées aux services externes.',

--- a/app/src/lib/i18n/chunks/hi-1.ts
+++ b/app/src/lib/i18n/chunks/hi-1.ts
@@ -363,6 +363,7 @@ const hi1: TranslationMap = {
     'रिकवरी फ्रेज़ कभी किसी से शेयर न करें। इन शब्दों से कोई भी आपका अकाउंट एक्सेस कर सकता है।',
   'mnemonic.copied': 'रिकवरी फ्रेज़ क्लिपबोर्ड पर कॉपी हो गया',
   'mnemonic.reveal': 'फ्रेज़ दिखाएं',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'रिकवरी फ्रेज़ छुपी हुई है',
   'privacy.title': 'प्राइवेसी और सिक्योरिटी',
   'privacy.description': 'बाहरी सर्विसेज़ को भेजे गए डेटा की ट्रांसपेरेंसी रिपोर्ट।',

--- a/app/src/lib/i18n/chunks/id-1.ts
+++ b/app/src/lib/i18n/chunks/id-1.ts
@@ -366,6 +366,7 @@ const id1: TranslationMap = {
     'Jangan pernah membagikan frasa pemulihan. Siapa pun yang memiliki kata-kata ini dapat mengakses akun Anda.',
   'mnemonic.copied': 'Frasa pemulihan disalin ke clipboard',
   'mnemonic.reveal': 'Tampilkan frasa',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'Frasa pemulihan disembunyikan',
   'privacy.title': 'Privasi & Keamanan',
   'privacy.description': 'Laporan transparansi data yang dikirim ke layanan eksternal.',

--- a/app/src/lib/i18n/chunks/it-1.ts
+++ b/app/src/lib/i18n/chunks/it-1.ts
@@ -370,6 +370,7 @@ const it1: TranslationMap = {
     'Non condividere mai la tua frase di recupero. Chiunque abbia queste parole può accedere al tuo account.',
   'mnemonic.copied': 'Frase di recupero copiata negli appunti',
   'mnemonic.reveal': 'Mostra frase',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'La frase di recupero è nascosta',
   'privacy.title': 'Privacy e sicurezza',
   'privacy.description': 'Report di trasparenza sui dati inviati a servizi esterni.',

--- a/app/src/lib/i18n/chunks/ko-1.ts
+++ b/app/src/lib/i18n/chunks/ko-1.ts
@@ -366,6 +366,7 @@ const ko1: TranslationMap = {
     '복구 문구를 절대 공유하지 마세요. 이 단어를 가진 사람은 누구나 계정에 접근할 수 있습니다.',
   'mnemonic.copied': '복구 문구가 클립보드에 복사되었습니다',
   'mnemonic.reveal': '문구 보기',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': '복구 문구가 숨겨져 있습니다',
   'privacy.title': '개인정보 및 보안',
   'privacy.description': '외부 서비스로 전송되는 데이터에 대한 투명성 보고서입니다.',

--- a/app/src/lib/i18n/chunks/pt-1.ts
+++ b/app/src/lib/i18n/chunks/pt-1.ts
@@ -374,6 +374,7 @@ const pt1: TranslationMap = {
     'Nunca compartilhe sua frase de recuperação. Qualquer pessoa com essas palavras pode acessar sua conta.',
   'mnemonic.copied': 'Frase de recuperação copiada para a área de transferência',
   'mnemonic.reveal': 'Revelar frase',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'Frase de recuperação está oculta',
   'privacy.title': 'Privacidade e Segurança',
   'privacy.description': 'Relatório de transparência de dados enviados a serviços externos.',

--- a/app/src/lib/i18n/chunks/ru-1.ts
+++ b/app/src/lib/i18n/chunks/ru-1.ts
@@ -366,6 +366,7 @@ const ru1: TranslationMap = {
     'Никогда не делись фразой восстановления. Любой, кто её знает, получит доступ к твоему аккаунту.',
   'mnemonic.copied': 'Фраза восстановления скопирована в буфер обмена',
   'mnemonic.reveal': 'Показать фразу',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'Фраза восстановления скрыта',
   'privacy.title': 'Конфиденциальность и безопасность',
   'privacy.description': 'Отчёт о данных, отправляемых во внешние сервисы.',

--- a/app/src/lib/i18n/chunks/zh-CN-1.ts
+++ b/app/src/lib/i18n/chunks/zh-CN-1.ts
@@ -362,6 +362,7 @@ const zhCN1: TranslationMap = {
   'mnemonic.copyWarning': '永远不要分享你的恢复短语。任何拥有这些单词的人都可以访问你的账户。',
   'mnemonic.copied': '恢复短语已复制到剪贴板',
   'mnemonic.reveal': '显示短语',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': '恢复短语已隐藏',
   'privacy.title': '隐私与安全',
   'privacy.description': '发送到外部服务的数据透明度报告。',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -549,6 +549,7 @@ const en: TranslationMap = {
     'Never share your recovery phrase. Anyone with these words can access your account.',
   'mnemonic.copied': 'Recovery phrase copied to clipboard',
   'mnemonic.reveal': 'Reveal phrase',
+  'mnemonic.revealPhrase': 'Reveal recovery phrase',
   'mnemonic.hidden': 'Recovery phrase is hidden',
 
   // What Leaves My Computer


### PR DESCRIPTION
Fixes #2657 

### Added a default blur/reveal flow for the recovery phrase screen in RecoveryPhrasePanel.tsx.

- recovery phrase is now blurred by default
- pointer events are disabled while hidden
- added centered eye-slash reveal overlay
- reveal is one-way and requires explicit user action
- disabled “Copy to Clipboard” until the phrase is revealed
- copy button now fades and shows the not-allowed cursor while locked

This prevents the recovery phrase from being visible or copied immediately when opening the panel.

### Screenshots

<img width="725" height="1071" alt="image" src="https://github.com/user-attachments/assets/a7e436d8-d00a-4011-8070-cda6f69c4ccc" />
<img width="712" height="1055" alt="image" src="https://github.com/user-attachments/assets/2377e569-a899-40c3-ad47-ff1b62cade9f" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery phrase is blurred and non-interactive by default in generate mode; users can reveal it with a new "Reveal recovery phrase" control.
  * Copy-to-clipboard is disabled until the phrase is revealed; disabled styling updated for improved clarity.

* **Chores**
  * Added "Reveal recovery phrase" translation entries across multiple language files to enable localization.

* **Tests**
  * UI test added to verify reveal behavior and that the copy button becomes enabled after reveal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->