### PR TITLE
docs(readme): fix Homebrew tap namespace in macOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ These paths verify the artifact through your OS package manager's signing chain 
 **macOS (Homebrew tap):**
 
 ```bash
-brew tap tinyhumansai/openhuman
+brew tap tinyhumansai/core
 brew install openhuman
 ```
 


### PR DESCRIPTION
## Summary

- Updated the macOS Homebrew tap command in `README.md` from `tinyhumansai/openhuman` to `tinyhumansai/core`.
- Kept the install flow unchanged (`brew install openhuman`) and only corrected the tap source.
- Improves first-run setup reliability for users following README install instructions.

## Problem

- The README pointed to an incorrect/outdated Homebrew tap namespace.
- Users following the old command could fail to install or tap the wrong repository, causing avoidable onboarding friction.

## Solution

- Replaced the tap command with the correct namespace in the macOS install snippet.
- Chose a minimal docs-only update with no code or behavior changes to keep risk near zero.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `N/A: docs-only change (README text correction)`
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. — `N/A: no executable code changed`
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — `N/A: docs-only change`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no feature behavior changed`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: does not touch release-cut runtime surface`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no linked issue for this docs correction`

## Impact

- Runtime/platform impact: none (desktop/web/CLI behavior unchanged).
- Compatibility/migration/security/performance impact: none.
- User impact: clearer and correct macOS Homebrew installation instructions.

## Related

- Closes: #2727 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated native installation instructions to reflect the correct macOS Homebrew "tap" repository source for accurate package installation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->