### PR TITLE
fix(observability): classify OpenHuman embedding 401 'Invalid token' as SessionExpired (TAURI-RUST-4K5)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -293,6 +293,19 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if is_backend_user_error_message(&lower) {
         return Some(ExpectedErrorKind::BackendUserError);
     }
+    // Check `is_session_expired_message` BEFORE `is_embedding_backend_auth_failure`:
+    // the OpenHuman-backend embedding 401 "Invalid token" envelope
+    // (`Embedding API error (401 …): {"error":"Invalid token"}`) is a
+    // recoverable session expiry (TAURI-RUST-4K5, #2786), not a generic
+    // backend error. The broader `is_embedding_backend_auth_failure` matcher
+    // below would otherwise demote that exact wire shape to `BackendUserError`
+    // first and swallow the re-auth signal. `is_session_expired_message` is
+    // narrowly anchored (parenthesised `(401` + the `"error":"Invalid token"`
+    // envelope), so the bare-status `Embedding API error 401 …` shape and
+    // BYO-key 401s still fall through to the matchers below.
+    if is_session_expired_message(message) {
+        return Some(ExpectedErrorKind::SessionExpired);
+    }
     if is_embedding_backend_auth_failure(&lower) {
         return Some(ExpectedErrorKind::BackendUserError);
     }
