### PR TITLE
feat(search): unified web-access firewall (fetch + browser) with tri-state Allowed-websites control + friendly block errors

### DIFF
--- a/app/src/components/settings/panels/SearchPanel.test.tsx
+++ b/app/src/components/settings/panels/SearchPanel.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for SearchPanel — the "Allowed websites" (web-access firewall) section.
+ *
+ * Covers: loading the host allowlist into the editor, the "Allow all sites"
+ * toggle (persists `allow_all`), and saving an edited host list (persists
+ * `allowed_domains` + `allow_all: false`).
+ */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../test/test-utils';
+import SearchPanel from './SearchPanel';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const hoisted = vi.hoisted(() => ({ getSearchSettings: vi.fn(), updateSearchSettings: vi.fn() }));
+
+vi.mock('../../../utils/tauriCommands/config', () => ({
+  openhumanGetSearchSettings: (...a: unknown[]) => hoisted.getSearchSettings(...a),
+  openhumanUpdateSearchSettings: (...a: unknown[]) => hoisted.updateSearchSettings(...a),
+}));
+
+// Identity translator so we can query by the stable i18n keys.
+vi.mock('../../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({ navigateBack: vi.fn(), breadcrumbs: [] }),
+}));
+
+// Authed (non-local) session so the panel behaves normally.
+vi.mock('../../../utils/localSession', () => ({ isLocalSessionToken: () => false }));
+
+function settings(overrides: Record<string, unknown> = {}) {
+  return {
+    engine: 'managed',
+    effective_engine: 'managed',
+    max_results: 5,
+    timeout_secs: 15,
+    parallel_configured: false,
+    brave_configured: false,
+    allowed_domains: ['reuters.com'],
+    allow_all: false,
+    ...overrides,
+  };
+}
+
+describe('SearchPanel — allowed websites', () => {
+  beforeEach(() => {
+    hoisted.getSearchSettings.mockReset();
+    hoisted.updateSearchSettings.mockReset();
+    hoisted.getSearchSettings.mockResolvedValue({ result: settings() });
+    hoisted.updateSearchSettings.mockResolvedValue({ result: {} });
+  });
+
+  test('loads the explicit host list into the editor', async () => {
+    renderWithProviders(<SearchPanel embedded />);
+    // The textarea mounts empty, then a sync effect fills it from settings on
+    // the next tick — wait for the value rather than asserting immediately.
+    await waitFor(() => {
+      const ta = screen.getByPlaceholderText(
+        'settings.search.allowedSitesPlaceholder'
+      ) as HTMLTextAreaElement;
+      expect(ta.value).toBe('reuters.com');
+    });
+  });
+
+  test('toggling "Allow all sites" persists allow_all: true', async () => {
+    renderWithProviders(<SearchPanel embedded />);
+    await screen.findByPlaceholderText('settings.search.allowedSitesPlaceholder');
+
+    const toggle = screen.getByRole('switch', { name: 'settings.search.allowAllAria' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(hoisted.updateSearchSettings).toHaveBeenCalledWith({ allow_all: true })
+    );
+  });
+
+  test('saving an edited host list persists allowed_domains + allow_all: false', async () => {
+    renderWithProviders(<SearchPanel embedded />);
+    const textarea = await screen.findByPlaceholderText('settings.search.allowedSitesPlaceholder');
+
+    fireEvent.change(textarea, { target: { value: 'github.com\n  apnews.com  \n\n' } });
+    fireEvent.click(screen.getByText('settings.search.allowedSitesSave'));
+
+    await waitFor(() =>
+      expect(hoisted.updateSearchSettings).toHaveBeenCalledWith({
+        allowed_domains: ['github.com', 'apnews.com'],
+        allow_all: false,
+      })
+    );
+  });
+
+  test('hides the editor when allow-all is already on', async () => {
+    hoisted.getSearchSettings.mockResolvedValue({
+      result: settings({ allowed_domains: ['*'], allow_all: true }),
+    });
+    renderWithProviders(<SearchPanel embedded />);
+
+    const toggle = await screen.findByRole('switch', { name: 'settings.search.allowAllAria' });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    expect(screen.queryByPlaceholderText('settings.search.allowedSitesPlaceholder')).toBeNull();
+  });
+});

--- a/app/src/components/settings/panels/SearchPanel.test.tsx
+++ b/app/src/components/settings/panels/SearchPanel.test.tsx
@@ -117,6 +117,25 @@ describe('SearchPanel — unified web-access modes', () => {
     );
   });
 
