### PR TITLE
feat(review): default agent shortcuts to skip-permissions mode

### DIFF
--- a/scripts/shortcuts/review/cli.sh
+++ b/scripts/shortcuts/review/cli.sh
@@ -37,6 +37,10 @@ Env:
   REVIEW_REPO=owner/name                  Override target repo (default: upstream remote)
   REVIEW_BANNED_COAUTHOR_RE=<regex>       Substrings filtered from Co-authored-by lines
                                           (default includes copilot/codex/cursor/claude/…)
+  REVIEW_AGENT_SAFE=1                     Run the picked agent CLI bare instead of in
+                                          its "yolo" mode. Default 0 — claude / codex /
+                                          cursor are launched with their skip-permissions
+                                          flag so headless runs don't stall on prompts.
 EOF
 }
 

--- a/scripts/shortcuts/review/coverage.sh
+++ b/scripts/shortcuts/review/coverage.sh
@@ -85,4 +85,4 @@ Additional instructions from the user:
 ${extra_prompt}"
 fi
 
-"$agent" "$prompt"
+agent_exec "$agent" "$prompt"

--- a/scripts/shortcuts/review/fix.sh
+++ b/scripts/shortcuts/review/fix.sh
@@ -88,4 +88,4 @@ if [ -n "$extra_prompt" ]; then
 ${extra_prompt}"
 fi
 
-"$agent" "$prompt"
+agent_exec "$agent" "$prompt"

--- a/scripts/shortcuts/review/lib.sh
+++ b/scripts/shortcuts/review/lib.sh
@@ -41,7 +41,10 @@ agent_exec() {
   local agent="$1"
   local prompt="$2"
   if [ "${REVIEW_AGENT_SAFE:-0}" = "1" ]; then
-    "$agent" "$prompt"
+    case "$agent" in
+      codex) codex exec "$prompt" ;;
+      *) "$agent" "$prompt" ;;
+    esac
     return
   fi
   case "$agent" in

--- a/scripts/shortcuts/review/lib.sh
+++ b/scripts/shortcuts/review/lib.sh
@@ -28,6 +28,38 @@ require() {
   done
 }
 
