### PR TITLE
ci(release): add linux arm64 desktop artifacts

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -85,8 +85,7 @@ on:
         type: boolean
         default: false
       skip_pretests:
-        description:
-          Metadata-only flag propagated by caller workflows when they
+        description: Metadata-only flag propagated by caller workflows when they
           intentionally bypass the upstream pretest phase. This reusable build
           workflow does not execute pretests itself, but it logs the policy so
           the build run captures whether the normal release gate was relaxed for
@@ -124,6 +123,10 @@ jobs:
             args: --target x86_64-unknown-linux-gnu --bundles deb appimage
             target: x86_64-unknown-linux-gnu
             artifact_suffix: ubuntu
+          - platform: ubuntu-24.04-arm
+            args: --target aarch64-unknown-linux-gnu --bundles deb appimage
+            target: aarch64-unknown-linux-gnu
+            artifact_suffix: ubuntu-arm64
           - platform: windows-latest
             args: --target x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
@@ -162,7 +165,7 @@ jobs:
         with:
           targets: ${{ matrix.settings.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Install Tauri dependencies (ubuntu only)
-        if: matrix.settings.platform == 'ubuntu-24.04'
+        if: startsWith(matrix.settings.platform, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -458,7 +461,7 @@ jobs:
       # ensures this still runs when `cargo tauri build` failed at bundling
       # (the binary itself is produced before bundling starts).
       - name: Dump linked libraries of built binary (ubuntu debug)
-        if: always() && matrix.settings.platform == 'ubuntu-24.04'
+        if: always() && startsWith(matrix.settings.platform, 'ubuntu-')
         shell: bash
         env:
           PROFILE: ${{ inputs.build_profile }}
@@ -487,7 +490,7 @@ jobs:
       # untouched. Re-signs the AppImage + updater tarball when signing
       # is enabled.
       - name: Strip host graphics libs from AppImage
-        if: matrix.settings.platform == 'ubuntu-24.04'
+        if: startsWith(matrix.settings.platform, 'ubuntu-')
         shell: bash
         env:
           MATRIX_TARGET: ${{ matrix.settings.target }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -668,6 +668,10 @@ jobs:
               // Linux desktop installer consumed by scripts/install.sh and
               // advertised in latest.json as linux-x86_64.
               /OpenHuman_.*_amd64\.AppImage$/,
+              // Linux arm64 desktop installer consumed by scripts/install.sh
+              // and advertised in latest.json as linux-aarch64.
+              /OpenHuman_.*_(arm64|aarch64)\.AppImage$/,
+              /OpenHuman_.*_(arm64|aarch64)\.deb$/,
               // Auto-updater manifest — without this, installed clients can't
               // discover new releases via plugins.updater.endpoints.
               /^latest\.json$/,

--- a/scripts/fixtures/latest.json
+++ b/scripts/fixtures/latest.json
@@ -5,6 +5,10 @@
       "url": "https://example.invalid/openhuman_0.0.0-test_amd64.AppImage",
       "signature": ""
     },
+    "linux-aarch64": {
+      "url": "https://example.invalid/openhuman_0.0.0-test_arm64.AppImage",
+      "signature": ""
+    },
     "darwin-aarch64": {
       "url": "https://example.invalid/openhuman_0.0.0-test_aarch64.dmg",
       "signature": ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,22 +143,14 @@ case "${ARCH_RAW}" in
     ;;
 esac
 
-if [ "${OS}" = "linux" ] && [ "${ARCH}" != "x86_64" ]; then
-  if [ "${DRY_RUN}" = true ]; then
-    log_warn "Linux installer currently supports x86_64 only; no install asset resolved for ${ARCH}."
-    echo "DRY RUN: skipping install for ${OS}/${ARCH} - no compatible asset is published."
-    exit 0
-  fi
-  log_err "Linux installer currently supports x86_64 only."
-  exit 1
-fi
-
 if [ "${OS}" = "darwin" ] && [ "${ARCH}" = "aarch64" ]; then
   PLATFORM_KEY="darwin-aarch64"
 elif [ "${OS}" = "darwin" ] && [ "${ARCH}" = "x86_64" ]; then
   PLATFORM_KEY="darwin-x86_64"
 elif [ "${OS}" = "linux" ] && [ "${ARCH}" = "x86_64" ]; then
   PLATFORM_KEY="linux-x86_64"
+elif [ "${OS}" = "linux" ] && [ "${ARCH}" = "aarch64" ]; then
+  PLATFORM_KEY="linux-aarch64"
 fi
 
 log_ok "Detected platform: ${OS}/${ARCH}"
@@ -344,7 +336,12 @@ def choose_asset():
                     break
     elif os_name == "linux" and arch == "x86_64":
         for n in names:
-            if n.endswith(".AppImage"):
+            if re.search(r"amd64\.AppImage$", n):
+                chosen = n
+                break
+    elif os_name == "linux" and arch == "aarch64":
+        for n in names:
+            if re.search(r"(arm64|aarch64)\.AppImage$", n):
                 chosen = n
                 break
     if not chosen:

--- a/scripts/release/publish-updater-manifest.sh
+++ b/scripts/release/publish-updater-manifest.sh
@@ -87,21 +87,24 @@ read_sig() {
 #   darwin-aarch64   — macOS Apple Silicon
 #   darwin-x86_64    — macOS Intel
 #   linux-x86_64     — Linux glibc x64 (AppImage)
+#   linux-aarch64    — Linux glibc arm64 (AppImage)
 #   windows-x86_64   — Windows x64 (NSIS setup)
 #
 # Naming conventions emitted by tauri-bundler with createUpdaterArtifacts:
 #   darwin  : <AppName>_<version>_<arch>.app.tar.gz
-#   linux   : <AppName>_<version>_amd64.AppImage
+#   linux   : <AppName>_<version>_amd64.AppImage / <AppName>_<version>_arm64.AppImage
 #   windows : <AppName>_<version>_x64-setup.exe
 MAC_AARCH64=$(find_asset "^OpenHuman(_| ).*aarch64(-apple-darwin)?\.app\.tar\.gz$")
 MAC_X86_64=$(find_asset  "^OpenHuman(_| ).*(x64|x86_64)(-apple-darwin)?\.app\.tar\.gz$")
 LIN_X86_64=$(find_asset  "^OpenHuman(_| ).*amd64\.AppImage$")
+LIN_AARCH64=$(find_asset "^OpenHuman(_| ).*(arm64|aarch64)\.AppImage$")
 WIN_X86_64=$(find_asset "^OpenHuman(_| ).*x64-setup\.exe$")
 
 echo "[updater] Resolved updater bundles:"
 echo "  darwin-aarch64  = ${MAC_AARCH64:-<missing>}"
 echo "  darwin-x86_64   = ${MAC_X86_64:-<missing>}"
 echo "  linux-x86_64    = ${LIN_X86_64:-<missing>}"
+echo "  linux-aarch64   = ${LIN_AARCH64:-<missing>}"
 echo "  windows-x86_64  = ${WIN_X86_64:-<missing>}"
 
 PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
@@ -132,12 +135,13 @@ add_platform() {
 add_platform "darwin-aarch64" "$MAC_AARCH64"
 add_platform "darwin-x86_64"  "$MAC_X86_64"
 add_platform "linux-x86_64"   "$LIN_X86_64"
+add_platform "linux-aarch64"  "$LIN_AARCH64"
 add_platform "windows-x86_64" "$WIN_X86_64"
 
 # Require every platform advertised by the public installers. A partial
 # latest.json leaves install.sh resolving a documented platform to nothing.
 missing_platforms=$(jq -r '
-  ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"]
+  ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "linux-aarch64", "windows-x86_64"]
   - (.platforms | keys)
   | join(", ")
 ' "$MANIFEST")

--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -50,7 +50,23 @@ EXCLUDE_PATTERNS=(
 # Default to a pinned release tag rather than the mutable `continuous` asset so
 # CI builds are reproducible and resistant to upstream replacement. Override via
 # APPIMAGETOOL_URL (and bump APPIMAGETOOL_SHA256 alongside it).
-APPIMAGETOOL_URL="${APPIMAGETOOL_URL:-https://github.com/AppImage/appimagetool/releases/download/1.9.0/appimagetool-x86_64.AppImage}"
+default_appimagetool_url() {
+  local target_arch="${APPIMAGE_TARGET_ARCH:-${MATRIX_TARGET:-$(uname -m)}}"
+  case "$target_arch" in
+    x86_64*|amd64*)
+      echo "https://github.com/AppImage/appimagetool/releases/download/1.9.0/appimagetool-x86_64.AppImage"
+      ;;
+    aarch64*|arm64*)
+      echo "https://github.com/AppImage/appimagetool/releases/download/1.9.0/appimagetool-aarch64.AppImage"
+      ;;
+    *)
+      echo "[strip-libs] ERROR: unsupported appimagetool architecture: $target_arch" >&2
+      return 1
+      ;;
+  esac
+}
+
+APPIMAGETOOL_URL="${APPIMAGETOOL_URL:-$(default_appimagetool_url)}"
 APPIMAGETOOL_SHA256="${APPIMAGETOOL_SHA256:-}"
 
 ensure_appimagetool() {
@@ -83,7 +99,26 @@ appimage_loader_name() {
     x86_64*|amd64*)
       echo "ld-linux-x86-64.so.2"
       ;;
+    aarch64*|arm64*)
+      echo "ld-linux-aarch64.so.1"
+      ;;
     *)
+      return 1
+      ;;
+  esac
+}
+
+appimagetool_arch() {
+  local target_arch="${APPIMAGE_TARGET_ARCH:-${MATRIX_TARGET:-$(uname -m)}}"
+  case "$target_arch" in
+    x86_64*|amd64*)
+      echo "x86_64"
+      ;;
+    aarch64*|arm64*)
+      echo "aarch64"
+      ;;
+    *)
+      echo "[strip-libs] ERROR: unsupported AppImage repack architecture: $target_arch" >&2
       return 1
       ;;
   esac
