### PR TITLE
fix(test): correct round21 summarize assertion to expect real newlines

### DIFF
--- a/tests/inference_local_services_round21_raw_coverage_e2e.rs
+++ b/tests/inference_local_services_round21_raw_coverage_e2e.rs
@@ -147,7 +147,7 @@ async fn local_services_cover_mocked_inference_assets_speech_and_whisper_install
             .summarize(&config, "decision: ship tests", Some(32))
             .await
             .expect("summary"),
-        "generated: Summarize this text in concise bullet points. Preserve decisions and commitments.\\n\\ndecision: ship tests"
+        "generated: Summarize this text in concise bullet points. Preserve decisions and commitments.\n\ndecision: ship tests"
     );
     assert_eq!(
         service


### PR DESCRIPTION
## Summary

The CI job [`local_services_cover_mocked_inference_assets_speech_and_whisper_install`](https://github.com/tinyhumansai/openhuman/actions/runs/26700035033/job/78691342452) was failing because the round21 raw-coverage E2E asserted the `summarize` output contained **literal backslash-n** (`\\n\\n`), but the prompt template in `src/openhuman/inference/local/service/public_infer.rs` uses **real newlines** (`\n\n`).

```
left:  "...commitments.\n\ndecision: ship tests"     (actual — real newlines)
right: "...commitments.\\n\\ndecision: ship tests"   (expected — literal backslash-n)
```

## Fix

Changed the expected string in `tests/inference_local_services_round21_raw_coverage_e2e.rs` to use real newlines so it matches the actual mock-generated output.

## Testing

```
cargo test --test inference_local_services_round21_raw_coverage_e2e -- --test-threads=1
# test result: ok. 1 passed; 0 failed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for summary output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->