### PR TITLE
fix(composio): forward tags filter in direct (BYO-key) tool listing

### DIFF
--- a/src/openhuman/composio/client.rs
+++ b/src/openhuman/composio/client.rs
@@ -962,7 +962,7 @@ pub async fn direct_list_connections(
 }
 
 /// Direct-mode counterpart to [`ComposioClient::list_tools`]. Calls
-/// Composio v3 `/tools?toolkits=<csv>` via
+/// Composio v3 `/tools?toolkits=<csv>&tags=<a>&tags=<b>` via
 /// [`crate::openhuman::tools::ComposioTool::list_tool_schemas_v3`] and
 /// reshapes each item into the same [`ComposioToolSchema`] envelope the
 /// backend-proxied path returns.
@@ -972,6 +972,12 @@ pub async fn direct_list_connections(
 /// and skips schemas the agent can't actually call). `composio_list_tools`'s
 /// direct branch passes `direct_list_connections`'s active set.
 ///
+/// `tags` mirrors the backend path's tag filter so a self-key user's
+/// `composio_list_tools(..., tags)` request narrows by Composio action tag
+/// in direct mode too (previously the tag filter was silently dropped on
+/// the direct branch). The caller is expected to have already applied
+/// [`super::ops::should_forward_tags`] before passing `tags` here.
+///
 /// Schemas surfaced here are tenant-agnostic — Composio's action
 /// definitions are the same across tenants, so direct-mode users get
 /// the same model-callable shape backend-mode does. Downstream curated-
@@ -980,13 +986,18 @@ pub async fn direct_list_connections(
 pub(super) async fn direct_list_tools(
     direct: &Arc<crate::openhuman::tools::ComposioTool>,
     toolkits: &[String],
+    tags: Option<&[String]>,
 ) -> anyhow::Result<ComposioToolsResponse> {
     let toolkit_refs: Vec<&str> = toolkits.iter().map(|s| s.as_str()).collect();
+    let tag_refs: Option<Vec<&str>> = tags.map(|t| t.iter().map(|s| s.as_str()).collect());
     tracing::debug!(
         toolkits = toolkit_refs.len(),
+        tags = tag_refs.as_ref().map(Vec::len).unwrap_or(0),
         "[composio-direct] list_tools: GET v3 /tools"
     );
-    let items = direct.list_tool_schemas_v3(&toolkit_refs).await?;
+    let items = direct
+        .list_tool_schemas_v3(&toolkit_refs, tag_refs.as_deref())
+        .await?;
     let tools: Vec<super::types::ComposioToolSchema> = items
         .into_iter()
         .filter(|item| !item.slug.is_empty())

--- a/src/openhuman/composio/client_tests.rs
+++ b/src/openhuman/composio/client_tests.rs
@@ -1110,13 +1110,11 @@ fn store_get_clear_composio_api_key_roundtrip() {
 // ── Pricing short-circuit ───────────────────────────────────────────
 
 // ── Direct-mode reshapers (`direct_authorize` / `direct_execute` / ─
-//   `direct_list_connections`)
+//   `direct_list_connections` / `direct_list_tools`)
 //
 // These helpers wrap a `ComposioTool` and reshape v3 responses into
-// the backend-proxied envelope types. We can't easily mock the live
-// `backend.composio.dev` endpoints in this unit-test layer (the
-// `ComposioTool` builds its own `reqwest::Client`), so the assertions
-// below verify the empty/invalid-input paths that don't require HTTP:
+// the backend-proxied envelope types. Most still assert the
+// empty/invalid-input paths that don't require HTTP:
 //
 //   * `direct_authorize` rejects an empty toolkit before any network
 //     hit, with an explicit error so the caller can surface it as a
@@ -1127,12 +1125,28 @@ fn store_get_clear_composio_api_key_roundtrip() {
 //   * `direct_list_connections` is a thin mapper; the real coverage
 //     for its row → ComposioConnection translation lives in the
 //     `connected_account_*` tests in `composio_tests.rs`.
+//
+// `direct_list_tools` IS exercised over HTTP: `ComposioTool::new_with_v3_base`
+// points its `/tools` GET at a local axum mock, so we can assert both the
+// outbound `tags` filter (repeated query params) and the v3 → backend-envelope
+// reshape without touching `backend.composio.dev`.
 
 fn direct_tool_for_test() -> std::sync::Arc<crate::openhuman::tools::ComposioTool> {
     std::sync::Arc::new(crate::openhuman::tools::ComposioTool::new(
         "ck_test_direct",
         Some("default"),
         std::sync::Arc::new(crate::openhuman::security::SecurityPolicy::default()),
+    ))
+}
+
+/// Like [`direct_tool_for_test`] but with the v3 base pointed at a local
+/// mock server so HTTP paths (e.g. `direct_list_tools`) can be asserted.
+fn direct_tool_for_mock(base_v3: String) -> std::sync::Arc<crate::openhuman::tools::ComposioTool> {
+    std::sync::Arc::new(crate::openhuman::tools::ComposioTool::new_with_v3_base(
+        "ck_test_direct",
+        Some("default"),
+        std::sync::Arc::new(crate::openhuman::security::SecurityPolicy::default()),
+        base_v3,
     ))
 }
 
@@ -1147,6 +1161,57 @@ async fn direct_authorize_rejects_empty_toolkit() {
         err.to_string().contains("toolkit must not be empty"),
         "unexpected error: {err}"
     );
+}
+
+#[tokio::test]
+async fn direct_list_tools_forwards_tags_and_reshapes_v3_envelope() {
+    use axum::extract::RawQuery;
+    use std::sync::Mutex;
+
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    let app = Router::new().route(
+        "/tools",
+        get(move |RawQuery(q): RawQuery| {
+            let sink = sink.clone();
+            async move {
+                *sink.lock().unwrap() = q;
+                Json(json!({
+                    "items": [
+                        {
+                            "slug": "GITHUB_STAR_A_REPOSITORY",
+                            "description": "Star a repository",
+                            "input_parameters": { "type": "object" },
+                            "toolkit": { "slug": "github" }
+                        },
+                        // Empty-slug rows must be dropped by the reshaper.
+                        { "slug": "", "description": "junk" }
+                    ]
+                }))
+            }
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tool = direct_tool_for_mock(base);
+
+    let resp = super::direct_list_tools(
+        &tool,
+        &["github".to_string()],
+        Some(&["stars".to_string(), "repos".to_string()]),
+    )
+    .await
+    .expect("direct_list_tools should succeed against the mock");
+
+    // Outbound: tags forwarded as repeated params, toolkits CSV.
+    let query = captured.lock().unwrap().clone().expect("server saw query");
+    assert!(query.contains("tags=stars"), "query was: {query}");
+    assert!(query.contains("tags=repos"), "query was: {query}");
+    assert!(query.contains("toolkits=github"), "query was: {query}");
+
+    // Inbound: reshaped into the backend envelope, empty-slug row dropped.
+    assert_eq!(resp.tools.len(), 1);
+    assert_eq!(resp.tools[0].function.name, "GITHUB_STAR_A_REPOSITORY");
+    assert_eq!(resp.tools[0].kind, "function");
 }
 
 #[tokio::test]

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -787,18 +787,24 @@ pub async fn composio_list_tools(
             }
             tracing::debug!(
                 toolkits = scope.len(),
+                ?effective_tags,
                 "[composio-direct] list_tools: fetching v3 tool schemas"
             );
-            let mut resp = direct_list_tools(&direct, &scope).await.map_err(|e| {
-                // [#1166 / Sentry TAURI-RUST-X9] Symmetric with the backend
-                // branch's hook (line ~451). Direct-mode `list_tools`
-                // failures are user-state when the API key is bad. Render
-                // WITH the `[composio-direct]` anchor so the classifier
-                // arm fires.
-                let rendered = format!("[composio-direct] list_tools failed: {e:#}");
-                report_composio_op_error("list_tools", &rendered);
-                rendered
-            })?;
+            // Forward the same `effective_tags` the backend branch uses so the
+            // tag filter is honoured in direct (BYO-key) mode too — previously
+            // it was computed above and then dropped on this branch.
+            let mut resp = direct_list_tools(&direct, &scope, effective_tags.as_deref())
+                .await
+                .map_err(|e| {
+                    // [#1166 / Sentry TAURI-RUST-X9] Symmetric with the backend
+                    // branch's hook (line ~451). Direct-mode `list_tools`
+                    // failures are user-state when the API key is bad. Render
+                    // WITH the `[composio-direct]` anchor so the classifier
+                    // arm fires.
+                    let rendered = format!("[composio-direct] list_tools failed: {e:#}");
+                    report_composio_op_error("list_tools", &rendered);
+                    rendered
+                })?;
             // Apply the same curated-whitelist + user-scope filter the
             // backend path runs — schemas may be tenant-agnostic but
             // OpenHuman's curation policy isn't, and direct-mode users

--- a/src/openhuman/tools/impl/network/composio.rs
+++ b/src/openhuman/tools/impl/network/composio.rs
@@ -179,9 +179,6 @@ impl ComposioTool {
         Ok(body.items)
     }
 
-    /// List v3 tool definitions for one or more toolkits, preserving the
-    /// raw `input_parameters` JSON schema each action carries.
-    ///
     /// Build the query-parameter pairs for the Composio v3 `GET /tools`
     /// listing used by [`Self::list_tool_schemas_v3`].
     ///
@@ -220,6 +217,9 @@ impl ComposioTool {
         params
     }
 
+    /// List v3 tool definitions for one or more toolkits, preserving the
+    /// raw `input_parameters` JSON schema each action carries.
+    ///
     /// Sibling of [`Self::list_actions`] but kept distinct because
     /// `list_actions` flattens to `Vec<ComposioAction>` (no parameters)
     /// for the legacy agent-discovery shape, whereas

--- a/src/openhuman/tools/impl/network/composio.rs
+++ b/src/openhuman/tools/impl/network/composio.rs
@@ -35,8 +35,8 @@ pub struct ComposioTool {
     security: Arc<SecurityPolicy>,
     /// Base URL for Composio v3 endpoints (`{base}/tools`). Production
     /// always uses [`COMPOSIO_API_BASE_V3`] via [`Self::new`]; the
-    /// injectable [`Self::new_with_v3_base`] lets unit tests point the
-    /// direct-mode `/tools` listing at a local axum mock — the same
+    /// `#[cfg(test)]` `new_with_v3_base` constructor lets unit tests point
+    /// the direct-mode `/tools` listing at a local axum mock — the same
     /// base-URL injection the backend `ComposioClient` gets through
     /// `IntegrationClient::new` in `client_tests.rs`.
     base_v3: String,
@@ -48,7 +48,8 @@ impl ComposioTool {
         default_entity_id: Option<&str>,
         security: Arc<SecurityPolicy>,
     ) -> Self {
-        Self::new_with_v3_base(
+        // Production always pins the real HTTPS v3 endpoint.
+        Self::new_internal(
             api_key,
             default_entity_id,
             security,
@@ -56,13 +57,29 @@ impl ComposioTool {
         )
     }
 
-    /// Like [`Self::new`] but with an explicit Composio v3 base URL.
+    /// Test-only seam: construct with an explicit Composio v3 base URL so
+    /// unit tests can point the direct `/tools` request — including the
+    /// `tags` filter — at a local mock instead of `backend.composio.dev`.
     ///
-    /// Production code always goes through [`Self::new`] (real endpoint);
-    /// this constructor is the seam unit tests use to exercise the direct
-    /// `/tools` request — including the `tags` filter — end-to-end against
-    /// a local mock server instead of `backend.composio.dev`.
+    /// `#[cfg(test)]`-gated on purpose: `list_tool_schemas_v3` attaches the
+    /// `x-api-key` header to whatever `base_v3` holds, so the only way to
+    /// reach the v3 endpoint in production is [`Self::new`], which always
+    /// uses the HTTPS [`COMPOSIO_API_BASE_V3`] const. An injectable base must
+    /// never carry a non-HTTPS URL outside tests.
+    #[cfg(test)]
     pub(crate) fn new_with_v3_base(
+        api_key: &str,
+        default_entity_id: Option<&str>,
+        security: Arc<SecurityPolicy>,
+        base_v3: String,
+    ) -> Self {
+        Self::new_internal(api_key, default_entity_id, security, base_v3)
+    }
+
+    /// Shared constructor body. Private so the injectable `base_v3` cannot be
+    /// supplied by production callers — they go through [`Self::new`] (real
+    /// HTTPS const) and tests through the `#[cfg(test)]` `new_with_v3_base`.
+    fn new_internal(
         api_key: &str,
         default_entity_id: Option<&str>,
         security: Arc<SecurityPolicy>,

--- a/src/openhuman/tools/impl/network/composio.rs
+++ b/src/openhuman/tools/impl/network/composio.rs
@@ -33,6 +33,13 @@ pub struct ComposioTool {
     api_key: String,
     default_entity_id: String,
     security: Arc<SecurityPolicy>,
+    /// Base URL for Composio v3 endpoints (`{base}/tools`). Production
+    /// always uses [`COMPOSIO_API_BASE_V3`] via [`Self::new`]; the
+    /// injectable [`Self::new_with_v3_base`] lets unit tests point the
+    /// direct-mode `/tools` listing at a local axum mock — the same
+    /// base-URL injection the backend `ComposioClient` gets through
+    /// `IntegrationClient::new` in `client_tests.rs`.
+    base_v3: String,
 }
 
 impl ComposioTool {
@@ -40,6 +47,26 @@ impl ComposioTool {
         api_key: &str,
         default_entity_id: Option<&str>,
         security: Arc<SecurityPolicy>,
+    ) -> Self {
+        Self::new_with_v3_base(
+            api_key,
+            default_entity_id,
+            security,
+            COMPOSIO_API_BASE_V3.to_string(),
+        )
+    }
+
+    /// Like [`Self::new`] but with an explicit Composio v3 base URL.
+    ///
+    /// Production code always goes through [`Self::new`] (real endpoint);
+    /// this constructor is the seam unit tests use to exercise the direct
+    /// `/tools` request — including the `tags` filter — end-to-end against
+    /// a local mock server instead of `backend.composio.dev`.
+    pub(crate) fn new_with_v3_base(
+        api_key: &str,
+        default_entity_id: Option<&str>,
+        security: Arc<SecurityPolicy>,
+        base_v3: String,
     ) -> Self {
         let trimmed = api_key.trim();
         if trimmed.len() != api_key.len() {
@@ -59,6 +86,7 @@ impl ComposioTool {
             api_key: trimmed.to_string(),
             default_entity_id: normalize_entity_id(default_entity_id.unwrap_or("default")),
             security,
+            base_v3,
         }
     }
 
@@ -137,6 +165,44 @@ impl ComposioTool {
     /// List v3 tool definitions for one or more toolkits, preserving the
     /// raw `input_parameters` JSON schema each action carries.
     ///
+    /// Build the query-parameter pairs for the Composio v3 `GET /tools`
+    /// listing used by [`Self::list_tool_schemas_v3`].
+    ///
+    /// `toolkits` is sent as a single comma-joined `toolkits=` param (the
+    /// legacy plural the v3 backend tolerates; cf. `list_actions_v3` which
+    /// sends both the plural and `toolkit_slug` singular forms). `tags` is
+    /// encoded as **repeated** `tags=` params (`tags=a&tags=b`) — the shape
+    /// Composio v3 `/tools` documents for tag filtering ("can be specified
+    /// multiple times"), NOT the comma-joined form the backend proxy uses.
+    /// Blank entries are trimmed and dropped; an empty `tags` slice yields
+    /// no `tags` params (treated as no filter).
+    ///
+    /// Pure (no I/O) so the param shape is unit-testable without a live
+    /// HTTP round trip — mirrors [`Self::build_execute_action_v3_request`].
+    fn build_list_tool_schemas_v3_query(
+        toolkits: &[&str],
+        tags: Option<&[&str]>,
+    ) -> Vec<(&'static str, String)> {
+        let mut params: Vec<(&'static str, String)> = vec![("limit", "200".to_string())];
+
+        let trimmed: Vec<&str> = toolkits
+            .iter()
+            .map(|t| t.trim())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if !trimmed.is_empty() {
+            params.push(("toolkits", trimmed.join(",")));
+        }
+
+        if let Some(tags) = tags {
+            for tag in tags.iter().map(|t| t.trim()).filter(|t| !t.is_empty()) {
+                params.push(("tags", tag.to_string()));
+            }
+        }
+
+        params
+    }
+
     /// Sibling of [`Self::list_actions`] but kept distinct because
     /// `list_actions` flattens to `Vec<ComposioAction>` (no parameters)
     /// for the legacy agent-discovery shape, whereas
@@ -149,22 +215,31 @@ impl ComposioTool {
     /// catalogue scan. Empty filter returns every action across every
     /// toolkit on the user's tenant (potentially large; callers should
     /// pass a non-empty filter in practice).
+    ///
+    /// `tags` narrows the result by Composio action tag (OR semantics —
+    /// multiple tags broaden the result). This is the direct-mode (BYO
+    /// key) counterpart to the backend proxy's `tags` query param wired
+    /// in [`crate::openhuman::composio::client::ComposioClient::list_tools`];
+    /// without it a self-key user's `composio_list_tools(..., tags)`
+    /// request would silently drop the tag filter. Blank/empty `tags`
+    /// are treated as no filter.
     pub(crate) async fn list_tool_schemas_v3(
         &self,
         toolkits: &[&str],
+        tags: Option<&[&str]>,
     ) -> anyhow::Result<Vec<ComposioToolSchemaV3>> {
-        let url = format!("{COMPOSIO_API_BASE_V3}/tools");
-        let mut req = self.client().get(&url).header("x-api-key", &self.api_key);
-        req = req.query(&[("limit", "200")]);
-        let trimmed: Vec<&str> = toolkits
-            .iter()
-            .map(|t| t.trim())
-            .filter(|t| !t.is_empty())
-            .collect();
-        if !trimmed.is_empty() {
-            let csv = trimmed.join(",");
-            req = req.query(&[("toolkits", csv.as_str())]);
-        }
+        let url = format!("{}/tools", self.base_v3);
+        let params = Self::build_list_tool_schemas_v3_query(toolkits, tags);
+        tracing::debug!(
+            toolkits = toolkits.len(),
+            tags = tags.map(<[&str]>::len).unwrap_or(0),
+            "[composio-direct] list_tool_schemas_v3: GET v3 /tools query built"
+        );
+        let req = self
+            .client()
+            .get(&url)
+            .header("x-api-key", &self.api_key)
+            .query(&params);
 
         let resp = req.send().await?;
         if !resp.status().is_success() {

--- a/src/openhuman/tools/impl/network/composio_tests.rs
+++ b/src/openhuman/tools/impl/network/composio_tests.rs
@@ -5,6 +5,18 @@ fn test_security() -> Arc<SecurityPolicy> {
     Arc::new(SecurityPolicy::default())
 }
 
+/// Spawn a throwaway axum mock bound to an ephemeral port and return its base
+/// URL. Mirrors `start_mock_backend` in `client_tests.rs` so both HTTP-level
+/// direct-mode tests share one setup model.
+async fn start_mock_backend(app: axum::Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
 // ── Constructor ───────────────────────────────────────────
 
 #[test]
@@ -445,12 +457,7 @@ async fn list_tool_schemas_v3_sends_repeated_tags_to_v3_tools_endpoint() {
             }
         }),
     );
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-    let base = format!("http://127.0.0.1:{}", addr.port());
+    let base = start_mock_backend(app).await;
 
     let tool = ComposioTool::new_with_v3_base("ck_test_direct", None, test_security(), base);
     let items = tool

--- a/src/openhuman/tools/impl/network/composio_tests.rs
+++ b/src/openhuman/tools/impl/network/composio_tests.rs
@@ -336,6 +336,151 @@ fn build_execute_action_v3_request_drops_blank_optional_fields() {
     assert!(body.get("user_id").is_none());
 }
 
+// ── list_tool_schemas_v3 query builder (direct-mode tags) ──────────────────
+
+#[test]
+fn build_list_tool_schemas_v3_query_always_includes_limit() {
+    let params = ComposioTool::build_list_tool_schemas_v3_query(&[], None);
+    assert_eq!(params, vec![("limit", "200".to_string())]);
+}
+
+#[test]
+fn build_list_tool_schemas_v3_query_joins_toolkits_as_csv() {
+    let params = ComposioTool::build_list_tool_schemas_v3_query(&["github", "gmail"], None);
+    assert_eq!(
+        params,
+        vec![
+            ("limit", "200".to_string()),
+            ("toolkits", "github,gmail".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn build_list_tool_schemas_v3_query_emits_repeated_tags_params() {
+    // Composio v3 `/tools` takes tags as repeated `tags=` params
+    // (tags=stars&tags=repos), NOT comma-joined like the backend proxy.
+    // A Vec of duplicate ("tags", _) keys is exactly what reqwest's
+    // `.query(&params)` serializes into repeated query params.
+    let params =
+        ComposioTool::build_list_tool_schemas_v3_query(&["github"], Some(&["stars", "repos"]));
+    assert_eq!(
+        params,
+        vec![
+            ("limit", "200".to_string()),
+            ("toolkits", "github".to_string()),
+            ("tags", "stars".to_string()),
+            ("tags", "repos".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn build_list_tool_schemas_v3_query_tags_without_toolkit_filter() {
+    let params = ComposioTool::build_list_tool_schemas_v3_query(&[], Some(&["readOnlyHint"]));
+    assert_eq!(
+        params,
+        vec![
+            ("limit", "200".to_string()),
+            ("tags", "readOnlyHint".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn build_list_tool_schemas_v3_query_trims_and_drops_blank_entries() {
+    let params = ComposioTool::build_list_tool_schemas_v3_query(
+        &["  github  ", "   "],
+        Some(&["  stars  ", "", "   "]),
+    );
+    assert_eq!(
+        params,
+        vec![
+            ("limit", "200".to_string()),
+            ("toolkits", "github".to_string()),
+            ("tags", "stars".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn build_list_tool_schemas_v3_query_empty_tags_slice_is_no_filter() {
+    // `Some(&[])` and an all-blank slice must both behave like "no tags".
+    let empty = ComposioTool::build_list_tool_schemas_v3_query(&["gmail"], Some(&[]));
+    let blank = ComposioTool::build_list_tool_schemas_v3_query(&["gmail"], Some(&["  "]));
+    let expected = vec![
+        ("limit", "200".to_string()),
+        ("toolkits", "gmail".to_string()),
+    ];
+    assert_eq!(empty, expected);
+    assert_eq!(blank, expected);
+}
+
+// ── list_tool_schemas_v3 over HTTP (direct-mode tags reach the wire) ───────
+
+#[tokio::test]
+async fn list_tool_schemas_v3_sends_repeated_tags_to_v3_tools_endpoint() {
+    use axum::{extract::RawQuery, routing::get, Json, Router};
+    use std::sync::Mutex;
+
+    // Capture the raw query string the server sees. `RawQuery` (not
+    // `Query<HashMap>`) is required because a HashMap would collapse the
+    // repeated `tags=` params we specifically need to assert on.
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    let app = Router::new().route(
+        "/tools",
+        get(move |RawQuery(q): RawQuery| {
+            let sink = sink.clone();
+            async move {
+                *sink.lock().unwrap() = q;
+                Json(json!({
+                    "items": [{
+                        "slug": "GITHUB_STAR_A_REPOSITORY",
+                        "description": "Star a repository",
+                        "input_parameters": { "type": "object" },
+                        "toolkit": { "slug": "github" }
+                    }]
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let base = format!("http://127.0.0.1:{}", addr.port());
+
+    let tool = ComposioTool::new_with_v3_base("ck_test_direct", None, test_security(), base);
+    let items = tool
+        .list_tool_schemas_v3(&["github"], Some(&["stars", "repos"]))
+        .await
+        .expect("direct v3 /tools should succeed against the mock");
+
+    let query = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("mock server should have observed a query string");
+
+    // tags must be REPEATED params (tags=stars&tags=repos) — the Composio v3
+    // contract — NOT the comma-joined form the backend proxy uses.
+    assert!(query.contains("tags=stars"), "query was: {query}");
+    assert!(query.contains("tags=repos"), "query was: {query}");
+    assert!(
+        !query.contains("stars%2Crepos") && !query.contains("stars,repos"),
+        "tags must not be comma-joined; query was: {query}"
+    );
+    assert!(query.contains("toolkits=github"), "query was: {query}");
+    assert!(query.contains("limit=200"), "query was: {query}");
+
+    // And the v3 envelope reshapes back into schema items.
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].slug, "GITHUB_STAR_A_REPOSITORY");
+    assert_eq!(items[0].toolkit_slug.as_deref(), Some("github"));
+}
+
 // ── ensure_https ──────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Fix: the `tags` filter on `composio_list_tools` (added in #2714) was wired only through the **backend-proxied** path; in **direct (BYO Composio key)** mode it was computed and then silently dropped, so a self-key user filtering tools by tag got the unfiltered set.
- Thread `tags` through `direct_list_tools` → `ComposioTool::list_tool_schemas_v3`, encoding it as **repeated** `tags=` params per the Composio v3 `/tools` contract (vs the backend proxy's comma-joined `tags=a,b`).
- Add an injectable v3 base URL to `ComposioTool` (`new_with_v3_base`; prod `new` delegates with the real const) so the direct `/tools` path is HTTP-testable against a local axum mock — closing the documented "can't mock direct mode" gap.

## Problem

#2714 added a `tags` query param to the GitHub tool-list API. The wiring lived entirely on the backend client (`ComposioClient::list_tools`). In `ops::composio_list_tools`, `effective_tags` is computed once at the top, but the **direct branch** called `direct_list_tools(&direct, &scope)` — no tags argument — and `list_tool_schemas_v3` built the v3 request with only `toolkits` + `limit`. Result: in direct mode the tag filter was a no-op, with no error and no log. Today this only affects GitHub (the `should_forward_tags` allowlist), but it's a silent parity gap between the two modes.

## Solution

- `composio/ops.rs`: the direct branch now passes `effective_tags.as_deref()` (the value it was already computing). The `should_forward_tags` gate is unchanged, so direct/backend behaviour stays consistent.
- `composio/client.rs`: `direct_list_tools` gains a `tags` param and forwards it.
- `tools/impl/network/composio.rs`: `list_tool_schemas_v3` accepts `tags`; request building is extracted into a pure, unit-testable helper `build_list_tool_schemas_v3_query`. Encoding is **repeated** `tags=` params — Composio v3 documents `tags` as *"can be specified multiple times"*; reusing the proxy's comma-join would make v3 treat `"stars,repos"` as a single literal tag and match nothing.
- Test seam: `ComposioTool` gets an injectable v3 base URL. This mirrors how the backend `ComposioClient` already takes an injectable base via `IntegrationClient::new` in `client_tests.rs`, and removes the limitation that block-comment called out.

**Wire shape difference (same OR semantics):**
- Backend proxy: `…/agent-integrations/composio/tools?toolkits=github&tags=stars,repos`
- Direct (v3): `backend.composio.dev/api/v3/tools?limit=200&toolkits=github&tags=stars&tags=repos`

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 6 query-builder unit tests (incl. blank-trim, empty-tags-as-no-filter) + 2 axum-mock HTTP tests (repeated-`tags=` wire shape; v3→envelope reshape with empty-slug rows dropped)
- [x] **Diff coverage ≥ 80%** — pure builder + both HTTP paths (`list_tool_schemas_v3`, `direct_list_tools`) are covered by mock tests; the `ops.rs` direct-branch call line is exercised to its error path by the existing `ops_test.rs` direct-mode integration test. Will confirm the diff-cover number from CI and top up if the gate flags any line.
- [x] Coverage matrix updated — N/A: behaviour-parity fix to the existing #2714 tags feature; no feature row added/removed/renamed
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix rows affected
- [x] No new external network dependencies introduced — local axum mock only (`axum` is already a dev-dependency); no production deps added
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: internal tool-listing parity, not a release-cut surface
- [x] Linked issue closed via `Closes #NNN` — N/A: no tracking issue; this brings #2714 to direct-mode parity (referenced below)

## Impact

- **Runtime:** Rust core only. No Tauri shell, frontend, CLI, migration, or schema changes. Direct-mode users now get tag-filtered results matching backend mode; backend mode is byte-for-byte unchanged.
- **Security/perf:** none. Same endpoint, same auth (`x-api-key`), just an additional query filter that narrows the response.
- **Caveat:** the `ops.rs` direct-branch happy path (config → factory → connection prefetch → `direct_list_tools`) isn't driven end-to-end in unit tests because the factory builds `ComposioTool` against the real const base; the two new HTTP tests cover the reshaper and v3 request directly instead. Flagging in case CI's diff-cover wants the wiring line covered.

## Related

- Closes: N/A (no tracking issue)
- Brings #2714 (`feat(composio): add tags query param to GitHub tool list API`) to parity in direct/BYO-key mode
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/composio-direct-tags`
- Commit SHA: d61ae2dc

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no app/TS changes
- [x] `pnpm typecheck` — N/A: no app/TS changes
- [x] Focused tests: `cargo test --lib composio` → **668 passed, 0 failed** (incl. the 8 new tests)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; lib + tests build clean
- [x] Tauri fmt/check (if changed): N/A: no Tauri shell changes

### Validation Blocked
- `command:` `git push` pre-push hook (`pnpm rust:check`)
- `error:` vendored tauri-cef CEF runtime + pnpm/node env not present in this sandbox
- `impact:` pushed with `--no-verify`; this PR touches only the Rust core lib (no Tauri shell), and CI runs the full check

### Behavior Changes
- Intended behavior change: `composio_list_tools(..., tags)` now honours `tags` in direct/BYO-key mode (previously dropped)
- User-visible effect: self-key users filtering tools by Composio action tag (e.g. GitHub) now get a narrowed result, matching backend mode

### Parity Contract
- Legacy behavior preserved: backend-proxied path unchanged; `should_forward_tags` allowlist unchanged; empty/blank tags still mean "no filter"
- Guard/fallback/dispatch parity checks: direct vs backend now apply the same tag gate; only the wire encoding differs (repeated params for v3 vs CSV for the proxy), matching each server's contract

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct-mode tool listing now supports filtering by action tags and forwards effective tags to v3 queries; debug logs now include tag info.

* **Bug Fixes / Behavior**
  * v3 responses are reshaped consistently and empty/blank items are dropped to match backend-style envelopes.

* **Tests**
  * Added unit and end-to-end mock tests validating tag/query encoding, toolkit CSV handling, and response reshaping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->