### PR TITLE
fix(agent): replay reasoning_content across native tool-call turns to prevent DeepSeek 400s

### DIFF
--- a/src/openhuman/agent/dispatcher.rs
+++ b/src/openhuman/agent/dispatcher.rs
@@ -555,11 +555,13 @@ impl ToolDispatcher for NativeToolDispatcher {
                     tool_calls,
                     reasoning_content,
                 } => {
-                    let payload = serde_json::json!({
+                    let mut payload = serde_json::json!({
                         "content": text,
                         "tool_calls": tool_calls,
-                        "reasoning_content": reasoning_content,
                     });
+                    if let Some(rc) = reasoning_content {
+                        payload["reasoning_content"] = serde_json::Value::String(rc.clone());
+                    }
                     vec![ChatMessage::assistant(payload.to_string())]
                 }
                 ConversationMessage::ToolResults(results) => results

--- a/src/openhuman/agent/dispatcher.rs
+++ b/src/openhuman/agent/dispatcher.rs
@@ -550,10 +550,15 @@ impl ToolDispatcher for NativeToolDispatcher {
             .into_iter()
             .flat_map(|i| match &history[i] {
                 ConversationMessage::Chat(chat) => vec![chat.clone()],
-                ConversationMessage::AssistantToolCalls { text, tool_calls } => {
+                ConversationMessage::AssistantToolCalls {
+                    text,
+                    tool_calls,
+                    reasoning_content,
+                } => {
                     let payload = serde_json::json!({
                         "content": text,
                         "tool_calls": tool_calls,
+                        "reasoning_content": reasoning_content,
                     });
                     vec![ChatMessage::assistant(payload.to_string())]
                 }

--- a/src/openhuman/agent/dispatcher_tests.rs
+++ b/src/openhuman/agent/dispatcher_tests.rs
@@ -269,6 +269,7 @@ fn assistant_tool_calls(id: &str) -> ConversationMessage {
             name: "shell".into(),
             arguments: "{}".into(),
         }],
+        reasoning_content: None,
     }
 }
 
@@ -398,7 +399,38 @@ fn assistant_tool_calls_multi(ids: &[&str]) -> ConversationMessage {
                 arguments: "{}".into(),
             })
             .collect(),
+        reasoning_content: None,
     }
+}
+
+#[test]
+fn native_dispatcher_serializes_reasoning_content_for_tool_call_turns() {
+    let dispatcher = NativeToolDispatcher;
+    let history = vec![
+        ConversationMessage::AssistantToolCalls {
+            text: Some("calling tools".into()),
+            tool_calls: vec![crate::openhuman::inference::provider::ToolCall {
+                id: "tc-1".into(),
+                name: "shell".into(),
+                arguments: "{}".into(),
+            }],
+            reasoning_content: Some("chain-of-thought replay blob".into()),
+        },
+        tool_results("tc-1"),
+    ];
+
+    let out = dispatcher.to_provider_messages(&history);
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].role, "assistant");
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&out[0].content).expect("assistant payload should be valid JSON");
+    assert_eq!(
+        payload
+            .get("reasoning_content")
+            .and_then(serde_json::Value::as_str),
+        Some("chain-of-thought replay blob")
+    );
 }
 
 fn tool_results_multi(ids: &[&str]) -> ConversationMessage {

--- a/src/openhuman/agent/dispatcher_tests.rs
+++ b/src/openhuman/agent/dispatcher_tests.rs
@@ -433,6 +433,23 @@ fn native_dispatcher_serializes_reasoning_content_for_tool_call_turns() {
     );
 }
 
