### PR TITLE
fix(memory): dedupe Composio sources to the latest authorization per identity

### DIFF
--- a/app/src/components/intelligence/MemorySources.test.tsx
+++ b/app/src/components/intelligence/MemorySources.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ComposioConnection } from '../../lib/composio/types';
+import type { MemorySyncStatus } from '../../services/memorySyncService';
+import { buildRows, isMoreRecentConnection } from './MemorySources';
+
+const SYNCABLE = new Set(['gmail', 'github', 'notion']);
+
+/** Small factory — only the fields the dedupe/render path reads. */
+function conn(
+  toolkit: string,
+  status: string,
+  createdAt: string,
+  extras: Partial<ComposioConnection> = {}
+): ComposioConnection {
+  return { id: `${toolkit}-${status}-${createdAt}`, toolkit, status, createdAt, ...extras };
+}
+
+describe('isMoreRecentConnection', () => {
+  it('picks larger createdAt — regardless of status', () => {
+    // The whole point of the fix: a newer EXPIRED supersedes an older
+    // ACTIVE, because the new EXPIRED is the user's actual current
+    // truth (they re-authorized and that fresh auth then died).
+    const older_active = conn('gmail', 'ACTIVE', '2026-01-01T00:00:00Z');
+    const newer_expired = conn('gmail', 'EXPIRED', '2026-05-26T00:00:00Z');
+    expect(isMoreRecentConnection(newer_expired, older_active)).toBe(true);
+    expect(isMoreRecentConnection(older_active, newer_expired)).toBe(false);
+  });
+
+  it('a row with createdAt beats a row missing it', () => {
+    const dated = conn('gmail', 'EXPIRED', '2026-01-01T00:00:00Z');
+    const undated: ComposioConnection = { id: 'x', toolkit: 'gmail', status: 'ACTIVE' };
+    expect(isMoreRecentConnection(dated, undated)).toBe(true);
+    expect(isMoreRecentConnection(undated, dated)).toBe(false);
+  });
+});
+
+describe('buildRows', () => {
+  const statuses: MemorySyncStatus[] = [];
+
+  it('collapses multiple connections for the same toolkit to one row, picking the newest by createdAt', () => {
+    const conns = [
+      conn('gmail', 'ACTIVE', '2026-05-26T14:55:00Z'),
+      conn('gmail', 'EXPIRED', '2026-05-24T20:13:00Z'),
+      conn('gmail', 'EXPIRED', '2026-04-17T08:46:00Z'),
+    ];
+    const rows = buildRows(conns, statuses, SYNCABLE);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].toolkit).toBe('gmail');
+    expect(rows[0].connection?.status).toBe('ACTIVE');
+    expect(rows[0].connection?.createdAt).toBe('2026-05-26T14:55:00Z');
+  });
+
+  it('a newer EXPIRED beats an older ACTIVE for the same toolkit', () => {
+    // Regression guard: an earlier draft used a status-priority rule
+    // that gave ACTIVE/CONNECTED precedence regardless of createdAt,
+    // which would zombify a superseded authorization.
+    const conns = [
+      conn('github', 'ACTIVE', '2025-01-01T00:00:00Z'),
+      conn('github', 'EXPIRED', '2026-05-26T14:31:00Z'),
+    ];
+    const rows = buildRows(conns, statuses, SYNCABLE);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].connection?.status).toBe('EXPIRED');
+    expect(rows[0].connection?.createdAt).toBe('2026-05-26T14:31:00Z');
+  });
+
+  it('with no ACTIVE in the group, falls back to the newest non-active state', () => {
+    const conns = [
+      conn('notion', 'REVOKED', '2026-05-20T09:06:00Z'),
+      conn('notion', 'EXPIRED', '2026-04-17T08:48:00Z'),
+      conn('notion', 'EXPIRED', '2026-04-17T08:47:00Z'),
+    ];
+    const rows = buildRows(conns, statuses, SYNCABLE);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].connection?.status).toBe('REVOKED');
+    expect(rows[0].connection?.createdAt).toBe('2026-05-20T09:06:00Z');
+  });
+
+  it('keeps distinct accounts on the same toolkit separate when identity is populated', () => {
+    // Once the backend ships identity fields (accountEmail/workspace/
+    // username), two genuinely different gmail accounts must NOT
+    // collapse into one row.
+    const conns = [
+      conn('gmail', 'ACTIVE', '2026-05-26T00:00:00Z', { accountEmail: 'alice@x.com' }),
+      conn('gmail', 'EXPIRED', '2026-05-25T00:00:00Z', { accountEmail: 'alice@x.com' }),
+      conn('gmail', 'ACTIVE', '2026-04-01T00:00:00Z', { accountEmail: 'bob@y.com' }),
+    ];
+    const rows = buildRows(conns, statuses, SYNCABLE);
+    expect(rows).toHaveLength(2);
+    const aliceRow = rows.find(r => r.connection?.accountEmail === 'alice@x.com');
+    const bobRow = rows.find(r => r.connection?.accountEmail === 'bob@y.com');
+    expect(aliceRow?.connection?.status).toBe('ACTIVE');
+    expect(aliceRow?.connection?.createdAt).toBe('2026-05-26T00:00:00Z');
+    expect(bobRow?.connection?.status).toBe('ACTIVE');
+  });
+
+  it('drops connections whose toolkit is not in the syncable set', () => {
+    const conns = [
+      conn('googledrive', 'EXPIRED', '2026-05-20T00:00:00Z'),
+      conn('gmail', 'ACTIVE', '2026-05-26T00:00:00Z'),
+    ];
+    const rows = buildRows(conns, statuses, SYNCABLE);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].toolkit).toBe('gmail');
+  });
+
+  it('attaches the matching MemorySyncStatus to each row by toolkit name', () => {
+    const conns = [conn('gmail', 'ACTIVE', '2026-05-26T00:00:00Z')];
+    const fakeStatus = {
+      provider: 'gmail',
+      freshness: 'idle',
+      last_chunk_at_ms: 0,
+      chunks_synced: 2,
+      chunks_pending: 0,
+      batch_total: 0,
+      batch_processed: 0,
+    } as unknown as MemorySyncStatus;
+    const rows = buildRows(conns, [fakeStatus], SYNCABLE);
+    expect(rows[0].status).toBe(fakeStatus);
+  });
+});

