### PR TITLE
test: unblock cargo test --lib on main (3 stale test fixtures)

### DIFF
--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -630,6 +630,7 @@ async fn apply_autonomy_settings_updates_action_budget() {
         &mut cfg,
         AutonomySettingsPatch {
             max_actions_per_hour: Some(64),
+            ..Default::default()
         },
     )
     .await

--- a/src/openhuman/inference/provider/factory_test.rs
+++ b/src/openhuman/inference/provider/factory_test.rs
@@ -759,9 +759,11 @@ fn invalid_models_fail() {
 fn make_openhuman_backend_forwards_unknown_hint_verbatim() {
     // Unrecognised hint:* strings (e.g. hint:reaction for lightweight models)
     // must be forwarded to the backend unchanged. The backend is authoritative
-    // over which hint values it accepts; the factory only translates the four
-    // canonical hints (reasoning/chat/agentic/coding).
-    for hint in ["hint:reaction", "hint:garbage", "hint:summarization"] {
+    // over which hint values it accepts; the factory only translates the
+    // canonical hints (reasoning/chat/agentic/coding/summarization).
+    // `hint:summarization` became canonical when `summarization-v1` shipped,
+    // so it is no longer a passthrough case.
+    for hint in ["hint:reaction", "hint:garbage"] {
         let mut config = Config::default();
         config.default_model = Some(hint.to_string());
         let (_, model) = make_openhuman_backend(&config).expect("factory should succeed");

--- a/src/openhuman/memory/chat.rs
+++ b/src/openhuman/memory/chat.rs
@@ -215,7 +215,10 @@ mod tests {
     fn build_chat_runtime_defaults_to_openhuman_resolved_model() {
         let cfg = Config::default();
         let (_provider, model) = build_chat_runtime(&cfg).unwrap();
-        assert_eq!(model, "reasoning-v1");
+        // build_chat_runtime resolves the "summarization" workload role,
+        // which routes to `summarization-v1` since the summarization tier
+        // shipped (PR #2690).
+        assert_eq!(model, "summarization-v1");
     }
 
     #[test]
@@ -223,6 +226,9 @@ mod tests {
         let mut cfg = Config::default();
         cfg.memory_tree.cloud_llm_model = Some("custom-summary-model".into());
         let (_provider, model) = build_chat_runtime(&cfg).unwrap();
+        // Setting memory_tree.cloud_llm_model overrides the cloud-memory
+        // model path; the routing falls back to the platform default
+        // (`reasoning-v1`) rather than the `summarization-v1` tier.
         assert_eq!(model, "reasoning-v1");
     }
 


### PR DESCRIPTION
## Summary

- Unblock `cargo test --lib` on `main` by fixing **3** test-side regressions that have shipped onto `main` without their tests being updated.
- Compile fix: `ops_tests.rs:631` `AutonomySettingsPatch` literal missing fields added in #2486.
- Behavior-update fix #1: `factory_test.rs:768` test was iterating `hint:summarization` as an unknown-passthrough case after #2690 made it canonical.
- Behavior-update fix #2: `chat.rs:218,226` test assertions hard-coded `reasoning-v1` even though `build_chat_runtime` now resolves to `summarization-v1` by default after #2690.

## Problem

`cargo test --lib` is red on `upstream/main` across the `Rust Core Coverage`, `Rust Core Tests + Quality`, and `Rust Core Tests (Windows — secrets ACL)` workflows. Every open PR inherits these failures regardless of what it touches.

Root cause: two recently-merged PRs shipped code changes without updating their tests in the same change.

### Failure 1 — `ops_tests.rs:631` (compile-time, hidden by silence)

```
error[E0063]: missing fields `allow_tool_install`, `allowed_commands`,
  `forbidden_paths` and 3 other fields in initializer of
  `openhuman::config::ops::AutonomySettingsPatch`
  --> src/openhuman/config/ops_tests.rs:631:9
```

`AutonomySettingsPatch` gained six `Option<…>` fields (`level`, `workspace_only`, `allowed_commands`, `forbidden_paths`, `trusted_roots`, `allow_tool_install`) via #2486 (`feat(app): UI control for max_actions_per_hour`). The test literal at line 631 still set only `max_actions_per_hour`. All other literals in the same file were updated; this one was missed.

### Failure 2 — `factory_test.rs:768` (assertion)

```
thread '…::make_openhuman_backend_forwards_unknown_hint_verbatim' panicked at
  src/openhuman/inference/provider/factory_test.rs:768:9:
  assertion `left == right` failed: hint 'hint:summarization' should pass through unchanged
    left: "summarization-v1"
   right: "hint:summarization"
```

`#2690` (`fix: … summarization-v1 tier …`) added `summarization-v1` as a canonical model tier. `is_known_openhuman_tier` (`src/openhuman/inference/provider/factory.rs:79-98`) explicitly includes `"hint:summarization"`, so the factory now translates that hint to `summarization-v1` rather than forwarding it verbatim. The test was iterating `hint:summarization` as an "unknown" passthrough case — that classification is no longer correct.

### Failure 3 — `chat.rs:218 / chat.rs:226` (assertion)

```
thread '…::build_chat_runtime_defaults_to_openhuman_resolved_model' panicked at
  src/openhuman/memory/chat.rs:218:9:
  assertion `left == right` failed
    left: "summarization-v1"
   right: "reasoning-v1"
```

`build_chat_runtime` calls `create_chat_provider("summarization", …)` (`src/openhuman/memory/chat.rs:127-147`). After #2690 the "summarization" workload routes to `summarization-v1` by default. The first assertion still expected `reasoning-v1`. Same file at line 226 (`build_chat_runtime_still_builds_when_cloud_memory_model_is_overridden`) is a sister case — but when `memory_tree.cloud_llm_model` is overridden, the routing actually does fall back to `reasoning-v1`. Both tests are updated to assert the value the function returns under each scenario.

## Solution

Three micro-commits, each `cargo check`-clean independently:

1. `fix(config/tests): init AutonomySettingsPatch with Default-padded fields` — single-line `..Default::default()` addition at `ops_tests.rs:632`. `AutonomySettingsPatch` derives `Default`, so the other `Option<…>` fields keep their previous (absent → `None`) value.
2. `test(inference): drop hint:summarization from passthrough loop` — remove the canonical hint from the iteration and tighten the comment.
3. `test(memory/chat): update expected default model after summarization-v1` — flip the two stale assertions (`reasoning-v1` → `summarization-v1` for the default; `reasoning-v1` is correct for the cloud-override case).

No production code changes. Three test files only.

## Submission Checklist

- [x] `cargo check --tests --lib` clean (was E0063 before)
- [x] `cargo test --lib openhuman::inference::provider::factory` clean
- [x] `cargo test --lib openhuman::memory::chat::tests::build_chat_runtime` — 3 / 3 pass
- [x] `cargo fmt --all -- --check` clean
- [x] N/A: i18n strings — non-UI change
- [x] N/A: frontend typecheck / lint / vitest — no TS surface touched
- [x] N/A: docs / changelog — pure test compile + assertion fix
- [x] N/A: tests added — this PR _restores_ existing tests; it doesn't change production behavior so no new assertions are warranted

## Known still-flaky tests (out of scope for this PR)

`cargo test --lib` (full local run) also fails two tests when run as part of the full suite that PASS in isolation:

- `openhuman::memory::ops::documents::tests::envelope_memory_handlers_report_counts_and_statuses` — surfaces `memory_init: "disk I/O error"` from sqlite when prior tests in the suite ran and contaminated process-global state. `GLOBAL_MEMORY_TEST_LOCK` exists already (added in #2649) for cross-test serialization but the sqlite open path appears to use `OnceLock`-style caching that breaks when tempdirs are recycled across tests. Same pattern flagged in earlier memory work.
- `openhuman::composio::action_tool::tests::mode_toggle_between_calls_is_observed` — the test asserts a direct-mode tool error must NOT contain `"no backend session"`, but under full-suite ordering a prior test leaves a cached backend client visible to this one. Same isolation issue, different domain.

Both pass in isolation:
```
cargo test --lib envelope_memory_handlers_report_counts_and_statuses → ok
cargo test --lib mode_toggle_between_calls_is_observed → ok
```

These are pre-existing test-isolation bugs (process-global state across tests), not regressions caused by this PR. Worth a follow-up that audits per-test reset hooks for the memory and composio singletons (`RwLock<Option<Arc>>` + `reset_for_tests` pattern is the usual fix shape).

## Impact

- Unblocks `cargo test --lib` matrix for every open PR (we hit these failures on #2708 and #2709 immediately after pushing).
- Zero production behavior change — only test code touched.

## Related

- Test-side fallout from #2486 (`AutonomySettingsPatch` field additions) and #2690 (`summarization-v1` tier).
- Surfaced while running CI on #2708 (wallet quote owner binding) and #2709 (in-process core token transport).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test coverage for hint handling and workload routing behavior to accurately reflect current system configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->