+#[test]
+fn native_dispatcher_omits_reasoning_content_when_absent() {
+    let dispatcher = NativeToolDispatcher;
+    let history = vec![assistant_tool_calls("tc-1"), tool_results("tc-1")];
+
+    let out = dispatcher.to_provider_messages(&history);
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].role, "assistant");
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&out[0].content).expect("assistant payload should be valid JSON");
+    assert!(
+        payload.get("reasoning_content").is_none(),
+        "reasoning_content should be omitted when absent"
+    );
+}
+
 fn tool_results_multi(ids: &[&str]) -> ConversationMessage {
     use crate::openhuman::inference::provider::ToolResultMessage;
     ConversationMessage::ToolResults(

--- a/src/openhuman/agent/harness/session/runtime_tests.rs
+++ b/src/openhuman/agent/harness/session/runtime_tests.rs
@@ -137,10 +137,12 @@ fn sanitizers_and_tool_call_helpers_cover_fallback_paths() {
         ConversationMessage::AssistantToolCalls {
             text: None,
             tool_calls: vec![],
+            reasoning_content: None,
         },
         ConversationMessage::AssistantToolCalls {
             text: None,
             tool_calls: vec![],
+            reasoning_content: None,
         },
     ];
     assert_eq!(Agent::count_iterations(&history), 3);

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -1016,6 +1016,12 @@ impl Agent {
                         Some(text.clone())
                     },
                     tool_calls: persisted_tool_calls,
+                    reasoning_content: response
+                        .reasoning_content
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(ToString::to_string),
                 });
 
                 // Persist the transcript **right after** the provider

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -391,6 +391,7 @@ fn trim_history_snaps_past_orphaned_tool_results() {
                 name: "shell".into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: None,
         },
         // ...orphaning this result at the head of the kept window.
         ConversationMessage::ToolResults(vec![ToolResultMessage {
@@ -799,7 +800,9 @@ async fn turn_runs_full_tool_cycle_with_context_and_hooks() {
     assert!(agent.last_memory_context.as_deref() == Some("[Injected]\n"));
     assert!(agent.history.iter().any(|message| matches!(
         message,
-        ConversationMessage::AssistantToolCalls { text, tool_calls }
+        ConversationMessage::AssistantToolCalls {
+            text, tool_calls, ..
+        }
             if text.as_deref().is_some_and(|value| value.contains("preface")) && tool_calls.len() == 1
     )));
     assert!(agent.history.iter().any(|message| matches!(

--- a/src/openhuman/agent/harness/token_budget.rs
+++ b/src/openhuman/agent/harness/token_budget.rs
@@ -33,7 +33,9 @@ pub fn estimate_chat_message_tokens(msg: &ChatMessage) -> usize {
 pub fn estimate_conversation_message_tokens(msg: &ConversationMessage) -> usize {
     match msg {
         ConversationMessage::Chat(chat) => estimate_chat_message_tokens(chat),
-        ConversationMessage::AssistantToolCalls { text, tool_calls } => {
+        ConversationMessage::AssistantToolCalls {
+            text, tool_calls, ..
+        } => {
             let body = text.as_deref().unwrap_or_default();
             let mut total = estimate_tokens(body);
             for call in tool_calls {
@@ -240,6 +242,7 @@ mod tests {
                 name: "echo".into(),
                 arguments: "{\"value\":\"x\"}".into(),
             }],
+            reasoning_content: None,
         };
         assert!(estimate_conversation_message_tokens(&msg) > 0);
     }

--- a/src/openhuman/agent/harness/token_budget.rs
+++ b/src/openhuman/agent/harness/token_budget.rs
@@ -34,10 +34,15 @@ pub fn estimate_conversation_message_tokens(msg: &ConversationMessage) -> usize 
     match msg {
         ConversationMessage::Chat(chat) => estimate_chat_message_tokens(chat),
         ConversationMessage::AssistantToolCalls {
-            text, tool_calls, ..
+            text,
+            tool_calls,
+            reasoning_content,
         } => {
             let body = text.as_deref().unwrap_or_default();
             let mut total = estimate_tokens(body);
+            if let Some(reasoning) = reasoning_content.as_deref() {
+                total = total.saturating_add(estimate_tokens(reasoning));
+            }
             for call in tool_calls {
                 total = total.saturating_add(estimate_tokens(&call.name));
                 total = total.saturating_add(estimate_tokens(&call.arguments));

--- a/src/openhuman/agent/tests.rs
+++ b/src/openhuman/agent/tests.rs
@@ -1177,6 +1177,7 @@ fn conversation_message_serialization_roundtrip() {
                 name: "shell".into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: Some("thinking".into()),
         },
         ConversationMessage::ToolResults(vec![ToolResultMessage {
             tool_call_id: "tc1".into(),
@@ -1199,14 +1200,17 @@ fn conversation_message_serialization_roundtrip() {
                 ConversationMessage::AssistantToolCalls {
                     text: a_text,
                     tool_calls: a_calls,
+                    reasoning_content: a_reasoning,
                 },
                 ConversationMessage::AssistantToolCalls {
                     text: b_text,
                     tool_calls: b_calls,
+                    reasoning_content: b_reasoning,
                 },
             ) => {
                 assert_eq!(a_text, b_text);
                 assert_eq!(a_calls.len(), b_calls.len());
+                assert_eq!(a_reasoning, b_reasoning);
             }
             (ConversationMessage::ToolResults(a), ConversationMessage::ToolResults(b)) => {
                 assert_eq!(a.len(), b.len());
@@ -1299,6 +1303,7 @@ fn xml_dispatcher_converts_history_to_provider_messages() {
                 name: "shell".into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: None,
         },
         ConversationMessage::ToolResults(vec![ToolResultMessage {
             tool_call_id: "tc1".into(),
@@ -1339,6 +1344,7 @@ fn native_dispatcher_converts_tool_results_to_tool_messages() {
                     arguments: "{}".into(),
                 },
             ],
+            reasoning_content: None,
         },
         ConversationMessage::ToolResults(vec![
             ToolResultMessage {

--- a/src/openhuman/context/manager_tests.rs
+++ b/src/openhuman/context/manager_tests.rs
@@ -15,6 +15,7 @@ fn call(id: &str) -> ConversationMessage {
             name: "t".into(),
             arguments: "{}".into(),
         }],
+        reasoning_content: None,
     }
 }
 

--- a/src/openhuman/context/microcompact.rs
+++ b/src/openhuman/context/microcompact.rs
@@ -116,6 +116,7 @@ mod tests {
                 name: name.into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: None,
         }
     }
 

--- a/src/openhuman/context/pipeline.rs
+++ b/src/openhuman/context/pipeline.rs
@@ -270,6 +270,7 @@ mod tests {
                 name: "t".into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: None,
         }
     }
 

--- a/src/openhuman/context/segment_recap_summarizer.rs
+++ b/src/openhuman/context/segment_recap_summarizer.rs
@@ -208,7 +208,9 @@ impl Summarizer for SegmentRecapSummarizer {
 fn conversation_message_approx_bytes(msg: &ConversationMessage) -> usize {
     match msg {
         ConversationMessage::Chat(m) => m.content.len(),
-        ConversationMessage::AssistantToolCalls { text, tool_calls } => {
+        ConversationMessage::AssistantToolCalls {
+            text, tool_calls, ..
+        } => {
             text.as_deref().map_or(0, str::len)
                 + tool_calls
                     .iter()

--- a/src/openhuman/context/summarizer.rs
+++ b/src/openhuman/context/summarizer.rs
@@ -288,7 +288,9 @@ fn render_transcript(msgs: &[ConversationMessage]) -> String {
             ConversationMessage::Chat(m) => {
                 let _ = writeln!(&mut out, "[{i}] {}: {}", m.role, m.content);
             }
-            ConversationMessage::AssistantToolCalls { text, tool_calls } => {
+            ConversationMessage::AssistantToolCalls {
+                text, tool_calls, ..
+            } => {
                 if let Some(t) = text.as_deref() {
                     if !t.is_empty() {
                         let _ = writeln!(&mut out, "[{i}] assistant: {t}");

--- a/src/openhuman/context/summarizer_tests.rs
+++ b/src/openhuman/context/summarizer_tests.rs
@@ -19,6 +19,7 @@ fn call(id: &str) -> ConversationMessage {
             name: "t".into(),
             arguments: "{}".into(),
         }],
+        reasoning_content: None,
     }
 }
 
@@ -217,6 +218,7 @@ fn transcript_renders_all_message_variants() {
                 name: "shell".into(),
                 arguments: r#"{"cmd":"ls"}"#.into(),
             }],
+            reasoning_content: None,
         },
         result("1", "file.txt"),
     ];

--- a/src/openhuman/inference/provider/traits.rs
+++ b/src/openhuman/inference/provider/traits.rs
@@ -169,6 +169,8 @@ pub enum ConversationMessage {
     AssistantToolCalls {
         text: Option<String>,
         tool_calls: Vec<ToolCall>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reasoning_content: Option<String>,
     },
     /// Results of tool executions, fed back to the LLM.
     ToolResults(Vec<ToolResultMessage>),


### PR DESCRIPTION
# Summary

- Persisted assistant reasoning_content on ConversationMessage::AssistantToolCalls so thinking-mode context survives tool-call turns.
- Updated native dispatcher serialization to include reasoning_content in assistant tool-call payloads sent back to providers.
- Patched agent session turn flow to capture and store non-empty reasoning_content when persisting assistant tool-call intents.
- Added a targeted regression test to verify reasoning_content is preserved in native tool-call history replay.
- Updated affected test fixtures/constructors for the new optional field to keep behavior backward-compatible.

# Problem

- Sentry issue TAURI-RUST-4K9 reports repeated DeepSeek 400 failures: The reasoning_content in the thinking mode must be passed back to the API.
- In multi-turn/native tool-call flows, reasoning output could be dropped before follow-up provider calls, causing request rejection.
- This resulted in high error volume and degraded reliability for thinking-capable providers.

# Solution

- Extended ConversationMessage::AssistantToolCalls with optional reasoning_content (serde-defaulted for compatibility with existing persisted transcripts).
- In agent turn execution, when assistant returns tool calls, capture trimmed non-empty response.reasoning_content and persist it alongside tool-call history.
- In NativeToolDispatcher::to_provider_messages, include reasoning_content in serialized assistant tool-call payload JSON so provider replay contract is satisfied.
- Preserved existing TAURI-RUST-7 pairing safeguards (unpaired tool-call cycles are still dropped), and adapted regression testing to valid paired cycles.
- Tradeoff: slightly larger serialized assistant tool-call payloads, but only when thinking content exists.

# Submission Checklist

If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.

- Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- Diff coverage ≥ 80% — changed lines (Vitest + cargo-llvm-cov merged via diff-cover) meet the gate enforced by `.github/workflows/coverage.yml`. Run pnpm test:coverage and pnpm test:rust locally; PRs below 80% on changed lines will not merge.
- Coverage matrix updated — added/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md` reflect this change (or N/A: behaviour-only change)
- All affected feature IDs from the matrix are listed in the PR description under ## Related
- No new external network dependencies introduced (mock backend used per Testing Strategy)
- Manual smoke checklist updated if this touches release-cut surfaces (`docs/RELEASE-MANUAL-SMOKE.md`)
- Linked issue closed via Closes #NNN in the ## Related section

# Impact

- Runtime/platform: Rust core + Tauri desktop inference path; affects native tool-calling providers in multi-turn sessions.
- Compatibility: backward-compatible transcript/history schema change (reasoning_content is optional + serde default).
- Performance: negligible overhead (small optional metadata field/payload extension).
- Security: no new permissions, secrets, or network surfaces introduced.

# Related 

- Closes : [TAURI-RUST-4K9](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5234/?project=4&query=assigned%3Anone%20is%3Aunresolved&referrer=issue-stream&sort=freq) and [TAURI-RUST-4KA](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5235/?project=4&referrer=issue-list&statsPeriod=14d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation messages now optionally capture and propagate model "reasoning content" alongside tool-call results; this is included in outgoing payloads when present and omitted when absent.
  * Token estimation and transcript/history reconstruction include reasoning content when available.

* **Testing**
  * Added and updated tests to verify serialization, preservation in history, omission when absent, and related handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->