--- a/app/src/components/intelligence/MemorySources.test.tsx
+++ b/app/src/components/intelligence/MemorySources.test.tsx
@@ -21,10 +21,10 @@ describe('isMoreRecentConnection', () => {
     // The whole point of the fix: a newer EXPIRED supersedes an older
     // ACTIVE, because the new EXPIRED is the user's actual current
     // truth (they re-authorized and that fresh auth then died).
-    const older_active = conn('gmail', 'ACTIVE', '2026-01-01T00:00:00Z');
-    const newer_expired = conn('gmail', 'EXPIRED', '2026-05-26T00:00:00Z');
-    expect(isMoreRecentConnection(newer_expired, older_active)).toBe(true);
-    expect(isMoreRecentConnection(older_active, newer_expired)).toBe(false);
+    const olderActive = conn('gmail', 'ACTIVE', '2026-01-01T00:00:00Z');
+    const newerExpired = conn('gmail', 'EXPIRED', '2026-05-26T00:00:00Z');
+    expect(isMoreRecentConnection(newerExpired, olderActive)).toBe(true);
+    expect(isMoreRecentConnection(olderActive, newerExpired)).toBe(false);
   });
 
   it('a row with createdAt beats a row missing it', () => {

--- a/app/src/components/intelligence/MemorySources.tsx
+++ b/app/src/components/intelligence/MemorySources.tsx
@@ -107,23 +107,43 @@ interface SourceRow {
   status: MemorySyncStatus | null;
 }
 
-function buildRows(
+export function buildRows(
   connections: ComposioConnection[],
   statuses: MemorySyncStatus[],
   syncableToolkits: ReadonlySet<string>
 ): SourceRow[] {
-  // Hide rows the user can't act on: only render identities that are
-  // (1) currently connected via Composio AND (2) whose toolkit has a
-  // memory-tree sync implementation. Orphan toolkits with chunks but
-  // no live auth, and connected toolkits without a sync provider, are
-  // both filtered out — neither offers a working Sync button so they
-  // were just clutter at the top of the Memory tab.
+  // Two-stage filter:
+  //   (1) Drop toolkits with no memory-tree sync implementation — Sync
+  //       would do nothing for them.
+  //   (2) Dedupe per (toolkit + identity) so re-authorizations don't
+  //       stack up as zombie EXPIRED rows next to the live one. Within a
+  //       group we keep the connection with the largest `createdAt` —
+  //       i.e. the user's most recent authorization for that account,
+  //       which is the actual current truth (a fresh EXPIRED supersedes
+  //       an older ACTIVE: the old row reflects an authorization the
+  //       user has since replaced, and the new EXPIRED tells them to
+  //       re-auth).
+  // When the backend doesn't surface a friendly identity (accountEmail/
+  // workspace/username — all null on the current Composio passthrough),
+  // we collapse by toolkit alone. Once identity fields land, multiple
+  // distinct accounts on the same toolkit will keep separate rows
+  // automatically.
   const statusByToolkit = new Map<string, MemorySyncStatus>();
   for (const s of statuses) statusByToolkit.set(s.provider, s);
 
-  const rows: SourceRow[] = [];
+  const latestByKey = new Map<string, ComposioConnection>();
   for (const conn of connections) {
     if (!syncableToolkits.has(conn.toolkit)) continue;
+    const identity = identityFor(conn);
+    const dedupKey = identity ? `${conn.toolkit}::${identity}` : conn.toolkit;
+    const existing = latestByKey.get(dedupKey);
+    if (!existing || isMoreRecentConnection(conn, existing)) {
+      latestByKey.set(dedupKey, conn);
+    }
+  }
+
+  const rows: SourceRow[] = [];
+  for (const conn of latestByKey.values()) {
     const label = TOOLKIT_LABEL[conn.toolkit] ?? conn.toolkit;
     const identity = identityFor(conn);
     const title = identity ? `${label} · ${identity}` : label;
@@ -136,6 +156,12 @@ function buildRows(
     });
   }
   return rows;
+}
+
+/** Pure recency: larger `createdAt` wins. A row missing `createdAt`
+ *  (empty string fallback) loses to any row that has one. */
+export function isMoreRecentConnection(a: ComposioConnection, b: ComposioConnection): boolean {
+  return (a.createdAt ?? '') > (b.createdAt ?? '');
 }
 
 export function MemorySources({


### PR DESCRIPTION
## Summary

- Intelligence → Memory was rendering every Composio connection ever returned by the backend, including superseded re-authorizations — visually 9 zombie rows where only 3 reflected current truth on a real account.
- Dedupe rows in `buildRows` by `(toolkit + identity)` and keep the **largest `createdAt`** per group.
- Drop the earlier status-priority idea (ACTIVE always wins) — a freshly re-authorized connection that then expires is the user's actual current truth and must beat a stale-but-still-marked-ACTIVE older row.
- Vitest coverage: 8 cases including a regression guard on the createdAt-vs-status precedence.

## Problem

`composio.list_connections` returns every connection record the Composio tenant has ever held for that account — including auths the user has since superseded by re-authorizing. The frontend dropped these into `buildRows` unchanged, so the Memory sources panel grew a row per historical authorization. On one tester's account this expanded to 9 rows (1 ACTIVE + 7 EXPIRED + 1 REVOKED across gmail/github/notion) where only 3 reflected anything actionable. Every duplicate row also shared the same per-toolkit `MemorySyncStatus` block, repeating the same "2 chunks · 1d ago" multiple times.

## Solution

Two-stage filter in `buildRows`:

1. **Toolkit gate** (unchanged) — drop toolkits with no memory-tree sync provider.
2. **Dedupe** — group by `${toolkit}::${identity}` when identity (`accountEmail ?? workspace ?? username`) is non-null; otherwise by toolkit alone. Within a group, keep the connection with the largest `createdAt`.

`isMoreRecentConnection` is pure recency. An earlier draft preferred `ACTIVE`/`CONNECTED` over other statuses regardless of timestamp, but that loses the right answer in one critical case: when a user re-authorizes and the fresh auth then expires, the new `EXPIRED` is the user's current state — the older row that is "still ACTIVE" is stale data from a superseded authorization. A regression test pins this.

Once the backend starts populating identity fields, two genuinely different accounts on the same toolkit (e.g. two Gmail addresses) will automatically keep separate rows without further code changes.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only change — no new feature row added to [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md), so the matrix doesn't need an update.
- [x] N/A: behaviour-only change — no feature IDs to list under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: cosmetic frontend cleanup that does not touch the [`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md) surfaces.
- [x] N/A: discovered organically while reviewing the Memory panel, no linked issue.

## Impact

- **Runtime / platform**: desktop only — pure `app/src/` change, no Rust, no schema, no backend.
- **Performance**: trivial; replaces one linear pass with a linear pass + a `Map<string, ComposioConnection>` lookup.
- **Behavior**: in any environment where a user has re-authorized a connection, the Memory sources panel will collapse from N rows per toolkit to 1 row per logical identity. The Sync button, freshness pill, and disabled-on-non-active rules continue to apply as before — they just apply to the one winning row.
- **Migration**: none. No persisted state, no API contract change.
- **Forward compatibility**: dedupe key uses identity when present, so when the backend starts populating `accountEmail` / `workspace` / `username`, distinct accounts on the same toolkit will automatically keep separate rows without further code changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs: surface a "history" affordance for users who genuinely want to see the prior superseded auths (currently they're invisible from the UI; only reachable via the raw RPC).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/memory-sources-dedupe-by-latest`
- Commit SHA: `ff0dd265`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for memory source deduplication, recency handling, status precedence, identity-preservation, and toolkit filtering.

* **Bug Fixes**
  * Improved memory connection deduplication so only the most recent relevant connection is shown per toolkit/identity, honors status precedence, and excludes non-syncable toolkits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->