### PR TITLE
ci(release): gate main_head push to main behind manual approval (#2622)

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -82,12 +82,52 @@ concurrency:
 # ---------------------------------------------------------------------------
 jobs:
   # =========================================================================
+  # Phase 0: Manual approval gate (main_head only).
+  #
+  # The `main_head` path bumps the version, COMMITS to `main`, and pushes that
+  # commit + tag using a GitHub App token that bypasses branch protection
+  # (prepare-build → "Commit, push and tag (main_head)"). If that App private
+  # key (secrets.XGITHUB_APP_PRIVATE_KEY) ever leaked, an attacker could push
+  # arbitrary commits to the default branch — CWE-250. This job parks the run
+  # on the `Release-Approval` environment (configured with required reviewers
+  # in repo settings) so a human must explicitly approve before prepare-build
+  # is allowed to run its push step. A rejected/cancelled approval leaves
+  # prepare-build skipped, so nothing is ever pushed.
+  #
+  # Scoped to `main_head` only: the `staging_tag` promotion path pushes just an
+  # immutable `v<version>` tag at an already-validated staging commit — it does
+  # NOT push a commit to `main` — so it stays gated only by the existing
+  # `Production` environment and is intentionally skipped here (no regression).
+  # =========================================================================
+  review-approval:
+    name: Manual approval gate (main_head)
+    runs-on: ubuntu-latest
+    environment: Release-Approval
+    if: inputs.release_source == 'main_head'
+    steps:
+      - name: Record approval
+        run: |
+          echo "[release-production] main_head push to main approved by a required reviewer."
+          echo "Proceeding to version bump + commit/tag push on prepare-build."
+
+  # =========================================================================
   # Phase 1: Resolve build ref and (for main_head) bump version + create tag
   # =========================================================================
   prepare-build:
     name: Prepare build context
     runs-on: ubuntu-latest
     environment: Production
+    needs: [review-approval]
+    # The push-to-main step lives inside this job (main_head path), so gating
+    # prepare-build on review-approval gates the push. `!cancelled()` (not
+    # `always()`) so a cancelled run never pushes; the success/skipped guard
+    # lets the `staging_tag` path through (review-approval is skipped there)
+    # while requiring an explicit approval success for `main_head`. A rejected
+    # approval yields result == 'failure', failing the guard → no push.
+    if: >-
+      !cancelled()
+      && (needs.review-approval.result == 'success'
+          || needs.review-approval.result == 'skipped')
     outputs:
       version: ${{ steps.resolve.outputs.version }}
       tag: ${{ steps.resolve.outputs.tag }}

--- a/gitbooks/developing/release-policy.md
+++ b/gitbooks/developing/release-policy.md
@@ -103,7 +103,8 @@ Rotate `XGITHUB_APP_PRIVATE_KEY` **every quarter** (and immediately on any suspe
 
 1. In the GitHub **App settings** (Org → Settings → Developer settings → GitHub Apps → the release App), under **Private keys** click **Generate a private key**. Download the new `.pem`.
 2. Update the repo secret: **Settings → Secrets and variables → Actions → `XGITHUB_APP_PRIVATE_KEY`** → paste the full new key (including the `-----BEGIN/END-----` lines). `XGITHUB_APP_ID` is unchanged.
-3. Trigger a low-risk verification run (e.g. **Release (Staging)**, or a `main_head` dry run with `create_release = false`) and confirm the **Generate GitHub App token** step succeeds and the push authenticates.
+3. Trigger a low-risk verification run (e.g. **Release (Staging)**) and confirm the **Generate GitHub App token** step succeeds and the push authenticates.
+   Do not use `main_head` for this check unless you intentionally want to cut a real bump commit and production tag — even with `create_release = false`, `prepare-build` still bumps the version, commits to `main`, and pushes the release tag.
 4. Back in **App settings → Private keys**, **delete the old key** so only the freshly-issued one remains valid.
 5. Record the rotation date (PR description, ops log, or `docs/OPERATIONS.md`) so the next quarter's owner can see when it last happened.
 

--- a/gitbooks/developing/release-policy.md
+++ b/gitbooks/developing/release-policy.md
@@ -68,8 +68,10 @@ There is no separate `staging` branch, staging cuts and production promotions bo
 ### Hotfix from `main` HEAD
 
 1. Run **Release Production** via `workflow_dispatch` with `release_source = main_head` and the desired `release_type` (`patch` / `minor` / `major`).
-2. The workflow runs the legacy bump-and-tag path: bump on `main`, commit `chore(release): vX.Y.Z`, push, tag `vX.Y.Z`, build.
+2. The run first parks on the **`review-approval`** job (`environment: Release-Approval`); a [required reviewer](#release-app-token-approval-gate-and-rotation) must approve before anything is pushed. Only after approval does `prepare-build` run the bump-and-tag path: bump on `main`, commit `chore(release): vX.Y.Z`, push, tag `vX.Y.Z`, build.
 3. Use this only when a production-only fix needs to ship without going through staging.
+
+> The `staging_tag` promotion path is **not** gated by `review-approval` — it pushes only an immutable `v<version>` tag at an already-validated staging commit, never a commit to `main`. It remains gated by the existing `Production` environment.
 
 ### Tag policy and rollback
 
@@ -78,3 +80,31 @@ There is no separate `staging` branch, staging cuts and production promotions bo
 - **Rollback (production).** A failed build matrix triggers `cleanup-failed-release`, which deletes both the draft GitHub Release and the `v<version>` tag. The staging tag it was promoted from is left untouched and can be re-promoted after fixing.
 - **Rollback (staging).** A failed staging build deletes the `v<version>-staging` tag. The bump commit on `main` is left in place; the next staging cut continues from the new patch number rather than re-using it (we accept a small “gap” in patch numbers over racing with concurrent merges).
 - **Who can delete tags.** Same write-access as `main`. Workflow-driven cleanup deletes run with the workflow's token via `actions/github-script` (the GitHub App token is only used by `prepare-build` for the bump commit + tag push); manual deletes (`git push --delete origin <tag>`) require equivalent maintainer permissions.
+
+## Release App token: approval gate and rotation
+
+The `main_head` path of `release-production.yml` bumps the version, **commits to `main`**, and pushes that commit + tag with a GitHub App token (`secrets.XGITHUB_APP_ID` / `secrets.XGITHUB_APP_PRIVATE_KEY`) that **bypasses branch protection**. A leaked private key (via a log, a compromised action, or a misconfigured runner) would let an attacker push arbitrary commits to the default branch — [CWE-250: Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html). Two controls bound that blast radius.
+
+### Manual approval gate
+
+The `review-approval` job runs **before** `prepare-build` and parks the run on the **`Release-Approval`** GitHub environment, so a human must approve before any push happens. It is scoped to `release_source == 'main_head'`; the `staging_tag` promotion path skips it (it pushes only a tag, never a commit to `main`).
+
+One-time setup (repo **Settings → Environments**):
+
+1. Create an environment named **`Release-Approval`** (exact name — the workflow references it verbatim).
+2. Under **Deployment protection rules**, enable **Required reviewers** and add the maintainers allowed to authorize a production push to `main`. A reviewer **cannot** approve their own run unless _Prevent self-review_ is left off; for a release gate, keeping a second approver is preferred.
+3. (Optional) Set a short **wait timer** of 0 — the gate is a human decision, not a delay.
+
+When a `main_head` run starts it shows **"Waiting"** on the `review-approval` job; an approver opens the run and clicks **Review deployments → Approve**. Rejecting (or cancelling) leaves `prepare-build` skipped, so nothing is pushed.
+
+### Quarterly key rotation
+
+Rotate `XGITHUB_APP_PRIVATE_KEY` **every quarter** (and immediately on any suspected exposure). Schedule: end of **Mar / Jun / Sep / Dec**.
+
+1. In the GitHub **App settings** (Org → Settings → Developer settings → GitHub Apps → the release App), under **Private keys** click **Generate a private key**. Download the new `.pem`.
+2. Update the repo secret: **Settings → Secrets and variables → Actions → `XGITHUB_APP_PRIVATE_KEY`** → paste the full new key (including the `-----BEGIN/END-----` lines). `XGITHUB_APP_ID` is unchanged.
+3. Trigger a low-risk verification run (e.g. **Release (Staging)**, or a `main_head` dry run with `create_release = false`) and confirm the **Generate GitHub App token** step succeeds and the push authenticates.
+4. Back in **App settings → Private keys**, **delete the old key** so only the freshly-issued one remains valid.
+5. Record the rotation date (PR description, ops log, or `docs/OPERATIONS.md`) so the next quarter's owner can see when it last happened.
+
+Rotating invalidates any copy of the old key that may have leaked, capping the exposure window at one quarter.


### PR DESCRIPTION
## Summary

- Add a `review-approval` job (pinned to a new `Release-Approval` GitHub environment) that parks `release-production.yml` before `prepare-build` on the `main_head` path, so a required reviewer must approve before the App-token push to `main` happens.
- Scope the gate to `main_head` only — the `staging_tag` promotion path (tag-only, no commit to `main`) is intentionally skipped, so it runs unblocked (no regression).
- Document the approval-gate setup and a quarterly `XGITHUB_APP_PRIVATE_KEY` rotation runbook in [`gitbooks/developing/release-policy.md`](../blob/c9b933a0507371713888070b961a1a9caa31de9e/gitbooks/developing/release-policy.md).

## Problem

`release-production.yml` uses a GitHub App token to push version-bump commits and tags directly to `main`, bypassing branch protection (`prepare-build` → "Commit, push and tag (main_head)", L176-188). If `secrets.XGITHUB_APP_PRIVATE_KEY` leaked through a log, a compromised action, or a misconfigured runner, an attacker could push arbitrary commits to the default branch — **CWE-250**. Identified by audit #2575 (H-3).

## Solution

- New `review-approval` job: `environment: Release-Approval`, `if: inputs.release_source == 'main_head'`. Parking on the environment forces a human approval (required reviewers configured in repo settings) before anything is pushed.
- `prepare-build` now `needs: [review-approval]` with a guard `!cancelled() && (review-approval == 'success' || 'skipped')`:
  - `main_head` → review-approval must succeed (approved) before the push step runs; a rejected approval yields `result == 'failure'` → guard fails → `prepare-build` skipped → **nothing pushed**.
  - `staging_tag` → review-approval is skipped → guard passes via the `'skipped'` branch → `prepare-build` runs exactly as before.
  - `!cancelled()` (not `always()`) so a cancelled run never pushes.
- The push-to-main step lives *inside* `prepare-build`, so gating the job is the minimal way to gate the push without splitting the bump/resolve/push steps across jobs.

## Submission Checklist

- [x] N/A: no testable code changed — this PR only edits a GitHub Actions workflow (`.github/workflows/release-production.yml`) and a runbook (`gitbooks/developing/release-policy.md`); neither is reachable by Vitest or cargo tests. Workflow behavior (environment gating, `needs`/`if` propagation) is enforced by GitHub Actions, not unit tests.
- [x] **Diff coverage ≥ 80%** — N/A: changed files are YAML + Markdown, which never appear in the merged `diff-cover` lcov inputs, so no changed lines are scored by the gate.
- [x] Coverage matrix updated — N/A: behaviour-only change to release CI; no feature row in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] All affected feature IDs from the matrix are listed — N/A: no matrix feature IDs apply.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: adds an approval gate to the `main_head` path only; existing `docs/RELEASE-MANUAL-SMOKE.md` steps are unchanged. The new one-time `Release-Approval` environment setup + rotation runbook is documented in `release-policy.md`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- **CI/release only** — no runtime, desktop, mobile, web, or CLI code changed.
- **Security:** bounds the blast radius of an `XGITHUB_APP_PRIVATE_KEY` leak by requiring an explicit human approval before any push-to-`main`, plus a documented quarterly rotation cadence.
- **Operational prerequisite:** a `main_head` production cut now blocks until a required reviewer approves. **The `Release-Approval` GitHub environment must be created with required reviewers in repo Settings → Environments** (documented in `release-policy.md`); without it the gate auto-passes (environment with no protection rules does not park).
- **No regression:** the default `staging_tag` promotion path is unaffected.

## Related

- Closes: #2622
- Parent: #2575 (H-3)
- Follow-up PR(s)/TODOs: (stretch) move to a PR-based release flow where CI opens a PR a human merges, rather than direct push.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `issue/2622-add-manual-approval-gate-to-release-prod`
- Commit SHA: `c9b933a0507371713888070b961a1a9caa31de9e`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no files under `app/` changed (root format only formats the `app/` workspace).
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: N/A: no testable code changed (YAML + Markdown only).
- [x] Rust fmt/check (if changed): N/A: no Rust changed.
- [x] Tauri fmt/check (if changed): N/A: no Rust changed.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow — passes (YAML valid).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `main_head` production cuts now require a required-reviewer approval (via the `Release-Approval` environment) before the version-bump commit + tag are pushed to `main`.
- User-visible effect: operators see the run pause on the `review-approval` job until approved; rejecting/cancelling pushes nothing.

### Parity Contract

- Legacy behavior preserved: `staging_tag` promotion path runs identically (review-approval skipped → `prepare-build` guard passes via the `'skipped'` branch).
- Guard/fallback/dispatch parity checks: `prepare-build.if = !cancelled() && (review-approval == 'success' || 'skipped')`; downstream `needs.prepare-build.result == 'success'` guards (pretest, create-release, cleanup) unchanged — a rejected approval skips `prepare-build`, transitively skipping the rest with nothing to clean up.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Production release workflow now requires a manual approval gate for main-branch releases before version bump/tag/build/push.

* **Documentation**
  * Release policy updated with approval gate setup, how the release app token is used for committing/tagging with branch-protection bypass, and quarterly private-key rotation and rotation verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
