### PR TITLE
test(security): add integration tests for load_and_get_security_policy_info (#2688)

### DIFF
--- a/src/openhuman/config/schema/load.rs
+++ b/src/openhuman/config/schema/load.rs
@@ -1416,6 +1416,9 @@ impl Config {
             let trimmed = raw.trim();
             if !trimmed.is_empty() {
                 match trimmed.parse::<u32>() {
+                    Ok(0) => tracing::warn!(
+                        "OPENHUMAN_MAX_ACTIONS_PER_HOUR=0 ignored; value must be ≥ 1"
+                    ),
                     Ok(limit) => self.autonomy.max_actions_per_hour = limit,
                     Err(_) => tracing::warn!(
                         value = %raw,

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -565,6 +565,12 @@ fn env_overlay_autonomy_max_actions_per_hour_accepts_valid_u32() {
         cfg.autonomy.max_actions_per_hour, 64,
         "invalid env value must leave the configured limit unchanged"
     );
+
+    cfg.apply_env_overlay_with(&HashMapEnv::new().with("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "0"));
+    assert_eq!(
+        cfg.autonomy.max_actions_per_hour, 64,
+        "zero is invalid (< 1); env overlay must leave the configured limit unchanged"
+    );
 }
 
 #[test]

--- a/src/openhuman/security/ops.rs
+++ b/src/openhuman/security/ops.rs
@@ -31,6 +31,71 @@ pub async fn load_and_get_security_policy_info() -> Result<RpcOutcome<serde_json
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::config::TEST_ENV_LOCK;
+
+    // ── load_and_get_security_policy_info integration tests ──────────────────
+
+    /// Full chain: `OPENHUMAN_MAX_ACTIONS_PER_HOUR` env var → config load →
+    /// `load_and_get_security_policy_info()` → RPC payload contains the value.
+    ///
+    /// Covers the path that was previously only exercised by the full
+    /// JSON-RPC smoke test (follow-up from #2499 / issue #2688).
+    #[tokio::test]
+    async fn load_and_get_security_policy_info_reflects_env_overlay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path());
+            std::env::set_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "42");
+        }
+
+        let outcome = load_and_get_security_policy_info()
+            .await
+            .expect("load_and_get_security_policy_info should succeed");
+
+        assert_eq!(
+            outcome.value["max_actions_per_hour"],
+            serde_json::json!(42),
+            "env overlay must flow through to the RPC payload"
+        );
+
+        unsafe {
+            std::env::remove_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR");
+            std::env::remove_var("OPENHUMAN_WORKSPACE");
+        }
+    }
+
+    /// Edge case: `OPENHUMAN_MAX_ACTIONS_PER_HOUR=0` — the limit is invalid
+    /// (must be ≥ 1) so the env var must be ignored and the default preserved.
+    #[tokio::test]
+    async fn load_and_get_security_policy_info_ignores_zero_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path());
+            std::env::set_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "0");
+        }
+
+        let outcome = load_and_get_security_policy_info()
+            .await
+            .expect("load should succeed even with invalid env var");
+
+        let default = crate::openhuman::config::Config::default()
+            .autonomy
+            .max_actions_per_hour;
+        assert_eq!(
+            outcome.value["max_actions_per_hour"],
+            serde_json::json!(default),
+            "OPENHUMAN_MAX_ACTIONS_PER_HOUR=0 should be ignored; default must be used"
+        );
+
+        unsafe {
+            std::env::remove_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR");
+            std::env::remove_var("OPENHUMAN_WORKSPACE");
+        }
+    }
+
+    // ── security_policy_info_for_config unit tests ───────────────────────────
 
     #[test]
     fn security_policy_info_returns_all_documented_fields() {

--- a/src/openhuman/security/ops.rs
+++ b/src/openhuman/security/ops.rs
@@ -32,6 +32,31 @@ pub async fn load_and_get_security_policy_info() -> Result<RpcOutcome<serde_json
 mod tests {
     use super::*;
     use crate::openhuman::config::TEST_ENV_LOCK;
+    use std::ffi::OsString;
+
+    struct EnvRestore {
+        key: &'static str,
+        prev: Option<OsString>,
+    }
+
+    impl EnvRestore {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     // ── load_and_get_security_policy_info integration tests ──────────────────
 
@@ -44,10 +69,8 @@ mod tests {
     async fn load_and_get_security_policy_info_reflects_env_overlay() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path());
-            std::env::set_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "42");
-        }
+        let _workspace = EnvRestore::set("OPENHUMAN_WORKSPACE", tmp.path());
+        let _budget = EnvRestore::set("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "42");
 
         let outcome = load_and_get_security_policy_info()
             .await
@@ -58,23 +81,18 @@ mod tests {
             serde_json::json!(42),
             "env overlay must flow through to the RPC payload"
         );
-
-        unsafe {
-            std::env::remove_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR");
-            std::env::remove_var("OPENHUMAN_WORKSPACE");
-        }
     }
 
     /// Edge case: `OPENHUMAN_MAX_ACTIONS_PER_HOUR=0` — the limit is invalid
     /// (must be ≥ 1) so the env var must be ignored and the default preserved.
+    /// The env overlay silently ignores 0 (consistent with the RPC update path
+    /// which rejects it with an error).
     #[tokio::test]
     async fn load_and_get_security_policy_info_ignores_zero_budget() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path());
