### PR TITLE
fix: resolve Sentry issue 5677

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -400,6 +400,17 @@ fn is_ollama_user_config_rejection(lower: &str) -> bool {
 ///   ~66 events). Tungstenite-only — reqwest renders HTTP 200 as
 ///   `"HTTP status server error (200)"`, so this can't collide with the
 ///   regular HTTP call path.
+/// - `"unexpected eof during handshake"` — `native-tls`'s render when the
+///   peer (or an intercepting firewall / antivirus / corporate TLS proxy)
+///   closes the TCP connection mid-TLS-handshake, surfacing as
+///   `"TLS error: native-tls error: unexpected EOF during handshake"`
+///   wrapped by `socket::ws_loop::run_connection` into
+///   `"WebSocket connect: …"` (`TAURI-RUST-4ZD`, first seen on
+///   `openhuman@0.56.0`, Windows). The existing `"tls handshake"` anchor
+///   misses it because the words aren't contiguous (`"tls error"` …
+///   `"during handshake"`). Same user-environment shape as the other
+///   handshake-stage entries — the socket supervisor already retries with
+///   exponential backoff and Sentry has no actionable signal.
 fn is_network_unreachable_message(lower: &str) -> bool {
     lower.contains("error sending request for url")
         || lower.contains("dns error")
@@ -410,6 +421,7 @@ fn is_network_unreachable_message(lower: &str) -> bool {
         || lower.contains("network is unreachable")
         || lower.contains("no route to host")
         || lower.contains("tls handshake")
+        || lower.contains("unexpected eof during handshake")
         || lower.contains("certificate verify failed")
         || lower.contains("http error: 200 ok")
 }
@@ -1614,6 +1626,60 @@ mod tests {
             expected_error_kind("upstream returned status: 200 OK after retry"),
             None
         );
+    }
+
+    #[test]
+    fn classifies_tls_handshake_eof_as_network_unreachable() {
+        // TAURI-RUST-4ZD (first seen on `openhuman@0.56.0+e8968077aeb5`,
+        // Windows): `native-tls` renders a peer / firewall / antivirus /
+        // corporate-proxy TCP close mid-TLS-handshake as
+        // `"TLS error: native-tls error: unexpected EOF during handshake"`,
+        // which `socket::ws_loop::run_connection` wraps as
+        // `"WebSocket connect: <inner>"` and the supervisor's
+        // sustained-outage escalation wraps again. The existing
+        // `"tls handshake"` arm misses it because the words are not
+        // contiguous in this render (`"tls error"` … `"during handshake"`).
+        // Same user-environment shape as the other handshake-stage entries:
+        // the socket supervisor already retries with exponential backoff and
+        // Sentry has no actionable signal beyond that.
+        assert_eq!(
+            expected_error_kind(
+                "[socket] Connection failed (sustained outage after 5 attempts): \
+                 WebSocket connect: TLS error: native-tls error: unexpected EOF during handshake"
+            ),
+            Some(ExpectedErrorKind::NetworkUnreachable)
+        );
+
+        // Bare native-tls render (no socket-supervisor wrap) — fires when the
+        // same handshake EOF escapes through a non-supervisor call site. The
+        // classifier runs on the full anyhow chain, so the shorter form must
+        // also match.
+        assert_eq!(
+            expected_error_kind("TLS error: native-tls error: unexpected EOF during handshake"),
+            Some(ExpectedErrorKind::NetworkUnreachable)
+        );
+    }
+
+    #[test]
+    fn tls_handshake_eof_anchor_does_not_silence_unrelated_log_lines() {
+        // The anchor is the literal `"unexpected eof during handshake"`
+        // phrase. A bare data-phase `"unexpected EOF"` (server closed
+        // mid-stream, parser truncation, …) MUST NOT classify — those are
+        // outside the handshake stage and may carry actionable signal. Pin
+        // the rejection contract so a future refactor doesn't loosen the
+        // substring into a generic `"unexpected eof"` matcher.
+        for raw in [
+            "stream closed: unexpected EOF",
+            "reqwest: unexpected EOF while reading body",
+            "json parser: unexpected EOF at byte 1024",
+            "decoder hit unexpected eof mid-frame",
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                None,
+                "non-handshake unexpected-EOF log line must NOT classify: {raw}"
+            );
+        }
     }
 
     #[test]

--- a/src/openhuman/socket/ws_loop_tests.rs
+++ b/src/openhuman/socket/ws_loop_tests.rs
@@ -340,6 +340,31 @@ fn sustained_outage_for_network_unreachable_classifies_as_expected() {
     );
 }
 
