### PR TITLE
fix(cron): accept bare cron string in Schedule deserialization (#2866)

### DIFF
--- a/src/openhuman/cron/types.rs
+++ b/src/openhuman/cron/types.rs
@@ -57,7 +57,7 @@ pub struct ActiveHours {
     pub end: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum Schedule {
     Cron {
@@ -73,6 +73,59 @@ pub enum Schedule {
     Every {
         every_ms: u64,
     },
+}
+
+impl<'de> Deserialize<'de> for Schedule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+
+        // Bare cron string: treat as Cron variant with defaults.
+        if let Some(expr) = value.as_str() {
+            return Ok(Schedule::Cron {
+                expr: expr.to_string(),
+                tz: None,
+                active_hours: None,
+            });
+        }
+
+        // Internally-tagged enum format: {"kind": "cron", "expr": "..."} etc.
+        #[derive(Deserialize)]
+        #[serde(tag = "kind", rename_all = "lowercase")]
+        enum ScheduleTagged {
+            Cron {
+                expr: String,
+                #[serde(default)]
+                tz: Option<String>,
+                #[serde(default)]
+                active_hours: Option<ActiveHours>,
+            },
+            At {
+                at: DateTime<Utc>,
+            },
+            Every {
+                every_ms: u64,
+            },
+        }
+
+        let tagged: ScheduleTagged =
+            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(match tagged {
+            ScheduleTagged::Cron {
+                expr,
+                tz,
+                active_hours,
+            } => Schedule::Cron {
+                expr,
+                tz,
+                active_hours,
+            },
+            ScheduleTagged::At { at } => Schedule::At { at },
+            ScheduleTagged::Every { every_ms } => Schedule::Every { every_ms },
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -341,5 +394,42 @@ mod tests {
         };
         assert!(p.agent_id.is_some());
         assert!(p.agent_id.as_ref().unwrap().is_none());
+    }
+
+    // ── Schedule: bare cron string acceptance (#2866) ──────────────
+
+    #[test]
+    fn schedule_deserializes_bare_cron_string() {
+        let schedule: Schedule = serde_json::from_str(r#""0 9 * * 1""#).unwrap();
+        assert_eq!(
+            schedule,
+            Schedule::Cron {
+                expr: "0 9 * * 1".to_string(),
+                tz: None,
+                active_hours: None,
+            }
+        );
+    }
+
+    #[test]
+    fn schedule_deserializes_tagged_cron_object() {
+        let schedule: Schedule =
+            serde_json::from_str(r#"{"kind": "cron", "expr": "0 9 * * 1"}"#).unwrap();
+        assert_eq!(
+            schedule,
+            Schedule::Cron {
+                expr: "0 9 * * 1".to_string(),
+                tz: None,
+                active_hours: None,
+            }
+        );
+    }
+
+    #[test]
+    fn schedule_bare_string_roundtrip_serializes_as_tagged() {
+        let schedule: Schedule = serde_json::from_str(r#""*/5 * * * *""#).unwrap();
+        let json = serde_json::to_value(&schedule).unwrap();
+        assert_eq!(json["kind"], "cron");
+        assert_eq!(json["expr"], "*/5 * * * *");
     }
 }


### PR DESCRIPTION
## Summary

- Fix `openhuman.cron_update` rejecting bare cron strings like `"0 9 * * 1"` — the `Schedule` enum now accepts both the bare string format and the existing tagged object format `{"kind": "cron", "expr": "..."}`

## Problem

Callers (including LLM tool calls) pass `{"schedule": "0 9 * * 1"}` but serde expected `{"schedule": {"kind": "cron", "expr": "0 9 * * 1"}}`, resulting in:
```
invalid type: string "0 9 * * 1", expected internally tagged enum Schedule
```

## Solution

Replaced the derived `Deserialize` on `Schedule` with a manual impl that:
1. Tries bare string first → wraps as `Schedule::Cron { expr, tz: None, active_hours: None }`
2. Falls back to the existing internally-tagged enum format
3. Serialization remains unchanged (always outputs the tagged format)

## Changes

- `src/openhuman/cron/types.rs`: Custom `Deserialize` impl + 3 new tests

## Test plan

- [x] `schedule_deserializes_bare_cron_string` — bare string parses correctly
- [x] `schedule_deserializes_tagged_cron_object` — existing format still works
- [x] `schedule_bare_string_roundtrip_serializes_as_tagged` — bare input serializes to tagged output
- [x] All existing Schedule tests unaffected

Closes #2866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule configuration now accepts bare cron strings for simplified input, reducing complexity for basic use cases while maintaining full backward compatibility with the existing structured format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->