### PR TITLE
test(memory): avoid PII-like tool rule names

### DIFF
--- a/src/openhuman/memory/ops/tool_memory.rs
+++ b/src/openhuman/memory/ops/tool_memory.rs
@@ -175,6 +175,8 @@ pub async fn tool_rules_json(params: ToolRuleListParams) -> Result<RpcOutcome<Va
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use crate::openhuman::memory_tools::ToolMemoryPriority;
 
@@ -183,8 +185,9 @@ mod tests {
     }
 
     fn unique_tool_name() -> String {
-        let short = &uuid::Uuid::new_v4().as_simple().to_string()[..12];
-        format!("toolmem{short}")
+        static NEXT_TOOL_ID: AtomicUsize = AtomicUsize::new(1);
+        let id = NEXT_TOOL_ID.fetch_add(1, Ordering::Relaxed);
+        format!("toolmem_test_{id}")
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace the UUID-based \`unique_tool_name\` helper in \`tool_memory.rs\` tests with a deterministic atomic counter, so generated tool names no longer look like a UUID to the PII detection rules introduced in \`b9925e0b\`.

## Problem

\`src/openhuman/memory/ops/tool_memory.rs\` tests generate per-test tool identifiers like \`toolmem<12-hex-chars>\`. The new PII detection module (\`src/openhuman/memory_store/safety/pii.rs\`, landed via \`b9925e0b\`) flags these as UUID-like and rejects the tool rule before storage, which makes every test in this module flake on a clean main.

## Solution

Swap \`uuid::Uuid::new_v4()\` for a process-local \`AtomicUsize\` counter:

\`\`\`rust
fn unique_tool_name() -> String {
    static NEXT_TOOL_ID: AtomicUsize = AtomicUsize::new(1);
    let id = NEXT_TOOL_ID.fetch_add(1, Ordering::Relaxed);
    format!(\"toolmem_test_{id}\")
}
\`\`\`

- Names look like \`toolmem_test_1\`, \`toolmem_test_2\`, ... — visibly not a UUID, not a hex blob, not anything PII detection would match.
- Still unique within a single \`cargo test\` invocation (the only collision surface the original UUID was guarding against).
- Cheaper than \`Uuid::new_v4\` and avoids a fallible random dep at the test path.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — N/A: this only updates a test helper. The existing test suite exercises the new helper.
- [x] **Diff coverage ≥ 80%** — N/A: test-only change. No production code touched.
- [x] Coverage matrix updated — N/A: no behaviour-visible feature row affected.
- [x] All affected feature IDs from the matrix are listed in the PR description under \`## Related\` — N/A.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([\`docs/RELEASE-MANUAL-SMOKE.md\`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: test-only.
- [x] Linked issue closed via \`Closes #NNN\` in the \`## Related\` section — N/A: no tracking issue.

## Impact

- **Platform**: cross-platform test-only change.
- **Behaviour**: none in shipped builds. The change is confined to \`#[cfg(test)]\` in \`tool_memory.rs\`.
- **Performance / migration / compatibility**: none.

## Related

- Split out from PR #2668 per reviewer request — \`tool_memory.rs\` test fix is orthogonal to the Windows reset / file-lock work that #2668 ships.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: \`chore/pii-resistant-tool-test-names\`
- Commit SHA: \`$(git rev-parse HEAD)\`

### Validation Run
- [x] \`pnpm --filter openhuman-app format:check\` — N/A: no frontend files changed.
- [x] \`pnpm typecheck\` — N/A: no TypeScript files changed.
- [x] Focused tests: \`GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml --lib\` clean.
- [x] Rust fmt/check (if changed): \`cargo fmt --check\` clean.
- [x] Tauri fmt/check (if changed): N/A — no \`app/src-tauri\` change.

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behaviour Changes
- Intended behaviour change: \`tool_memory.rs\` tests use a deterministic atomic counter rather than a UUID for per-test tool names, so they no longer collide with the PII detection introduced by \`b9925e0b\`.
- User-visible effect: none.

### Parity Contract
- Legacy behaviour preserved: per-test uniqueness still holds (every call returns a fresh value within a single \`cargo test\` invocation). The surrounding test bodies are unchanged.
- Guard/fallback/dispatch parity checks: no production code paths touched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test helpers for tool memory operations: unique test identifiers now use a stable process-wide counter, producing simpler, deterministic names.
  * This reduces reliance on random UUIDs and improves test stability and reproducibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->