### PR TITLE
fix(composio/triage): demote provider-config-rejection rollups (Sentry TAURI-RUST-1V)

### DIFF
--- a/src/openhuman/inference/provider/config_rejection.rs
+++ b/src/openhuman/inference/provider/config_rejection.rs
@@ -204,6 +204,17 @@ pub fn is_provider_config_rejection_message(body: &str) -> bool {
         // -4FS, -4F6, -2YA, -4KR, -4KH, -4KY — ~458 events). The user
         // must pick a tool-capable model; Sentry has no remediation.
         "does not support tools",
+        // TAURI-RUST-1V — reliable-provider chain rolls up exhausted
+        // fallbacks into `All providers/models failed. Attempts:\n…\nThe
+        // model `<id>` may not be available on your provider. Configure
+        // a fallback chain via `reliability.model_fallbacks` in …`.
+        // Emitted at `src/openhuman/inference/provider/reliable.rs:332`.
+        // The remediation is "fix your `model_fallbacks` config" — pure
+        // user-config, nothing Sentry can act on. Anchor on the canonical
+        // remediation phrase so this doesn't collide with unrelated
+        // mentions of model availability (`reliable.rs:332` is the sole
+        // producer in-tree).
+        "may not be available on your provider",
     ];
 
     let lower = body.to_ascii_lowercase();
@@ -489,6 +500,41 @@ mod tests {
                 "{body:?} must NOT classify as a provider config-rejection"
             );
         }
+    }
+
+    #[test]
+    fn detects_reliable_chain_exhaustion_rollup() {
+        // TAURI-RUST-1V — `reliable.rs:325` rolls every attempt into
+        // `All providers/models failed. Attempts:\n…\nThe model `<id>`
+        // may not be available on your provider. Configure a fallback
+        // chain via `reliability.model_fallbacks` in …`. The wrapped err
+        // bubbles to `memory_sync::composio::bus` which previously
+        // emitted it as a raw `tracing::error!` — 10.7k events / 14d on
+        // self-hosted Sentry. The remediation lives entirely in the
+        // user's `reliability.model_fallbacks` config; Sentry has no
+        // remediation path.
+        let rollup = "All providers/models failed. Attempts:\n\
+            provider=openhuman model=gemini-3-flash-preview attempt 1/3: \
+            non_retryable; error=custom_openai API error (404 Not Found): \
+            <html>...</html>\n\
+            The model `gemini-3-flash-preview` may not be available on \
+            your provider. Configure a fallback chain via \
+            `reliability.model_fallbacks` in your config to route around \
+            unavailable models.";
+        assert!(
+            is_provider_config_rejection_message(rollup),
+            "TAURI-RUST-1V multi-line rollup must classify as provider config-rejection"
+        );
+
+        // Single-line `reliable.rs:332` emission (without the outer
+        // rollup wrapper) also matches — defensive against callers that
+        // surface only the inner remediation message.
+        let bare = "The model `chat-v1` may not be available on your provider. \
+            Configure a fallback chain via `reliability.model_fallbacks` in …";
+        assert!(
+            is_provider_config_rejection_message(bare),
+            "bare `may not be available on your provider` phrase must classify"
+        );
     }
 
     #[test]

