### PR TITLE
feat(intelligence): add Subject-Predicate Specialisation (mutual information)

### DIFF
--- a/app/src/components/intelligence/SubjectPredicateMIPanel.test.tsx
+++ b/app/src/components/intelligence/SubjectPredicateMIPanel.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { computeSubjectPredicateMI } from '../../lib/memory/subjectPredicateMI';
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import SubjectPredicateMIPanel from './SubjectPredicateMIPanel';
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'n',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+// s1 fully specialised (all "knows"), s2 fully generalist (3 distinct predicates evenly).
+const profile = computeSubjectPredicateMI([
+  rel('s1', 'knows', 'a'),
+  rel('s1', 'knows', 'b'),
+  rel('s1', 'knows', 'c'),
+  rel('s2', 'knows', 'a'),
+  rel('s2', 'trusts', 'b'),
+  rel('s2', 'mentors', 'c'),
+]);
+
+describe('<SubjectPredicateMIPanel />', () => {
+  it('renders the loading skeleton', () => {
+    render(<SubjectPredicateMIPanel result={null} loading />);
+    expect(screen.getByTestId('subject-predicate-mi-loading')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no relations', () => {
+    render(<SubjectPredicateMIPanel result={computeSubjectPredicateMI([])} />);
+    expect(screen.getByText('No knowledge graph yet.')).toBeInTheDocument();
+  });
+
+  it('renders an error with a working retry button', () => {
+    const onRetry = vi.fn();
+    render(<SubjectPredicateMIPanel result={null} error="graph unavailable" onRetry={onRetry} />);
+    expect(screen.getByRole('alert').textContent).toMatch(/graph unavailable/);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders metric tiles, summary caption, and the per-subject specialisation table', () => {
+    render(<SubjectPredicateMIPanel result={profile} />);
+    expect(screen.getByText('Mutual information (bits)')).toBeInTheDocument();
+    expect(screen.getByText('Normalised MI')).toBeInTheDocument();
+    expect(screen.getByText('Subjects')).toBeInTheDocument();
+    expect(screen.getByText('Most-to-least specialised subjects')).toBeInTheDocument();
+    // specialist s1 leads with 100% specialisation; generalist s2 has 0%.
+    expect(screen.getByText('s1')).toBeInTheDocument();
+    expect(screen.getByText('s2')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/intelligence/SubjectPredicateMIPanel.tsx
+++ b/app/src/components/intelligence/SubjectPredicateMIPanel.tsx
@@ -1,0 +1,201 @@
+/**
+ * Subject-Predicate MI — presentational view. Pure: renders the global MI
+ * tiles (MI / H(S) / H(P) / normalised MI) and a per-subject specialisation
+ * ranking. No data fetching, no clock, no randomness.
+ */
+import { useT } from '../../lib/i18n/I18nContext';
+import type { SubjectPredicateMIResult } from '../../lib/memory/subjectPredicateMI';
+
+const MAX_ROWS = 25;
+
+interface SubjectPredicateMIPanelProps {
+  result: SubjectPredicateMIResult | null;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+}
+
+const SubjectPredicateMIPanel = ({
+  result,
+  loading,
+  error,
+  onRetry,
+}: SubjectPredicateMIPanelProps) => {
+  const { t } = useT();
+
+  const intro = (
+    <div
+      role="note"
+      className="rounded-lg border border-primary-200 dark:border-primary-500/30 bg-primary-50 dark:bg-primary-500/10 px-3 py-2 text-xs text-stone-700 dark:text-neutral-200">
+      <p className="font-medium mb-1">{t('subjectPredicateMI.title')}</p>
+      <p>{t('subjectPredicateMI.intro')}</p>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {intro}
+        <div
+          className="space-y-3"
+          role="status"
+          aria-label={t('subjectPredicateMI.loading')}
+          data-testid="subject-predicate-mi-loading">
+          <div className="grid gap-2 sm:grid-cols-3">
+            {[0, 1, 2].map(i => (
+              <div
+                key={i}
+                className="animate-pulse rounded-lg border border-stone-200 dark:border-neutral-800 bg-stone-50 dark:bg-neutral-800/60 h-16"
+              />
+            ))}
+          </div>
+          {[0, 1, 2, 3].map(i => (
+            <div
+              key={i}
+              className="animate-pulse rounded-lg border border-stone-200 dark:border-neutral-800 bg-stone-50 dark:bg-neutral-800/60 h-8"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        {intro}
+        <div className="rounded-lg border border-coral-200 dark:border-coral-500/30 p-4 text-center">
+          <p role="alert" className="text-xs text-coral-700 dark:text-coral-300">
+            {t('subjectPredicateMI.errorPrefix')} {error}
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-2 rounded-lg bg-primary-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-primary-600">
+              {t('subjectPredicateMI.retry')}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (!result || result.totalRelations === 0) {
+    return (
+      <div className="space-y-4">
+        {intro}
+        <div className="py-8 text-center">
+          <h3 className="text-sm font-semibold text-stone-700 dark:text-neutral-200">
+            {t('subjectPredicateMI.empty')}
+          </h3>
+          <p className="mt-1 text-xs text-stone-500 dark:text-neutral-400">
+            {t('subjectPredicateMI.emptyHint')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const rows = result.subjects.slice(0, MAX_ROWS);
+  const nmiPct = Math.max(0, Math.min(100, Math.round(result.normalisedMI * 100)));
+
+  return (
+    <div className="space-y-4">
+      {intro}
+
+      {/* Metric tiles */}
+      <div className="grid gap-2 sm:grid-cols-3">
+        {[
+          { label: t('subjectPredicateMI.metricMI'), value: result.mutualInformation.toFixed(2) },
+          { label: t('subjectPredicateMI.metricNMI'), value: `${nmiPct}%` },
+          { label: t('subjectPredicateMI.metricSubjects'), value: result.distinctSubjects },
+        ].map(tile => (
+          <div
+            key={tile.label}
+            className="rounded-lg border border-stone-200 dark:border-neutral-800 p-3">
+            <div className="text-[10px] uppercase tracking-wider text-stone-400 dark:text-neutral-500">
+              {tile.label}
+            </div>
+            <div className="text-lg font-semibold tabular-nums text-stone-900 dark:text-neutral-100">
+              {tile.value}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-[11px] text-stone-500 dark:text-neutral-400">
+        {t('subjectPredicateMI.summaryCaption')
+          .replace('{hs}', result.subjectEntropy.toFixed(2))
+          .replace('{hp}', result.predicateEntropy.toFixed(2))}
+      </p>
+
+      {/* Ranked specialisation */}
+      <section aria-labelledby="subject-predicate-mi-heading" className="space-y-1">
+        <h3
+          id="subject-predicate-mi-heading"
+          className="text-xs font-semibold uppercase tracking-wider text-stone-500 dark:text-neutral-400">
+          {t('subjectPredicateMI.rankedHeading')}
+        </h3>
+        <table
+          aria-labelledby="subject-predicate-mi-heading"
+          className="w-full text-left text-[11px] tabular-nums">
+          <thead className="text-stone-400 dark:text-neutral-500">
+            <tr>
+              <th scope="col" className="w-8 py-1 pr-2 font-medium">
+                {t('subjectPredicateMI.colRank')}
+              </th>
+              <th scope="col" className="py-1 pr-2 font-medium">
+                {t('subjectPredicateMI.colSubject')}
+              </th>
+              <th scope="col" className="w-1/3 py-1 pr-2 font-medium">
+                {t('subjectPredicateMI.colSpecialisation')}
+              </th>
+              <th scope="col" className="w-16 py-1 pr-2 text-right font-medium">
+                {t('subjectPredicateMI.colDominant')}
+              </th>
+              <th scope="col" className="w-10 py-1 text-right font-medium">
+                {t('subjectPredicateMI.colRelations')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              const widthPct = Math.max(0, Math.min(100, row.specialisation * 100));
+              return (
+                <tr
+                  key={row.subject}
+                  className="border-t border-stone-100 dark:border-neutral-800/60">
+                  <td className="py-1 pr-2 text-stone-400 dark:text-neutral-500">{i + 1}</td>
+                  <td className="py-1 pr-2 text-stone-800 dark:text-neutral-100 break-words">
+                    {row.subject}
+                  </td>
+                  <td className="py-1 pr-2">
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1 h-2 rounded bg-stone-100 dark:bg-neutral-800 overflow-hidden">
+                        <div
+                          className="h-full bg-primary-400/70"
+                          style={{ width: `${widthPct}%` }}
+                        />
+                      </div>
+                      <span className="w-10 shrink-0 text-right text-stone-500 dark:text-neutral-400">
+                        {(row.specialisation * 100).toFixed(0)}%
+                      </span>
+                    </div>
+                  </td>
+                  <td className="py-1 pr-2 text-right text-stone-500 dark:text-neutral-400 break-words">
+                    {row.dominantPredicate}
+                  </td>
+                  <td className="py-1 text-right text-stone-500 dark:text-neutral-400">
+                    {row.relationCount}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+};
+
+export default SubjectPredicateMIPanel;

--- a/app/src/components/intelligence/SubjectPredicateMITab.test.tsx
+++ b/app/src/components/intelligence/SubjectPredicateMITab.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { computeSubjectPredicateMI } from '../../lib/memory/subjectPredicateMI';
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import SubjectPredicateMITab from './SubjectPredicateMITab';
+
+const mockLoadMI = vi.fn();
+const mockLoadNamespaces = vi.fn();
+
+vi.mock('../../services/api/subjectPredicateMIApi', () => ({
+  loadSubjectPredicateMI: (...args: unknown[]) => mockLoadMI(...args),
+  loadNamespaces: (...args: unknown[]) => mockLoadNamespaces(...args),
+}));
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'n',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+const result = computeSubjectPredicateMI([rel('A', 'knows', 'X'), rel('B', 'trusts', 'X')]);
+
+describe('<SubjectPredicateMITab />', () => {
+  beforeEach(() => {
+    mockLoadMI.mockReset();
+    mockLoadNamespaces.mockReset();
+    mockLoadMI.mockResolvedValue(result);
+    mockLoadNamespaces.mockResolvedValue([]);
+  });
+
+  it('loads MI (all namespaces) on mount and renders the result', async () => {
+    render(<SubjectPredicateMITab />);
+    expect(mockLoadMI).toHaveBeenCalledWith(undefined);
+    await waitFor(() =>
+      expect(screen.getByText('Most-to-least specialised subjects')).toBeInTheDocument()
+    );
+  });
+
+  it('shows the namespace selector and re-queries on change', async () => {
+    mockLoadNamespaces.mockResolvedValueOnce(['work', 'personal']);
+    render(<SubjectPredicateMITab />);
+    await waitFor(() => screen.getByRole('combobox'));
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'work' } });
+    await waitFor(() => expect(mockLoadMI).toHaveBeenCalledWith('work'));
+  });
+
+  it('surfaces an error when the load fails', async () => {
+    mockLoadMI.mockReset();
+    mockLoadMI.mockRejectedValueOnce(new Error('graph unavailable'));
+    render(<SubjectPredicateMITab />);
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toMatch(/graph unavailable/));
+  });
+});

--- a/app/src/components/intelligence/SubjectPredicateMITab.tsx
+++ b/app/src/components/intelligence/SubjectPredicateMITab.tsx
@@ -1,0 +1,83 @@
+/**
+ * Subject-Predicate MI tab (container). Owns load-on-mount and the namespace
+ * selector; delegates all rendering to the pure <SubjectPredicateMIPanel>.
+ * Read-only — the result is recomputed from the live graph, never persisted.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useT } from '../../lib/i18n/I18nContext';
+import type { SubjectPredicateMIResult } from '../../lib/memory/subjectPredicateMI';
+import { loadNamespaces, loadSubjectPredicateMI } from '../../services/api/subjectPredicateMIApi';
+import SubjectPredicateMIPanel from './SubjectPredicateMIPanel';
+
+const SubjectPredicateMITab = () => {
+  const { t } = useT();
+  const [result, setResult] = useState<SubjectPredicateMIResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [namespaces, setNamespaces] = useState<string[]>([]);
+  const [namespace, setNamespace] = useState('');
+  // Monotonic token: ignore a response if a newer load has since started, so
+  // an out-of-order resolution can never overwrite the latest result.
+  const latestRequestId = useRef(0);
+
+  const load = useCallback(async (ns: string) => {
+    const requestId = (latestRequestId.current += 1);
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await loadSubjectPredicateMI(ns || undefined);
+      if (requestId !== latestRequestId.current) return;
+      setResult(next);
+    } catch (err) {
+      if (requestId !== latestRequestId.current) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (requestId === latestRequestId.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Namespaces are optional UI sugar; a failure to list them must not block
+    // the specialisation view, so swallow that error specifically.
+    loadNamespaces()
+      .then(setNamespaces)
+      .catch(() => setNamespaces([]));
+    void load('');
+  }, [load]);
+
+  const handleNamespace = (next: string): void => {
+    setNamespace(next);
+    void load(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      {namespaces.length > 0 && (
+        <label className="flex items-center gap-2 text-xs text-stone-600 dark:text-neutral-300">
+          {t('subjectPredicateMI.namespaceLabel')}
+          <select
+            value={namespace}
+            onChange={e => handleNamespace(e.target.value)}
+            className="rounded-lg border border-stone-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-sm text-stone-800 dark:text-neutral-100">
+            <option value="">{t('subjectPredicateMI.namespaceAll')}</option>
+            {namespaces.map(ns => (
+              <option key={ns} value={ns}>
+                {ns}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <SubjectPredicateMIPanel
+        result={result}
+        loading={loading}
+        error={error}
+        onRetry={() => void load(namespace)}
+      />
+    </div>
+  );
+};
+
+export default SubjectPredicateMITab;

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -4350,6 +4350,27 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'رفض التخزين المحلي',
   'pages.settings.account.security': 'الأمان',
   'pages.settings.account.securityDesc': 'وضع تخزين الأسرار وحالة سلسلة المفاتيح',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'أعلى مسند',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'علاقات',
+  'subjectPredicateMI.colSpecialisation': 'التخصص',
+  'subjectPredicateMI.colSubject': 'الموضوع',
+  'subjectPredicateMI.empty': 'لا يوجد رسم معرفي بعد.',
+  'subjectPredicateMI.emptyHint': 'كلما سجّل المساعد علاقات عنك، سيظهر هنا ملف التخصص لكل موضوع.',
+  'subjectPredicateMI.errorPrefix': 'تعذّر تحميل الرسم البياني:',
+  'subjectPredicateMI.intro':
+    'المعلومات المتبادلة بين المواضيع والمسندات: كم تنبئنا معرفة الكيان بنوع العلاقة التي سيستخدمها؟ عالمياً تكشف ما إذا كانت المواضيع تتحدث بأدوار ثابتة أم تتشارك مفردات حرة. لكل كيان، ترتب المتخصصين (مواضيع تركز على مسند واحد) فوق الموسوعيين (مواضيع مسنداتها موزعة بالتساوي).',
+  'subjectPredicateMI.loading': 'حساب ملف التخصص…',
+  'subjectPredicateMI.metricMI': 'المعلومات المتبادلة (بت)',
+  'subjectPredicateMI.metricNMI': 'MI معيارية',
+  'subjectPredicateMI.metricSubjects': 'المواضيع',
+  'subjectPredicateMI.namespaceAll': 'كل مساحات الأسماء',
+  'subjectPredicateMI.namespaceLabel': 'مساحة الأسماء',
+  'subjectPredicateMI.rankedHeading': 'المواضيع من الأكثر إلى الأقل تخصصاً',
+  'subjectPredicateMI.retry': 'إعادة المحاولة',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} بت · H(P) = {hp} بت',
+  'subjectPredicateMI.title': 'تخصص الموضوع-المسند',
 };
 
 export default messages;

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -4427,6 +4427,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'স্থানীয় সঞ্চয়স্থান প্রত্যাখ্যান করুন',
   'pages.settings.account.security': 'নিরাপত্তা',
   'pages.settings.account.securityDesc': 'গোপনীয়তা সঞ্চয়স্থান মোড এবং কিচেন অবস্থা',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'শীর্ষ বিধেয়',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'সম্প.',
+  'subjectPredicateMI.colSpecialisation': 'বিশেষীকরণ',
+  'subjectPredicateMI.colSubject': 'বিষয়',
+  'subjectPredicateMI.empty': 'এখনও কোনো জ্ঞান গ্রাফ নেই।',
+  'subjectPredicateMI.emptyHint':
+    'সহকারী যখন আপনার সম্পর্কে সম্পর্ক রেকর্ড করে, প্রতি-বিষয় বিশেষীকরণ প্রোফাইল এখানে উঠে আসবে।',
+  'subjectPredicateMI.errorPrefix': 'গ্রাফ লোড করা যায়নি:',
+  'subjectPredicateMI.intro':
+    'বিষয় এবং বিধেয়ের মধ্যে পারস্পরিক তথ্য: সত্তাটি জানা কতটা ভবিষ্যদ্বাণী করে যে এটি কোন ধরনের সম্পর্ক ব্যবহার করবে? বৈশ্বিকভাবে এটি প্রকাশ করে বিষয়গুলি স্থির ভূমিকায় কথা বলে নাকি একটি মুক্ত শব্দভাণ্ডার ভাগ করে। প্রতি সত্তা, এটি বিশেষজ্ঞদের (একক বিধেয়ে মনোনিবেশকারী বিষয়) সাধারণজ্ঞদের (যাদের বিধেয় সমানভাবে ছড়িয়ে আছে) উপরে স্থান দেয়।',
+  'subjectPredicateMI.loading': 'বিশেষীকরণ প্রোফাইল গণনা করা হচ্ছে…',
+  'subjectPredicateMI.metricMI': 'পারস্পরিক তথ্য (বিট)',
+  'subjectPredicateMI.metricNMI': 'স্বাভাবিকীকৃত MI',
+  'subjectPredicateMI.metricSubjects': 'বিষয়',
+  'subjectPredicateMI.namespaceAll': 'সমস্ত নেমস্পেস',
+  'subjectPredicateMI.namespaceLabel': 'নেমস্পেস',
+  'subjectPredicateMI.rankedHeading': 'সর্বাধিক থেকে স্বল্পতম বিশেষায়িত বিষয়',
+  'subjectPredicateMI.retry': 'পুনরায় চেষ্টা',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} বিট · H(P) = {hp} বিট',
+  'subjectPredicateMI.title': 'বিষয়-বিধেয় বিশেষীকরণ',
 };
 
 export default messages;

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -4543,6 +4543,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Lokalen Speicher ablehnen',
   'pages.settings.account.security': 'Sicherheit',
   'pages.settings.account.securityDesc': 'Geheimnisspeicher-Modus und Schlüsselbund-Status',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Top-Prädikat',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Spezialisierung',
+  'subjectPredicateMI.colSubject': 'Subjekt',
+  'subjectPredicateMI.empty': 'Noch kein Wissensgraph.',
+  'subjectPredicateMI.emptyHint':
+    'Während der Assistent Relationen über Sie erfasst, erscheint hier das Spezialisierungsprofil pro Subjekt.',
+  'subjectPredicateMI.errorPrefix': 'Graph konnte nicht geladen werden:',
+  'subjectPredicateMI.intro':
+    'Wechselseitige Information zwischen Subjekten und Prädikaten: wie viel sagt das Wissen über die Entität voraus, welche Relationsart sie verwendet? Global zeigt sie, ob Subjekte in festen Rollen sprechen oder ein freies Vokabular teilen. Pro Entität rankt sie Spezialisten (Subjekte mit Konzentration auf ein einziges Prädikat) über Generalisten (Subjekte mit gleichmäßig verteilten Prädikaten).',
+  'subjectPredicateMI.loading': 'Berechne Spezialisierungsprofil…',
+  'subjectPredicateMI.metricMI': 'Wechselseitige Information (Bits)',
+  'subjectPredicateMI.metricNMI': 'Normalisierte MI',
+  'subjectPredicateMI.metricSubjects': 'Subjekte',
+  'subjectPredicateMI.namespaceAll': 'Alle Namensräume',
+  'subjectPredicateMI.namespaceLabel': 'Namensraum',
+  'subjectPredicateMI.rankedHeading': 'Subjekte von am stärksten bis am wenigsten spezialisiert',
+  'subjectPredicateMI.retry': 'Wiederholen',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} Bits · H(P) = {hp} Bits',
+  'subjectPredicateMI.title': 'Subjekt-Prädikat-Spezialisierung',
 };
 
 export default messages;

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -307,6 +307,7 @@ const en: TranslationMap = {
   'memory.tab.namespaces': 'Namespaces',
   'memory.tab.timeline': 'Timeline',
   'memory.tab.cohesion': 'Cohesion',
+  'memory.tab.specialisation': 'Specialisation',
   'memory.tab.settings': 'Settings',
   'memory.tab.council': 'Council',
   'modelCouncil.title': 'Model Council',
@@ -488,6 +489,28 @@ const en: TranslationMap = {
   'graphCohesion.brokerBadge': 'broker',
   'graphCohesion.brokerTitle':
     "Structural hole: this entity's neighbours aren't connected to each other — it's the sole link between them.",
+
+  'subjectPredicateMI.title': 'Subject-Predicate Specialisation',
+  'subjectPredicateMI.intro':
+    'Mutual information between subjects and predicates: how much does knowing the entity predict which relation kind it will use? Globally it surfaces whether subjects speak in fixed roles or share a free vocabulary. Per entity, it ranks the specialists (subjects who concentrate on a single predicate) above the generalists (subjects whose predicates are evenly spread).',
+  'subjectPredicateMI.loading': 'Computing specialisation profile…',
+  'subjectPredicateMI.errorPrefix': 'Could not load the graph:',
+  'subjectPredicateMI.retry': 'Retry',
+  'subjectPredicateMI.empty': 'No knowledge graph yet.',
+  'subjectPredicateMI.emptyHint':
+    'As the assistant records relations about you, the per-subject specialisation profile will surface here.',
+  'subjectPredicateMI.namespaceLabel': 'Namespace',
+  'subjectPredicateMI.namespaceAll': 'All namespaces',
+  'subjectPredicateMI.metricMI': 'Mutual information (bits)',
+  'subjectPredicateMI.metricNMI': 'Normalised MI',
+  'subjectPredicateMI.metricSubjects': 'Subjects',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bits · H(P) = {hp} bits',
+  'subjectPredicateMI.rankedHeading': 'Most-to-least specialised subjects',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colSubject': 'Subject',
+  'subjectPredicateMI.colSpecialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Top predicate',
+  'subjectPredicateMI.colRelations': 'Rels',
 
   // Memory Tree status panel (#1856 Part 1)
   'memoryTree.status.title': 'Memory Tree',
@@ -2500,7 +2523,7 @@ const en: TranslationMap = {
   'app.openhumanLink.notifications.send': 'Send test notification',
   'app.openhumanLink.notifications.sendFailed': "Couldn't send: {error}",
   'app.openhumanLink.notifications.sent':
-    "Test notification sent. If you didn't receive it, go to System Settings → Notifications → OpenHuman, turn on Allow Notifications, and set Banner Style to Persistent.",
+    'Test notification sent. If you didn’t receive it, go to System Settings → Notifications → OpenHuman, turn on Allow Notifications, and set Banner Style to Persistent.',
   'app.openhumanLink.skipForNow': 'Skip for now',
   'app.openhumanLink.telegramUnavailable': 'Telegram unavailable',
   'app.openhumanLink.title.accounts': 'Connect your apps',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -4509,6 +4509,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Rechazar almacenamiento local',
   'pages.settings.account.security': 'Seguridad',
   'pages.settings.account.securityDesc': 'Modo de almacenamiento de secretos y estado del llavero',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Predicado principal',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Especialización',
+  'subjectPredicateMI.colSubject': 'Sujeto',
+  'subjectPredicateMI.empty': 'Aún no hay grafo de conocimiento.',
+  'subjectPredicateMI.emptyHint':
+    'A medida que el asistente registra relaciones sobre usted, el perfil de especialización por sujeto aparecerá aquí.',
+  'subjectPredicateMI.errorPrefix': 'No se pudo cargar el grafo:',
+  'subjectPredicateMI.intro':
+    'Información mutua entre sujetos y predicados: ¿cuánto predice conocer la entidad qué tipo de relación usará? Globalmente revela si los sujetos hablan en roles fijos o comparten un vocabulario libre. Por entidad, clasifica a los especialistas (sujetos que se concentran en un solo predicado) por encima de los generalistas (sujetos cuyos predicados están distribuidos uniformemente).',
+  'subjectPredicateMI.loading': 'Calculando perfil de especialización…',
+  'subjectPredicateMI.metricMI': 'Información mutua (bits)',
+  'subjectPredicateMI.metricNMI': 'IM normalizada',
+  'subjectPredicateMI.metricSubjects': 'Sujetos',
+  'subjectPredicateMI.namespaceAll': 'Todos los espacios de nombres',
+  'subjectPredicateMI.namespaceLabel': 'Espacio de nombres',
+  'subjectPredicateMI.rankedHeading': 'Sujetos de más a menos especializado',
+  'subjectPredicateMI.retry': 'Reintentar',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bits · H(P) = {hp} bits',
+  'subjectPredicateMI.title': 'Especialización sujeto-predicado',
 };
 
 export default messages;

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -4524,6 +4524,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Refuser le stockage local',
   'pages.settings.account.security': 'Sécurité',
   'pages.settings.account.securityDesc': 'Mode de stockage des secrets et état du trousseau',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Prédicat principal',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Spécialisation',
+  'subjectPredicateMI.colSubject': 'Sujet',
+  'subjectPredicateMI.empty': 'Pas encore de graphe de connaissances.',
+  'subjectPredicateMI.emptyHint':
+    "À mesure que l'assistant enregistre des relations à votre sujet, le profil de spécialisation par sujet apparaîtra ici.",
+  'subjectPredicateMI.errorPrefix': 'Impossible de charger le graphe :',
+  'subjectPredicateMI.intro':
+    "Information mutuelle entre sujets et prédicats : à quel point connaître l'entité prédit-il le type de relation qu'elle utilisera ? Globalement, elle révèle si les sujets parlent dans des rôles fixes ou partagent un vocabulaire libre. Par entité, elle classe les spécialistes (sujets qui se concentrent sur un seul prédicat) au-dessus des généralistes (sujets dont les prédicats sont répartis uniformément).",
+  'subjectPredicateMI.loading': 'Calcul du profil de spécialisation…',
+  'subjectPredicateMI.metricMI': 'Information mutuelle (bits)',
+  'subjectPredicateMI.metricNMI': 'IM normalisée',
+  'subjectPredicateMI.metricSubjects': 'Sujets',
+  'subjectPredicateMI.namespaceAll': 'Tous les espaces de noms',
+  'subjectPredicateMI.namespaceLabel': 'Espace de noms',
+  'subjectPredicateMI.rankedHeading': 'Sujets du plus au moins spécialisé',
+  'subjectPredicateMI.retry': 'Réessayer',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bits · H(P) = {hp} bits',
+  'subjectPredicateMI.title': 'Spécialisation sujet-prédicat',
 };
 
 export default messages;

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -4434,6 +4434,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'स्थानीय भंडारण अस्वीकार करें',
   'pages.settings.account.security': 'सुरक्षा',
   'pages.settings.account.securityDesc': 'रहस्य भंडारण मोड और कीचेन स्थिति',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'शीर्ष विधेय',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'सं.',
+  'subjectPredicateMI.colSpecialisation': 'विशेषज्ञता',
+  'subjectPredicateMI.colSubject': 'विषय',
+  'subjectPredicateMI.empty': 'अभी कोई नॉलेज ग्राफ नहीं।',
+  'subjectPredicateMI.emptyHint':
+    'जैसे-जैसे सहायक आपके बारे में संबंध दर्ज करता है, प्रति-विषय विशेषज्ञता प्रोफ़ाइल यहाँ उभरेगी।',
+  'subjectPredicateMI.errorPrefix': 'ग्राफ लोड नहीं हो सका:',
+  'subjectPredicateMI.intro':
+    'विषयों और विधेयों के बीच पारस्परिक सूचना: इकाई को जानना कितना भविष्यवाणी करता है कि वह किस तरह का संबंध उपयोग करेगी? वैश्विक रूप से यह दिखाती है कि विषय निश्चित भूमिकाओं में बोलते हैं या मुक्त शब्दावली साझा करते हैं। प्रति इकाई, यह विशेषज्ञों (एक ही विधेय पर केंद्रित विषय) को सामान्यविदों (समान रूप से फैले विधेयों वाले विषय) से ऊपर रैंक करती है।',
+  'subjectPredicateMI.loading': 'विशेषज्ञता प्रोफ़ाइल गणना हो रही है…',
+  'subjectPredicateMI.metricMI': 'पारस्परिक सूचना (बिट्स)',
+  'subjectPredicateMI.metricNMI': 'सामान्यीकृत MI',
+  'subjectPredicateMI.metricSubjects': 'विषय',
+  'subjectPredicateMI.namespaceAll': 'सभी नेमस्पेस',
+  'subjectPredicateMI.namespaceLabel': 'नेमस्पेस',
+  'subjectPredicateMI.rankedHeading': 'सबसे अधिक से सबसे कम विशेषज्ञ विषय',
+  'subjectPredicateMI.retry': 'पुनः प्रयास',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} बिट · H(P) = {hp} बिट',
+  'subjectPredicateMI.title': 'विषय-विधेय विशेषज्ञता',
 };
 
 export default messages;

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -4443,6 +4443,29 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Tolak penyimpanan lokal',
   'pages.settings.account.security': 'Keamanan',
   'pages.settings.account.securityDesc': 'Mode penyimpanan rahasia dan status keychain',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Predikat teratas',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Spesialisasi',
+  'subjectPredicateMI.colSubject': 'Subjek',
+  'subjectPredicateMI.empty': 'Belum ada graf pengetahuan.',
+  'subjectPredicateMI.emptyHint':
+    'Saat asisten mencatat relasi tentang Anda, profil spesialisasi per subjek akan muncul di sini.',
+  'subjectPredicateMI.errorPrefix': 'Tidak dapat memuat graf:',
+  'subjectPredicateMI.intro':
+    'Informasi mutual antara subjek dan predikat: seberapa besar mengetahui entitas memprediksi jenis relasi yang akan digunakannya? Secara global, ini mengungkap apakah subjek berbicara dalam peran tetap atau berbagi kosakata bebas. Per entitas, ini memeringkat spesialis (subjek yang berkonsentrasi pada satu predikat) di atas generalis (subjek yang predikatnya tersebar merata).',
+  'subjectPredicateMI.loading': 'Menghitung profil spesialisasi…',
+  'subjectPredicateMI.metricMI': 'Informasi mutual (bit)',
+  'subjectPredicateMI.metricNMI': 'IM dinormalisasi',
+  'subjectPredicateMI.metricSubjects': 'Subjek',
+  'subjectPredicateMI.namespaceAll': 'Semua ruang nama',
+  'subjectPredicateMI.namespaceLabel': 'Ruang nama',
+  'subjectPredicateMI.rankedHeading':
+    'Subjek dari yang paling hingga paling sedikit terspesialisasi',
+  'subjectPredicateMI.retry': 'Coba lagi',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bit · H(P) = {hp} bit',
+  'subjectPredicateMI.title': 'Spesialisasi subjek-predikat',
 };
 
 export default messages;

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -4501,6 +4501,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Rifiuta archiviazione locale',
   'pages.settings.account.security': 'Sicurezza',
   'pages.settings.account.securityDesc': 'Modalità archiviazione segreti e stato del portachiavi',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Predicato principale',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Specializzazione',
+  'subjectPredicateMI.colSubject': 'Soggetto',
+  'subjectPredicateMI.empty': 'Ancora nessun grafo della conoscenza.',
+  'subjectPredicateMI.emptyHint':
+    "Man mano che l'assistente registra relazioni su di te, qui apparirà il profilo di specializzazione per soggetto.",
+  'subjectPredicateMI.errorPrefix': 'Impossibile caricare il grafo:',
+  'subjectPredicateMI.intro':
+    "Informazione mutua tra soggetti e predicati: quanto conoscere l'entità predice quale tipo di relazione userà? Globalmente rivela se i soggetti parlano in ruoli fissi o condividono un vocabolario libero. Per entità, classifica gli specialisti (soggetti che si concentrano su un solo predicato) sopra i generalisti (soggetti i cui predicati sono distribuiti uniformemente).",
+  'subjectPredicateMI.loading': 'Calcolo profilo di specializzazione…',
+  'subjectPredicateMI.metricMI': 'Informazione mutua (bit)',
+  'subjectPredicateMI.metricNMI': 'IM normalizzata',
+  'subjectPredicateMI.metricSubjects': 'Soggetti',
+  'subjectPredicateMI.namespaceAll': 'Tutti gli spazi dei nomi',
+  'subjectPredicateMI.namespaceLabel': 'Spazio dei nomi',
+  'subjectPredicateMI.rankedHeading': 'Soggetti dal più al meno specializzato',
+  'subjectPredicateMI.retry': 'Riprova',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bit · H(P) = {hp} bit',
+  'subjectPredicateMI.title': 'Specializzazione soggetto-predicato',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -4393,6 +4393,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': '로컬 저장소 거부',
   'pages.settings.account.security': '보안',
   'pages.settings.account.securityDesc': '비밀 저장 모드 및 키체인 상태',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': '상위 술어',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': '관계',
+  'subjectPredicateMI.colSpecialisation': '전문화',
+  'subjectPredicateMI.colSubject': '주어',
+  'subjectPredicateMI.empty': '아직 지식 그래프가 없습니다.',
+  'subjectPredicateMI.emptyHint':
+    '어시스턴트가 사용자에 대한 관계를 기록함에 따라, 주제별 전문화 프로필이 여기에 나타납니다.',
+  'subjectPredicateMI.errorPrefix': '그래프를 불러올 수 없습니다:',
+  'subjectPredicateMI.intro':
+    '주어와 술어 간의 상호 정보: 엔티티를 아는 것이 어떤 종류의 관계를 사용할지 얼마나 예측하는가? 전역적으로 주어가 고정된 역할로 말하는지 자유 어휘를 공유하는지 드러냅니다. 엔티티별로, 전문가(단일 술어에 집중하는 주어)를 일반론자(술어가 고르게 퍼진 주어) 위에 순위 매깁니다.',
+  'subjectPredicateMI.loading': '전문화 프로필 계산 중…',
+  'subjectPredicateMI.metricMI': '상호 정보 (비트)',
+  'subjectPredicateMI.metricNMI': '정규화 MI',
+  'subjectPredicateMI.metricSubjects': '주어',
+  'subjectPredicateMI.namespaceAll': '모든 네임스페이스',
+  'subjectPredicateMI.namespaceLabel': '네임스페이스',
+  'subjectPredicateMI.rankedHeading': '가장에서 가장 적게 전문화된 주제',
+  'subjectPredicateMI.retry': '다시 시도',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} 비트 · H(P) = {hp} 비트',
+  'subjectPredicateMI.title': '주어-술어 전문화',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -4501,6 +4501,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Odmów lokalnego przechowywania',
   'pages.settings.account.security': 'Bezpieczeństwo',
   'pages.settings.account.securityDesc': 'Tryb przechowywania sekretów i stan pęku kluczy',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Najlepszy predykat',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Specjalizacja',
+  'subjectPredicateMI.colSubject': 'Podmiot',
+  'subjectPredicateMI.empty': 'Jeszcze brak grafu wiedzy.',
+  'subjectPredicateMI.emptyHint':
+    'Gdy asystent zapisuje relacje o tobie, profil specjalizacji na podmiot pojawi się tutaj.',
+  'subjectPredicateMI.errorPrefix': 'Nie udało się załadować grafu:',
+  'subjectPredicateMI.intro':
+    'Informacja wzajemna między podmiotami a predykatami: o ile znajomość encji przewiduje, jakiego rodzaju relacji użyje? Globalnie ujawnia, czy podmioty mówią w stałych rolach, czy dzielą wolny słownik. Per encja klasyfikuje specjalistów (podmioty skupione na jednym predykacie) ponad generalistami (podmioty, których predykaty są rozłożone równomiernie).',
+  'subjectPredicateMI.loading': 'Obliczanie profilu specjalizacji…',
+  'subjectPredicateMI.metricMI': 'Informacja wzajemna (bity)',
+  'subjectPredicateMI.metricNMI': 'Znormalizowana IM',
+  'subjectPredicateMI.metricSubjects': 'Podmioty',
+  'subjectPredicateMI.namespaceAll': 'Wszystkie przestrzenie nazw',
+  'subjectPredicateMI.namespaceLabel': 'Przestrzeń nazw',
+  'subjectPredicateMI.rankedHeading': 'Podmioty od najbardziej do najmniej wyspecjalizowanych',
+  'subjectPredicateMI.retry': 'Spróbuj ponownie',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bitów · H(P) = {hp} bitów',
+  'subjectPredicateMI.title': 'Specjalizacja podmiot-predykat',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -4498,6 +4498,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Recusar armazenamento local',
   'pages.settings.account.security': 'Segurança',
   'pages.settings.account.securityDesc': 'Modo de armazenamento de segredos e status do chaveiro',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Predicado principal',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Rel.',
+  'subjectPredicateMI.colSpecialisation': 'Especialização',
+  'subjectPredicateMI.colSubject': 'Sujeito',
+  'subjectPredicateMI.empty': 'Ainda sem grafo de conhecimento.',
+  'subjectPredicateMI.emptyHint':
+    'À medida que o assistente registra relações sobre você, o perfil de especialização por sujeito aparecerá aqui.',
+  'subjectPredicateMI.errorPrefix': 'Não foi possível carregar o grafo:',
+  'subjectPredicateMI.intro':
+    'Informação mútua entre sujeitos e predicados: quanto conhecer a entidade prevê qual tipo de relação ela usará? Globalmente revela se os sujeitos falam em papéis fixos ou compartilham um vocabulário livre. Por entidade, classifica os especialistas (sujeitos que se concentram em um único predicado) acima dos generalistas (sujeitos cujos predicados são distribuídos uniformemente).',
+  'subjectPredicateMI.loading': 'Calculando perfil de especialização…',
+  'subjectPredicateMI.metricMI': 'Informação mútua (bits)',
+  'subjectPredicateMI.metricNMI': 'IM normalizada',
+  'subjectPredicateMI.metricSubjects': 'Sujeitos',
+  'subjectPredicateMI.namespaceAll': 'Todos os espaços de nomes',
+  'subjectPredicateMI.namespaceLabel': 'Espaço de nomes',
+  'subjectPredicateMI.rankedHeading': 'Sujeitos do mais ao menos especializado',
+  'subjectPredicateMI.retry': 'Tentar novamente',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} bits · H(P) = {hp} bits',
+  'subjectPredicateMI.title': 'Especialização sujeito-predicado',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -4469,6 +4469,28 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Отклонить локальное хранилище',
   'pages.settings.account.security': 'Безопасность',
   'pages.settings.account.securityDesc': 'Режим хранения секретов и статус связки ключей',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': 'Топ-предикат',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': 'Отн.',
+  'subjectPredicateMI.colSpecialisation': 'Специализация',
+  'subjectPredicateMI.colSubject': 'Субъект',
+  'subjectPredicateMI.empty': 'Пока нет графа знаний.',
+  'subjectPredicateMI.emptyHint':
+    'По мере того как ассистент фиксирует отношения о вас, здесь появится профиль специализации по субъекту.',
+  'subjectPredicateMI.errorPrefix': 'Не удалось загрузить граф:',
+  'subjectPredicateMI.intro':
+    'Взаимная информация между субъектами и предикатами: насколько знание сущности предсказывает, какой тип отношения она будет использовать? Глобально она вскрывает, говорят ли субъекты в фиксированных ролях или делят свободный словарь. На сущность она ранжирует специалистов (субъекты, сосредоточенные на одном предикате) выше универсалов (субъекты, чьи предикаты распределены равномерно).',
+  'subjectPredicateMI.loading': 'Вычисление профиля специализации…',
+  'subjectPredicateMI.metricMI': 'Взаимная информация (биты)',
+  'subjectPredicateMI.metricNMI': 'Нормализованная ВИ',
+  'subjectPredicateMI.metricSubjects': 'Субъекты',
+  'subjectPredicateMI.namespaceAll': 'Все пространства имён',
+  'subjectPredicateMI.namespaceLabel': 'Пространство имён',
+  'subjectPredicateMI.rankedHeading': 'Субъекты от самых до наименее специализированных',
+  'subjectPredicateMI.retry': 'Повторить',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} бит · H(P) = {hp} бит',
+  'subjectPredicateMI.title': 'Специализация субъект-предикат',
 };
 
 export default messages;

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -4214,6 +4214,27 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': '拒绝本地存储',
   'pages.settings.account.security': '安全',
   'pages.settings.account.securityDesc': '密钥存储模式和密钥链状态',
+  'memory.tab.specialisation': 'Specialisation',
+  'subjectPredicateMI.colDominant': '首位谓词',
+  'subjectPredicateMI.colRank': '#',
+  'subjectPredicateMI.colRelations': '关系',
+  'subjectPredicateMI.colSpecialisation': '专门化',
+  'subjectPredicateMI.colSubject': '主体',
+  'subjectPredicateMI.empty': '暂无知识图。',
+  'subjectPredicateMI.emptyHint': '随着助手记录你的相关关系,按主体的专门化画像将在此显现。',
+  'subjectPredicateMI.errorPrefix': '无法加载图:',
+  'subjectPredicateMI.intro':
+    '主体与谓词之间的互信息:知道实体在多大程度上预测它将使用何种关系?在全局层面,揭示主体是以固定角色发声还是共享自由词汇。在每个实体层面,将专才(集中于单一谓词的主体)排在通才(谓词分布均匀的主体)之上。',
+  'subjectPredicateMI.loading': '正在计算专门化画像…',
+  'subjectPredicateMI.metricMI': '互信息(比特)',
+  'subjectPredicateMI.metricNMI': '归一化 MI',
+  'subjectPredicateMI.metricSubjects': '主体',
+  'subjectPredicateMI.namespaceAll': '所有命名空间',
+  'subjectPredicateMI.namespaceLabel': '命名空间',
+  'subjectPredicateMI.rankedHeading': '从最专门到最不专门的主体',
+  'subjectPredicateMI.retry': '重试',
+  'subjectPredicateMI.summaryCaption': 'H(S) = {hs} 比特 · H(P) = {hp} 比特',
+  'subjectPredicateMI.title': '主体-谓词专门化',
 };
 
 export default messages;

--- a/app/src/lib/memory/subjectPredicateMI.test.ts
+++ b/app/src/lib/memory/subjectPredicateMI.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import { computeSubjectPredicateMI } from './subjectPredicateMI';
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'work',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+function subj(result: ReturnType<typeof computeSubjectPredicateMI>, id: string) {
+  const s = result.subjects.find(x => x.subject === id);
+  if (!s) throw new Error(`subject ${id} not found`);
+  return s;
+}
+
+describe('computeSubjectPredicateMI — basic shapes', () => {
+  it('returns a zeroed result for no relations', () => {
+    const r = computeSubjectPredicateMI([]);
+    expect(r.totalRelations).toBe(0);
+    expect(r.distinctSubjects).toBe(0);
+    expect(r.distinctPredicates).toBe(0);
+    expect(r.mutualInformation).toBe(0);
+    expect(r.subjectEntropy).toBe(0);
+    expect(r.predicateEntropy).toBe(0);
+    expect(r.normalisedMI).toBe(0);
+    expect(r.subjects).toEqual([]);
+  });
+
+  it('one subject, one predicate, many relations: MI is 0 (nothing varies)', () => {
+    const r = computeSubjectPredicateMI([
+      rel('A', 'knows', 'B'),
+      rel('A', 'knows', 'C'),
+      rel('A', 'knows', 'D'),
+    ]);
+    expect(r.mutualInformation).toBe(0);
+    expect(r.subjectEntropy).toBe(0); // p(A) = 1
+    expect(r.predicateEntropy).toBe(0); // p(knows) = 1
+    expect(r.normalisedMI).toBe(0); // min(H(S),H(P)) === 0
+    // Subject A uses only one predicate -> maximally specialised by convention.
+    expect(subj(r, 'A').specialisation).toBe(1);
+    expect(subj(r, 'A').dominantPredicate).toBe('knows');
+    expect(subj(r, 'A').dominantPredicateShare).toBe(1);
+  });
+
+  it('one subject, two predicates equally: MI is 0 (subject does not vary)', () => {
+    const r = computeSubjectPredicateMI([rel('A', 'knows', 'B'), rel('A', 'likes', 'B')]);
+    expect(r.subjectEntropy).toBe(0); // single subject
+    expect(r.predicateEntropy).toBe(1); // H = 1 bit
+    expect(r.mutualInformation).toBe(0); // S is constant -> no information shared
+    expect(r.normalisedMI).toBe(0); // min(0, 1) = 0 -> 0
+    expect(subj(r, 'A').distinctPredicates).toBe(2);
+    expect(subj(r, 'A').specialisation).toBe(0); // perfectly even -> generalist
+  });
+
+  it('two subjects, each with a different predicate: MI is 1 bit (perfect prediction)', () => {
+    const r = computeSubjectPredicateMI([rel('A', 'knows', 'X'), rel('B', 'trusts', 'X')]);
+    expect(r.subjectEntropy).toBe(1); // H(S) = 1
+    expect(r.predicateEntropy).toBe(1); // H(P) = 1
+    expect(r.mutualInformation).toBe(1); // I(S; P) = 1
+    expect(r.normalisedMI).toBe(1); // perfect correspondence
+    // Each subject uses a unique predicate -> max specialisation.
+    expect(subj(r, 'A').specialisation).toBe(1);
+    expect(subj(r, 'B').specialisation).toBe(1);
+  });
+});
+
+describe('computeSubjectPredicateMI — specialisation profile', () => {
+  // s1 always says "knows" (3 times) -> fully specialised.
+  // s2 spreads across knows, trusts, mentors evenly -> fully generalist.
+  const r = computeSubjectPredicateMI([
+    rel('s1', 'knows', 'a'),
+    rel('s1', 'knows', 'b'),
+    rel('s1', 'knows', 'c'),
+    rel('s2', 'knows', 'a'),
+    rel('s2', 'trusts', 'b'),
+    rel('s2', 'mentors', 'c'),
+  ]);
+
+  it('marks the single-predicate subject as fully specialised', () => {
+    expect(subj(r, 's1').distinctPredicates).toBe(1);
+    expect(subj(r, 's1').specialisation).toBe(1);
+    expect(subj(r, 's1').dominantPredicate).toBe('knows');
+    expect(subj(r, 's1').dominantPredicateShare).toBe(1);
+  });
+
+  it('marks the uniformly-spread subject as fully generalist (specialisation 0)', () => {
+    expect(subj(r, 's2').distinctPredicates).toBe(3);
+    expect(subj(r, 's2').specialisation).toBe(0);
+    // Tied counts (1 each) -> dominant predicate broken by predicate ASC.
+    expect(subj(r, 's2').dominantPredicate).toBe('knows');
+    expect(subj(r, 's2').dominantPredicateShare).toBeCloseTo(1 / 3, 12);
+  });
+
+  it('puts the specialist first in the ranked list', () => {
+    expect(r.subjects[0].subject).toBe('s1');
+    expect(r.subjects[1].subject).toBe('s2');
+  });
+});
+
+describe('computeSubjectPredicateMI — normalisation & determinism', () => {
+  it('drops relations with a non-string subject or predicate', () => {
+    const badSubject = { ...rel('A', 'knows', 'B'), subject: null as unknown as string };
+    const badPredicate = { ...rel('A', 'knows', 'B'), predicate: 42 as unknown as string };
+    const r = computeSubjectPredicateMI([rel('A', 'knows', 'B'), badSubject, badPredicate]);
+    expect(r.totalRelations).toBe(1);
+  });
+
+  it('does NOT collapse parallel relations: every occurrence is counted', () => {
+    const r = computeSubjectPredicateMI([
+      rel('A', 'knows', 'B'),
+      rel('A', 'knows', 'B'), // duplicate
+      rel('A', 'knows', 'B'), // duplicate
+      rel('A', 'trusts', 'B'),
+    ]);
+    expect(r.totalRelations).toBe(4);
+    expect(subj(r, 'A').dominantPredicate).toBe('knows');
+    expect(subj(r, 'A').dominantPredicateShare).toBe(0.75);
+  });
+
+  it('treats "Knows" and "knows" as distinct predicates (no case-folding)', () => {
+    const r = computeSubjectPredicateMI([rel('A', 'Knows', 'B'), rel('A', 'knows', 'C')]);
+    expect(r.distinctPredicates).toBe(2);
+    expect(subj(r, 'A').distinctPredicates).toBe(2);
+  });
+
+  it('is order-independent: shuffled input yields BYTE-identical MI and entropy', () => {
+    // A mixed fixture with non-trivial conditional entropy (2/3 type summands)
+    // — exactly the case where input-order summation drifts at the ULP level.
+    const edges = [
+      rel('alice', 'knows', 'bob'),
+      rel('alice', 'knows', 'carol'),
+      rel('alice', 'trusts', 'dave'),
+      rel('bob', 'knows', 'eve'),
+      rel('bob', 'mentors', 'frank'),
+      rel('carol', 'reports_to', 'alice'),
+      rel('dave', 'trusts', 'eve'),
+    ];
+    const forward = computeSubjectPredicateMI(edges);
+    const reversed = computeSubjectPredicateMI([...edges].reverse());
+    const rotated = computeSubjectPredicateMI([...edges.slice(3), ...edges.slice(0, 3)]);
+    expect(reversed).toEqual(forward);
+    expect(rotated).toEqual(forward);
+    // strict bit equality, not toBeCloseTo
+    expect(reversed.mutualInformation).toBe(forward.mutualInformation);
+    expect(reversed.subjects[0].specialisation).toBe(forward.subjects[0].specialisation);
+  });
+
+  it('sorts subjects by specialisation DESC, then relationCount DESC, then subject ASC', () => {
+    // s1: 5 relations, specialisation 1 (one predicate)
+    // s2: 3 relations, specialisation 1 (one predicate) — same spec, fewer relations
+    // s3: 4 relations, specialisation 0 (perfectly even across 4 predicates)
+    const r = computeSubjectPredicateMI([
+      rel('s1', 'knows', 'a'),
+      rel('s1', 'knows', 'b'),
+      rel('s1', 'knows', 'c'),
+      rel('s1', 'knows', 'd'),
+      rel('s1', 'knows', 'e'),
+      rel('s2', 'mentors', 'a'),
+      rel('s2', 'mentors', 'b'),
+      rel('s2', 'mentors', 'c'),
+      rel('s3', 'knows', 'a'),
+      rel('s3', 'trusts', 'b'),
+      rel('s3', 'mentors', 'c'),
+      rel('s3', 'likes', 'd'),
+    ]);
+    expect(r.subjects.map(s => s.subject)).toEqual(['s1', 's2', 's3']);
+  });
+});

--- a/app/src/lib/memory/subjectPredicateMI.ts
+++ b/app/src/lib/memory/subjectPredicateMI.ts
@@ -1,0 +1,200 @@
+/**
+ * Subject-Predicate Mutual Information — pure information-theoretic engine.
+ *
+ * Predicate Diversity (#17) tells you how varied the GLOBAL predicate
+ * vocabulary is. Predicate Bundles (#18) tells you which entity pairs share
+ * many predicates. Relationship Types (#7) tells you which predicates are
+ * most frequent. None of them tells you what THIS lens does: how MUCH a
+ * subject predicts which predicate it will use — and which subjects speak
+ * in a SPECIALISED vocabulary versus a GENERALIST one.
+ *
+ *   - GLOBAL: mutual information I(S; P) in bits, with normalised
+ *     I(S; P) / min(H(S), H(P)). When subjects always use the same
+ *     predicate per subject (perfect correspondence) the normalised value
+ *     is 1.0; when subjects and predicates are independent it is 0.
+ *   - PER-SUBJECT: a specialisation score in [0, 1]. 1.0 = this subject
+ *     concentrates its relations on a single predicate (most specialised);
+ *     0 = this subject's predicates are perfectly evenly distributed.
+ *
+ * Why it matters: a knowledge graph with many SPECIALIST subjects is one
+ * the assistant has carved into well-typed roles ("Alice has 12 facts of
+ * type 'worked_at'"); a graph dominated by GENERALIST subjects is one
+ * where one entity attracts many different relation kinds (a person
+ * everything is being said about). The specialisation rank surfaces
+ * exactly which entities sit at each end.
+ *
+ * Everything here is PURE and DETERMINISTIC: no React, no RPC, no clock,
+ * no randomness. To keep the entropy / MI sums BYTE-identical across input
+ * permutations (floating-point addition is not associative and p·log2(p)
+ * terms are not exactly representable), all running sums walk pairs in
+ * a CANONICAL sorted order — never in Map iteration order. The same graph
+ * therefore always yields identical numbers, and every branch is
+ * unit-testable.
+ *
+ * Load-bearing design choices (do not "fix" without reading the tests):
+ *   - Self-loops, parallel edges, and multi-document evidence are NOT
+ *     collapsed — this is a frequency analysis over RELATIONS, matching
+ *     Predicate Diversity. Each relation contributes ONE (subject,
+ *     predicate) observation.
+ *   - A relation with a non-string subject OR predicate is dropped
+ *     entirely (matches sibling-engine malformed-row handling).
+ *   - For a subject with only one distinct predicate used, the
+ *     specialisation score is defined as 1.0 — the conditional entropy is
+ *     mathematically 0 over a 1-symbol distribution and the maximum is
+ *     also 0, so the "normalised" form is filled with the convention
+ *     "single-predicate subject is maximally specialised".
+ *   - Global maxEntropy(P) is 0 when fewer than 2 distinct predicates
+ *     exist; normalisedMI is 0 in that boundary.
+ */
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+
+export interface SubjectStat {
+  subject: string;
+  relationCount: number; // number of relations where this is the subject
+  distinctPredicates: number; // how many distinct predicates this subject uses
+  dominantPredicate: string; // the predicate this subject uses most (tie: predicate ASC)
+  dominantPredicateShare: number; // count(dominant) / relationCount, in (0, 1]
+  specialisation: number; // 1 - H(P|S=s)/log2(D_s); 1 when D_s <= 1
+}
+
+export interface SubjectPredicateMIResult {
+  subjects: SubjectStat[]; // sorted specialisation DESC, relationCount DESC, subject ASC
+  totalRelations: number;
+  distinctSubjects: number;
+  distinctPredicates: number;
+  mutualInformation: number; // I(S; P) in bits
+  subjectEntropy: number; // H(S) in bits
+  predicateEntropy: number; // H(P) in bits
+  normalisedMI: number; // I / min(H(S), H(P)); 0 when min === 0
+}
+
+/** Compute subject-predicate mutual information + per-subject specialisation. PURE. */
+export function computeSubjectPredicateMI(relations: GraphRelation[]): SubjectPredicateMIResult {
+  const subjectCounts = new Map<string, number>();
+  const predicateCounts = new Map<string, number>();
+  // Per-subject: predicate -> count for the conditional distribution P|S=s.
+  const subjectPredicateCounts = new Map<string, Map<string, number>>();
+  let totalRelations = 0;
+
+  for (const relation of relations) {
+    if (typeof relation.subject !== 'string') continue;
+    if (typeof relation.predicate !== 'string') continue;
+    const { subject, predicate } = relation;
+    subjectCounts.set(subject, (subjectCounts.get(subject) ?? 0) + 1);
+    predicateCounts.set(predicate, (predicateCounts.get(predicate) ?? 0) + 1);
+    let perSubject = subjectPredicateCounts.get(subject);
+    if (perSubject === undefined) {
+      perSubject = new Map<string, number>();
+      subjectPredicateCounts.set(subject, perSubject);
+    }
+    perSubject.set(predicate, (perSubject.get(predicate) ?? 0) + 1);
+    totalRelations += 1;
+  }
+
+  // Canonical sorted ids so every Σ-over-distribution walks the same order.
+  const sortedSubjects = [...subjectCounts.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const sortedPredicates = [...predicateCounts.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  // Global H(S) and H(P) — canonical-order sum.
+  let subjectEntropy = 0;
+  if (totalRelations > 0) {
+    for (const s of sortedSubjects) {
+      const p = (subjectCounts.get(s) ?? 0) / totalRelations;
+      if (p > 0) subjectEntropy -= p * Math.log2(p);
+    }
+  }
+  let predicateEntropy = 0;
+  if (totalRelations > 0) {
+    for (const p of sortedPredicates) {
+      const probability = (predicateCounts.get(p) ?? 0) / totalRelations;
+      if (probability > 0) predicateEntropy -= probability * Math.log2(probability);
+    }
+  }
+
+  // Mutual information I(S; P) — canonical (subject, predicate) order. For
+  // each subject we iterate its predicate map in sorted-predicate order; the
+  // double walk in (sortedSubjects, sortedPredicates) order gives a single
+  // total ordering over the (s, p) pairs we sum.
+  let mutualInformation = 0;
+  if (totalRelations > 0) {
+    for (const s of sortedSubjects) {
+      const perSubject = subjectPredicateCounts.get(s);
+      if (perSubject === undefined) continue;
+      const countS = subjectCounts.get(s) ?? 0;
+      for (const p of sortedPredicates) {
+        const countSP = perSubject.get(p) ?? 0;
+        if (countSP === 0) continue;
+        const countP = predicateCounts.get(p) ?? 0;
+        if (countS === 0 || countP === 0) continue;
+        const joint = countSP / totalRelations;
+        const ratio = (countSP * totalRelations) / (countS * countP);
+        mutualInformation += joint * Math.log2(ratio);
+      }
+    }
+  }
+
+  const minMarginal = Math.min(subjectEntropy, predicateEntropy);
+  const normalisedMI = minMarginal === 0 ? 0 : mutualInformation / minMarginal;
+
+  // Per-subject specialisation walks predicates in canonical sorted order so
+  // the conditional entropy is byte-identical across input permutations.
+  const subjects: SubjectStat[] = sortedSubjects.map(subject => {
+    const perSubject = subjectPredicateCounts.get(subject);
+    const countS = subjectCounts.get(subject) ?? 0;
+    if (perSubject === undefined || countS === 0) {
+      return {
+        subject,
+        relationCount: 0,
+        distinctPredicates: 0,
+        dominantPredicate: '',
+        dominantPredicateShare: 0,
+        specialisation: 1,
+      };
+    }
+    const predicates = [...perSubject.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    // Conditional entropy H(P|S=s).
+    let conditionalEntropy = 0;
+    for (const p of predicates) {
+      const probability = (perSubject.get(p) ?? 0) / countS;
+      if (probability > 0) conditionalEntropy -= probability * Math.log2(probability);
+    }
+    const maxConditional = predicates.length <= 1 ? 0 : Math.log2(predicates.length);
+    const specialisation = maxConditional === 0 ? 1 : 1 - conditionalEntropy / maxConditional;
+    // Dominant predicate: max count; ties broken by predicate ASC for stable
+    // output regardless of intra-Map iteration order.
+    let dominantPredicate = predicates[0];
+    let dominantCount = perSubject.get(dominantPredicate) ?? 0;
+    for (const p of predicates) {
+      const c = perSubject.get(p) ?? 0;
+      if (c > dominantCount) {
+        dominantCount = c;
+        dominantPredicate = p;
+      }
+    }
+    return {
+      subject,
+      relationCount: countS,
+      distinctPredicates: predicates.length,
+      dominantPredicate,
+      dominantPredicateShare: dominantCount / countS,
+      specialisation,
+    };
+  });
+
+  subjects.sort((a, b) => {
+    if (b.specialisation !== a.specialisation) return b.specialisation - a.specialisation;
+    if (b.relationCount !== a.relationCount) return b.relationCount - a.relationCount;
+    return a.subject < b.subject ? -1 : a.subject > b.subject ? 1 : 0;
+  });
+
+  return {
+    subjects,
+    totalRelations,
+    distinctSubjects: sortedSubjects.length,
+    distinctPredicates: sortedPredicates.length,
+    mutualInformation,
+    subjectEntropy,
+    predicateEntropy,
+    normalisedMI,
+  };
+}

--- a/app/src/services/api/subjectPredicateMIApi.test.ts
+++ b/app/src/services/api/subjectPredicateMIApi.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { computeSubjectPredicateMI } from '../../lib/memory/subjectPredicateMI';
+import type { GraphRelation } from '../../utils/tauriCommands/memory';
+import {
+  loadNamespaces,
+  loadSubjectPredicateMI,
+  subjectPredicateMIApi,
+} from './subjectPredicateMIApi';
+
+const mockGraphQuery = vi.fn();
+const mockListNamespaces = vi.fn();
+
+vi.mock('../../utils/tauriCommands/memory', () => ({
+  memoryGraphQuery: (...args: unknown[]) => mockGraphQuery(...args),
+  memoryListNamespaces: (...args: unknown[]) => mockListNamespaces(...args),
+}));
+
+function rel(subject: string, predicate: string, object: string): GraphRelation {
+  return {
+    namespace: 'work',
+    subject,
+    predicate,
+    object,
+    attrs: {},
+    updatedAt: 0,
+    evidenceCount: 1,
+    orderIndex: null,
+    documentIds: [],
+    chunkIds: [],
+  };
+}
+
+describe('subjectPredicateMIApi.loadSubjectPredicateMI', () => {
+  beforeEach(() => {
+    mockGraphQuery.mockReset();
+  });
+
+  it('passes the namespace through and returns the engine result', async () => {
+    const triples = [rel('A', 'knows', 'X'), rel('B', 'trusts', 'X')];
+    mockGraphQuery.mockResolvedValueOnce(triples);
+    const out = await loadSubjectPredicateMI('work');
+    expect(mockGraphQuery).toHaveBeenCalledWith('work');
+    expect(out).toEqual(computeSubjectPredicateMI(triples));
+    expect(out.normalisedMI).toBe(1);
+  });
+
+  it('queries all namespaces when none is given', async () => {
+    mockGraphQuery.mockResolvedValueOnce([]);
+    const out = await loadSubjectPredicateMI();
+    expect(mockGraphQuery).toHaveBeenCalledWith(undefined);
+    expect(out.subjects).toEqual([]);
+    expect(out.totalRelations).toBe(0);
+  });
+
+  it('propagates query errors', async () => {
+    mockGraphQuery.mockRejectedValueOnce(new Error('graph unavailable'));
+    await expect(loadSubjectPredicateMI()).rejects.toThrow('graph unavailable');
+  });
+});
+
+describe('subjectPredicateMIApi.loadNamespaces', () => {
+  beforeEach(() => {
+    mockListNamespaces.mockReset();
+  });
+
+  it('returns the namespace list from the RPC', async () => {
+    mockListNamespaces.mockResolvedValueOnce(['work', 'personal']);
+    expect(await loadNamespaces()).toEqual(['work', 'personal']);
+  });
+});
+
+describe('subjectPredicateMIApi object', () => {
+  it('exposes the public surface', () => {
+    expect(typeof subjectPredicateMIApi.loadSubjectPredicateMI).toBe('function');
+    expect(typeof subjectPredicateMIApi.loadNamespaces).toBe('function');
+  });
+});

--- a/app/src/services/api/subjectPredicateMIApi.ts
+++ b/app/src/services/api/subjectPredicateMIApi.ts
@@ -1,0 +1,34 @@
+/**
+ * RPC facade for Subject-Predicate Mutual Information.
+ *
+ * Adds ZERO new core surface. It composes two already-shipped JSON-RPC wrappers:
+ *   - memoryGraphQuery     (openhuman.memory_graph_query)     — the triples
+ *   - memoryListNamespaces (openhuman.memory_list_namespaces) — the selector
+ * and delegates all math to the pure, deterministic engine. Read-only: there is
+ * no persistence — the result is always reproducible from the current graph.
+ */
+import debug from 'debug';
+
+import {
+  computeSubjectPredicateMI,
+  type SubjectPredicateMIResult,
+} from '../../lib/memory/subjectPredicateMI';
+import { memoryGraphQuery, memoryListNamespaces } from '../../utils/tauriCommands/memory';
+
+const log = debug('subject-predicate-mi:api');
+
+/** Fetch graph relations for a namespace (or all) and compute MI + specialisation. */
+export async function loadSubjectPredicateMI(
+  namespace?: string
+): Promise<SubjectPredicateMIResult> {
+  const relations = await memoryGraphQuery(namespace);
+  log('loadSubjectPredicateMI namespace=%s relations=%d', namespace ?? '(all)', relations.length);
+  return computeSubjectPredicateMI(relations);
+}
+
+/** List the namespaces available for the namespace selector. */
+export async function loadNamespaces(): Promise<string[]> {
+  return memoryListNamespaces();
+}
+
+export const subjectPredicateMIApi = { loadSubjectPredicateMI, loadNamespaces };


### PR DESCRIPTION
## Summary

Adds a new read-only **"Specialisation"** tab. The vocabulary lens (#17 Predicate Diversity) tells you how varied the global predicate set is. The thickness lens (#18 Predicate Bundles) tells you which entity pairs share many predicates. The frequency lens (#7 Relationship Types) tells you which predicates dominate overall.

**None of them answers the question this lens does**: how much does knowing the **subject** predict which **predicate** it will use? And which entities speak in a specialised vocabulary versus a generalist one?

The classical information-theoretic answer is **mutual information** `I(S; P)` between the subject and predicate distributions, in bits, and the normalised form `I / min(H(S), H(P))` (0 = independent, 1 = perfect correspondence). Per entity, the same machinery gives a **specialisation index** in [0, 1] (1 = always uses one predicate, 0 = predicates perfectly evenly spread).

### Provenance & design discipline
This is the **runner-up from the prior loop-19 judge-panel design workflow** (8.35/10, the closest competitor to Document Provenance) — a genuinely distinct lens not covered by any of the 19 shipped features. Re-using vetted design work; built solo following the proven pattern; then adversarial-reviewed before push (5 raw findings, **0 confirmed**).

### Engine design (pure, deterministic — no React/RPC/clock/RNG)
- Counts `(subject, predicate)` co-occurrences (every relation contributes one observation; parallels not collapsed).
- Global `H(S)`, `H(P)`, `I(S; P)` summed in **canonical sorted order** (sortedSubjects × sortedPredicates) so the entropy / MI is **byte-identical regardless of relation input order** — float addition is not associative and `p·log2(p)` summands are not exactly representable; the cohesion-bug lesson applied throughout.
- Per-subject `specialisation = 1 - H(P|S=s)/log2(D_s)`, with the conventional fill `1.0` when `D_s <= 1` (single-predicate subject is maximally specialised).
- `dominantPredicate` tie-broken by predicate ASC for stable output.
- A relation with a non-string subject OR predicate is dropped; no case-folding.

### Zero new core surface
Composes the already-shipped `memoryGraphQuery` / `memoryListNamespaces` JSON-RPC wrappers. Container/presentational split with a monotonic request-token race guard for load-on-mount; i18n across all 13 locales.

### Test plan
- [x] `vitest` — 24 tests (engine: 4 boundary fixtures with hand-derived MI (1×1 = 0; fixed-subject = 0; perfect-bijection = 1; specialist-vs-generalist) + specialisation rank + non-string s/p drop + no case-folding + **byte-identical MI/entropy across permutations** + tie-break ordering + duplicate-relation parallel-count behaviour — plus api facade, panel metric tiles + ranked table, container load/namespace-requery/error)
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors
- [x] `prettier --check` — clean
- [x] i18n coverage gate — EXIT 0, no missing/extra/drifted keys across 13 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Subject–Predicate Specialisation tab and panel showing mutual information, normalised MI %, subject specialisation rankings, dominant predicates, relation counts, namespace filtering, retry on error, and loading/empty states.

* **Internationalization**
  * Added translations for the new view across many locales.

* **Tests**
  * Added unit and UI tests covering computation outcomes, API loading, namespace selection, and loading/empty/error/success states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->