### PR TITLE
fix(memory-workspace): show all native Composio memory-sync sources (not Gmail-only)

### DIFF
--- a/app/src/components/intelligence/MemorySources.tsx
+++ b/app/src/components/intelligence/MemorySources.tsx
@@ -21,7 +21,7 @@
  * "Connected sources" panel with one section, one Sync button, one
  * stats block per identity. Sync only appears when:
  *   1. the connection is currently ACTIVE/CONNECTED, AND
- *   2. the toolkit is in the syncable allow-list (today: gmail).
+ *   2. the toolkit is in the syncable allow-list passed by the parent.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 

--- a/app/src/components/intelligence/MemoryWorkspace.tsx
+++ b/app/src/components/intelligence/MemoryWorkspace.tsx
@@ -54,11 +54,17 @@ interface MemoryWorkspaceProps {
  * adding chunks to the memory tree.
  *
  * Source of truth: providers under
- * `src/openhuman/composio/providers/<toolkit>/` that call
- * `ingest_page_into_memory_tree`. Today that's gmail. Add a slug here
- * when a new provider lands a memory-tree ingest path.
+ * `src/openhuman/memory_sync/composio/providers/<toolkit>/` that
+ * persist items via `store_skill_sync` into the memory tree.
  */
-const SYNCABLE_TOOLKITS: ReadonlySet<string> = new Set(['gmail']);
+const SYNCABLE_TOOLKITS: ReadonlySet<string> = new Set([
+   'clickup',
+   'github',
+   'gmail',
+   'linear',
+   'notion',
+   'slack',
+]);
 
 export function MemoryWorkspace({ onToast }: MemoryWorkspaceProps) {
   const { t } = useT();

--- a/app/src/components/intelligence/MemoryWorkspace.tsx
+++ b/app/src/components/intelligence/MemoryWorkspace.tsx
@@ -58,12 +58,12 @@ interface MemoryWorkspaceProps {
  * persist items via `store_skill_sync` into the memory tree.
  */
 const SYNCABLE_TOOLKITS: ReadonlySet<string> = new Set([
-   'clickup',
-   'github',
-   'gmail',
-   'linear',
-   'notion',
-   'slack',
+  'clickup',
+  'github',
+  'gmail',
+  'linear',
+  'notion',
+  'slack',
 ]);
 
 export function MemoryWorkspace({ onToast }: MemoryWorkspaceProps) {

--- a/app/src/components/intelligence/__tests__/MemoryWorkspace.test.tsx
+++ b/app/src/components/intelligence/__tests__/MemoryWorkspace.test.tsx
@@ -245,7 +245,7 @@ describe('MemoryWorkspace (graph view)', () => {
       ],
     });
     renderWithProviders(<MemoryWorkspace />);
-    // Provider-backed toolkits should render actionable Sync rows.
+    // Provider-backed toolkits should render actionable Sync rows
     expect(await screen.findByTestId('memory-source-sync-gmail')).toBeInTheDocument();
     expect(screen.getByTestId('memory-source-sync-slack')).toBeInTheDocument();
     expect(screen.getByTestId('memory-source-sync-notion')).toBeInTheDocument();

--- a/app/src/components/intelligence/__tests__/MemoryWorkspace.test.tsx
+++ b/app/src/components/intelligence/__tests__/MemoryWorkspace.test.tsx
@@ -235,24 +235,23 @@ describe('MemoryWorkspace (graph view)', () => {
     });
   });
 
-  it('hides toolkits without a memory-tree ingest provider entirely', async () => {
+  it('shows sync rows for provider-backed toolkits and hides non-syncable ones', async () => {
     listConnections.mockResolvedValue({
       connections: [
         { id: 'conn-gmail', toolkit: 'gmail', status: 'ACTIVE', accountEmail: 'a@x' },
         { id: 'conn-slack', toolkit: 'slack', status: 'ACTIVE', workspace: 'acme' },
         { id: 'conn-notion', toolkit: 'notion', status: 'ACTIVE' },
+        { id: 'conn-discord', toolkit: 'discord', status: 'ACTIVE' },
       ],
     });
     renderWithProviders(<MemoryWorkspace />);
-    // Gmail row exists with a working Sync button.
+    // Provider-backed toolkits should render actionable Sync rows.
     expect(await screen.findByTestId('memory-source-sync-gmail')).toBeInTheDocument();
-    // Non-syncable toolkits are filtered out completely — neither
-    // the row nor the Sync button render. Cleaner than a "no sync
-    // yet" placeholder for an action the user can't take.
-    expect(screen.queryByTestId('memory-source-row-slack')).toBeNull();
-    expect(screen.queryByTestId('memory-source-row-notion')).toBeNull();
-    expect(screen.queryByTestId('memory-source-sync-slack')).toBeNull();
-    expect(screen.queryByTestId('memory-source-sync-notion')).toBeNull();
+    expect(screen.getByTestId('memory-source-sync-slack')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-source-sync-notion')).toBeInTheDocument();
+    // Non-syncable toolkits stay hidden.
+    expect(screen.queryByTestId('memory-source-row-discord')).toBeNull();
+    expect(screen.queryByTestId('memory-source-sync-discord')).toBeNull();
   });
 
   it('toggling to Contacts mode re-fetches the graph with mode=contacts', async () => {

--- a/src/openhuman/memory_sync/composio/providers/mod.rs
+++ b/src/openhuman/memory_sync/composio/providers/mod.rs
@@ -149,8 +149,8 @@ pub fn capability_matrix() -> Vec<ComposioCapability> {
 ///
 /// This is consulted by the meta-tool layer alongside any registered
 /// provider's [`ComposioProvider::curated_tools`]. It lets toolkits
-/// without a full native provider (e.g. `github`, which has no sync
-/// logic yet) still benefit from curated whitelisting.
+/// without a full native provider still benefit from curated
+/// whitelisting.
 ///
 /// Lookup key is the lowercased prefix returned by
 /// [`toolkit_from_slug`] applied to the action slug — e.g.


### PR DESCRIPTION
## Summary

- Expanded Memory Workspace sync allowlist from gmail only to native provider-backed toolkits: clickup, github, gmail, linear, notion, slack.
- Fixed the user-visible mismatch where connected non-Gmail sources were hidden from the Memory sync UI.
- Updated Memory Workspace tests to assert provider-backed toolkits render sync rows while non-syncable toolkits remain hidden.
- Updated stale comments/docs in frontend and Rust provider metadata to match current backend capabilities.

## Problem

- Users could connect and use GitHub/Notion/Slack/etc., but Memory Workspace only exposed Gmail sync controls.
- This created a false impression that non-Gmail toolkits had no memory-ingest support, even though backend provider sync existed.
- Review risk: enabling additional rows could introduce UI regressions or reveal toolkits without actual ingest support.

## Solution

- Kept the existing frontend guardrail pattern (explicit syncable allowlist), but aligned it with currently registered native memory-sync providers.
- Verified backend capability path: providers are registered and synced through generic composio_sync dispatch (not Gmail-specific).
- Updated tests to protect against regression in both directions:
- provider-backed toolkits remain visible/actionable
- non-syncable toolkits remain hidden
- Tradeoff: allowlist is still static in frontend; a future improvement can source this dynamically from backend capability metadata.

## Submission Checklist

- Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.
- N/A: behaviour-only allowlist/test alignment; no feature-row add/remove/rename required in `docs/TEST-COVERAGE-MATRIX.md`
- All affected feature IDs from the matrix are listed in the PR description under ## Related
- No new external network dependencies introduced (mock backend used per Testing Strategy)
- N/A: no release-cut surface changes requiring `docs/RELEASE-MANUAL-SMOKE.md` updates
- Linked issue closed via Closes #NNN in the ## Related section

## Impact

- Runtime/platform: frontend desktop memory workspace behavior only (no new RPC/API surface).
- Performance: negligible (renders more eligible rows; existing polling unchanged).
- Security: no auth model changes, no new permissions, no new network dependencies.
- Compatibility: backward-compatible; only broadens visibility of already-supported provider sync actions.

## Related

- Closes #2477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory Sync now recognizes and supports multiple toolkits (e.g., Gmail, Slack, Notion), showing actionable sync rows for supported providers.

* **Documentation**
  * Clarified when the per-identity Sync button appears and updated references for which toolkits are considered syncable.

* **Tests**
  * Expanded tests to validate memory sync visibility and behavior across multiple toolkit scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->