-            std::env::set_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "0");
-        }
+        let _workspace = EnvRestore::set("OPENHUMAN_WORKSPACE", tmp.path());
+        let _budget = EnvRestore::set("OPENHUMAN_MAX_ACTIONS_PER_HOUR", "0");
 
         let outcome = load_and_get_security_policy_info()
             .await
@@ -88,11 +106,6 @@ mod tests {
             serde_json::json!(default),
             "OPENHUMAN_MAX_ACTIONS_PER_HOUR=0 should be ignored; default must be used"
         );
-
-        unsafe {
-            std::env::remove_var("OPENHUMAN_MAX_ACTIONS_PER_HOUR");
-            std::env::remove_var("OPENHUMAN_WORKSPACE");
-        }
     }
 
     // ── security_policy_info_for_config unit tests ───────────────────────────


### PR DESCRIPTION
## Summary

- Adds two async integration tests for `load_and_get_security_policy_info` in `src/openhuman/security/ops.rs`, covering the full env-var → config load → RPC payload chain that was previously only exercised by the JSON-RPC smoke test (follow-up from issue #2688)
- `load_and_get_security_policy_info_reflects_env_overlay` — sets `OPENHUMAN_MAX_ACTIONS_PER_HOUR=42` and asserts the RPC payload contains `42`
- `load_and_get_security_policy_info_ignores_zero_budget` — sets the var to `0` (invalid value, must be ≥ 1) and asserts the config default is preserved instead

Both tests use `TEST_ENV_LOCK` for process-wide env serialisation, matching the pattern used across the test suite. Env vars are now restored via an RAII `EnvRestore` drop guard so cleanup is panic-safe (CodeRabbit review). Also aligned the env overlay zero-check with the RPC update path: `apply_env_overlay` now ignores `OPENHUMAN_MAX_ACTIONS_PER_HOUR=0` with a warning, consistent with the RPC handler that already rejects zero.

## Test plan

- [x] `cargo test -p openhuman security::ops` passes
- [x] `load_and_get_security_policy_info_reflects_env_overlay` asserts `max_actions_per_hour == 42`
- [x] `load_and_get_security_policy_info_ignores_zero_budget` asserts `max_actions_per_hour == <default>` when env var is `0`
- [x] No regressions in existing `security_policy_info_*` unit tests

Closes #2688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to validate that environment-based configuration overlays propagate correctly into security policy payloads and respect fallback behavior.

* **Bug Fixes**
  * Treat zero-value environment overrides for the max-actions-per-hour setting as invalid; retain the configured default instead of applying the invalid override.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->