### PR TITLE
fix(tauri): harden Windows pre-CEF single-instance mutex handling

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2230,8 +2230,34 @@ pub fn run() {
 
         // SAFETY: mutex_name is null-terminated UTF-16; handle is checked below.
         let handle = unsafe { CreateMutexW(std::ptr::null(), 0, mutex_name.as_ptr()) };
+        // Capture GetLastError immediately after CreateMutexW so no intervening
+        // syscall (e.g. logging) can clobber the thread-local error code.
+        let last_error = unsafe { GetLastError() };
 
-        if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+        // Primary: hold the handle until run() returns.
+        struct OwnedMutex(isize);
+        impl Drop for OwnedMutex {
+            fn drop(&mut self) {
+                if self.0 != 0 {
+                    unsafe { CloseHandle(self.0 as _) };
+                }
+            }
+        }
+
+        if handle.is_null() {
+            // CreateMutexW failed for a reason other than "already exists"
+            // (which returns a valid handle plus ERROR_ALREADY_EXISTS). Likely
+            // causes: out-of-memory, security-descriptor fault, or other
+            // Win32-level anomaly. Without the guard, a concurrent second
+            // launch can re-trigger the cef::initialize panic this block was
+            // added to prevent — but refusing to start at all is strictly
+            // worse for the user. Log loudly so the failure is observable in
+            // Sentry / log files and continue best-effort.
+            log::error!(
+                "[single-instance] CreateMutexW returned NULL handle (GetLastError={last_error}); continuing without pre-CEF single-instance guard — concurrent launches may hit OPENHUMAN-TAURI-A"
+            );
+            OwnedMutex(0)
+        }else if last_error == ERROR_ALREADY_EXISTS {
             // Another instance is already past this point — exit before we
             // touch CEF at all. Forward deep links first so OAuth callbacks
             // are not dropped by this early pre-plugin exit.
@@ -2244,25 +2270,14 @@ pub fn run() {
                     );
                 }
             }
-            if !handle.is_null() {
-                unsafe { CloseHandle(handle) };
-            }
+            unsafe { CloseHandle(handle) };
             log::info!(
                 "[single-instance] pre-CEF mutex held by primary; secondary exiting (OPENHUMAN-TAURI-A fix)"
             );
             std::process::exit(0);
+        } else {
+            OwnedMutex(handle as isize)
         }
-
-        // Primary: hold the handle until run() returns.
-        struct OwnedMutex(isize);
-        impl Drop for OwnedMutex {
-            fn drop(&mut self) {
-                if self.0 != 0 {
-                    unsafe { CloseHandle(self.0 as _) };
-                }
-            }
-        }
-        OwnedMutex(handle as isize)
     };
 
     #[cfg(windows)]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2257,7 +2257,7 @@ pub fn run() {
                 "[single-instance] CreateMutexW returned NULL handle (GetLastError={last_error}); continuing without pre-CEF single-instance guard — concurrent launches may hit OPENHUMAN-TAURI-A"
             );
             OwnedMutex(0)
-        }else if last_error == ERROR_ALREADY_EXISTS {
+        } else if last_error == ERROR_ALREADY_EXISTS {
             // Another instance is already past this point — exit before we
             // touch CEF at all. Forward deep links first so OAuth callbacks
             // are not dropped by this early pre-plugin exit.


### PR DESCRIPTION
## Summary

- Hardens the Windows pre-CEF single-instance guard in app/src-tauri/src/lib.rs to better handle Win32 edge cases.

- Captures GetLastError() immediately after CreateMutexW so the mutex result cannot be clobbered by later calls.

- Adds explicit CreateMutexW == NULL handling with an error log and best-effort continuation.

- Preserves existing secondary-instance early-exit behavior (ERROR_ALREADY_EXISTS) and deep-link forwarding path.

## Problem

- On Windows, this guard exists to prevent secondary launches from reaching cef::initialize() and triggering the known panic path (OPENHUMAN-TAURI-A).

- The previous logic relied on reading GetLastError() inline and did not explicitly handle a NULL mutex handle path with strong observability.

- That made rare Win32 failure modes harder to diagnose and increased risk of unclear startup behavior during concurrency.

## Solution

- Read and store last_error immediately after CreateMutexW.

- Branch explicitly for handle.is_null(), log the Win32 error, and continue startup best-effort rather than crashing early.

- Keep the ERROR_ALREADY_EXISTS branch as the authoritative secondary-instance exit path, including deep-link forwarding attempt before exit.

- Retain RAII mutex ownership for the primary instance so handle lifetime is clean and deterministic.

## Submission Checklist

- If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.

- Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy

- Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.

- Coverage matrix updated — added/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md` reflect this change (or N/A: behaviour-only change)

- All affected feature IDs from the matrix are listed in the PR description under ## Related

- No new external network dependencies introduced (mock backend used per Testing Strategy)

- Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`)

- Linked issue closed via Closes #NNN in the ## Related section

## Impact

- Platform/runtime: Windows desktop Tauri startup path only; no intended behavior change on macOS/Linux.

- Security/compatibility: improves failure observability and startup robustness; no API or config migration required.

- Performance: negligible (one extra error-code capture and logging only on failure path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Windows single-instance enforcement to prevent application crashes when multiple instances attempt to launch simultaneously. Enhanced logging and resource management for better stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->