### PR TITLE
Fix memory letterhead local timestamp display

### DIFF
--- a/app/src/components/intelligence/MemoryChunkLetterhead.tsx
+++ b/app/src/components/intelligence/MemoryChunkLetterhead.tsx
@@ -38,12 +38,12 @@ function parseSourceParts(chunk: Chunk): LetterheadParts {
 
 function formatLetterDate(ms: number): string {
   const d = new Date(ms);
-  const yyyy = d.getUTCFullYear();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
-  const dd = String(d.getUTCDate()).padStart(2, '0');
-  const hh = String(d.getUTCHours()).padStart(2, '0');
-  const mi = String(d.getUTCMinutes()).padStart(2, '0');
-  return `${yyyy}·${mm}·${dd} · ${hh}:${mi} utc`;
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  return `${yyyy}·${mm}·${dd} · ${hh}:${mi}`;
 }
 
 export function MemoryChunkLetterhead({ chunk }: { chunk: Chunk }) {

--- a/app/src/components/intelligence/__tests__/MemoryChunkLetterhead.test.tsx
+++ b/app/src/components/intelligence/__tests__/MemoryChunkLetterhead.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Chunk } from '../../../utils/tauriCommands';
 import { MemoryChunkLetterhead } from '../MemoryChunkLetterhead';
@@ -19,6 +19,10 @@ const BASE_CHUNK: Chunk = {
 };
 
 describe('MemoryChunkLetterhead', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('renders the from/to/date frontmatter from a personalized email source', () => {
     const chunk: Chunk = { ...BASE_CHUNK, tags: ['person/Steven-Enamakel'] };
     render(<MemoryChunkLetterhead chunk={chunk} />);
@@ -30,8 +34,37 @@ describe('MemoryChunkLetterhead', () => {
     // The raw address is rendered as secondary text.
     expect(screen.getByText('steve@example.com')).toBeInTheDocument();
     expect(screen.getByText('sanil@vezures.xyz')).toBeInTheDocument();
-    // Date formatted as YYYY·MM·DD · HH:MM utc (UTC components).
-    expect(screen.getByText('2026·05·04 · 09:14 utc')).toBeInTheDocument();
+    // Date formatted as YYYY·MM·DD · HH:MM in the viewer's local timezone.
+    expect(screen.getByText(/2026·05·04 · \d{2}:\d{2}/)).toBeInTheDocument();
+  });
+
+  it('formats the date using local time instead of UTC components', () => {
+    class LocalTimeDate extends Date {
+      getFullYear() {
+        return 2026;
+      }
+
+      getMonth() {
+        return 4;
+      }
+
+      getDate() {
+        return 4;
+      }
+
+      getHours() {
+        return 14;
+      }
+
+      getMinutes() {
+        return 44;
+      }
+    }
+
+    vi.stubGlobal('Date', LocalTimeDate);
+    render(<MemoryChunkLetterhead chunk={BASE_CHUNK} />);
+
+    expect(screen.getByText('2026·05·04 · 14:44')).toBeInTheDocument();
   });
 
   it('falls back to the raw email when no person/* tag is present', () => {


### PR DESCRIPTION
Fixes #3128.

## Problem
Memory chunk letterheads format timestamps with UTC date/time getters and append `utc`. That can make email and memory timestamps appear offset from the viewer's local time.

## Approach
Format the letterhead timestamp from the viewer's local `Date` components instead of UTC components, and remove the UTC suffix. I also updated the existing letterhead test coverage and added a regression case that proves the local getters are used.

## Tradeoffs
This keeps the compact numeric letterhead format, but the displayed time now follows the user's local environment rather than a fixed UTC representation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated timestamp formatting in memory chunk display to reflect local time while maintaining the same visual format (YYYY·MM·DD · HH:MM).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->