### PR TITLE
feat(skills): hide preview Composio toolkits by default + add Preview filter pill

### DIFF
--- a/app/src/components/skills/skillCategories.ts
+++ b/app/src/components/skills/skillCategories.ts
@@ -7,7 +7,8 @@ export type SkillCategory =
   | 'Tools & Automation'
   | 'Social'
   | 'Platform'
-  | 'Other';
+  | 'Other'
+  | 'Preview';
 
 export const SKILL_CATEGORY_ORDER: SkillCategory[] = [
   'All',
@@ -19,4 +20,5 @@ export const SKILL_CATEGORY_ORDER: SkillCategory[] = [
   'Social',
   'Platform',
   'Other',
+  'Preview',
 ];

--- a/app/src/components/skills/skillIcons.tsx
+++ b/app/src/components/skills/skillIcons.tsx
@@ -7,6 +7,7 @@ import YuanbaoIcon from '../channels/YuanbaoIcon';
 import {
   LuBlocks,
   LuBot,
+  LuEye,
   LuKeyboard,
   LuMessageSquareMore,
   LuMic,
@@ -154,6 +155,12 @@ const CATEGORY_META: Record<
     chipClassName: 'bg-stone-100 dark:bg-neutral-800 text-stone-700 dark:text-neutral-200',
     iconClassName: 'text-stone-500 dark:text-neutral-400',
     headingClassName: 'text-stone-500 dark:text-neutral-400',
+  },
+  Preview: {
+    icon: LuEye,
+    chipClassName: 'bg-amber-50 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+    iconClassName: 'text-amber-600 dark:text-amber-300',
+    headingClassName: 'text-amber-600 dark:text-amber-300',
   },
 };
 

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -658,17 +658,41 @@ export default function Skills() {
     return entries;
   }, [composioCatalogToolkits, composioConnectionByToolkit]);
 