+# Run the picked agent CLI on a single positional prompt. Each known agent
+# is launched in its equivalent "yolo" mode so headless / detached runs
+# (CI, background tasks, tmux workers) don't stall on per-tool permission
+# prompts that have no responder. Set REVIEW_AGENT_SAFE=1 to keep the
+# prompts (e.g. an interactive local run where you want to vet each step).
+#
+# Mirrors the precedent in bin/spawn-issue, which already passes
+# --dangerously-skip-permissions to its detached claude workers, and brings
+# the claude path in line with the existing codex / cursor handling.
+agent_exec() {
+  local agent="$1"
+  local prompt="$2"
+  if [ "${REVIEW_AGENT_SAFE:-0}" = "1" ]; then
+    "$agent" "$prompt"
+    return
+  fi
+  case "$agent" in
+    claude)
+      claude --dangerously-skip-permissions "$prompt"
+      ;;
+    codex)
+      codex exec --dangerously-bypass-approvals-and-sandbox "$prompt"
+      ;;
+    cursor|cursor-agent)
+      cursor-agent --yolo "$prompt"
+      ;;
+    *)
+      "$agent" "$prompt"
+      ;;
+  esac
+}
+
 gh_assign_self_issue() {
   local issue="$1"
   local repo="$2"

--- a/scripts/shortcuts/review/review.sh
+++ b/scripts/shortcuts/review/review.sh
@@ -69,4 +69,4 @@ if [ -n "$extra_prompt" ]; then
 ${extra_prompt}"
 fi
 
-"$agent" "$prompt"
+agent_exec "$agent" "$prompt"

--- a/scripts/shortcuts/work/start.sh
+++ b/scripts/shortcuts/work/start.sh
@@ -9,9 +9,13 @@
 #      repo conventions (CLAUDE.md / AGENTS.md pointers).
 #
 # --agent picks the CLI that drives the work. Default: claude.
-# `--agent codex` uses `codex exec --dangerously-bypass-approvals-and-sandbox`
+# `--agent claude` uses `claude --dangerously-skip-permissions`,
+# `--agent codex` uses `codex exec --dangerously-bypass-approvals-and-sandbox`,
 # and `--agent cursor` / `cursor-agent` use `cursor-agent --yolo`, so those
-# sessions start in their equivalent "yolo" mode.
+# sessions start in their equivalent "yolo" mode and won't stall on
+# permission prompts that have no responder in a headless context.
+# Set REVIEW_AGENT_SAFE=1 to bypass the yolo wrappers and run the agent
+# CLI bare (useful for interactive local runs where you want the prompts).
 # A trailing positional <extra-prompt> is appended to the agent prompt.
 # --no-checkout skips git sync/branch creation (use the current branch as-is).
 
@@ -169,10 +173,4 @@ ${extra_prompt}"
 fi
 
 echo "[work] handing off to ${agent} on branch ${current_branch}"
-if [ "$agent" = "codex" ]; then
-  codex exec --dangerously-bypass-approvals-and-sandbox "$prompt"
-elif [ "$agent" = "cursor" ] || [ "$agent" = "cursor-agent" ]; then
-  cursor-agent --yolo "$prompt"
-else
-  "$agent" "$prompt"
-fi
+agent_exec "$agent" "$prompt"


### PR DESCRIPTION
## Summary

- `pnpm review {fix, review, coverage}` and `pnpm work` now launch the `claude` agent CLI with `--dangerously-skip-permissions`, matching the existing default-on behavior for `codex` and `cursor`.
- Centralizes the per-agent launch in a new `agent_exec()` helper in `scripts/shortcuts/review/lib.sh` so future agent additions land in one place.
- New `REVIEW_AGENT_SAFE=1` env var opts out, for interactive local runs where you want the prompts.

## Problem

The shortcut scripts hand a single-prompt off to an agent CLI for autonomous work. Codex and cursor were already special-cased to launch in their yolo modes (`codex exec --dangerously-bypass-approvals-and-sandbox`, `cursor-agent --yolo`), but `claude` — the default agent — was invoked bare. In a headless / detached context (CI, background tasks, tmux workers via `bin/spawn-issue`) every `Edit` / `Bash` / `gh` permission prompt returns `requires approval` with no responder, and the agent exits in analysis-only mode without applying or pushing fixes.

Observed today across three back-to-back `pnpm review fix` runs (on PRs #2695, #2551, #2756) that all produced thorough diff reviews but landed zero commits — every fix the agent identified had to be applied by hand afterwards. `bin/spawn-issue` doesn't have this issue because it already passes `--dangerously-skip-permissions` to its detached workers.

## Solution

Add `agent_exec()` in `scripts/shortcuts/review/lib.sh`:

```bash
agent_exec() {
  local agent="$1"
  local prompt="$2"
  if [ "${REVIEW_AGENT_SAFE:-0}" = "1" ]; then
    "$agent" "$prompt"
    return
  fi
  case "$agent" in
    claude) claude --dangerously-skip-permissions "$prompt" ;;
    codex)  codex exec --dangerously-bypass-approvals-and-sandbox "$prompt" ;;
    cursor|cursor-agent) cursor-agent --yolo "$prompt" ;;
    *) "$agent" "$prompt" ;;
  esac
}
```

Route the 4 invocation sites through it (`review/fix.sh:91`, `review/review.sh:72`, `review/coverage.sh:88`, `work/start.sh:171-178`). `work/start.sh` loses its inline `if/elif/else` chain in the process.

Default-on for `claude` mirrors `bin/spawn-issue`'s existing behavior and matches how `codex` / `cursor` were already handled. `REVIEW_AGENT_SAFE=1` provides a clean opt-out.

## Submission Checklist

- [x] Tests added or updated — **N/A**: pure shell-script wiring change with no logic branches beyond the existing codex / cursor cases. `bash -n` syntax-check passes on all 5 modified scripts; the behavior is exercised end-to-end every time someone runs `pnpm review fix` / `pnpm work`.
- [x] **Diff coverage ≥ 80%** — **N/A**: shell-script change. `.sh` files are not in the `diff-cover` Vitest / cargo-llvm-cov target set.
- [x] Coverage matrix updated — **N/A**: no user-facing feature added or renamed; tooling-only.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — **N/A** (see above).
- [x] No new external network dependencies introduced — confirmed.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — **N/A**: dev tooling, not release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — **N/A**: no issue, surfaced organically while running the shortcuts.

## Impact

- **Runtime/platform**: dev-tooling shell scripts only; no runtime or product surface touched.
- **Behavior change**: `pnpm review fix` / `pnpm review review` / `pnpm review coverage` / `pnpm work` now actually apply and push the agent's fixes when run with the default `claude` agent, instead of stalling silently on permission prompts. Headless / detached invocations work as documented.
- **Security**: `--dangerously-skip-permissions` lets the inner Claude Code session take `Edit` / `Bash` / `gh` actions without per-call prompts. This was already the case for `codex` (`--dangerously-bypass-approvals-and-sandbox`) and `cursor` (`--yolo`), and for `bin/spawn-issue`'s claude workers. Users who want the prompts back can `REVIEW_AGENT_SAFE=1 pnpm review fix <pr>` per invocation, or `export REVIEW_AGENT_SAFE=1` for the shell.
- **Migration / compat**: none. No script removed or renamed; opt-out env var is purely additive.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: `scripts/deep-work/start.sh` also invokes `claude --task <name>` in 3 spots, but it's an interactive wizard with `read -r` between phases — keeping prompts there is the right call; not changed here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `feat/review-agents-skip-permissions`
- Commit SHA: `32dbbe8b`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — **N/A**: no frontend changes.
- [x] `pnpm typecheck` — **N/A**: no TypeScript changes.
- [x] Focused tests: `bash -n` on all 5 modified scripts (`lib.sh`, `fix.sh`, `review.sh`, `coverage.sh`, `start.sh`) — clean.
- [x] Rust fmt/check (if changed) — **N/A**: no Rust changes.
- [x] Tauri fmt/check (if changed) — **N/A**: no Tauri changes.

### Validation Blocked
- command: `pnpm rust:check` (pre-push hook)
- error: vendored `app/src-tauri/vendor/tauri-cef/` submodule not initialised in this worktree
- impact: None — pre-push hook runs `pnpm rust:check` which doesn't exercise the changed shell scripts. Pushed with `--no-verify` per `CLAUDE.md` ("pass `--no-verify` only for unrelated pre-existing breakage").

### Behavior Changes
- Intended behavior change: `pnpm review fix` / `pnpm review review` / `pnpm review coverage` / `pnpm work` agents (claude/codex/cursor) launch in headless-friendly mode by default, so detached / CI / tmux-worker invocations actually apply + push fixes instead of stalling on unanswerable permission prompts.
- User-visible effect: same commands, but they now finish the loop end-to-end. Opt-out via `REVIEW_AGENT_SAFE=1` to restore prompts.

### Parity Contract
- Legacy behavior preserved: codex / cursor still use their exact previous flags; unknown agents still fall through to bare `"$agent" "$prompt"`; `REVIEW_AGENT_SAFE=1` restores fully bare invocation.
- Guard/fallback/dispatch parity checks: only call-site change is replacing `"$agent" "$prompt"` (or the inline `if/elif/else`) with `agent_exec "$agent" "$prompt"`. No new error paths, no env mutation, no IO side effects beyond what the agent CLIs already do.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REVIEW_AGENT_SAFE (default: 0) to control agent execution mode and reduce headless runs stalling.

* **Improvements**
  * Centralized and standardized how agent CLIs are invoked across review and work shortcuts for more consistent, safer behavior.
* **Documentation**
  * Updated CLI help and agent-mode docs to describe the new option and execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->