### PR TITLE
fix(auth): gracefully drop OAuth profiles with missing access_token

### DIFF
--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -682,9 +682,18 @@ impl AuthProfilesStore {
             };
             let token_set = match kind {
                 AuthProfileKind::OAuth => {
-                    let access = access_token.ok_or_else(|| {
-                        anyhow::anyhow!("OAuth profile missing access_token: {id}")
-                    })?;
+                    let access = match access_token {
+                        Some(a) => a,
+                        None => {
+                            log::warn!(
+                                "[auth] dropping OAuth profile with missing access_token: \
+                                 provider={}. Re-authenticate to restore.",
+                                p.provider
+                            );
+                            dropped_ids.push(id.clone());
+                            continue;
+                        }
+                    };
                     Some(TokenSet {
                         access_token: access,
                         refresh_token,


### PR DESCRIPTION
## Summary

- Fix a hard crash in the auth profile store when an OAuth profile has a null `access_token`.
- The corrupted profile is now gracefully dropped and purged from disk (matching existing patterns for decrypt failures and unrecognized kinds).
- Prevents infinite error-retry loop that locked users out of their session.

## Problem

- An OAuth profile stored with `access_token: null` (e.g. after a partial OAuth flow or lost keychain entry) caused `AuthProfilesStore::load()` to return a hard error via `?` propagation.
- This poisoned the **entire** profile store load — including the valid `app-session:default` profile — so the app could never read its session token.
- The core entered an infinite retry loop (`rpc.invoke_method failed: OAuth profile missing access_token`) and the frontend thought the user was signed out.

## Solution

- Replace the hard `?` error with the same graceful-drop pattern used for decrypt failures (line 588) and unrecognized profile kinds (line 664): log a warning, push to `dropped_ids`, and `continue`.
- The existing purge logic at line 721 already handles removing dropped profiles from disk and clearing `active_profiles` pointers.
- On next launch, the corrupted entry is gone and the app-session loads normally. The user can re-authenticate the provider OAuth if needed.

## Submission Checklist

- [ ] N/A: Tests added — the fix is a 3-line control-flow change in an existing recovery pattern; the existing `dropped_ids` purge logic is already tested. Adding a unit test would require mocking the entire keychain + profile store filesystem which is out of scope for this hotfix.
- [ ] N/A: Diff coverage — single control-flow branch change in error handling; no new logic paths to cover beyond the existing purge tests.
- [ ] N/A: Coverage matrix — no new feature, behaviour-only defensive fix.
- [ ] N/A: Feature IDs — no matrix feature affected.
- [x] No new external network dependencies introduced.
- [ ] N/A: Manual smoke checklist — auth login/logout already covered.
- [ ] N/A: Linked issue — discovered during live debugging, no pre-existing issue.

## Impact

- **Desktop**: fixes a startup crash loop when any OAuth provider profile has a missing token.
- **Security**: no change — the profile is purged, not silently accepted.
- **Migration**: none — the purge is self-healing on first load.

## Related

- Follow-up: the OAuth flow that created the incomplete profile (provider:openai) should be investigated to prevent writing tokenless OAuth profiles in the first place.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/auth-oauth-profile-missing-token
- Commit SHA: 57c98d1f4

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` (pre-push hook passed)
- [x] Focused tests: N/A (control-flow change only)
- [x] Rust fmt/check: `cargo check --manifest-path Cargo.toml` passed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: OAuth profiles with null access_token are dropped instead of crashing the store load.
- User-visible effect: App no longer gets stuck in an error loop on startup; user stays logged in.

### Parity Contract

- Legacy behavior preserved: All other profile types (Token, valid OAuth) load identically.
- Guard/fallback/dispatch parity checks: Matches existing `dropped_ids` + purge pattern used by decrypt-failure and unrecognized-kind recovery.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None
- Canonical PR: This one
- Resolution: N/A