### PR TITLE
fix(observability): demote WhatsApp ingest SQLite lock noise 

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -183,6 +183,17 @@ pub enum ExpectedErrorKind {
     /// reset window elapses and a subsequent init succeeds.
     ///
     MemoryStoreBreakerOpen,
+    /// WhatsApp structured-ingest write hit a transient SQLite file lock
+    /// (`SQLITE_BUSY` / `SQLITE_LOCKED`) after exhausting the local retry
+    /// budget. This is an expected local-contention condition (typically on
+    /// Windows when another process briefly holds a file lock) and the
+    /// scanner retries on the next tick, so Sentry has no immediate
+    /// remediation path.
+    ///
+    /// Anchored narrowly to the whatsapp ingest failure envelope plus the
+    /// SQLite lock text, so unrelated DB lock errors in other domains still
+    /// reach Sentry.
+    WhatsAppDataSqliteBusy,
     /// Host disk is full — the filesystem returned `ENOSPC` to a write,
     /// `mkdir`, or `open` syscall. The user cannot recover from this without
     /// freeing space on their machine, and Sentry has no remediation path
@@ -385,6 +396,9 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if is_memory_store_breaker_open(&lower) {
         return Some(ExpectedErrorKind::MemoryStoreBreakerOpen);
     }
+    if is_whatsapp_data_sqlite_busy_message(&lower) {
+        return Some(ExpectedErrorKind::WhatsAppDataSqliteBusy);
+    }
     if is_disk_full_message(&lower) {
         return Some(ExpectedErrorKind::DiskFull);
     }
@@ -423,6 +437,22 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
 ///   The text anchor already covers it.
 fn is_disk_full_message(lower: &str) -> bool {
     lower.contains("no space left on device") || lower.contains("not enough space on the disk")
+}
+
+/// Match whatsapp structured-ingest failures caused by transient SQLite lock
+/// contention. Keep this matcher scoped to the whatsapp ingest envelope so we
+/// don't demote unrelated database failures in other domains.
+fn is_whatsapp_data_sqlite_busy_message(lower: &str) -> bool {
+    if !lower.contains("[whatsapp_data] ingest failed:") {
+        return false;
+    }
+    if !lower.contains("upsert wa_message") {
+        return false;
+    }
+    lower.contains("database is locked")
+        || lower.contains("database table is locked")
+        || lower.contains("database file is locked")
+        || lower.contains("error code 5")
 }
 
 fn is_embedding_backend_auth_failure(lower: &str) -> bool {
@@ -1451,6 +1481,14 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 operation = operation,
                 kind = "memory_store_breaker_open",
                 "[observability] {domain}.{operation} skipped expected memory-store circuit-breaker-open error"
+            );
+        }
+        ExpectedErrorKind::WhatsAppDataSqliteBusy => {
+            tracing::warn!(
+                domain = domain,
+                operation = operation,
+                kind = "whatsapp_data_sqlite_busy",
+                "[observability] {domain}.{operation} skipped expected whatsapp_data sqlite busy/locked error"
             );
         }
         ExpectedErrorKind::FilesystemUserPathInvalid => {
@@ -2487,6 +2525,35 @@ mod tests {
             expected_error_kind("not enough memory to allocate buffer"),
             None
         );
+    }
+
+    #[test]
+    fn classifies_whatsapp_data_sqlite_busy_errors() {
+        for raw in [
+            r#"[whatsapp_data] ingest failed: upsert wa_message chat=120363402402350155@g.us msg=false_120363402402350155@g.us_3A357F28AE74548B1507_207897942335683@lid: database is locked: Error code 5: The database file is locked"#,
+            r#"rpc.invoke_method failed: [whatsapp_data] ingest failed: upsert wa_message [email] msg=false_120363402402350155@g.us_3A357F28AE74548B1507_207897942335683@lid: database is locked: Error code 5: The database file is locked"#,
+        ] {
+            assert_eq!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::WhatsAppDataSqliteBusy),
+                "should classify whatsapp_data sqlite busy/locked: {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_sqlite_lock_messages_as_whatsapp_busy() {
+        for raw in [
+            "failed to run subconscious schema DDL: database is locked",
+            "memory queue write failed: database table is locked",
+            "[whatsapp_data] list_messages failed: database is locked",
+        ] {
+            assert_ne!(
+                expected_error_kind(raw),
+                Some(ExpectedErrorKind::WhatsAppDataSqliteBusy),
+                "must not classify as whatsapp_data sqlite busy: {raw}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION

## Summary

- Added `ExpectedErrorKind::WhatsAppDataSqliteBusy` for WhatsApp ingest lock-contention errors.

- Added a narrow classifier that matches only the WhatsApp ingest envelope (`[whatsapp_data] ingest failed` + `upsert wa_message`) with SQLite lock markers.

- Wired the new error kind into expected-error reporting so this known transient condition is demoted from Sentry error events.

- Added unit tests for both positive and negative cases to protect classification boundaries.

- Kept behavior unchanged for non-WhatsApp and non-ingest SQLite lock failures to avoid over-demotion.

## Problem

- Sentry issue TAURI-RUST-BH reports repeated errors from `openhumman.whatsapp_data_ingest` with `database is locked` / `Error code 5`.

- The WhatsApp write path already has retries and busy timeout, but longer-lived external file locks can still exceed retry windows.

- These events are expected transient local-contention conditions and currently create alert noise without actionable remediation.

## Solution

- Added a new expected-error kind specific to WhatsApp ingest SQLite busy/locked failures.

- Implemented strict message matching to avoid demoting unrelated lock errors:

- Requires WhatsApp ingest failure prefix.

- Requires `upsert wa_message` context.

- Requires SQLite lock indicators (`database is locked`, `database table is locked`, `database file is locked`, or `error code 5`).

- Routed this kind through observability expected-error handling (warn breadcrumb, no Sentry error event).

- Added tests covering:

- Canonical and wrapped WhatsApp ingest lock messages.

- Negative cases from other SQLite lock domains to prevent false positives.

## Submission Checklist

If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.

* Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
* Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
* Coverage matrix updated — added/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md` reflect this change (or N/A: behaviour-only change)

N/A: behaviour-only observability classification change.

* All affected feature IDs from the matrix are listed in the PR description under ## Related

N/A: no feature-row change.

* No new external network dependencies introduced (mock backend used per Testing Strategy)
* Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`)

N/A: no release-cut UI/runtime surface changes.

* Linked issue closed via Closes #NNN in the ## Related section

N/A: tracked via Sentry issue (no linked GitHub issue in this PR).

## Impact

- Runtime/platform: Rust core observability path only; impacts desktop telemetry classification.

- Performance: negligible string-match checks in error classification path.

- Security/privacy: reduces unnecessary Sentry error noise for known local contention cases.

- Compatibility: no API/schema/data-model changes; no migration required; no breaking changes expected.

## Related

Closes: [TAURI-RUST-BH](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/487/?project=4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp data synchronization by better managing transient database lock errors to prevent unnecessary error alerts while maintaining proper logging and monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->