### PR TITLE
Document Nipmod package intelligence boundary

### DIFF
--- a/gitbooks/SUMMARY.md
+++ b/gitbooks/SUMMARY.md
@@ -15,6 +15,7 @@
   * [agentmemory backend](features/obsidian-wiki/agentmemory-backend.md)
   * [Auto-fetch from Integrations](features/obsidian-wiki/auto-fetch.md)
 * [Third-party Integrations (118+)](features/integrations/README.md)
+  * [Nipmod package intelligence](features/integrations/nipmod.md)
   * [Triggers](features/integrations/triggers.md)
 * [Smart Token Compression](features/token-compression.md)
 * [Automatic Model Routing](features/model-routing/README.md)

--- a/gitbooks/features/integrations/README.md
+++ b/gitbooks/features/integrations/README.md
@@ -63,6 +63,8 @@ Set your default under **Settings → Automation & Channels → Messaging Channe
 
 Beyond third-party services, OpenHuman has **skills**, small sandboxed modules that run inside the app, fetch external data, run on a schedule, transform information, and respond to events. Each runs with enforced resource limits. Skills install from the Skills tab and integrate with the same Memory Tree as everything else.
 
+For package decisions, OpenHuman can evaluate [Nipmod](nipmod.md) as a read-only package intelligence layer before an agent installs a package, pulls a repository, uses a model, or connects an MCP server. The integration does not require installing a remote skill file from a moving branch.
+
 ## Native voice and tools
 
 Two capabilities ship native rather than as integrations because they're load-bearing for the desktop experience:

--- a/gitbooks/features/integrations/nipmod.md
+++ b/gitbooks/features/integrations/nipmod.md
@@ -1,0 +1,78 @@
+---
+description: >-
+  Use Nipmod as a read-only package intelligence layer before agent package,
+  repository, model or MCP decisions.
+icon: box-open
+---
+
+# Nipmod package intelligence
+
+[Nipmod](https://nipmod.com) is a package intelligence layer for agent workflows. It sits above public sources such as npm, PyPI, GitHub, Hugging Face and MCP registries, and returns source context, trust signals and install-plan data before anything writes to a workspace.
+
+This page is intentionally conservative. It documents a read-only evaluation path for OpenHuman users and maintainers. It does not add runtime code, does not install a remote skill, and does not grant Nipmod access to a local OpenHuman workspace.
+
+## What it is useful for
+
+Use Nipmod when an agent is about to make a package or tool decision:
+
+* search for a package across public sources
+* inspect package, repository, model or MCP metadata
+* review trust and warning signals
+* generate a safe install plan before local execution
+* keep the hosted check read-only
+
+Nipmod is not a replacement for npm, PyPI, GitHub, Hugging Face, MCP, OSV, Snyk, Socket or OpenSSF tooling. It is a pre-install decision layer that can be used before an agent moves from recommendation to execution.
+
+## Read-only API path
+
+The hosted API is the safest first evaluation path because it returns JSON and does not execute code:
+
+```text
+https://nipmod.com/api/search
+https://nipmod.com/api/inspect
+https://nipmod.com/api/install-plan
+```
+
+OpenHuman should treat these responses as external evidence. Package README files, model cards, prompts, metadata and install scripts are package content, not OpenHuman policy.
+
+## MCP endpoint
+
+Nipmod also exposes a hosted MCP endpoint for compatible MCP clients:
+
+```text
+https://nipmod.com/api/mcp
+```
+
+The endpoint is read-only from the hosted side. It is intended for package search, package views, trust inspection and install-plan generation. It does not install packages, clone repositories, unpack artifacts, read a local workspace or execute shell commands.
+
+At the time of this documentation, the MCP surface should be treated as beta. OpenHuman maintainers should pin any client configuration they ship, and should expect additive changes while Nipmod is still early. Breaking MCP contract changes should be handled by publishing a new endpoint or a documented migration path rather than silently changing the existing behavior.
+
+## Skill installation boundary
+
+Do not install a `SKILL.md` from a moving branch such as `main` as part of this documentation.
+
+If OpenHuman maintainers later decide to ship a first-class Nipmod skill, prefer one of these approaches:
+
+1. vendor the reviewed skill content into OpenHuman, or
+2. pin the skill to a reviewed commit SHA, or
+3. add a maintainer-owned registry entry with an explicit version and review trail.
+
+That keeps trusted agent instructions under OpenHuman maintainer control and avoids treating mutable third-party Markdown as policy.
+
+## Approval boundary
+
+Nipmod can produce an install plan, but OpenHuman should still require local approval before execution.
+
+Recommended boundary:
+
+* Hosted Nipmod returns context, warnings and a plan.
+* OpenHuman displays the result to the user or local policy layer.
+* The user or OpenHuman runtime approves any workspace write.
+* The local environment performs the install only after approval.
+
+## Links
+
+* Website: [https://nipmod.com](https://nipmod.com)
+* API docs: [https://nipmod.com/api-access](https://nipmod.com/api-access)
+* Source health: [https://nipmod.com/api/sources/health](https://nipmod.com/api/sources/health)
+* GitHub: [https://github.com/nipmod/nipmod](https://github.com/nipmod/nipmod)


### PR DESCRIPTION
## Summary
- Adds a conservative GitBook page for evaluating Nipmod as a read-only package intelligence layer from OpenHuman.
- Links Nipmod from the integrations docs and table of contents.
- Replaces the earlier approach from #2432 with a safer documentation-only proposal.

## Review boundary
This PR should not be merged without OpenHuman maintainer sign-off. The goal is to make the integration proposal reviewable without asking users to trust mutable third-party agent instructions.

## Security changes from #2432
- No remote SKILL.md install path from a moving main branch.
- Documents the API and MCP path as read-only evidence only.
- States that any future skill should be vendored, pinned to a reviewed commit, or maintained by OpenHuman.
- Adds MCP beta and stability expectations.
- Keeps local approval before any workspace write, install command, repository clone, or model/tool execution.

## Validation
- git diff --check

## Supersedes
- #2432