### PR TITLE
fix(observability): demote backend Cloudflare anti-bot wrap (Sentry TAURI-RUST-34H)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -636,6 +636,25 @@ fn is_provider_user_state_message(lower: &str) -> bool {
         return true;
     }
 
+    // TAURI-RUST-34H — composio backend endpoint (e.g.
+    // `/agent-integrations/composio/connections`) wraps an upstream
+    // Cloudflare anti-bot challenge as `Backend returned 500 Internal
+    // Server Error … 403 <!DOCTYPE html>…<title>Just a moment...</title>…`.
+    // The CF interstitial is keyed by the user's network reputation /
+    // geo / cookie state — there is nothing in `openhuman_core` that
+    // can act on it. Backend ops or the user's network is the
+    // remediation path; Sentry has no signal.
+    //
+    // Double-anchor on the Cloudflare challenge title + the literal
+    // "cloudflare" token to avoid colliding with unrelated bodies that
+    // merely mention "Just a moment" in a different context.
+    //
+    // Drops ~8.9 k events / 14d (TAURI-RUST-34H, sibling -32G / -34J /
+    // -323 share the same cascade).
+    if lower.contains("just a moment...") && lower.contains("cloudflare") {
+        return true;
+    }
+
     false
 }
 
@@ -2296,6 +2315,80 @@ mod tests {
             expected_error_kind(msg),
             None,
             "composio-direct 500 with no auth body must NOT demote — it is a real bug shape"
+        );
+    }
+
+    // ── TAURI-RUST-34H: backend-wrapped Cloudflare anti-bot interstitial ─
+
+    #[test]
+    fn classifies_backend_cloudflare_antibot_wrap_as_provider_user_state() {
+        // Canonical Sentry TAURI-RUST-34H wire shape — the verbatim title
+        // body from the issue (8,851 events / 14d on self-hosted
+        // `tauri-rust`). The backend wraps an upstream Cloudflare 403
+        // anti-bot challenge as `Backend returned 500 … 403 <!DOCTYPE …
+        // Just a moment... … cloudflare …`. The 500 escapes the 4xx-only
+        // `is_backend_user_error_message` classifier, so this body-shape
+        // arm catches it and demotes to `ProviderUserState`.
+        let msg = r#"Backend returned 500 Internal Server Error for GET https://api.tinyhumans.ai/agent-integrations/composio/connections: 403 <!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="robots" content="noindex,nofollow"><meta name="viewport" content="width=device-width,initial-scale=1"><link href="/cdn-cgi/styles/challenges.css" rel="stylesheet"></head><body class="no-js"><div class="main-wrapper" role="main"><div class="main-content"><h1 class="zone-name-title h1"><img class="heading-favicon" src="/favicon.ico" onerror="this.onerror=null;this.parentNode.removeChild(this)" alt="Icon for api.tinyhumans.ai">api.tinyhumans.ai</h1>...Powered by Cloudflare..."#;
+        assert_eq!(
+            expected_error_kind(msg),
+            Some(ExpectedErrorKind::ProviderUserState),
+            "backend-wrapped Cloudflare anti-bot interstitial must demote to ProviderUserState"
+        );
+    }
+
+    #[test]
+    fn classifies_minimal_cloudflare_antibot_body_as_provider_user_state() {
+        // Strip the wire shape down to just the two anchors — the
+        // matcher should still fire so future renderings (different
+        // line breaks, stripped HTML, alternate caller wrappers) still
+        // demote.
+        let msg = "Just a moment...\ncloudflare\n";
+        assert_eq!(
+            expected_error_kind(msg),
+            Some(ExpectedErrorKind::ProviderUserState),
+            "minimal `Just a moment...` + `cloudflare` body must demote"
+        );
+    }
+
+    #[test]
+    fn does_not_classify_half_anchor_cloudflare_messages_as_user_state() {
+        // Discrimination test for the double-anchor: either half on its
+        // own must NOT match. This guards against unrelated bodies that
+        // happen to use either phrase out of context.
+
+        // Half-anchor 1: `just a moment` without `cloudflare` — e.g.
+        // a daemon restart spinner blurb.
+        let half_a = "Just a moment, while we restart the daemon";
+        assert_ne!(
+            expected_error_kind(half_a),
+            Some(ExpectedErrorKind::ProviderUserState),
+            "`Just a moment` without `cloudflare` must NOT match the CF anti-bot arm"
+        );
+
+        // Half-anchor 2: `cloudflare` without `just a moment...` — e.g.
+        // a CF Workers footer mention elsewhere.
+        let half_b = "Powered by Cloudflare";
+        assert_ne!(
+            expected_error_kind(half_b),
+            Some(ExpectedErrorKind::ProviderUserState),
+            "`cloudflare` without `Just a moment...` must NOT match the CF anti-bot arm"
+        );
+    }
+
+    #[test]
+    fn does_not_classify_genuine_backend_500_without_cloudflare_body() {
+        // Real bug shape — a 500 from the same backend endpoint with no
+        // Cloudflare interstitial body — must still fall through so
+        // Sentry sees it. Without this guard the arm could be too
+        // permissive and silence genuine database / handler faults.
+        let msg = "Backend returned 500 Internal Server Error for GET \
+                   https://api.tinyhumans.ai/agent-integrations/composio/connections: \
+                   database connection pool exhausted";
+        assert_eq!(
+            expected_error_kind(msg),
+            None,
+            "genuine backend 500 without Cloudflare body must NOT demote — it is a real bug"
         );
     }
 


