### PR TITLE
fix(test): pin OPENHUMAN_WORKSPACE under TEST_ENV_LOCK in memory documents tests

### DIFF
--- a/src/openhuman/memory/ops/documents.rs
+++ b/src/openhuman/memory/ops/documents.rs
@@ -496,8 +496,53 @@ mod tests {
 
     use super::*;
 
-    fn ensure_memory_client() {
-        crate::openhuman::memory::ops::ensure_shared_memory_client();
+    /// Pins `OPENHUMAN_WORKSPACE` to the shared memory workspace for a test's
+    /// duration, holding [`crate::openhuman::config::TEST_ENV_LOCK`] so sibling
+    /// tests that mutate the env var (e.g. `config::ops`, `update::ops`,
+    /// autonomy settings) cannot change it mid-run.
+    ///
+    /// `documents` tests are the only `memory::ops` tests that resolve the
+    /// workspace from the env var (`memory_init` → `current_workspace_dir` →
+    /// `Config::load_or_init`), so without this pin they race those tests and
+    /// `memory_init` intermittently fails — surfaced under `cargo-llvm-cov`
+    /// timing. Lock order is `GLOBAL_MEMORY_TEST_LOCK` → `TEST_ENV_LOCK` (the
+    /// test takes the memory lock first, then this guard takes the env lock); no
+    /// code path takes them in the opposite order, so there is no deadlock.
+    struct WorkspaceEnvGuard {
+        _env_lock: std::sync::MutexGuard<'static, ()>,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl WorkspaceEnvGuard {
+        fn pin(workspace: &std::path::Path) -> Self {
+            let env_lock = crate::openhuman::config::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous = std::env::var_os("OPENHUMAN_WORKSPACE");
+            std::env::set_var("OPENHUMAN_WORKSPACE", workspace);
+            Self {
+                _env_lock: env_lock,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for WorkspaceEnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("OPENHUMAN_WORKSPACE", value),
+                None => std::env::remove_var("OPENHUMAN_WORKSPACE"),
+            }
+        }
+    }
+
+    /// Bind the shared memory client and pin `OPENHUMAN_WORKSPACE` to its
+    /// workspace for the test (see [`WorkspaceEnvGuard`]). Hold the returned
+    /// guard for the whole test: `let _env = ensure_memory_client();`.
+    #[must_use]
+    fn ensure_memory_client() -> WorkspaceEnvGuard {
+        let workspace = crate::openhuman::memory::ops::ensure_shared_memory_client();
+        WorkspaceEnvGuard::pin(&workspace)
     }
 
     fn unique_namespace(prefix: &str) -> String {

--- a/src/openhuman/memory/ops/test_support.rs
+++ b/src/openhuman/memory/ops/test_support.rs
@@ -10,11 +10,17 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-/// Binds the process-global memory client to a single shared temp workspace.
+/// Binds the process-global memory client to a single shared temp workspace and
+/// returns that workspace path.
 ///
 /// Safe to call from multiple test threads concurrently — subsequent calls with
 /// the same workspace path return the existing client without rebinding.
-pub(crate) fn ensure_shared_memory_client() {
+///
+/// The returned path lets callers whose RPC path *also* resolves the workspace
+/// from `OPENHUMAN_WORKSPACE` (notably `memory::ops::documents` via
+/// `memory_init` → `current_workspace_dir`) pin the env var to this same path so
+/// the env and the bound client agree. See `documents::tests`.
+pub(crate) fn ensure_shared_memory_client() -> PathBuf {
     static WORKSPACE: OnceLock<PathBuf> = OnceLock::new();
     let workspace = WORKSPACE.get_or_init(|| {
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -25,4 +31,5 @@ pub(crate) fn ensure_shared_memory_client() {
     });
     crate::openhuman::memory::global::init(workspace.clone())
         .expect("initialize shared test memory client");
+    workspace.clone()
 }


### PR DESCRIPTION
## Summary

- Fix the intermittent `Rust Core Coverage (cargo-llvm-cov)` failure on `memory::ops::documents::tests::envelope_memory_handlers_report_counts_and_statuses` (a `9637 passed; 1 failed` flake that recurs under coverage timing).
- `documents` test helper now pins `OPENHUMAN_WORKSPACE` under `TEST_ENV_LOCK` for the test's duration, so sibling tests can't change the env var mid-run.
- Test-only change (2 files, both `#[cfg(test)]` / test-support).

## Problem

`memory::ops::documents` tests resolve the workspace from the `OPENHUMAN_WORKSPACE` env var (`memory_init` → `current_workspace_dir` → `Config::load_or_init`), but they only held `GLOBAL_MEMORY_TEST_LOCK` — **not** `TEST_ENV_LOCK`, the lock that `config::ops` / `update::ops` / autonomy-settings tests take when they `set_var`/`remove_var` `OPENHUMAN_WORKSPACE`. Under `cargo-llvm-cov`'s instrumented timing, a sibling test can change the env between a documents test's setup and its `memory_init` call, so `memory_init` resolves a stale/removed workspace and fails intermittently. `documents` is the only `memory::ops` module that reads the workspace from the env (`kv_graph`/`sync`/`tool_memory` don't), so they're unaffected.

## Solution

- `ensure_memory_client()` now returns a `WorkspaceEnvGuard` that holds `TEST_ENV_LOCK` and pins `OPENHUMAN_WORKSPACE` to the shared memory workspace for the test's duration (restoring the prior value on drop). The two documents tests already capture it as `let _env = ensure_memory_client();`.
- `ensure_shared_memory_client()` returns the shared workspace path so the env var and the bound client agree.
- Lock order is `GLOBAL_MEMORY_TEST_LOCK` → `TEST_ENV_LOCK` (the test takes the memory lock first, then the guard takes the env lock); no code path takes them in the reverse order, so there is no deadlock. This mirrors the existing `update::ops` tests, which take `TEST_ENV_LOCK` for the same reason.

## Submission Checklist

- [x] Tests added or updated — this *is* a test-isolation fix; `documents` tests now serialize on `TEST_ENV_LOCK` and pass deterministically. Verified the full parallel `cargo test --lib` run with `documents` green and no deadlock.
- [x] **Diff coverage ≥ 80%** — changed lines are entirely test / test-support code, exercised by the `documents` tests themselves.
- N/A Coverage matrix updated — test-infrastructure-only change; no feature behavior added/removed/renamed.
- N/A All affected feature IDs listed — no feature change.
- [x] No new external network dependencies introduced — no deps changed.
- N/A Manual smoke checklist — test-only change, no release-cut surface.
- N/A Linked issue closed via `Closes #NNN` — no tracked issue; this is a CI flake fix found while landing #2706 (its coverage job recurs on this test).

## Impact

- CI only — makes `Rust Core Coverage` deterministic for this test; unblocks every PR that currently inherits this flake (e.g. #2706 once rebased on top). No runtime/product code touched.

## Related

- Closes: —
- Follow-up PR(s)/TODOs: there are separate, unrelated global-state flakes (`composio::action_tool` / `composio::ops` mock state) observed in the same suite — out of scope here; can be a follow-up.

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/documents-env-race-test-isolation`
- Commit SHA: `d492b1ba`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A (no `app/` changes); `cargo fmt --check` clean
- N/A `pnpm typecheck` — no TypeScript changed
- [x] Focused tests: `cargo test --lib openhuman::memory::ops::documents::tests` (2 pass); full `cargo test --lib` run with `documents` green, no deadlock
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo check --tests` clean; `cargo clippy --lib` clean (changed files produce zero findings)
- N/A Tauri fmt/check: shell unchanged

### Validation Blocked
- `command:` full `cargo test --lib` shows pre-existing unrelated flakes (`composio::*`) and `cargo clippy --tests` shows pre-existing `approx_constant` lints in `rpc_log`/`pformat`/`vectors/store_tests`
- `error:` unrelated to this change
- `impact:` none on this fix; noted as separate follow-ups

### Behavior Changes
- Intended: none at runtime — test isolation only.
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: `ensure_shared_memory_client()` still binds the same shared workspace; callers that ignore the new return value are unaffected.
- Guard/fallback/dispatch parity checks: lock order documented (GLOBAL → ENV), no deadlock.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure to prevent race conditions in shared-memory tests by better managing environment variable handling across concurrent test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->