### PR TITLE
fix(tools): coerce zero http_request timeout/size + migrate stale-zero configs (5→6)

### DIFF
--- a/src/openhuman/migrations/mod.rs
+++ b/src/openhuman/migrations/mod.rs
@@ -26,11 +26,12 @@ use crate::openhuman::config::Config;
 mod expand_autonomy_defaults;
 mod phase_out_profile_md;
 mod remove_write_auto_approve;
+mod repair_http_request_limits;
 mod retire_chat_v1_model;
 mod unify_ai_provider_settings;
 
 /// Current target schema version. Bumped alongside every new migration.
-pub const CURRENT_SCHEMA_VERSION: u32 = 5;
+pub const CURRENT_SCHEMA_VERSION: u32 = 6;
 
 /// Run any migrations whose `schema_version` gate hasn't yet been
 /// crossed for this workspace.
@@ -245,6 +246,50 @@ pub async fn run_pending(config: &mut Config) {
             Err(err) => {
                 log::warn!(
                     "[migrations] remove_write_auto_approve failed: {err:#} — \
+                     will retry on next launch"
+                );
+            }
+        }
+    }
+
+    // 5 -> 6: repair stale-zero `[http_request]` limits. Older builds could
+    // persist `timeout_secs = 0` / `max_response_size = 0`, which the network
+    // tools apply literally — `Duration::from_secs(0)` is an instant timeout
+    // that fails every web_fetch/http_request, and a 0-byte cap truncates
+    // every body. serde defaults only fill *missing* keys, so a persisted 0
+    // survives an update. Coerce to schema defaults (30s / 1 MB). Guard on
+    // `== 5` so an earlier failed step doesn't get skipped.
+    //
+    // NOTE: another in-flight migration (`reconcile_orphaned_providers`) also
+    // targets the 5 -> 6 transition. When that lands, both modules run inside
+    // this single `== 5` branch before the version is bumped to 6 — keep them
+    // as separate modules, one shared version bump. The tool constructors
+    // also clamp 0 at the point of use, so a user who crosses this gate via
+    // the other migration without running this one still gets working fetches.
+    if config.schema_version == 5 {
+        match repair_http_request_limits::run(config) {
+            Ok(stats) => {
+                let previous_version = config.schema_version;
+                config.schema_version = 6;
+                if let Err(err) = config.save().await {
+                    config.schema_version = previous_version;
+                    log::warn!(
+                        "[migrations] repair_http_request_limits ran but config.save failed: \
+                         {err:#} — rolled in-memory schema_version back to {previous_version}, \
+                         will retry on next launch"
+                    );
+                    return;
+                }
+                log::info!(
+                    "[migrations] schema_version bumped to 6 (repair_http_request_limits \
+                     timeout_repaired={} max_response_size_repaired={})",
+                    stats.timeout_repaired,
+                    stats.max_response_size_repaired,
+                );
+            }
+            Err(err) => {
+                log::warn!(
+                    "[migrations] repair_http_request_limits failed: {err:#} — \
                      will retry on next launch"
                 );
             }

--- a/src/openhuman/migrations/mod_tests.rs
+++ b/src/openhuman/migrations/mod_tests.rs
@@ -112,8 +112,8 @@ async fn run_pending_runs_phase_out_when_version_zero() {
 
     let on_disk = std::fs::read_to_string(&config.config_path).unwrap();
     assert!(
-        on_disk.contains("schema_version = 5"),
-        "saved config.toml must record schema_version=5, got:\n{on_disk}"
+        on_disk.contains("schema_version = 6"),
+        "saved config.toml must record schema_version=6, got:\n{on_disk}"
     );
 }
 
@@ -128,7 +128,7 @@ async fn run_pending_bumps_version_on_fresh_install() {
 
     assert_eq!(config.schema_version, CURRENT_SCHEMA_VERSION);
     let on_disk = std::fs::read_to_string(&config.config_path).unwrap();
-    assert!(on_disk.contains("schema_version = 5"));
+    assert!(on_disk.contains("schema_version = 6"));
 }
 
 #[tokio::test]
@@ -252,8 +252,8 @@ async fn run_pending_expands_autonomy_defaults_from_v3() {
     // On-disk config must reflect the new schema_version.
     let on_disk = fs::read_to_string(&config.config_path).unwrap();
     assert!(
-        on_disk.contains("schema_version = 5"),
-        "saved config.toml must record schema_version=5, got:\n{on_disk}"
+        on_disk.contains("schema_version = 6"),
+        "saved config.toml must record schema_version=6, got:\n{on_disk}"
     );
 }
 
@@ -285,8 +285,8 @@ async fn run_pending_v4_to_v5_removes_write_tools_from_auto_approve() {
 
     let on_disk = fs::read_to_string(&config.config_path).unwrap();
     assert!(
-        on_disk.contains("schema_version = 5"),
-        "saved config.toml must record schema_version=5, got:\n{on_disk}"
+        on_disk.contains("schema_version = 6"),
+        "saved config.toml must record schema_version=6, got:\n{on_disk}"
     );
 }
 

--- a/src/openhuman/migrations/mod_tests.rs
+++ b/src/openhuman/migrations/mod_tests.rs
@@ -290,6 +290,42 @@ async fn run_pending_v4_to_v5_removes_write_tools_from_auto_approve() {
     );
 }
 
+// ── v5 → v6: repair_http_request_limits integration test ────────────────────
+
+/// A workspace persisted at schema_version=5 with stale-zero `[http_request]`
+/// limits (the exact bug this PR fixes) must be repaired to the schema
+/// defaults and bumped to v6 by the full `run_pending` wiring — not just the
+/// migration's own unit tests.
+#[tokio::test]
+async fn run_pending_v5_to_v6_repairs_http_request_limits() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("workspace")).unwrap();
+
+    let mut config = config_in(&tmp);
+    config.schema_version = 5;
+    config.http_request.timeout_secs = 0;
+    config.http_request.max_response_size = 0;
+
+    run_pending(&mut config).await;
+
+    let defaults = crate::openhuman::config::HttpRequestConfig::default();
+    assert_eq!(config.schema_version, CURRENT_SCHEMA_VERSION);
+    assert_eq!(config.http_request.timeout_secs, defaults.timeout_secs);
+    assert_eq!(
+        config.http_request.max_response_size,
+        defaults.max_response_size
+    );
+    assert_ne!(config.http_request.timeout_secs, 0);
+    assert_ne!(config.http_request.max_response_size, 0);
+
+    // The version bump must be persisted to disk too.
+    let on_disk = fs::read_to_string(&config.config_path).unwrap();
+    assert!(
+        on_disk.contains("schema_version = 6"),
+        "saved config.toml must record schema_version=6, got:\n{on_disk}"
+    );
+}
+
 /// Verify that a user at v3 with a deliberately customised
 /// `max_actions_per_hour` does NOT have it reset by the migration.
 #[tokio::test]

