### PR TITLE
refactor(memory): route Obsidian deep link through workspace-link layer (#2492)

### DIFF
--- a/app/src-tauri/permissions/allow-workspace-files.toml
+++ b/app/src-tauri/permissions/allow-workspace-files.toml
@@ -8,6 +8,7 @@ allow = [
     "open_workspace_path",
     "reveal_workspace_path",
     "preview_workspace_text",
+    "resolve_workspace_absolute_path",
 ]
 
 deny = []

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3243,6 +3243,7 @@ pub fn run() {
             workspace_paths::open_workspace_path,
             workspace_paths::reveal_workspace_path,
             workspace_paths::preview_workspace_text,
+            workspace_paths::resolve_workspace_absolute_path,
             meet_call::meet_call_open_window,
             meet_call::meet_call_close_window,
             companion_commands::register_companion_hotkey,

--- a/app/src-tauri/src/workspace_paths.rs
+++ b/app/src-tauri/src/workspace_paths.rs
@@ -424,7 +424,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_workspace_path_returns_absolute_inside_workspace() {
+    fn resolve_workspace_path_resolves_memory_tree_content_inside_workspace() {
         let workspace = tempdir().unwrap();
         let docs = workspace.path().join("memory_tree").join("content");
         fs::create_dir_all(&docs).unwrap();
@@ -442,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_workspace_path_rejects_empty_input() {
+    fn resolve_workspace_path_rejects_empty_whitespace_input() {
         let workspace = tempdir().unwrap();
 
         let err = resolve_workspace_path(workspace.path(), "   ").unwrap_err();

--- a/app/src-tauri/src/workspace_paths.rs
+++ b/app/src-tauri/src/workspace_paths.rs
@@ -235,7 +235,7 @@ pub(crate) fn resolve_workspace_path(
     log::debug!(
         "[workspace-paths] resolved workspace path: {} -> {}",
         normalized_path,
-        target.display()
+        workspace_path_label(workspace_root, &target)
     );
     Ok(target)
 }

--- a/app/src-tauri/src/workspace_paths.rs
+++ b/app/src-tauri/src/workspace_paths.rs
@@ -51,6 +51,29 @@ pub async fn preview_workspace_text(path: String) -> Result<WorkspaceTextPreview
     preview_workspace_text_from_root(&workspace, &path, DEFAULT_PREVIEW_MAX_BYTES)
 }
 
+/// Resolve a workspace-relative path to its canonical absolute path on disk,
+/// after validating it stays inside the active OpenHuman workspace.
+///
+/// This exposes the internal [`resolve_workspace_path`] helper so UI flows that
+/// need an absolute path to compose with a platform-specific URL scheme (e.g.
+/// `obsidian://open?path=<abs>`) can route through the shared workspace-link
+/// layer instead of re-implementing path normalization in the renderer.
+///
+/// Errors mirror the other workspace-path commands — empty input, parent-dir
+/// escape, NUL bytes, URI-scheme prefixes, paths outside the workspace, and
+/// missing files all surface a non-leaky message.
+#[tauri::command]
+pub async fn resolve_workspace_absolute_path(path: String) -> Result<String, String> {
+    let workspace = active_workspace_root().await?;
+    let target = resolve_workspace_path(&workspace, &path)?;
+    log::debug!(
+        "[workspace-paths] resolve_workspace_absolute_path: {} -> {}",
+        path,
+        target.display()
+    );
+    Ok(target.to_string_lossy().into_owned())
+}
+
 async fn active_workspace_root() -> Result<PathBuf, String> {
     let config = openhuman_core::openhuman::config::Config::load_or_init()
         .await
@@ -398,6 +421,33 @@ mod tests {
             !err.contains(&workspace.path().display().to_string()),
             "error leaked workspace root: {err}"
         );
+    }
+
+    #[test]
+    fn resolve_workspace_path_returns_absolute_inside_workspace() {
+        let workspace = tempdir().unwrap();
+        let docs = workspace.path().join("memory_tree").join("content");
+        fs::create_dir_all(&docs).unwrap();
+
+        let resolved = resolve_workspace_path(workspace.path(), "memory_tree/content").unwrap();
+
+        let canonical_root = fs::canonicalize(workspace.path()).unwrap();
+        assert!(
+            resolved.starts_with(&canonical_root),
+            "resolved path escaped workspace root: {} not under {}",
+            resolved.display(),
+            canonical_root.display()
+        );
+        assert_eq!(resolved, docs.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_workspace_path_rejects_empty_input() {
+        let workspace = tempdir().unwrap();
+
+        let err = resolve_workspace_path(workspace.path(), "   ").unwrap_err();
+
+        assert!(err.contains("empty"), "unexpected error: {err}");
     }
 
     #[cfg(unix)]

--- a/app/src-tauri/src/workspace_paths.rs
+++ b/app/src-tauri/src/workspace_paths.rs
@@ -66,10 +66,10 @@ pub async fn preview_workspace_text(path: String) -> Result<WorkspaceTextPreview
 pub async fn resolve_workspace_absolute_path(path: String) -> Result<String, String> {
     let workspace = active_workspace_root().await?;
     let target = resolve_workspace_path(&workspace, &path)?;
+    let workspace_label = workspace_path_label(&workspace, &target);
     log::debug!(
-        "[workspace-paths] resolve_workspace_absolute_path: {} -> {}",
-        path,
-        target.display()
+        "[workspace-paths] resolve_workspace_absolute_path: {}",
+        workspace_label
     );
     Ok(target.to_string_lossy().into_owned())
 }

--- a/app/src/components/intelligence/ObsidianVaultSection.tsx
+++ b/app/src/components/intelligence/ObsidianVaultSection.tsx
@@ -25,7 +25,10 @@ import { useT } from '../../lib/i18n/I18nContext';
 import type { ToastNotification } from '../../types/intelligence';
 import { openUrl } from '../../utils/openUrl';
 import { memoryTreeObsidianVaultStatus } from '../../utils/tauriCommands';
-import { revealWorkspacePath } from '../../utils/tauriCommands/workspacePaths';
+import {
+  resolveWorkspaceAbsolutePath,
+  revealWorkspacePath,
+} from '../../utils/tauriCommands/workspacePaths';
 import { MEMORY_CONTENT_WORKSPACE_PATH } from './memoryWorkspacePaths';
 
 /** localStorage key for the optional Obsidian config-dir override. */
@@ -55,18 +58,29 @@ export function ObsidianVaultSection({ contentRootAbs, onToast }: ObsidianVaultS
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [configDir, setConfigDir] = useState<string>(readConfigDirOverride);
 
-  /** Build + fire the `obsidian://` deep link. Resolves to an error or null. */
+  /**
+   * Build + fire the `obsidian://` deep link.
+   *
+   * The absolute path is resolved through the shared workspace-link layer
+   * (`resolve_workspace_absolute_path` Tauri command) rather than reused from
+   * the `contentRootAbs` prop — this routes Obsidian deep links through the
+   * same canonicalize + workspace-containment guard as `open_workspace_path`
+   * and `preview_workspace_text` (see issue #2492 / #2476).
+   *
+   * Resolves to an error or null.
+   */
   const fireDeepLink = useCallback(async (): Promise<unknown | null> => {
-    const url = `obsidian://open?path=${encodeURIComponent(contentRootAbs)}`;
     console.debug('[ui-flow][obsidian-vault] firing deep link');
     try {
+      const absolutePath = await resolveWorkspaceAbsolutePath(MEMORY_CONTENT_WORKSPACE_PATH);
+      const url = `obsidian://open?path=${encodeURIComponent(absolutePath)}`;
       await openUrl(url);
       return null;
     } catch (err) {
-      console.error('[ui-flow][obsidian-vault] openUrl failed', err);
+      console.error('[ui-flow][obsidian-vault] resolve/open failed', err);
       return err;
     }
-  }, [contentRootAbs]);
+  }, []);
 
   const reveal = useCallback(() => {
     void (async () => {

--- a/app/src/components/intelligence/ObsidianVaultSection.tsx
+++ b/app/src/components/intelligence/ObsidianVaultSection.tsx
@@ -72,7 +72,16 @@ export function ObsidianVaultSection({ contentRootAbs, onToast }: ObsidianVaultS
   const fireDeepLink = useCallback(async (): Promise<unknown | null> => {
     console.debug('[ui-flow][obsidian-vault] firing deep link');
     try {
-      const absolutePath = await resolveWorkspaceAbsolutePath(MEMORY_CONTENT_WORKSPACE_PATH);
+      let absolutePath: string;
+      try {
+        absolutePath = await resolveWorkspaceAbsolutePath(MEMORY_CONTENT_WORKSPACE_PATH);
+      } catch {
+        // The content directory may not exist yet (fresh workspace). Fall
+        // back to the prop from the graph-export RPC — the deep link URL
+        // is still valid; Obsidian will surface its own "vault not found"
+        // error if the folder is truly missing.
+        absolutePath = contentRootAbs;
+      }
       const url = `obsidian://open?path=${encodeURIComponent(absolutePath)}`;
       await openUrl(url);
       return null;
@@ -80,7 +89,7 @@ export function ObsidianVaultSection({ contentRootAbs, onToast }: ObsidianVaultS
       console.error('[ui-flow][obsidian-vault] resolve/open failed', err);
       return err;
     }
-  }, []);
+  }, [contentRootAbs]);
 
   const reveal = useCallback(() => {
     void (async () => {

--- a/app/src/components/intelligence/ObsidianVaultSection.tsx
+++ b/app/src/components/intelligence/ObsidianVaultSection.tsx
@@ -72,16 +72,7 @@ export function ObsidianVaultSection({ contentRootAbs, onToast }: ObsidianVaultS
   const fireDeepLink = useCallback(async (): Promise<unknown | null> => {
     console.debug('[ui-flow][obsidian-vault] firing deep link');
     try {
-      let absolutePath: string;
-      try {
-        absolutePath = await resolveWorkspaceAbsolutePath(MEMORY_CONTENT_WORKSPACE_PATH);
-      } catch {
-        // The content directory may not exist yet (fresh workspace). Fall
-        // back to the prop from the graph-export RPC — the deep link URL
-        // is still valid; Obsidian will surface its own "vault not found"
-        // error if the folder is truly missing.
-        absolutePath = contentRootAbs;
-      }
+      const absolutePath = await resolveWorkspaceAbsolutePath(MEMORY_CONTENT_WORKSPACE_PATH);
       const url = `obsidian://open?path=${encodeURIComponent(absolutePath)}`;
       await openUrl(url);
       return null;
@@ -89,7 +80,7 @@ export function ObsidianVaultSection({ contentRootAbs, onToast }: ObsidianVaultS
       console.error('[ui-flow][obsidian-vault] resolve/open failed', err);
       return err;
     }
-  }, [contentRootAbs]);
+  }, []);
 
   const reveal = useCallback(() => {
     void (async () => {

--- a/app/src/components/intelligence/__tests__/MemoryWorkspace.test.tsx
+++ b/app/src/components/intelligence/__tests__/MemoryWorkspace.test.tsx
@@ -34,6 +34,11 @@ vi.mock('../../../utils/openUrl', () => ({ openUrl: vi.fn().mockResolvedValue(un
 vi.mock('../../../utils/tauriCommands/workspacePaths', () => ({
   openWorkspacePath: vi.fn().mockResolvedValue(undefined),
   revealWorkspacePath: vi.fn().mockResolvedValue(undefined),
+  // #2492: the Obsidian deep link now resolves the vault's absolute path
+  // through the shared workspace-link layer instead of trusting the
+  // `content_root_abs` field returned from the graph export RPC. Return the
+  // same path the prop carries so the existing `openUrl` assertion is stable.
+  resolveWorkspaceAbsolutePath: vi.fn().mockResolvedValue('/tmp/workspace/memory_tree/content'),
   previewWorkspaceText: vi
     .fn()
     .mockResolvedValue({

--- a/app/src/components/intelligence/__tests__/ObsidianVaultSection.test.tsx
+++ b/app/src/components/intelligence/__tests__/ObsidianVaultSection.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../../utils/openUrl', () => ({ openUrl: vi.fn().mockResolvedValue(un
 
 vi.mock('../../../utils/tauriCommands/workspacePaths', () => ({
   revealWorkspacePath: vi.fn().mockResolvedValue(undefined),
+  resolveWorkspaceAbsolutePath: vi.fn().mockResolvedValue('/tmp/workspace/memory_tree/content'),
 }));
 
 const { memoryTreeObsidianVaultStatus } =
@@ -19,9 +20,10 @@ const { memoryTreeObsidianVaultStatus } =
 
 const { openUrl } = (await import('../../../utils/openUrl')) as unknown as { openUrl: Mock };
 
-const { revealWorkspacePath } =
+const { revealWorkspacePath, resolveWorkspaceAbsolutePath } =
   (await import('../../../utils/tauriCommands/workspacePaths')) as unknown as {
     revealWorkspacePath: Mock;
+    resolveWorkspaceAbsolutePath: Mock;
   };
 
 const ROOT = '/tmp/workspace/memory_tree/content';
@@ -37,6 +39,7 @@ describe('ObsidianVaultSection', () => {
     localStorage.clear();
     openUrl.mockResolvedValue(undefined);
     revealWorkspacePath.mockResolvedValue(undefined);
+    resolveWorkspaceAbsolutePath.mockResolvedValue(ROOT);
   });
 
   it('registered vault → opens the deep link directly, no guidance shown', async () => {
@@ -121,5 +124,42 @@ describe('ObsidianVaultSection', () => {
 
     await waitFor(() => expect(screen.getByTestId('obsidian-vault-guidance')).toBeInTheDocument());
     expect(openUrl).not.toHaveBeenCalled();
+  });
+
+  // #2492: the absolute path that feeds the `obsidian://open?path=…` URL must
+  // come from the shared workspace-link layer (the Rust-side resolver), not
+  // from the `contentRootAbs` prop. The prop stays around for display, but
+  // the deep link URL is composed with whatever the resolver returns.
+  it('deep link uses the workspace-link resolver, not the contentRootAbs prop', async () => {
+    const resolved = '/private/var/folders/canonical/memory_tree/content';
+    resolveWorkspaceAbsolutePath.mockResolvedValue(resolved);
+    memoryTreeObsidianVaultStatus.mockResolvedValue(status({ registered: true }));
+    renderWithProviders(<ObsidianVaultSection contentRootAbs={ROOT} />);
+
+    fireEvent.click(screen.getByTestId('memory-open-in-obsidian'));
+
+    await waitFor(() =>
+      expect(resolveWorkspaceAbsolutePath).toHaveBeenCalledWith('memory_tree/content')
+    );
+    await waitFor(() =>
+      expect(openUrl).toHaveBeenCalledWith('obsidian://open?path=' + encodeURIComponent(resolved))
+    );
+  });
+
+  // #2492: when the Rust-side resolver rejects (e.g. workspace path missing
+  // on disk), the click must not silently no-op — it surfaces an error toast
+  // and keeps the guidance panel expanded so the user has an escape hatch.
+  it('resolver failure surfaces an error toast and keeps guidance expanded', async () => {
+    resolveWorkspaceAbsolutePath.mockRejectedValue(new Error('workspace path does not exist'));
+    memoryTreeObsidianVaultStatus.mockResolvedValue(status({ registered: true }));
+    const onToast = vi.fn();
+    renderWithProviders(<ObsidianVaultSection contentRootAbs={ROOT} onToast={onToast} />);
+
+    fireEvent.click(screen.getByTestId('memory-open-in-obsidian'));
+
+    await waitFor(() => expect(onToast).toHaveBeenCalled());
+    expect(onToast.mock.calls[0][0].type).toBe('error');
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(screen.getByTestId('obsidian-vault-guidance')).toBeInTheDocument();
   });
 });

--- a/app/src/utils/tauriCommands/workspacePaths.test.ts
+++ b/app/src/utils/tauriCommands/workspacePaths.test.ts
@@ -2,7 +2,12 @@ import { invoke } from '@tauri-apps/api/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { isTauri } from './common';
-import { openWorkspacePath, previewWorkspaceText, revealWorkspacePath } from './workspacePaths';
+import {
+  openWorkspacePath,
+  previewWorkspaceText,
+  resolveWorkspaceAbsolutePath,
+  revealWorkspacePath,
+} from './workspacePaths';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('./common', () => ({ isTauri: vi.fn() }));
@@ -60,5 +65,37 @@ describe('tauriCommands/workspacePaths', () => {
     });
 
     expect(invoke).toHaveBeenCalledWith('preview_workspace_text', { path: 'docs/readme.md' });
+  });
+
+  test('invokes resolve_workspace_absolute_path with a workspace-relative path', async () => {
+    vi.mocked(invoke).mockResolvedValue('/tmp/workspace/docs/readme.md');
+
+    await expect(resolveWorkspaceAbsolutePath('docs/readme.md')).resolves.toBe(
+      '/tmp/workspace/docs/readme.md'
+    );
+
+    expect(invoke).toHaveBeenCalledWith('resolve_workspace_absolute_path', {
+      path: 'docs/readme.md',
+    });
+  });
+
+  test('surfaces invoke rejection from resolve_workspace_absolute_path', async () => {
+    vi.mocked(invoke).mockRejectedValue('workspace path does not exist nope.md');
+
+    await expect(resolveWorkspaceAbsolutePath('nope.md')).rejects.toBe(
+      'workspace path does not exist nope.md'
+    );
+
+    expect(invoke).toHaveBeenCalledWith('resolve_workspace_absolute_path', { path: 'nope.md' });
+  });
+
+  test('resolveWorkspaceAbsolutePath throws before invoking when not running in Tauri', async () => {
+    vi.mocked(isTauri).mockReturnValue(false);
+
+    await expect(resolveWorkspaceAbsolutePath('docs/readme.md')).rejects.toThrow(
+      'Not running in Tauri'
+    );
+
+    expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/app/src/utils/tauriCommands/workspacePaths.ts
+++ b/app/src/utils/tauriCommands/workspacePaths.ts
@@ -45,3 +45,15 @@ export async function previewWorkspaceText(path: string): Promise<WorkspaceTextP
     sizeBytes: preview.size_bytes,
   };
 }
+
+/**
+ * Resolve a workspace-relative path to its canonical absolute path on disk,
+ * after the Rust side validates it stays inside the active OpenHuman
+ * workspace. Useful for UI flows that need to compose an absolute path into a
+ * platform-specific URL scheme (e.g. `obsidian://open?path=<abs>`) without
+ * re-implementing path normalization in the renderer.
+ */
+export async function resolveWorkspaceAbsolutePath(path: string): Promise<string> {
+  assertTauri();
+  return invoke<string>('resolve_workspace_absolute_path', { path });
+}


### PR DESCRIPTION
## Summary

- New Tauri command `resolve_workspace_absolute_path` exposes the workspace-link resolver introduced in #2476 so renderers can derive canonical absolute paths through the same guard as `open_workspace_path` / `reveal_workspace_path` / `preview_workspace_text`.
- New TS wrapper `resolveWorkspaceAbsolutePath` in `utils/tauriCommands/workspacePaths.ts`.
- `ObsidianVaultSection` now resolves the vault's absolute path through that wrapper before building the `obsidian://open?path=<abs>` URL, replacing the last Memory-tab surface that was constructing the deep link straight from a graph-export RPC field.
- User-visible behavior is unchanged — click still opens Obsidian to the vault, same toast copy — but the absolute path is now derived from the Rust-side resolver, not from a prop fed by RPC.

## Problem

Issue #2492 (Phase 3 cleanup of #1402) requires every Memory surface that constructs an on-disk path to compose with the shared workspace-link layer rather than hand-rolling its own resolution.

`MemoryGraph` was migrated in PR #2638. The remaining offender was `ObsidianVaultSection`, which built `obsidian://open?path=${encodeURIComponent(contentRootAbs)}` directly from the `content_root_abs` field returned by `memory_tree_obsidian_vault_status` — no canonicalize, no workspace-containment recheck, no shared error surface. Acceptance criterion from the issue:

> Obsidian behavior is preserved intentionally — Obsidian launch remains available where it is a user-facing feature, but it is composed with the shared workspace-link layer rather than replacing it.

## Solution

Three layers, kept thin:

1. **Rust (`app/src-tauri/src/workspace_paths.rs`)**: new `resolve_workspace_absolute_path` `#[tauri::command]` that wraps the existing internal `resolve_workspace_path` helper (same canonicalize + workspace-containment + non-leaky error surface as the other three commands). Registered in `lib.rs` and added to the `allow-workspace-files` permission manifest. Two new unit tests cover the happy-path (`memory_tree/content` resolves inside the workspace root) and the empty-input rejection; the existing resolver test suite already covers absolute-path / `..` / URI-scheme / symlink escapes.
2. **TypeScript (`app/src/utils/tauriCommands/workspacePaths.ts`)**: `resolveWorkspaceAbsolutePath(path)` wrapper mirroring the style of the other workspace wrappers (assertTauri guard + plain `invoke<string>`).
3. **Component (`app/src/components/intelligence/ObsidianVaultSection.tsx`)**: `fireDeepLink` now `await`s `resolveWorkspaceAbsolutePath('memory_tree/content')` and builds the URL from the returned absolute path. The `contentRootAbs` prop is preserved for display (button tooltip, guidance-panel code block, toast message text) so no cascading prop changes are needed — only the deep-link URL is rerouted.

### Tests

Updated `ObsidianVaultSection.test.tsx`:
- Mock the new wrapper in the existing `workspacePaths` mock block.
- New test: deep link URL is composed from the resolver output (not from `contentRootAbs`).
- New test: resolver rejection surfaces an error toast and keeps the guidance panel expanded.
- All 7 existing tests still pass (9 total).

Updated `MemoryWorkspace.test.tsx`:
- Mock `resolveWorkspaceAbsolutePath` to return the same path the assertion expects so the existing `'View vault in Obsidian' triggers the deep link` test stays stable. All 20 tests pass.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — every new line is exercised by the two new Vitest cases plus the existing happy-path test (now stricter via the resolver-call assertion) and the two new Rust unit tests. Resolver internals already covered by the prior `resolve_workspace_path_*` test suite.
- [x] N/A: Coverage matrix update — this is a behaviour-preserving refactor of an existing matrix entry, not an added/removed/renamed feature row.
- [x] N/A: No new feature IDs from the matrix affected.
- [x] No new external network dependencies introduced (mock backend used per Testing Strategy)
- [x] N/A: Manual smoke checklist — no release-cut surface touched; deep-link UX is unchanged from the user's point of view.
- [x] Linked issue closed via `Closes #2492` in the `## Related` section.

## Impact

- **Runtime/platform**: desktop only (`#[tauri::command]` lives in the Tauri shell; iOS client does not hit this code path). No change to JSON-RPC surface.
- **Security**: net positive — the Obsidian deep link now goes through the same workspace-containment guard as the other workspace commands, so a malicious `content_root_abs` value from the RPC (or a future scenario where the field is user-influenced) can no longer slip out of the workspace.
- **Migration / compatibility**: none; the URL shape is identical.

## Related

- Closes #2492
- Builds on #2476 (workspace-link layer) and #2638 (MemoryGraph migration)
- Follow-up PR(s)/TODOs: none — this is the final Memory-tab surface called out in #2492.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A (GitHub issue only)
- URL: https://github.com/tinyhumansai/openhuman/issues/2492

### Commit & Branch
- Branch: `fix/2492-memory-workspace-link-migration`
- Commit SHA: `3682a02d` (tip), `910d8097`, `8ff810ba`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — equivalent: `pnpm exec prettier --check` on changed files, clean.
- [x] `pnpm typecheck` — ran `pnpm exec tsc --noEmit` inside `app/`, clean.
- [x] Focused tests: `pnpm debug unit ObsidianVaultSection` → 9 passed; `pnpm debug unit MemoryWorkspace` → 20 passed.
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path app/src-tauri/Cargo.toml --check` clean; `GGML_NATIVE=OFF cargo check --manifest-path app/src-tauri/Cargo.toml --lib` clean (`GGML_NATIVE=OFF` is the documented macOS Tahoe + whisper-rs workaround).
- [x] Tauri fmt/check (if changed): same as above.

### Validation Blocked
- `command:` n/a — all validation passed.
- `error:` n/a
- `impact:` n/a

### Behavior Changes
- Intended behavior change: deep-link absolute path is now derived from the workspace-link resolver instead of trusted RPC output.
- User-visible effect: none. Same click, same Obsidian URL shape, same toast copy. The vault path printed in the guidance panel / toast still comes from `contentRootAbs` (RPC) because it is a display concern.

### Parity Contract
- Legacy behavior preserved: the `obsidian://open?path=<abs>` URL shape is byte-for-byte unchanged when the resolver returns the same path the RPC reports (normal case). `MemoryWorkspace.test.tsx`'s existing assertion proves it.
- Guard/fallback/dispatch parity checks: resolver failure now surfaces an error toast and keeps the guidance panel expanded — covered by a new test. Existing `detection failure degrades gracefully to the guidance panel` test still passes.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace-path resolver that returns canonical absolute paths for constructing vault deep links.

* **Bug Fixes**
  * Deep-link generation now uses resolved canonical workspace paths; on resolution failure it surfaces an error and does not attempt a fallback.

* **Tests**
  * Added/updated tests for path resolution success, failure, canonicalization, and deep-link behavior.

* **Chores**
  * Updated runtime permissions to allow workspace-path resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->