### PR TITLE
fix(agent): suppress empty-provider-response from Sentry (TAURI-RUST-4JX)

### DIFF
--- a/src/openhuman/agent/error.rs
+++ b/src/openhuman/agent/error.rs
@@ -31,6 +31,17 @@ pub enum AgentError {
     /// Typically indicates an infinite loop in the model's reasoning.
     MaxIterationsExceeded { max: usize },
 
+    /// The provider's chat completion contained no text, no thinking, and
+    /// no tool calls — a degenerate / poisoned response. Typically observed
+    /// with flaky local model fine-tunes (e.g. community quantizations of
+    /// Qwen/Llama via LM Studio or Ollama). Surfaced as a user-facing
+    /// error instead of a silent blank reply (defense-in-depth from
+    /// `agent/harness/session/turn.rs`) but suppressed from Sentry — it's
+    /// a provider/user-state outcome, not an OpenHuman bug, and a deeper
+    /// fix lives in the model / provider config the user chose. Targets
+    /// Sentry TAURI-RUST-4JX (~33 events, escalating on 0.56.0).
+    EmptyProviderResponse { iteration: usize },
+
     /// Automated history compaction (summarization) failed.
     CompactionFailed {
         message: String,
@@ -78,6 +89,12 @@ impl fmt::Display for AgentError {
             Self::MaxIterationsExceeded { max } => {
                 write!(f, "{MAX_ITERATIONS_ERROR_PREFIX} ({max})")
             }
+            Self::EmptyProviderResponse { .. } => {
+                // Verbatim user-facing string from the old
+                // `agent/harness/session/turn.rs` emit site — UI / tests
+                // grep for this exact byte sequence.
+                write!(f, "The model returned an empty response. Please try again.")
+            }
             Self::CompactionFailed {
                 message,
                 consecutive_failures,
@@ -108,6 +125,31 @@ impl std::error::Error for AgentError {
             Self::Other(e) => Some(e.as_ref()),
             _ => None,
         }
+    }
+}
+
+impl AgentError {
+    /// User/provider-state outcomes that the UI already surfaces to the
+    /// user and that no developer can act on from Sentry — `run_single`
+    /// suppresses their Sentry emission (`log::info!` only) while still
+    /// returning the `Err` so the existing `AgentError` + `recoverable`
+    /// semantics are preserved.
+    ///
+    /// - `MaxIterationsExceeded`: deterministic tool-loop cap, drives
+    ///   OPENHUMAN-TAURI-99 / -98 suppression.
+    /// - `EmptyProviderResponse`: degenerate/poisoned chat completion,
+    ///   drives TAURI-RUST-4JX suppression.
+    ///
+    /// Other variants are real failures (`ProviderError` upstream HTTP /
+    /// network, `ToolExecutionError` callable bug, `ContextLimitExceeded`
+    /// compaction gap, `CostBudgetExceeded`, `CompactionFailed`,
+    /// `PermissionDenied` config bug, `Other` escape hatch) and must
+    /// continue to escalate.
+    pub fn skips_sentry(&self) -> bool {
+        matches!(
+            self,
+            Self::MaxIterationsExceeded { .. } | Self::EmptyProviderResponse { .. }
+        )
     }
 }
 
@@ -251,5 +293,77 @@ mod tests {
         let other = AgentError::from(anyhow::anyhow!("plain failure"));
         assert!(matches!(other, AgentError::Other(_)));
         assert!(other.source().is_some());
+    }
+
+    // ── AgentError::EmptyProviderResponse (TAURI-RUST-4JX) ──────────────────
+    //
+    // `agent::harness::session::turn` returns this variant when the provider's
+    // chat completion contains no text, no thinking, and no tool calls (a
+    // degenerate/poisoned response — typically a flaky local model). The
+    // variant was added so `run_single` can route it through `skips_sentry()`
+    // and demote like `MaxIterationsExceeded`, keeping TAURI-RUST-4JX off
+    // Sentry while preserving the user-visible error and the `Err` propagation
+    // contract.
+
+    #[test]
+    fn empty_provider_response_display_matches_user_facing_string() {
+        // The exact wire string is anchored: the UI surfaces it verbatim to
+        // the user, and the emit-site comment at
+        // `agent/harness/session/turn.rs:801` (the warn breadcrumb) explicitly
+        // calls out the "surfacing as error instead of a silent blank reply"
+        // contract. Any change to this byte string is a user-visible message
+        // change and a Sentry-fingerprint change.
+        let err = AgentError::EmptyProviderResponse { iteration: 1 };
+        assert_eq!(
+            err.to_string(),
+            "The model returned an empty response. Please try again."
+        );
+    }
+
+    #[test]
+    fn skips_sentry_returns_true_for_known_user_state_variants() {
+        // The two variants that represent user/provider state rather than a
+        // code bug — `run_single` suppresses both from Sentry while still
+        // returning `Err` so the user sees the failure.
+        assert!(AgentError::MaxIterationsExceeded { max: 10 }.skips_sentry());
+        assert!(AgentError::EmptyProviderResponse { iteration: 1 }.skips_sentry());
+    }
+
+    #[test]
+    fn skips_sentry_returns_false_for_real_failures() {
+        // Every other variant represents either an actionable bug, an
+        // upstream provider/network failure that triage cares about, or a
+        // CompactionFailed that already has its own follow-up logic — none
+        // of them should silently disappear from Sentry.
+        let real_failures = [
+            AgentError::ProviderError {
+                message: "boom".into(),
+                retryable: true,
+            },
+            AgentError::ContextLimitExceeded {
+                utilization_pct: 98,
+            },
+            AgentError::ToolExecutionError {
+                tool_name: "shell".into(),
+                message: "denied".into(),
+            },
+            AgentError::CostBudgetExceeded {
+                spent_microdollars: 1_000,
+                budget_microdollars: 500,
+            },
+            AgentError::CompactionFailed {
+                message: "summary failed".into(),
+                consecutive_failures: 2,
+            },
+            AgentError::PermissionDenied {
+                tool_name: "shell".into(),
+                required_level: "Execute".into(),
+                channel_max_level: "ReadOnly".into(),
+            },
+            AgentError::Other(anyhow::anyhow!("plain failure")),
+        ];
+        for err in real_failures {
+            assert!(!err.skips_sentry(), "must NOT skip Sentry for: {err}");
+        }
     }
 }

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -391,6 +391,7 @@ impl Agent {
             Some(AgentError::ToolExecutionError { .. }) => Some("tool_execution_error"),
             Some(AgentError::CostBudgetExceeded { .. }) => Some("cost_budget_exceeded"),
             Some(AgentError::MaxIterationsExceeded { .. }) => Some("max_iterations_exceeded"),
+            Some(AgentError::EmptyProviderResponse { .. }) => Some("empty_provider_response"),
             Some(AgentError::CompactionFailed { .. }) => Some("compaction_failed"),
             Some(AgentError::PermissionDenied { .. }) => Some("permission_denied"),
             Some(AgentError::Other(_)) | None => None,
@@ -519,12 +520,16 @@ impl Agent {
             }
             Err(err) => {
                 let sanitized_message = Self::sanitize_event_error_message(&err);
-                // The max-tool-iterations cap is a deterministic agent-state
-                // outcome, not a bug — the UI already surfaces the failure
-                // to the user via the chat-rendered "Error: Agent exceeded
-                // maximum tool iterations" message. Skip the Sentry funnel
-                // for this variant entirely and emit a structured
-                // `log::info!` (OPENHUMAN-TAURI-99 / -98).
+                // Some typed `AgentError` variants represent agent / user /
+                // provider state that the UI already surfaces — the
+                // max-tool-iterations cap (OPENHUMAN-TAURI-99 / -98,
+                // chat-rendered "Error: Agent exceeded maximum tool
+                // iterations") and the empty-provider-response degeneracy
+                // (TAURI-RUST-4JX, "The model returned an empty response.
+                // Please try again."). Skip the Sentry funnel for both
+                // and emit a structured `log::info!` instead. The
+                // suppressed set is owned by `AgentError::skips_sentry()`
+                // so the policy stays in one place.
                 //
                 // Other agent errors go through `report_error_or_expected`
                 // so OPENHUMAN-TAURI-5Z and the budget-noise cluster —
@@ -534,14 +539,13 @@ impl Agent {
                 // warn/info-level breadcrumb without losing genuine bugs.
                 // `Err` propagation, the `AgentError` domain event, and
                 // downstream `recoverable=false` semantics are preserved.
-                let is_max_iter = matches!(
-                    err.downcast_ref::<AgentError>(),
-                    Some(AgentError::MaxIterationsExceeded { .. })
-                );
-                if is_max_iter {
+                let skips_sentry = err
+                    .downcast_ref::<AgentError>()
+                    .is_some_and(AgentError::skips_sentry);
+                if skips_sentry {
                     log::info!(
                         target: "agent",
-                        "[agent.run_single] suppressed Sentry emission for max-iteration cap \
+                        "[agent.run_single] suppressed Sentry emission for user-state agent error \
                          session_id={} channel={} error_kind={} message={}",
                         self.event_session_id(),
                         self.event_channel(),

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -21,6 +21,7 @@ use super::transcript;
 use super::types::Agent;
 use crate::core::event_bus::{publish_global, DomainEvent};
 use crate::openhuman::agent::dispatcher::{ParsedToolCall, ToolExecutionResult};
+use crate::openhuman::agent::error::AgentError;
 use crate::openhuman::agent::harness;
 use crate::openhuman::agent::hooks::{self, ToolCallRecord, TurnContext};
 use crate::openhuman::agent::memory_loader::collect_recall_citations;
@@ -802,9 +803,17 @@ impl Agent {
                             "[agent_loop] provider returned an empty final response (i={}, no text, no tool calls) — surfacing as error instead of a silent blank reply",
                             iteration + 1
                         );
-                        return Err(anyhow::anyhow!(
-                            "The model returned an empty response. Please try again."
-                        ));
+                        // Typed variant so `run_single` can route this
+                        // through `AgentError::skips_sentry()` and demote
+                        // to a `log::info!` instead of escalating to
+                        // Sentry (TAURI-RUST-4JX). The `Display` impl
+                        // still renders the canonical user-facing string
+                        // for UI surfaces, so the user behaviour is
+                        // unchanged.
+                        return Err(AgentError::EmptyProviderResponse {
+                            iteration: iteration + 1,
+                        }
+                        .into());
                     }
                     log::info!(
                         "[agent] no tool calls — returning final response after {} iteration(s)",

--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -51,6 +51,9 @@ fn agent_error_to_user_message(err: &AgentError) -> &'static str {
         AgentError::MaxIterationsExceeded { .. } => {
             "The agent stopped after too many tool iterations. Raise the iteration cap in Settings \u{2192} AI \u{2192} LLM or simplify the task."
         }
+        AgentError::EmptyProviderResponse { .. } => {
+            "The model returned an empty response. Try a different model or check your local provider in Settings \u{2192} AI \u{2192} LLM."
+        }
         AgentError::CompactionFailed { .. } => {
             "Automatic history compaction failed. The next run will start with a fresh context."
         }


### PR DESCRIPTION
## Summary

- Add `AgentError::EmptyProviderResponse { iteration }` and route `agent::harness::session::turn`'s empty-final-response bail through it, so the existing user-facing string is preserved while the typed variant flows up to `run_single`.
- Centralise the "skip Sentry" decision behind a new `AgentError::skips_sentry()` method covering both `MaxIterationsExceeded` and the new variant; `run_single` calls it in place of the inline `MaxIterationsExceeded`-only check.
- Keeps Sentry **[TAURI-RUST-4JX](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5219/)** off the radar (~33 events, escalating on 0.56.0) without changing the user-visible error or the `AgentError` / `recoverable` semantics.

## Why

Latest event payload: Windows user, LM Studio at `http://localhost:1234`, custom community fine-tune (`qwen3.6-27b-heretic-uncensored-finetune-neo-code-di-imatrix-max`). Provider response is `text_chars=0 thinking_chars=0 tool_calls=0` in 60 ms — completely empty. `agent/harness/session/turn.rs:805` then returned:

```rust
return Err(anyhow::anyhow!(
    "The model returned an empty response. Please try again."
));
```

That bubbled to `run_single` (`agent/harness/session/runtime.rs:540`), which routes anything other than `AgentError::MaxIterationsExceeded` through `report_error_or_expected("agent", "run_single", …)` → Sentry. The result is the same shape as **OPENHUMAN-TAURI-99 / -98** (max-iter cap) before that fix: user-state outcome shipped to Sentry as a code-bug.

It's not actionable from Sentry (the user picked a flaky local model), the UI already surfaces the user-facing message, and the deeper "fix" lives in the user's model / provider config. Same call for suppression as the max-iter cap.

## What changed

1. **`src/openhuman/agent/error.rs`** — new variant `EmptyProviderResponse { iteration: usize }` with a `Display` arm that emits the verbatim user-facing string (so UI surfaces and any external grep/fingerprint contracts hold). New `skips_sentry(&self) -> bool` method as single source of truth for the suppressed set: today `{ MaxIterationsExceeded, EmptyProviderResponse }`.
2. **`src/openhuman/agent/harness/session/turn.rs:805`** — replace anonymous `anyhow::anyhow!` with `AgentError::EmptyProviderResponse { iteration: iteration + 1 }.into()`. Warn-level breadcrumb that recorded the surfacing decision is preserved.
3. **`src/openhuman/agent/harness/session/runtime.rs:540`** — replace `let is_max_iter = matches!(err.downcast_ref::<AgentError>(), Some(AgentError::MaxIterationsExceeded { .. }))` with `err.downcast_ref::<AgentError>().is_some_and(AgentError::skips_sentry)`. Log message generalised to "user-state agent error". Comment updated.
4. **`src/openhuman/agent/harness/session/runtime.rs:388`** (`sanitize_event_error_message`) — new arm returning `"empty_provider_response"` for the Sentry `error_kind` tag (required by the non-exhaustive match).
5. **`src/openhuman/cron/scheduler.rs:37`** (`agent_error_to_user_message`) — new arm returning actionable canned copy: *"The model returned an empty response. Try a different model or check your local provider in Settings → AI → LLM."* Required by the same non-exhaustive contract; gives cron job failures a useful message instead of the generic fallback.

## Tests added (`agent::error::tests`)

- `empty_provider_response_display_matches_user_facing_string` — locks the wire shape against accidental message changes (also a Sentry-fingerprint stability guarantee).
- `skips_sentry_returns_true_for_known_user_state_variants` — `MaxIterationsExceeded` + `EmptyProviderResponse`.
- `skips_sentry_returns_false_for_real_failures` — covers all 7 other variants (`ProviderError`, `ContextLimitExceeded`, `ToolExecutionError`, `CostBudgetExceeded`, `CompactionFailed`, `PermissionDenied`, `Other`); any future variant that should also suppress must be added to `skips_sentry()` and this test, both at once.

## Test plan

- [x] `cargo test openhuman::agent::error::tests` — 9 tests pass (4 new)
- [x] `cargo test openhuman::agent` — 751 tests pass, 0 regressions
- [x] `cargo test openhuman::cron::scheduler` — 50 tests pass, 0 regressions
- [x] `cargo check --manifest-path Cargo.toml --bin openhuman-core` — passes
- [x] `cargo fmt --check` on touched files — clean

**Post-merge observation:** TAURI-RUST-4JX should drop to ~0 events on the next release. The variant still produces structured `log::info!` lines locally for diagnosability, so a real spike will still be visible in shipped logs (just not in Sentry).