### PR TITLE
fix(e2e/oauth): gate Redux store exposure and fix loopback listener timeout race

### DIFF
--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -11,7 +11,7 @@ import {
   REHYDRATE,
 } from 'redux-persist';
 
-import { IS_DEV } from '../utils/config';
+import { E2E_RESTART_APP_AS_RELOAD, IS_DEV } from '../utils/config';
 import accountsReducer from './accountsSlice';
 import agentProfileReducer from './agentProfileSlice';
 import channelConnectionsReducer from './channelConnectionsSlice';
@@ -183,10 +183,12 @@ export const store = configureStore({
 export const persistor = persistStore(store);
 
 // Expose the store on `window` so WDIO E2E specs can read Redux state directly
-// to assert backing-state changes (see app/test/e2e/specs/*.spec.ts). The store
-// holds no secrets that aren't already in the renderer's memory; this only
-// surfaces the existing handle under a stable, namespaced key.
-if (typeof window !== 'undefined') {
+// to assert backing-state changes (see app/test/e2e/specs/*.spec.ts). Gated on
+// the E2E build flag (`VITE_OPENHUMAN_E2E_RESTART_APP_AS_RELOAD`, baked by
+// `app/scripts/e2e-build.sh`) so shipped production bundles do NOT expose the
+// store handle — denying a same-origin attacker (compromised CDN, supply-chain
+// asset, XSS) a one-call read/mutate path into full Redux state.
+if (typeof window !== 'undefined' && (IS_DEV || E2E_RESTART_APP_AS_RELOAD)) {
   (window as unknown as { __OPENHUMAN_STORE__?: typeof store }).__OPENHUMAN_STORE__ = store;
 }
 

--- a/app/src/utils/__tests__/loopbackOauthListener.test.ts
+++ b/app/src/utils/__tests__/loopbackOauthListener.test.ts
@@ -133,16 +133,25 @@ describe('startLoopbackOauthListener', () => {
 describe('E2E build hook', () => {
   // Top-level side effect in loopbackOauthListener.ts: when the
   // VITE_OPENHUMAN_E2E_RESTART_APP_AS_RELOAD flag is set to 'true' at
-  // build time, the module exposes startLoopbackOauthListener on
+  // build time (surfaced via the `E2E_RESTART_APP_AS_RELOAD` constant in
+  // utils/config.ts per the CLAUDE.md "no direct import.meta.env" rule),
+  // the module exposes startLoopbackOauthListener on
   // window.__startLoopbackOauthListener so E2E spec helpers can drive
   // the real loopback flow. Exercise both branches so the conditional
   // assignment is covered.
+  //
+  // We mock `../config` directly rather than `vi.stubEnv` + `vi.resetModules`
+  // because the gate is now a derived constant, not a live read of
+  // `import.meta.env`. Stubbing the env after the module graph has already
+  // been loaded does not flip the already-evaluated constant unless EVERY
+  // transitive importer is also reset, which is brittle. Mocking the module
+  // export is direct and resilient to refactors of how the flag is derived.
 
   type WithE2eHook = Window & { __startLoopbackOauthListener?: typeof startLoopbackOauthListener };
 
   test('exposes __startLoopbackOauthListener on window when the E2E build flag is set', async () => {
     vi.resetModules();
-    vi.stubEnv('VITE_OPENHUMAN_E2E_RESTART_APP_AS_RELOAD', 'true');
+    vi.doMock('../config', () => ({ E2E_RESTART_APP_AS_RELOAD: true }));
     delete (window as WithE2eHook).__startLoopbackOauthListener;
     try {
       const mod = await import('../loopbackOauthListener');
@@ -150,20 +159,20 @@ describe('E2E build hook', () => {
         mod.startLoopbackOauthListener
       );
     } finally {
-      vi.unstubAllEnvs();
+      vi.doUnmock('../config');
       delete (window as WithE2eHook).__startLoopbackOauthListener;
     }
   });
 
   test('does NOT expose the hook when the E2E build flag is absent', async () => {
     vi.resetModules();
-    vi.stubEnv('VITE_OPENHUMAN_E2E_RESTART_APP_AS_RELOAD', '');
+    vi.doMock('../config', () => ({ E2E_RESTART_APP_AS_RELOAD: false }));
     delete (window as WithE2eHook).__startLoopbackOauthListener;
     try {
       await import('../loopbackOauthListener');
       expect((window as WithE2eHook).__startLoopbackOauthListener).toBeUndefined();
     } finally {
-      vi.unstubAllEnvs();
+      vi.doUnmock('../config');
       delete (window as WithE2eHook).__startLoopbackOauthListener;
     }
   });

--- a/app/src/utils/__tests__/loopbackOauthListener.test.ts
+++ b/app/src/utils/__tests__/loopbackOauthListener.test.ts
@@ -122,7 +122,7 @@ describe('startLoopbackOauthListener', () => {
 
       await expect(callbackPromise).rejects.toThrow('Loopback OAuth listener timed out');
       expect(unlisten).toHaveBeenCalledTimes(1);
-      // Drain the queued microtask that calls stop().
+      // Drain the queued microtask that calls stop()
       await Promise.resolve();
       expect(mockInvoke).toHaveBeenNthCalledWith(2, 'stop_loopback_oauth_listener');
 

--- a/app/src/utils/__tests__/loopbackOauthListener.test.ts
+++ b/app/src/utils/__tests__/loopbackOauthListener.test.ts
@@ -109,7 +109,8 @@ describe('startLoopbackOauthListener', () => {
     try {
       mockInvoke
         .mockResolvedValueOnce({ redirectUri: 'http://127.0.0.1:53824/auth', state: 's' })
-        .mockResolvedValueOnce(undefined);
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ redirectUri: 'http://127.0.0.1:53824/auth', state: 's2' });
       const unlisten = vi.fn();
       mockListen.mockResolvedValue(unlisten);
 
@@ -124,6 +125,79 @@ describe('startLoopbackOauthListener', () => {
       // Drain the queued microtask that calls stop().
       await Promise.resolve();
       expect(mockInvoke).toHaveBeenNthCalledWith(2, 'stop_loopback_oauth_listener');
+
+      // Ensure timeout cleanup removed activeUnlisten (starting a new listener
+      // should not invoke the previous unlisten again).
+      await startLoopbackOauthListener();
+      expect(unlisten).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('tears down late listen registration when timeout fires before listen() resolves', async () => {
+    vi.useFakeTimers();
+    try {
+      mockInvoke
+        .mockResolvedValueOnce({ redirectUri: 'http://127.0.0.1:53824/auth', state: 's' })
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ redirectUri: 'http://127.0.0.1:53824/auth', state: 's2' });
+
+      let resolveListen: ((fn: () => void) => void) | null = null;
+      const lateUnlisten = vi.fn();
+      mockListen.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveListen = resolve;
+          })
+      );
+
+      const handle = await startLoopbackOauthListener({ timeoutSecs: 1 });
+      const callbackPromise = handle!.awaitCallback();
+      vi.advanceTimersByTime(1000);
+
+      await expect(callbackPromise).rejects.toThrow('Loopback OAuth listener timed out');
+      await Promise.resolve();
+      expect(mockInvoke).toHaveBeenNthCalledWith(2, 'stop_loopback_oauth_listener');
+
+      // listen() resolves after timeout: the returned unlisten must be called
+      // immediately and must not become the active global handle.
+      resolveListen!(lateUnlisten);
+      await Promise.resolve();
+      expect(lateUnlisten).toHaveBeenCalledTimes(1);
+
+      await startLoopbackOauthListener();
+      expect(lateUnlisten).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('ignores callback events that arrive after timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      mockInvoke
+        .mockResolvedValueOnce({ redirectUri: 'http://127.0.0.1:53824/auth', state: 's' })
+        .mockResolvedValueOnce(undefined);
+      const unlisten = vi.fn();
+      let registered: ((event: { payload: { url: string } }) => void) | null = null;
+      mockListen.mockImplementation((_event, handler) => {
+        registered = handler;
+        return Promise.resolve(unlisten);
+      });
+
+      const handle = await startLoopbackOauthListener({ timeoutSecs: 1 });
+      const callbackPromise = handle!.awaitCallback();
+      await Promise.resolve();
+      vi.advanceTimersByTime(1000);
+
+      await expect(callbackPromise).rejects.toThrow('Loopback OAuth listener timed out');
+      expect(unlisten).toHaveBeenCalledTimes(1);
+
+      // Late callback should be ignored by the timedOut guard.
+      registered!({ payload: { url: 'http://127.0.0.1:53824/auth?token=late&state=s' } });
+      await Promise.resolve();
+      expect(unlisten).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/app/src/utils/loopbackOauthListener.ts
+++ b/app/src/utils/loopbackOauthListener.ts
@@ -108,8 +108,8 @@ export const startLoopbackOauthListener = async (
       const timer = window.setTimeout(() => {
         timedOut = true;
         if (unlisten) {
-        unlisten();
-        if (activeUnlisten === unlisten) activeUnlisten = null;
+          unlisten();
+          if (activeUnlisten === unlisten) activeUnlisten = null;
         }
         void stop();
         reject(new Error('Loopback OAuth listener timed out'));

--- a/app/src/utils/loopbackOauthListener.ts
+++ b/app/src/utils/loopbackOauthListener.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 
+import { E2E_RESTART_APP_AS_RELOAD } from './config';
 import { isTauri } from './tauriCommands/common';
 
 /**
@@ -97,14 +98,25 @@ export const startLoopbackOauthListener = async (
 
   const awaitCallback = (): Promise<string> =>
     new Promise<string>((resolve, reject) => {
+      // `timedOut` closes the race where `setTimeout` fires *before* the async
+      // `listen()` registration resolves: previously the just-registered
+      // unlisten handle was stored in module-global `activeUnlisten` after the
+      // promise had already rejected, leaving the listener armed until the
+      // next `startLoopbackOauthListener` call cleaned it up.
+      let timedOut = false;
       let unlisten: UnlistenFn | null = null;
       const timer = window.setTimeout(() => {
-        if (unlisten) unlisten();
+        timedOut = true;
+        if (unlisten) {
+        unlisten();
+        if (activeUnlisten === unlisten) activeUnlisten = null;
+        }
         void stop();
         reject(new Error('Loopback OAuth listener timed out'));
       }, timeoutSecs * 1000);
 
       listen<CallbackPayload>(CALLBACK_EVENT, event => {
+        if (timedOut) return;
         window.clearTimeout(timer);
         if (unlisten) {
           unlisten();
@@ -113,10 +125,18 @@ export const startLoopbackOauthListener = async (
         resolve(event.payload.url);
       })
         .then(fn => {
+          if (timedOut) {
+            // Timer already rejected the promise — tear down the
+            // just-registered handle so it does not leak into
+            // `activeUnlisten` and stay armed past the timeout.
+            fn();
+            return;
+          }
           unlisten = fn;
           activeUnlisten = fn;
         })
         .catch(err => {
+          if (timedOut) return;
           window.clearTimeout(timer);
           reject(err);
         });
@@ -135,10 +155,7 @@ const appendState = (uri: string, state: string): string => {
 // emit + frontend listener) without scripting the OAuth button UI itself.
 // Gated on the E2E-mode VITE flag baked in by app/scripts/e2e-build.sh so it
 // never leaks into release bundles.
-if (
-  typeof window !== 'undefined' &&
-  import.meta.env.VITE_OPENHUMAN_E2E_RESTART_APP_AS_RELOAD === 'true'
-) {
+if (typeof window !== 'undefined' && E2E_RESTART_APP_AS_RELOAD) {
   type WithE2eHook = Window & { __startLoopbackOauthListener?: typeof startLoopbackOauthListener };
   (window as WithE2eHook).__startLoopbackOauthListener = startLoopbackOauthListener;
 }


### PR DESCRIPTION
## Summary

- Fixes a timeout-vs-listener-registration race in startLoopbackOauthListener() that could leave a stale listener active after promise rejection.
- Ensures late listener registration is immediately torn down if timeout already fired, and clears stale activeUnlisten references safely.
- Gates window.__OPENHUMAN_STORE__ exposure to dev/E2E-only builds instead of exposing it unconditionally in renderer runtime.
- Uses centralized config (E2E_RESTART_APP_AS_RELOAD) instead of direct import.meta.env checks in loopback OAuth listener code.

## Problem

- The Redux store handle was being attached to window whenever window existed, which created unnecessary production attack surface.
- Loopback OAuth callback setup had an async race: timeout could reject before listen() resolved, then the returned unlisten function could still be stored globally, leaving a leaked/armed listener.
- These issues affect security posture (store exposure) and correctness/stability (stale OAuth listener lifecycle).

## Solution

- Added IS_DEV || E2E_RESTART_APP_AS_RELOAD gating around global store exposure so production bundles do not publish the Redux store handle.
- Replaced direct env-flag checks with E2E_RESTART_APP_AS_RELOAD from config.ts to follow centralized config access conventions.
- Introduced a timedOut guard in loopback OAuth listener setup:timeout marks state and rejects once;
- callback path no-ops after timeout;
- post-timeout listen().then(fn) path immediately calls fn() instead of storing it;
- activeUnlisten is cleared only when the same handle is removed.

- Tradeoff: slightly more listener lifecycle code, but deterministic cleanup and safer behavior under timing edge cases.

## Submission Checklist

- If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.
- Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.
- Coverage matrix updated — added/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md` reflect this change (or N/A: behaviour-only change)
- All affected feature IDs from the matrix are listed in the PR description under ## Related
- No new external network dependencies introduced (mock backend used per Testing Strategy)
- Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`)
- Linked issue closed via Closes #NNN in the ## Related section

## Impact

- Runtime/platform: frontend renderer behavior used in desktop Tauri app; impacts OAuth loopback flow handling and E2E/dev test hooks.
- Security: reduces production exposure of global Redux store handle.
- Compatibility/migration: no config migration required; no API contract changes.
- Performance: negligible; extra branching only in listener lifecycle paths.

## Related

- N/A: No existing tracking issue; this PR hardens OAuth listener lifecycle and E2E/dev store exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth listener timeout handling to prevent resource leaks, avoid double-cleanup, and ignore callbacks arriving after timeouts.

* **Chores**
  * Strengthened unit and E2E tests for authentication edge cases and teardown behavior.
  * Reduced debug surface in production by restricting when internal runtime handles are exposed in the browser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->