### PR TITLE
fix(observability): classify embedding API 401 'Invalid token' as SessionExpired (TAURI-RUST-4K5 regression)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -315,7 +315,7 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
         return Some(ExpectedErrorKind::BackendUserError);
     }
     if is_embedding_backend_auth_failure(&lower) {
-        return Some(ExpectedErrorKind::BackendUserError);
+        return Some(ExpectedErrorKind::SessionExpired);
     }
     // Provider config-rejection (unknown model / abstract tier leaked to a
     // custom provider / model-specific temperature). Body-shape based and
@@ -1943,17 +1943,20 @@ mod tests {
 
     #[test]
     fn classifies_embedding_backend_auth_failure() {
-        // TAURI-RUST-T (~4k events): OpenHuman backend rejected the
-        // embeddings worker's bearer token. Both the bare-status and
-        // parenthesised wire shapes must classify.
+        // TAURI-RUST-T (~4k events) — companion of TAURI-RUST-4K5: the
+        // OpenHuman backend rejected the embeddings worker's bearer
+        // token. Both the bare-status and parenthesised wire shapes
+        // must classify as SessionExpired so the FE re-login prompt
+        // fires (matches the contract introduced by #2786 and
+        // exercised by classifies_embedding_api_invalid_token_401_as_session_expired).
         for raw in [
             r#"Embedding API error 401 Unauthorized: {"success":false,"error":"Invalid token"}"#,
             r#"Embedding API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#,
         ] {
             assert_eq!(
                 expected_error_kind(raw),
-                Some(ExpectedErrorKind::BackendUserError),
-                "should classify embedding backend auth failure: {raw}"
+                Some(ExpectedErrorKind::SessionExpired),
+                "should classify embedding backend auth failure as SessionExpired: {raw}"
             );
         }
     }


### PR DESCRIPTION
## Summary

Fix the `core::observability::tests::classifies_embedding_api_invalid_token_401_as_session_expired` test that's been failing on every PR rebased onto current `main`.

## Root cause

PR #2786 (commit `14ff92b2`) introduced the `is_embedding_backend_auth_failure` matcher and the 4K5 wire-shape test, both targeting `SessionExpired` so the FE re-login prompt fires (alongside the 4P0 OpenHuman-backend variant).

PR #2830 (commit `d578b57e`, "demote expected-error Sentry buckets across embeddings, provider, memory-store, FS, and thinking-mode wire shapes") landed shortly after on a pre-#2786 base. Its merge:
- kept the `is_embedding_backend_auth_failure` matcher arm in `expected_error_kind`, but
- reverted the return value from `Some(ExpectedErrorKind::SessionExpired)` to `Some(ExpectedErrorKind::BackendUserError)`, and
- the older `classifies_embedding_backend_auth_failure` test (also asserting `BackendUserError`) survived the merge unchanged, masking the regression in #2830's own CI.

The result: `classifies_embedding_api_invalid_token_401_as_session_expired` (added by #2786) panics on current `main`:

```
assertion `left == right` failed: TAURI-RUST-4K5 verbatim wire shape must classify as SessionExpired
  left:  Some(BackendUserError)
  right: Some(SessionExpired)
```

Verified reproducer: `git checkout upstream/main && cargo test --lib core::observability::tests::classifies_embedding_api_invalid_token_401_as_session_expired` fails.

## What this PR changes

`src/core/observability.rs` only:

1. **One-char classifier fix** — flip the `is_embedding_backend_auth_failure` arm's return from `BackendUserError` back to `SessionExpired`, the intent introduced by #2786.
2. **Reconcile the older test** — `classifies_embedding_backend_auth_failure` (TAURI-RUST-T) was asserting the pre-#2786 behavior. Update it to expect `SessionExpired`, matching the design contract. Updated the doc-comment to cross-reference #2786 and the companion 4K5 test.

Both tests share the same wire shapes (`Embedding API error 401 Unauthorized:` and `Embedding API error (401 Unauthorized):` + `"error":"Invalid token"`); now they classify consistently.

## Impact

Unblocks every PR rebasing onto current `main`. Confirmed downstream:
- #2687, #2715, #2549 — all in this session's shepherd queue, all inheriting this failure on their post-#2795 heads.

## Test plan

- [x] All 121 `core::observability::tests::*` pass locally (`121 passed; 0 failed`).
- [x] No other tests affected — the change only flips the kind returned for a wire shape that two tests already pin to a single expected value.
- [x] CI green on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)