### PR TITLE
fix(legacy_aliases): tolerate unquoted keys + skip comments in alias-table parser

### DIFF
--- a/src/core/legacy_aliases.rs
+++ b/src/core/legacy_aliases.rs
@@ -223,7 +223,7 @@ mod tests {
         let compact = body
             .lines()
             .map(str::trim)
-            .filter(|line| !line.is_empty())
+            .filter(|line| !line.is_empty() && !line.starts_with("//"))
             .collect::<Vec<_>>()
             .join(" ");
         let mut aliases = BTreeMap::new();
@@ -235,7 +235,14 @@ mod tests {
             let (legacy, target_expr) = entry
                 .split_once(':')
                 .unwrap_or_else(|| panic!("expected legacy alias entry, got `{entry}`"));
-            let legacy = quoted_value(legacy);
+            // Prettier strips quotes from keys that are valid JS identifiers
+            // (e.g. `health_snapshot`), so accept both `'foo':` and bare `foo:`.
+            let legacy_trimmed = legacy.trim();
+            let legacy = if legacy_trimmed.starts_with('\'') || legacy_trimmed.starts_with('"') {
+                quoted_value(legacy)
+            } else {
+                legacy_trimmed.to_string()
+            };
             let target_expr = target_expr.trim();
             let canonical = if let Some(key) = target_expr.strip_prefix("CORE_RPC_METHODS.") {
                 core_methods

--- a/src/core/legacy_aliases.rs
+++ b/src/core/legacy_aliases.rs
@@ -373,7 +373,9 @@ mod tests {
             "bare-identifier key should resolve (Prettier-normalized form)"
         );
         assert!(
-            !aliases.keys().any(|k| k.contains("//") || k.contains("legacy aliases")),
+            !aliases
+                .keys()
+                .any(|k| k.contains("//") || k.contains("legacy aliases")),
             "comment text must not be captured as a key"
         );
     }

--- a/src/core/legacy_aliases.rs
+++ b/src/core/legacy_aliases.rs
@@ -353,6 +353,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_frontend_legacy_aliases_accepts_bare_identifier_keys_and_skips_comments() {
+        // Prettier strips redundant quotes from keys that are valid JS
+        // identifiers, so the canonical form for a simple key like
+        // `health_snapshot` is unquoted. The parser must accept both
+        // `'foo':` and bare `foo:`, and must ignore `//` comment lines
+        // in the LEGACY_METHOD_ALIASES body.
+        let source = "export const CORE_RPC_METHODS = {\n  alphaMethod: 'openhuman.alpha',\n  betaMethod: 'openhuman.beta',\n} as const;\n\nexport const LEGACY_METHOD_ALIASES: Record<string, CoreRpcMethod> = {\n  // legacy aliases for the alpha method\n  'openhuman.legacy_alpha': CORE_RPC_METHODS.alphaMethod,\n  beta_legacy: CORE_RPC_METHODS.betaMethod,\n};\n";
+        let core_methods = parse_core_rpc_methods(source);
+        let aliases = parse_frontend_legacy_aliases(source, &core_methods);
+        assert_eq!(
+            aliases.get("openhuman.legacy_alpha").map(String::as_str),
+            Some("openhuman.alpha"),
+            "quoted-key entry should still resolve"
+        );
+        assert_eq!(
+            aliases.get("beta_legacy").map(String::as_str),
+            Some("openhuman.beta"),
+            "bare-identifier key should resolve (Prettier-normalized form)"
+        );
+        assert!(
+            !aliases.keys().any(|k| k.contains("//") || k.contains("legacy aliases")),
+            "comment text must not be captured as a key"
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "legacy alias references unknown CORE_RPC_METHODS")]
     fn parse_frontend_legacy_aliases_panics_on_unknown_core_method_ref() {
         let source = "export const CORE_RPC_METHODS = {\n  alphaMethod: 'openhuman.alpha',\n} as const;\n\nexport const LEGACY_METHOD_ALIASES: Record<string, CoreRpcMethod> = {\n  'openhuman.legacy_alpha': CORE_RPC_METHODS.doesNotExist,\n};\n";


### PR DESCRIPTION
## Summary

Fix the `core::legacy_aliases::tests::frontend_legacy_aliases_match_server_alias_table` test, which #2853 broke by adding `health_snapshot: CORE_RPC_METHODS.healthSnapshot,` to `LEGACY_METHOD_ALIASES`.

## Why the test was broken

Prettier strips quotes from object keys that are valid JS identifiers, so `'health_snapshot':` round-trips to `health_snapshot:`. The Rust test parser's `parse_frontend_legacy_aliases` then called `quoted_value()` on the bare identifier and panicked:

```
expected quoted value in `health_snapshot`
```

My first attempt was the obvious one — quote the key in `rpcMethods.ts`. CI caught the next layer: Prettier's `format:check` rejects the redundant quotes. So the fix has to be in the parser, not the source file.

## What this PR changes

`src/core/legacy_aliases.rs` — `parse_frontend_legacy_aliases` only:

1. **Skip `//`-comment lines** when compacting the `LEGACY_METHOD_ALIASES` body. Without this the first quoted key picks up the inline comment header (regression in the prior attempt; caught by full test run).
2. **Accept both quoted and bare-identifier keys.** `'foo':` continues to work; bare `foo:` (valid JS identifier) is now accepted too. Detection is by leading `'` or `"`.

## Impact

This unblocks every PR rebasing onto current main. Confirmed downstream effects:
- #2687 (architecture diagram viewer): 2 fails (`test / Rust Core Tests + Quality` + `Rust Core Coverage (cargo-llvm-cov)`) — both this root cause.
- #2715 (tool_policy diagnostics): same 2 fails after rebase.

## Test plan

- [x] All 20 `core::legacy_aliases::tests::*` pass locally (`20 passed; 0 failed`).
- [x] `app/src/services/rpcMethods.ts` left untouched — no Prettier regression.
- [x] CI green on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved robustness of legacy-alias parsing tests: now tolerate comment lines and accept legacy keys written as bare identifiers or quoted strings, with added coverage to assert these behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->