### PR TITLE
fix: redirect to home after login (#2726)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -78,6 +78,20 @@ function App() {
 
 /** Inner shell — lives inside the Router so it can use useLocation. */
 function AppShell() {
+  const { storeSessionToken } = useCoreState();
+
+  // Listen for core-state:session-token-updated event from deep-link login, and update context
+  useEffect(() => {
+    const handler = (event) => {
+      const sessionToken = event.detail?.sessionToken;
+      if (sessionToken) {
+        storeSessionToken(sessionToken);
+      }
+    };
+    window.addEventListener('core-state:session-token-updated', handler);
+    return () => window.removeEventListener('core-state:session-token-updated', handler);
+  }, [storeSessionToken]);
+
   const location = useLocation();
   const navigate = useNavigate();
   const { snapshot, isBootstrapping } = useCoreState();


### PR DESCRIPTION
### Issue Fixed
- Fixes #2726: After successful login, users are now automatically redirected to their dashboard/home page.
### What was broken
- After successful OAuth or magic link login, session state was patched to a non-React/global store instead of the React context, so UI and routing logic did not detect the new session and did not redirect users.
### Fix
- Added a listener in the main app shell to handle the session token update event. It updates the React context (via `storeSessionToken`). The routing guards then automatically route users home on login.
- No changes to logout, signup, or other flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session token management to properly synchronize token updates across the application, ensuring consistent session state during active sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->