### PR TITLE
fix(observability): classify list_models 404 as ProviderUserState (Sentry TAURI-RUST-YJ)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -963,6 +963,33 @@ fn is_provider_user_state_message(lower: &str) -> bool {
         return true;
     }
 
+    // OPENHUMAN-TAURI-YJ: `inference/provider/ops.rs::list_models` probed a
+    // user-configured custom-provider's `/models` endpoint and the upstream
+    // server returned 404. Wire shape emitted at `ops.rs:118-122`:
+    //
+    //   "provider returned 404: {\"error\":\"path \\\"/api/v1/models\\\" not found\"}"
+    //
+    // (the trailing body is whatever the upstream server wrote — `{"error":...}`,
+    // `{"detail":...}`, bare HTML, etc.; we only anchor on the `provider returned
+    // 404` prefix). The semantic is unambiguous: the user pointed a custom
+    // OpenAI-compatible provider at a base URL that does not host a `/models`
+    // listing endpoint (wrong base, model-only proxy, typo'd path). The model
+    // dropdown already surfaces the failure inline — Sentry has no remediation.
+    //
+    // **404 only**. Other 4xx from the same emit site stay actionable:
+    //   - 401 / 403: BYO-key auth wall — actionable misconfiguration; the
+    //     `does_not_classify_byo_key_provider_401_as_session_expired` contract
+    //     (#2286) intentionally keeps these in Sentry.
+    //   - 400: typically request-shape bugs in OUR client; must escalate.
+    //   - 429 / 5xx: transient — handled by other matchers / retry policy.
+    //
+    // No `inference/provider/ops.rs::list_models` other than this site emits
+    // the `provider returned NNN` prefix (verified via grep), so the prefix
+    // alone is a sufficient anchor.
+    if lower.starts_with("provider returned 404") {
+        return true;
+    }
+
     false
 }
 
@@ -3420,6 +3447,65 @@ mod tests {
             None,
             "genuine backend 500 without Cloudflare body must NOT demote — it is a real bug"
         );
+    }
+
+    #[test]
+    fn classifies_list_models_404_as_provider_user_state() {
+        // OPENHUMAN-TAURI-YJ: `inference/provider/ops.rs::list_models` probed
+        // a custom-provider's `/models` endpoint and the upstream server
+        // returned 404 because the base URL is wrong / doesn't host a models
+        // listing. User-config state — the model-dropdown probe already
+        // surfaces it inline. Pin the verbatim Sentry payload plus a few
+        // body-shape variants (different upstreams emit different 404 bodies)
+        // so the path-agnostic prefix anchor stays the source of truth.
+        for raw in [
+            // Verbatim shape from the Sentry event.
+            r#"provider returned 404: {"error":"path \"/api/v1/models\" not found"}"#,
+            // FastAPI-style: `{"detail":"Not Found"}`.
+            r#"provider returned 404: {"detail":"Not Found"}"#,
+            // Bare HTML — happens when the user pointed at a non-API origin
+            // (e.g. the provider's docs site).
+            "provider returned 404: <html><body>Not Found</body></html>",
+            // After `truncate_with_ellipsis(.., 300)` clips a longer body —
+            // prefix anchor must still match.
+            r#"provider returned 404: {"error":{"message":"The requested URL /api/v1/models was not found on this server. Please check the URL or co…"#,
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::ProviderUserState),
+                "OPENHUMAN-TAURI-YJ list_models 404 must classify as ProviderUserState: {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_classify_non_404_list_models_failures_as_user_state() {
+        // Discrimination guard: only the 404 prefix demotes. Sibling 4xx /
+        // 5xx codes from the same `provider returned NNN:` emit site must
+        // stay actionable in Sentry — they map to BYO-key auth walls (401 /
+        // 403), client-shape bugs (400), and transient / server faults
+        // (429 / 5xx) respectively. Pinning each shape here protects the
+        // #2286 BYO-key 401 contract and prevents the arm from silently
+        // widening to all 4xx.
+        for raw in [
+            // BYO-key auth wall — must still escalate (`does_not_classify_byo_key_provider_401_as_session_expired` sibling guard).
+            r#"provider returned 401: {"error":"Invalid API key"}"#,
+            r#"provider returned 403: {"error":"Forbidden: API key revoked"}"#,
+            // Request-shape mismatch — likely a bug in our client.
+            r#"provider returned 400: {"error":"Bad Request"}"#,
+            // Transient — caught by retry/backoff at the provider layer,
+            // does NOT belong in the user-state bucket.
+            r#"provider returned 429: {"error":"rate_limited"}"#,
+            r#"provider returned 503: upstream temporarily unavailable"#,
+            // 500 — a real upstream bug; must reach Sentry.
+            r#"provider returned 500: {"error":"internal_server_error"}"#,
+        ] {
+            assert_ne!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::ProviderUserState),
+                "non-404 list_models failure must NOT demote to ProviderUserState: {raw}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Rebased version of #2793 by @CodeGhost21 on the latest `upstream/main`. The original PR's CI failed because a new test (`classifies_embedding_api_invalid_token_401_as_session_expired`) was added to main via #2869 after the branch was cut, and the stale base couldn't pass it.

This branch is identical in intent to #2793 — only rebased to include the session-expired ordering fix from main (PR #2786/#2869).

**No functional changes from #2793:** the single new branch in `is_provider_user_state_message` and its two tests are preserved exactly.

- `inference/provider/ops.rs::list_models` probes a user-configured custom-provider's `/models` endpoint. When the upstream returns 404 (wrong base URL, model-only proxy, typo'd path), the wire shape `"provider returned 404: {<body>}"` was unclassified and filed a Sentry event.
- New arm: `lower.starts_with("provider returned 404")` → `ProviderUserState`.
- 404 only — sibling 4xx/5xx from the same emit site stay actionable (401/403 BYO-key auth, 400 client-shape bugs, 429/5xx transient).

Closes #2793.

## Test plan

- [x] `classifies_list_models_404_as_provider_user_state` — pins verbatim Sentry payload + 3 body-shape variants
- [x] `does_not_classify_non_404_list_models_failures_as_user_state` — exercises every sibling status code
- [x] All 9991 pre-existing core tests pass (including the new `classifies_embedding_api_invalid_token_401_as_session_expired` from main)
- [x] Diff coverage ≥ 80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Provider 404 errors during model discovery are now correctly classified as expected behavior, reducing false error reporting in observability logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->