### PR TITLE
fix(composio): log daily budget reset

### DIFF
--- a/src/openhuman/memory_sync/composio/providers/sync_state.rs
+++ b/src/openhuman/memory_sync/composio/providers/sync_state.rs
@@ -129,6 +129,13 @@ impl DailyBudget {
     pub fn record_requests(&mut self, n: u32) {
         let today = today_str();
         if self.date != today {
+            tracing::info!(
+                old_date = %self.date,
+                new_date = %today,
+                requests_used = self.requests_used,
+                limit = self.limit,
+                "[composio:sync-state] daily request budget reset"
+            );
             self.date = today;
             self.requests_used = 0;
         }


### PR DESCRIPTION
## Summary

- Add an explicit Composio sync-state log when the daily request budget rolls over to a new UTC day.
- Include the old date, new date, previous request count, and limit so operators can tell budget exhaustion recovered.
- Keep provider behavior unchanged: stale budgets still reset before the new request count is recorded.

## Problem

- #2437 item G notes that providers log when the daily request budget is exhausted, but there is no matching reset/resume log when the date changes.
- Without that rollover signal, support logs can make it unclear whether sync resumed on the next day or remained stuck behind a stale budget state.

## Solution

- Emit a non-sensitive `tracing::info!` event from `DailyBudget::record_requests` when the stored budget date differs from the current UTC date.
- Reuse the existing reset branch, so the existing date-rollover unit coverage exercises the changed line.
- Do not change the budget math, limits, persistence format, or provider scheduling.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — existing stale-date regression test covers the rollover branch.
- [x] **Diff coverage >= 80%** — changed lines are covered by `daily_budget_resets_on_date_change`; CI will run the full diff-cover gate.
- [x] Coverage matrix updated — N/A: behavior-only observability change, no feature row added or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature matrix row.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)).
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: this addresses only #2437 item G; the broader triage issue should stay open.

## Impact

- Runtime/platform: Rust core Composio memory-sync state only.
- Performance: negligible; one log event only when a stale budget rolls over to a new UTC day.
- Security/privacy: log fields are dates and counters only; no connection ids, item ids, tokens, or user content are emitted.
- Compatibility: no state schema, API, scheduling, or provider behavior changes.

## Related

- Refs #2437 (item G only)
- Follow-up PR(s)/TODOs: broader #2437 items A-F remain separate triage/design work.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `sunil/2437-composio-budget-reset-log`
- Commit SHA: `575e852207e939e58edb94f19a4dba753183c1fb`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no app files changed.
- [x] `pnpm typecheck` — N/A: no TypeScript files changed.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib sync_state::tests` — 13 passed.
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --check` — passed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri shell files changed.

### Validation Blocked
- `command:` `cargo test --manifest-path Cargo.toml memory_sync::composio::providers::sync_state::tests::daily_budget_resets_on_date_change -- --exact`
- `error:` Without `--lib`, Cargo compiled unrelated bins/integration tests and hit pre-existing crate/linkage issues such as `can't find crate for openhuman_core`, `found possibly newer version of crate windows_sys`, and `crate hound required to be available in rlib format`.
- `impact:` The focused library tests for the changed module pass; the blocked command did not reach this PR's test surface and is unrelated to the one-line observability change.

### Behavior Changes
- Intended behavior change: stale Composio daily budgets now emit an info log before they reset.
- User-visible effect: support/debug logs now show when a budget exhausted on a previous UTC day becomes available again.

### Parity Contract
- Legacy behavior preserved: date rollover still resets `requests_used` to zero before recording the new request count.
- Guard/fallback/dispatch parity checks: no provider dispatch, rate limit math, budget limit, or persistence schema changes.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for #2437 item G.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added informational logging for daily request budget reset tracking to improve system observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->