+/// Regression guard for TAURI-RUST-4ZD: a TLS handshake aborted by the
+/// peer / a firewall / antivirus / corporate TLS proxy surfaces from
+/// `run_connection` as `WebSocket connect: TLS error: native-tls error:
+/// unexpected EOF during handshake`. The exact wire shape the
+/// sustained-outage escalation builds must classify as a
+/// network-unreachable expected error so an affected Windows client logs
+/// a warn breadcrumb rather than a Sentry event. The pre-existing
+/// `"tls handshake"` substring does NOT match this render (the words are
+/// not contiguous), so this pins the dedicated `"unexpected eof during
+/// handshake"` anchor to the emit site.
+#[test]
+fn sustained_outage_for_tls_handshake_eof_classifies_as_expected() {
+    use crate::core::observability::{expected_error_kind, ExpectedErrorKind};
+
+    let reason = "WebSocket connect: TLS error: native-tls error: unexpected EOF during handshake";
+    let detailed = format!(
+        "[socket] Connection failed (sustained outage after {FAIL_ESCALATE_THRESHOLD} attempts): {reason}"
+    );
+    assert_eq!(
+        expected_error_kind(&detailed),
+        Some(ExpectedErrorKind::NetworkUnreachable),
+        "TLS-handshake-EOF shape must classify as expected; got message: {detailed}"
+    );
+}
+
 /// Counterpart: a genuine outage that lacks any of the transport-level
 /// markers (e.g. a server-side HTTP 500 wrapped by tungstenite) must
 /// still surface as an actionable Sentry event — i.e. not classify as


### PR DESCRIPTION
## Summary

- Add the `native-tls` handshake-EOF render (`"unexpected eof during handshake"`) to the `is_network_unreachable_message` anchor list in `src/core/observability.rs` so the socket supervisor's sustained-outage escalation routes it to `ExpectedErrorKind::NetworkUnreachable` (warn breadcrumb, no Sentry event) instead of firing an error event.
- Targets self-hosted Sentry **TAURI-RUST-4ZD** (https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5677/) — `domain=socket operation=ws_connect`, first seen on `openhuman@0.56.0+e8968077aeb5`, Windows.
- Same shape and routing as the existing `"tls handshake"` / `"certificate verify failed"` / `"http error: 200 ok"` (captive-portal) entries that already inhabit this matcher; sibling of merged PR #2792 (CORE-RUST-DP, HTTP/2 handshake).

## Problem

`src/openhuman/socket/ws_loop.rs:178` routes the one-shot sustained-outage escalation (`consecutive == FAIL_ESCALATE_THRESHOLD`, default 5 attempts) through `crate::core::observability::report_error_or_expected` with the message:

```
[socket] Connection failed (sustained outage after 5 attempts):
WebSocket connect: TLS error: native-tls error: unexpected EOF during handshake
```

The inner string is `native-tls`'s rendering of a TCP connection closed by the peer **mid-TLS-handshake**. This is a user-environment / upstream-infra condition — most commonly an intercepting firewall, antivirus, or corporate TLS proxy resetting the connection before the handshake completes (the captured event is `os=windows`, where SChannel/AV TLS interception is common), a captive portal, or a transient server/middlebox drop.

`expected_error_kind` did not classify it, so it escaped to `report_error_message` and fired a `domain=socket` Sentry **error**. The existing `"tls handshake"` anchor does **not** match this render because the words are not contiguous — the string is `"tls error: … unexpected EOF during handshake"` (i.e. `"tls error"` … `"during handshake"`).

The socket supervisor already retries with exponential backoff and bounds the Sentry-visible event to one per affected client per outage. There is no actionable Sentry signal beyond the breadcrumb already logged at every retry tier — no client-side remediation can pierce a middlebox that resets the user's TLS handshake.

## Solution

Add one anchor to the existing `is_network_unreachable_message` OR-chain, pinned to the literal `native-tls` Display fragment:

```rust
fn is_network_unreachable_message(lower: &str) -> bool {
    lower.contains("error sending request for url")
        // … existing transport / handshake-stage anchors …
        || lower.contains("tls handshake")
        || lower.contains("unexpected eof during handshake")   // ← new (TAURI-RUST-4ZD)
        || lower.contains("certificate verify failed")
        || lower.contains("http error: 200 ok")
}
```

The phrase is anchored to `"unexpected eof during handshake"` (not a bare `"unexpected eof"`) on purpose: a data-phase EOF (server closed mid-stream, parser truncation) lives outside the handshake stage and may carry actionable signal, so it must not be silenced. The dispatcher precedence in `expected_error_kind` is unchanged — `is_loopback_unavailable` still runs first, then the network-unreachable matcher catches this shape and demotes to `tracing::warn!`. The matching doc-comment gains a bullet covering the new anchor and pointing at TAURI-RUST-4ZD.

This is squarely the "skip is correct" bucket: the connection genuinely failed at the TLS/network layer due to the user's environment — there is no code defect to fix on top of the classification, and the whole `FAIL_ESCALATE_THRESHOLD` + classifier design exists precisely to suppress this class of transport noise while preserving genuine-outage paging.

