### PR TITLE
docs(prompts): add zero-match search guardrail to SOUL.md/Personality

### DIFF
--- a/src/openhuman/agent/prompts/SOUL.md
+++ b/src/openhuman/agent/prompts/SOUL.md
@@ -22,3 +22,4 @@ You are OpenHuman — the user's AI teammate for productivity, research, and tea
 - **Tool failure:** try a different approach before escalating. If you're stuck, name what failed and what you'd need to proceed.
 - **Lost the thread:** offer to reset — "I think I've drifted; want to restate what you need?"
 - **User frustration:** acknowledge it directly and fix it. No excuses, no over-explaining.
+- **Search returns zero matches:** stop the loop and confirm the target with the user before broadening to external sources or guessing at file names. Confabulated repo and file names waste iterations and lose trust.


### PR DESCRIPTION
## Summary

- Adds one bullet to the \"When things go wrong\" section of `src/openhuman/agent/prompts/SOUL.md` telling the agent to stop and confirm with the user when a workspace search returns zero matches, instead of escalating to external sources and guessing at file / repo names.

## Motivation

Observed in a live v0.56.0 session: user asked the agent to ingest a vault and chat about their situation. A previous turn referenced filenames the workspace no longer contained, so workspace `list` / `grep` calls returned zero matches. The agent then:

1. Searched GitHub for `yoheinakajima/agent-memory` — confabulated; no such repo with that name has the file it was looking for.
2. Searched GitHub code for `\"SOUL.md ARISE\"` — no results.
3. Burned ~5–8 iterations of `web_fetch` / `memory_recall` / `grep` cycles before draining the iteration budget.
4. Eventually produced a Progress Checkpoint whose **last** bullet of \"Next steps\" was \"Ask user for clarification on what 'ARISE ritual', 'SOUL.md', or the agent-memory project refers to in their context, since these don't appear to be standard/public resources.\"

That \"ask user\" step is the right move — but as a *first* response to a zero-match workspace search, not as the fourth step after a research tangent. A one-bullet rule in the canonical persona doc steers the model there directly.

## Diff

```diff
 - **User frustration:** acknowledge it directly and fix it. No excuses, no over-explaining.
+- **Search returns zero matches:** stop the loop and confirm the target with the user before broadening to external sources or guessing at file names. Confabulated repo and file names waste iterations and lose trust.
```

Matches the existing trigger-prefixed, single-sentence style of the three sibling bullets.

## Test plan

- [x] No behavior tests; pure prompt-content change.
- [x] File is bundled via `include_str!(\"SOUL.md\")` at `src/openhuman/agent/prompts/mod.rs:1382` — new content ships automatically.
- [x] Existing tests at `prompts/mod_tests.rs:89-98` only assert the file is seeded and starts with `# OpenHuman`; both still hold.
- [x] No i18n / security / logging concerns.

## Note on the base commit

This PR is one commit on top of `6d0657e4` rather than current `main` (`d7b1291` at time of writing). The fork's main was behind upstream and `gh repo sync` needed `workflow` scope I don't currently have. Happy to rebase on request — the diff is a single line that won't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for search scenarios returning zero results to specify that the system will confirm with users before broadening search scope or attempting alternative approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->