### PR DESCRIPTION
## Summary

- Demote backend-wrapped Cloudflare anti-bot challenge interstitials (`Backend returned 500 … <title>Just a moment...</title> … cloudflare …`) from Sentry errors to `tracing::info!` breadcrumbs via a new arm in `is_provider_user_state_message`.
- Reuses existing `ExpectedErrorKind::ProviderUserState` info-tier — no new kind, no new dispatch arm.
- Drops ~8.9 k events / 14 d on self-hosted `tauri-rust` (Sentry TAURI-RUST-34H); sibling IDs in the same cascade (`-32G`, `-34J`, `-323`) may also collapse under this fix.

## Problem

Self-hosted Sentry's \#5 unresolved issue by event count on `tauri-rust` (8,851 events / 14 d) is the wire shape:

```
Backend returned 500 Internal Server Error for GET https://api.tinyhumans.ai/agent-integrations/composio/connections: 403 <!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>...Powered by Cloudflare...
```

This is the **same cascade** as `BACKEND-NODEJS-2` (679 user impact — the Cloudflare 403 as seen by the backend itself). The composio backend endpoint's upstream is behind a Cloudflare zone with bot-challenge enabled and trips on cold caches / specific geos.

Two layers wrong:

1. **Backend root** (separate follow-up in `tinyhumansai/backend`): `IntegrationClient` wraps the upstream CF 403 as a 500 and embeds the CF HTML body. Should propagate the 403 as a 403.
2. **Client classifier**: a 500 escapes the 4xx-only `is_backend_user_error_message`. The body is unmistakably a Cloudflare anti-bot interstitial — Sentry has no remediation path (the CF challenge is keyed by the user's network reputation / geo / cookie state, not anything `openhuman_core` can act on).

## Solution

Add a body-shape arm to `is_provider_user_state_message` in `src/core/observability.rs` that double-anchors on `"just a moment..."` AND `"cloudflare"`. Both must be present to demote — half-anchors (daemon-restart spinner blurb, unrelated CF Workers footer) still reach Sentry.

The new arm sits in the existing `is_provider_user_state_message` chain so it routes through the established `ExpectedErrorKind::ProviderUserState` dispatch (info-tier breadcrumb only, no Sentry event). No new variant, no new dispatch arm.

Tests cover:

- **Positive (full wire shape)**: canonical TAURI-RUST-34H body with embedded HTML classifies as `ExpectedErrorKind::ProviderUserState`.
- **Positive (minimal)**: `"Just a moment...\ncloudflare\n"` classifies — guards against future renderings with stripped HTML / alternate caller wrappers.
- **Negative (half-anchor)**: `"Just a moment, while we restart the daemon"` alone OR `"Powered by Cloudflare"` alone does NOT classify.
- **Negative (real backend bug)**: `"Backend returned 500 … database connection pool exhausted"` still classifies as `None` (reaches Sentry as an actionable signal).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 4 new tests in `src/core/observability.rs` covering both positive shapes (full wire + minimal) and both negative shapes (half-anchor + genuine 500).
- [x] **Diff coverage ≥ 80%** — every changed line in this PR is the new classifier arm (covered by the 4 new tests) or test code itself. Full `pnpm test:coverage` / `pnpm test:rust` not run locally; `cargo test --lib core::observability::tests` passes (92/92).
- [x] N/A: Coverage matrix updated — behaviour-only change in an observability classifier; no new user-facing feature row.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — same reason; no matrix rows touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure in-process classifier change, no network surface.
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces — no UI / RPC surface change; the only visible effect is Sentry event volume.
- [x] N/A: Linked issue closed via `Closes \#NNN` in the `## Related` section — Sentry-only fix, no GitHub issue.

## Impact

- **Runtime/platform**: desktop (all OSes). No mobile/web/CLI surface change.
- **Performance**: zero — one extra substring check inside an already-cold error-classification path that only runs on the unexpected-error route.
- **Security**: zero — does not silence any actionable error; the CF interstitial is keyed by network / geo / cookie state with no remediation path inside `openhuman_core`.
- **Migration / compatibility**: none.
- **Sentry signal**: drops ~8.9 k events / 14 d on self-hosted `tauri-rust` (TAURI-RUST-34H). Sibling IDs `-32G`, `-34J`, `-323` are believed to share the same cascade and may also collapse under this fix — not verified in this PR; tracked in retrospect.

## Related

Sentry-Issue: TAURI-RUST-34H
- Believed-similar (same cascade, not verified): TAURI-RUST-32G, TAURI-RUST-34J, TAURI-RUST-323
- Backend cascade twin: BACKEND-NODEJS-2 (679 user impact — same CF 403, raw at the backend layer)

Follow-ups:
- **Root fix belongs in `tinyhumansai/backend`**: `IntegrationClient` should propagate Cloudflare's 403 as 403, not wrap it as 500. Tracked as a separate PR against the backend repo.
- **Phase 7 Step 4.5 grep regex needs widening** to accept the `TAURI-RUST-*` prefix (current regex is anchored to `OPENHUMAN-(TAURI|REACT|CORE)`). Without it, the post-merge Sentry-resolve sweep will skip self-hosted `tauri-rust` IDs.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A — Sentry-only fix, no Linear ticket.
- URL: N/A

### Commit & Branch
- Branch: `fix/sentry-34h-cloudflare-antibot-wrap`
- Commit SHA: `889744797ffb4803782c170c524bba17c9016c6c`

### Validation Run
- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust-only change, no frontend touched.
- [x] N/A: `pnpm typecheck` — Rust-only change.
- [x] Focused tests: `cargo test --lib core::observability::tests` — 92 passed / 0 failed, including 4 new TAURI-RUST-34H tests.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --manifest-path Cargo.toml` clean; `cargo clippy --lib --manifest-path Cargo.toml` = 168 warnings (matches `main` baseline, no new warnings introduced).
- [x] N/A: Tauri fmt/check (if changed) — `app/src-tauri` not touched.

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Backend-wrapped Cloudflare anti-bot interstitials (HTTP 500 body containing both `"just a moment..."` and `"cloudflare"`) are demoted from Sentry errors to `tracing::info!` breadcrumbs.
- User-visible effect: None on the desktop client (the call still fails; the UI surfaces its existing error toast); Sentry-side, ~8.9 k events / 14 d disappear from the `tauri-rust` project's "what's burning" view.

### Parity Contract
- Legacy behavior preserved: All existing arms in `is_provider_user_state_message` left untouched; the new arm is appended at the end of the chain so existing matches keep their precedence. Existing `is_backend_user_error_message` 4xx coverage unchanged (the new arm only catches 500-wrapped CF bodies that were never in scope of the 4xx classifier).
- Guard/fallback/dispatch parity checks: Negative tests pin both half-anchors and the genuine-backend-500 surface so a future narrowing or broadening of the matcher surfaces here instead of silently re-bucketing.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for Cloudflare anti-bot interstitial messages, now treated as expected errors to reduce noise in error reporting.

* **Tests**
  * Added comprehensive test cases for error handling including Cloudflare interstitials, minimal payloads, and edge cases to ensure accurate error discrimination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