**Files changed**
- `src/core/observability.rs` — new OR-chain anchor + doc bullet; 2 new classifier tests.
- `src/openhuman/socket/ws_loop_tests.rs` — 1 new emit-site regression guard for the exact sustained-outage wire shape.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 3 new tests:
  - `classifies_tls_handshake_eof_as_network_unreachable` (observability.rs) — happy path; covers BOTH the supervisor-wrapped wire shape (verbatim 4ZD body) AND the bare `native-tls` render (escapes through a non-supervisor call site; the classifier runs on the full anyhow chain).
  - `tls_handshake_eof_anchor_does_not_silence_unrelated_log_lines` (observability.rs) — rejection contract over 4 non-handshake `"unexpected EOF"` lines so a future refactor that loosens the substring fails loudly.
  - `sustained_outage_for_tls_handshake_eof_classifies_as_expected` (ws_loop_tests.rs) — emit-site guard mirroring the existing network-unreachable guard; pins `log_connection_failure`'s format string to the new anchor.
- [x] **Diff coverage ≥ 80%** — every new line (the OR-chain anchor and the doc-comment bullet) is exercised by the new tests; the actionable-error counterpart (`sustained_outage_for_actionable_server_error_does_not_classify`) confirms genuine outages still surface.
- [x] (N/A) Coverage matrix updated — observability classifier change is behaviour-only inside `core::observability`; not a tracked feature row in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] (N/A) All affected feature IDs from the matrix are listed under `## Related` — no matrix feature IDs affected.
- [x] No new external network dependencies introduced — pure in-process classifier addition; no mock backend needed (lib unit tests only).
- [x] (N/A) Manual smoke checklist updated — observability classifier; no user-visible UI surface, no release-cut behaviour change.
- [x] (N/A) Linked issue closed via `Closes #NNN` — Sentry-only fix; no GitHub issue. The `Sentry-Issue` trailer below carries the back-reference.

## Impact

- **Runtime**: Desktop (Tauri shell) + core. The sustained-outage escalation at `socket::ws_loop:188` now classifies as `ExpectedErrorKind::NetworkUnreachable` for `native-tls` handshake-EOF, demoting to `tracing::warn!` (no Sentry event). No change to the supervisor's restart loop, the WS reconnect logic, or `health.bus` escalation.
- **Performance / noise**: Net positive — removes the TAURI-RUST-4ZD event stream for users behind TLS-intercepting firewalls/AV/proxies.
- **Security**: None — no new code paths, no new headers, no PII, no auth surface.
- **Migration / compatibility**: None — additive substring entry in an existing OR-chain.
- **Observability trade-off**: a sustained outage caused solely by a TLS handshake reset now shows up only as a `tracing::warn!` breadcrumb locally, never as a Sentry event. Per-attempt logs (below and after threshold) are unchanged and remain available for local diagnosis.

## Notes for reviewers

- **Risk level: low.** Single additive substring in an existing OR-chain + tests; no behavioural change beyond the demotion of this one wire shape. The anchor is conservative (`"… during handshake"`) so data-phase EOFs are not silenced.
- **Conflict-adjacency** with PR #2792 (`fix/sentry-core-rust-dp-ws-protocol-mismatch`): both extend the same `is_network_unreachable_message` OR-chain, but at different anchor lines (this one next to `"tls handshake"`, #2792 next to `"http error: 200 ok"`). Either merge order is a trivial concurrent edit; git auto-merges.
- **Follow-up**: none required. (The stale `// uses rustls TLS` comment at `ws_loop.rs:230` is inaccurate — the runtime build uses `native-tls`, per this error render — but correcting it is out of scope for this Sentry fix.)
- Pre-push `pnpm format` runs `cargo fmt --check` via the Rust hook; the change is Rust-only and `cargo fmt --manifest-path Cargo.toml` is clean. If the JS side of the hook can't run in the fresh worktree (no `node_modules`), the push uses `--no-verify` and this is the only reason.

## Related

- Sentry-Issue: TAURI-RUST-4ZD (https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5677/)
- Adjacent matchers in the same dispatcher: `is_loopback_unavailable` (loopback `Connection refused`), `is_transient_upstream_http_message` (gateway 5xx), `is_network_unreachable_message` (other transport / handshake shapes — this PR extends the latter).
- Sibling: #2792 (CORE-RUST-DP, HTTP/2 handshake), same OR-chain.
- Emit site: `src/openhuman/socket/ws_loop.rs` `log_connection_failure`.
- Closes:
- Follow-up PR(s)/TODOs: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to correctly identify TLS handshake failures as network-related errors, ensuring they are handled appropriately as expected environmental issues rather than unexpected failures.

* **Tests**
  * Added regression tests to validate proper classification of TLS handshake connection failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->