@@ -344,10 +379,13 @@ strip_one_appimage() {
   for candidate in \
     "$appdir/usr/lib" \
     "$appdir/usr/lib/x86_64-linux-gnu" \
+    "$appdir/usr/lib/aarch64-linux-gnu" \
     "$appdir/shared/lib" \
     "$appdir/shared/lib/x86_64-linux-gnu" \
+    "$appdir/shared/lib/aarch64-linux-gnu" \
     "$appdir/lib" \
-    "$appdir/lib/x86_64-linux-gnu"; do
+    "$appdir/lib/x86_64-linux-gnu" \
+    "$appdir/lib/aarch64-linux-gnu"; do
     [ -d "$candidate" ] && lib_roots+=("$candidate")
   done
 
@@ -381,9 +419,11 @@ strip_one_appimage() {
   echo "[strip-libs] Removed $removed file(s), added $added_loader loader file(s); repacking AppImage."
 
   local rebuilt="$workdir/$name"
+  local appimage_arch
+  appimage_arch="$(appimagetool_arch)"
   (
     cd "$workdir"
-    ARCH=x86_64 "$APPIMAGETOOL_BIN" --appimage-extract-and-run \
+    ARCH="$appimage_arch" "$APPIMAGETOOL_BIN" --appimage-extract-and-run \
       --no-appstream squashfs-root "$rebuilt" >/dev/null
   )
   mv "$rebuilt" "$original"

--- a/scripts/test_install.sh
+++ b/scripts/test_install.sh
@@ -20,13 +20,10 @@ if [[ "$resolved" != "$expected" ]]; then
   exit 1
 fi
 
-# Also test a missing platform produces exit code 3.
-set +e
-resolve_asset_url "$FIXTURE" "linux" "aarch64" >/dev/null 2>&1
-missing_platform_rc=$?
-set -e
-if [[ "$missing_platform_rc" -ne 3 ]]; then
-  echo "FAIL: expected exit code 3 for missing platform linux-aarch64, got $missing_platform_rc"
+resolved_arm64=$(resolve_asset_url "$FIXTURE" "linux" "aarch64")
+expected_arm64="https://example.invalid/openhuman_0.0.0-test_arm64.AppImage"
+if [[ "$resolved_arm64" != "$expected_arm64" ]]; then
+  echo "FAIL: expected $expected_arm64, got $resolved_arm64"
   exit 1
 fi
 

--- a/scripts/validate-release-assets.sh
+++ b/scripts/validate-release-assets.sh
@@ -58,6 +58,7 @@ SUPPORTED = [
     "darwin-aarch64",
     "darwin-x86_64",
     "linux-x86_64",
+    "linux-aarch64",
     "windows-x86_64",
 ]
 
@@ -67,7 +68,8 @@ SUPPORTED = [
 ASSET_PATTERNS = {
     "darwin-aarch64": r"aarch64.*\.app\.tar\.gz$|aarch64\.dmg$",
     "darwin-x86_64":  r"(x86_64-apple-darwin|x64).*\.app\.tar\.gz$|x64\.dmg$",
-    "linux-x86_64":   r"\.AppImage$",
+    "linux-x86_64":   r"amd64\.AppImage$",
+    "linux-aarch64":  r"(arm64|aarch64)\.AppImage$",
     "windows-x86_64": r"x64.*\.msi$|x64.*setup\.exe$",
 }
 


### PR DESCRIPTION
## Summary

- Adds a native `ubuntu-24.04-arm` desktop build row for Linux `aarch64-unknown-linux-gnu` bundles.
- Publishes and validates `linux-aarch64` AppImage entries in `latest.json` alongside existing Linux x86_64 assets.
- Updates the Linux installer resolver to accept `linux-aarch64` AppImage assets instead of hard-failing ARM64 Linux.
- Teaches the AppImage graphics-library strip/repack helper to select ARM64 appimagetool, loader, library roots, and repack `ARCH` values.

## Problem

Linux ARM64 users currently only get the standalone `openhuman-core` tarball. The desktop release workflow, updater manifest, release validator, and installer all only advertise Linux x86_64 desktop assets, so ARM64 Linux users cannot install the full desktop app from official release assets.

## Solution

This keeps the change in the release/install layer:

- Build desktop Linux ARM64 on GitHub's native `ubuntu-24.04-arm` runner.
- Require the ARM64 AppImage and `.deb` in production release validation.
- Add `linux-aarch64` to updater manifest generation and release-asset validation.
- Resolve `linux-aarch64` in `scripts/install.sh` and cover it in the installer fixture smoke test.
- Keep runtime/product behavior unchanged.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — N/A: CI workflow and shell installer/release scripts only; no Vitest/cargo-covered runtime lines changed.
- [x] Coverage matrix updated — N/A: release/install infrastructure change, no feature row added or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: existing release gate is script-enforced here via `scripts/validate-release-assets.sh`; docs not changed to keep this ci-config pass scoped to `.github/workflows/` and `scripts/`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Release workflow impact only. Future production releases should include Linux ARM64 desktop AppImage and `.deb` assets, and `install.sh` can resolve the ARM64 AppImage through `latest.json` or the release API fallback.

## Related

Closes #1599

- Follow-up PR(s)/TODOs: none in this PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `sunil/1599-linux-arm64-desktop-release`
- Commit SHA: `c3c82e2f478e65e2141e5071117e960244e88ef7`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — scoped equivalent run: `app/node_modules/.bin/prettier.cmd --check .github/workflows/build-desktop.yml .github/workflows/release-production.yml scripts/fixtures/latest.json`
- [x] `pnpm typecheck` — N/A: no TypeScript/runtime source changed.
- [x] Focused tests: `bash -n scripts/install.sh scripts/test_install.sh scripts/release/publish-updater-manifest.sh scripts/release/strip-appimage-graphics-libs.sh scripts/validate-release-assets.sh`; `bash scripts/test_install.sh`; temp-fixture `scripts/validate-release-assets.sh` with `linux-aarch64`.
- [x] Rust fmt/check (if changed): N/A: no Rust changed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri Rust changed.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: release pipeline can build, publish, validate, and advertise Linux ARM64 desktop artifacts.
- User-visible effect: ARM64 Linux users can install official desktop releases once a release is cut from this workflow.

### Parity Contract
- Legacy behavior preserved: existing macOS, Windows, and Linux x86_64 artifact keys and installer resolution remain intact.
- Guard/fallback/dispatch parity checks: installer latest.json path and release API fallback both understand Linux ARM64; release validator requires the new platform entry.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for #1599 at PR creation time.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Linux ARM64 (aarch64) architecture for desktop application builds, installers, and releases.

* **Chores**
  * Updated build workflows, release processes, and validation scripts to support ARM64 platform across installation, updates, and artifact management.
  * Expanded installer and release asset resolution to handle ARM64-specific package formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->