--- a/src/openhuman/migrations/repair_http_request_limits.rs
+++ b/src/openhuman/migrations/repair_http_request_limits.rs
@@ -23,6 +23,11 @@ pub struct MigrationStats {
     pub max_response_size_repaired: bool,
 }
 
+/// Returns `anyhow::Result` to match the shared migration-step signature that
+/// [`crate::openhuman::migrations::run_pending`] dispatches (`Ok` → bump +
+/// save, `Err` → log + retry next launch). This step is a pure in-memory
+/// transform and is currently infallible, but keeping the `Result` lets a
+/// future I/O-backed repair slot in without churning the runner or callers.
 pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
     // Source the replacement values from the schema's own defaults so this
     // migration can't drift from `HttpRequestConfig`'s canonical defaults.

--- a/src/openhuman/migrations/repair_http_request_limits.rs
+++ b/src/openhuman/migrations/repair_http_request_limits.rs
@@ -1,0 +1,104 @@
+//! Migration 5 -> 6: repair stale-zero `[http_request]` limits.
+//!
+//! Older builds could persist `http_request.timeout_secs = 0` and/or
+//! `http_request.max_response_size = 0` (the plain numeric default before
+//! the custom serde defaults landed). The network tools apply these
+//! literally: `reqwest`'s `Duration::from_secs(0)` is an *instant* timeout
+//! that fails every `web_fetch` / `http_request`, and a 0-byte cap
+//! truncates every response body to nothing. `#[serde(default = …)]` only
+//! fills *missing* keys, so a persisted `0` is taken as-is and silently
+//! survives an app update — there is no way to express "blocked" or
+//! "unlimited" with these zeros, only "broken".
+//!
+//! Coerce any `0` back to the schema default (30s / 1 MB). The tool
+//! constructors also clamp `0` at the point of use (defence in depth); this
+//! migration additionally repairs the persisted `config.toml` so it stops
+//! shipping the misleading zeros to every consumer.
+
+use crate::openhuman::config::{Config, HttpRequestConfig};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationStats {
+    pub timeout_repaired: bool,
+    pub max_response_size_repaired: bool,
+}
+
+pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
+    // Source the replacement values from the schema's own defaults so this
+    // migration can't drift from `HttpRequestConfig`'s canonical defaults.
+    let defaults = HttpRequestConfig::default();
+    let mut stats = MigrationStats::default();
+
+    if config.http_request.timeout_secs == 0 {
+        config.http_request.timeout_secs = defaults.timeout_secs;
+        stats.timeout_repaired = true;
+    }
+    if config.http_request.max_response_size == 0 {
+        config.http_request.max_response_size = defaults.max_response_size;
+        stats.max_response_size_repaired = true;
+    }
+
+    log::info!(
+        "[migrations][repair-http-request-limits] done timeout_repaired={} \
+         max_response_size_repaired={}",
+        stats.timeout_repaired,
+        stats.max_response_size_repaired
+    );
+
+    Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::config::Config;
+
+    #[test]
+    fn repairs_zero_timeout_and_size() {
+        let mut config = Config::default();
+        config.http_request.timeout_secs = 0;
+        config.http_request.max_response_size = 0;
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        let defaults = HttpRequestConfig::default();
+        assert!(stats.timeout_repaired);
+        assert!(stats.max_response_size_repaired);
+        assert_eq!(config.http_request.timeout_secs, defaults.timeout_secs);
+        assert_eq!(
+            config.http_request.max_response_size,
+            defaults.max_response_size
+        );
+        // The whole point: no zeros survive.
+        assert_ne!(config.http_request.timeout_secs, 0);
+        assert_ne!(config.http_request.max_response_size, 0);
+    }
+
+    #[test]
+    fn repairs_only_the_zero_field() {
+        let mut config = Config::default();
+        config.http_request.timeout_secs = 0;
+        config.http_request.max_response_size = 2_000_000;
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(stats.timeout_repaired);
+        assert!(!stats.max_response_size_repaired);
+        assert_ne!(config.http_request.timeout_secs, 0);
+        assert_eq!(config.http_request.max_response_size, 2_000_000);
+    }
+
+    #[test]
+    fn leaves_nonzero_values_untouched() {
+        let mut config = Config::default();
+        config.http_request.timeout_secs = 45;
+        config.http_request.max_response_size = 3_000_000;
+
+        let stats = run(&mut config).expect("migration should succeed");
+
+        assert!(!stats.timeout_repaired);
+        assert!(!stats.max_response_size_repaired);
+        assert_eq!(config.http_request.timeout_secs, 45);
+        assert_eq!(config.http_request.max_response_size, 3_000_000);
+    }
+}

