### PR TITLE
docs(memory-tree): update stale comment on translate_query_global_args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,7 @@ test-map.md
 
 # AI assistant progress tracking
 .kimi/
+.specify/
+.claude/skills/
 .codex-tmp
 *.enc

--- a/src/openhuman/memory/query/mod.rs
+++ b/src/openhuman/memory/query/mod.rs
@@ -174,16 +174,13 @@ impl Tool for MemoryTreeTool {
 ///
 /// The consolidated `parameters_schema()` exposes one shared
 /// `time_window_days` field for both `query_source` and `query_global` (the
-/// `query_source` backend uses that exact name). The `query_global` backend
-/// — `QueryGlobalRequest { window_days: u32 }` in `memory/tree/retrieval/rpc.rs`
-/// — was never aligned with that schema, so any call following the
-/// consolidated contract failed with `missing field 'window_days'`.
-///
-/// Translating in the dispatch keeps the LLM-facing schema stable and
-/// leaves the standalone [`MemoryTreeQueryGlobalTool`] (which advertises
-/// `window_days` natively) untouched. An explicit `window_days` always
-/// wins so callers can opt into the underlying contract if they ever
-/// want to.
+/// `query_source` backend uses that exact name). `QueryGlobalRequest` in
+/// `memory_tree/retrieval/rpc.rs` uses `time_window_days` as its primary
+/// field name and accepts `window_days` via `#[serde(alias = "window_days")]`.
+/// The translation here keeps the LLM-facing consolidated schema stable
+/// (callers always send `time_window_days`) while routing through the alias
+/// path, which is equivalent. An explicit `window_days` in the payload
+/// always wins — the translator is a no-op for callers that already use it.
 fn translate_query_global_args(mut args: serde_json::Value) -> serde_json::Value {
     if let Some(obj) = args.as_object_mut() {
         if !obj.contains_key("window_days") {


### PR DESCRIPTION
## Summary
- Update stale doc comment on `translate_query_global_args` in `tools/impl/memory/tree/mod.rs`
- Comment described `QueryGlobalRequest` as `{ window_days: u32 }` (pre-fix shape); field is now `time_window_days` with `#[serde(alias = "window_days")]`
- Add `.specify/` and `.claude/skills/` to `.gitignore` to exclude spec-kit scaffolding

## Test plan
- [x] No logic changes — doc comment only
- [x] `cargo fmt --check` passes
- [x] Existing tests in `mod.rs` and `rpc.rs` cover the field alias behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated gitignore configuration to exclude local tooling directories used during development.

* **Documentation**
  * Clarified internal module comments to reflect current behavior and aliasing for query time-window handling (maintainer-facing; no functional changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->