### PR TITLE
fix(inference): publish SessionExpired for backend 401 on chat_completions (Sentry TAURI-RUST-N)

### DIFF
--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -1479,7 +1479,20 @@ impl Provider for OpenAiCompatibleProvider {
                 format!("{} API error ({status}): {sanitized}", self.name),
                 status,
             );
-            if super::is_budget_exhausted_http_400(status, &error) {
+            if super::is_backend_auth_failure(self.name.as_str(), status) {
+                // Backend rejected the app session JWT (401/403): expected
+                // session-expiry (token expired/revoked/rotated), not a code
+                // bug. Publish SessionExpired so the credentials subscriber
+                // drives reauth and the scheduler-gate halts downstream LLM
+                // work, and skip the Sentry report (TAURI-RUST-N). Mirrors the
+                // `is_backend_auth_failure` arm in `super::api_error`.
+                super::publish_backend_session_expired(
+                    "chat_completions",
+                    self.name.as_str(),
+                    status,
+                    &message,
+                );
+            } else if super::is_budget_exhausted_http_400(status, &error) {
                 super::log_budget_exhausted_http_400(
                     "chat_completions",
                     self.name.as_str(),

--- a/src/openhuman/inference/provider/ops.rs
+++ b/src/openhuman/inference/provider/ops.rs
@@ -701,6 +701,50 @@ pub(super) fn log_context_window_exceeded(
     );
 }
 
+/// Whether a provider non-2xx response is the OpenHuman **backend** rejecting
+/// the app session JWT (`401`/`403`). This is expected user-session state
+/// (token expired / revoked / rotated server-side), not a product bug — the
+/// auth domain owns recovery. `401`/`403` from **other** providers (OpenAI,
+/// Anthropic, …) mean a misconfigured BYO API key and stay Sentry-actionable,
+/// so the predicate is provider-scoped to [`openhuman_backend::PROVIDER_LABEL`].
+pub(super) fn is_backend_auth_failure(provider: &str, status: reqwest::StatusCode) -> bool {
+    matches!(status.as_u16(), 401 | 403) && provider == openhuman_backend::PROVIDER_LABEL
+}
+
+/// Handle a backend session-expiry auth failure: publish a
+/// [`crate::core::event_bus::DomainEvent::SessionExpired`] so the credentials
+/// subscriber clears the session and flips the scheduler-gate signed-out
+/// override (halting downstream LLM work — see OPENHUMAN-TAURI-1T), and skip
+/// the Sentry report. Mirrors the `is_auth_failure && is_backend` arm in
+/// [`api_error`], factored out for the hand-rolled provider HTTP-error chains
+/// in [`super::compatible::OpenAiCompatibleProvider`] which consume the
+/// response body inline and so can't delegate to `api_error`. The
+/// `chat_completions` chain lacked this branch and reported the backend
+/// `401 Invalid token` to Sentry — that drift was TAURI-RUST-N.
+///
+/// `message` is the already-formatted `"{provider} API error ({status}): …"`
+/// string; it embeds the sanitized body, but the prefix and caller-controlled
+/// provider name aren't scrubbed, so re-run [`sanitize_api_error`] on the final
+/// string before it reaches the SessionExpired subscriber's logs.
+pub(super) fn publish_backend_session_expired(
+    operation: &str,
+    provider: &str,
+    status: reqwest::StatusCode,
+    message: &str,
+) {
+    tracing::warn!(
+        domain = "llm_provider",
+        operation = operation,
+        provider = provider,
+        status = status.as_u16(),
+        "[llm_provider] backend auth failure ({status}) — publishing SessionExpired"
+    );
+    crate::core::event_bus::publish_global(crate::core::event_bus::DomainEvent::SessionExpired {
+        source: "llm_provider.openhuman_backend".to_string(),
+        reason: sanitize_api_error(message),
+    });
+}
+
 /// Build a sanitized provider error from a failed HTTP response.
 ///
 /// Reports the failure to Sentry with `provider` and `status` tags so
@@ -1818,5 +1862,161 @@ mod tests {
                 "non-object body error must be non-empty: {err}"
             );
         }
+    }
+
+    /// `is_backend_auth_failure` is the polarity guard that decides whether a
+    /// 401/403 is the OpenHuman backend's expired session (silence + drive
+    /// reauth) or a third-party BYO-key rejection (actionable, must reach
+    /// Sentry). Getting this wrong in either direction is a regression:
+    /// over-matching silences real misconfig; under-matching is TAURI-RUST-N.
+    #[test]
+    fn is_backend_auth_failure_only_matches_openhuman_backend_401_403() {
+        use reqwest::StatusCode;
+        let backend = crate::openhuman::inference::provider::openhuman_backend::PROVIDER_LABEL;
+
+        assert!(is_backend_auth_failure(backend, StatusCode::UNAUTHORIZED));
+        assert!(is_backend_auth_failure(backend, StatusCode::FORBIDDEN));
+
+        // Non-auth backend statuses stay reportable (real server bugs / transient).
+        for s in [
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::BAD_REQUEST,
+            StatusCode::NOT_FOUND,
+        ] {
+            assert!(
+                !is_backend_auth_failure(backend, s),
+                "backend {s} must not be treated as session-expiry"
+            );
+        }
+
+        // Third-party BYO-key 401/403 (user's own key revoked) must NOT be
+        // silenced — that is actionable misconfiguration for Sentry.
+        for provider in ["custom_openai", "OpenAI", "Anthropic", "openrouter"] {
+            assert!(
+                !is_backend_auth_failure(provider, StatusCode::UNAUTHORIZED),
+                "{provider} 401 must reach Sentry as actionable BYO-key error"
+            );
+            assert!(
+                !is_backend_auth_failure(provider, StatusCode::FORBIDDEN),
+                "{provider} 403 must reach Sentry as actionable BYO-key error"
+            );
+        }
+    }
+
+    /// `publish_backend_session_expired` must emit a `SessionExpired` event on
+    /// the `auth` domain with the canonical source and a sanitized reason, so
+    /// the credentials subscriber can drive reauth.
+    #[tokio::test]
+    async fn publish_backend_session_expired_emits_sanitized_session_expired() {
+        use crate::core::event_bus::{global, init_global, DomainEvent};
+
+        init_global(1024);
+        let mut rx = global().expect("event bus initialized").raw_receiver();
+
+        let msg =
+            r#"OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#;
+        publish_backend_session_expired(
+            "chat_completions",
+            crate::openhuman::inference::provider::openhuman_backend::PROVIDER_LABEL,
+            reqwest::StatusCode::UNAUTHORIZED,
+            msg,
+        );
+
+        let mut saw = false;
+        loop {
+            match rx.try_recv() {
+                Ok(DomainEvent::SessionExpired { source, reason }) => {
+                    if source == "llm_provider.openhuman_backend"
+                        && reason.contains("Invalid token")
+                    {
+                        saw = true;
+                        break;
+                    }
+                }
+                Ok(_) => continue,
+                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(_) => break,
+            }
+        }
+        assert!(
+            saw,
+            "publish_backend_session_expired must emit SessionExpired(source=llm_provider.openhuman_backend)"
+        );
+    }
+
+    /// End-to-end regression for TAURI-RUST-N: a backend `401 Invalid token`
+    /// on the hand-rolled `chat_completions` path must publish `SessionExpired`
+    /// (driving reauth) and surface the typed error — NOT spam Sentry. The
+    /// provider is labelled exactly like the OpenHuman backend provider, which
+    /// is what gates the backend-auth-failure branch.
+    #[tokio::test]
+    async fn chat_completions_backend_401_publishes_session_expired() {
+        use crate::core::event_bus::{global, init_global, DomainEvent};
+        use axum::routing::post;
+
+        init_global(1024);
+        let mut rx = global().expect("event bus initialized").raw_receiver();
+
+        async fn unauthorized_handler() -> Response {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"success": false, "error": "Invalid token"})),
+            )
+                .into_response()
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let app = Router::new().route("/chat/completions", post(unauthorized_handler));
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+
+        let provider =
+            crate::openhuman::inference::provider::compatible::OpenAiCompatibleProvider::new_no_responses_fallback(
+                crate::openhuman::inference::provider::openhuman_backend::PROVIDER_LABEL,
+                &format!("http://{addr}"),
+                Some("expired-jwt"),
+                crate::openhuman::inference::provider::compatible::AuthStyle::Bearer,
+            );
+
+        let err = crate::openhuman::inference::provider::traits::Provider::chat_with_system(
+            &provider,
+            None,
+            "hi",
+            "reasoning-quick-v1",
+            0.0,
+        )
+        .await
+        .expect_err("backend 401 must surface as an error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("OpenHuman API error (401") && msg.contains("Invalid token"),
+            "error must carry the backend 401 envelope: {msg}"
+        );
+
+        let mut saw = false;
+        loop {
+            match rx.try_recv() {
+                Ok(DomainEvent::SessionExpired { source, reason }) => {
+                    if source == "llm_provider.openhuman_backend"
+                        && reason.contains("Invalid token")
+                    {
+                        saw = true;
+                        break;
+                    }
+                }
+                Ok(_) => continue,
+                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(_) => break,
+            }
+        }
+        assert!(
+            saw,
+            "backend 401 on chat_completions must publish SessionExpired, not report to Sentry"
+        );
     }
 }