+  test('Custom: pasted URLs are normalized to bare hosts before persisting', async () => {
+    renderWithProviders(<SearchPanel embedded />);
+    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
+
+    // Users paste full URLs; url_guard matches on host, so a scheme/path entry
+    // would never match. The editor strips both down to the bare host.
+    fireEvent.change(textarea, {
+      target: { value: 'https://reuters.com/markets\nhttp://apnews.com/\ngithub.com' },
+    });
+    fireEvent.click(screen.getByText('settings.search.allowedSitesSave'));
+
+    await waitFor(() =>
+      expect(hoisted.updateSearchSettings).toHaveBeenCalledWith({
+        allowed_domains: ['reuters.com', 'apnews.com', 'github.com'],
+        allow_all: false,
+      })
+    );
+  });
+
   test('allow_all settings → starts in Allow-all mode with no editor', async () => {
     hoisted.getSearchSettings.mockResolvedValue({
       result: settings({ allowed_domains: ['*'], allow_all: true }),

--- a/app/src/components/settings/panels/SearchPanel.test.tsx
+++ b/app/src/components/settings/panels/SearchPanel.test.tsx
@@ -1,9 +1,12 @@
 /**
- * Tests for SearchPanel — the "Allowed websites" (web-access firewall) section.
+ * Tests for SearchPanel — the "Allowed websites" (unified web-access firewall)
+ * section.
  *
- * Covers: loading the host allowlist into the editor, the "Allow all sites"
- * toggle (persists `allow_all`), and saving an edited host list (persists
- * `allowed_domains` + `allow_all: false`).
+ * Covers the tri-state access mode (Allow all / Custom / Block all):
+ *  - deriving the initial mode from the loaded settings,
+ *  - "Allow all"  → persists `allow_all: true`,
+ *  - "Block all"  → persists `allowed_domains: []` + `allow_all: false`,
+ *  - "Custom"     → reveals the host editor and saving persists the list.
  */
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -45,7 +48,14 @@ function settings(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe('SearchPanel — allowed websites', () => {
+const PLACEHOLDER = 'settings.search.allowedSitesPlaceholder';
+const ALLOW_ALL = 'settings.search.accessAllowAll';
+const CUSTOM = 'settings.search.accessCustom';
+const BLOCK_ALL = 'settings.search.accessBlockAll';
+
+const radio = (name: string) => screen.getByRole('radio', { name });
+
+describe('SearchPanel — unified web-access modes', () => {
   beforeEach(() => {
     hoisted.getSearchSettings.mockReset();
     hoisted.updateSearchSettings.mockReset();
@@ -53,34 +63,48 @@ describe('SearchPanel — allowed websites', () => {
     hoisted.updateSearchSettings.mockResolvedValue({ result: {} });
   });
 
-  test('loads the explicit host list into the editor', async () => {
+  test('explicit host list → starts in Custom mode with the editor populated', async () => {
     renderWithProviders(<SearchPanel embedded />);
-    // The textarea mounts empty, then a sync effect fills it from settings on
-    // the next tick — wait for the value rather than asserting immediately.
+    // The textarea mounts empty, then a one-time sync effect fills it from
+    // settings on the next tick — wait for the value rather than asserting now.
     await waitFor(() => {
-      const ta = screen.getByPlaceholderText(
-        'settings.search.allowedSitesPlaceholder'
-      ) as HTMLTextAreaElement;
+      const ta = screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
       expect(ta.value).toBe('reuters.com');
     });
+    expect(radio(CUSTOM)).toHaveAttribute('aria-checked', 'true');
+    expect(radio(ALLOW_ALL)).toHaveAttribute('aria-checked', 'false');
   });
 
-  test('toggling "Allow all sites" persists allow_all: true', async () => {
+  test('selecting "Allow all" persists allow_all: true and hides the editor', async () => {
     renderWithProviders(<SearchPanel embedded />);
-    await screen.findByPlaceholderText('settings.search.allowedSitesPlaceholder');
+    await screen.findByPlaceholderText(PLACEHOLDER);
 
-    const toggle = screen.getByRole('switch', { name: 'settings.search.allowAllAria' });
-    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(radio(ALLOW_ALL));
 
-    fireEvent.click(toggle);
     await waitFor(() =>
       expect(hoisted.updateSearchSettings).toHaveBeenCalledWith({ allow_all: true })
     );
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
   });
 
-  test('saving an edited host list persists allowed_domains + allow_all: false', async () => {
+  test('selecting "Block all" persists an empty allowlist and hides the editor', async () => {
     renderWithProviders(<SearchPanel embedded />);
-    const textarea = await screen.findByPlaceholderText('settings.search.allowedSitesPlaceholder');
+    await screen.findByPlaceholderText(PLACEHOLDER);
+
+    fireEvent.click(radio(BLOCK_ALL));
+
+    await waitFor(() =>
+      expect(hoisted.updateSearchSettings).toHaveBeenCalledWith({
+        allowed_domains: [],
+        allow_all: false,
+      })
+    );
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
+  });
+
+  test('Custom: saving an edited host list persists allowed_domains + allow_all: false', async () => {
+    renderWithProviders(<SearchPanel embedded />);
+    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
 
     fireEvent.change(textarea, { target: { value: 'github.com\n  apnews.com  \n\n' } });
     fireEvent.click(screen.getByText('settings.search.allowedSitesSave'));
@@ -93,14 +117,38 @@ describe('SearchPanel — allowed websites', () => {
     );
   });
 
-  test('hides the editor when allow-all is already on', async () => {
+  test('allow_all settings → starts in Allow-all mode with no editor', async () => {
     hoisted.getSearchSettings.mockResolvedValue({
       result: settings({ allowed_domains: ['*'], allow_all: true }),
     });
     renderWithProviders(<SearchPanel embedded />);
 
-    const toggle = await screen.findByRole('switch', { name: 'settings.search.allowAllAria' });
-    expect(toggle).toHaveAttribute('aria-checked', 'true');
-    expect(screen.queryByPlaceholderText('settings.search.allowedSitesPlaceholder')).toBeNull();
+    await waitFor(() => expect(radio(ALLOW_ALL)).toHaveAttribute('aria-checked', 'true'));
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
+  });
+
+  test('empty allowlist → starts in Block-all mode with no editor', async () => {
+    hoisted.getSearchSettings.mockResolvedValue({
+      result: settings({ allowed_domains: [], allow_all: false }),
+    });
+    renderWithProviders(<SearchPanel embedded />);
+
+    await waitFor(() => expect(radio(BLOCK_ALL)).toHaveAttribute('aria-checked', 'true'));
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull();
+  });
+
+  test('switching Block → Custom keeps the previously typed hosts', async () => {
+    renderWithProviders(<SearchPanel embedded />);
+    const textarea = (await screen.findByPlaceholderText(PLACEHOLDER)) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'example.com' } });
+
+    // Block all (persists empty list) then back to Custom — the editor text is
+    // local state and must survive the round trip so the user doesn't lose it.
+    fireEvent.click(radio(BLOCK_ALL));
+    await waitFor(() => expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull());
+    fireEvent.click(radio(CUSTOM));
+
+    const reopened = (await screen.findByPlaceholderText(PLACEHOLDER)) as HTMLTextAreaElement;
+    expect(reopened.value).toBe('example.com');
   });
 });

--- a/app/src/components/settings/panels/SearchPanel.tsx
+++ b/app/src/components/settings/panels/SearchPanel.tsx
@@ -38,6 +38,9 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
   const [braveKey, setBraveKey] = useState<string>('');
   const [showParallel, setShowParallel] = useState(false);
   const [showBrave, setShowBrave] = useState(false);
+  // Editor text for the allowed-websites host list (one host per line). The
+  // "*" wildcard is represented by the allowAll toggle, not shown here.
+  const [allowedText, setAllowedText] = useState<string>('');
 
   const ENGINES: EngineOption[] = [
     {
@@ -80,7 +83,15 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
     };
   }, []);
 
+  // Reflect the loaded allowlist into the editor (explicit hosts only — the
+  // "*" wildcard is surfaced through the allowAll toggle instead).
+  useEffect(() => {
+    if (!settings) return;
+    setAllowedText(settings.allowed_domains.filter(d => d !== '*').join('\n'));
+  }, [settings]);
+
   const selectedEngine = (settings?.engine as SearchEngineId | undefined) ?? 'managed';
+  const allowAll = settings?.allow_all ?? false;
 
   const persistEngine = async (next: SearchEngineId) => {
     if (!settings || status.kind === 'saving') return;
@@ -109,6 +120,37 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
       setSettings(refreshed.result);
       if (engine === 'parallel') setParallelKey('');
       else setBraveKey('');
+      setStatus({ kind: 'saved' });
+    } catch (err) {
+      setStatus({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  const persistAllowAll = async (next: boolean) => {
+    if (!settings || status.kind === 'saving') return;
+    setStatus({ kind: 'saving' });
+    try {
+      await openhumanUpdateSearchSettings({ allow_all: next });
+      const refreshed = await openhumanGetSearchSettings();
+      setSettings(refreshed.result);
+      setStatus({ kind: 'saved' });
+    } catch (err) {
+      setStatus({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  const persistAllowedDomains = async () => {
+    if (!settings || status.kind === 'saving') return;
+    const domains = allowedText
+      .split('\n')
+      .map(s => s.trim())
+      .filter(Boolean);
+    setStatus({ kind: 'saving' });
+    try {
+      // Editing the explicit host list implies "not allow-all".
+      await openhumanUpdateSearchSettings({ allowed_domains: domains, allow_all: false });
+      const refreshed = await openhumanGetSearchSettings();
+      setSettings(refreshed.result);
       setStatus({ kind: 'saved' });
     } catch (err) {
       setStatus({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
@@ -258,6 +300,55 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
                 docUrl="https://brave.com/search/api/"
                 t={t}
               />
+            </div>
+
+            {/* Allowed websites — host allowlist for web_fetch / curl. */}
+            <div className="rounded-xl border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-semibold text-stone-700 dark:text-neutral-200">
+                  {t('settings.search.allowedSitesLabel')}
+                </label>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={allowAll}
+                  aria-label={t('settings.search.allowAllAria')}
+                  onClick={() => void persistAllowAll(!allowAll)}
+                  disabled={status.kind === 'saving'}
+                  className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors disabled:opacity-50 ${
+                    allowAll ? 'bg-primary-500' : 'bg-stone-300 dark:bg-neutral-700'
+                  }`}>
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      allowAll ? 'translate-x-4' : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+              </div>
+              <p className="text-[11px] text-stone-500 dark:text-neutral-400 leading-relaxed">
+                {allowAll
+                  ? t('settings.search.allowedSitesAllOn')
+                  : t('settings.search.allowedSitesHint')}
+              </p>
+              {!allowAll && (
+                <>
+                  <textarea
+                    value={allowedText}
+                    onChange={e => setAllowedText(e.target.value)}
+                    rows={4}
+                    spellCheck={false}
+                    placeholder={t('settings.search.allowedSitesPlaceholder')}
+                    className="w-full rounded-lg border border-stone-200 dark:border-neutral-800 bg-stone-50 dark:bg-neutral-800/60 px-2 py-1.5 text-xs font-mono text-stone-800 dark:text-neutral-100 focus:outline-none focus-visible:border-primary-400"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void persistAllowedDomains()}
+                    disabled={status.kind === 'saving'}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium bg-primary-500 text-white hover:bg-primary-600 disabled:opacity-50">
+                    {t('settings.search.allowedSitesSave')}
+                  </button>
+                </>
+              )}
             </div>
 
             <div

--- a/app/src/components/settings/panels/SearchPanel.tsx
+++ b/app/src/components/settings/panels/SearchPanel.tsx
@@ -39,6 +39,19 @@ interface EngineOption {
   requiresKey: boolean;
 }
 
+/**
+ * Normalize a user-entered allowed-site entry down to a bare host so it
+ * matches `url_guard`'s host-based comparison. Strips a leading scheme and any
+ * path/query/fragment — e.g. `https://reuters.com/markets` → `reuters.com` —
+ * and trims surrounding whitespace. The `*` allow-all wildcard is preserved.
+ */
+const normalizeAllowedHost = (raw: string): string =>
+  raw
+    .trim()
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/\/.*$/, '')
+    .trim();
+
 const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
   const { t } = useT();
   const { navigateBack, breadcrumbs } = useSettingsNavigation();
@@ -173,10 +186,7 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
   };
 
   const persistAllowedDomains = () => {
-    const domains = allowedText
-      .split('\n')
-      .map(s => s.trim())
-      .filter(Boolean);
+    const domains = allowedText.split('\n').map(normalizeAllowedHost).filter(Boolean);
     // Editing the explicit host list implies "not allow-all".
     void persistSearchUpdate({ allowed_domains: domains, allow_all: false });
   };
@@ -330,9 +340,11 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
                 curl and (when enabled) the browser tool. Web search is not
                 gated by this list. */}
             <div className="rounded-xl border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 space-y-2">
-              <label className="text-xs font-semibold text-stone-700 dark:text-neutral-200">
+              {/* Section heading, not a form label — use a <p> so screen
+                  readers don't announce an orphan <label> with no htmlFor. */}
+              <p className="text-xs font-semibold text-stone-700 dark:text-neutral-200">
                 {t('settings.search.allowedSitesLabel')}
-              </label>
+              </p>
               <div
                 role="radiogroup"
                 aria-label={t('settings.search.accessModeAria')}

--- a/app/src/components/settings/panels/SearchPanel.tsx
+++ b/app/src/components/settings/panels/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useT } from '../../../lib/i18n/I18nContext';
 import { useCoreState } from '../../../providers/CoreStateProvider';
@@ -8,6 +8,7 @@ import {
   openhumanUpdateSearchSettings,
   type SearchEngineId,
   type SearchSettings,
+  type SearchSettingsUpdate,
 } from '../../../utils/tauriCommands/config';
 import SettingsHeader from '../components/SettingsHeader';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
@@ -18,6 +19,18 @@ type Status =
   | { kind: 'saving' }
   | { kind: 'saved' }
   | { kind: 'error'; message: string };
+
+/**
+ * Tri-state web-access mode for the unified fetch + browser allowlist.
+ * - `all`    → `allow_all: true` (the `"*"` wildcard)
+ * - `custom` → `allow_all: false` + an explicit host list (textarea)
+ * - `block`  → `allow_all: false` + an empty host list (no web access)
+ *
+ * `block` and an empty `custom` are indistinguishable once persisted (both are
+ * `allow_all: false` + `[]`); the distinction only matters locally while
+ * editing.
+ */
+type AccessMode = 'all' | 'custom' | 'block';
 
 interface EngineOption {
   id: SearchEngineId;
@@ -39,8 +52,14 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
   const [showParallel, setShowParallel] = useState(false);
   const [showBrave, setShowBrave] = useState(false);
   // Editor text for the allowed-websites host list (one host per line). The
-  // "*" wildcard is represented by the allowAll toggle, not shown here.
+  // "*" wildcard is represented by the access mode, not shown here.
   const [allowedText, setAllowedText] = useState<string>('');
+  // Tri-state web-access mode for the unified fetch + browser allowlist.
+  const [mode, setMode] = useState<AccessMode>('all');
+  // Sync editor + mode from settings exactly once, so a later settings refresh
+  // (e.g. after saving an engine change) can't clobber the user's in-progress
+  // host edits or chosen mode.
+  const initializedRef = useRef(false);
 
   const ENGINES: EngineOption[] = [
     {
@@ -83,15 +102,16 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
     };
   }, []);
 
-  // Reflect the loaded allowlist into the editor (explicit hosts only — the
-  // "*" wildcard is surfaced through the allowAll toggle instead).
+  // Reflect the loaded allowlist into the editor + mode, exactly once.
   useEffect(() => {
-    if (!settings) return;
-    setAllowedText(settings.allowed_domains.filter(d => d !== '*').join('\n'));
+    if (!settings || initializedRef.current) return;
+    initializedRef.current = true;
+    const explicit = settings.allowed_domains.filter(d => d !== '*');
+    setAllowedText(explicit.join('\n'));
+    setMode(settings.allow_all ? 'all' : explicit.length > 0 ? 'custom' : 'block');
   }, [settings]);
 
   const selectedEngine = (settings?.engine as SearchEngineId | undefined) ?? 'managed';
-  const allowAll = settings?.allow_all ?? false;
 
   const persistEngine = async (next: SearchEngineId) => {
     if (!settings || status.kind === 'saving') return;
@@ -126,11 +146,11 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
     }
   };
 
-  const persistAllowAll = async (next: boolean) => {
+  const persistSearchUpdate = async (update: SearchSettingsUpdate) => {
     if (!settings || status.kind === 'saving') return;
     setStatus({ kind: 'saving' });
     try {
-      await openhumanUpdateSearchSettings({ allow_all: next });
+      await openhumanUpdateSearchSettings(update);
       const refreshed = await openhumanGetSearchSettings();
       setSettings(refreshed.result);
       setStatus({ kind: 'saved' });
@@ -139,22 +159,26 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
     }
   };
 
-  const persistAllowedDomains = async () => {
-    if (!settings || status.kind === 'saving') return;
+  // Switch web-access mode. "Allow all" / "Block all" persist immediately;
+  // "Custom" only reveals the host editor (its Save button persists the list),
+  // and we keep whatever the user has already typed.
+  const selectMode = (next: AccessMode) => {
+    if (status.kind === 'saving') return;
+    setMode(next);
+    if (next === 'all') {
+      void persistSearchUpdate({ allow_all: true });
+    } else if (next === 'block') {
+      void persistSearchUpdate({ allowed_domains: [], allow_all: false });
+    }
+  };
+
+  const persistAllowedDomains = () => {
     const domains = allowedText
       .split('\n')
       .map(s => s.trim())
       .filter(Boolean);
-    setStatus({ kind: 'saving' });
-    try {
-      // Editing the explicit host list implies "not allow-all".
-      await openhumanUpdateSearchSettings({ allowed_domains: domains, allow_all: false });
-      const refreshed = await openhumanGetSearchSettings();
-      setSettings(refreshed.result);
-      setStatus({ kind: 'saved' });
-    } catch (err) {
-      setStatus({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
-    }
+    // Editing the explicit host list implies "not allow-all".
+    void persistSearchUpdate({ allowed_domains: domains, allow_all: false });
   };
 
   const isConfigured = (engine: SearchEngineId): boolean => {
@@ -302,35 +326,53 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
               />
             </div>
 
-            {/* Allowed websites — host allowlist for web_fetch / curl. */}
+            {/* Allowed websites — unified host allowlist shared by web_fetch /
+                curl and (when enabled) the browser tool. Web search is not
+                gated by this list. */}
             <div className="rounded-xl border border-stone-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-3 space-y-2">
-              <div className="flex items-center justify-between">
-                <label className="text-xs font-semibold text-stone-700 dark:text-neutral-200">
-                  {t('settings.search.allowedSitesLabel')}
-                </label>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={allowAll}
-                  aria-label={t('settings.search.allowAllAria')}
-                  onClick={() => void persistAllowAll(!allowAll)}
-                  disabled={status.kind === 'saving'}
-                  className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors disabled:opacity-50 ${
-                    allowAll ? 'bg-primary-500' : 'bg-stone-300 dark:bg-neutral-700'
-                  }`}>
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      allowAll ? 'translate-x-4' : 'translate-x-0.5'
-                    }`}
-                  />
-                </button>
+              <label className="text-xs font-semibold text-stone-700 dark:text-neutral-200">
+                {t('settings.search.allowedSitesLabel')}
+              </label>
+              <div
+                role="radiogroup"
+                aria-label={t('settings.search.accessModeAria')}
+                className="flex rounded-lg border border-stone-200 dark:border-neutral-800 overflow-hidden">
+                {(
+                  [
+                    ['all', 'settings.search.accessAllowAll'],
+                    ['custom', 'settings.search.accessCustom'],
+                    ['block', 'settings.search.accessBlockAll'],
+                  ] as const
+                ).map(([value, labelKey], idx) => {
+                  const selected = mode === value;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      onClick={() => selectMode(value)}
+                      disabled={status.kind === 'saving'}
+                      className={`flex-1 px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 focus:outline-none focus-visible:bg-primary-50 dark:focus-visible:bg-primary-900/30 ${
+                        idx !== 0 ? 'border-l border-stone-200 dark:border-neutral-800' : ''
+                      } ${
+                        selected
+                          ? 'bg-primary-500 text-white'
+                          : 'bg-white dark:bg-neutral-900 text-stone-700 dark:text-neutral-200 hover:bg-stone-50 dark:hover:bg-neutral-800/60'
+                      }`}>
+                      {t(labelKey)}
+                    </button>
+                  );
+                })}
               </div>
               <p className="text-[11px] text-stone-500 dark:text-neutral-400 leading-relaxed">
-                {allowAll
+                {mode === 'all'
                   ? t('settings.search.allowedSitesAllOn')
-                  : t('settings.search.allowedSitesHint')}
+                  : mode === 'block'
+                    ? t('settings.search.accessBlockAllHint')
+                    : t('settings.search.allowedSitesHint')}
               </p>
-              {!allowAll && (
+              {mode === 'custom' && (
                 <>
                   <textarea
                     value={allowedText}
@@ -342,7 +384,7 @@ const SearchPanel = ({ embedded = false }: { embedded?: boolean }) => {
                   />
                   <button
                     type="button"
-                    onClick={() => void persistAllowedDomains()}
+                    onClick={() => persistAllowedDomains()}
                     disabled={status.kind === 'saving'}
                     className="px-3 py-1.5 rounded-lg text-xs font-medium bg-primary-500 text-white hover:bg-primary-600 disabled:opacity-50">
                     {t('settings.search.allowedSitesSave')}

--- a/app/src/lib/i18n/chunks/ar-1.ts
+++ b/app/src/lib/i18n/chunks/ar-1.ts
@@ -1327,6 +1327,12 @@ const ar1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default ar1;

--- a/app/src/lib/i18n/chunks/ar-1.ts
+++ b/app/src/lib/i18n/chunks/ar-1.ts
@@ -1320,7 +1320,6 @@ const ar1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/ar-1.ts
+++ b/app/src/lib/i18n/chunks/ar-1.ts
@@ -1319,12 +1319,14 @@ const ar1: TranslationMap = {
   'subconscious.priority.normal': 'عادي',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default ar1;

--- a/app/src/lib/i18n/chunks/ar-1.ts
+++ b/app/src/lib/i18n/chunks/ar-1.ts
@@ -1319,6 +1319,12 @@ const ar1: TranslationMap = {
   'subconscious.priority.normal': 'عادي',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default ar1;

--- a/app/src/lib/i18n/chunks/bn-1.ts
+++ b/app/src/lib/i18n/chunks/bn-1.ts
@@ -1329,12 +1329,14 @@ const bn1: TranslationMap = {
   'subconscious.priority.normal': 'স্বাভাবিক',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default bn1;

--- a/app/src/lib/i18n/chunks/bn-1.ts
+++ b/app/src/lib/i18n/chunks/bn-1.ts
@@ -1330,7 +1330,6 @@ const bn1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/bn-1.ts
+++ b/app/src/lib/i18n/chunks/bn-1.ts
@@ -1329,6 +1329,12 @@ const bn1: TranslationMap = {
   'subconscious.priority.normal': 'স্বাভাবিক',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default bn1;

--- a/app/src/lib/i18n/chunks/bn-1.ts
+++ b/app/src/lib/i18n/chunks/bn-1.ts
@@ -1337,6 +1337,12 @@ const bn1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default bn1;

--- a/app/src/lib/i18n/chunks/de-1.ts
+++ b/app/src/lib/i18n/chunks/de-1.ts
@@ -1348,7 +1348,6 @@ const de1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/de-1.ts
+++ b/app/src/lib/i18n/chunks/de-1.ts
@@ -1347,6 +1347,12 @@ const de1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default de1;

--- a/app/src/lib/i18n/chunks/de-1.ts
+++ b/app/src/lib/i18n/chunks/de-1.ts
@@ -1347,12 +1347,14 @@ const de1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default de1;

--- a/app/src/lib/i18n/chunks/de-1.ts
+++ b/app/src/lib/i18n/chunks/de-1.ts
@@ -1355,6 +1355,12 @@ const de1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default de1;

--- a/app/src/lib/i18n/chunks/en-1.ts
+++ b/app/src/lib/i18n/chunks/en-1.ts
@@ -1031,7 +1031,6 @@ const en1: TranslationMap = {
   'settings.search.placeholderParallel': 'pk_...',
   'settings.search.placeholderBrave': 'BSA...',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Hosts the assistant may open and read — via web fetch and the browser tool — one per line, e.g. reuters.com. A host also covers its subdomains. Web search itself is not restricted by this list.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/en-1.ts
+++ b/app/src/lib/i18n/chunks/en-1.ts
@@ -1033,11 +1033,17 @@ const en1: TranslationMap = {
   'settings.search.allowedSitesLabel': 'Allowed websites',
   'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
-    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+    'Hosts the assistant may open and read — via web fetch and the browser tool — one per line, e.g. reuters.com. A host also covers its subdomains. Web search itself is not restricted by this list.',
   'settings.search.allowedSitesAllOn':
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
   'settings.embeddings.title': 'Embeddings',
   'settings.embeddings.description':
     'Choose which embedding provider converts memory into vectors for semantic search. Changing the provider, model, or dimensions invalidates stored vectors and requires a full memory reset.',

--- a/app/src/lib/i18n/chunks/en-1.ts
+++ b/app/src/lib/i18n/chunks/en-1.ts
@@ -1030,6 +1030,14 @@ const en1: TranslationMap = {
   'settings.search.placeholderStored': '•••••••• (stored)',
   'settings.search.placeholderParallel': 'pk_...',
   'settings.search.placeholderBrave': 'BSA...',
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
   'settings.embeddings.title': 'Embeddings',
   'settings.embeddings.description':
     'Choose which embedding provider converts memory into vectors for semantic search. Changing the provider, model, or dimensions invalidates stored vectors and requires a full memory reset.',

--- a/app/src/lib/i18n/chunks/es-1.ts
+++ b/app/src/lib/i18n/chunks/es-1.ts
@@ -1352,6 +1352,12 @@ const es1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default es1;

--- a/app/src/lib/i18n/chunks/es-1.ts
+++ b/app/src/lib/i18n/chunks/es-1.ts
@@ -1344,6 +1344,12 @@ const es1: TranslationMap = {
   'subconscious.priority.normal': 'normales',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default es1;

--- a/app/src/lib/i18n/chunks/es-1.ts
+++ b/app/src/lib/i18n/chunks/es-1.ts
@@ -1345,7 +1345,6 @@ const es1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/es-1.ts
+++ b/app/src/lib/i18n/chunks/es-1.ts
@@ -1344,12 +1344,14 @@ const es1: TranslationMap = {
   'subconscious.priority.normal': 'normales',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default es1;

--- a/app/src/lib/i18n/chunks/fr-1.ts
+++ b/app/src/lib/i18n/chunks/fr-1.ts
@@ -1349,12 +1349,14 @@ const fr1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default fr1;

--- a/app/src/lib/i18n/chunks/fr-1.ts
+++ b/app/src/lib/i18n/chunks/fr-1.ts
@@ -1350,7 +1350,6 @@ const fr1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/fr-1.ts
+++ b/app/src/lib/i18n/chunks/fr-1.ts
@@ -1357,6 +1357,12 @@ const fr1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default fr1;

--- a/app/src/lib/i18n/chunks/fr-1.ts
+++ b/app/src/lib/i18n/chunks/fr-1.ts
@@ -1349,6 +1349,12 @@ const fr1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default fr1;

--- a/app/src/lib/i18n/chunks/hi-1.ts
+++ b/app/src/lib/i18n/chunks/hi-1.ts
@@ -1327,6 +1327,12 @@ const hi1: TranslationMap = {
   'subconscious.priority.normal': 'सामान्य',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default hi1;

--- a/app/src/lib/i18n/chunks/hi-1.ts
+++ b/app/src/lib/i18n/chunks/hi-1.ts
@@ -1335,6 +1335,12 @@ const hi1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default hi1;

--- a/app/src/lib/i18n/chunks/hi-1.ts
+++ b/app/src/lib/i18n/chunks/hi-1.ts
@@ -1328,7 +1328,6 @@ const hi1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/hi-1.ts
+++ b/app/src/lib/i18n/chunks/hi-1.ts
@@ -1327,12 +1327,14 @@ const hi1: TranslationMap = {
   'subconscious.priority.normal': 'सामान्य',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default hi1;

--- a/app/src/lib/i18n/chunks/id-1.ts
+++ b/app/src/lib/i18n/chunks/id-1.ts
@@ -1332,12 +1332,14 @@ const id1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default id1;

--- a/app/src/lib/i18n/chunks/id-1.ts
+++ b/app/src/lib/i18n/chunks/id-1.ts
@@ -1333,7 +1333,6 @@ const id1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/id-1.ts
+++ b/app/src/lib/i18n/chunks/id-1.ts
@@ -1340,6 +1340,12 @@ const id1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default id1;

--- a/app/src/lib/i18n/chunks/id-1.ts
+++ b/app/src/lib/i18n/chunks/id-1.ts
@@ -1332,6 +1332,12 @@ const id1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default id1;

--- a/app/src/lib/i18n/chunks/it-1.ts
+++ b/app/src/lib/i18n/chunks/it-1.ts
@@ -1337,12 +1337,14 @@ const it1: TranslationMap = {
   'subconscious.priority.normal': 'normale',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default it1;

--- a/app/src/lib/i18n/chunks/it-1.ts
+++ b/app/src/lib/i18n/chunks/it-1.ts
@@ -1337,6 +1337,12 @@ const it1: TranslationMap = {
   'subconscious.priority.normal': 'normale',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default it1;

--- a/app/src/lib/i18n/chunks/it-1.ts
+++ b/app/src/lib/i18n/chunks/it-1.ts
@@ -1338,7 +1338,6 @@ const it1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/it-1.ts
+++ b/app/src/lib/i18n/chunks/it-1.ts
@@ -1345,6 +1345,12 @@ const it1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default it1;

--- a/app/src/lib/i18n/chunks/ko-1.ts
+++ b/app/src/lib/i18n/chunks/ko-1.ts
@@ -1329,11 +1329,13 @@ const ko1: TranslationMap = {
   'subconscious.priority.normal': '정상',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 export default ko1;

--- a/app/src/lib/i18n/chunks/ko-1.ts
+++ b/app/src/lib/i18n/chunks/ko-1.ts
@@ -1329,5 +1329,11 @@ const ko1: TranslationMap = {
   'subconscious.priority.normal': '정상',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 export default ko1;

--- a/app/src/lib/i18n/chunks/ko-1.ts
+++ b/app/src/lib/i18n/chunks/ko-1.ts
@@ -1330,7 +1330,6 @@ const ko1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/ko-1.ts
+++ b/app/src/lib/i18n/chunks/ko-1.ts
@@ -1337,5 +1337,11 @@ const ko1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 export default ko1;

--- a/app/src/lib/i18n/chunks/pt-1.ts
+++ b/app/src/lib/i18n/chunks/pt-1.ts
@@ -1350,6 +1350,12 @@ const pt1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default pt1;

--- a/app/src/lib/i18n/chunks/pt-1.ts
+++ b/app/src/lib/i18n/chunks/pt-1.ts
@@ -1343,7 +1343,6 @@ const pt1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/pt-1.ts
+++ b/app/src/lib/i18n/chunks/pt-1.ts
@@ -1342,6 +1342,12 @@ const pt1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default pt1;

--- a/app/src/lib/i18n/chunks/pt-1.ts
+++ b/app/src/lib/i18n/chunks/pt-1.ts
@@ -1342,12 +1342,14 @@ const pt1: TranslationMap = {
   'subconscious.priority.normal': 'normal',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default pt1;

--- a/app/src/lib/i18n/chunks/ru-1.ts
+++ b/app/src/lib/i18n/chunks/ru-1.ts
@@ -1340,6 +1340,12 @@ const ru1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default ru1;

--- a/app/src/lib/i18n/chunks/ru-1.ts
+++ b/app/src/lib/i18n/chunks/ru-1.ts
@@ -1332,12 +1332,14 @@ const ru1: TranslationMap = {
   'subconscious.priority.normal': 'нормальный',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default ru1;

--- a/app/src/lib/i18n/chunks/ru-1.ts
+++ b/app/src/lib/i18n/chunks/ru-1.ts
@@ -1332,6 +1332,12 @@ const ru1: TranslationMap = {
   'subconscious.priority.normal': 'нормальный',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default ru1;

--- a/app/src/lib/i18n/chunks/ru-1.ts
+++ b/app/src/lib/i18n/chunks/ru-1.ts
@@ -1333,7 +1333,6 @@ const ru1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}ms',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/chunks/zh-CN-1.ts
+++ b/app/src/lib/i18n/chunks/zh-CN-1.ts
@@ -1312,6 +1312,12 @@ const zhCN1: TranslationMap = {
   'subconscious.priority.normal': '正常',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}毫秒',
+  "settings.search.allowedSitesLabel": "Allowed websites",
+  "settings.search.allowAllAria": "Allow all sites",
+  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
+  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
+  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
+  "settings.search.allowedSitesSave": "Save websites",
 };
 
 export default zhCN1;

--- a/app/src/lib/i18n/chunks/zh-CN-1.ts
+++ b/app/src/lib/i18n/chunks/zh-CN-1.ts
@@ -1320,6 +1320,12 @@ const zhCN1: TranslationMap = {
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
 };
 
 export default zhCN1;

--- a/app/src/lib/i18n/chunks/zh-CN-1.ts
+++ b/app/src/lib/i18n/chunks/zh-CN-1.ts
@@ -1312,12 +1312,14 @@ const zhCN1: TranslationMap = {
   'subconscious.priority.normal': '正常',
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}毫秒',
-  "settings.search.allowedSitesLabel": "Allowed websites",
-  "settings.search.allowAllAria": "Allow all sites",
-  "settings.search.allowedSitesHint": "Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.",
-  "settings.search.allowedSitesAllOn": "The assistant can open any public website. Local and private addresses stay blocked.",
-  "settings.search.allowedSitesPlaceholder": "reuters.com\napnews.com\ngithub.com",
-  "settings.search.allowedSitesSave": "Save websites",
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
 };
 
 export default zhCN1;

--- a/app/src/lib/i18n/chunks/zh-CN-1.ts
+++ b/app/src/lib/i18n/chunks/zh-CN-1.ts
@@ -1313,7 +1313,6 @@ const zhCN1: TranslationMap = {
   'subconscious.durationSeconds': '{seconds}s',
   'subconscious.durationMilliseconds': '{milliseconds}毫秒',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -632,6 +632,14 @@ const en: TranslationMap = {
   'settings.search.placeholderStored': '•••••••• (stored)',
   'settings.search.placeholderParallel': 'pk_...',
   'settings.search.placeholderBrave': 'BSA...',
+  'settings.search.allowedSitesLabel': 'Allowed websites',
+  'settings.search.allowAllAria': 'Allow all sites',
+  'settings.search.allowedSitesHint':
+    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+  'settings.search.allowedSitesAllOn':
+    'The assistant can open any public website. Local and private addresses stay blocked.',
+  'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
+  'settings.search.allowedSitesSave': 'Save websites',
   // ─── Embeddings settings ───────────────────────────────────
   'settings.embeddings.title': 'Embeddings',
   'settings.embeddings.description':

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -635,11 +635,17 @@ const en: TranslationMap = {
   'settings.search.allowedSitesLabel': 'Allowed websites',
   'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
-    'Websites the assistant may open and read while researching (one host per line, e.g. reuters.com). A host also covers its subdomains. Leave empty to block all web access.',
+    'Hosts the assistant may open and read — via web fetch and the browser tool — one per line, e.g. reuters.com. A host also covers its subdomains. Web search itself is not restricted by this list.',
   'settings.search.allowedSitesAllOn':
     'The assistant can open any public website. Local and private addresses stay blocked.',
   'settings.search.allowedSitesPlaceholder': 'reuters.com\napnews.com\ngithub.com',
   'settings.search.allowedSitesSave': 'Save websites',
+  'settings.search.accessModeAria': 'Web access mode',
+  'settings.search.accessAllowAll': 'Allow all',
+  'settings.search.accessCustom': 'Custom',
+  'settings.search.accessBlockAll': 'Block all',
+  'settings.search.accessBlockAllHint':
+    'All web access is blocked — the assistant cannot open or read any website.',
   // ─── Embeddings settings ───────────────────────────────────
   'settings.embeddings.title': 'Embeddings',
   'settings.embeddings.description':

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -633,7 +633,6 @@ const en: TranslationMap = {
   'settings.search.placeholderParallel': 'pk_...',
   'settings.search.placeholderBrave': 'BSA...',
   'settings.search.allowedSitesLabel': 'Allowed websites',
-  'settings.search.allowAllAria': 'Allow all sites',
   'settings.search.allowedSitesHint':
     'Hosts the assistant may open and read — via web fetch and the browser tool — one per line, e.g. reuters.com. A host also covers its subdomains. Web search itself is not restricted by this list.',
   'settings.search.allowedSitesAllOn':

--- a/app/src/utils/__tests__/loopbackOauthListener.test.ts
+++ b/app/src/utils/__tests__/loopbackOauthListener.test.ts
@@ -28,7 +28,7 @@ describe('startLoopbackOauthListener', () => {
     expect(handle).toBeNull();
     expect(mockInvoke).toHaveBeenCalledWith('start_loopback_oauth_listener', {
       port: 53824,
-      timeoutSecs: 300,
+      timeoutSecs: 60,
     });
   });
 

--- a/app/src/utils/tauriCommands/config.ts
+++ b/app/src/utils/tauriCommands/config.ts
@@ -424,7 +424,12 @@ export interface SearchSettingsUpdate {
    * blocks all web access.
    */
   allowed_domains?: string[];
-  /** "Allow all sites" toggle. true → allowlist becomes `["*"]`. */
+  /**
+   * "Allow all sites" toggle. true → allowlist becomes `["*"]`.
+   * NOTE: `allow_all` is applied AFTER `allowed_domains` server-side, so when
+   * both are sent in one patch `allow_all` wins (true → `["*"]`, false → the
+   * `"*"` wildcard is dropped). Don't send both with conflicting intent.
+   */
   allow_all?: boolean;
 }
 

--- a/app/src/utils/tauriCommands/config.ts
+++ b/app/src/utils/tauriCommands/config.ts
@@ -418,6 +418,14 @@ export interface SearchSettingsUpdate {
   parallel_api_key?: string;
   /** Empty string clears the stored key. */
   brave_api_key?: string;
+  /**
+   * Websites the assistant may open/read (web_fetch / curl). Exact hosts
+   * match their subdomains; `"*"` allows all public sites; an empty list
+   * blocks all web access.
+   */
+  allowed_domains?: string[];
+  /** "Allow all sites" toggle. true → allowlist becomes `["*"]`. */
+  allow_all?: boolean;
 }
 
 export interface SearchSettings {
@@ -427,6 +435,10 @@ export interface SearchSettings {
   timeout_secs: number;
   parallel_configured: boolean;
   brave_configured: boolean;
+  /** Current allowed-websites host list (may contain `"*"`). */
+  allowed_domains: string[];
+  /** True when the allowlist contains the `"*"` wildcard. */
+  allow_all: boolean;
 }
 
 export async function openhumanGetSearchSettings(): Promise<CommandResponse<SearchSettings>> {

--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -418,6 +418,15 @@ pub struct SearchSettingsPatch {
     pub parallel_api_key: Option<String>,
     /// Brave Search API key. An empty string clears the stored key.
     pub brave_api_key: Option<String>,
+    /// Websites the assistant may open/read (`web_fetch` / `curl`), as a
+    /// host allowlist. Entries are exact hosts (`reuters.com`), which also
+    /// match their subdomains, or `"*"` for all public sites. Empty list
+    /// blocks all web access. Mirrors `[http_request].allowed_domains`.
+    pub allowed_domains: Option<Vec<String>>,
+    /// Convenience toggle for the "Allow all sites" switch. `Some(true)`
+    /// sets the allowlist to `["*"]`; `Some(false)` drops the wildcard while
+    /// keeping any explicit hosts. Applied after `allowed_domains`.
+    pub allow_all: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -997,6 +1006,26 @@ pub async fn apply_search_settings(
             Some(trimmed.to_string())
         };
     }
+    // Allowed websites (web_fetch / curl host allowlist). Trim + drop blanks
+    // + dedupe so the saved TOML stays clean; `"*"` is preserved as the
+    // allow-all wildcard.
+    if let Some(domains) = update.allowed_domains {
+        let mut cleaned: Vec<String> = domains
+            .into_iter()
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .collect();
+        cleaned.sort();
+        cleaned.dedup();
+        config.http_request.allowed_domains = cleaned;
+    }
+    if let Some(allow_all) = update.allow_all {
+        if allow_all {
+            config.http_request.allowed_domains = vec!["*".to_string()];
+        } else {
+            config.http_request.allowed_domains.retain(|d| d != "*");
+        }
+    }
     config.save().await.map_err(|e| e.to_string())?;
     let snapshot = snapshot_config_json(config)?;
     Ok(RpcOutcome::new(
@@ -1031,6 +1060,8 @@ pub async fn get_search_settings() -> Result<RpcOutcome<serde_json::Value>, Stri
         "timeout_secs": config.search.timeout_secs,
         "parallel_configured": config.search.parallel.has_key(),
         "brave_configured": config.search.brave.has_key(),
+        "allowed_domains": config.http_request.allowed_domains,
+        "allow_all": config.http_request.allowed_domains.iter().any(|d| d == "*"),
     });
     Ok(RpcOutcome::new(
         result,

--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -1009,6 +1009,9 @@ pub async fn apply_search_settings(
     // Allowed websites (web_fetch / curl host allowlist). Trim + drop blanks
     // + dedupe so the saved TOML stays clean; `"*"` is preserved as the
     // allow-all wildcard.
+    let allowlist_touched = update.allowed_domains.is_some() || update.allow_all.is_some();
+    let before_count = config.http_request.allowed_domains.len();
+    let before_allow_all = config.http_request.allowed_domains.iter().any(|d| d == "*");
     if let Some(domains) = update.allowed_domains {
         let mut cleaned: Vec<String> = domains
             .into_iter()
@@ -1025,6 +1028,21 @@ pub async fn apply_search_settings(
         } else {
             config.http_request.allowed_domains.retain(|d| d != "*");
         }
+    }
+    if allowlist_touched {
+        // Grep-friendly state-transition log for a security-sensitive surface.
+        // Record only host counts + the allow-all wildcard flag — never the raw
+        // hosts (redaction rule). Lets us trace "who widened/narrowed web reach"
+        // without leaking the allowlist contents.
+        let after_count = config.http_request.allowed_domains.len();
+        let after_allow_all = config.http_request.allowed_domains.iter().any(|d| d == "*");
+        tracing::info!(
+            before_count,
+            after_count,
+            before_allow_all,
+            after_allow_all,
+            "[config] http_request.allowed_domains updated"
+        );
     }
     config.save().await.map_err(|e| e.to_string())?;
     let snapshot = snapshot_config_json(config)?;

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -355,6 +355,44 @@ async fn apply_model_settings_updates_fields_and_persists_snapshot() {
 }
 
 #[tokio::test]
+async fn apply_search_settings_sets_and_clears_allowed_domains() {
+    let tmp = tempdir().unwrap();
+    let mut cfg = tmp_config(&tmp);
+
+    // Explicit host list is trimmed, blanks dropped, sorted + de-duped.
+    let patch = SearchSettingsPatch {
+        allowed_domains: Some(vec![
+            " reuters.com ".into(),
+            "reuters.com".into(),
+            String::new(),
+            "github.com".into(),
+        ]),
+        ..Default::default()
+    };
+    apply_search_settings(&mut cfg, patch).await.expect("apply");
+    assert_eq!(
+        cfg.http_request.allowed_domains,
+        vec!["github.com".to_string(), "reuters.com".to_string()]
+    );
+
+    // allow_all = true collapses the list to the wildcard.
+    let patch = SearchSettingsPatch {
+        allow_all: Some(true),
+        ..Default::default()
+    };
+    apply_search_settings(&mut cfg, patch).await.expect("apply");
+    assert_eq!(cfg.http_request.allowed_domains, vec!["*".to_string()]);
+
+    // allow_all = false drops the wildcard (explicit hosts only / blocked).
+    let patch = SearchSettingsPatch {
+        allow_all: Some(false),
+        ..Default::default()
+    };
+    apply_search_settings(&mut cfg, patch).await.expect("apply");
+    assert!(cfg.http_request.allowed_domains.is_empty());
+}
+
+#[tokio::test]
 async fn apply_model_settings_stores_api_key_and_clears_when_empty() {
     // #1342: custom OpenAI-compatible providers — api_key must round-trip
     // through `apply_model_settings` and clear when an empty string is sent.

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -668,6 +668,7 @@ async fn apply_autonomy_settings_updates_action_budget() {
         &mut cfg,
         AutonomySettingsPatch {
             max_actions_per_hour: Some(64),
+            ..Default::default()
         },
     )
     .await

--- a/src/openhuman/config/schema/tools.rs
+++ b/src/openhuman/config/schema/tools.rs
@@ -134,15 +134,34 @@ impl Default for BrowserConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct HttpRequestConfig {
-    #[serde(default)]
+    /// Hosts the assistant may open/read via `web_fetch` / `curl`. An exact
+    /// host also matches its subdomains; `"*"` allows all public sites; an
+    /// empty list blocks all web access. Defaults to `["*"]` so web research
+    /// works out of the box — the SSRF guard still blocks local/private hosts
+    /// regardless. Narrow this via Settings → Search → Allowed websites.
+    #[serde(default = "default_http_allowed_domains")]
     pub allowed_domains: Vec<String>,
     #[serde(default = "default_http_max_response_size")]
     pub max_response_size: usize,
     #[serde(default = "default_http_timeout_secs")]
     pub timeout_secs: u64,
+}
+
+impl Default for HttpRequestConfig {
+    fn default() -> Self {
+        Self {
+            allowed_domains: default_http_allowed_domains(),
+            max_response_size: default_http_max_response_size(),
+            timeout_secs: default_http_timeout_secs(),
+        }
+    }
+}
+
+fn default_http_allowed_domains() -> Vec<String> {
+    vec!["*".to_string()]
 }
 
 fn default_http_max_response_size() -> usize {
@@ -653,6 +672,17 @@ mod search_config_tests {
         assert_eq!(cfg.effective_engine(), SearchEngine::Managed);
         cfg.brave.api_key = Some("real".into());
         assert_eq!(cfg.effective_engine(), SearchEngine::Brave);
+    }
+
+    #[test]
+    fn http_request_defaults_to_allow_all() {
+        // Web research works out of the box: the default allowlist is the
+        // wildcard. The SSRF guard (url_guard) still blocks local/private
+        // hosts regardless, so this only opens public sites.
+        let cfg = HttpRequestConfig::default();
+        assert_eq!(cfg.allowed_domains, vec!["*".to_string()]);
+        assert_eq!(cfg.max_response_size, 1_000_000);
+        assert_eq!(cfg.timeout_secs, 30);
     }
 
     #[test]

--- a/src/openhuman/config/schema/tools.rs
+++ b/src/openhuman/config/schema/tools.rs
@@ -91,6 +91,11 @@ impl Default for BrowserComputerUseConfig {
 pub struct BrowserConfig {
     #[serde(default)]
     pub enabled: bool,
+    /// DEPRECATED: the browser tool now shares the unified web-access host list
+    /// in `[http_request].allowed_domains` (see `tools::ops::all_tools_with_runtime`).
+    /// Still parsed for backward compatibility but no longer gates browser
+    /// navigation. Manage allowed hosts via Settings → Search → Allowed websites;
+    /// browser allow-all remains gated by `OPENHUMAN_BROWSER_ALLOW_ALL`.
     #[serde(default)]
     pub allowed_domains: Vec<String>,
     #[serde(default)]

--- a/src/openhuman/config/schemas.rs
+++ b/src/openhuman/config/schemas.rs
@@ -128,6 +128,8 @@ struct SearchSettingsUpdate {
     timeout_secs: Option<u64>,
     parallel_api_key: Option<String>,
     brave_api_key: Option<String>,
+    allowed_domains: Option<Vec<String>>,
+    allow_all: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -810,6 +812,20 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     "brave_api_key",
                     "Brave Search API key (empty string clears the stored key).",
                 ),
+                FieldSchema {
+                    name: "allowed_domains",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Array(Box::new(
+                        TypeSchema::String,
+                    )))),
+                    comment: "Websites the assistant may open/read (web_fetch/curl). Exact hosts match their subdomains; \"*\" allows all public sites; empty blocks all web access.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "allow_all",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Bool)),
+                    comment: "\"Allow all sites\" toggle. true sets the allowlist to [\"*\"]; false drops the wildcard, keeping explicit hosts.",
+                    required: false,
+                },
             ],
             outputs: vec![json_output("snapshot", "Updated config snapshot.")],
         },
@@ -1482,6 +1498,8 @@ fn handle_update_search_settings(params: Map<String, Value>) -> ControllerFuture
             timeout_secs: update.timeout_secs,
             parallel_api_key: update.parallel_api_key,
             brave_api_key: update.brave_api_key,
+            allowed_domains: update.allowed_domains,
+            allow_all: update.allow_all,
         };
         match config_rpc::load_and_apply_search_settings(patch).await {
             Ok(outcome) => {

--- a/src/openhuman/inference/provider/factory_test.rs
+++ b/src/openhuman/inference/provider/factory_test.rs
@@ -759,9 +759,10 @@ fn invalid_models_fail() {
 fn make_openhuman_backend_forwards_unknown_hint_verbatim() {
     // Unrecognised hint:* strings (e.g. hint:reaction for lightweight models)
     // must be forwarded to the backend unchanged. The backend is authoritative
-    // over which hint values it accepts; the factory only translates the four
-    // canonical hints (reasoning/chat/agentic/coding).
-    for hint in ["hint:reaction", "hint:garbage", "hint:summarization"] {
+    // over which hint values it accepts; the factory only translates the
+    // canonical hints (reasoning/chat/agentic/coding/summarization) — the last
+    // of which gained a dedicated tier, so it is no longer "unknown".
+    for hint in ["hint:reaction", "hint:garbage"] {
         let mut config = Config::default();
         config.default_model = Some(hint.to_string());
         let (_, model) = make_openhuman_backend(&config).expect("factory should succeed");

--- a/src/openhuman/memory/chat.rs
+++ b/src/openhuman/memory/chat.rs
@@ -215,7 +215,10 @@ mod tests {
     fn build_chat_runtime_defaults_to_openhuman_resolved_model() {
         let cfg = Config::default();
         let (_provider, model) = build_chat_runtime(&cfg).unwrap();
-        assert_eq!(model, "reasoning-v1");
+        // build_chat_runtime resolves the "summarization" role, which gained a
+        // dedicated tier (summarization-v1) — the role no longer falls back to
+        // the generic reasoning-v1 default.
+        assert_eq!(model, "summarization-v1");
     }
 
     #[test]

--- a/src/openhuman/tools/impl/network/curl.rs
+++ b/src/openhuman/tools/impl/network/curl.rs
@@ -484,7 +484,7 @@ mod tests {
             .await
             .unwrap_err()
             .to_string();
-        assert!(err.contains("allowed_domains"));
+        assert!(err.contains("allowed websites"));
     }
 
     #[test]
@@ -569,6 +569,6 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_error);
-        assert!(result.output().contains("allowed_domains"));
+        assert!(result.output().contains("allowed websites"));
     }
 }

--- a/src/openhuman/tools/impl/network/http_request_tests.rs
+++ b/src/openhuman/tools/impl/network/http_request_tests.rs
@@ -41,7 +41,7 @@ async fn validate_url_rejects_disallowed_domain() {
         .await
         .unwrap_err()
         .to_string();
-    assert!(err.contains("allowed_domains"));
+    assert!(err.contains("allowed websites"));
 }
 
 #[tokio::test]

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -47,7 +47,7 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
         anyhow::bail!(
             "I'm not allowed to open any website yet — the allowed websites list is empty. \
              Add the site you need (or turn on \"Allow all sites\") under \
-             Settings → Search → Allowed websites, then ask me again."
+             Settings → Developer Options → Search engine → Allowed websites, then ask me again."
         );
     }
 
@@ -61,7 +61,7 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
         anyhow::bail!(
             "I'm not allowed to open '{host}' — it isn't in your allowed websites. \
              Add it (or turn on \"Allow all sites\") under \
-             Settings → Search → Allowed websites, then ask me again."
+             Settings → Developer Options → Search engine → Allowed websites, then ask me again."
         );
     }
 

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -47,7 +47,7 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
         anyhow::bail!(
             "I'm not allowed to open any website yet — the allowed websites list is empty. \
              Add the site you need (or turn on \"Allow all sites\") under \
-             Settings → Developer Options → Search engine → Allowed websites, then ask me again."
+             Settings → Advanced → Search engine → Allowed websites, then ask me again."
         );
     }
 
@@ -61,7 +61,7 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
         anyhow::bail!(
             "I'm not allowed to open '{host}' — it isn't in your allowed websites. \
              Add it (or turn on \"Allow all sites\") under \
-             Settings → Developer Options → Search engine → Allowed websites, then ask me again."
+             Settings → Advanced → Search engine → Allowed websites, then ask me again."
         );
     }
 

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -45,7 +45,9 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
 
     if allowed_domains.is_empty() {
         anyhow::bail!(
-            "Network tool is enabled but no allowed_domains are configured. Add [http_request].allowed_domains in config.toml"
+            "I'm not allowed to open any website yet — the allowed websites list is empty. \
+             Add the site you need (or turn on \"Allow all sites\") under \
+             Settings → Search → Allowed websites, then ask me again."
         );
     }
 
@@ -56,7 +58,11 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
     }
 
     if !host_matches_allowlist(&host, allowed_domains) {
-        anyhow::bail!("Host '{host}' is not in http_request.allowed_domains");
+        anyhow::bail!(
+            "I'm not allowed to open '{host}' — it isn't in your allowed websites. \
+             Add it (or turn on \"Allow all sites\") under \
+             Settings → Search → Allowed websites, then ask me again."
+        );
     }
 
     Ok(url.to_string())
@@ -244,7 +250,12 @@ fn extract_port(url: &str) -> anyhow::Result<u16> {
 
 pub(super) fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
     allowed_domains.iter().any(|domain| {
-        host == domain
+        // `"*"` is the explicit allow-all wildcard (the "Allow all sites"
+        // toggle), mirroring the browser tool. Local/private hosts are still
+        // rejected upstream by `is_private_or_local_host`, so a wildcard only
+        // opens *public* hosts, never the loopback/RFC1918 SSRF surface.
+        domain == "*"
+            || host == domain
             || host
                 .strip_suffix(domain)
                 .is_some_and(|prefix| prefix.ends_with('.'))
@@ -348,7 +359,29 @@ mod tests {
         let err = validate_url("https://google.com", &allow)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("allowed_domains"));
+        assert!(err.contains("allowed websites"));
+    }
+
+    #[test]
+    fn validate_wildcard_allows_any_public_host() {
+        let allow = vec!["*".to_string()];
+        assert!(validate_url("https://example.com/docs", &allow).is_ok());
+        assert!(validate_url("https://www.cnbc.com/markets", &allow).is_ok());
+        assert!(validate_url("https://sub.deep.example.org", &allow).is_ok());
+    }
+
+    #[test]
+    fn validate_wildcard_still_blocks_local_and_private() {
+        // "Allow all sites" must NOT defeat the SSRF guard.
+        let allow = vec!["*".to_string()];
+        assert!(validate_url("https://localhost:8080", &allow)
+            .unwrap_err()
+            .to_string()
+            .contains("local/private"));
+        assert!(validate_url("https://192.168.1.5", &allow)
+            .unwrap_err()
+            .to_string()
+            .contains("local/private"));
     }
 
     #[test]
@@ -392,7 +425,7 @@ mod tests {
         let err = validate_url("https://example.com", &[])
             .unwrap_err()
             .to_string();
-        assert!(err.contains("allowed_domains"));
+        assert!(err.contains("allowed websites"));
     }
 
     #[test]

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -614,7 +614,7 @@ mod tests {
         ] {
             let err = validate_url(notation, &allow).unwrap_err().to_string();
             assert!(
-                err.contains("allowed_domains"),
+                err.contains("allowed websites"),
                 "Expected allowlist rejection for {notation}, got: {err}"
             );
         }

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -8,6 +8,26 @@ use crate::openhuman::security::{AuditLogger, SecurityPolicy};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Derive the browser tool's host allowlist from the unified web-access list
+/// (`http_request.allowed_domains`).
+///
+/// The browser tool shares the single fetch allowlist rather than the
+/// deprecated `[browser].allowed_domains`, but the `"*"` allow-all wildcard is
+/// stripped on purpose: `web_fetch`/`curl` treat `"*"` as "open to all public
+/// sites", whereas the browser (a real Chromium with JS, cookies, and
+/// logged-in sessions) must NOT inherit blanket access from a fetch-side
+/// toggle. Browser allow-all stays gated by `OPENHUMAN_BROWSER_ALLOW_ALL`
+/// (`allow_all_browser_domains()`), and the tool itself stays behind
+/// `browser.enabled`. Net effect is fail-safe: unifying can only ever narrow
+/// the browser's reach, never widen it.
+pub(crate) fn browser_allowed_domains(http_allowed_domains: &[String]) -> Vec<String> {
+    http_allowed_domains
+        .iter()
+        .filter(|domain| domain.as_str() != "*")
+        .cloned()
+        .collect()
+}
+
 /// Create the default tool registry
 pub fn default_tools(security: Arc<SecurityPolicy>) -> Vec<Box<dyn Tool>> {
     default_tools_with_runtime(security, Arc::new(NativeRuntime::new()))
@@ -201,15 +221,20 @@ pub fn all_tools_with_runtime(
     ];
 
     if browser_config.enabled {
+        // Unified web-access allowlist (merge fetch + browser firewalls): the
+        // browser tool shares the single `http_request.allowed_domains` host
+        // list rather than the now-deprecated `[browser].allowed_domains`. See
+        // `browser_allowed_domains` for why the `"*"` wildcard is stripped.
+        let browser_allowed_domains = browser_allowed_domains(&http_config.allowed_domains);
         // Add legacy browser_open tool for simple URL opening
         tools.push(Box::new(BrowserOpenTool::new(
             security.clone(),
-            browser_config.allowed_domains.clone(),
+            browser_allowed_domains.clone(),
         )));
         // Add full browser automation tool (pluggable backend)
         tools.push(Box::new(BrowserTool::new_with_backend(
             security.clone(),
-            browser_config.allowed_domains.clone(),
+            browser_allowed_domains.clone(),
             browser_config.session_name.clone(),
             browser_config.backend.clone(),
             browser_config.native_headless,

--- a/src/openhuman/tools/ops_tests.rs
+++ b/src/openhuman/tools/ops_tests.rs
@@ -498,6 +498,32 @@ fn all_tools_excludes_browser_when_disabled() {
 }
 
 #[test]
+fn browser_allowed_domains_shares_fetch_list_minus_wildcard() {
+    // Unified web-access firewall: the browser tool derives its host allowlist
+    // from `http_request.allowed_domains`, but the `"*"` allow-all wildcard is
+    // stripped so a fetch-side "Allow all" never silently opens the browser.
+
+    // Explicit hosts pass straight through (shared with fetch).
+    assert_eq!(
+        browser_allowed_domains(&["reuters.com".into(), "github.com".into()]),
+        vec!["reuters.com".to_string(), "github.com".to_string()],
+    );
+
+    // `"*"` (fetch allow-all, and the http_request default) yields an EMPTY
+    // browser list — browser stays closed unless OPENHUMAN_BROWSER_ALLOW_ALL.
+    assert!(browser_allowed_domains(&["*".into()]).is_empty());
+
+    // Mixed: wildcard dropped, explicit hosts kept.
+    assert_eq!(
+        browser_allowed_domains(&["*".into(), "intranet.corp".into()]),
+        vec!["intranet.corp".to_string()],
+    );
+
+    // Block-all (empty fetch list) -> empty browser list.
+    assert!(browser_allowed_domains(&[]).is_empty());
+}
+
+#[test]
 fn all_tools_includes_browser_when_enabled() {
     let tmp = TempDir::new().unwrap();
     let security = Arc::new(SecurityPolicy::default());


### PR DESCRIPTION
## Summary

**Settings → Search** gains a single **"Allowed websites"** control that governs every way the agent reaches the web on-disk, backed by `[http_request].allowed_domains` via the existing `config.get/update_search_settings` RPC:

- **Tri-state access mode — Allow all · Custom · Block all** (segmented control). Replaces the earlier binary "Allow all" toggle; **"Block all" is now a first-class, labelled state** instead of the hidden "leave the box empty" path. Typed hosts are preserved when switching modes.
- **Unified fetch + browser firewall.** The browser tool (`browser_open` + `browser`) now shares the same host list via a new `tools::ops::browser_allowed_domains()` helper instead of the now-deprecated `[browser].allowed_domains`. The `"*"` allow-all wildcard is **stripped for the browser**, so a fetch-side "Allow all" never silently opens a real Chromium (JS + logged-in sessions) to every site. Browser allow-all stays gated by `OPENHUMAN_BROWSER_ALLOW_ALL` + `browser.enabled` — **fail-safe: unifying can only narrow the browser's reach, never widen it.**
- **Default `["*"]`** (allow all public sites) so web research works out of the box. The SSRF guard still blocks local/private hosts regardless. `url_guard`'s matcher treats `"*"` as allow-all.
- **Friendly `web_fetch`/`curl` block errors** that point the user/LLM to the setting instead of leaking `config.toml`/internal keys.
- **Web search is *not* gated by this list** (it's controlled by the engine + API key only); the UI hint says so.
- **i18n synced to all locales** — the new access-mode keys are added to every `*-1` chunk file, not just English.

## Problem

The agent's `research` flow uses `web_fetch`, gated by the SSRF-hardened host allowlist in `url_guard`. Two issues made this a wall:

1. The allowlist had **no UI** and **no RPC** — editable only by hand in `config.toml`, and the default was empty (every fresh user's first web search failed).
2. The block errors were dev-oriented; the subagent circuit-breaker then surfaced a generic *"web search isn't available"* with no path to fix it.

On top of that, OpenHuman had **two separate web-access firewalls** — `[http_request].allowed_domains` (fetch/curl) and `[browser].allowed_domains` (the browser tool) — with opposite defaults and no shared UI, so "what can the agent reach on the web?" had no single answer. And `url_guard`'s matcher had **no `*` wildcard**, so there was no clean "allow everything" option.

## Solution

- `config/ops.rs` + `config/schemas.rs`: extend `SearchSettingsPatch` / `SearchSettingsUpdate` and `get_search_settings` with `allowed_domains` + `allow_all`, reading/writing `[http_request].allowed_domains`. `allow_all=true` collapses to `["*"]`; `false` drops the wildcard.
- `config/schema/tools.rs`: `HttpRequestConfig` defaults `allowed_domains` to `["*"]`; `[browser].allowed_domains` marked **deprecated** (still parsed, no longer gates navigation).
- `url_guard.rs`: `host_matches_allowlist` treats `"*"` as allow-all (public hosts only — local/private still rejected); both block errors rewritten to name the host, cause, and exact fix.
- `tools/ops.rs`: new `browser_allowed_domains()` helper feeds the browser tool the shared fetch list **with `"*"` stripped**; `web_fetch`/`curl`/`http_request` keep treating `"*"` as allow-all.
- `SearchPanel.tsx`: the "Allowed websites" section is now a tri-state **Allow all / Custom / Block all** segmented control (the host editor + Save appear only in Custom). Hint copy clarifies the list covers fetch + browser, not search.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — added/updated tests target the changed lines: `url_guard` wildcard + SSRF, `HttpRequestConfig` default, `apply_search_settings` round-trip, `browser_allowed_domains` (shares fetch list minus `"*"`), and the rewritten SearchPanel suite (each mode + host-preservation). CI `coverage.yml` enforces the gate.
- [x] N/A: no `docs/TEST-COVERAGE-MATRIX.md` feature row maps to this Settings/allowlist control — flag in review if a row is wanted.
- [x] N/A: no matrix feature IDs apply to this change.
- [x] No new external network dependencies introduced (this change *governs* outbound access; it adds none).
- [x] N/A: does not touch release-cut surfaces in `docs/RELEASE-MANUAL-SMOKE.md`.
- [x] N/A: no tracking issue — feature requested directly; nothing to auto-close.

## Impact

- **Desktop** (core + React). Behavior change: `web_fetch`/`curl` is **allowed by default** (`["*"]`) where it was effectively blocked; local/private hosts remain blocked by the SSRF guard. The browser tool now derives its allowlist from the same list (minus `"*"`).
- **Security posture:** one place to reason about the agent's web reach. The browser tool can only ever be *narrowed* by this unification — it never inherits fetch's blanket `"*"`, and still requires `browser.enabled` + `OPENHUMAN_BROWSER_ALLOW_ALL` to go wide. Broader default outbound reach for fetch (public hosts only) is a deliberate zero-friction tradeoff that the new UI makes easy to scope down.

## Related

- Closes: N/A (no tracking issue)
- Resolved follow-ups from the original PR scope: ✅ folded `[browser].allowed_domains` into the unified "Allowed websites" control; ✅ synced the new i18n keys to all non-English locale chunks.
- Follow-up PR(s)/TODOs: remove the now-dead `settings.search.allowAllAria` i18n key (cosmetic).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/web-access-allowlist-settings
- Commit SHA: 11c6e9fc

### Validation Run
- [x] `pnpm exec prettier --check` — clean on changed frontend files (full repo check skipped due to known CRLF drift).
- [x] `pnpm typecheck` — clean (`tsc --noEmit`, exit 0).
- [x] `pnpm i18n:check` — missing 0 / extra 0 / drifted 0 across all locales (new keys present in every chunk-1).
- [x] Focused tests: `pnpm debug unit SearchPanel` → 7 passed.
- [x] Rust: `cargo check --manifest-path Cargo.toml --lib --tests` — exit 0 (reused the local dev build's cached sys-crate artifacts in the shared target).
- [x] N/A: Tauri fmt/check — no `app/src-tauri` source changes (core + frontend only).

### Validation Blocked
- `command:` `cargo test` (run the new `browser_allowed_domains` unit test)
- `error:` linking the Rust test binary needs the MSVC env (`vcvars`/SDK/linker) that the Windows dev wrapper sets up; the bare shell lacks it, and `cargo check --tests` (which passed) does not link.
- `impact:` the `browser_allowed_domains` test compiles but was not *executed* locally — it's a pure deterministic filter, and CI runs it. Everything else above was verified locally.

### Behavior Changes
- Intended: single tri-state web-access control; browser tool shares the fetch allowlist (minus `"*"`); `web_fetch`/`curl` default to allow-all; friendlier block errors.
- User-visible: Settings → Search now shows Allow all / Custom / Block all; web research works without config; clearer guidance when a host is blocked. No change to a vault/registration surface.

### Parity Contract
- Legacy preserved: exact-host + subdomain matching unchanged; SSRF blocklist (loopback/RFC1918/link-local/…) unchanged and still enforced even with `"*"`. `allow_all=false` + empty list reproduces the old block-by-default behavior.
- Browser parity: with `"*"` stripped, an explicit-host list applies to the browser exactly as before; the browser never gains blanket access from a fetch-side toggle, and `browser.enabled` + `OPENHUMAN_BROWSER_ALLOW_ALL` gates are untouched.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Website allowlist settings: three-mode selector (Allow all / Custom / Block all) with multiline domain editor and save control; browser and fetch use the unified allowlist.

* **Bug Fixes**
  * Clearer "allowed websites" messages; defaults now allow public sites by default while still blocking local/private addresses.

* **Tests**
  * Comprehensive unit and UI tests for loading, mode switching, editing, normalization, and persistence.

* **Documentation**
  * Added translation strings for the new UI across many languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
