### PR TITLE
fix(artifacts): harden artifact ID validation and absolute_path

### DIFF
--- a/src/openhuman/artifacts/ops.rs
+++ b/src/openhuman/artifacts/ops.rs
@@ -61,12 +61,16 @@ pub async fn ai_get_artifact(
     let meta = store::get_artifact(&config.workspace_dir, artifact_id).await?;
 
     // Compute absolute path for the caller's convenience.
-    let absolute_path = config
-        .workspace_dir
-        .join("artifacts")
-        .join(&meta.path)
-        .to_string_lossy()
-        .into_owned();
+    // Guard against a corrupt or adversarial meta.path that escapes the artifacts root.
+    let artifacts_root = config.workspace_dir.join("artifacts");
+    let resolved = artifacts_root.join(&meta.path);
+    if !resolved.starts_with(&artifacts_root) {
+        return Err(format!(
+            "[artifacts] meta.path {:?} escapes artifacts root for id={artifact_id}",
+            meta.path
+        ));
+    }
+    let absolute_path = resolved.to_string_lossy().into_owned();
 
     let mut value =
         serde_json::to_value(&meta).map_err(|e| format!("[artifacts] serialization error: {e}"))?;

--- a/src/openhuman/artifacts/schemas.rs
+++ b/src/openhuman/artifacts/schemas.rs
@@ -84,12 +84,56 @@ pub fn schemas(function: &str) -> ControllerSchema {
             function: "get_artifact",
             description: "Retrieve metadata for a single artifact by ID.",
             inputs: vec![artifact_id_input("Identifier of the artifact to retrieve.")],
-            outputs: vec![FieldSchema {
-                name: "artifact",
-                ty: TypeSchema::Ref("ArtifactMeta"),
-                comment: "Artifact metadata plus absolute_path field.",
-                required: true,
-            }],
+            outputs: vec![
+                FieldSchema {
+                    name: "id",
+                    ty: TypeSchema::String,
+                    comment: "Unique artifact identifier.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "kind",
+                    ty: TypeSchema::String,
+                    comment: "Category of the artifact (presentation, document, image, other).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "title",
+                    ty: TypeSchema::String,
+                    comment: "Human-readable title.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "path",
+                    ty: TypeSchema::String,
+                    comment: "Relative path from the artifacts root.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "size_bytes",
+                    ty: TypeSchema::U64,
+                    comment: "Artifact file size in bytes.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "status",
+                    ty: TypeSchema::String,
+                    comment: "Lifecycle status (pending, ready, failed).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "created_at",
+                    ty: TypeSchema::String,
+                    comment: "UTC timestamp when the artifact was created (ISO 8601).",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "absolute_path",
+                    ty: TypeSchema::String,
+                    comment: "Absolute on-disk path to the artifact directory.",
+                    required: true,
+                },
+            ],
         },
         "delete_artifact" => ControllerSchema {
             namespace: "ai",
@@ -252,6 +296,18 @@ mod tests {
         assert_eq!(s.inputs.len(), 1);
         assert_eq!(s.inputs[0].name, "artifact_id");
         assert!(s.inputs[0].required);
+        // Output should be flat fields matching the actual JSON response shape
+        let output_names: Vec<_> = s.outputs.iter().map(|f| f.name).collect();
+        assert!(output_names.contains(&"id"));
+        assert!(output_names.contains(&"kind"));
+        assert!(output_names.contains(&"title"));
+        assert!(output_names.contains(&"path"));
+        assert!(output_names.contains(&"size_bytes"));
+        assert!(output_names.contains(&"status"));
+        assert!(output_names.contains(&"created_at"));
+        assert!(output_names.contains(&"absolute_path"));
+        // Must NOT have an opaque "artifact" wrapper
+        assert!(!output_names.contains(&"artifact"));
     }
 
     #[test]

--- a/src/openhuman/artifacts/store.rs
+++ b/src/openhuman/artifacts/store.rs
@@ -27,6 +27,9 @@ fn validate_artifact_id(id: &str) -> Result<(), String> {
     if id.is_empty() {
         return Err("[artifacts] artifact_id must not be empty".to_string());
     }
+    if id == "." {
+        return Err("[artifacts] artifact_id must not be '.'".to_string());
+    }
     if id.contains('/') {
         return Err(format!(
             "[artifacts] artifact_id must not contain '/': {id:?}"

--- a/src/openhuman/artifacts/store_tests.rs
+++ b/src/openhuman/artifacts/store_tests.rs
@@ -168,6 +168,13 @@ async fn list_skips_corrupt_meta() {
 }
 
 #[tokio::test]
+async fn validate_artifact_id_rejects_dot() {
+    let tmp = TempDir::new().unwrap();
+    let err = get_artifact(tmp.path(), ".").await.unwrap_err();
+    assert!(err.contains("must not be '.'"), "unexpected error: {err}");
+}
+
+#[tokio::test]
 async fn validate_artifact_id_rejects_slashes() {
     let tmp = TempDir::new().unwrap();
     let err = get_artifact(tmp.path(), "a/b").await.unwrap_err();


### PR DESCRIPTION
## Summary

Security hardening for the artifacts persistence layer introduced in #2801:

- **Reject `.` as artifact ID** — `validate_artifact_id` in `store.rs` now explicitly rejects `"."`, which previously resolved to the artifacts root directory itself, allowing operations to target the root instead of a specific artifact subdirectory
- **Harden `absolute_path` in `ai_get_artifact`** — `ops.rs` now verifies that `artifacts_root.join(&meta.path)` still starts with `artifacts_root` before returning the path, guarding against corrupt or adversarial `meta.path` values in stored `meta.json` files that could expose paths outside the artifacts sandbox
- **Fix `get_artifact` schema output shape** — The schema in `schemas.rs` previously declared a single `"artifact": ArtifactMeta` wrapper output, but the actual JSON response returns all `ArtifactMeta` fields flat at the top level plus an `absolute_path` field. Schema now matches the real response shape.
- **Add `validate_artifact_id_rejects_dot` test** in `store_tests.rs`

## Test plan

- [x] `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` passes (only pre-existing warnings)
- [x] `cargo fmt --manifest-path Cargo.toml --check` passes
- [x] New test `validate_artifact_id_rejects_dot` covers the `.` rejection
- [x] Schema test `schemas_get_artifact_requires_artifact_id` now asserts flat output fields including `absolute_path` and absence of the `"artifact"` wrapper

## Notes

This PR was not included in the original #2801 because it was merged before these fixes could be applied. These are follow-up hardening changes with no functional regression risk.

- [x] N/A: no UI changes
- [x] N/A: no breaking RPC contract changes (schema fix makes it more accurate, not less)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced artifact path validation to prevent directory traversal vulnerabilities and unauthorized access to files outside the designated artifact directory
  * Improved artifact ID validation by rejecting reserved path components that could create security issues

* **Improvements**
  * Simplified artifact API response format to return artifact details directly, improving usability for API consumers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->