@@ -310,9 +323,6 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     }
     if crate::openhuman::inference::provider::is_budget_exhausted_message(message) {
         return Some(ExpectedErrorKind::BudgetExhausted);
-    }
-    if is_session_expired_message(message) {
-        return Some(ExpectedErrorKind::SessionExpired);
     }
     if is_prompt_injection_blocked_message(&lower) {
         return Some(ExpectedErrorKind::PromptInjectionBlocked);
@@ -1847,18 +1857,23 @@ mod tests {
     #[test]
     fn classifies_embedding_backend_auth_failure() {
         // TAURI-RUST-T (~4k events): OpenHuman backend rejected the
-        // embeddings worker's bearer token. Both the bare-status and
-        // parenthesised wire shapes must classify.
-        for raw in [
-            r#"Embedding API error 401 Unauthorized: {"success":false,"error":"Invalid token"}"#,
-            r#"Embedding API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#,
-        ] {
-            assert_eq!(
-                expected_error_kind(raw),
-                Some(ExpectedErrorKind::BackendUserError),
-                "should classify embedding backend auth failure: {raw}"
-            );
-        }
+        // embeddings worker's bearer token, rendered as the bare-status
+        // `Embedding API error 401 …` wire shape. The parenthesised
+        // `Embedding API error (401 …)` shape carrying the same
+        // `"error":"Invalid token"` envelope is now owned by
+        // `is_session_expired_message` (TAURI-RUST-4K5, #2786) and asserted by
+        // `classifies_embedding_api_invalid_token_401_as_session_expired`;
+        // since `is_session_expired_message` runs first in
+        // `expected_error_kind`, only the bare-status shape (which the
+        // session matcher's `(401` anchor does not match) still reaches this
+        // `BackendUserError` bucket.
+        assert_eq!(
+            expected_error_kind(
+                r#"Embedding API error 401 Unauthorized: {"success":false,"error":"Invalid token"}"#
+            ),
+            Some(ExpectedErrorKind::BackendUserError),
+            "bare-status embedding backend auth failure must classify as BackendUserError"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes a self-contradicting classification on `main`: the embedding-401 wire shape `Embedding API error (401 …): {"error":"Invalid token"}` was asserted to be **two different buckets** by two merged PRs, leaving the Rust test suite red on `main` (and therefore on every open PR).
- `expected_error_kind` now runs `is_session_expired_message` **before** `is_embedding_backend_auth_failure`, so the OpenHuman-backend embedding 401 "Invalid token" envelope classifies as `SessionExpired` (recoverable re-auth signal) instead of `BackendUserError`.
- Amends #2830's `classifies_embedding_backend_auth_failure` test to drop the parenthesised case now owned by the session matcher; the bare-status shape still classifies as `BackendUserError`.

## Problem

PR #2786 (TAURI-RUST-4K5, current `main` tip `14ff92b2`) added an `is_session_expired_message` arm + the test `classifies_embedding_api_invalid_token_401_as_session_expired`, asserting that `Embedding API error (401 Unauthorized): {"success":false,"error":"Invalid token"}` → `SessionExpired`.

The older PR #2830 (TAURI-RUST-T) had already added `is_embedding_backend_auth_failure`, which matches the **identical** string and returns `BackendUserError`, and runs **earlier** in `expected_error_kind`. Its test `classifies_embedding_backend_auth_failure` asserts `BackendUserError` for that same string.

The two are mutually exclusive. Because the embedding matcher ran first, #2786's own test fails on `main`:

```
core::observability::tests::classifies_embedding_api_invalid_token_401_as_session_expired
  left: Some(BackendUserError)
 right: Some(SessionExpired)
```

This turns the Rust CI job red on `main` and on every PR that merges current `main`.

## Solution

- Move the `is_session_expired_message` check to immediately after `is_backend_user_error_message` and **before** `is_embedding_backend_auth_failure` in `expected_error_kind`. `is_backend_user_error_message` only matches the literal `"backend returned <status>"` substring (which this wire shape lacks), so the new placement is the earliest point that can intercept the embedding 401 envelope.
- The session matcher is narrowly anchored: it requires the parenthesised `(401` prefix **and** the `"error":"Invalid token"` envelope. Therefore:
  - Parenthesised OpenHuman-backend embedding 401 "Invalid token" → `SessionExpired` (fixed).
  - Bare-status `Embedding API error 401 …` → still falls through to `is_embedding_backend_auth_failure` → `BackendUserError` (unchanged).
  - BYO-key embedding 401s (`invalid_api_key`, `authentication_error`, no `"Invalid token"` envelope) → still `None`/actionable in Sentry (unchanged; guarded by `does_not_classify_embedding_byo_key_401_as_session_expired`).
- Amend #2830's test to assert only the bare-status shape, with a comment documenting the new ownership boundary between the two matchers.

Design decision: SessionExpired is the more specific and more recent intent (#2786 deliberately covers 4P0 + 4K5 + 1EE with BYO-key guards), and a "401 Invalid token" from the OpenHuman backend genuinely is an expired user session that should drive re-auth rather than a generic backend error.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — amended `classifies_embedding_backend_auth_failure`; the `SessionExpired` happy path (`classifies_embedding_api_invalid_token_401_as_session_expired`) and the negative guards (`does_not_classify_embedding_byo_key_401_as_session_expired`, `does_not_classify_unrelated_invalid_token_messages`) now all pass.
- [x] **Diff coverage ≥ 80%** — the only non-comment changed lines are the relocated `is_session_expired_message` branch (exercised by the 4K5 test) and the amended test body; all are covered.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (re-buckets one already-tracked error classification; no feature row added/removed/renamed).
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure in-process classifier change.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: observability classification only, no user-facing surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no tracked issue; this fixes a regression introduced by #2786 vs #2830 racing on main`.

## Impact

- Runtime/platform: desktop core (`src/core/observability.rs`) only; no UI, mobile, or CLI changes.
- Behavioural: OpenHuman-backend embedding 401 "Invalid token" now reports `SessionExpired` instead of `BackendUserError`. Both are Sentry-suppressed "expected" buckets, so Sentry volume is unchanged; the difference is the downstream re-auth signal.
- Restores green Rust CI on `main` and unblocks all open PRs that were failing on the pre-existing contradiction.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: surfaces the same root regression noticed while resolving conflicts on #2795.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/observability-embedding-401-session-precedence`
- Commit SHA: `ed9c9704`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — `N/A: Rust-only change, no app/ files touched`
- [x] `pnpm typecheck` — `N/A: Rust-only change, no TypeScript touched`
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib core::observability` → 118 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; lib compiles under `cargo test`
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched`

### Validation Blocked
- `command:` `pnpm test:coverage` / `pnpm typecheck`
- `error:` worktree lacks `node_modules` (`prettier: command not found`); not installed for this Rust-only fix
- `impact:` none — change is confined to the Rust core classifier; Rust fmt + focused tests verified

### Behavior Changes
- Intended behavior change: re-bucket the OpenHuman-backend embedding 401 "Invalid token" envelope from `BackendUserError` to `SessionExpired`.
- User-visible effect: none directly (both buckets skip Sentry); downstream consumers of `SessionExpired` can now treat the embedding 401 as a recoverable re-auth event.

### Parity Contract
- Legacy behavior preserved: bare-status `Embedding API error 401 …` → `BackendUserError`; BYO-key embedding 401s → `None`/actionable; non-embedding session shapes (4P0 OpenHuman, 1EE streaming) unchanged.
- Guard/fallback/dispatch parity checks: `does_not_classify_embedding_byo_key_401_as_session_expired` and `does_not_classify_unrelated_invalid_token_messages` still pass.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): reconciles the conflicting matchers from #2786 (SessionExpired) and #2830 (BackendUserError) in favour of #2786's classification for the parenthesised envelope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session expiration error handling. Session-expired messages are now correctly identified and reported with proper precedence, ensuring more accurate error detection and clearer feedback when sessions expire.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->