### PR TITLE
fix(inference): include model field in nvidia-nim API requests (#2784)

### DIFF
--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -761,9 +761,22 @@ fn make_cloud_provider_by_slug(
     })?;
 
     // Resolve effective model: use provided model if non-empty, else fall back
-    // to the entry's legacy default_model (if any), else empty → error.
+    // to the entry's legacy default_model, then to config.default_model, then
+    // to the global DEFAULT_MODEL constant.  An empty model sent to an
+    // OpenAI-compatible /v1/chat/completions endpoint produces a 400 error
+    // ("model field is required"), so we must never let it reach the wire.
     let mut effective_model = if model.trim().is_empty() {
-        entry.default_model.clone().unwrap_or_default()
+        entry
+            .default_model
+            .clone()
+            .filter(|m| !m.trim().is_empty())
+            .or_else(|| {
+                config
+                    .default_model
+                    .clone()
+                    .filter(|m| !m.trim().is_empty())
+            })
+            .unwrap_or_else(|| crate::openhuman::config::DEFAULT_MODEL.to_string())
     } else {
         model.to_string()
     };


### PR DESCRIPTION
Closes #2784

## Root cause
In `make_cloud_provider_by_slug` (factory.rs), when a provider string like `"nvidia-nim:"` was used (slug with empty model after the colon), the effective model resolution fell through to `entry.default_model.clone().unwrap_or_default()`. If the cloud provider entry had no `default_model` configured, this produced an empty string `""`, which was then sent as the `model` field in the OpenAI-compatible `/v1/chat/completions` request body, causing a 400 error (`"model field is required"`).

## Fix
Added a two-level fallback chain in `make_cloud_provider_by_slug`:
1. Try `config.default_model` (the user's top-level default model setting)
2. Fall back to the global `DEFAULT_MODEL` constant (`reasoning-quick-v1`)

This mirrors the same fallback pattern already used by `cloud_entry_provider_string` (the sibling function that builds provider strings for the primary cloud route).

## Verified
- `cargo check -p openhuman` — compiles cleanly
- All 78 factory unit tests pass
- All 91 compatible-provider unit tests pass