### PR TITLE
ci(e2e): strip full DWARF from rust-e2e test build to fix runner disk exhaustion

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -376,6 +376,15 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
       RUST_BACKTRACE: "1"
+      # The full-workspace debug test build (`cargo test --workspace` over
+      # every `tests/*_e2e.rs` binary) was overflowing the runner disk and
+      # failing with `System.IO.IOException: No space left on device`. Full
+      # DWARF (type/variable tables) is the largest part of `target/debug`;
+      # `line-tables-only` drops it while PRESERVING panic locations
+      # (`#[track_caller]`) and `RUST_BACKTRACE=1` file:line frames, so we
+      # lose only debugger-symbol data CI never reads.
+      CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
+      CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- Fixes the chronic `System.IO.IOException: No space left on device` failures in the **`E2E (Linux / Rust integration suite)`** job (`rust-e2e-linux`).
- Sets `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG` to `line-tables-only` so the full-workspace debug test build stops overflowing the runner disk.
- No code change — one env block in `.github/workflows/e2e-reusable.yml`.

## Problem

`rust-e2e-linux` runs `cargo test --workspace` over every `tests/*_e2e.rs` integration binary in debug mode with **full DWARF**. On the `ubuntu-22.04` runner (inside the CI container) the resulting `target/debug` overflows the host disk, and the job dies with `System.IO.IOException: No space left on device` while the runner writes its own `_diag/Worker_*.log`. It's intermittent because the build lands right at the disk edge — observed failing **2 of 3** attempts on #3140, and it has hit unrelated PRs too. The required `Rust E2E (mock backend)` check is the merge gate, so this flakily blocks otherwise-green, approved PRs.

## Solution

Full DWARF (type/variable tables) is the single largest contributor to a debug `target/`. `line-tables-only` drops it while **preserving everything CI actually reads**:

- Panic locations (`panicked at file:line:col`) come from `#[track_caller]` / `core::panic::Location` — constant data baked at the call site, **not** DWARF — so they survive.
- `RUST_BACKTRACE=1` (set on this job) keeps `file:line` in backtrace frames because line tables are retained.
- Only debugger-only symbol data (variable/type inspection) is lost, which CI never uses.

So it's a strictly-safe shrink: same diagnostics, much smaller `target/`. (If `line-tables-only` ever proves insufficient, the next lever is `"0"` — losing only deep-backtrace line numbers — and/or a `free-disk-space` step.)

## Submission Checklist

- [x] N/A: Tests — CI workflow/env change only; no application code.
- [x] N/A: Diff coverage ≥ 80% — no code lines changed.
- [x] N/A: Coverage matrix — no feature rows affected.
- [x] No new external network dependencies introduced.
- [x] N/A: release-cut smoke surfaces untouched.
- [x] N/A: no associated issue to close.

## Impact

- **CI only.** Affects the `rust-e2e-linux` job's build profile; runtime/product unchanged.
- Reduces `target/debug` footprint enough to clear the runner disk budget; backtraces remain fully symbolized to file:line.

## Related

- Closes: N/A
- Unblocks: #3140 (its `Rust E2E (mock backend)` check has been failing on this disk error)
- Follow-up: if disk pressure persists, add a host `free-disk-space` step or drop to `DEBUG: "0"`.

> NOTE: this is a fork PR, so GitHub runs the **base** repo's workflow definitions for `pull_request` events — the modified `e2e-reusable.yml` therefore won't execute on *this* PR and can't fully self-test here. The change is a self-contained, reviewable env tweak; it takes effect once merged to `main` and applies to all subsequent runs (re-run #3140's Rust E2E afterward to confirm green).

---

## AI Authored PR Metadata

### Commit & Branch
- Branch: `ci/strip-test-debug-info`
- Commit SHA: `766770f5`

### Validation Run
- [x] N/A: format:check / typecheck — no app code.
- [x] N/A: Rust fmt/check — no Rust source changed.
- [x] Reasoning verified: panic `Location` is `#[track_caller]` (not DWARF); `line-tables-only` retains backtrace file:line.

### Behavior Changes
- Intended: shrink the rust-e2e debug build's disk footprint.
- User-visible effect: none (CI-only); failing-test diagnostics are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configuration for Linux E2E testing to reduce disk usage during builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->