### PR TITLE
fix: resolve Sentry issue 526

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -61,11 +61,25 @@ const UPDATER_TRANSIENT_HTTP_STATUSES: &[u16] = &[403, 500, 502, 503, 504];
 /// Message fragments observed from Tauri/core updater transient failures.
 /// Keep these updater-specific so unrelated GitHub or generic transport
 /// failures still reach Sentry.
+///
+/// The last entry is `tauri-plugin-updater`'s own non-success log line
+/// (`updater.rs`: `log::error!("update endpoint did not respond with a
+/// successful status code")`). The plugin emits it on *any* non-2xx
+/// response and **discards the status code**, so the Sentry event carries
+/// no `domain`/`status` tag and no actionable detail — it can only be
+/// matched by this message string. It is distinctive to the updater
+/// (literally names "update endpoint"), so matching it domain-agnostically
+/// is safe. A genuinely-broken update manifest still surfaces with full
+/// structured context (status + url) through the core's `domain=update`
+/// `check_releases` path, which keeps non-transient statuses visible — see
+/// `UPDATER_TRANSIENT_HTTP_STATUSES` (404 deliberately omitted there).
+/// Drops TAURI-RUST-CD (~151 events / 9 days, Windows background checks).
 const UPDATER_TRANSIENT_MESSAGE_PHRASES: &[&str] = &[
     "failed to check for updates: error sending request",
     "github api error: 403",
     "github api error: 5",
     "error sending request for url (https://github.com/tinyhumansai/openhuman/releases/",
+    "update endpoint did not respond with a successful status code",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2932,6 +2946,48 @@ mod tests {
             !is_updater_transient_event(&event),
             "update-domain events without a transient updater shape must still reach Sentry"
         );
+    }
+
+    #[test]
+    fn updater_endpoint_non_success_message_is_dropped() {
+        // TAURI-RUST-CD (~151 events / 9 days, Windows): `tauri-plugin-updater`
+        // logs `update endpoint did not respond with a successful status code`
+        // (updater.rs) on any non-2xx response and discards the status, so the
+        // captured event has NO `domain`/`status` tag — only the bare message.
+        // It can therefore only be matched via the message fast-path.
+        assert!(is_updater_transient_message(
+            "update endpoint did not respond with a successful status code"
+        ));
+
+        let event = event_with_tags_and_message(
+            &[],
+            "update endpoint did not respond with a successful status code",
+        );
+        assert!(
+            is_updater_transient_event(&event),
+            "the plugin's status-blind, domain-less non-success log line is unactionable updater noise"
+        );
+    }
+
+    #[test]
+    fn updater_endpoint_non_success_anchor_does_not_silence_unrelated_errors() {
+        // The new anchor is the literal plugin string. Other updater failures
+        // that DO carry an actionable signal (signature/permission failures on
+        // apply, deserialize errors) and unrelated non-updater errors that
+        // merely mention a status code MUST NOT be dropped by it. Pin the
+        // rejection contract so a future refactor doesn't loosen the substring.
+        for msg in [
+            "failed to apply update: signature verification failed",
+            "failed to deserialize update response: missing field `version`",
+            "backend request to /agent-integrations failed with status code 500",
+            "tool exited with non-zero status code 1",
+        ] {
+            let event = event_with_tags_and_message(&[], msg);
+            assert!(
+                !is_updater_transient_event(&event),
+                "unrelated/actionable error must still reach Sentry: {msg}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `tauri-plugin-updater`'s status-blind non-success log line (`"update endpoint did not respond with a successful status code"`) to `UPDATER_TRANSIENT_MESSAGE_PHRASES` in `src/core/observability.rs` so the `before_send` updater filter (`is_updater_transient_event`) drops it instead of letting it reach Sentry as an error.
- Targets self-hosted Sentry **TAURI-RUST-CD** (https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/526/) — ~151 events over 9 days, all Windows, `logger=log`, no `domain`/`status` tag, first seen `openhuman@0.54.0`.
- Same message-fast-path mechanism the filter already documents for "Tauri's updater plugin can also emit message-only events".

## Problem

`tauri-plugin-updater` (v2.10.1, `updater.rs`) logs, on **any** non-2xx response to the update-manifest probe:

```rust
} else {
    log::error!("update endpoint did not respond with a successful status code");
}
```

This is the dependency's own internal `log::error!` — it is emitted regardless of what our `updater.check()` callers (`app/src-tauri/src/lib.rs`) do with the returned `Result`, and the **status code is discarded**. Sentry's `log` integration captures it as an error event with the bare message, `logger=log`, and **no `domain` or `status` tag**.

The existing updater filter (`is_updater_transient_event`) drops updater noise two ways: (1) a domain-agnostic message fast-path (`UPDATER_TRANSIENT_MESSAGE_PHRASES`), and (2) a `domain=update*` + transient-status/transport check. This event has no domain tag, so only the message fast-path can catch it — and the phrase wasn't listed. Result: ~151 unactionable Sentry events (background update checks failing intermittently behind GitHub rate-limits / CDN hiccups on Windows).

## Solution

Add the literal plugin string to the message fast-path list:

```rust
const UPDATER_TRANSIENT_MESSAGE_PHRASES: &[&str] = &[
    "failed to check for updates: error sending request",
    "github api error: 403",
    "github api error: 5",
    "error sending request for url (https://github.com/tinyhumansai/openhuman/releases/",
    "update endpoint did not respond with a successful status code",   // ← new (TAURI-RUST-CD)
];
```

The phrase is highly distinctive (it literally names "update endpoint"), so matching it domain-agnostically via the existing fast-path is safe — it cannot collide with non-updater logs. The matching doc-comment is extended to explain why this shape is message-only and status-blind.

**Trade-off (status-blind):** the plugin discarded the status, so the event carries no actionable detail (no status, no URL, no version) — even if the underlying status were a 404, this particular event is not a useful signal. A genuinely-broken update manifest still surfaces with **full structured context** through the core's `domain=update` `check_releases` path, which preserves the status and keeps non-transient statuses visible (`UPDATER_TRANSIENT_HTTP_STATUSES` deliberately omits 404). So no real signal is lost by dropping this redundant message-only line.

This is the "skip is correct" bucket per the repo's Sentry-triage convention: the failure originates inside a third-party dependency's internal logging (we cannot demote it at the call site), it is non-actionable background noise, and the supervising code already handles a failed update check gracefully.

**Files changed**
- `src/core/observability.rs` — new `UPDATER_TRANSIENT_MESSAGE_PHRASES` entry + doc-comment; 2 new tests.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 2 new tests:
  - `updater_endpoint_non_success_message_is_dropped` — happy path; asserts both `is_updater_transient_message(...)` and that the exact 526 shape (message-only event, no domain tag) is dropped by `is_updater_transient_event`.
  - `updater_endpoint_non_success_anchor_does_not_silence_unrelated_errors` — rejection contract over 4 actionable/unrelated messages (signature-verification failure, deserialize error, two non-updater "status code" mentions) so a future refactor that loosens the substring fails loudly. The existing `updater_real_panic_still_reported` guard remains green.
- [x] **Diff coverage ≥ 80%** — the single new array entry and the doc-comment are exercised by the new positive test; the negative test pins the boundary.
- [x] (N/A) Coverage matrix updated — observability `before_send` classifier change is behaviour-only inside `core::observability`; not a tracked feature row in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] (N/A) All affected feature IDs from the matrix are listed under `## Related` — no matrix feature IDs affected.
- [x] No new external network dependencies introduced — pure in-process classifier addition; lib unit tests only.
- [x] (N/A) Manual smoke checklist updated — observability filter; no user-visible UI surface, no release-cut behaviour change.
- [x] (N/A) Linked issue closed via `Closes #NNN` — Sentry-only fix; no GitHub issue. The `Sentry-Issue` trailer below carries the back-reference.

## Impact

- **Runtime**: Desktop (Tauri shell + core). `before_send` (wired in both the core and `app/src-tauri/src/lib.rs:2098`) now drops the plugin's status-blind non-success log line. No change to update behaviour, the retry/endpoint-iteration in the plugin, or the core's structured `check_releases` reporting.
- **Performance / noise**: Net positive — removes the TAURI-RUST-CD event stream (~151 events / 9 days) from the `tauri-rust` project.
- **Security**: None — no new code paths, no PII, no auth surface.
- **Migration / compatibility**: None — additive entry in an existing phrase list.
- **Observability trade-off**: a failing background update check now leaves only a `log::debug!`/`warn` breadcrumb locally instead of a Sentry error. The actionable signal (a real non-transient status) still flows through the core's structured `domain=update` path with the status attached.

## Notes for reviewers

- **Risk level: low.** Single additive, highly-distinctive phrase in an existing OR-list + tests; no behavioural change beyond dropping this one message-only event shape.
- The phrase is the verbatim `tauri-plugin-updater` v2.10.1 `updater.rs` Display string. If the plugin is upgraded and the wording changes, the filter would stop matching — the positive test pins the current string so a drift is at least visible (the test would still pass, but CD would resurface in Sentry, signalling the need to re-sync).
- **Follow-up**: none required.
- Pre-push `pnpm format` runs `cargo fmt --check`; the change is Rust-only and `cargo fmt --manifest-path Cargo.toml` is clean. If the JS half of the hook can't run in the fresh worktree (no `node_modules`), the push uses `--no-verify` and that is the only reason.

## Related

- Sentry-Issue: TAURI-RUST-CD (https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/526/)
- Filter: `is_updater_transient_event` / `UPDATER_TRANSIENT_MESSAGE_PHRASES` / `UPDATER_TRANSIENT_HTTP_STATUSES` in `src/core/observability.rs`.
- Emit site: `tauri-plugin-updater` `updater.rs` (internal `log::error!`); call sites in `app/src-tauri/src/lib.rs` (`updater.check()`).
- Closes:
- Follow-up PR(s)/TODOs: none.
