### PR TITLE
fix(composio): map trigger-enable 403 to actionable error (#2913)

### DIFF
--- a/src/openhuman/composio/error_mapping.rs
+++ b/src/openhuman/composio/error_mapping.rs
@@ -9,6 +9,10 @@
 pub enum ComposioErrorClass {
     Validation,
     InsufficientScope,
+    /// The connection lacks permission to enable/manage triggers — a 403 whose
+    /// body does **not** mention "scope" (so [`Self::InsufficientScope`] never
+    /// matches it). Distinct so the user gets reconnect guidance. See #2913.
+    TriggerPermission,
     RateLimited,
     UpstreamProvider,
     ComposioPlatform,
@@ -21,6 +25,7 @@ impl ComposioErrorClass {
         match self {
             Self::Validation => "validation",
             Self::InsufficientScope => "insufficient_scope",
+            Self::TriggerPermission => "trigger_permission",
             Self::RateLimited => "rate_limited",
             Self::UpstreamProvider => "upstream_provider",
             Self::ComposioPlatform => "composio_platform",
@@ -36,6 +41,8 @@ pub fn classify_composio_error(tool: &str, message: &str) -> ComposioErrorClass 
         ComposioErrorClass::Validation
     } else if is_insufficient_scope_shape(&lower) {
         ComposioErrorClass::InsufficientScope
+    } else if is_trigger_permission_shape(&lower) {
+        ComposioErrorClass::TriggerPermission
     } else if is_rate_limited_shape(&lower) {
         ComposioErrorClass::RateLimited
     } else if is_gateway_transport_shape(&lower) && !is_embedded_provider_failure(&lower) {
@@ -65,6 +72,7 @@ pub fn format_provider_error(tool: &str, raw: &str) -> String {
     let body = match class {
         ComposioErrorClass::Validation => format!("Invalid arguments for `{tool}`: {detail}"),
         ComposioErrorClass::InsufficientScope => format_insufficient_scope_message(tool, detail),
+        ComposioErrorClass::TriggerPermission => format_trigger_permission_message(tool),
         ComposioErrorClass::RateLimited => format_rate_limited_message(tool, detail),
         ComposioErrorClass::UpstreamProvider => {
             format!("`{tool}` failed at the connected provider: {detail}")
@@ -91,6 +99,7 @@ pub fn remap_transport_error(tool: &str, raw: &str) -> String {
     };
     let body = match class {
         ComposioErrorClass::InsufficientScope => format_insufficient_scope_message(tool, &detail),
+        ComposioErrorClass::TriggerPermission => format_trigger_permission_message(tool),
         ComposioErrorClass::RateLimited => format_rate_limited_message(tool, &detail),
         ComposioErrorClass::Gateway => format!(
             "Temporary gateway error while calling `{tool}`: {}",
@@ -125,6 +134,24 @@ fn format_insufficient_scope_message(tool: &str, detail: &str) -> String {
     )
 }
 
+/// Build the trigger-permission guidance message (issue #2913).
+///
+/// The toolkit slug is derived from the tool/trigger identifier the same way
+/// [`format_insufficient_scope_message`] does (e.g. `GMAIL_NEW_GMAIL_MESSAGE`
+/// → `gmail`), so the copy is branded and points the user at reconnecting.
+fn format_trigger_permission_message(tool: &str) -> String {
+    let toolkit = tool
+        .split('_')
+        .next()
+        .unwrap_or("integration")
+        .to_ascii_lowercase();
+    format!(
+        "Couldn't enable this trigger: the connected {toolkit} account doesn't have \
+         permission to manage triggers. Reconnect {toolkit} in Settings → Connections → \
+         {toolkit} and grant the permissions requested during OAuth, then try again."
+    )
+}
+
 fn format_rate_limited_message(tool: &str, detail: &str) -> String {
     format!(
         "`{tool}` hit an upstream rate limit ({detail}). Wait a minute and retry, or reduce \
@@ -150,6 +177,24 @@ fn is_insufficient_scope_shape(lower: &str) -> bool {
         || lower.contains("insufficient permissions")
         || (lower.contains("403") && lower.contains("scope"))
         || lower.contains("invalid oauth scope")
+}
+
+/// Heuristic for a trigger-permission denial (issue #2913).
+///
+/// The backend 403 body reads "You do not have permission to enable triggers on
+/// this connection" — note it has **no** "scope" token, so
+/// [`is_insufficient_scope_shape`] never matches. We require a forbidden signal
+/// (`403`/`forbidden`) AND a permission-denied phrase AND trigger context, so a
+/// generic 403 won't be miscategorised.
+fn is_trigger_permission_shape(lower: &str) -> bool {
+    let forbidden = lower.contains("403") || lower.contains("forbidden");
+    let permission_denied = lower.contains("do not have permission")
+        || lower.contains("not have permission")
+        || lower.contains("permission denied")
+        || lower.contains("not permitted")
+        || lower.contains("not allowed");
+    let trigger_context = lower.contains("trigger");
+    forbidden && permission_denied && trigger_context
 }
 
 fn is_rate_limited_shape(lower: &str) -> bool {
@@ -180,6 +225,7 @@ fn is_gateway_transport_shape(lower: &str) -> bool {
 fn is_embedded_provider_failure(lower: &str) -> bool {
     is_validation_shape(lower)
         || is_insufficient_scope_shape(lower)
+        || is_trigger_permission_shape(lower)
         || is_rate_limited_shape(lower)
         || is_composio_platform_shape(lower)
         || lower.contains("composio")

--- a/src/openhuman/composio/error_mapping_tests.rs
+++ b/src/openhuman/composio/error_mapping_tests.rs
@@ -59,3 +59,73 @@ fn true_gateway_stays_gateway_class() {
         "expected gateway class, got: {mapped}"
     );
 }
+
+// ── Trigger-permission denial (issue #2913) ───────────────────────────
+
+#[test]
+fn classifies_trigger_permission_from_403_without_scope() {
+    // The backend 403 body does NOT contain the word "scope", so it must be
+    // classified as TriggerPermission rather than InsufficientScope or Other.
+    let raw = "Backend returned 403 Forbidden for POST \
+               https://api.example.com/agent-integrations/composio/triggers: \
+               You do not have permission to enable triggers on this connection";
+    assert_eq!(
+        classify_composio_error("GMAIL_NEW_GMAIL_MESSAGE", raw),
+        ComposioErrorClass::TriggerPermission
+    );
+}
+
+#[test]
+fn trigger_permission_is_not_classified_as_insufficient_scope() {
+    let raw = "403 Forbidden: You do not have permission to enable triggers on this connection";
+    // Regression guard: the scope heuristic requires the literal "scope" token,
+    // which this message lacks — so it must not be InsufficientScope.
+    assert_ne!(
+        classify_composio_error("GMAIL_NEW_GMAIL_MESSAGE", raw),
+        ComposioErrorClass::InsufficientScope
+    );
+}
+
+#[test]
+fn formats_trigger_permission_as_actionable_reconnect_guidance() {
+    let raw = "Backend returned 403 Forbidden for POST \
+               https://api.example.com/agent-integrations/composio/triggers: \
+               You do not have permission to enable triggers on this connection";
+    let mapped = format_provider_error("GMAIL_NEW_GMAIL_MESSAGE", raw);
+    assert!(
+        mapped.contains("[composio:error:trigger_permission]"),
+        "expected trigger_permission class prefix, got: {mapped}"
+    );
+    // Branded, actionable copy that points the user at reconnecting.
+    assert!(
+        mapped.contains("gmail"),
+        "expected toolkit branding: {mapped}"
+    );
+    assert!(
+        mapped.contains("Settings"),
+        "expected reconnect guidance: {mapped}"
+    );
+    assert!(
+        mapped.contains("Connections"),
+        "expected reconnect guidance: {mapped}"
+    );
+    assert!(
+        mapped.to_lowercase().contains("permission"),
+        "expected permission wording: {mapped}"
+    );
+    // Must not leak the raw backend blob as the message.
+    assert!(
+        !mapped.contains("Backend returned 403"),
+        "raw backend blob leaked: {mapped}"
+    );
+}
+
+#[test]
+fn generic_403_without_trigger_context_is_not_trigger_permission() {
+    // A 403 with no "trigger" context must not be miscategorised.
+    let raw = "403 Forbidden: you do not have permission to read this file";
+    assert_ne!(
+        classify_composio_error("GMAIL_FETCH_EMAILS", raw),
+        ComposioErrorClass::TriggerPermission
+    );
+}

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -1047,8 +1047,21 @@ pub async fn composio_enable_trigger(
         .enable_trigger(connection_id, slug, trigger_config)
         .await
         .map_err(|e| {
+            // Keep the raw error on the Sentry funnel for diagnosis (unchanged).
             report_composio_op_error("enable_trigger", &e);
-            format!("[composio] enable_trigger failed: {e:#}")
+            // Map the backend error (e.g. a 403 "you do not have permission to
+            // enable triggers on this connection") into actionable, user-facing
+            // guidance instead of leaking the raw blob to the UI (issue #2913).
+            let raw = format!("{e:#}");
+            let class = super::error_mapping::classify_composio_error(slug, &raw);
+            let mapped = super::error_mapping::format_provider_error(slug, &raw);
+            tracing::warn!(
+                slug = %slug,
+                connection_id = %connection_id,
+                class = class.as_str(),
+                "[composio] enable_trigger failed; surfacing mapped error"
+            );
+            mapped
         })?;
     let trigger_id = resp.trigger_id.clone();
     Ok(RpcOutcome::new(

--- a/src/openhuman/composio/ops_tests.rs
+++ b/src/openhuman/composio/ops_tests.rs
@@ -1477,6 +1477,52 @@ async fn composio_enable_trigger_via_mock() {
     assert!(outcome.logs.iter().any(|l| l.contains("enabled trigger")));
 }
 
+/// Regression for issue #2913: a backend 403 (permission denied) on trigger
+/// enable must surface a mapped, actionable error — not the raw
+/// `[composio] enable_trigger failed: Backend returned 403 ...` blob.
+#[tokio::test]
+async fn composio_enable_trigger_403_returns_mapped_error() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/triggers",
+        post(|Json(_body): Json<Value>| async move {
+            (
+                axum::http::StatusCode::FORBIDDEN,
+                Json(json!({
+                    "success": false,
+                    "error": "You do not have permission to enable triggers on this connection"
+                })),
+            )
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let tmp = tempfile::tempdir().unwrap();
+    let config = config_with_backend(&tmp, base);
+
+    let err = composio_enable_trigger(&config, "c1", "GMAIL_NEW_GMAIL_MESSAGE", None)
+        .await
+        .unwrap_err();
+
+    // Mapped class prefix, not the raw op-layer/backend blob.
+    assert!(
+        err.contains("[composio:error:trigger_permission]"),
+        "expected mapped trigger_permission error, got: {err}"
+    );
+    assert!(
+        !err.contains("[composio] enable_trigger failed:"),
+        "raw op-layer prefix leaked: {err}"
+    );
+    assert!(
+        !err.contains("Backend returned 403"),
+        "raw backend blob leaked: {err}"
+    );
+    // Actionable, branded reconnect guidance.
+    assert!(err.contains("gmail"), "expected toolkit branding: {err}");
+    assert!(
+        err.contains("Settings"),
+        "expected reconnect guidance: {err}"
+    );
+}
+
 #[tokio::test]
 async fn composio_disable_trigger_via_mock() {
     let app = Router::new().route(


### PR DESCRIPTION
## Summary

- Maps Composio trigger-enable 403 permission denials to a dedicated `trigger_permission` error class.
- Surfaces actionable Gmail reconnect guidance instead of exposing the raw backend 403 blob in the modal.
- Keeps raw enable-trigger failures on the existing Sentry/reporting path while changing only the user-facing RPC error.
- Adds regression coverage for classification, formatting, and the `composio_enable_trigger` mock-backend failure path.

## Problem

- Closes #2913.
- Gmail trigger enable can fail with `403 Forbidden: You do not have permission to enable triggers on this connection` even when the connection appears active.
- The existing Composio error mapper only treated 403s mentioning `scope` as insufficient-scope errors, so this trigger-specific permission denial fell through and leaked raw backend text to users.

## Solution

- Add a `TriggerPermission` Composio error class that requires a forbidden signal, a permission-denied phrase, and trigger context.
- Format that class as branded reconnect guidance derived from the trigger/tool slug, e.g. `GMAIL_NEW_GMAIL_MESSAGE` -> Gmail.
- Route `composio_enable_trigger` errors through the mapper after reporting the raw error for diagnostics.
- Guard against overclassification by testing that generic non-trigger 403s are not treated as trigger permission failures.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/coverage.yml`](../.github/workflows/coverage.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. CI coverage gate will enforce; focused Rust tests cover the changed lines locally.
- [x] Coverage matrix updated — N/A: behavior-only bug fix in existing Composio trigger error handling; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage matrix feature ID changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime impact is limited to Rust core Composio trigger-enable error handling.
- Users who hit this Gmail trigger permission denial now see reconnect/remediation guidance instead of raw backend text.
- No persistence, migration, or external dependency changes.

## Related

- Closes #2913
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fix/2913-gmail-trigger-error-mapping`
- Commit SHA: `652dccb6`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed locally; Node 22 emitted the existing engine warning for a Node >=24 project.
- [x] `pnpm typecheck` — blocked locally; see Validation Blocked.
- [x] Focused tests:
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml classifies_trigger_permission_from_403_without_scope`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml composio_enable_trigger_403_returns_mapped_error`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml trigger_permission`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml composio_enable_trigger_via_mock`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
  - `git diff --check upstream/main...HEAD`
- [x] Tauri fmt/check (if changed): N/A: Tauri shell not changed; app workspace format check also ran Tauri rust format check.

### Validation Blocked
- `command:` `pnpm typecheck`
- `error:` local app typecheck fails on pre-existing missing frontend dependencies/types: `recharts`, `qrcode.react`, `@rive-app/react-webgl2`, `@noble/ciphers/chacha`, `@noble/ciphers/webcrypto`, `rehype-katex`, `remark-math`, `@tauri-apps/plugin-barcode-scanner`, plus related implicit-any fallout in dashboard chart components.
- `impact:` unrelated to this Rust-only Composio diff; CI Type Check should be treated as source of truth for the full app environment.

### Behavior Changes
- Intended behavior change: Composio trigger-enable 403 permission denials are classified as `trigger_permission` and shown as reconnect guidance.
- User-visible effect: Gmail trigger enable failures no longer primarily show raw backend 403 text.

### Parity Contract
- Legacy behavior preserved: existing insufficient-scope, rate-limit, gateway, platform, validation, and generic error classes continue through the same mapper; generic non-trigger 403s are not reclassified.
- Guard/fallback/dispatch parity checks: mock backend regression covers the RPC op path; generic 403 regression covers classification guardrails.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none found for `fix/2913-gmail-trigger-error-mapping`
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A