+  // Exclude preview toolkits (not in the agent-ready catalog) from the default
+  // grid. Toolkits with an existing connection are always shown so users can
+  // manage or disconnect them. The filter is skipped while the agent-ready list
+  // is loading or errored — both cases degrade to showing everything.
+  // When the user selects the 'Preview' filter pill this memo is bypassed in
+  // composioFilteredEntries, which reads directly from composioGridEntries.
+  const composioAgentReadyEntries = useMemo(() => {
+    const resolved = !agentReadyLoading && !agentReadyError;
+    if (!resolved) return composioGridEntries;
+    return composioGridEntries.filter(
+      ({ meta, connection }) => Boolean(connection) || agentReadyToolkits.has(meta.slug)
+    );
+  }, [composioGridEntries, agentReadyToolkits, agentReadyLoading, agentReadyError]);
+
   const composioFilteredEntries = useMemo(() => {
     const q = searchQuery.toLowerCase();
+    const matchesSearch = (meta: ComposioToolkitMeta) =>
+      !q || meta.name.toLowerCase().includes(q) || meta.description.toLowerCase().includes(q);
+
+    if (selectedCategory === 'Preview') {
+      // Show only toolkits that are not in the agent-ready catalog.
+      const resolved = !agentReadyLoading && !agentReadyError;
+      if (!resolved) return [];
+      return composioGridEntries.filter(
+        ({ meta }) => matchesSearch(meta) && !agentReadyToolkits.has(meta.slug)
+      );
+    }
+
     const matchesCategory =
       selectedCategory === 'All'
         ? () => true
         : (meta: ComposioToolkitMeta) => meta.category === selectedCategory;
-    const matchesSearch = (meta: ComposioToolkitMeta) =>
-      !q || meta.name.toLowerCase().includes(q) || meta.description.toLowerCase().includes(q);
 
-    return composioGridEntries.filter(({ meta }) => matchesCategory(meta) && matchesSearch(meta));
-  }, [composioGridEntries, searchQuery, selectedCategory]);
+    return composioAgentReadyEntries.filter(({ meta }) => matchesCategory(meta) && matchesSearch(meta));
+  }, [composioAgentReadyEntries, composioGridEntries, searchQuery, selectedCategory, agentReadyToolkits, agentReadyLoading, agentReadyError]);
 
   const composioSortedEntries = useMemo(() => {
     return [...composioFilteredEntries].sort((a, b) => {
@@ -696,11 +720,17 @@ export default function Skills() {
       if (item.category === 'Channels') continue;
       cats.add(item.category);
     }
-    for (const { meta } of composioGridEntries) {
+    for (const { meta } of composioAgentReadyEntries) {
       cats.add(meta.category);
     }
+    // Show the 'Preview' pill when there are toolkits outside the agent-ready
+    // catalog (i.e., there's something to see in that filter).
+    const resolved = !agentReadyLoading && !agentReadyError;
+    if (resolved && composioGridEntries.some(({ meta }) => !agentReadyToolkits.has(meta.slug))) {
+      cats.add('Preview');
+    }
     return SKILL_CATEGORY_ORDER.filter(c => c !== 'Channels' && cats.has(c));
-  }, [allItems, composioGridEntries]);
+  }, [allItems, composioAgentReadyEntries, composioGridEntries, agentReadyToolkits, agentReadyLoading, agentReadyError]);
 
   const filteredItems = useMemo(() => {
     const q = searchQuery.toLowerCase();

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -679,8 +679,13 @@ export default function Skills() {
 
     if (selectedCategory === 'Preview') {
       // Show only toolkits that are not in the agent-ready catalog.
+      // If data is still loading or errored, show all matching entries so the
+      // grid doesn't flash blank — same graceful-degradation contract as the
+      // default view.
       const resolved = !agentReadyLoading && !agentReadyError;
-      if (!resolved) return [];
+      if (!resolved) {
+        return composioGridEntries.filter(({ meta }) => matchesSearch(meta));
+      }
       return composioGridEntries.filter(
         ({ meta }) => matchesSearch(meta) && !agentReadyToolkits.has(meta.slug)
       );

--- a/app/src/pages/Skills.tsx
+++ b/app/src/pages/Skills.tsx
@@ -691,8 +691,18 @@ export default function Skills() {
         ? () => true
         : (meta: ComposioToolkitMeta) => meta.category === selectedCategory;
 
-    return composioAgentReadyEntries.filter(({ meta }) => matchesCategory(meta) && matchesSearch(meta));
-  }, [composioAgentReadyEntries, composioGridEntries, searchQuery, selectedCategory, agentReadyToolkits, agentReadyLoading, agentReadyError]);
+    return composioAgentReadyEntries.filter(
+      ({ meta }) => matchesCategory(meta) && matchesSearch(meta)
+    );
+  }, [
+    composioAgentReadyEntries,
+    composioGridEntries,
+    searchQuery,
+    selectedCategory,
+    agentReadyToolkits,
+    agentReadyLoading,
+    agentReadyError,
+  ]);
 
   const composioSortedEntries = useMemo(() => {
     return [...composioFilteredEntries].sort((a, b) => {
@@ -730,7 +740,14 @@ export default function Skills() {
       cats.add('Preview');
     }
     return SKILL_CATEGORY_ORDER.filter(c => c !== 'Channels' && cats.has(c));
-  }, [allItems, composioAgentReadyEntries, composioGridEntries, agentReadyToolkits, agentReadyLoading, agentReadyError]);
+  }, [
+    allItems,
+    composioAgentReadyEntries,
+    composioGridEntries,
+    agentReadyToolkits,
+    agentReadyLoading,
+    agentReadyError,
+  ]);
 
   const filteredItems = useMemo(() => {
     const q = searchQuery.toLowerCase();

--- a/app/src/pages/__tests__/Skills.preview-filter.test.tsx
+++ b/app/src/pages/__tests__/Skills.preview-filter.test.tsx
@@ -166,15 +166,16 @@ describe('Skills page — Preview filter pill', () => {
   });
 
   // ── Test 5 ──────────────────────────────────────────────────────────────────
-  it('while agent-ready data is loading, Preview mode also shows all toolkits instead of a blank grid', () => {
+  it('while agent-ready data is loading, Preview pill is hidden and integrations grid remains populated', () => {
     agentReadyState = { agentReady: new Set(), loading: true, error: null };
 
     renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
 
-    // In loading state the Preview pill is not shown (availableCategories won't
-    // add it until resolved), so we cannot click it.  The important invariant is
-    // that the default grid is not blank; verified above in test 4.
-    // When Preview IS reachable (e.g. after data resolves), test 3 covers it.
+    // Preview pill must not appear until agent-ready data resolves.
+    expect(screen.queryByRole('tab', { name: /Preview/i })).not.toBeInTheDocument();
+    // Default grid must remain non-empty (no flash of blank grid while loading).
+    const section = getIntegrationsSection();
+    expect(getComposioSlugs(section).length).toBeGreaterThan(0);
   });
 
   // ── Test 6 ──────────────────────────────────────────────────────────────────

--- a/app/src/pages/__tests__/Skills.preview-filter.test.tsx
+++ b/app/src/pages/__tests__/Skills.preview-filter.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * Tests for the "Preview" composio filter pill introduced in issue #2283.
+ *
+ * Covers:
+ *  - Default grid hides non-agent-ready toolkits that have no connection.
+ *  - Toolkits with an existing connection always appear in the default grid.
+ *  - The "Preview" pill reveals non-agent-ready toolkits and hides curated ones.
+ *  - While agent-ready data is loading, all toolkits are shown (no blank flash).
+ *  - On agent-ready fetch error, all toolkits are shown (graceful degradation).
+ *  - Search works correctly in both default and Preview modes.
+ *  - The "Preview" pill is absent when every toolkit is agent-ready.
+ */
+import { fireEvent, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../../test/mockDefaultSkillStatusHooks';
+import { renderWithProviders } from '../../test/test-utils';
+import Skills from '../Skills';
+
+// ── Mutable state shared across tests ─────────────────────────────────────────
+
+let composioToolkits: string[] = [];
+let composioConnectionByToolkit = new Map<string, { id: string; toolkit: string; status: string }>();
+let agentReadyState: { agentReady: Set<string>; loading: boolean; error: string | null } = {
+  agentReady: new Set<string>(),
+  loading: false,
+  error: null,
+};
+let composioModeStatus = { result: { mode: 'backend', api_key_set: true }, logs: [] };
+let sessionToken = 'jwt-abc';
+
+// ── Mocks (module-level, hoisted by Vitest) ────────────────────────────────────
+
+vi.mock('../../hooks/useChannelDefinitions', () => ({
+  useChannelDefinitions: () => ({ definitions: [], loading: false, error: null }),
+}));
+
+vi.mock('../../lib/skills/skillsApi', () => ({
+  installSkill: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../lib/skills/hooks', () => ({
+  useAvailableSkills: () => ({ skills: [], loading: false, refresh: vi.fn() }),
+}));
+
+vi.mock('../../lib/composio/hooks', () => ({
+  useComposioIntegrations: () => ({
+    toolkits: composioToolkits,
+    connectionByToolkit: composioConnectionByToolkit,
+    refresh: vi.fn(),
+    loading: false,
+    error: null,
+  }),
+  useAgentReadyComposioToolkits: () => agentReadyState,
+}));
+
+vi.mock('../../lib/coreState/store', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/coreState/store')>(
+    '../../lib/coreState/store'
+  );
+  return { ...actual, getCoreStateSnapshot: () => ({ snapshot: { sessionToken } }) };
+});
+
+vi.mock('../../utils/tauriCommands', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/tauriCommands')>(
+    '../../utils/tauriCommands'
+  );
+  return {
+    ...actual,
+    openhumanComposioGetMode: vi.fn(async () => composioModeStatus),
+    subconsciousEscalationsDismiss: vi.fn(),
+  };
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Returns the integrations section container element. */
+function getIntegrationsSection(): HTMLElement {
+  const heading = screen.getByRole('heading', { name: 'Composio Integrations' });
+  const section = heading.closest('.rounded-2xl');
+  expect(section).not.toBeNull();
+  return section as HTMLElement;
+}
+
+/** Queries all `data-testid="skill-row-composio-<slug>"` within an element. */
+function getComposioSlugs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-testid^="skill-row-composio-"]')).map(el =>
+    (el as HTMLElement).dataset.testid!.replace('skill-row-composio-', '')
+  );
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+describe('Skills page — Preview filter pill', () => {
+  beforeEach(() => {
+    composioToolkits = [];
+    composioConnectionByToolkit = new Map();
+    composioModeStatus = { result: { mode: 'backend', api_key_set: true }, logs: [] };
+    sessionToken = 'jwt-abc';
+    // Resolved state with two agent-ready toolkits and two preview-only ones.
+    agentReadyState = {
+      agentReady: new Set(['gmail', 'github']),
+      loading: false,
+      error: null,
+    };
+  });
+
+  // ── Test 1 ──────────────────────────────────────────────────────────────────
+  it('default grid shows agent-ready toolkits and hides non-agent-ready unconnected ones', () => {
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    expect(slugs).toContain('gmail');
+    expect(slugs).toContain('github');
+    // airtable is in KNOWN_COMPOSIO_TOOLKITS but NOT agent-ready and has no
+    // connection — it must be hidden from the default view.
+    expect(slugs).not.toContain('airtable');
+  });
+
+  // ── Test 2 ──────────────────────────────────────────────────────────────────
+  it('default grid always shows a connected toolkit even if it is not agent-ready', () => {
+    // notion is NOT in the agent-ready set but has an active connection.
+    composioConnectionByToolkit = new Map([
+      ['notion', { id: 'ca_notion', toolkit: 'notion', status: 'ACTIVE' }],
+    ]);
+
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    expect(slugs).toContain('notion');
+    expect(slugs).not.toContain('airtable');
+  });
+
+  // ── Test 3 ──────────────────────────────────────────────────────────────────
+  it('Preview pill appears and shows only non-agent-ready toolkits when selected', () => {
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+
+    // The Preview pill must be visible.
+    const previewTab = screen.getByRole('tab', { name: /Preview/i });
+    expect(previewTab).toBeInTheDocument();
+
+    fireEvent.click(previewTab);
+
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    // Agent-ready toolkits must not appear in Preview mode.
+    expect(slugs).not.toContain('gmail');
+    expect(slugs).not.toContain('github');
+    // A non-agent-ready toolkit (airtable) must appear.
+    expect(slugs).toContain('airtable');
+  });
+
+  // ── Test 4 ──────────────────────────────────────────────────────────────────
+  it('while agent-ready data is loading, all toolkits are shown in the default view', () => {
+    agentReadyState = { agentReady: new Set(), loading: true, error: null };
+
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    // Non-agent-ready toolkit must still be visible (no flash of empty grid).
+    expect(slugs).toContain('airtable');
+    expect(slugs).toContain('gmail');
+  });
+
+  // ── Test 5 ──────────────────────────────────────────────────────────────────
+  it('while agent-ready data is loading, Preview mode also shows all toolkits instead of a blank grid', () => {
+    agentReadyState = { agentReady: new Set(), loading: true, error: null };
+
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+
+    // In loading state the Preview pill is not shown (availableCategories won't
+    // add it until resolved), so we cannot click it.  The important invariant is
+    // that the default grid is not blank; verified above in test 4.
+    // When Preview IS reachable (e.g. after data resolves), test 3 covers it.
+  });
+
+  // ── Test 6 ──────────────────────────────────────────────────────────────────
+  it('on agent-ready fetch error, all toolkits are shown (graceful degradation)', () => {
+    agentReadyState = { agentReady: new Set(), loading: false, error: 'rpc unavailable' };
+
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    expect(slugs).toContain('airtable');
+    expect(slugs).toContain('gmail');
+    // No Preview badges — we cannot tell which toolkits are non-agent-ready.
+    expect(within(section).queryAllByTestId(/composio-preview-badge-/)).toHaveLength(0);
+  });
+
+  // ── Test 7 ──────────────────────────────────────────────────────────────────
+  it('search query filters results in default mode', () => {
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+
+    const searchInput = screen.getByPlaceholderText('Search skills…');
+    fireEvent.change(searchInput, { target: { value: 'gmail' } });
+
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    expect(slugs).toContain('gmail');
+    expect(slugs).not.toContain('github');
+  });
+
+  // ── Test 8 ──────────────────────────────────────────────────────────────────
+  it('search query filters results in Preview mode', () => {
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+
+    const previewTab = screen.getByRole('tab', { name: /Preview/i });
+    fireEvent.click(previewTab);
+
+    const searchInput = screen.getByPlaceholderText('Search skills…');
+    fireEvent.change(searchInput, { target: { value: 'airtable' } });
+
+    const section = getIntegrationsSection();
+    const slugs = getComposioSlugs(section);
+
+    expect(slugs).toContain('airtable');
+    // Other non-agent-ready toolkits filtered out by search.
+    expect(slugs).not.toContain('notion');
+  });
+
+  // ── Test 9 ──────────────────────────────────────────────────────────────────
+  it('Preview pill does not appear when every catalog toolkit is agent-ready', () => {
+    // Mark every KNOWN toolkit as agent-ready by providing a wildcard check.
+    // We achieve this by setting agentReady to a very large set — in practice
+    // we make loading=false, error=null, and every toolkit appear in agentReady
+    // by stubbing it with a custom has() implementation.
+    const allAgentReady = {
+      has: () => true,
+      [Symbol.iterator]: function* () {},
+      size: 999,
+    } as unknown as Set<string>;
+    agentReadyState = { agentReady: allAgentReady, loading: false, error: null };
+
+    renderWithProviders(<Skills />, { initialEntries: ['/skills'] });
+
+    expect(screen.queryByRole('tab', { name: /Preview/i })).not.toBeInTheDocument();
+  });
+});

--- a/app/src/pages/__tests__/Skills.preview-filter.test.tsx
+++ b/app/src/pages/__tests__/Skills.preview-filter.test.tsx
@@ -20,7 +20,10 @@ import Skills from '../Skills';
 // ── Mutable state shared across tests ─────────────────────────────────────────
 
 let composioToolkits: string[] = [];
-let composioConnectionByToolkit = new Map<string, { id: string; toolkit: string; status: string }>();
+let composioConnectionByToolkit = new Map<
+  string,
+  { id: string; toolkit: string; status: string }
+>();
 let agentReadyState: { agentReady: Set<string>; loading: boolean; error: string | null } = {
   agentReady: new Set<string>(),
   loading: false,
@@ -98,11 +101,7 @@ describe('Skills page — Preview filter pill', () => {
     composioModeStatus = { result: { mode: 'backend', api_key_set: true }, logs: [] };
     sessionToken = 'jwt-abc';
     // Resolved state with two agent-ready toolkits and two preview-only ones.
-    agentReadyState = {
-      agentReady: new Set(['gmail', 'github']),
-      loading: false,
-      error: null,
-    };
+    agentReadyState = { agentReady: new Set(['gmail', 'github']), loading: false, error: null };
   });
 
   // ── Test 1 ──────────────────────────────────────────────────────────────────
@@ -232,7 +231,7 @@ describe('Skills page — Preview filter pill', () => {
     // by stubbing it with a custom has() implementation.
     const allAgentReady = {
       has: () => true,
-      [Symbol.iterator]: function* () {},
+      *[Symbol.iterator] () {},
       size: 999,
     } as unknown as Set<string>;
     agentReadyState = { agentReady: allAgentReady, loading: false, error: null };

--- a/app/src/pages/__tests__/Skills.preview-filter.test.tsx
+++ b/app/src/pages/__tests__/Skills.preview-filter.test.tsx
@@ -231,7 +231,7 @@ describe('Skills page — Preview filter pill', () => {
     // by stubbing it with a custom has() implementation.
     const allAgentReady = {
       has: () => true,
-      *[Symbol.iterator] () {},
+      *[Symbol.iterator]() {},
       size: 999,
     } as unknown as Set<string>;
     agentReadyState = { agentReady: allAgentReady, loading: false, error: null };


### PR DESCRIPTION
## Summary

- Toolkits not in the agent-ready catalog (issue #2283) are now hidden from the integrations grid by default to prevent the max-iterations failure loop that occurred when the agent called \`composio_list_tools\` on uncurated toolkits
- A **Preview** filter pill is added to the category bar so users can still browse and connect preview toolkits explicitly
- Toolkits with an existing connection are always shown regardless of agent-ready status so users can manage or disconnect them
- The filter degrades gracefully: while the agent-ready list is loading or errored, all toolkits are shown (no flash of empty grid)

## Problem

Uncurated Composio toolkits in the skills grid caused the agent to hit max-iterations when calling \`composio_list_tools\` on toolkits without a curated catalog. There was no UI distinction between agent-ready integrations and preview/experimental ones, and no way for users to browse preview toolkits intentionally.

## Solution

- Added \`'Preview'\` to \`SkillCategory\` and \`SKILL_CATEGORY_ORDER\`
- New \`composioAgentReadyEntries\` memo filters non-agent-ready toolkits from the default view; connected toolkits always pass through
- \`composioFilteredEntries\`: when \`selectedCategory === 'Preview'\`, inverts the agent-ready check and applies the same loading/error fallback (show all) to avoid blank grid
- \`availableCategories\`: adds the \`'Preview'\` pill only when there are preview toolkits to display and data is resolved

## Submission Checklist

> If a section does not apply to this change, mark the item as \`N/A\` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — \`Skills.preview-filter.test.tsx\` covers all 9 behaviours: default filter, connected-toolkit passthrough, Preview mode, loading/error fallback, search in both modes, no pill when all curated.
- [x] **Diff coverage ≥ 80%** — Frontend Coverage gate passed in CI.
- [x] N/A: Coverage matrix updated — no existing row maps to this control; feature is new.
- [x] N/A: All affected feature IDs from the matrix are listed — no matrix row applies.
- [x] No new external network dependencies introduced — change governs existing \`useAgentReadyComposioToolkits\` hook, no new API calls.
- [x] N/A: Manual smoke checklist — does not touch release-cut surfaces in \`docs/RELEASE-MANUAL-SMOKE.md\`.
- [x] N/A: Linked issue closed via \`Closes #NNN\` — tracked in Related below.

## Impact

- **Desktop** (React only; no Rust/Tauri changes). Grid behavior change: non-agent-ready unconnected toolkits hidden by default; Preview pill surfaces them on demand. Loading/error fallback unchanged (all toolkits shown).
- No migration needed — purely additive UI state.

## Related

- Closes: N/A (no Linear tracking issue; see issue #2283 for background)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: feat/composio-preview-filter
- Commit SHA: 8c7b1a07

### Validation Run
- [x] \`pnpm --filter openhuman-app format:check\` — clean on changed files.
- [x] \`pnpm typecheck\` — clean (tsc --noEmit, exit 0).
- [x] Focused tests: \`pnpm debug unit Skills.preview-filter\` → 9 passed; \`pnpm debug unit Skills.composio-catalog\` → existing suite still green.
- [x] N/A: Rust fmt/check — no Rust changes.
- [x] N/A: Tauri fmt/check — no \`app/src-tauri\` changes.

### Validation Blocked
- \`command:\` N/A
- \`error:\` N/A
- \`impact:\` N/A

### Behavior Changes
- Intended: non-agent-ready toolkits hidden from default Skills grid; visible via Preview pill; connected toolkits always shown; graceful fallback on loading/error.
- User-visible: fewer integrations shown by default (only curated ones); new amber "Preview" pill to browse experimental integrations.

### Parity Contract
- Legacy behavior preserved: connected toolkit management unaffected; all existing category filters unchanged; search behaviour unchanged.
- Fallback/degradation: loading or error state reverts to showing all toolkits (pre-#2283 behaviour).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Preview" category to surface non-production-ready integrations and a dedicated filter pill.
  * Preview items receive distinctive amber-themed styling for chip, icon, and headings.
  * Composio grid now conditionally shows/hides preview toolkits based on agent-ready status and connection state; search and default/category filters apply consistently.

* **Tests**
  * Added end-to-end tests covering Preview filtering, search interaction, loading/error states, and conditional pill visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->