--- a/src/openhuman/memory_sync/composio/bus.rs
+++ b/src/openhuman/memory_sync/composio/bus.rs
@@ -352,10 +352,26 @@ impl EventHandler for ComposioTriggerSubscriber {
                     );
                 }
                 Err(e) => {
-                    tracing::error!(
-                        label = %envelope.display_label,
-                        error = %e,
-                        "[composio][triage] run_triage failed"
+                    // Route through the central observability classifier
+                    // so user-config / budget-exhausted / provider-state
+                    // rollups from `reliable.rs` (e.g. `The model
+                    // \`<id>\` may not be available on your provider …`)
+                    // get demoted to info-level breadcrumbs instead of
+                    // surfacing as raw Sentry errors. Previously this
+                    // call used `tracing::error!` directly and bypassed
+                    // the classifier — 10.7k events / 14d on self-hosted
+                    // Sentry TAURI-RUST-1V, dominated by
+                    // ProviderConfigRejection-class rollups whose inner
+                    // attempts the provider layer already demoted.
+                    let detail = format!(
+                        "[composio][triage] run_triage failed (label={}): {e:#}",
+                        envelope.display_label
+                    );
+                    crate::core::observability::report_error_or_expected(
+                        detail.as_str(),
+                        "composio",
+                        "trigger_triage",
+                        &[("label", envelope.display_label.as_str())],
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- Routes `[composio][triage] run_triage failed` through the central observability classifier instead of raw `tracing::error!` — so user-config / budget-exhausted rollups from the upstream provider chain get demoted to info-level breadcrumbs.
- Adds `"may not be available on your provider"` to `is_provider_config_rejection_message` — the canonical phrase emitted by `reliable.rs:332` when the user's `reliability.model_fallbacks` chain is misconfigured.
- Net effect: drops the bulk of self-hosted Sentry **TAURI-RUST-1V** (10,692 events / 14d) where the inner provider attempts the provider layer already demoted were re-surfaced by the outer composio re-emit.

## Problem

Self-hosted Sentry `tauri-rust` project's #4 unresolved by event count (14d, sort=freq) is `[composio][triage] run_triage failed` at 10,692 events. Breadcrumbs show every event boils down to:

```
[llm_provider] native_chat budget-exhausted 400 — not reporting to Sentry          (correct demote, inner)
Non-retryable error, moving on
Exhausted retries, trying next provider/model
llm_provider.reliable_chat skipped expected budget-exhausted error: The model `chat-v1` may not be available on your provider. Configure a fallback chain via `reliability.model_fallbacks` in …    (correct demote, inner)
[triage::evaluator] agent turn dispatch failed
[composio][triage] run_triage failed       ← raw tracing::error! emits a Sentry error event
```

The reliable-provider stack and the inference observability layer already classify these as user-config — but the bus-level re-emit at `memory_sync/composio/bus.rs:354` used a raw `tracing::error!` that bypassed the classifier entirely.

Root cause is user-side: the user's `reliability.model_fallbacks` config doesn't list a model the provider actually serves. Remediation = fix that config. Sentry has no remediation path.

## Solution

Two surgical changes, kept as separate micro-commits for review:

1. **`src/openhuman/inference/provider/config_rejection.rs`** — append `"may not be available on your provider"` to the `PHRASES` table feeding `is_provider_config_rejection_message`. Canonical phrase, anchored to `reliable.rs:332` (the sole producer in-tree). Comment cross-links the call site so future drift of that wording is caught at review.

2. **`src/openhuman/memory_sync/composio/bus.rs`** — swap the raw `tracing::error!` at L354 with `crate::core::observability::report_error_or_expected(..., "composio", "trigger_triage", &[("label", …)])`. Same structured fields as before, but now the classifier runs. Genuine runtime bugs that don't classify still surface as full Sentry errors.

The two changes are additive; either landed alone would partially help, but only the pair fully closes the loop.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — classifier anchor + call-site swap, no new user-facing feature row. (Coverage matrix updated for added/removed/renamed feature rows.)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: observability classifier internals — no release-cut surface touched. (Manual smoke checklist not required.)
- [x] N/A: Sentry-only fix — no GitHub issue. `Sentry-Issue: TAURI-RUST-1V` is in `## Related` instead of `Closes #NNN`.

## Impact

- Runtime/platform: desktop only. Demoted events still appear as `info!` breadcrumbs in local trace, so support can still inspect them. Sustained outages — were they ever to indicate a real triage bug — would surface via separate health/escalation paths.
- Performance: negligible (classifier already runs on the surrounding paths; one extra substring scan per failed triage turn).
- Security/migration: none.
- Compatibility: no public API change.

## Related

- Sentry-Issue: TAURI-RUST-1V (self-hosted sentry.tinyhumans.ai → `tauri-rust` project, 10,692 events / 14d)
- Pattern precedent: #2481 (composio direct-mode 401 demote), #2612 (Ollama embed user-config demote), #2619 (CEF IPC fallback guard)
- Closes:
- Follow-up PR(s)/TODOs:
  - Companion PRs for self-hosted Sentry **TAURI-RUST-15** (Discord supervision restart-storm, 11.4k events) and **TAURI-RUST-34H** (Cloudflare anti-bot 500 wrap, 8.9k events) — coming behind this one to keep PR surface small.
  - Phase 7 Step 4.5 auto-resolve grep regex currently only matches `OPENHUMAN-(TAURI|REACT|CORE)-…` and `BACKEND-ALPHAHUMAN-…` shapes; self-hosted prefix is `TAURI-RUST-…`. Widen the regex (separate workflow-tooling PR) so the post-merge Sentry resolve sweep finds these IDs.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A: Sentry-only — no Linear issue
- URL: N/A: Sentry-only — no Linear issue

### Commit & Branch
- Branch: fix/sentry-1v-composio-triage-noise
- Commit SHA: $(git rev-parse HEAD)

### Validation Run
- [x] N/A: no app/ files touched — `pnpm --filter openhuman-app format:check` not needed.
- [x] N/A: no app/ files touched — `pnpm typecheck` not needed.
- [x] Focused tests: \`cargo test --lib openhuman::inference::provider::config_rejection\` (7/7 passed)
- [x] Rust fmt/check (if changed): \`cargo fmt --check\` clean; \`cargo check --manifest-path Cargo.toml\` clean (pre-existing warnings only, not from this PR)
- [x] N/A: no Tauri shell files touched — Tauri fmt/check not needed.

### Validation Blocked
- \`command:\`
- \`error:\`
- \`impact:\`

### Behavior Changes
- Intended behavior change: Composio-triage failures whose underlying err already classifies as user-state via the central observability classifier now demote to info-level breadcrumbs instead of emitting Sentry errors.
- User-visible effect: None — UI surfaces of the underlying conditions (budget-exhausted toasts, model-unavailable banners) are emitted at the inner layers and unchanged. Only the Sentry noise drops.

### Parity Contract
- Legacy behavior preserved: All structured fields previously logged (\`label\`, \`error\`) are preserved in the routed report's message and tag set. Genuine runtime errors that don't classify still reach Sentry.
- Guard/fallback/dispatch parity checks: \`is_provider_config_rejection_message\` continues to require an anchored substring match — false-positive surface is identical to existing entries; new entry is the canonical \`reliable.rs:332\` remediation phrase.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A: no duplicates
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of provider-configuration rejection messages so fallback remediation notices are correctly classified as provider-config issues.

* **Chores**
  * Updated triage error handling to route failures into structured observability/reporting for clearer diagnostics and monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-quality re-trigger: stale rerun used pre-fix body payload -->
