### PR TITLE
fix(health): add legacy alias for health_snapshot (#2852)

### DIFF
--- a/app/src/services/rpcMethods.ts
+++ b/app/src/services/rpcMethods.ts
@@ -35,11 +35,13 @@ export const CORE_RPC_METHODS = {
   embeddingsClearApiKey: 'openhuman.embeddings_clear_api_key',
   embeddingsEmbed: 'openhuman.embeddings_embed',
   embeddingsTestConnection: 'openhuman.embeddings_test_connection',
+  healthSnapshot: 'openhuman.health_snapshot',
 } as const;
 
 export type CoreRpcMethod = (typeof CORE_RPC_METHODS)[keyof typeof CORE_RPC_METHODS];
 
 export const LEGACY_METHOD_ALIASES: Record<string, CoreRpcMethod> = {
+  health_snapshot: CORE_RPC_METHODS.healthSnapshot,
   'openhuman.get_analytics_settings': CORE_RPC_METHODS.configGetAnalyticsSettings,
   'openhuman.get_composio_trigger_settings': CORE_RPC_METHODS.configGetComposioTriggerSettings,
   'openhuman.get_config': CORE_RPC_METHODS.configGet,

--- a/src/core/legacy_aliases.rs
+++ b/src/core/legacy_aliases.rs
@@ -21,6 +21,7 @@
 /// Order doesn't matter for correctness, but is kept alphabetical by legacy
 /// key for easier diffing against the frontend table.
 const LEGACY_ALIASES: &[(&str, &str)] = &[
+    ("health_snapshot", "openhuman.health_snapshot"),
     (
         "openhuman.get_analytics_settings",
         "openhuman.config_get_analytics_settings",
@@ -349,6 +350,14 @@ mod tests {
         assert_eq!(
             resolve_legacy("openhuman.update_composio_trigger_settings"),
             "openhuman.config_update_composio_trigger_settings",
+        );
+    }
+
+    #[test]
+    fn health_snapshot_resolves_to_canonical() {
+        assert_eq!(
+            resolve_legacy("health_snapshot"),
+            "openhuman.health_snapshot"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `health_snapshot` → `openhuman.health_snapshot` legacy alias for older clients that call the RPC method without the `openhuman.` prefix

## Changes

- `src/core/legacy_aliases.rs`: Added alias entry + unit test
- `app/src/services/rpcMethods.ts`: Added matching frontend alias (enforced by `frontend_legacy_aliases_match_server_alias_table` test)

## Test plan

- [x] `health_snapshot_resolves_to_canonical` unit test
- [x] Existing `frontend_legacy_aliases_match_server_alias_table` parity test covers both sides

Closes #2852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for legacy health snapshot method names to ensure backward compatibility with proper RPC method mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->