### PR TITLE
fix(ci): bump Windows test timeout to 35m and fix dead security::secrets filter

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -150,12 +150,15 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run Windows-specific secrets tests
-        # Runs the keyring::encrypted_store suite, which includes all
-        # #[cfg(windows)] tests: self-repair ACL path (OPENHUMAN-TAURI-GN),
-        # domain-qualified icacls username, is_permission_error,
-        # repair_windows_acl.  The old filter (security::secrets) matched
-        # nothing because security/secrets.rs is a thin re-export — the
-        # actual test module lives at keyring::encrypted_store::tests.
+        # Runs the keyring::encrypted_store suite (keyring::encrypted_store::tests),
+        # which contains the #[cfg(windows)] tests:
+        #   - self_repair_recovers_from_locked_key_file (OPENHUMAN-TAURI-GN)
+        #   - self_repair_does_not_trigger_for_corrupt_file
+        #   - is_permission_error_* (access denied, not-found, raw OS error 5)
+        #   - qualify_windows_username_* (local, domain, case, empty env vars)
+        # Note: repair_windows_acl is a helper fn, not a test.
+        # security/secrets.rs is a one-line re-export with no tests of its own;
+        # the old filter (-- security::secrets) silently matched nothing.
         run: bash scripts/ci-cancel-aware.sh cargo test -p openhuman -- keyring::encrypted_store --nocapture
 
   rust-tauri-tests:

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -128,7 +128,7 @@ jobs:
     if: inputs.run_rust_core
     name: Rust Core Tests (Windows — secrets ACL)
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     env:
       CARGO_INCREMENTAL: '0'
       SCCACHE_GHA_ENABLED: 'true'
@@ -150,10 +150,13 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run Windows-specific secrets tests
-        # Runs the full security::secrets suite including all #[cfg(windows)]
-        # tests: self-repair ACL path (OPENHUMAN-TAURI-GN), domain-qualified
-        # icacls username, is_permission_error, repair_windows_acl.
-        run: bash scripts/ci-cancel-aware.sh cargo test -p openhuman -- security::secrets --nocapture
+        # Runs the keyring::encrypted_store suite, which includes all
+        # #[cfg(windows)] tests: self-repair ACL path (OPENHUMAN-TAURI-GN),
+        # domain-qualified icacls username, is_permission_error,
+        # repair_windows_acl.  The old filter (security::secrets) matched
+        # nothing because security/secrets.rs is a thin re-export — the
+        # actual test module lives at keyring::encrypted_store::tests.
+        run: bash scripts/ci-cancel-aware.sh cargo test -p openhuman -- keyring::encrypted_store --nocapture
 
   rust-tauri-tests:
     if: inputs.run_rust_tauri


### PR DESCRIPTION
## Summary

- Raise `timeout-minutes` for the `rust-core-tests-windows` CI job from 20 → 35 minutes.
- Fix the test filter from `-- security::secrets` (matched **zero** tests) to `-- keyring::encrypted_store` (the actual module path for the Windows ACL suite).

## Problem

- The production release workflow (`main Release Production`, run [26514109166](https://github.com/tinyhumansai/openhuman/actions/runs/26514109166)) failed on the `Pretest — unit + rust / Rust Core Tests (Windows — secrets ACL)` job with: **"The job has exceeded the maximum execution time of 20m0s"**.
- Cold-cache Windows compilation of the full `openhuman` crate takes ~19 minutes (only 12.75% sccache hit rate on the failing run), leaving no time for the post-job cache-save step within the 20-minute budget — the runner was killed mid-cleanup.
- The test filter `-- security::secrets` has always matched **zero tests**: `src/openhuman/security/secrets.rs` is a one-line re-export (`pub use crate::openhuman::keyring::encrypted_store::*`), not a module with its own tests. The actual Windows ACL test module (`repair_windows_acl`, `is_permission_error`, `icacls` grant args, self-repair path) lives at `openhuman::keyring::encrypted_store::tests`.

## Solution

- **Timeout**: 35 minutes gives ample headroom for cold-cache Windows builds (~19 min compile + ~1 min tests + ~2 min cache save) while still catching genuine hangs.
- **Filter**: Changed to `-- keyring::encrypted_store` which correctly matches `openhuman::keyring::encrypted_store::tests::*`, including all `#[cfg(windows)]` tests described in the step comment.

## Submission Checklist

- [x] N/A: no new application code — CI workflow change only; no test additions needed for workflow YAML
- [x] N/A: no changed application lines — diff-cover gate does not apply to `.github/` files
- [x] N/A: no feature added/removed/renamed
- [x] N/A: all affected feature IDs from the matrix — no matrix rows affected
- [x] N/A: no new network dependencies
- [x] N/A: no release-cut surfaces touched
- [x] N/A: no tracked issue to close (this is a CI infrastructure fix)

## Impact

- CI only: no runtime/product behavior changes.
- Windows test job will now actually run its intended test suite instead of silently passing with 0 tests.

## Related

- Production build run that failed: https://github.com/tinyhumansai/openhuman/actions/runs/26514109166
- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/production-build-timeout`
- Commit SHA: 040cce5e

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] N/A: pnpm typecheck — no TS changes
- [x] N/A: Focused tests — workflow-only change
- [x] N/A: Rust fmt/check — no Rust changes
- [x] N/A: Tauri fmt/check — no Tauri changes

### Validation Blocked
- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: Windows CI job now actually runs `keyring::encrypted_store` tests instead of 0 tests, and has 35 min to complete rather than 20.
- User-visible effect: None (CI infrastructure only).

### Parity Contract
- Legacy behavior preserved: All other jobs unchanged.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI testing infrastructure to improve test reliability and coverage for Windows environments.

**Note:** This release contains internal infrastructure improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->