### PR TITLE
feat(intelligence): add Predicate Bundles (per-pair predicate multiplicity)

### DIFF
--- a/app/src/components/intelligence/PredicateBundlesPanel.test.tsx
+++ b/app/src/components/intelligence/PredicateBundlesPanel.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { computePredicateBundles } from '../../lib/memory/predicateBundles';
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import PredicateBundlesPanel from './PredicateBundlesPanel';
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'n',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+// 1 thick pair (A-B: 3 predicates × 1 dup) + 1 thin pair (C-D) + duplicate C-D
+const mixed = computePredicateBundles([
+  rel('A', 'knows', 'B'),
+  rel('A', 'trusts', 'B'),
+  rel('A', 'mentors', 'B'),
+  rel('C', 'knows', 'D'),
+  rel('C', 'knows', 'D'), // dup of thin pair
+]);
+
+describe('<PredicateBundlesPanel />', () => {
+  it('renders the loading skeleton', () => {
+    render(<PredicateBundlesPanel result={null} loading />);
+    expect(screen.getByTestId('predicate-bundles-loading')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no bundles', () => {
+    render(<PredicateBundlesPanel result={computePredicateBundles([])} />);
+    expect(screen.getByText('No knowledge graph yet.')).toBeInTheDocument();
+  });
+
+  it('renders an error with a working retry button', () => {
+    const onRetry = vi.fn();
+    render(<PredicateBundlesPanel result={null} error="graph unavailable" onRetry={onRetry} />);
+    expect(screen.getByRole('alert').textContent).toMatch(/graph unavailable/);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders metric tiles, the summary caption, and the ranked bundle list with predicate chips', () => {
+    render(<PredicateBundlesPanel result={mixed} />);
+    expect(screen.getByText('Distinct pairs')).toBeInTheDocument();
+    expect(screen.getByText('Thick relationships')).toBeInTheDocument();
+    expect(screen.getByText('Max thickness')).toBeInTheDocument();
+    expect(screen.getByText('Top bundles')).toBeInTheDocument();
+    // 5 relations across 2 pairs -> fully-plural caption variant.
+    expect(screen.getByText('5 relations across 2 pairs')).toBeInTheDocument();
+    // thick pair's predicate chips render alphabetically. 'knows' appears in
+    // both bundles (A->B thick, C->D thin) so use getAllByText for it.
+    expect(screen.getAllByText('knows')).toHaveLength(2);
+    expect(screen.getByText('trusts')).toBeInTheDocument();
+    expect(screen.getByText('mentors')).toBeInTheDocument();
+    // thin pair's totalRelations count badge "2×" appears.
+    expect(screen.getByText('2×')).toBeInTheDocument();
+  });
+
+  it('uses an all-singular caption when there is exactly 1 relation in 1 pair', () => {
+    const single = computePredicateBundles([rel('A', 'knows', 'B')]);
+    render(<PredicateBundlesPanel result={single} />);
+    expect(screen.getByText('1 relation across 1 pair')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/intelligence/PredicateBundlesPanel.tsx
+++ b/app/src/components/intelligence/PredicateBundlesPanel.tsx
@@ -1,0 +1,176 @@
+/**
+ * Predicate Bundles — presentational view. Pure: renders the bundle summary
+ * tiles (distinct pairs / thick pairs / max thickness) and the ranked bundle
+ * list with predicate chips. No data fetching, no clock, no randomness.
+ */
+import { useT } from '../../lib/i18n/I18nContext';
+import type { BundleResult } from '../../lib/memory/predicateBundles';
+
+const MAX_ROWS = 25;
+
+interface PredicateBundlesPanelProps {
+  result: BundleResult | null;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+}
+
+const PredicateBundlesPanel = ({ result, loading, error, onRetry }: PredicateBundlesPanelProps) => {
+  const { t } = useT();
+
+  const intro = (
+    <div
+      role="note"
+      className="rounded-lg border border-primary-200 dark:border-primary-500/30 bg-primary-50 dark:bg-primary-500/10 px-3 py-2 text-xs text-stone-700 dark:text-neutral-200">
+      <p className="font-medium mb-1">{t('predicateBundles.title')}</p>
+      <p>{t('predicateBundles.intro')}</p>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {intro}
+        <div
+          className="space-y-3"
+          role="status"
+          aria-label={t('predicateBundles.loading')}
+          data-testid="predicate-bundles-loading">
+          <div className="grid gap-2 sm:grid-cols-3">
+            {[0, 1, 2].map(i => (
+              <div
+                key={i}
+                className="animate-pulse rounded-lg border border-stone-200 dark:border-neutral-800 bg-stone-50 dark:bg-neutral-800/60 h-16"
+              />
+            ))}
+          </div>
+          {[0, 1, 2, 3].map(i => (
+            <div
+              key={i}
+              className="animate-pulse rounded-lg border border-stone-200 dark:border-neutral-800 bg-stone-50 dark:bg-neutral-800/60 h-8"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        {intro}
+        <div className="rounded-lg border border-coral-200 dark:border-coral-500/30 p-4 text-center">
+          <p role="alert" className="text-xs text-coral-700 dark:text-coral-300">
+            {t('predicateBundles.errorPrefix')} {error}
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-2 rounded-lg bg-primary-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-primary-600">
+              {t('predicateBundles.retry')}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (!result || result.bundles.length === 0) {
+    return (
+      <div className="space-y-4">
+        {intro}
+        <div className="py-8 text-center">
+          <h3 className="text-sm font-semibold text-stone-700 dark:text-neutral-200">
+            {t('predicateBundles.empty')}
+          </h3>
+          <p className="mt-1 text-xs text-stone-500 dark:text-neutral-400">
+            {t('predicateBundles.emptyHint')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const rows = result.bundles.slice(0, MAX_ROWS);
+  const onePair = result.pairCount === 1;
+  const oneRelation = result.totalRelations === 1;
+  const summaryCaption = oneRelation
+    ? onePair
+      ? t('predicateBundles.summaryCaptionOneEach')
+      : t('predicateBundles.summaryCaptionOneRelation').replace('{pairs}', String(result.pairCount))
+    : onePair
+      ? t('predicateBundles.summaryCaptionOnePair').replace(
+          '{relations}',
+          String(result.totalRelations)
+        )
+      : t('predicateBundles.summaryCaption')
+          .replace('{relations}', String(result.totalRelations))
+          .replace('{pairs}', String(result.pairCount));
+
+  return (
+    <div className="space-y-4">
+      {intro}
+
+      {/* Metric tiles */}
+      <div className="grid gap-2 sm:grid-cols-3">
+        {[
+          { label: t('predicateBundles.metricPairs'), value: result.pairCount },
+          { label: t('predicateBundles.metricThick'), value: result.multiPredicatePairCount },
+          { label: t('predicateBundles.metricMaxThickness'), value: result.maxPredicateCount },
+        ].map(tile => (
+          <div
+            key={tile.label}
+            className="rounded-lg border border-stone-200 dark:border-neutral-800 p-3">
+            <div className="text-[10px] uppercase tracking-wider text-stone-400 dark:text-neutral-500">
+              {tile.label}
+            </div>
+            <div className="text-lg font-semibold tabular-nums text-stone-900 dark:text-neutral-100">
+              {tile.value}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-[11px] text-stone-500 dark:text-neutral-400">{summaryCaption}</p>
+
+      {/* Ranked bundle list */}
+      <section aria-labelledby="predicate-bundles-heading" className="space-y-1">
+        <h3
+          id="predicate-bundles-heading"
+          className="text-xs font-semibold uppercase tracking-wider text-stone-500 dark:text-neutral-400">
+          {t('predicateBundles.rankedHeading')}
+        </h3>
+        <ul className="space-y-2">
+          {rows.map((row, i) => (
+            <li
+              key={JSON.stringify([row.subject, row.object])}
+              className="border-t border-stone-100 dark:border-neutral-800/60 pt-2 text-[11px] text-stone-700 dark:text-neutral-200">
+              <div className="flex items-center gap-2">
+                <span className="w-6 shrink-0 text-stone-400 dark:text-neutral-500 tabular-nums">
+                  {i + 1}
+                </span>
+                <span className="font-medium break-words">{row.subject}</span>
+                <span className="text-stone-400 dark:text-neutral-500">→</span>
+                <span className="font-medium break-words">{row.object}</span>
+                <span className="ml-auto text-[10px] tabular-nums text-stone-500 dark:text-neutral-400">
+                  {row.totalRelations}×
+                </span>
+              </div>
+              <div className="mt-1 ml-8 flex flex-wrap gap-1">
+                {row.predicates.map(predicate => (
+                  <span
+                    key={predicate}
+                    className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] bg-stone-100 dark:bg-neutral-800 text-stone-700 dark:text-neutral-200">
+                    {predicate}
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default PredicateBundlesPanel;

--- a/app/src/components/intelligence/PredicateBundlesTab.test.tsx
+++ b/app/src/components/intelligence/PredicateBundlesTab.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { computePredicateBundles } from '../../lib/memory/predicateBundles';
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import PredicateBundlesTab from './PredicateBundlesTab';
+
+const mockLoadBundles = vi.fn();
+const mockLoadNamespaces = vi.fn();
+
+vi.mock('../../services/api/predicateBundlesApi', () => ({
+  loadBundles: (...args: unknown[]) => mockLoadBundles(...args),
+  loadNamespaces: (...args: unknown[]) => mockLoadNamespaces(...args),
+}));
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'n',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+const result = computePredicateBundles([rel('A', 'knows', 'B'), rel('A', 'trusts', 'B')]);
+
+describe('<PredicateBundlesTab />', () => {
+  beforeEach(() => {
+    mockLoadBundles.mockReset();
+    mockLoadNamespaces.mockReset();
+    mockLoadBundles.mockResolvedValue(result);
+    mockLoadNamespaces.mockResolvedValue([]);
+  });
+
+  it('loads bundles (all namespaces) on mount and renders the result', async () => {
+    render(<PredicateBundlesTab />);
+    expect(mockLoadBundles).toHaveBeenCalledWith(undefined);
+    await waitFor(() => expect(screen.getByText('Top bundles')).toBeInTheDocument());
+  });
+
+  it('shows the namespace selector and re-queries on change', async () => {
+    mockLoadNamespaces.mockResolvedValueOnce(['work', 'personal']);
+    render(<PredicateBundlesTab />);
+    await waitFor(() => screen.getByRole('combobox'));
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'work' } });
+    await waitFor(() => expect(mockLoadBundles).toHaveBeenCalledWith('work'));
+  });
+
+  it('surfaces an error when the load fails', async () => {
+    mockLoadBundles.mockReset();
+    mockLoadBundles.mockRejectedValueOnce(new Error('graph unavailable'));
+    render(<PredicateBundlesTab />);
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toMatch(/graph unavailable/));
+  });
+});

--- a/app/src/components/intelligence/PredicateBundlesTab.tsx
+++ b/app/src/components/intelligence/PredicateBundlesTab.tsx
@@ -1,0 +1,83 @@
+/**
+ * Predicate Bundles tab (container). Owns load-on-mount and the namespace
+ * selector; delegates all rendering to the pure <PredicateBundlesPanel>.
+ * Read-only — the result is recomputed from the live graph, never persisted.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useT } from '../../lib/i18n/I18nContext';
+import type { BundleResult } from '../../lib/memory/predicateBundles';
+import { loadBundles, loadNamespaces } from '../../services/api/predicateBundlesApi';
+import PredicateBundlesPanel from './PredicateBundlesPanel';
+
+const PredicateBundlesTab = () => {
+  const { t } = useT();
+  const [result, setResult] = useState<BundleResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [namespaces, setNamespaces] = useState<string[]>([]);
+  const [namespace, setNamespace] = useState('');
+  // Monotonic token: ignore a response if a newer load has since started, so
+  // an out-of-order resolution can never overwrite the latest result.
+  const latestRequestId = useRef(0);
+
+  const load = useCallback(async (ns: string) => {
+    const requestId = (latestRequestId.current += 1);
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await loadBundles(ns || undefined);
+      if (requestId !== latestRequestId.current) return;
+      setResult(next);
+    } catch (err) {
+      if (requestId !== latestRequestId.current) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (requestId === latestRequestId.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Namespaces are optional UI sugar; a failure to list them must not block
+    // the bundles view, so swallow that error specifically.
+    loadNamespaces()
+      .then(setNamespaces)
+      .catch(() => setNamespaces([]));
+    void load('');
+  }, [load]);
+
+  const handleNamespace = (next: string): void => {
+    setNamespace(next);
+    void load(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      {namespaces.length > 0 && (
+        <label className="flex items-center gap-2 text-xs text-stone-600 dark:text-neutral-300">
+          {t('predicateBundles.namespaceLabel')}
+          <select
+            value={namespace}
+            onChange={e => handleNamespace(e.target.value)}
+            className="rounded-lg border border-stone-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-sm text-stone-800 dark:text-neutral-100">
+            <option value="">{t('predicateBundles.namespaceAll')}</option>
+            {namespaces.map(ns => (
+              <option key={ns} value={ns}>
+                {ns}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <PredicateBundlesPanel
+        result={result}
+        loading={loading}
+        error={error}
+        onRetry={() => void load(namespace)}
+      />
+    </div>
+  );
+};
+
+export default PredicateBundlesTab;

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -4350,6 +4350,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'رفض التخزين المحلي',
   'pages.settings.account.security': 'الأمان',
   'pages.settings.account.securityDesc': 'وضع تخزين الأسرار وحالة سلسلة المفاتيح',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'لا يوجد رسم معرفة بعد.',
+  'predicateBundles.emptyHint':
+    'كلما سجّل المساعد علاقات عنك، ستظهر هنا الأزواج الكثيفة (متعددة المسندات).',
+  'predicateBundles.errorPrefix': 'تعذّر تحميل الرسم البياني:',
+  'predicateBundles.intro':
+    'لكل زوج كيانات مرتّب: كم عدد المسندات المتمايزة التي تربطه؟ زوج يربطه مسند واحد علاقة رقيقة؛ زوج يربطه ثلاثة أو أربعة مسندات علاقة كثيفة — كيانان مرتبطان بشكل ذي معنى بأكثر من طريقة. لا تكشف لا تكرارات المسند ولا تداخل الجوار عن ذلك.',
+  'predicateBundles.loading': 'يجري حساب كثافة العلاقات…',
+  'predicateBundles.metricMaxThickness': 'أقصى كثافة',
+  'predicateBundles.metricPairs': 'أزواج متمايزة',
+  'predicateBundles.metricThick': 'علاقات كثيفة',
+  'predicateBundles.namespaceAll': 'كل مساحات الأسماء',
+  'predicateBundles.namespaceLabel': 'مساحة الأسماء',
+  'predicateBundles.rankedHeading': 'أعلى الحزم',
+  'predicateBundles.retry': 'إعادة المحاولة',
+  'predicateBundles.summaryCaption': '{relations} علاقات عبر {pairs} أزواج',
+  'predicateBundles.summaryCaptionOneEach': 'علاقة واحدة عبر زوج واحد',
+  'predicateBundles.summaryCaptionOnePair': '{relations} علاقات عبر زوج واحد',
+  'predicateBundles.summaryCaptionOneRelation': 'علاقة واحدة عبر {pairs} أزواج',
+  'predicateBundles.title': 'حزم المسندات',
 };
 
 export default messages;

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -4427,6 +4427,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'স্থানীয় সঞ্চয়স্থান প্রত্যাখ্যান করুন',
   'pages.settings.account.security': 'নিরাপত্তা',
   'pages.settings.account.securityDesc': 'গোপনীয়তা সঞ্চয়স্থান মোড এবং কিচেন অবস্থা',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'এখনও কোনো জ্ঞান গ্রাফ নেই।',
+  'predicateBundles.emptyHint':
+    'সহকারী যখন আপনার সম্পর্কে সম্পর্কগুলো রেকর্ড করে, ঘন (বহু-বিধেয়) জোড়াগুলো এখানে উঠে আসবে।',
+  'predicateBundles.errorPrefix': 'গ্রাফ লোড করা যায়নি:',
+  'predicateBundles.intro':
+    'প্রতিটি ক্রমিক সত্তা-জোড়ার জন্য, কতগুলো ভিন্ন বিধেয় তাদের যুক্ত করে? একটিমাত্র বিধেয়ে বাঁধা জোড়া হলো পাতলা সম্পর্ক; তিন বা চারটি বিধেয়ে বাঁধা জোড়া হলো ঘন সম্পর্ক — দুটি সত্তা একাধিক উপায়ে অর্থপূর্ণভাবে সংযুক্ত। প্রতি-বিধেয় ফ্রিকোয়েন্সি বা প্রতিবেশ ওভারল্যাপ কোনটিই এটি উন্মোচন করে না।',
+  'predicateBundles.loading': 'সম্পর্কের ঘনত্ব গণনা করা হচ্ছে…',
+  'predicateBundles.metricMaxThickness': 'সর্বোচ্চ ঘনত্ব',
+  'predicateBundles.metricPairs': 'স্বতন্ত্র জোড়া',
+  'predicateBundles.metricThick': 'ঘন সম্পর্ক',
+  'predicateBundles.namespaceAll': 'সমস্ত নেমস্পেস',
+  'predicateBundles.namespaceLabel': 'নেমস্পেস',
+  'predicateBundles.rankedHeading': 'শীর্ষ বান্ডিল',
+  'predicateBundles.retry': 'পুনরায় চেষ্টা',
+  'predicateBundles.summaryCaption': '{pairs}টি জোড়ায় {relations}টি সম্পর্ক',
+  'predicateBundles.summaryCaptionOneEach': '১টি জোড়ায় ১টি সম্পর্ক',
+  'predicateBundles.summaryCaptionOnePair': '১টি জোড়ায় {relations}টি সম্পর্ক',
+  'predicateBundles.summaryCaptionOneRelation': '{pairs}টি জোড়ায় ১টি সম্পর্ক',
+  'predicateBundles.title': 'বিধেয় বান্ডিল',
 };
 
 export default messages;

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -4543,6 +4543,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Lokalen Speicher ablehnen',
   'pages.settings.account.security': 'Sicherheit',
   'pages.settings.account.securityDesc': 'Geheimnisspeicher-Modus und Schlüsselbund-Status',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Noch kein Wissensgraph.',
+  'predicateBundles.emptyHint':
+    'Während der Assistent Relationen über Sie erfasst, erscheinen hier dichte (mehrfach-prädikative) Paare.',
+  'predicateBundles.errorPrefix': 'Graph konnte nicht geladen werden:',
+  'predicateBundles.intro':
+    'Pro geordnetem Entitätspaar: wie viele verschiedene Prädikate verbinden sie? Ein Paar mit nur einem Prädikat ist eine dünne Beziehung; ein Paar mit drei oder vier Prädikaten ist eine DICHTE Beziehung — zwei Entitäten, die auf mehr als eine Weise sinnvoll verbunden sind. Weder Prädikat-Häufigkeit noch Nachbarschaftsüberlappung deckt das auf.',
+  'predicateBundles.loading': 'Berechne Beziehungsdichte…',
+  'predicateBundles.metricMaxThickness': 'Maximale Dichte',
+  'predicateBundles.metricPairs': 'Verschiedene Paare',
+  'predicateBundles.metricThick': 'Dichte Beziehungen',
+  'predicateBundles.namespaceAll': 'Alle Namensräume',
+  'predicateBundles.namespaceLabel': 'Namensraum',
+  'predicateBundles.rankedHeading': 'Top-Bündel',
+  'predicateBundles.retry': 'Wiederholen',
+  'predicateBundles.summaryCaption': '{relations} Relationen über {pairs} Paare',
+  'predicateBundles.summaryCaptionOneEach': '1 Relation über 1 Paar',
+  'predicateBundles.summaryCaptionOnePair': '{relations} Relationen über 1 Paar',
+  'predicateBundles.summaryCaptionOneRelation': '1 Relation über {pairs} Paare',
+  'predicateBundles.title': 'Prädikat-Bündel',
 };
 
 export default messages;

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -2521,7 +2521,7 @@ const en: TranslationMap = {
   'app.openhumanLink.notifications.send': 'Send test notification',
   'app.openhumanLink.notifications.sendFailed': "Couldn't send: {error}",
   'app.openhumanLink.notifications.sent':
-    "Test notification sent. If you didn't receive it, go to System Settings → Notifications → OpenHuman, turn on Allow Notifications, and set Banner Style to Persistent.",
+    'Test notification sent. If you didn’t receive it, go to System Settings → Notifications → OpenHuman, turn on Allow Notifications, and set Banner Style to Persistent.',
   'app.openhumanLink.skipForNow': 'Skip for now',
   'app.openhumanLink.telegramUnavailable': 'Telegram unavailable',
   'app.openhumanLink.title.accounts': 'Connect your apps',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -307,6 +307,7 @@ const en: TranslationMap = {
   'memory.tab.namespaces': 'Namespaces',
   'memory.tab.timeline': 'Timeline',
   'memory.tab.cohesion': 'Cohesion',
+  'memory.tab.bundles': 'Bundles',
   'memory.tab.settings': 'Settings',
   'memory.tab.council': 'Council',
   'modelCouncil.title': 'Model Council',
@@ -488,6 +489,26 @@ const en: TranslationMap = {
   'graphCohesion.brokerBadge': 'broker',
   'graphCohesion.brokerTitle':
     "Structural hole: this entity's neighbours aren't connected to each other — it's the sole link between them.",
+
+  'predicateBundles.title': 'Predicate Bundles',
+  'predicateBundles.intro':
+    'Per ordered entity pair, how many distinct predicates link them? A pair tied by a single predicate is a thin relationship; a pair tied by three or four predicates is a THICK relationship — two entities meaningfully connected in more than one way. Neither per-predicate frequency nor neighbourhood overlap surfaces this.',
+  'predicateBundles.loading': 'Computing relationship thickness…',
+  'predicateBundles.errorPrefix': 'Could not load the graph:',
+  'predicateBundles.retry': 'Retry',
+  'predicateBundles.empty': 'No knowledge graph yet.',
+  'predicateBundles.emptyHint':
+    'As the assistant records relations about you, the thick (multi-predicate) pairs will surface here.',
+  'predicateBundles.namespaceLabel': 'Namespace',
+  'predicateBundles.namespaceAll': 'All namespaces',
+  'predicateBundles.metricPairs': 'Distinct pairs',
+  'predicateBundles.metricThick': 'Thick relationships',
+  'predicateBundles.metricMaxThickness': 'Max thickness',
+  'predicateBundles.summaryCaption': '{relations} relations across {pairs} pairs',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relations across 1 pair',
+  'predicateBundles.summaryCaptionOneRelation': '1 relation across {pairs} pairs',
+  'predicateBundles.summaryCaptionOneEach': '1 relation across 1 pair',
+  'predicateBundles.rankedHeading': 'Top bundles',
 
   // Memory Tree status panel (#1856 Part 1)
   'memoryTree.status.title': 'Memory Tree',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -4509,6 +4509,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Rechazar almacenamiento local',
   'pages.settings.account.security': 'Seguridad',
   'pages.settings.account.securityDesc': 'Modo de almacenamiento de secretos y estado del llavero',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Aún no hay grafo de conocimiento.',
+  'predicateBundles.emptyHint':
+    'A medida que el asistente registra relaciones sobre usted, aquí aparecerán los pares densos (multi-predicado).',
+  'predicateBundles.errorPrefix': 'No se pudo cargar el grafo:',
+  'predicateBundles.intro':
+    'Por cada par ordenado de entidades, ¿cuántos predicados distintos las enlazan? Un par unido por un único predicado es una relación delgada; un par unido por tres o cuatro predicados es una relación DENSA — dos entidades significativamente conectadas de más de una manera. Ni la frecuencia por predicado ni el solapamiento de vecindario lo revelan.',
+  'predicateBundles.loading': 'Calculando densidad de relaciones…',
+  'predicateBundles.metricMaxThickness': 'Densidad máxima',
+  'predicateBundles.metricPairs': 'Pares distintos',
+  'predicateBundles.metricThick': 'Relaciones densas',
+  'predicateBundles.namespaceAll': 'Todos los espacios de nombres',
+  'predicateBundles.namespaceLabel': 'Espacio de nombres',
+  'predicateBundles.rankedHeading': 'Principales paquetes',
+  'predicateBundles.retry': 'Reintentar',
+  'predicateBundles.summaryCaption': '{relations} relaciones a través de {pairs} pares',
+  'predicateBundles.summaryCaptionOneEach': '1 relación a través de 1 par',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relaciones a través de 1 par',
+  'predicateBundles.summaryCaptionOneRelation': '1 relación a través de {pairs} pares',
+  'predicateBundles.title': 'Paquetes de predicados',
 };
 
 export default messages;

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -4524,6 +4524,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Refuser le stockage local',
   'pages.settings.account.security': 'Sécurité',
   'pages.settings.account.securityDesc': 'Mode de stockage des secrets et état du trousseau',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Pas encore de graphe de connaissances.',
+  'predicateBundles.emptyHint':
+    "À mesure que l'assistant enregistre des relations à votre sujet, les paires denses (à prédicats multiples) apparaîtront ici.",
+  'predicateBundles.errorPrefix': 'Impossible de charger le graphe :',
+  'predicateBundles.intro':
+    "Par paire ordonnée d'entités, combien de prédicats distincts les relient ? Une paire reliée par un seul prédicat est une relation mince ; une paire reliée par trois ou quatre prédicats est une relation DENSE — deux entités significativement connectées de plus d'une manière. Ni la fréquence par prédicat ni le chevauchement de voisinage ne le révèlent.",
+  'predicateBundles.loading': 'Calcul de la densité des relations…',
+  'predicateBundles.metricMaxThickness': 'Densité max',
+  'predicateBundles.metricPairs': 'Paires distinctes',
+  'predicateBundles.metricThick': 'Relations denses',
+  'predicateBundles.namespaceAll': 'Tous les espaces de noms',
+  'predicateBundles.namespaceLabel': 'Espace de noms',
+  'predicateBundles.rankedHeading': 'Faisceaux principaux',
+  'predicateBundles.retry': 'Réessayer',
+  'predicateBundles.summaryCaption': '{relations} relations sur {pairs} paires',
+  'predicateBundles.summaryCaptionOneEach': '1 relation sur 1 paire',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relations sur 1 paire',
+  'predicateBundles.summaryCaptionOneRelation': '1 relation sur {pairs} paires',
+  'predicateBundles.title': 'Faisceaux de prédicats',
 };
 
 export default messages;

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -4434,6 +4434,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'स्थानीय भंडारण अस्वीकार करें',
   'pages.settings.account.security': 'सुरक्षा',
   'pages.settings.account.securityDesc': 'रहस्य भंडारण मोड और कीचेन स्थिति',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'अभी तक कोई नॉलेज ग्राफ नहीं।',
+  'predicateBundles.emptyHint':
+    'जैसे-जैसे सहायक आपके बारे में संबंध दर्ज करता है, सघन (बहु-विधेय) जोड़ियाँ यहाँ उभरेंगी।',
+  'predicateBundles.errorPrefix': 'ग्राफ लोड नहीं हो सका:',
+  'predicateBundles.intro':
+    'हर क्रमित इकाई-जोड़ी के लिए: कितने भिन्न विधेय उन्हें जोड़ते हैं? एक विधेय से बंधी जोड़ी पतला संबंध है; तीन या चार विधेयों से बंधी जोड़ी सघन संबंध है — दो इकाइयाँ जो एक से अधिक तरीके से सार्थक रूप से जुड़ी हैं। न प्रति-विधेय आवृत्ति और न पड़ोस ओवरलैप इसे दिखाते हैं।',
+  'predicateBundles.loading': 'संबंध सघनता गणना हो रही है…',
+  'predicateBundles.metricMaxThickness': 'अधिकतम सघनता',
+  'predicateBundles.metricPairs': 'विशिष्ट जोड़ियाँ',
+  'predicateBundles.metricThick': 'सघन संबंध',
+  'predicateBundles.namespaceAll': 'सभी नेमस्पेस',
+  'predicateBundles.namespaceLabel': 'नेमस्पेस',
+  'predicateBundles.rankedHeading': 'शीर्ष बंडल',
+  'predicateBundles.retry': 'पुनः प्रयास',
+  'predicateBundles.summaryCaption': '{pairs} जोड़ियों में {relations} संबंध',
+  'predicateBundles.summaryCaptionOneEach': '1 जोड़ी में 1 संबंध',
+  'predicateBundles.summaryCaptionOnePair': '1 जोड़ी में {relations} संबंध',
+  'predicateBundles.summaryCaptionOneRelation': '{pairs} जोड़ियों में 1 संबंध',
+  'predicateBundles.title': 'विधेय बंडल',
 };
 
 export default messages;

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -4443,6 +4443,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Tolak penyimpanan lokal',
   'pages.settings.account.security': 'Keamanan',
   'pages.settings.account.securityDesc': 'Mode penyimpanan rahasia dan status keychain',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Belum ada graf pengetahuan.',
+  'predicateBundles.emptyHint':
+    'Saat asisten mencatat relasi tentang Anda, pasangan tebal (multi-predikat) akan muncul di sini.',
+  'predicateBundles.errorPrefix': 'Tidak dapat memuat graf:',
+  'predicateBundles.intro':
+    'Per pasangan entitas terurut, berapa banyak predikat berbeda yang menghubungkan mereka? Pasangan yang diikat oleh satu predikat adalah hubungan tipis; pasangan yang diikat oleh tiga atau empat predikat adalah hubungan TEBAL — dua entitas yang terhubung secara bermakna dengan lebih dari satu cara. Baik frekuensi per predikat maupun tumpang tindih lingkungan tidak mengungkap hal ini.',
+  'predicateBundles.loading': 'Menghitung kepadatan hubungan…',
+  'predicateBundles.metricMaxThickness': 'Kepadatan maks.',
+  'predicateBundles.metricPairs': 'Pasangan berbeda',
+  'predicateBundles.metricThick': 'Hubungan tebal',
+  'predicateBundles.namespaceAll': 'Semua ruang nama',
+  'predicateBundles.namespaceLabel': 'Ruang nama',
+  'predicateBundles.rankedHeading': 'Bundel teratas',
+  'predicateBundles.retry': 'Coba lagi',
+  'predicateBundles.summaryCaption': '{relations} relasi pada {pairs} pasang',
+  'predicateBundles.summaryCaptionOneEach': '1 relasi pada 1 pasang',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relasi pada 1 pasang',
+  'predicateBundles.summaryCaptionOneRelation': '1 relasi pada {pairs} pasang',
+  'predicateBundles.title': 'Bundel Predikat',
 };
 
 export default messages;

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -4501,6 +4501,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Rifiuta archiviazione locale',
   'pages.settings.account.security': 'Sicurezza',
   'pages.settings.account.securityDesc': 'Modalità archiviazione segreti e stato del portachiavi',
+  'memory.tab.bundles': 'Fasci',
+  'predicateBundles.empty': 'Ancora nessun grafo della conoscenza.',
+  'predicateBundles.emptyHint':
+    "Man mano che l'assistente registra relazioni su di te, qui appariranno le coppie dense (multi-predicato).",
+  'predicateBundles.errorPrefix': 'Impossibile caricare il grafo:',
+  'predicateBundles.intro':
+    'Per ogni coppia ordinata di entità, quanti predicati distinti le collegano? Una coppia legata da un solo predicato è una relazione sottile; una coppia legata da tre o quattro predicati è una relazione DENSA — due entità connesse in modo significativo in più modi. Né la frequenza per predicato né la sovrapposizione di vicinato lo rivelano.',
+  'predicateBundles.loading': 'Calcolo della densità delle relazioni…',
+  'predicateBundles.metricMaxThickness': 'Densità massima',
+  'predicateBundles.metricPairs': 'Coppie distinte',
+  'predicateBundles.metricThick': 'Relazioni dense',
+  'predicateBundles.namespaceAll': 'Tutti gli spazi dei nomi',
+  'predicateBundles.namespaceLabel': 'Spazio dei nomi',
+  'predicateBundles.rankedHeading': 'Fasci principali',
+  'predicateBundles.retry': 'Riprova',
+  'predicateBundles.summaryCaption': '{relations} relazioni su {pairs} coppie',
+  'predicateBundles.summaryCaptionOneEach': '1 relazione su 1 coppia',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relazioni su 1 coppia',
+  'predicateBundles.summaryCaptionOneRelation': '1 relazione su {pairs} coppie',
+  'predicateBundles.title': 'Fasci di predicati',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -4393,6 +4393,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': '로컬 저장소 거부',
   'pages.settings.account.security': '보안',
   'pages.settings.account.securityDesc': '비밀 저장 모드 및 키체인 상태',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': '아직 지식 그래프가 없습니다.',
+  'predicateBundles.emptyHint':
+    '어시스턴트가 당신에 관한 관계들을 기록함에 따라, 두꺼운(다중 술어) 쌍들이 여기에 드러납니다.',
+  'predicateBundles.errorPrefix': '그래프를 불러올 수 없습니다:',
+  'predicateBundles.intro':
+    '순서가 정해진 엔티티 쌍별로, 몇 개의 서로 다른 술어가 이들을 연결합니까? 단일 술어로 묶인 쌍은 얇은 관계이며, 3~4개의 술어로 묶인 쌍은 두꺼운 관계입니다 — 두 엔티티가 둘 이상의 방식으로 의미 있게 연결된 것입니다. 술어별 빈도나 이웃 중복으로는 드러나지 않습니다.',
+  'predicateBundles.loading': '관계 두께 계산 중…',
+  'predicateBundles.metricMaxThickness': '최대 두께',
+  'predicateBundles.metricPairs': '고유 쌍',
+  'predicateBundles.metricThick': '두꺼운 관계',
+  'predicateBundles.namespaceAll': '모든 네임스페이스',
+  'predicateBundles.namespaceLabel': '네임스페이스',
+  'predicateBundles.rankedHeading': '상위 묶음',
+  'predicateBundles.retry': '다시 시도',
+  'predicateBundles.summaryCaption': '쌍 {pairs}개에 걸친 관계 {relations}개',
+  'predicateBundles.summaryCaptionOneEach': '쌍 1개에 걸친 관계 1개',
+  'predicateBundles.summaryCaptionOnePair': '쌍 1개에 걸친 관계 {relations}개',
+  'predicateBundles.summaryCaptionOneRelation': '쌍 {pairs}개에 걸친 관계 1개',
+  'predicateBundles.title': '술어 묶음',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -4501,6 +4501,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Odmów lokalnego przechowywania',
   'pages.settings.account.security': 'Bezpieczeństwo',
   'pages.settings.account.securityDesc': 'Tryb przechowywania sekretów i stan pęku kluczy',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Jeszcze brak grafu wiedzy.',
+  'predicateBundles.emptyHint':
+    'W miarę jak asystent zapisuje relacje o Tobie, gęste (wielo-predykatowe) pary pojawią się tutaj.',
+  'predicateBundles.errorPrefix': 'Nie udało się załadować grafu:',
+  'predicateBundles.intro':
+    'Dla każdej uporządkowanej pary encji: ile odrębnych predykatów je łączy? Para związana jednym predykatem to cienka relacja; para związana trzema lub czterema predykatami to GĘSTA relacja — dwie encje znacząco połączone na więcej niż jeden sposób. Ani częstotliwość per predykat, ani nakładanie się sąsiedztw tego nie ujawni.',
+  'predicateBundles.loading': 'Obliczanie gęstości relacji…',
+  'predicateBundles.metricMaxThickness': 'Maks. gęstość',
+  'predicateBundles.metricPairs': 'Różne pary',
+  'predicateBundles.metricThick': 'Gęste relacje',
+  'predicateBundles.namespaceAll': 'Wszystkie przestrzenie nazw',
+  'predicateBundles.namespaceLabel': 'Przestrzeń nazw',
+  'predicateBundles.rankedHeading': 'Najlepsze pakiety',
+  'predicateBundles.retry': 'Spróbuj ponownie',
+  'predicateBundles.summaryCaption': '{relations} relacji w {pairs} parach',
+  'predicateBundles.summaryCaptionOneEach': '1 relacja w 1 parze',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relacji w 1 parze',
+  'predicateBundles.summaryCaptionOneRelation': '1 relacja w {pairs} parach',
+  'predicateBundles.title': 'Pakiety predykatów',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -4498,6 +4498,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Recusar armazenamento local',
   'pages.settings.account.security': 'Segurança',
   'pages.settings.account.securityDesc': 'Modo de armazenamento de segredos e status do chaveiro',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Ainda sem grafo de conhecimento.',
+  'predicateBundles.emptyHint':
+    'À medida que o assistente registra relações sobre você, os pares densos (multi-predicado) aparecerão aqui.',
+  'predicateBundles.errorPrefix': 'Não foi possível carregar o grafo:',
+  'predicateBundles.intro':
+    'Por par ordenado de entidades, quantos predicados distintos os ligam? Um par ligado por um único predicado é uma relação tênue; um par ligado por três ou quatro predicados é uma relação DENSA — duas entidades significativamente conectadas de mais de uma forma. Nem a frequência por predicado nem a sobreposição de vizinhança revelam isso.',
+  'predicateBundles.loading': 'Calculando densidade dos relacionamentos…',
+  'predicateBundles.metricMaxThickness': 'Densidade máxima',
+  'predicateBundles.metricPairs': 'Pares distintos',
+  'predicateBundles.metricThick': 'Relações densas',
+  'predicateBundles.namespaceAll': 'Todos os espaços de nomes',
+  'predicateBundles.namespaceLabel': 'Espaço de nomes',
+  'predicateBundles.rankedHeading': 'Principais pacotes',
+  'predicateBundles.retry': 'Tentar novamente',
+  'predicateBundles.summaryCaption': '{relations} relações em {pairs} pares',
+  'predicateBundles.summaryCaptionOneEach': '1 relação em 1 par',
+  'predicateBundles.summaryCaptionOnePair': '{relations} relações em 1 par',
+  'predicateBundles.summaryCaptionOneRelation': '1 relação em {pairs} pares',
+  'predicateBundles.title': 'Pacotes de predicados',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -4469,6 +4469,26 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Отклонить локальное хранилище',
   'pages.settings.account.security': 'Безопасность',
   'pages.settings.account.securityDesc': 'Режим хранения секретов и статус связки ключей',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': 'Пока нет графа знаний.',
+  'predicateBundles.emptyHint':
+    'По мере того как ассистент фиксирует связи о вас, здесь появятся плотные (много-предикатные) пары.',
+  'predicateBundles.errorPrefix': 'Не удалось загрузить граф:',
+  'predicateBundles.intro':
+    'Для каждой упорядоченной пары сущностей: сколько различных предикатов их связывает? Пара, связанная одним предикатом, — тонкое отношение; пара, связанная тремя или четырьмя предикатами, — ПЛОТНОЕ отношение — две сущности, осмысленно связанные более чем одним способом. Ни частота по предикатам, ни перекрытие окрестностей этого не вскрывают.',
+  'predicateBundles.loading': 'Вычисление плотности связей…',
+  'predicateBundles.metricMaxThickness': 'Макс. плотность',
+  'predicateBundles.metricPairs': 'Различных пар',
+  'predicateBundles.metricThick': 'Плотные отношения',
+  'predicateBundles.namespaceAll': 'Все пространства имён',
+  'predicateBundles.namespaceLabel': 'Пространство имён',
+  'predicateBundles.rankedHeading': 'Топ пучков',
+  'predicateBundles.retry': 'Повторить',
+  'predicateBundles.summaryCaption': '{relations} связей в {pairs} парах',
+  'predicateBundles.summaryCaptionOneEach': '1 связь в 1 паре',
+  'predicateBundles.summaryCaptionOnePair': '{relations} связей в 1 паре',
+  'predicateBundles.summaryCaptionOneRelation': '1 связь в {pairs} парах',
+  'predicateBundles.title': 'Пучки предикатов',
 };
 
 export default messages;

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -4214,6 +4214,25 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': '拒绝本地存储',
   'pages.settings.account.security': '安全',
   'pages.settings.account.securityDesc': '密钥存储模式和密钥链状态',
+  'memory.tab.bundles': 'Bundles',
+  'predicateBundles.empty': '暂无知识图。',
+  'predicateBundles.emptyHint': '随着助手记录有关你的关系,稠密(多谓词)对将在此呈现。',
+  'predicateBundles.errorPrefix': '无法加载图:',
+  'predicateBundles.intro':
+    '对每对有序实体而言,有多少不同的谓词在连接它们?以单一谓词相连的对是薄关系;以三到四个谓词相连的对是稠密关系——两个实体在不止一种意义上相连。按谓词的频率或邻域重叠都无法揭示这一点。',
+  'predicateBundles.loading': '正在计算关系稠度…',
+  'predicateBundles.metricMaxThickness': '最大稠度',
+  'predicateBundles.metricPairs': '不同对',
+  'predicateBundles.metricThick': '稠密关系',
+  'predicateBundles.namespaceAll': '所有命名空间',
+  'predicateBundles.namespaceLabel': '命名空间',
+  'predicateBundles.rankedHeading': '顶尖束',
+  'predicateBundles.retry': '重试',
+  'predicateBundles.summaryCaption': '在 {pairs} 对上有 {relations} 个关系',
+  'predicateBundles.summaryCaptionOneEach': '在 1 对上有 1 个关系',
+  'predicateBundles.summaryCaptionOnePair': '在 1 对上有 {relations} 个关系',
+  'predicateBundles.summaryCaptionOneRelation': '在 {pairs} 对上有 1 个关系',
+  'predicateBundles.title': '谓词束',
 };
 
 export default messages;

--- a/app/src/lib/memory/predicateBundles.test.ts
+++ b/app/src/lib/memory/predicateBundles.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import { computePredicateBundles } from './predicateBundles';
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'work',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+function bundle(result: ReturnType<typeof computePredicateBundles>, s: string, o: string) {
+  const b = result.bundles.find(x => x.subject === s && x.object === o);
+  if (!b) throw new Error(`bundle (${s},${o}) not found`);
+  return b;
+}
+
+describe('computePredicateBundles — basic shapes', () => {
+  it('returns an empty result for no relations', () => {
+    const r = computePredicateBundles([]);
+    expect(r.bundles).toEqual([]);
+    expect(r.pairCount).toBe(0);
+    expect(r.multiPredicatePairCount).toBe(0);
+    expect(r.maxPredicateCount).toBe(0);
+    expect(r.totalRelations).toBe(0);
+  });
+
+  it('a single relation makes a thin bundle of one predicate', () => {
+    const r = computePredicateBundles([rel('A', 'knows', 'B')]);
+    expect(r.pairCount).toBe(1);
+    expect(r.multiPredicatePairCount).toBe(0); // thin pair, not "multi"
+    expect(r.maxPredicateCount).toBe(1);
+    expect(r.totalRelations).toBe(1);
+    expect(r.bundles[0]).toEqual({
+      subject: 'A',
+      object: 'B',
+      predicates: ['knows'],
+      predicateCount: 1,
+      totalRelations: 1,
+    });
+  });
+
+  it('two distinct predicates on the same ordered pair make a thick bundle', () => {
+    const r = computePredicateBundles([rel('A', 'knows', 'B'), rel('A', 'trusts', 'B')]);
+    expect(r.pairCount).toBe(1);
+    expect(r.multiPredicatePairCount).toBe(1);
+    expect(r.maxPredicateCount).toBe(2);
+    expect(bundle(r, 'A', 'B')).toEqual({
+      subject: 'A',
+      object: 'B',
+      predicates: ['knows', 'trusts'], // sorted ASC
+      predicateCount: 2,
+      totalRelations: 2,
+    });
+  });
+
+  it('puts the thickest bundle first in the ranked output', () => {
+    const r = computePredicateBundles([
+      rel('A', 'knows', 'B'),
+      rel('A', 'trusts', 'B'),
+      rel('A', 'mentors', 'B'), // pair (A,B) has 3 distinct predicates
+      rel('C', 'knows', 'D'), // pair (C,D) has 1
+    ]);
+    expect(r.bundles[0]).toMatchObject({ subject: 'A', object: 'B', predicateCount: 3 });
+    expect(r.bundles[1]).toMatchObject({ subject: 'C', object: 'D', predicateCount: 1 });
+  });
+});
+
+describe('computePredicateBundles — direction & duplicate handling', () => {
+  it('treats (A,B) and (B,A) as distinct ordered pairs', () => {
+    const r = computePredicateBundles([rel('A', 'mentors', 'B'), rel('B', 'reports_to', 'A')]);
+    expect(r.pairCount).toBe(2);
+    expect(bundle(r, 'A', 'B').predicates).toEqual(['mentors']);
+    expect(bundle(r, 'B', 'A').predicates).toEqual(['reports_to']);
+  });
+
+  it('collapses duplicate triples in the predicate set but counts each toward totalRelations', () => {
+    // Same triple A-knows-B asserted three times: predicate set is just {knows}
+    // (size 1, so the bundle is THIN), but totalRelations is 3 — a heavily-
+    // attested thin relationship is distinguishable from a one-off thin one.
+    const r = computePredicateBundles([
+      rel('A', 'knows', 'B'),
+      rel('A', 'knows', 'B'),
+      rel('A', 'knows', 'B'),
+      rel('A', 'trusts', 'B'),
+    ]);
+    const b = bundle(r, 'A', 'B');
+    expect(b.predicateCount).toBe(2); // {knows, trusts}
+    expect(b.totalRelations).toBe(4);
+    expect(r.totalRelations).toBe(4);
+  });
+
+  it('keeps self-loop pairs (A,A) and bundles their predicates', () => {
+    const r = computePredicateBundles([
+      rel('Alice', 'reflects_on', 'Alice'),
+      rel('Alice', 'reminds_of', 'Alice'),
+    ]);
+    expect(r.pairCount).toBe(1);
+    expect(bundle(r, 'Alice', 'Alice').predicateCount).toBe(2);
+  });
+});
+
+describe('computePredicateBundles — normalization & determinism', () => {
+  it('drops a relation with a non-string subject, predicate, or object', () => {
+    const badSubject = { ...rel('A', 'knows', 'B'), subject: null as unknown as string };
+    const badPredicate = { ...rel('A', 'knows', 'B'), predicate: 42 as unknown as string };
+    const badObject = { ...rel('A', 'knows', 'B'), object: undefined as unknown as string };
+    const r = computePredicateBundles([
+      rel('A', 'knows', 'B'),
+      badSubject,
+      badPredicate,
+      badObject,
+    ]);
+    expect(r.totalRelations).toBe(1);
+    expect(r.pairCount).toBe(1);
+  });
+
+  it('treats "Alice" / "alice" and "Knows" / "knows" as distinct (no case-folding)', () => {
+    const r = computePredicateBundles([
+      rel('Alice', 'knows', 'Bob'),
+      rel('alice', 'knows', 'Bob'),
+      rel('Alice', 'Knows', 'Bob'),
+    ]);
+    // distinct subject case -> two pairs; within "Alice"-"Bob" two predicates.
+    expect(r.pairCount).toBe(2);
+    expect(bundle(r, 'Alice', 'Bob').predicateCount).toBe(2);
+    expect(bundle(r, 'alice', 'Bob').predicateCount).toBe(1);
+  });
+
+  it('keys pairs safely so commas / separators in ids cannot collide', () => {
+    // The JSON.stringify([s,o]) pair key avoids a naive `${s}|${o}` collision
+    // where "A|B" + "C" and "A" + "|B|C" would conflict.
+    const r = computePredicateBundles([rel('A|B', 'knows', 'C'), rel('A', 'trusts', '|B|C')]);
+    expect(r.pairCount).toBe(2);
+  });
+
+  it('is order-independent: shuffled input yields identical output', () => {
+    const edges = [
+      rel('A', 'knows', 'B'),
+      rel('A', 'trusts', 'B'),
+      rel('A', 'mentors', 'B'),
+      rel('B', 'reports_to', 'A'),
+      rel('C', 'knows', 'D'),
+      rel('A', 'knows', 'B'), // duplicate
+    ];
+    const forward = computePredicateBundles(edges);
+    const reversed = computePredicateBundles([...edges].reverse());
+    const rotated = computePredicateBundles([...edges.slice(3), ...edges.slice(0, 3)]);
+    expect(reversed).toEqual(forward);
+    expect(rotated).toEqual(forward);
+  });
+
+  it('sorts predicateCount DESC, then totalRelations DESC, then subject ASC, then object ASC', () => {
+    // (X,Y): 1 predicate × 5 totalRelations (thin but very attested)
+    // (A,B): 1 predicate × 1 totalRelations (thin)
+    // (C,D): 1 predicate × 1 totalRelations (thin)
+    const r = computePredicateBundles([
+      rel('X', 'knows', 'Y'),
+      rel('X', 'knows', 'Y'),
+      rel('X', 'knows', 'Y'),
+      rel('X', 'knows', 'Y'),
+      rel('X', 'knows', 'Y'),
+      rel('A', 'knows', 'B'),
+      rel('C', 'knows', 'D'),
+    ]);
+    // tied at predicateCount=1: totalRelations DESC -> X,Y leads; then A,B by id.
+    expect(r.bundles.map(b => `${b.subject}->${b.object}`)).toEqual(['X->Y', 'A->B', 'C->D']);
+  });
+});

--- a/app/src/lib/memory/predicateBundles.ts
+++ b/app/src/lib/memory/predicateBundles.ts
@@ -1,0 +1,123 @@
+/**
+ * Predicate Bundles — pure relationship-thickness engine.
+ *
+ * The memory knowledge graph is a set of (subject)-[predicate]->(object)
+ * triples. The frequency lens (Relationship Types) tells you which PREDICATES
+ * dominate; the topology lenses tell you which ENTITIES dominate. This lens
+ * asks a different question: for each ordered ENTITY PAIR, how MANY distinct
+ * predicates link them?
+ *
+ * A pair connected by a single predicate is a thin relationship; a pair
+ * connected by three or four predicates (e.g. "knows" + "trusts" +
+ * "mentors" + "works_with") is a THICK relationship — the same two entities
+ * are tied together by multiple independent assertions. Thick pairs are the
+ * memory's signal that "these two are meaningfully connected, in more than one
+ * way" — something neither the per-predicate frequency lens nor the
+ * neighbourhood-overlap lens surfaces, because both flatten direction or
+ * predicate.
+ *
+ * Everything here is PURE and DETERMINISTIC: no React, no RPC, no clock, no
+ * randomness. All counts are integer, and the output pair list is sorted in a
+ * total order (predicateCount DESC, totalRelations DESC, subject ASC, object
+ * ASC), so the same input always yields byte-identical output regardless of
+ * relation insertion order.
+ *
+ * Load-bearing design choices (do not "fix" without reading the tests):
+ *   - Direction is PRESERVED: (A, B) and (B, A) are distinct pairs. The same
+ *     pair of names tied by "mentors" one way and "reports_to" the other are
+ *     two separate bundles — that asymmetry is the signal.
+ *   - Identical triples (same subject, predicate, object) are COLLAPSED in the
+ *     bundle's predicate set (a predicate is either in the bundle or not) but
+ *     each duplicate still counts toward totalRelations, so a frequently-
+ *     asserted thin relationship can be distinguished from a one-off one.
+ *   - Self-loops (subject === object) are kept — a self-loop pair with several
+ *     predicates is just as meaningful as any other thick relationship.
+ *   - Entity / predicate identity is the raw string AS-IS: NO trimming, NO
+ *     case-folding — matching the sibling lenses.
+ *   - A relation with a non-string subject, predicate, or object is dropped.
+ */
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+
+export interface PredicateBundle {
+  subject: string;
+  object: string;
+  predicates: string[]; // distinct predicates, sorted ASC for determinism
+  predicateCount: number; // === predicates.length
+  totalRelations: number; // raw count including duplicate triples
+}
+
+export interface BundleResult {
+  bundles: PredicateBundle[]; // sorted predicateCount DESC, totalRelations DESC, subject ASC, object ASC
+  pairCount: number; // distinct ordered (subject, object) pairs
+  multiPredicatePairCount: number; // pairs with predicateCount >= 2 (the "thick" relationships)
+  maxPredicateCount: number; // max predicateCount across all pairs (0 if empty)
+  totalRelations: number; // sum across pairs (raw count, parallels included)
+}
+
+function isRelation(relation: GraphRelation): boolean {
+  return (
+    typeof relation.subject === 'string' &&
+    typeof relation.predicate === 'string' &&
+    typeof relation.object === 'string'
+  );
+}
+
+/** Compute the per-pair predicate bundles. PURE. */
+export function computePredicateBundles(relations: GraphRelation[]): BundleResult {
+  // Per-pair accumulator: key is JSON.stringify([subject, object]) so a pair
+  // with any characters (commas, separators) can never collide with a
+  // different pair.
+  interface Accum {
+    subject: string;
+    object: string;
+    predicates: Set<string>;
+    totalRelations: number;
+  }
+  const accums = new Map<string, Accum>();
+  let totalRelations = 0;
+
+  for (const relation of relations) {
+    if (!isRelation(relation)) continue;
+    const { subject, predicate, object } = relation;
+    const key = JSON.stringify([subject, object]);
+    let accum = accums.get(key);
+    if (accum === undefined) {
+      accum = { subject, object, predicates: new Set<string>(), totalRelations: 0 };
+      accums.set(key, accum);
+    }
+    accum.predicates.add(predicate);
+    accum.totalRelations += 1;
+    totalRelations += 1;
+  }
+
+  const bundles: PredicateBundle[] = [];
+  let maxPredicateCount = 0;
+  let multiPredicatePairCount = 0;
+  for (const accum of accums.values()) {
+    const predicates = [...accum.predicates].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    bundles.push({
+      subject: accum.subject,
+      object: accum.object,
+      predicates,
+      predicateCount: predicates.length,
+      totalRelations: accum.totalRelations,
+    });
+    if (predicates.length > maxPredicateCount) maxPredicateCount = predicates.length;
+    if (predicates.length >= 2) multiPredicatePairCount += 1;
+  }
+
+  bundles.sort((a, b) => {
+    if (b.predicateCount !== a.predicateCount) return b.predicateCount - a.predicateCount;
+    if (b.totalRelations !== a.totalRelations) return b.totalRelations - a.totalRelations;
+    if (a.subject !== b.subject) return a.subject < b.subject ? -1 : 1;
+    return a.object < b.object ? -1 : a.object > b.object ? 1 : 0;
+  });
+
+  return {
+    bundles,
+    pairCount: bundles.length,
+    multiPredicatePairCount,
+    maxPredicateCount,
+    totalRelations,
+  };
+}

--- a/app/src/services/api/predicateBundlesApi.test.ts
+++ b/app/src/services/api/predicateBundlesApi.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { computePredicateBundles } from '../../lib/memory/predicateBundles';
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import { loadBundles, loadNamespaces, predicateBundlesApi } from './predicateBundlesApi';
+
+const mockGraphQuery = vi.fn();
+const mockListNamespaces = vi.fn();
+
+vi.mock('../../utils/tauriCommands/memory', () => ({
+  memoryGraphQuery: (...args: unknown[]) => mockGraphQuery(...args),
+  memoryListNamespaces: (...args: unknown[]) => mockListNamespaces(...args),
+}));
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'work',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+describe('predicateBundlesApi.loadBundles', () => {
+  beforeEach(() => {
+    mockGraphQuery.mockReset();
+  });
+
+  it('passes the namespace through and returns the engine result', async () => {
+    const triples = [rel('A', 'knows', 'B'), rel('A', 'trusts', 'B')];
+    mockGraphQuery.mockResolvedValueOnce(triples);
+    const out = await loadBundles('work');
+    expect(mockGraphQuery).toHaveBeenCalledWith('work');
+    expect(out).toEqual(computePredicateBundles(triples));
+    expect(out.multiPredicatePairCount).toBe(1);
+  });
+
+  it('queries all namespaces when none is given', async () => {
+    mockGraphQuery.mockResolvedValueOnce([]);
+    const out = await loadBundles();
+    expect(mockGraphQuery).toHaveBeenCalledWith(undefined);
+    expect(out.bundles).toEqual([]);
+    expect(out.pairCount).toBe(0);
+  });
+
+  it('propagates query errors', async () => {
+    mockGraphQuery.mockRejectedValueOnce(new Error('graph unavailable'));
+    await expect(loadBundles()).rejects.toThrow('graph unavailable');
+  });
+});
+
+describe('predicateBundlesApi.loadNamespaces', () => {
+  beforeEach(() => {
+    mockListNamespaces.mockReset();
+  });
+
+  it('returns the namespace list from the RPC', async () => {
+    mockListNamespaces.mockResolvedValueOnce(['work', 'personal']);
+    expect(await loadNamespaces()).toEqual(['work', 'personal']);
+  });
+});
+
+describe('predicateBundlesApi object', () => {
+  it('exposes the public surface', () => {
+    expect(typeof predicateBundlesApi.loadBundles).toBe('function');
+    expect(typeof predicateBundlesApi.loadNamespaces).toBe('function');
+  });
+});

--- a/app/src/services/api/predicateBundlesApi.ts
+++ b/app/src/services/api/predicateBundlesApi.ts
@@ -1,0 +1,29 @@
+/**
+ * RPC facade for Predicate Bundles (per-pair predicate multiplicity).
+ *
+ * Adds ZERO new core surface. It composes two already-shipped JSON-RPC wrappers:
+ *   - memoryGraphQuery     (openhuman.memory_graph_query)     — the triples
+ *   - memoryListNamespaces (openhuman.memory_list_namespaces) — the selector
+ * and delegates all math to the pure, deterministic engine. Read-only: there is
+ * no persistence — the result is always reproducible from the current graph.
+ */
+import debug from 'debug';
+
+import { type BundleResult, computePredicateBundles } from '../../lib/memory/predicateBundles';
+import { memoryGraphQuery, memoryListNamespaces } from '../../utils/tauriCommands/memory';
+
+const log = debug('predicate-bundles:api');
+
+/** Fetch the graph relations for a namespace (or all) and compute bundles. */
+export async function loadBundles(namespace?: string): Promise<BundleResult> {
+  const relations = await memoryGraphQuery(namespace);
+  log('loadBundles namespace=%s relations=%d', namespace ?? '(all)', relations.length);
+  return computePredicateBundles(relations);
+}
+
+/** List the namespaces available for the namespace selector. */
+export async function loadNamespaces(): Promise<string[]> {
+  return memoryListNamespaces();
+}
+
+export const predicateBundlesApi = { loadBundles, loadNamespaces };


### PR DESCRIPTION
## Summary

Adds a new read-only **"Bundles"** tab to the Intelligence view: relationship-thickness analysis. For each ordered `(subject, object)` pair, **how many distinct predicates link them?**

- **Thin** pair — one predicate (e.g. `"knows"`).
- **THICK** pair — multiple predicates (e.g. `"knows"` + `"trusts"` + `"mentors"`).

Thick pairs are the memory's signal that two entities are meaningfully connected in **more than one way** — something neither the per-predicate frequency lens (#2951 Relationship Types) nor the neighbourhood-overlap lens (#2942 Entity Associations) surfaces, because both flatten direction or predicate. This lens preserves both.

### Design
- **Pure deterministic engine** (`lib/memory/predicateBundles.ts`):
  - per-pair distinct-predicate **set** + raw `totalRelations` (parallels counted, so a heavily-asserted thin pair is distinguishable from a one-off one),
  - **direction preserved**: `(A, B)` and `(B, A)` are distinct bundles — the asymmetry is the signal,
  - **self-loop** pairs `(A, A)` kept (a self-loop bundle with several predicates is just as meaningful),
  - pair key uses `JSON.stringify([s, o])` so any characters in entity ids (commas, separators) cannot collide,
  - total-order output sort: `predicateCount DESC, totalRelations DESC, subject ASC, object ASC` — output is byte-identical regardless of input order.
- **Zero new core surface**: composes the already-shipped `memoryGraphQuery` / `memoryListNamespaces` wrappers. **Read-only**.
- Container/presentational split with a monotonic request-token race guard for load-on-mount. i18n across all 13 locales with a **four-way singular/plural caption switch** so "1 relation across 1 pair" never renders as "1 relations across 1 pairs".

### Test plan
- [x] `vitest` — 25 tests (engine: empty / single-relation (thin) / two-predicate (thick) / ranked-thickest-first / direction preserved / duplicate triples collapsed in set but counted in totalRelations / self-loop pairs kept / non-string subject/predicate/object drop / no case-folding / pair-key safety against separator collisions / order-independent output / total-order sort with tied predicateCount — plus api facade, panel singular & plural caption variants + predicate chips, container load/namespace-requery/error)
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors
- [x] `prettier --check` — clean
- [x] i18n coverage gate — EXIT 0, no missing/extra/drifted keys across 13 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Predicate Bundles” tab to Intelligence: grouped subject→object bundles, three key metric tiles (distinct pairs, thick pairs, max thickness), ranked bundle list with predicate chips and counts, namespace filter, loading/empty/error states, and a retry action.

* **Tests**
  * Added UI and unit tests covering rendering states, data scenarios, namespace filtering, and computation correctness.

* **Localization**
  * Added translations for the new bundles UI in multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinyhumansai/openhuman/pull/2990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->