--- a/src/openhuman/tools/impl/network/http_request.rs
+++ b/src/openhuman/tools/impl/network/http_request.rs
@@ -6,6 +6,17 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Fallback when a caller passes `0` for the response cap. A literal `0`
+/// would make `truncate_response` clip every body to nothing. Mirrors
+/// `[http_request]`'s schema default (`default_http_max_response_size`).
+const DEFAULT_MAX_RESPONSE_SIZE: usize = 1_000_000;
+/// Fallback when a caller passes `0` for the timeout. `Duration::from_secs(0)`
+/// is an *instant* timeout that fails every request, so `0` must never reach
+/// reqwest. Mirrors `[http_request]`'s schema default. Stale-zero configs are
+/// also repaired on load (migration 5→6), but this guard is the always-on
+/// safety net regardless of how the value got here.
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
 /// HTTP request tool for API interactions.
 /// Supports GET, POST, PUT, DELETE methods with configurable security.
 pub struct HttpRequestTool {
@@ -25,8 +36,18 @@ impl HttpRequestTool {
         Self {
             security,
             allowed_domains: normalize_allowed_domains(allowed_domains),
-            max_response_size,
-            timeout_secs,
+            // Treat `0` as "use default": a 0-byte cap or 0-second timeout is
+            // never a meaningful limit, only a footgun (see migration 5→6).
+            max_response_size: if max_response_size == 0 {
+                DEFAULT_MAX_RESPONSE_SIZE
+            } else {
+                max_response_size
+            },
+            timeout_secs: if timeout_secs == 0 {
+                DEFAULT_TIMEOUT_SECS
+            } else {
+                timeout_secs
+            },
         }
     }
 

--- a/src/openhuman/tools/impl/network/http_request.rs
+++ b/src/openhuman/tools/impl/network/http_request.rs
@@ -33,21 +33,33 @@ impl HttpRequestTool {
         max_response_size: usize,
         timeout_secs: u64,
     ) -> Self {
+        // Treat `0` as "use default": a 0-byte cap or 0-second timeout is
+        // never a meaningful limit, only a footgun (see migration 5→6). A `0`
+        // here means a stale/invalid config slipped past the migration, so
+        // surface it with a stable, grep-friendly, non-sensitive log line.
+        let max_response_size = if max_response_size == 0 {
+            log::warn!(
+                "[tool.http_request] coercing invalid limit field=max_response_size \
+                 from=0 to={DEFAULT_MAX_RESPONSE_SIZE} (stale/invalid config — see migration 5→6)"
+            );
+            DEFAULT_MAX_RESPONSE_SIZE
+        } else {
+            max_response_size
+        };
+        let timeout_secs = if timeout_secs == 0 {
+            log::warn!(
+                "[tool.http_request] coercing invalid limit field=timeout_secs \
+                 from=0 to={DEFAULT_TIMEOUT_SECS} (stale/invalid config — see migration 5→6)"
+            );
+            DEFAULT_TIMEOUT_SECS
+        } else {
+            timeout_secs
+        };
         Self {
             security,
             allowed_domains: normalize_allowed_domains(allowed_domains),
-            // Treat `0` as "use default": a 0-byte cap or 0-second timeout is
-            // never a meaningful limit, only a footgun (see migration 5→6).
-            max_response_size: if max_response_size == 0 {
-                DEFAULT_MAX_RESPONSE_SIZE
-            } else {
-                max_response_size
-            },
-            timeout_secs: if timeout_secs == 0 {
-                DEFAULT_TIMEOUT_SECS
-            } else {
-                timeout_secs
-            },
+            max_response_size,
+            timeout_secs,
         }
     }
 

--- a/src/openhuman/tools/impl/network/http_request.rs
+++ b/src/openhuman/tools/impl/network/http_request.rs
@@ -1,21 +1,11 @@
 use super::url_guard::{normalize_allowed_domains, validate_url_with_dns_check};
+use crate::openhuman::config::HttpRequestConfig;
 use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{Tool, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
-
-/// Fallback when a caller passes `0` for the response cap. A literal `0`
-/// would make `truncate_response` clip every body to nothing. Mirrors
-/// `[http_request]`'s schema default (`default_http_max_response_size`).
-const DEFAULT_MAX_RESPONSE_SIZE: usize = 1_000_000;
-/// Fallback when a caller passes `0` for the timeout. `Duration::from_secs(0)`
-/// is an *instant* timeout that fails every request, so `0` must never reach
-/// reqwest. Mirrors `[http_request]`'s schema default. Stale-zero configs are
-/// also repaired on load (migration 5→6), but this guard is the always-on
-/// safety net regardless of how the value got here.
-const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 /// HTTP request tool for API interactions.
 /// Supports GET, POST, PUT, DELETE methods with configurable security.
@@ -33,25 +23,30 @@ impl HttpRequestTool {
         max_response_size: usize,
         timeout_secs: u64,
     ) -> Self {
-        // Treat `0` as "use default": a 0-byte cap or 0-second timeout is
-        // never a meaningful limit, only a footgun (see migration 5→6). A `0`
+        // Treat `0` as "use default": a 0-byte cap or 0-second timeout is never
+        // a meaningful limit, only a footgun (see migration 5→6). Pull the
+        // fallbacks from `HttpRequestConfig::default()` so the tool, the schema
+        // default, and the migration share one source and can't drift. A `0`
         // here means a stale/invalid config slipped past the migration, so
         // surface it with a stable, grep-friendly, non-sensitive log line.
+        let defaults = HttpRequestConfig::default();
         let max_response_size = if max_response_size == 0 {
             log::warn!(
                 "[tool.http_request] coercing invalid limit field=max_response_size \
-                 from=0 to={DEFAULT_MAX_RESPONSE_SIZE} (stale/invalid config — see migration 5→6)"
+                 from=0 to={} (stale/invalid config — see migration 5→6)",
+                defaults.max_response_size
             );
-            DEFAULT_MAX_RESPONSE_SIZE
+            defaults.max_response_size
         } else {
             max_response_size
         };
         let timeout_secs = if timeout_secs == 0 {
             log::warn!(
                 "[tool.http_request] coercing invalid limit field=timeout_secs \
-                 from=0 to={DEFAULT_TIMEOUT_SECS} (stale/invalid config — see migration 5→6)"
+                 from=0 to={} (stale/invalid config — see migration 5→6)",
+                defaults.timeout_secs
             );
-            DEFAULT_TIMEOUT_SECS
+            defaults.timeout_secs
         } else {
             timeout_secs
         };

--- a/src/openhuman/tools/impl/network/http_request_tests.rs
+++ b/src/openhuman/tools/impl/network/http_request_tests.rs
@@ -24,8 +24,9 @@ fn zero_limits_fall_back_to_defaults() {
         ..SecurityPolicy::default()
     });
     let tool = HttpRequestTool::new(security, vec!["example.com".to_string()], 0, 0);
-    assert_eq!(tool.max_response_size, DEFAULT_MAX_RESPONSE_SIZE);
-    assert_eq!(tool.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    let defaults = crate::openhuman::config::HttpRequestConfig::default();
+    assert_eq!(tool.max_response_size, defaults.max_response_size);
+    assert_eq!(tool.timeout_secs, defaults.timeout_secs);
     assert_ne!(tool.timeout_secs, 0);
     assert_ne!(tool.max_response_size, 0);
 }

--- a/src/openhuman/tools/impl/network/http_request_tests.rs
+++ b/src/openhuman/tools/impl/network/http_request_tests.rs
@@ -15,6 +15,33 @@ fn test_tool(allowed_domains: Vec<&str>) -> HttpRequestTool {
 }
 
 #[test]
+fn zero_limits_fall_back_to_defaults() {
+    // Stale configs (or a bad write) can pass 0; a 0-second timeout fails
+    // every request and a 0-byte cap truncates every body. The constructor
+    // must coerce both to the module defaults — never let 0 reach reqwest.
+    let security = Arc::new(SecurityPolicy {
+        autonomy: AutonomyLevel::Supervised,
+        ..SecurityPolicy::default()
+    });
+    let tool = HttpRequestTool::new(security, vec!["example.com".to_string()], 0, 0);
+    assert_eq!(tool.max_response_size, DEFAULT_MAX_RESPONSE_SIZE);
+    assert_eq!(tool.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    assert_ne!(tool.timeout_secs, 0);
+    assert_ne!(tool.max_response_size, 0);
+}
+
+#[test]
+fn nonzero_limits_are_preserved() {
+    let security = Arc::new(SecurityPolicy {
+        autonomy: AutonomyLevel::Supervised,
+        ..SecurityPolicy::default()
+    });
+    let tool = HttpRequestTool::new(security, vec!["example.com".to_string()], 2048, 12);
+    assert_eq!(tool.max_response_size, 2048);
+    assert_eq!(tool.timeout_secs, 12);
+}
+
+#[test]
 fn validate_accepts_valid_methods() {
     let tool = test_tool(vec!["example.com"]);
     assert!(tool.validate_method("GET").is_ok());

--- a/src/openhuman/tools/impl/network/web_fetch.rs
+++ b/src/openhuman/tools/impl/network/web_fetch.rs
@@ -7,15 +7,13 @@
 //! as text, capped, with a tiny preamble (status + final URL).
 
 use super::url_guard::{normalize_allowed_domains, validate_url_with_dns_check};
+use crate::openhuman::config::HttpRequestConfig;
 use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
-
-const DEFAULT_MAX_BYTES: usize = 1_000_000;
-const DEFAULT_TIMEOUT_SECS: u64 = 20;
 
 pub struct WebFetchTool {
     security: Arc<SecurityPolicy>,
@@ -35,30 +33,35 @@ impl WebFetchTool {
         // from `[http_request]`, and a 0-byte cap truncates every body to
         // nothing while a 0-second timeout fails every request instantly.
         // Stale-zero configs are repaired on load (migration 5→6); this clamp
-        // is the always-on guard at the point of use. `Some(0)` is a genuine
+        // is the always-on guard at the point of use. Pull the fallbacks from
+        // `HttpRequestConfig::default()` so the tool shares one source with the
+        // schema + migration (no cross-layer drift). `Some(0)` is a genuine
         // misconfiguration, so log it (grep-friendly, no payload); a bare
         // `None` is a normal "use default" call and stays quiet.
+        let defaults = HttpRequestConfig::default();
         let max_bytes = match max_bytes {
             Some(0) => {
                 log::warn!(
                     "[tool.web_fetch] coercing invalid limit field=max_bytes \
-                     from=0 to={DEFAULT_MAX_BYTES} (stale/invalid config — see migration 5→6)"
+                     from=0 to={} (stale/invalid config — see migration 5→6)",
+                    defaults.max_response_size
                 );
-                DEFAULT_MAX_BYTES
+                defaults.max_response_size
             }
             Some(n) => n,
-            None => DEFAULT_MAX_BYTES,
+            None => defaults.max_response_size,
         };
         let timeout_secs = match timeout_secs {
             Some(0) => {
                 log::warn!(
                     "[tool.web_fetch] coercing invalid limit field=timeout_secs \
-                     from=0 to={DEFAULT_TIMEOUT_SECS} (stale/invalid config — see migration 5→6)"
+                     from=0 to={} (stale/invalid config — see migration 5→6)",
+                    defaults.timeout_secs
                 );
-                DEFAULT_TIMEOUT_SECS
+                defaults.timeout_secs
             }
             Some(n) => n,
-            None => DEFAULT_TIMEOUT_SECS,
+            None => defaults.timeout_secs,
         };
         Self {
             security,
@@ -228,21 +231,22 @@ mod tests {
     fn zero_and_none_limits_fall_back_to_defaults() {
         // Callers wire these from `[http_request]`; a stale `Some(0)` is a
         // 0-byte cap (empty bodies) and a 0-second timeout (instant failure).
-        // Both `None` and `Some(0)` must coerce to the module defaults.
+        // Both `None` and `Some(0)` must coerce to the shared schema defaults.
+        let defaults = crate::openhuman::config::HttpRequestConfig::default();
         let from_zero = WebFetchTool::new(
             test_security(),
             vec!["example.com".into()],
             Some(0),
             Some(0),
         );
-        assert_eq!(from_zero.max_bytes, DEFAULT_MAX_BYTES);
-        assert_eq!(from_zero.timeout_secs, DEFAULT_TIMEOUT_SECS);
+        assert_eq!(from_zero.max_bytes, defaults.max_response_size);
+        assert_eq!(from_zero.timeout_secs, defaults.timeout_secs);
         assert_ne!(from_zero.timeout_secs, 0);
         assert_ne!(from_zero.max_bytes, 0);
 
         let from_none = WebFetchTool::new(test_security(), vec!["example.com".into()], None, None);
-        assert_eq!(from_none.max_bytes, DEFAULT_MAX_BYTES);
-        assert_eq!(from_none.timeout_secs, DEFAULT_TIMEOUT_SECS);
+        assert_eq!(from_none.max_bytes, defaults.max_response_size);
+        assert_eq!(from_none.timeout_secs, defaults.timeout_secs);
     }
 
     #[test]

--- a/src/openhuman/tools/impl/network/web_fetch.rs
+++ b/src/openhuman/tools/impl/network/web_fetch.rs
@@ -31,18 +31,40 @@ impl WebFetchTool {
         max_bytes: Option<usize>,
         timeout_secs: Option<u64>,
     ) -> Self {
+        // Treat both `None` and `Some(0)` as "use default": callers wire these
+        // from `[http_request]`, and a 0-byte cap truncates every body to
+        // nothing while a 0-second timeout fails every request instantly.
+        // Stale-zero configs are repaired on load (migration 5→6); this clamp
+        // is the always-on guard at the point of use. `Some(0)` is a genuine
+        // misconfiguration, so log it (grep-friendly, no payload); a bare
+        // `None` is a normal "use default" call and stays quiet.
+        let max_bytes = match max_bytes {
+            Some(0) => {
+                log::warn!(
+                    "[tool.web_fetch] coercing invalid limit field=max_bytes \
+                     from=0 to={DEFAULT_MAX_BYTES} (stale/invalid config — see migration 5→6)"
+                );
+                DEFAULT_MAX_BYTES
+            }
+            Some(n) => n,
+            None => DEFAULT_MAX_BYTES,
+        };
+        let timeout_secs = match timeout_secs {
+            Some(0) => {
+                log::warn!(
+                    "[tool.web_fetch] coercing invalid limit field=timeout_secs \
+                     from=0 to={DEFAULT_TIMEOUT_SECS} (stale/invalid config — see migration 5→6)"
+                );
+                DEFAULT_TIMEOUT_SECS
+            }
+            Some(n) => n,
+            None => DEFAULT_TIMEOUT_SECS,
+        };
         Self {
             security,
             allowed_domains: normalize_allowed_domains(allowed_domains),
-            // Treat both `None` and `Some(0)` as "use default": callers wire
-            // these from `[http_request]`, and a 0-byte cap truncates every
-            // body to nothing while a 0-second timeout fails every request
-            // instantly. Stale-zero configs are repaired on load (migration
-            // 5→6); this clamp is the always-on guard at the point of use.
-            max_bytes: max_bytes.filter(|n| *n > 0).unwrap_or(DEFAULT_MAX_BYTES),
-            timeout_secs: timeout_secs
-                .filter(|n| *n > 0)
-                .unwrap_or(DEFAULT_TIMEOUT_SECS),
+            max_bytes,
+            timeout_secs,
         }
     }
 }

--- a/src/openhuman/tools/impl/network/web_fetch.rs
+++ b/src/openhuman/tools/impl/network/web_fetch.rs
@@ -34,8 +34,15 @@ impl WebFetchTool {
         Self {
             security,
             allowed_domains: normalize_allowed_domains(allowed_domains),
-            max_bytes: max_bytes.unwrap_or(DEFAULT_MAX_BYTES),
-            timeout_secs: timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS),
+            // Treat both `None` and `Some(0)` as "use default": callers wire
+            // these from `[http_request]`, and a 0-byte cap truncates every
+            // body to nothing while a 0-second timeout fails every request
+            // instantly. Stale-zero configs are repaired on load (migration
+            // 5→6); this clamp is the always-on guard at the point of use.
+            max_bytes: max_bytes.filter(|n| *n > 0).unwrap_or(DEFAULT_MAX_BYTES),
+            timeout_secs: timeout_secs
+                .filter(|n| *n > 0)
+                .unwrap_or(DEFAULT_TIMEOUT_SECS),
         }
     }
 }
@@ -193,6 +200,39 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&json!("url")));
+    }
+
+    #[test]
+    fn zero_and_none_limits_fall_back_to_defaults() {
+        // Callers wire these from `[http_request]`; a stale `Some(0)` is a
+        // 0-byte cap (empty bodies) and a 0-second timeout (instant failure).
+        // Both `None` and `Some(0)` must coerce to the module defaults.
+        let from_zero = WebFetchTool::new(
+            test_security(),
+            vec!["example.com".into()],
+            Some(0),
+            Some(0),
+        );
+        assert_eq!(from_zero.max_bytes, DEFAULT_MAX_BYTES);
+        assert_eq!(from_zero.timeout_secs, DEFAULT_TIMEOUT_SECS);
+        assert_ne!(from_zero.timeout_secs, 0);
+        assert_ne!(from_zero.max_bytes, 0);
+
+        let from_none = WebFetchTool::new(test_security(), vec!["example.com".into()], None, None);
+        assert_eq!(from_none.max_bytes, DEFAULT_MAX_BYTES);
+        assert_eq!(from_none.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn nonzero_limits_are_preserved() {
+        let tool = WebFetchTool::new(
+            test_security(),
+            vec!["example.com".into()],
+            Some(4096),
+            Some(15),
+        );
+        assert_eq!(tool.max_bytes, 4096);
+        assert_eq!(tool.timeout_secs, 15);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- A persisted `[http_request].timeout_secs = 0` made `reqwest` build a 0-second total timeout (`Duration::from_secs(0)`), so **every `web_fetch` / `http_request` failed instantly** — even with the allowlist set to "Allow all". `max_response_size = 0` separately truncated every body to nothing.
- These zeros are **stale values from older builds**: `#[serde(default = …)]` only fills *missing* keys, so a present `0` is taken literally and survives an app update with nothing to repair it.
- **Always-on guard**: `HttpRequestTool` / `WebFetchTool` constructors now coerce `0 → schema default`, so `0` can never reach reqwest regardless of how it got into the config.
- **Migration 5→6** (`repair_http_request_limits`) rewrites persisted zeros to `HttpRequestConfig::default()` (30s / 1 MB) and tidies the on-disk `config.toml`.

## Problem

After updating from an older build, web research silently broke: the agent's `web_fetch`/`http_request` returned `"Request failed: … timed out"` on every call. The cause was not the allowlist (which was `["*"]`) but `[http_request].timeout_secs = 0` applied as a literal 0-second timeout (`http_request.rs` / `web_fetch.rs` both did `reqwest…timeout(Duration::from_secs(self.timeout_secs))` with no `> 0` guard). `max_response_size = 0` was a second, latent bug masked behind the timeout. Nothing coerced these stale zeros on load, and `#[serde(default)]` doesn't catch present-but-zero values.

## Solution

- `tools/impl/network/{http_request,web_fetch}.rs`: constructors coerce `0` (and, for `web_fetch`, `Some(0)`/`None`) to fallbacks pulled from `HttpRequestConfig::default()` — one shared source with the schema + migration, no tool-local constants left to drift. A genuine `0`/`Some(0)` is logged (`[tool.*] coercing invalid limit …`, grep-friendly, no payload); a bare `None` stays quiet.
- `migrations/repair_http_request_limits.rs`: new 5→6 migration sourcing replacements from `HttpRequestConfig::default()` (can't drift from the schema). Registered in `migrations/mod.rs`, `CURRENT_SCHEMA_VERSION` 5→6, following the existing rollback-on-save-failure pattern.
- `0` is treated as **"use default"**, not "unlimited" — an unbounded timeout can hang and an unbounded body is a memory risk; the schema defaults are finite.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge): tool-guard tests (`zero → default`, nonzero preserved) for both tools; migration unit tests (both-zero, one-zero, no-op); existing `run_pending_*` integration tests updated for the version bump.
- [x] **Diff coverage ≥ 80%** — CI **Coverage Gate (diff-cover)** passed; changed lines are covered by the added unit tests.
- [x] N/A: Coverage matrix — behaviour/repair-only change; no feature row added/removed/renamed.
- [x] N/A: no matrix feature IDs apply.
- [x] No new external network dependencies (this *governs* outbound limits; adds none).
- [x] N/A: does not touch release-cut surfaces in `docs/RELEASE-MANUAL-SMOKE.md`.
- [x] N/A: no tracking issue — reported directly.

## Impact

- **Desktop (core only).** Behaviour change: an existing config with `timeout_secs = 0` / `max_response_size = 0` (broken) is repaired to working defaults; web research starts succeeding again. No change for configs with sane non-zero values.
- **Migration/compatibility:** one-shot `5 → 6`, idempotent, best-effort (failures logged, retried next launch). The tool guard means even a config that never runs the migration still gets working fetches.

## Related

- Closes: N/A (no tracking issue)
- **Version coordination with #2761 (`reconcile_orphaned_providers`)** — both PRs add a `5 → 6` migration. **Resolution: ship both in the same release**, merging their `== 5` branches into one block that runs both modules before the single bump to 6 (the code is already structured for this — see the note in `migrations/mod.rs`). This stays safe even if the two merge a few commits apart, because the tool-layer guard makes a skipped repair non-fatal: an un-migrated config keeps a cosmetic `0` on disk but the tools still coerce it at use. (If release plans ever split them across separate builds, re-sequence this one to `6 → 7`.)

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/http-request-zero-limits
- Commit SHA: 6cbc16f7

### Validation Run
- [x] Rust: `cargo check --manifest-path Cargo.toml --lib --tests` — exit 0 (no new warnings).
- [x] Focused tests (`cargo test --lib`): tool-guard tests (zero→default, nonzero preserved), migration unit tests, and the new `run_pending_v5_to_v6_repairs_http_request_limits` integration test all pass.
- [x] `cargo fmt` — clean on changed files.
- [x] N/A: frontend `format:check` / `typecheck` — no `app/` changes.
- [x] N/A: Tauri fmt/check — no `app/src-tauri` changes.

### Behavior Changes
- Intended: stale-zero `[http_request]` limits no longer disable web tools; `0` is coerced to the schema default at both the config layer (migration) and the tool layer (guard).
- User-visible: `web_fetch`/`http_request` work after an update that previously left them timing out instantly.
- **Minor, intentional:** removing `web_fetch`'s tool-local `DEFAULT_TIMEOUT_SECS = 20` means a caller passing `timeout_secs: None` now falls back to the schema default (**30s**, was 20s). Production wires `Some(<config>)`, so this only affects unconfigured/`None` callers; the change aligns `web_fetch` with the single `HttpRequestConfig::default()` source (removes the cross-layer drift raised in review).

### Parity Contract
- Legacy preserved: non-zero `timeout_secs` / `max_response_size` are untouched; allowlist/SSRF behaviour unchanged.
- Guard/fallback parity: both `None` and `Some(0)` resolve to the same finite default in `WebFetchTool`; `HttpRequestTool` maps `0 → default` for both fields.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP request tools treat zero timeouts/limits as invalid, coercing them to safe defaults and emitting warning logs.
  * Startup now repairs persisted HTTP-request settings saved as zero and persists the updated schema version (bumped to v6).

* **Tests**
  * Added unit and integration tests validating fallback behavior, warning logs, on-disk repairs, and the v5→v6 migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

