### PR TITLE
fix(voice): auto-select first preset when mascot voice gender changes

### DIFF
--- a/app/src/components/settings/panels/MascotPanel.tsx
+++ b/app/src/components/settings/panels/MascotPanel.tsx
@@ -215,6 +215,13 @@ const MascotPanel = () => {
 
   const onGenderChange = (next: MascotVoiceGender) => {
     dispatch(setMascotVoiceGender(next));
+    const firstPreset = ELEVENLABS_VOICE_PRESETS.find(p => p.gender === next);
+    if (firstPreset) {
+      setVoicePasteMode(false);
+      setVoicePreviewError(null);
+      setVoiceDraft(firstPreset.id);
+      dispatch(setMascotVoiceId(firstPreset.id));
+    }
   };
 
   const onLocaleDefaultToggle = (next: boolean) => {


### PR DESCRIPTION
## Summary

- When the user selects a gender (Male/Female) in Mascot Settings → Voice, the voice preset now automatically switches to the first curated preset for that gender instead of keeping the previous gender's voice selected.
- Male → defaults to **George** (first male preset, `JBFqnCBsd6RMkjVDRZzb`)
- Female → defaults to **Rachel** (first female preset, `21m00Tcm4TlvDq8ikWAM`)
- Resets paste-mode and preview error state to keep the picker clean on gender switch.

**Root cause:** `onGenderChange` in `MascotPanel.tsx` only dispatched `setMascotVoiceGender` but never updated the voice ID, leaving the preset dropdown pointing at a voice from the previous gender.

## Test plan

- [ ] Open Settings → Mascot → Voice section
- [ ] Select **Male** — verify preset dropdown switches to George (multilingual)
- [ ] Select **Female** — verify preset dropdown switches to Rachel (US female)
- [ ] Verify the preset dropdown updates immediately without requiring a page reload
- [ ] Verify that switching gender while "Use locale default" is checked does not conflict (locale default toggle is unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice selection in mascot settings now automatically selects a compatible voice when you change the voice gender. This ensures your voice choice is always properly aligned with your selected gender, clears any previous preview issues, and maintains consistent selection throughout the configuration interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->