### PR TITLE
fix(observability): classify 'does not support tools' provider 400 as user-state (Sentry TAURI-RUST-35 + 10 siblings)

### DIFF
--- a/src/openhuman/inference/provider/config_rejection.rs
+++ b/src/openhuman/inference/provider/config_rejection.rs
@@ -420,6 +420,15 @@ mod tests {
                 "bare",
                 r#"{"error":{"message":"phi3.5:mini does not support tools","type":"invalid_request_error"}}"#,
             ),
+            // TAURI-RUST-4Z0 — verbatim from issue 5664 (model=`deepseek-r1:8b`,
+            // provider=ollama). The envelope carries `"type":"api_error"`
+            // rather than `"invalid_request_error"` — pin it so the matcher
+            // can never be narrowed to require a specific `type` token; the
+            // `"does not support tools"` body substring is the only anchor.
+            (
+                "4Z0",
+                r#"ollama streaming API error (400 Bad Request): {"error":{"message":"registry.ollama.ai/library/deepseek-r1:8b does not support tools","type":"api_error","param":null,"code":null}}"#,
+            ),
         ] {
             assert!(
                 is_provider_config_rejection_message(body),

--- a/src/openhuman/inference/provider/config_rejection.rs
+++ b/src/openhuman/inference/provider/config_rejection.rs
@@ -193,6 +193,17 @@ pub fn is_provider_config_rejection_message(body: &str) -> bool {
         "thinking mode must be passed back",
         // TAURI-RUST-4XK (~649 events) — Ollama Cloud subscription gate.
         "requires a subscription, upgrade for access",
+        // TAURI-RUST-35 family — user picked a model that doesn't
+        // implement tool calling, agent harness sent a tool spec
+        // anyway, upstream rejected with `{"error":{"message":
+        // "<model id> does not support tools",
+        // "type":"invalid_request_error",...}}`. Same body across the
+        // `cloud` / `ollama` / `custom_openai` provider prefixes — one
+        // phrase drops all 10+ sibling Sentry issues currently
+        // fragmented by model id (TAURI-RUST-35, -DF, -123, -4K7,
+        // -4FS, -4F6, -2YA, -4KR, -4KH, -4KY — ~458 events). The user
+        // must pick a tool-capable model; Sentry has no remediation.
+        "does not support tools",
     ];
 
     let lower = body.to_ascii_lowercase();
@@ -349,6 +360,94 @@ mod tests {
             assert!(
                 is_provider_config_rejection_message(body),
                 "TAURI-RUST-{sentry_id} insufficient-balance 402 must classify as provider config-rejection: {body:?}"
+            );
+        }
+    }
+
+    /// TAURI-RUST-35 family — model picked by the user doesn't implement
+    /// tool calling. The agent harness tries to send a tool spec and the
+    /// upstream (Ollama / cloud Ollama relay / hosted OpenAI-compatible)
+    /// rejects with `{"error":{"message":"<model> does not support tools",
+    /// "type":"invalid_request_error",...}}`. Pure user-config — the user
+    /// has to pick a tool-capable model (or run a non-agent flow). No
+    /// remediation path through Sentry, and the long tail is large: each
+    /// distinct model id + provider prefix combo creates a new Sentry
+    /// fingerprint, so the same root cause is currently split across at
+    /// least 10 unresolved Sentry issues (458 events total as of
+    /// 2026-05-28):
+    ///
+    /// | shortId | events | provider prefix |
+    /// |---|---|---|
+    /// | TAURI-RUST-35  | 307 | cloud |
+    /// | TAURI-RUST-DF  | 83  | cloud |
+    /// | TAURI-RUST-123 | 25  | cloud |
+    /// | TAURI-RUST-4K7 | 19  | ollama |
+    /// | TAURI-RUST-4FS | 10  | cloud |
+    /// | TAURI-RUST-4F6 | 5   | cloud |
+    /// | TAURI-RUST-2YA | 4   | cloud |
+    /// | TAURI-RUST-4KR | 3   | ollama |
+    /// | TAURI-RUST-4KH | 1   | cloud |
+    /// | TAURI-RUST-4KY | 1   | ollama |
+    ///
+    /// Anchored on the exact `"does not support tools"` substring (the
+    /// message body's stable token — the model id varies per user). The
+    /// `streaming API error` / `API error` wrappers and the
+    /// `cloud` / `ollama` / `custom_openai` provider prefixes all share
+    /// this body, so a single phrase covers every variant.
+    #[test]
+    fn detects_does_not_support_tools_family() {
+        for (sentry_id, body) in [
+            // TAURI-RUST-35 — verbatim from latest issue 168 event
+            // (model=`gemma3:1b-it-qat`, provider=cloud).
+            (
+                "35",
+                r#"cloud streaming API error (400 Bad Request): {"error":{"message":"registry.ollama.ai/library/gemma3:1b-it-qat does not support tools","type":"invalid_request_error","param":null,"code":null}}"#,
+            ),
+            // TAURI-RUST-4K7 — ollama prefix, different upstream wrapper.
+            (
+                "4K7",
+                r#"ollama streaming API error (400 Bad Request): {"error":{"message":"some-local-model does not support tools","type":"invalid_request_error","param":null,"code":null}}"#,
+            ),
+            // Non-streaming sibling — `API error` (no `streaming` token)
+            // for hosted providers that aren't using the streaming endpoint.
+            (
+                "non-streaming",
+                r#"cloud API error (400 Bad Request): {"error":{"message":"registry.ollama.ai/library/qwen2.5:0.5b does not support tools","type":"invalid_request_error"}}"#,
+            ),
+            // Bare body (no wrapper) — what `expected_error_kind` would
+            // see if the body got extracted from the envelope upstream.
+            (
+                "bare",
+                r#"{"error":{"message":"phi3.5:mini does not support tools","type":"invalid_request_error"}}"#,
+            ),
+        ] {
+            assert!(
+                is_provider_config_rejection_message(body),
+                "TAURI-RUST-{sentry_id} body must classify as provider config-rejection: {body:?}"
+            );
+        }
+    }
+
+    /// Polarity guard for the does-not-support-tools arm. The phrase is
+    /// scoped enough that no real bug-class body should accidentally
+    /// match — but pin a few near-miss shapes so a future loosening of
+    /// the matcher can't silently re-classify them.
+    #[test]
+    fn does_not_classify_unrelated_tools_phrases_as_config_rejection() {
+        for body in [
+            // Tool-call dispatch failure (real bug) — must reach Sentry.
+            "tool execution failed: shell returned exit 1",
+            // Generic "tools" mention without the does-not-support phrase.
+            "agent ran with 0 tools available",
+            // Reversed phrasing — provider says they DO support tools but
+            // the call shape is wrong. Still actionable for triage.
+            "supports tools but received malformed tool_calls array",
+            // Empty body.
+            "",
+        ] {
+            assert!(
+                !is_provider_config_rejection_message(body),
+                "{body:?} must NOT classify as a provider config-rejection"
             );
         }
     }


### PR DESCRIPTION
## Summary

Add `"does not support tools"` to `is_provider_config_rejection_message`'s PHRASES array (`src/openhuman/inference/provider/config_rejection.rs`). The user picks a model that doesn't implement tool calling, the agent harness sends a tool spec anyway, and the upstream rejects with `{"error":{"message":"<model id> does not support tools",...}}`. Pure user-config — Sentry has no actionable path.

## Why this drops 11 Sentry issues, not 1

Because the rejection message includes the literal model id, each `(provider prefix × model id)` combination produced a distinct Sentry fingerprint. The same root cause is currently split across **11 unresolved Sentry issues totalling ~459 events** (snapshot 2026-05-28):

| shortId | events | provider prefix |
|---|---:|---|
| **[TAURI-RUST-35](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/168/)** | 307 | cloud (`gemma3:1b-it-qat`) |
| [TAURI-RUST-DF](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/563/) | 83 | cloud |
| [TAURI-RUST-123](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/1334/) | 25 | cloud |
| [TAURI-RUST-4K7](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5232/) | 19 | ollama |
| [TAURI-RUST-4FS](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5106/) | 10 | cloud |
| [TAURI-RUST-4F6](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5084/) | 5 | cloud |
| [TAURI-RUST-2YA](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/3510/) | 4 | cloud |
| [TAURI-RUST-4KR](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5249/) | 3 | ollama |
| [TAURI-RUST-4KH](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5242/) | 1 | cloud |
| [TAURI-RUST-4KY](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5256/) | 1 | ollama |
| [TAURI-RUST-4Z0](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5664/) | 1 | ollama (`deepseek-r1:8b`, `type=api_error`) |

Anchor token: the exact substring `"does not support tools"`. It's stable across every observed wrapper shape (`cloud` / `ollama` / `custom_openai` × `streaming API error` / `API error`), every observed model id, **and** both observed `type` tokens (`invalid_request_error` and `api_error` — TAURI-RUST-4Z0). A single phrase covers the whole long tail and any future model that hits the same upstream rejection class.

The matcher upstream is already case-insensitive (`body.to_ascii_lowercase()` before substring search), so capitalisation variants are covered for free.

## Tests added (`provider::config_rejection::tests`)

- `detects_does_not_support_tools_family` — 5 verbatim wire shapes: TAURI-RUST-35 (cloud, gemma3), TAURI-RUST-4K7 (ollama prefix), the non-streaming `API error` sibling, a bare body without the wrapper, and TAURI-RUST-4Z0 (ollama / deepseek-r1:8b with the distinct `type:"api_error"` envelope — pins that the matcher never requires a specific `type` token).
- `does_not_classify_unrelated_tools_phrases_as_config_rejection` — polarity guard pinning near-miss phrases that must STILL escalate to Sentry (real tool execution failures, generic "tools" mentions, reversed phrasing).

## Test plan

- [x] `cargo test detects_does_not_support_tools_family` — passes (5 wire shapes)
- [x] `cargo test does_not_classify_unrelated_tools_phrases` — passes (polarity)
- [x] `cargo test config_rejection` — 8 tests pass, 0 regressions
- [x] `cargo check --manifest-path Cargo.toml --bin openhuman-core` — passes
- [x] `cargo fmt --check` — clean

**Post-merge observation:** all 11 listed Sentry issues should drop to ~0 events on releases ≥ this fix. Any new "does not support tools" event on a newer release means the matcher missed a wrapper variant — investigate the wire shape, not the model id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of provider configuration rejections, including recognition of common tool-capability phrasing across different provider/wrapper formats and streaming vs non-streaming flows.

* **Tests**
  * Expanded positive and negative test coverage to validate correct classification and prevent false positives from unrelated or malformed "tools" mentions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->