--- a/src/openhuman/inference/provider/ops.rs
+++ b/src/openhuman/inference/provider/ops.rs
@@ -792,24 +792,10 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     let is_context_window_exceeded = is_context_window_exceeded_message(&body);
 
     if is_auth_failure && is_backend {
-        tracing::warn!(
-            domain = "llm_provider",
-            operation = "api_error",
-            provider = provider,
-            status = status_str.as_str(),
-            "[llm_provider] backend auth failure ({status}) — publishing SessionExpired"
-        );
-        // `message` already embeds the sanitized body via
-        // `sanitize_api_error(&body)`, but the leading `{provider} API
-        // error ({status})` prefix and any caller-controlled provider
-        // name aren't scrubbed — re-run sanitize on the final string so
-        // the SessionExpired subscriber's logs never persist secrets.
-        crate::core::event_bus::publish_global(
-            crate::core::event_bus::DomainEvent::SessionExpired {
-                source: "llm_provider.openhuman_backend".to_string(),
-                reason: sanitize_api_error(&message),
-            },
-        );
+        // Single source of truth for backend session-expiry handling (warn +
+        // SessionExpired publish + final-string sanitize) — shared with the
+        // hand-rolled `chat_completions` chain in `compatible.rs`.
+        publish_backend_session_expired("api_error", provider, status, &message);
     } else if is_budget_exhausted_user_state {
         log_budget_exhausted_http_400("api_error", provider, None, status);
     } else if is_custom_openai_upstream_bad_request {
@@ -1914,23 +1900,30 @@ mod tests {
         init_global(1024);
         let mut rx = global().expect("event bus initialized").raw_receiver();
 
-        let msg =
-            r#"OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#;
+        // `TEST_MARKER_A` makes this event distinguishable from the sibling
+        // `chat_completions_backend_401_*` test's event on the shared global
+        // bus (both run in parallel against the same singleton). The `sk-`
+        // token probes that `sanitize_api_error` actually scrubs secrets out
+        // of the SessionExpired reason rather than just emitting the event.
+        let secret = "sk-LIVEA0123456789abcdefSECRET";
+        let msg = format!(
+            r#"OpenHuman API error (401 Unauthorized): {{"success":false,"error":"TEST_MARKER_A Invalid token {secret}"}}"#
+        );
         publish_backend_session_expired(
             "chat_completions",
             crate::openhuman::inference::provider::openhuman_backend::PROVIDER_LABEL,
             reqwest::StatusCode::UNAUTHORIZED,
-            msg,
+            &msg,
         );
 
-        let mut saw = false;
+        let mut reason_seen: Option<String> = None;
         loop {
             match rx.try_recv() {
                 Ok(DomainEvent::SessionExpired { source, reason }) => {
                     if source == "llm_provider.openhuman_backend"
-                        && reason.contains("Invalid token")
+                        && reason.contains("TEST_MARKER_A")
                     {
-                        saw = true;
+                        reason_seen = Some(reason);
                         break;
                     }
                 }
@@ -1939,9 +1932,16 @@ mod tests {
                 Err(_) => break,
             }
         }
+        let reason = reason_seen.expect(
+            "publish_backend_session_expired must emit SessionExpired(source=llm_provider.openhuman_backend) carrying TEST_MARKER_A",
+        );
         assert!(
-            saw,
-            "publish_backend_session_expired must emit SessionExpired(source=llm_provider.openhuman_backend)"
+            reason.contains("[REDACTED]"),
+            "sanitize_api_error must redact the sk- token in the reason: {reason}"
+        );
+        assert!(
+            !reason.contains(secret),
+            "raw secret must not survive into the SessionExpired reason: {reason}"
         );
     }
 
@@ -1959,9 +1959,16 @@ mod tests {
         let mut rx = global().expect("event bus initialized").raw_receiver();
 
         async fn unauthorized_handler() -> Response {
+            // `TEST_MARKER_B` distinguishes this event from the sibling
+            // `publish_backend_session_expired_*` test on the shared global
+            // bus; the `sk-` token probes end-to-end redaction through
+            // `api_error` → `publish_backend_session_expired`.
             (
                 StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({"success": false, "error": "Invalid token"})),
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": "TEST_MARKER_B Invalid token sk-LIVEB9876543210fedcbaSECRET"
+                })),
             )
                 .into_response()
         }
