### PR TITLE
fix(inference): default empty model to reasoning-v1 on OpenHuman backend

### DIFF
--- a/src/openhuman/inference/local/ops.rs
+++ b/src/openhuman/inference/local/ops.rs
@@ -69,7 +69,21 @@ pub async fn agent_chat(
 ) -> Result<RpcOutcome<String>, String> {
     enforce_user_prompt_or_reject(message, "local_ai.ops.agent_chat")?;
 
-    if let Some(model) = model_override {
+    // TAURI-RUST-RS: an upstream caller (frontend, JSON-RPC client) can pass
+    // `model_override: Some("")`. Without this normalization the empty string
+    // overwrites `config.default_model`, propagates through routing as a
+    // `"<slug>:"` (empty-model) form, and reaches the OpenHuman backend, which
+    // rejects it with `400 {"success":false,"error":"model is required"}`.
+    // Treat an empty / whitespace-only override the same as `None` so the
+    // existing default-resolution path applies.
+    if let Some(model) = model_override.as_ref().and_then(|m| {
+        let t = m.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    }) {
         config.default_model = Some(model);
     }
     if let Some(temp) = temperature {
@@ -90,7 +104,15 @@ pub async fn agent_chat_simple(
     enforce_user_prompt_or_reject(message, "local_ai.ops.agent_chat_simple")?;
 
     let mut effective = config.clone();
-    if let Some(model) = model_override {
+    // TAURI-RUST-RS: see `agent_chat` above for the same normalization.
+    if let Some(model) = model_override.as_ref().and_then(|m| {
+        let t = m.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    }) {
         effective.default_model = Some(model);
     }
     if let Some(temp) = temperature {

--- a/src/openhuman/inference/local/ops.rs
+++ b/src/openhuman/inference/local/ops.rs
@@ -32,6 +32,29 @@ fn prompt_guard_user_message(action: PromptEnforcementAction) -> &'static str {
     }
 }
 
+/// Normalize a `model_override` string into the `Option<String>` form the
+/// downstream config-resolution path expects.
+///
+/// `None` → `None`. `Some(non-empty-after-trim)` → `Some(trimmed)`. Anything
+/// else (`Some("")`, `Some("   ")`, `Some("\t\n")`) collapses to `None` so
+/// the existing default-model fallback applies instead of overwriting
+/// `config.default_model` with a blank string that the OpenHuman backend
+/// would reject with `400 model is required` (Sentry TAURI-RUST-RS).
+///
+/// Extracted to keep `agent_chat` and `agent_chat_simple` in lockstep —
+/// future tweaks (additional log lines, tightening the trim rules) live in
+/// exactly one place.
+fn normalize_model_override(opt: Option<String>) -> Option<String> {
+    opt.and_then(|m| {
+        let t = m.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    })
+}
+
 fn enforce_user_prompt_or_reject(prompt: &str, source: &'static str) -> Result<(), String> {
     let decision = enforce_prompt_input(
         prompt,
@@ -70,20 +93,9 @@ pub async fn agent_chat(
     enforce_user_prompt_or_reject(message, "local_ai.ops.agent_chat")?;
 
     // TAURI-RUST-RS: an upstream caller (frontend, JSON-RPC client) can pass
-    // `model_override: Some("")`. Without this normalization the empty string
-    // overwrites `config.default_model`, propagates through routing as a
-    // `"<slug>:"` (empty-model) form, and reaches the OpenHuman backend, which
-    // rejects it with `400 {"success":false,"error":"model is required"}`.
-    // Treat an empty / whitespace-only override the same as `None` so the
-    // existing default-resolution path applies.
-    if let Some(model) = model_override.as_ref().and_then(|m| {
-        let t = m.trim();
-        if t.is_empty() {
-            None
-        } else {
-            Some(t.to_string())
-        }
-    }) {
+    // `model_override: Some("")`. See `normalize_model_override` for the
+    // rationale — an empty / whitespace-only override collapses to `None`.
+    if let Some(model) = normalize_model_override(model_override) {
         config.default_model = Some(model);
     }
     if let Some(temp) = temperature {
@@ -104,15 +116,8 @@ pub async fn agent_chat_simple(
     enforce_user_prompt_or_reject(message, "local_ai.ops.agent_chat_simple")?;
 
     let mut effective = config.clone();
-    // TAURI-RUST-RS: see `agent_chat` above for the same normalization.
-    if let Some(model) = model_override.as_ref().and_then(|m| {
-        let t = m.trim();
-        if t.is_empty() {
-            None
-        } else {
-            Some(t.to_string())
-        }
-    }) {
+    // TAURI-RUST-RS: see `normalize_model_override` for the rationale.
+    if let Some(model) = normalize_model_override(model_override) {
         effective.default_model = Some(model);
     }
     if let Some(temp) = temperature {

--- a/src/openhuman/inference/local/ops_tests.rs
+++ b/src/openhuman/inference/local/ops_tests.rs
@@ -146,3 +146,37 @@ async fn local_ai_assets_status_returns_without_panic() {
     let config = test_config(&tmp);
     let _ = local_ai_assets_status(&config).await;
 }
+
+// ── normalize_model_override (TAURI-RUST-RS) ───────────────────────────
+
+#[test]
+fn normalize_model_override_passthrough_none() {
+    assert_eq!(normalize_model_override(None), None);
+}
+
+#[test]
+fn normalize_model_override_blank_collapses_to_none() {
+    assert_eq!(normalize_model_override(Some(String::new())), None);
+    assert_eq!(normalize_model_override(Some("   ".to_string())), None);
+    assert_eq!(normalize_model_override(Some("\t\n".to_string())), None);
+}
+
+#[test]
+fn normalize_model_override_trims_surrounding_whitespace() {
+    assert_eq!(
+        normalize_model_override(Some("  reasoning-v1  ".to_string())),
+        Some("reasoning-v1".to_string())
+    );
+}
+
+#[test]
+fn normalize_model_override_passes_non_empty_verbatim() {
+    assert_eq!(
+        normalize_model_override(Some("agentic-v1".to_string())),
+        Some("agentic-v1".to_string())
+    );
+    assert_eq!(
+        normalize_model_override(Some("hint:reasoning".to_string())),
+        Some("hint:reasoning".to_string())
+    );
+}

--- a/src/openhuman/inference/provider/openhuman_backend.rs
+++ b/src/openhuman/inference/provider/openhuman_backend.rs
@@ -15,6 +15,34 @@ use std::path::PathBuf;
 
 pub const PROVIDER_LABEL: &str = "OpenHuman";
 
+/// Normalize an inbound `model` argument before forwarding to the OpenHuman backend.
+///
+/// The backend rejects a blank `model` field with
+/// `400 {"success":false,"error":"model is required"}` (Sentry **TAURI-RUST-RS**,
+/// 163 events / 14d). Empty values reach this layer when a workload routes to
+/// `<slug>:` with no model after the colon (see the `[config][migrate]`
+/// rewrites in `src/openhuman/config/schema/load.rs:967`) or when an upstream
+/// caller passes `model_override: Some("")`.
+///
+/// Substitute the canonical default tier so the call succeeds instead of
+/// failing the wire round-trip. Mirrors the same fallback `make_openhuman_backend`
+/// already applies when `default_model` is missing
+/// (`src/openhuman/inference/provider/factory.rs:404`), so behavior stays
+/// consistent across both entry paths.
+fn resolve_model(model: &str) -> String {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        log::warn!(
+            "[providers][openhuman-backend] empty model passed to OpenHuman backend; \
+             substituting default `{}` (TAURI-RUST-RS)",
+            crate::openhuman::config::MODEL_REASONING_V1
+        );
+        crate::openhuman::config::MODEL_REASONING_V1.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 /// Routes chat to `config.api_url` + `/openai` with `Authorization: Bearer` from the `app-session` profile.
 pub struct OpenHumanBackendProvider {
     options: ProviderRuntimeOptions,
@@ -109,8 +137,9 @@ impl Provider for OpenHumanBackendProvider {
     ) -> anyhow::Result<String> {
         let token = self.resolve_bearer()?;
         let inner = self.inner(&token)?;
+        let model = resolve_model(model);
         inner
-            .chat_with_system(system_prompt, message, model, temperature)
+            .chat_with_system(system_prompt, message, &model, temperature)
             .await
     }
 
@@ -122,7 +151,10 @@ impl Provider for OpenHumanBackendProvider {
     ) -> anyhow::Result<String> {
         let token = self.resolve_bearer()?;
         let inner = self.inner(&token)?;
-        inner.chat_with_history(messages, model, temperature).await
+        let model = resolve_model(model);
+        inner
+            .chat_with_history(messages, &model, temperature)
+            .await
     }
 
     async fn chat(
@@ -133,7 +165,8 @@ impl Provider for OpenHumanBackendProvider {
     ) -> anyhow::Result<ChatResponse> {
         let token = self.resolve_bearer()?;
         let inner = self.inner(&token)?;
-        inner.chat(request, model, temperature).await
+        let model = resolve_model(model);
+        inner.chat(request, &model, temperature).await
     }
 
     async fn warmup(&self) -> anyhow::Result<()> {
@@ -160,5 +193,50 @@ impl Provider for OpenHumanBackendProvider {
             ))
         })
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TAURI-RUST-RS regression coverage: the OpenHuman backend rejects an
+    // empty `model` field with 400 `model is required`. `resolve_model` must
+    // intercept blank / whitespace-only values before they hit the wire and
+    // substitute the canonical default tier.
+
+    #[test]
+    fn resolve_model_substitutes_default_for_empty() {
+        assert_eq!(
+            resolve_model(""),
+            crate::openhuman::config::MODEL_REASONING_V1
+        );
+    }
+
+    #[test]
+    fn resolve_model_substitutes_default_for_whitespace_only() {
+        assert_eq!(
+            resolve_model("   "),
+            crate::openhuman::config::MODEL_REASONING_V1
+        );
+        assert_eq!(
+            resolve_model("\t\n"),
+            crate::openhuman::config::MODEL_REASONING_V1
+        );
+    }
+
+    #[test]
+    fn resolve_model_trims_surrounding_whitespace() {
+        assert_eq!(resolve_model("  reasoning-v1  "), "reasoning-v1");
+    }
+
+    #[test]
+    fn resolve_model_preserves_non_empty_value_verbatim() {
+        // Non-empty values are passed through unchanged (after trim) — no
+        // canonicalisation, no remapping. The backend is authoritative over
+        // which model strings it accepts.
+        assert_eq!(resolve_model("agentic-v1"), "agentic-v1");
+        assert_eq!(resolve_model("hint:reasoning"), "hint:reasoning");
+        assert_eq!(resolve_model("some-custom-model"), "some-custom-model");
     }
 }

--- a/src/openhuman/inference/provider/openhuman_backend.rs
+++ b/src/openhuman/inference/provider/openhuman_backend.rs
@@ -152,9 +152,7 @@ impl Provider for OpenHumanBackendProvider {
         let token = self.resolve_bearer()?;
         let inner = self.inner(&token)?;
         let model = resolve_model(model);
-        inner
-            .chat_with_history(messages, &model, temperature)
-            .await
+        inner.chat_with_history(messages, &model, temperature).await
     }
 
     async fn chat(

--- a/src/openhuman/inference/provider/openhuman_backend.rs
+++ b/src/openhuman/inference/provider/openhuman_backend.rs
@@ -32,7 +32,13 @@ pub const PROVIDER_LABEL: &str = "OpenHuman";
 fn resolve_model(model: &str) -> String {
     let trimmed = model.trim();
     if trimmed.is_empty() {
-        log::warn!(
+        // Debug-tier on purpose: the routing-migration path
+        // (`config/schema/load.rs:967`) can hit this on every chat turn for
+        // an affected user (~163 events / 14d on Sentry pre-fix). Warn-tier
+        // here would just move the noise from Sentry to local log dashboards.
+        // Per-process throttling via `Once` was considered — debug is simpler
+        // and gives the same diagnostic when needed (set RUST_LOG=debug).
+        log::debug!(
             "[providers][openhuman-backend] empty model passed to OpenHuman backend; \
              substituting default `{}` (TAURI-RUST-RS)",
             crate::openhuman::config::MODEL_REASONING_V1
@@ -185,6 +191,9 @@ impl Provider for OpenHumanBackendProvider {
         _temperature: f64,
         _options: StreamOptions,
     ) -> futures_util::stream::BoxStream<'static, StreamResult<StreamChunk>> {
+        // TODO(stream-support): when streaming is enabled here, route
+        // `_model` through `resolve_model` before forwarding — same blank
+        // model guard as the non-streaming methods (TAURI-RUST-RS).
         stream::once(async move {
             Ok(StreamChunk::error(
                 "streaming is not supported for OpenHuman backend provider",


### PR DESCRIPTION
## Summary

- Substitute a default model (`reasoning-v1`) instead of forwarding a blank `model` field to the OpenHuman backend, which rejects it with `400 model is required`.
- Normalize empty / whitespace-only `model_override` strings to `None` at the `agent_chat` / `agent_chat_simple` RPC entry points so they no longer overwrite `default_model` with an empty value.
- Add inline unit tests covering the empty / whitespace / trim / passthrough cases for the new `resolve_model` helper.

## Problem

Sentry issue **TAURI-RUST-RS** — `OpenHuman API error (400 Bad Request): {"success":false,"error":"model is required"}` — 163 events / 14d on the `tauri-rust` project.

Two reachable paths produce a blank `model` argument that gets sent on the wire:

1. **Routing migration**: `src/openhuman/config/schema/load.rs:967` rewrites legacy `routing = "cloud"` entries to `"<slug>:"` with an empty model after the colon when the user's primary cloud slug is non-`openhuman`. `make_cloud_provider_by_slug` (`src/openhuman/inference/provider/factory.rs:765`) then returns `effective_model = ""` when both the supplied model and `entry.default_model` are blank, and that empty string flows into `Provider::chat(..., model: "")`.
2. **Frontend / JSON-RPC**: `agent.chat` / `agent.chat_simple` accept a `model_override: Option<String>`. A `Some("")` value (sent by some frontend code paths after the user clears the model field in Settings) overwrites `config.default_model = Some("")`, which then propagates into routing and onto the wire.

`OpenHumanBackendProvider` forwarded the blank value verbatim to the hosted OpenHuman API, which correctly returned `400 model is required`. Every chat turn affected by either path failed user-side.

## Solution

`src/openhuman/inference/provider/openhuman_backend.rs`:

- New `fn resolve_model(model: &str) -> String` helper. Trims and, on a blank result, substitutes `crate::openhuman::config::MODEL_REASONING_V1` (the same default that `make_openhuman_backend` already applies when `config.default_model` is missing — see `factory.rs:404`). Emits a `log::warn!` so the substitution is visible in logs while the underlying upstream call path is identified.
- Wires `resolve_model(model)` into `chat`, `chat_with_history`, and `chat_with_system` before delegating to the inner `OpenAiCompatibleProvider`. Non-blank values are passed through verbatim (after trim) — no canonicalisation, no remapping. The backend stays authoritative over which model strings it accepts.
- Inline `#[cfg(test)] mod tests` block covering: empty, whitespace-only, surrounding-whitespace trim, and non-empty passthrough (`agentic-v1`, `hint:reasoning`, custom strings).

`src/openhuman/inference/local/ops.rs`:

- `agent_chat` and `agent_chat_simple` now treat `model_override: Some("")` (and any whitespace-only string) as equivalent to `None`. The existing default-resolution path then applies. Same `and_then(|m| ... )` shape used elsewhere in the codebase for this kind of normalization.

**Design choices**

- Substitute rather than bail. The OpenHuman backend already defaults to `reasoning-v1` via `make_openhuman_backend`, so the new fallback matches existing behaviour for the symmetric "missing `default_model`" case — no new defaulting policy, just consistency across both entry paths.
- `resolve_model` is a free function (not a method) so it can be unit-tested without standing up a provider, an auth service, or a workspace dir.
- Provider trait signatures unchanged. Inner `OpenAiCompatibleProvider` untouched — fix is confined to the OpenHuman backend wrapper plus the two RPC entry points that already own `Option<String>` semantics.
- Non-OpenHuman compatible providers (Anthropic / Bearer / None auth) intentionally **not** changed. Their `make_cloud_provider_by_slug` empty-model path stays loud (deferred to a follow-up PR) so we don't mask BYOK misconfiguration during this targeted fix.

## Submission Checklist

- Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- **Diff coverage ≥ 80%** — pending local `pnpm test:rust` run
- Coverage matrix updated — `N/A: bug-fix behaviour-only change, no new feature row`
- All affected feature IDs from the matrix are listed in the PR description under `## Related`
- No new external network dependencies introduced
- Manual smoke checklist updated — `N/A: no release-cut surface touched`
- Linked issue closed via `Closes #NNN` — `N/A: Sentry-tracked issue, no GitHub issue yet`

## Impact

- **Runtime**: desktop (Rust core). No mobile / web / CLI surface change.
- **Performance**: none — single string trim + empty check on the existing chat path. No additional allocations on the non-empty branch beyond what was already happening.
- **Security**: none — no new network surface, no new inputs trusted, no auth path touched.
- **Migration / compatibility**: none. Provider trait signatures, RPC schema, and the `agent_chat{,_simple}` public contract are unchanged. A previously-failing call now succeeds with the documented default tier and a `warn!` log line.

## Related

- Closes: Sentry [TAURI-RUST-RS](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/1004/?project=4&referrer=issue-list&statsPeriod=14d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize model override inputs so empty or whitespace-only values now fall back to the configured default instead of being propagated as empty model identifiers.
  * Ensure non-streaming chat requests consistently trim and resolve model identifiers before sending to the backend, preventing invalid remote calls.

* **Tests**
  * Added unit tests covering empty, whitespace-only, trimmed, and non-empty model override cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->