### PR TITLE
fix(observability): demote unknown-provider list_models error (Sentry TAURI-RUST-X)

### DIFF
--- a/src/openhuman/inference/ops.rs
+++ b/src/openhuman/inference/ops.rs
@@ -9,9 +9,25 @@ use crate::openhuman::inference::{device, presets, sentiment, SentimentResult};
 use crate::openhuman::inference::{LocalAiEmbeddingResult, LocalAiStatus};
 use crate::rpc::RpcOutcome;
 use serde_json::{json, Value};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 const LOG_PREFIX: &str = "[inference::ops]";
+
+/// User picked a provider id (slug) that isn't registered in the cloud
+/// provider list — e.g. selecting `"ollama"` as a cloud provider when it's
+/// actually a local runtime. Matches the literal phrase emitted at
+/// `src/openhuman/inference/provider/ops.rs:54`
+/// (`"no cloud provider with id or slug '{}' found"`).
+///
+/// Used by [`inference_list_models`] to demote this user-config case to
+/// `warn!` so it stops escalating to Sentry (TAURI-RUST-X, ~5740 events).
+/// The matcher is anchored on the exact phrase so unrelated sibling
+/// failures (TAURI-RUST-12 JSON parse, TAURI-RUST-2W reqwest builder,
+/// TAURI-RUST-JP local ollama_admin transport) still surface as real
+/// errors.
+fn is_unknown_provider_user_config(err: &str) -> bool {
+    err.contains("no cloud provider with id or slug")
+}
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct InferenceTestProviderModelResult {
@@ -245,7 +261,29 @@ pub async fn inference_list_models(provider_id: &str) -> Result<RpcOutcome<Value
     let result = providers::ops::list_configured_models(provider_id).await;
     match &result {
         Ok(_) => debug!("{LOG_PREFIX} list_models:ok"),
-        Err(err) => error!(error = %err, "{LOG_PREFIX} list_models:error"),
+        Err(err) => {
+            if is_unknown_provider_user_config(err) {
+                // User selected a provider id that isn't a registered
+                // cloud provider (e.g. picking "ollama", a local runtime).
+                // Demote to `warn!` so it stays in local logs but doesn't
+                // escalate to Sentry. Targets TAURI-RUST-X (~5740 events).
+                warn!(
+                    provider_id,
+                    error = %err,
+                    "{LOG_PREFIX} list_models:unknown-provider (user-config)"
+                );
+            } else {
+                // Real error — embed `{err}` in the format string so
+                // Sentry's event title carries the actionable cause
+                // instead of the opaque `list_models:error` shape that
+                // made TAURI-RUST-X untriageable.
+                error!(
+                    provider_id,
+                    error = %err,
+                    "{LOG_PREFIX} list_models:error: {err}"
+                );
+            }
+        }
     }
     result
 }

--- a/src/openhuman/inference/ops_tests.rs
+++ b/src/openhuman/inference/ops_tests.rs
@@ -258,3 +258,61 @@ async fn inference_openai_oauth_disconnect_returns_removed_flag() {
     assert_eq!(outcome.value["disconnected"], true);
     assert_eq!(outcome.logs, vec!["openai oauth disconnected"]);
 }