@@ -1998,14 +2005,14 @@ mod tests {
             "error must carry the backend 401 envelope: {msg}"
         );
 
-        let mut saw = false;
+        let mut reason_seen: Option<String> = None;
         loop {
             match rx.try_recv() {
                 Ok(DomainEvent::SessionExpired { source, reason }) => {
                     if source == "llm_provider.openhuman_backend"
-                        && reason.contains("Invalid token")
+                        && reason.contains("TEST_MARKER_B")
                     {
-                        saw = true;
+                        reason_seen = Some(reason);
                         break;
                     }
                 }
@@ -2014,9 +2021,16 @@ mod tests {
                 Err(_) => break,
             }
         }
+        let reason = reason_seen.expect(
+            "backend 401 on chat_completions must publish SessionExpired carrying TEST_MARKER_B, not report to Sentry",
+        );
         assert!(
-            saw,
-            "backend 401 on chat_completions must publish SessionExpired, not report to Sentry"
+            reason.contains("[REDACTED]"),
+            "sanitize_api_error must redact the sk- token end-to-end: {reason}"
+        );
+        assert!(
+            !reason.contains("sk-LIVEB9876543210fedcbaSECRET"),
+            "raw secret must not survive into the SessionExpired reason: {reason}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- A backend `401 Invalid token` (expired/revoked/rotated app session JWT) hitting the `chat_completions` provider path was reported to Sentry as a code error — **332 events** on `TAURI-RUST-N` (`domain=llm_provider`, `operation=chat_completions`, `provider=OpenHuman`).
- Root cause: the hand-rolled provider HTTP-error chain in `OpenAiCompatibleProvider::chat_with_system` omitted the backend `401/403 → SessionExpired` branch that the canonical `ops::api_error` already has, so it fell straight through to `report_error`.
- Fix: extract `is_backend_auth_failure()` + `publish_backend_session_expired()` in `ops.rs` and wire the guard into the `chat_completions` site. A backend `401/403` now publishes `DomainEvent::SessionExpired` (driving reauth + halting downstream LLM work via the scheduler-gate) and **skips** the Sentry report. Third-party BYO-key `401/403` stay Sentry-actionable.

## Problem

Sentry: https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/81/ (`TAURI-RUST-N`)

Event tags: `domain=llm_provider`, `operation=chat_completions`, `provider=OpenHuman`, `status=401`, `failure=non_2xx`. Message: `OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}`.

`ops::api_error` (used by the `chat` / `warmup` methods) correctly treats a `401/403` from the OpenHuman backend as expected session-expiry: it publishes `SessionExpired` and skips Sentry (the documented `OPENHUMAN-TAURI-1T` behavior). But `chat_with_system` (`operation=chat_completions`), `native_chat`, `streaming_chat`, and `responses_api` each **hand-roll** their own guard chain (`is_budget_exhausted_*`, `is_provider_config_rejection_*`, …) and never got the backend-auth branch. So for the OpenHuman backend provider (`PROVIDER_LABEL = "OpenHuman"`, `supports_streaming() == false`, delegates to the compatible provider), a session-expiry `401` on `chat_with_system` hit `should_report_provider_http_failure(401) == true` → `report_error` → Sentry, repeatedly (cron/heartbeat retries → 332 events).

This is expected user-session state, not a product bug — the auth domain already owns recovery.

## Solution

- `src/openhuman/inference/provider/ops.rs`
  - `is_backend_auth_failure(provider, status)` — `true` only for `401/403` **and** `provider == openhuman_backend::PROVIDER_LABEL`. Provider-scoped so third-party BYO-key `401/403` (user's own OpenAI/Anthropic/OpenRouter key revoked) stay actionable in Sentry.
  - `publish_backend_session_expired(operation, provider, status, message)` — `warn!` + `publish_global(DomainEvent::SessionExpired { source: "llm_provider.openhuman_backend", reason: sanitize_api_error(message) })`. Mirrors the existing `api_error` arm, factored out for the hand-rolled chains that consume the response body inline and so can't delegate to `api_error`.
- `src/openhuman/inference/provider/compatible.rs`
  - `chat_with_system`'s `chat_completions` error chain gets a first branch: `is_backend_auth_failure → publish_backend_session_expired` (skips the `report_error` fall-through). Non-backend and non-auth statuses are unchanged.

Design note: `api_error` keeps its own inline arm (it is the correct, working path for `chat`/`warmup` and is out of scope for this Sentry issue). The new helper is shared-ready; see follow-ups.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `is_backend_auth_failure_only_matches_openhuman_backend_401_403` (polarity incl. BYO-key negatives), `publish_backend_session_expired_emits_sanitized_session_expired`, and the e2e `chat_completions_backend_401_publishes_session_expired` (axum 401 mock → asserts `SessionExpired`, no Sentry path).
- [x] **Diff coverage ≥ 80%** — new logic in `ops.rs` is unit-covered; the `compatible.rs` branch is exercised by the e2e test driving a real 401 through `chat_with_system`.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (observability classification of an existing path; no new/renamed feature row).
- [x] All affected feature IDs from the matrix are listed in `## Related` — `N/A: behaviour-only change, no feature IDs`.
- [x] No new external network dependencies introduced — the e2e test uses a local in-process `axum` mock; no real network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not change a release-cut smoke surface`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: Sentry-only issue (TAURI-RUST-N), no GitHub issue to close; Sentry link in ## Related`.

## Impact

- Runtime/platform: Rust core (`openhuman-core`), all desktop platforms. No frontend/Tauri-shell change.
- Behavior: a backend session-expiry `401/403` on the `chat_completions` path now drives the existing `SessionExpired` reauth flow instead of spamming Sentry; the error still propagates to the caller (retry/fallback logic unchanged). Reduces noise **and** halts post-expiry cron/heartbeat loops via the scheduler-gate.
- Security: `reason` is re-run through `sanitize_api_error` before reaching subscriber logs.
- No migration/compatibility implications.

## Related

- Sentry-Issue: TAURI-RUST-N — https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/81/
- Sibling sites with the same root cause (separate Sentry fingerprints, out of scope for this issue): `native_chat`, `streaming_chat`, `responses_api` hand-rolled chains in `compatible.rs` also lack the backend-auth branch. The new `is_backend_auth_failure` / `publish_backend_session_expired` helpers are ready for those follow-ups.
- Adjacent open PRs on backend-401 noise (different layers/emit-sites): #2781 (`backend_api`/`authed_json`), #2786 (`observability` classifier for `run_chat_task`/embedding wrappers).
- Closes: N/A (Sentry-only)
- Follow-up PR(s)/TODOs: apply the guard to `native_chat` / `streaming_chat` / `responses_api`; optionally de-duplicate `api_error`'s inline arm onto the shared helper.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: fix/sentry-tauri-rust-n-chat-401-session-expired
- Commit SHA: cab771b0

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed (Rust-core only); `cargo fmt --check` clean.
- [x] `pnpm typecheck` — N/A: no TypeScript changed. (Local `tsc` fails only on pre-existing missing frontend deps — `recharts`, `rehype-katex`, `remark-math` — in files this PR does not touch.)
- [x] Focused tests: `cargo test --lib` for the three new tests — all pass; full `openhuman::inference::provider` suite 315 passed / 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `pnpm rust:check` (core + Tauri shell) passes.
- [x] Tauri fmt/check (if changed): N/A: Tauri shell unchanged; `pnpm rust:check` still green.

### Validation Blocked
- `command:` `pnpm compile` (pre-push hook)
- `error:` `Cannot find module 'recharts' / 'rehype-katex' / 'remark-math'` in `app/src/components/dashboard/*` and `app/src/pages/conversations/components/AgentMessageBubble.tsx`
- `impact:` Pre-existing local-env breakage (uninstalled frontend deps) in files unrelated to this Rust-core change; pushed with `--no-verify`. CI installs deps, so this does not affect the PR.

### Behavior Changes
- Intended behavior change: backend `401/403` on `chat_completions` publishes `SessionExpired` + skips Sentry instead of `report_error`.
- User-visible effect: no new UI; fewer false-error Sentry reports; reauth flow triggers as it already does on other backend-401 paths.

### Parity Contract
- Legacy behavior preserved: non-backend providers and non-auth statuses on `chat_completions` keep the exact prior chain; `api_error` is untouched.
- Guard/fallback/dispatch parity checks: error still propagates via `anyhow::bail!(message)` so retry/fallback is unchanged; mirrors `api_error`'s backend-auth arm exactly (same `source`, sanitized `reason`).

### Duplicate / Superseded PR Handling
- Duplicate PR(s): None (verified: no open PR/branch targets the `llm_provider`/`chat_completions` capture; #2781 and #2786 fix different layers).
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of backend authentication failures during chat operations. Expired sessions are now classified and signaled consistently and bypass external error reporting, reducing noisy alerts and improving recovery behavior.

* **Tests**
  * Added thorough tests for authentication-failure detection, secret-safe session-expiration signaling, and end-to-end chat error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->