+
+// ── is_unknown_provider_user_config (TAURI-RUST-X) ───────────────────────
+//
+// `inference_list_models` calls `providers::ops::list_configured_models`,
+// which surfaces a `String` error when the user-selected provider id isn't
+// registered in the cloud-provider list (e.g. picking "ollama" — a local
+// runtime — as a cloud provider). The error string is emitted at
+// `src/openhuman/inference/provider/ops.rs:54`. Before this fix the emit
+// site at `inference/ops.rs:248` escalated every such error to `error!`,
+// which sentry-tracing ships to Sentry as `"[inference::ops]
+// list_models:error"` — 5740+ events with the underlying error hidden in
+// a tracing field where no Sentry classifier can reach it. The helper
+// gate keeps the demote anchored so unrelated failures (HTTP / JSON / IO)
+// still escalate.
+
+#[test]
+fn is_unknown_provider_user_config_matches_canonical_emit_site_string() {
+    // Verbatim shape from `provider/ops.rs:54`:
+    //   format!("no cloud provider with id or slug '{}' found", provider_id)
+    // Latest TAURI-RUST-X event (Sentry id 95) carried provider_id="ollama";
+    // every well-formed provider id slug must trigger the demote.
+    assert!(is_unknown_provider_user_config(
+        "no cloud provider with id or slug 'ollama' found"
+    ));
+    assert!(is_unknown_provider_user_config(
+        "no cloud provider with id or slug 'made-up-custom-id' found"
+    ));
+    assert!(is_unknown_provider_user_config(
+        "no cloud provider with id or slug '' found"
+    ));
+}
+
+#[test]
+fn is_unknown_provider_user_config_rejects_other_list_models_failures() {
+    // Defense in depth: the sibling list_models Sentry issues
+    // (TAURI-RUST-12 JSON parse, TAURI-RUST-2W HTTP builder, etc.) are
+    // real bugs that MUST still escalate to Sentry. The matcher must stay
+    // strictly anchored on the "no cloud provider with id or slug" phrase
+    // so it can't accidentally silence them.
+    for raw in [
+        // TAURI-RUST-12 (362 events) — provider/ops.rs JSON decode failure
+        "[providers][list_models] failed to parse JSON: error decoding response",
+        // TAURI-RUST-2W (100 events) — provider/ops.rs reqwest builder failure
+        "[providers][list_models] HTTP request failed: builder error",
+        // TAURI-RUST-JP (8 events) — local_ai ollama_admin transport failure
+        "[local_ai:ollama_admin] list_models: request send failed",
+        // Generic shapes from elsewhere in the call chain
+        "request timed out after 30s",
+        "permission denied accessing config",
+        "no cloud provider configured for slug 'openai' (role 'chat')",
+        "",
+    ] {
+        assert!(
+            !is_unknown_provider_user_config(raw),
+            "must NOT demote real error: {raw:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Demote the user-config "no cloud provider with id or slug '<id>' found" error in `inference_list_models` from `error!` to `warn!`, so it stops escalating to Sentry as a code bug.
- Embed `{err}` in the surviving `error!` format string so future genuine `list_models` failures land in Sentry with actionable titles instead of the opaque `"[inference::ops] list_models:error"` shape.

## Why

Sentry **[TAURI-RUST-X](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/95/)** has accumulated ~5740 events. Every event has the same opaque title because the emit site at `src/openhuman/inference/ops.rs:248` was:

```rust
Err(err) => error!(error = %err, "{LOG_PREFIX} list_models:error"),
```

`sentry-tracing` ships this as a Sentry message of `"[inference::ops] list_models:error"`; the actual error sits in the `Rust Tracing Fields.error` context, which no body-level classifier in `core::observability` can reach (this is why none of the sibling "demote provider-config" classifiers caught it).

The latest event's underlying error: `"no cloud provider with id or slug 'ollama' found"` — emitted at `src/openhuman/inference/provider/ops.rs:54` when the user picks a provider id (e.g. `ollama`, which is actually a local runtime) that isn't a registered cloud provider. User-config state, not a code bug. Actionable for the user (pick a registered provider, or configure Ollama via the local runtime path), not actionable for any developer reading Sentry.

## What changed

1. **New helper** `is_unknown_provider_user_config(err: &str) -> bool` in `inference/ops.rs`, anchored on the literal phrase from `provider/ops.rs:54`. Narrow on purpose so sibling failures stay observable.
2. **Emit-site match arm** in `inference_list_models` now:
   - `warn!` on the user-config case → not picked up by sentry-tracing's error-level filter
   - `error!` on everything else, **with `{err}` interpolated into the format string** so the Sentry title carries the underlying cause and future events are triageable
3. **Tests** added: positive (canonical emit-site phrase across well-formed slugs) + negative (sibling Sentry shapes TAURI-RUST-12 JSON parse, TAURI-RUST-2W reqwest builder, TAURI-RUST-JP local ollama_admin transport, plus generic timeout/permission/empty cases must still escalate).

## Out of scope (noted for follow-up)

- The same `error!(..., "{LOG_PREFIX} <op>:error")` template anti-pattern exists in ~6 other `inference::ops` functions (`status`, `summarize`, `update_local_settings`, …). If those spike as their own Sentry issues, the same pattern (or an extracted `log_inference_result(op, result)` helper) can address them. Not bundling here to keep the PR scoped to TAURI-RUST-X.
- Complementary work in flight (`fix/sentry-28z-local-runtime-list-models`, separate Sentry ID TAURI-RUST-28Z) makes Ollama/LMStudio lookups *succeed* by synthesizing transient `cloud_providers` entries. Different layer (`provider/ops.rs`, the source) vs. this PR (`inference/ops.rs`, the emit site). The two are complementary defense-in-depth: that PR removes most of the cases; this PR demotes any residual unknown-provider misconfigurations so they don't reappear as a new Sentry issue.

## Test plan

- [x] `cargo test is_unknown_provider_user_config` — 2 new tests pass (positive + negative)
- [x] `cargo test openhuman::inference` — 687 tests pass, 0 regressions
- [x] `cargo check --manifest-path Cargo.toml --bin openhuman-core` — passes
- [x] `cargo fmt --check` on touched files — clean

## Post-merge monitoring

Watch TAURI-RUST-X event rate drop to ~0 on the next release; any residual events should now carry the actual error string in their title (kept out of the Test-plan checklist because it's a follow-up observation, not a pre-merge gate — the PR Submission Checklist workflow only counts `[x]` items).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for cloud provider configuration issues with improved diagnostic logging
  * Better distinction between user-configuration problems and system-level errors in application logs
  * More detailed error messages to support troubleshooting and accelerate issue resolution
  * Improved operational visibility through refined error categorization and more granular logging information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
