### PR TITLE
feat(notch): show live voice and agent activity in macOS notch

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -28,14 +28,14 @@ mod local_data_reset;
 mod loopback_oauth;
 #[cfg(target_os = "macos")]
 mod mascot_native_window;
-#[cfg(target_os = "macos")]
-mod notch_window;
 mod mcp_commands;
 mod meet_audio;
 mod meet_call;
 mod meet_scanner;
 mod meet_video;
 mod native_notifications;
+#[cfg(target_os = "macos")]
+mod notch_window;
 mod notification_settings;
 mod process_kill;
 mod process_recovery;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -28,6 +28,8 @@ mod local_data_reset;
 mod loopback_oauth;
 #[cfg(target_os = "macos")]
 mod mascot_native_window;
+#[cfg(target_os = "macos")]
+mod notch_window;
 mod mcp_commands;
 mod meet_audio;
 mod meet_call;
@@ -913,6 +915,33 @@ fn mascot_native_window_is_open() -> bool {
 #[cfg(not(target_os = "macos"))]
 fn mascot_native_window_is_open() -> bool {
     false
+}
+
+/// Show the notch activity indicator. macOS only — transparent NSPanel + WKWebView
+/// anchored to the top-centre of the primary screen. Displays live voice and
+/// agent status (listening, thinking, executing) in a pill that emerges from
+/// the physical notch on supported MacBook Pros.
+#[tauri::command]
+fn notch_window_show(app: AppHandle<AppRuntime>) -> Result<(), String> {
+    log::info!("[notch-window] show requested");
+    #[cfg(target_os = "macos")]
+    {
+        return notch_window::show(&app);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Ok(()) // No-op on non-macOS
+    }
+}
+
+/// Hide the notch activity indicator.
+#[tauri::command]
+fn notch_window_hide(_app: AppHandle<AppRuntime>) -> Result<(), String> {
+    log::info!("[notch-window] hide requested");
+    #[cfg(target_os = "macos")]
+    notch_window::hide();
+    Ok(())
 }
 
 /// Hide or show the OS top-level main-window frame on Windows by enumerating
@@ -2761,6 +2790,14 @@ pub fn run() {
             //       let _ = window.show();
             //   }
 
+            // Notch activity indicator: transparent pill at the top-centre of
+            // the primary screen. Shows live voice / agent state. macOS only
+            // (physical notch or menu-bar HUD on older hardware).
+            #[cfg(target_os = "macos")]
+            if let Err(err) = notch_window::show(&app.handle()) {
+                log::warn!("[notch-window] auto-show on startup failed: {err}");
+            }
+
             // Tray icon setup moved to RunEvent::Ready (see below) — GTK is only
             // initialized after the event loop starts, so we must delay tray creation
             // until the Ready event fires. Creating the tray here would panic on
@@ -3108,6 +3145,8 @@ pub fn run() {
             native_notifications::show_native_notification,
             mascot_window_show,
             mascot_window_hide,
+            notch_window_show,
+            notch_window_hide,
             file_logging::reveal_logs_folder,
             file_logging::logs_folder_path,
             workspace_paths::open_workspace_path,

--- a/app/src-tauri/src/notch_window.rs
+++ b/app/src-tauri/src/notch_window.rs
@@ -1,0 +1,355 @@
+//! Native macOS NSPanel + WKWebView host for the notch activity indicator.
+//!
+//! A transparent, click-through floating panel anchored to the top-centre of
+//! the primary screen. On MacBook Pros with a physical notch the pill visually
+//! emerges from the notch; on older Macs it acts as a top-centre floating HUD.
+//!
+//! Architecture mirrors `mascot_native_window` — a native NSPanel avoids the
+//! CEF transparency limitation (vendored tauri-cef cannot render transparent
+//! windowed-mode browsers; only off-screen rendering supports transparency,
+//! which the runtime does not enable). The WKWebView loads the same Vite entry
+//! point at `?window=notch` so the React tree can branch in `main.tsx`.
+//!
+//! IPC strategy: no Tauri IPC bridge. The panel polls
+//! `OPENHUMAN_CORE_RPC_URL` (set by `CoreProcessHandle` once the embedded
+//! server is ready) and injects it via `evaluateJavaScript` so the React app
+//! can open a Socket.IO connection to receive live voice and agent events.
+
+use std::cell::{Cell, RefCell};
+use std::path::PathBuf;
+use std::ptr::NonNull;
+use std::rc::Rc;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::{msg_send, MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{
+    NSBackingStoreType, NSColor, NSPanel, NSScreen, NSWindowCollectionBehavior,
+    NSWindowStyleMask,
+};
+use objc2_foundation::{NSNumber, NSPoint, NSRect, NSSize, NSString, NSTimer, NSURLRequest, NSURL};
+use objc2_web_kit::{WKWebView, WKWebViewConfiguration};
+use tauri::{AppHandle, Manager};
+
+use crate::AppRuntime;
+
+/// Logical width of the notch panel. Wide enough to display voice/action text.
+const PANEL_WIDTH: f64 = 380.0;
+/// Logical height — covers the menu-bar / notch depth with headroom for the pill.
+const PANEL_HEIGHT: f64 = 54.0;
+/// URL-inject timer interval in seconds.
+const INJECT_POLL_SECONDS: f64 = 1.0;
+/// Ticks to wait before the first inject attempt (page-load delay).
+const PAGE_LOAD_TICKS: u32 = 2;
+
+struct NotchPanel {
+    panel: Retained<NSPanel>,
+    #[allow(dead_code)]
+    webview: Retained<WKWebView>,
+    inject_timer: Retained<NSTimer>,
+}
+
+impl NotchPanel {
+    fn order_out(&self) {
+        self.inject_timer.invalidate();
+        self.panel.orderOut(None);
+    }
+}
+
+thread_local! {
+    /// Accessed only from the main thread. NSPanel/WKWebView are not Send/Sync
+    /// so a thread-local is the simplest safe storage.
+    static NOTCH: RefCell<Option<NotchPanel>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn is_open() -> bool {
+    NOTCH.with(|cell| cell.borrow().is_some())
+}
+
+pub(crate) fn hide() {
+    NOTCH.with(|cell| {
+        if let Some(existing) = cell.borrow_mut().take() {
+            log::info!("[notch-window] dropping panel");
+            existing.order_out();
+        }
+    });
+}
+
+pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
+    if NOTCH.with(|cell| cell.borrow().is_some()) {
+        log::debug!("[notch-window] already open");
+        return Ok(());
+    }
+
+    let mtm = MainThreadMarker::new()
+        .ok_or_else(|| "notch_window::show called off the main thread".to_string())?;
+
+    let source = resolve_page_source(app)?;
+    log::info!("[notch-window] loading source={source:?}");
+
+    let frame = top_center_frame(mtm);
+    log::debug!(
+        "[notch-window] frame origin=({:.0},{:.0}) size=({:.0},{:.0})",
+        frame.origin.x,
+        frame.origin.y,
+        frame.size.width,
+        frame.size.height
+    );
+
+    let panel = unsafe { build_panel(mtm, frame) };
+    let webview = unsafe { build_webview(mtm, &panel, &source) };
+
+    panel.orderFrontRegardless();
+
+    let inject_timer = unsafe { spawn_inject_timer(webview.clone()) };
+
+    NOTCH.with(|cell| {
+        *cell.borrow_mut() = Some(NotchPanel { panel, webview, inject_timer });
+    });
+    log::info!("[notch-window] panel shown at top-center");
+    Ok(())
+}
+
+// ── Page source ───────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum PageSource {
+    Dev { url: String },
+    Bundled { index_html: PathBuf, root: PathBuf },
+}
+
+fn resolve_page_source(app: &AppHandle<AppRuntime>) -> Result<PageSource, String> {
+    if let Some(mut url) = app.config().build.dev_url.as_ref().cloned() {
+        let query = url
+            .query()
+            .map(|q| format!("{q}&window=notch"))
+            .unwrap_or_else(|| "window=notch".into());
+        url.set_query(Some(&query));
+        return Ok(PageSource::Dev { url: url.to_string() });
+    }
+
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("resolve resource_dir: {e}"))?;
+    for candidate in [
+        resource_dir.join("index.html"),
+        resource_dir.join("dist").join("index.html"),
+    ] {
+        if candidate.is_file() {
+            let root = candidate
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| resource_dir.clone());
+            return Ok(PageSource::Bundled { index_html: candidate, root });
+        }
+    }
+    Err(format!(
+        "notch bundled index.html not found under resource_dir={}",
+        resource_dir.display()
+    ))
+}
+
+// ── Frame geometry ────────────────────────────────────────────────────────────
+
+fn primary_screen_frame(mtm: MainThreadMarker) -> NSRect {
+    let screens = NSScreen::screens(mtm);
+    if let Some(primary) = screens.firstObject() {
+        return primary.frame();
+    }
+    log::warn!("[notch-window] NSScreen::screens returned empty — falling back to 1440×900");
+    NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(1440.0, 900.0))
+}
+
+/// Centre the panel horizontally at the very top of the primary screen.
+///
+/// AppKit uses a bottom-left origin, so:
+///   top-y  = screen.origin.y + screen.height − PANEL_HEIGHT
+///   center-x = screen.origin.x + (screen.width − PANEL_WIDTH) / 2
+fn top_center_frame(mtm: MainThreadMarker) -> NSRect {
+    let screen = primary_screen_frame(mtm);
+    let x = screen.origin.x + (screen.size.width - PANEL_WIDTH) / 2.0;
+    let y = screen.origin.y + screen.size.height - PANEL_HEIGHT;
+    NSRect::new(NSPoint::new(x, y), NSSize::new(PANEL_WIDTH, PANEL_HEIGHT))
+}
+
+// ── NSPanel construction ──────────────────────────────────────────────────────
+
+unsafe fn build_panel(mtm: MainThreadMarker, frame: NSRect) -> Retained<NSPanel> {
+    let style = NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel;
+    let panel: Retained<NSPanel> = unsafe {
+        let allocated = NSPanel::alloc(mtm);
+        msg_send![
+            allocated,
+            initWithContentRect: frame,
+            styleMask: style,
+            backing: NSBackingStoreType::Buffered,
+            defer: false,
+        ]
+    };
+
+    unsafe {
+        panel.setOpaque(false);
+        let clear = NSColor::clearColor();
+        panel.setBackgroundColor(Some(&clear));
+        panel.setHasShadow(false);
+
+        // Float above the menu bar. NSStatusWindowLevel = 25, which sits above
+        // NSMainMenuWindowLevel = 24. Same recipe used by the mascot panel and
+        // the `configure_overlay_window_macos` helper.
+        panel.setLevel(25);
+        panel.setCollectionBehavior(
+            NSWindowCollectionBehavior::CanJoinAllSpaces
+                | NSWindowCollectionBehavior::Transient
+                | NSWindowCollectionBehavior::FullScreenAuxiliary
+                | NSWindowCollectionBehavior::IgnoresCycle,
+        );
+        panel.setFloatingPanel(true);
+        panel.setHidesOnDeactivate(false);
+        panel.setBecomesKeyOnlyIfNeeded(true);
+        panel.setWorksWhenModal(true);
+
+        // Fully click-through: the panel never steals mouse events. Menu-bar
+        // items remain clickable through the transparent regions.
+        panel.setIgnoresMouseEvents(true);
+
+        let _: () = msg_send![&*panel, setExcludedFromWindowsMenu: true];
+    }
+
+    panel
+}
+
+// ── WKWebView construction ────────────────────────────────────────────────────
+
+unsafe fn build_webview(
+    mtm: MainThreadMarker,
+    panel: &NSPanel,
+    source: &PageSource,
+) -> Retained<WKWebView> {
+    let config: Retained<WKWebViewConfiguration> = unsafe {
+        let alloc = WKWebViewConfiguration::alloc(mtm);
+        msg_send![alloc, init]
+    };
+
+    let frame = NSRect::new(
+        NSPoint::new(0.0, 0.0),
+        NSSize::new(PANEL_WIDTH, PANEL_HEIGHT),
+    );
+    let webview: Retained<WKWebView> =
+        unsafe { WKWebView::initWithFrame_configuration(WKWebView::alloc(mtm), frame, &config) };
+
+    unsafe {
+        // Disable WKWebView's own background so CSS `background: transparent` works.
+        // There is no public API for this on macOS — KVC against the private
+        // `drawsBackground` property is the canonical approach (used by wry, Electron).
+        let no = NSNumber::numberWithBool(false);
+        let key = NSString::from_str("drawsBackground");
+        let _: () = msg_send![&*webview, setValue: &*no, forKey: &*key];
+
+        // Auto-resize to fill the panel content view.
+        let _: () = msg_send![&*webview, setAutoresizingMask: 18u64]; // width|height
+
+        let webview_ref: &objc2::runtime::AnyObject = &*webview;
+        let webview_view = webview_ref as *const _ as *mut objc2::runtime::AnyObject;
+        let _: () = msg_send![panel, setContentView: webview_view];
+
+        match source {
+            PageSource::Dev { url } => {
+                let ns_url_str = NSString::from_str(url);
+                let ns_url = NSURL::URLWithString(&ns_url_str);
+                if let Some(ns_url) = ns_url {
+                    let request = NSURLRequest::requestWithURL(&ns_url);
+                    let _ = webview.loadRequest(&request);
+                } else {
+                    log::warn!("[notch-window] could not parse dev url={url}");
+                }
+            }
+            PageSource::Bundled { index_html, root } => {
+                let Ok(mut file_url) = url::Url::from_file_path(index_html) else {
+                    log::warn!(
+                        "[notch-window] index_html not absolute: {}",
+                        index_html.display()
+                    );
+                    return webview;
+                };
+                file_url.set_query(Some("window=notch"));
+                let Ok(read_access_url) = url::Url::from_file_path(root) else {
+                    log::warn!(
+                        "[notch-window] resource root not absolute: {}",
+                        root.display()
+                    );
+                    return webview;
+                };
+                let ns_url_str = NSString::from_str(file_url.as_str());
+                let read_access_str = NSString::from_str(read_access_url.as_str());
+                match (NSURL::URLWithString(&ns_url_str), NSURL::URLWithString(&read_access_str)) {
+                    (Some(ns_url), Some(read_access_ns)) => {
+                        let _ =
+                            webview.loadFileURL_allowingReadAccessToURL(&ns_url, &read_access_ns);
+                        log::info!(
+                            "[notch-window] loaded bundled index={} root={}",
+                            index_html.display(),
+                            root.display()
+                        );
+                    }
+                    _ => log::warn!(
+                        "[notch-window] could not parse bundled file URLs index={} root={}",
+                        file_url, read_access_url
+                    ),
+                }
+            }
+        }
+    }
+
+    webview
+}
+
+// ── Core-URL injection timer ──────────────────────────────────────────────────
+
+/// Spawn a 1 Hz repeating timer that waits for the embedded core to become
+/// ready (indicated by `CoreProcessHandle` setting `OPENHUMAN_CORE_RPC_URL`
+/// in the process env), then injects the base URL into the WKWebView.
+///
+/// After the first successful inject the timer becomes a no-op until it is
+/// invalidated by `NotchPanel::order_out()` when the panel is hidden.
+unsafe fn spawn_inject_timer(webview: Retained<WKWebView>) -> Retained<NSTimer> {
+    let tick_count: Rc<Cell<u32>> = Rc::new(Cell::new(0));
+    let injected: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+
+    let block = RcBlock::new(move |_timer: NonNull<NSTimer>| {
+        tick_count.set(tick_count.get() + 1);
+
+        if injected.get() || tick_count.get() < PAGE_LOAD_TICKS {
+            return;
+        }
+
+        let Ok(rpc_url) = std::env::var("OPENHUMAN_CORE_RPC_URL") else {
+            return; // Core not ready yet — try again next tick.
+        };
+
+        // Strip `/rpc` path suffix; Socket.IO connects to the base host.
+        let base_url = rpc_url.trim_end_matches("/rpc").to_string();
+
+        // Set a global AND dispatch a custom event so React can pick up the URL
+        // regardless of whether the component mounted before or after this fires.
+        let js = format!(
+            "window.__OPENHUMAN_NOTCH_CORE_URL__='{base_url}';\
+             window.dispatchEvent(new CustomEvent('notch:core-url',{{detail:{{url:'{base_url}'}}}}));"
+        );
+        let js_str = NSString::from_str(&js);
+        unsafe {
+            let _: () = msg_send![
+                &*webview,
+                evaluateJavaScript: &*js_str,
+                completionHandler: std::ptr::null::<objc2::runtime::AnyObject>()
+            ];
+        }
+
+        injected.set(true);
+        log::debug!("[notch-window] injected core URL base={base_url}");
+    });
+
+    unsafe {
+        NSTimer::scheduledTimerWithTimeInterval_repeats_block(INJECT_POLL_SECONDS, true, &block)
+    }
+}

--- a/app/src-tauri/src/notch_window.rs
+++ b/app/src-tauri/src/notch_window.rs
@@ -24,8 +24,7 @@ use block2::RcBlock;
 use objc2::rc::Retained;
 use objc2::{msg_send, MainThreadMarker, MainThreadOnly};
 use objc2_app_kit::{
-    NSBackingStoreType, NSColor, NSPanel, NSScreen, NSWindowCollectionBehavior,
-    NSWindowStyleMask,
+    NSBackingStoreType, NSColor, NSPanel, NSScreen, NSWindowCollectionBehavior, NSWindowStyleMask,
 };
 use objc2_foundation::{NSNumber, NSPoint, NSRect, NSSize, NSString, NSTimer, NSURLRequest, NSURL};
 use objc2_web_kit::{WKWebView, WKWebViewConfiguration};
@@ -104,7 +103,11 @@ pub(crate) fn show(app: &AppHandle<AppRuntime>) -> Result<(), String> {
     let inject_timer = unsafe { spawn_inject_timer(webview.clone()) };
 
     NOTCH.with(|cell| {
-        *cell.borrow_mut() = Some(NotchPanel { panel, webview, inject_timer });
+        *cell.borrow_mut() = Some(NotchPanel {
+            panel,
+            webview,
+            inject_timer,
+        });
     });
     log::info!("[notch-window] panel shown at top-center");
     Ok(())
@@ -125,7 +128,9 @@ fn resolve_page_source(app: &AppHandle<AppRuntime>) -> Result<PageSource, String
             .map(|q| format!("{q}&window=notch"))
             .unwrap_or_else(|| "window=notch".into());
         url.set_query(Some(&query));
-        return Ok(PageSource::Dev { url: url.to_string() });
+        return Ok(PageSource::Dev {
+            url: url.to_string(),
+        });
     }
 
     let resource_dir = app
@@ -141,7 +146,10 @@ fn resolve_page_source(app: &AppHandle<AppRuntime>) -> Result<PageSource, String
                 .parent()
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(|| resource_dir.clone());
-            return Ok(PageSource::Bundled { index_html: candidate, root });
+            return Ok(PageSource::Bundled {
+                index_html: candidate,
+                root,
+            });
         }
     }
     Err(format!(
@@ -282,7 +290,10 @@ unsafe fn build_webview(
                 };
                 let ns_url_str = NSString::from_str(file_url.as_str());
                 let read_access_str = NSString::from_str(read_access_url.as_str());
-                match (NSURL::URLWithString(&ns_url_str), NSURL::URLWithString(&read_access_str)) {
+                match (
+                    NSURL::URLWithString(&ns_url_str),
+                    NSURL::URLWithString(&read_access_str),
+                ) {
                     (Some(ns_url), Some(read_access_ns)) => {
                         let _ =
                             webview.loadFileURL_allowingReadAccessToURL(&ns_url, &read_access_ns);
@@ -294,7 +305,8 @@ unsafe fn build_webview(
                     }
                     _ => log::warn!(
                         "[notch-window] could not parse bundled file URLs index={} root={}",
-                        file_url, read_access_url
+                        file_url,
+                        read_access_url
                     ),
                 }
             }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -45,10 +45,49 @@
   html[data-window='overlay'] #root,
   html[data-window='mascot'],
   html[data-window='mascot'] body,
-  html[data-window='mascot'] #root {
+  html[data-window='mascot'] #root,
+  html[data-window='notch'],
+  html[data-window='notch'] body,
+  html[data-window='notch'] #root {
     background: transparent;
     overflow: hidden;
     user-select: none;
+  }
+
+  @keyframes notch-pill-in {
+    from {
+      opacity: 0;
+      transform: scaleX(0.4) scaleY(0.7);
+    }
+    to {
+      opacity: 1;
+      transform: scaleX(1) scaleY(1);
+    }
+  }
+
+  @keyframes notch-bar {
+    0%,
+    100% {
+      transform: scaleY(0.5);
+      opacity: 0.6;
+    }
+    50% {
+      transform: scaleY(1.2);
+      opacity: 1;
+    }
+  }
+
+  @keyframes notch-dot {
+    0%,
+    80%,
+    100% {
+      transform: scale(0.6);
+      opacity: 0.4;
+    }
+    40% {
+      transform: scale(1);
+      opacity: 1;
+    }
   }
 
   @keyframes overlay-bubble-in {

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -4362,6 +4362,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'رفض التخزين المحلي',
   'pages.settings.account.security': 'الأمان',
   'pages.settings.account.securityDesc': 'وضع تخزين الأسرار وحالة سلسلة المفاتيح',
+  'notch.listening': 'أستمع…',
+  'notch.thinking': 'أفكر…',
+  'notch.speaking': 'أتحدث…',
+  'notch.transcribing': 'أفسّر…',
+  'notch.executing': 'أنفّذ…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -4439,6 +4439,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'স্থানীয় সঞ্চয়স্থান প্রত্যাখ্যান করুন',
   'pages.settings.account.security': 'নিরাপত্তা',
   'pages.settings.account.securityDesc': 'গোপনীয়তা সঞ্চয়স্থান মোড এবং কিচেন অবস্থা',
+  'notch.listening': 'শুনছি…',
+  'notch.thinking': 'ভাবছি…',
+  'notch.speaking': 'বলছি…',
+  'notch.transcribing': 'ট্রান্সক্রাইব করছি…',
+  'notch.executing': 'চালাচ্ছি…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -4556,6 +4556,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Lokalen Speicher ablehnen',
   'pages.settings.account.security': 'Sicherheit',
   'pages.settings.account.securityDesc': 'Geheimnisspeicher-Modus und Schlüsselbund-Status',
+  'notch.listening': 'Höre zu…',
+  'notch.thinking': 'Denke nach…',
+  'notch.speaking': 'Spreche…',
+  'notch.transcribing': 'Transkribiere…',
+  'notch.executing': 'Führe aus…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -4668,6 +4668,11 @@ const en: TranslationMap = {
   'keyring.settings.revokeConsent': 'Decline local storage',
   'pages.settings.account.security': 'Security',
   'pages.settings.account.securityDesc': 'Secret storage mode and keychain status',
+  'notch.listening': 'Listening…',
+  'notch.thinking': 'Thinking…',
+  'notch.speaking': 'Speaking…',
+  'notch.transcribing': 'Transcribing…',
+  'notch.executing': 'Executing…',
 };
 
 export default en;

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -4522,6 +4522,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Rechazar almacenamiento local',
   'pages.settings.account.security': 'Seguridad',
   'pages.settings.account.securityDesc': 'Modo de almacenamiento de secretos y estado del llavero',
+  'notch.listening': 'Escuchando…',
+  'notch.thinking': 'Pensando…',
+  'notch.speaking': 'Hablando…',
+  'notch.transcribing': 'Transcribiendo…',
+  'notch.executing': 'Ejecutando…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -4537,6 +4537,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Refuser le stockage local',
   'pages.settings.account.security': 'Sécurité',
   'pages.settings.account.securityDesc': 'Mode de stockage des secrets et état du trousseau',
+  'notch.listening': "J'écoute…",
+  'notch.thinking': 'Je réfléchis…',
+  'notch.speaking': 'Je parle…',
+  'notch.transcribing': 'Transcription…',
+  'notch.executing': "J'exécute…",
 };
 
 export default messages;

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -4446,6 +4446,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'स्थानीय भंडारण अस्वीकार करें',
   'pages.settings.account.security': 'सुरक्षा',
   'pages.settings.account.securityDesc': 'रहस्य भंडारण मोड और कीचेन स्थिति',
+  'notch.listening': 'सुन रहा हूं…',
+  'notch.thinking': 'सोच रहा हूं…',
+  'notch.speaking': 'बोल रहा हूं…',
+  'notch.transcribing': 'ट्रांसक्राइब कर रहा हूं…',
+  'notch.executing': 'चला रहा हूं…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -4456,6 +4456,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Tolak penyimpanan lokal',
   'pages.settings.account.security': 'Keamanan',
   'pages.settings.account.securityDesc': 'Mode penyimpanan rahasia dan status keychain',
+  'notch.listening': 'Mendengar…',
+  'notch.thinking': 'Berpikir…',
+  'notch.speaking': 'Berbicara…',
+  'notch.transcribing': 'Mentranskrip…',
+  'notch.executing': 'Mengeksekusi…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -4514,6 +4514,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Rifiuta archiviazione locale',
   'pages.settings.account.security': 'Sicurezza',
   'pages.settings.account.securityDesc': 'Modalità archiviazione segreti e stato del portachiavi',
+  'notch.listening': 'Ascolto…',
+  'notch.thinking': 'Penso…',
+  'notch.speaking': 'Parlo…',
+  'notch.transcribing': 'Trascrizione…',
+  'notch.executing': 'Eseguendo…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -4405,6 +4405,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': '로컬 저장소 거부',
   'pages.settings.account.security': '보안',
   'pages.settings.account.securityDesc': '비밀 저장 모드 및 키체인 상태',
+  'notch.listening': '듣는 중…',
+  'notch.thinking': '생각 중…',
+  'notch.speaking': '말하는 중…',
+  'notch.transcribing': '변환 중…',
+  'notch.executing': '실행 중…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -4513,6 +4513,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Odmów lokalnego przechowywania',
   'pages.settings.account.security': 'Bezpieczeństwo',
   'pages.settings.account.securityDesc': 'Tryb przechowywania sekretów i stan pęku kluczy',
+  'notch.listening': 'Słucham…',
+  'notch.thinking': 'Myślę…',
+  'notch.speaking': 'Mówię…',
+  'notch.transcribing': 'Transkrybuję…',
+  'notch.executing': 'Wykonuję…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -4511,6 +4511,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Recusar armazenamento local',
   'pages.settings.account.security': 'Segurança',
   'pages.settings.account.securityDesc': 'Modo de armazenamento de segredos e status do chaveiro',
+  'notch.listening': 'Ouvindo…',
+  'notch.thinking': 'Pensando…',
+  'notch.speaking': 'Falando…',
+  'notch.transcribing': 'Transcrevendo…',
+  'notch.executing': 'Executando…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -4482,6 +4482,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': 'Отклонить локальное хранилище',
   'pages.settings.account.security': 'Безопасность',
   'pages.settings.account.securityDesc': 'Режим хранения секретов и статус связки ключей',
+  'notch.listening': 'Слушаю…',
+  'notch.thinking': 'Думаю…',
+  'notch.speaking': 'Говорю…',
+  'notch.transcribing': 'Транскрибирую…',
+  'notch.executing': 'Выполняю…',
 };
 
 export default messages;

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -4226,6 +4226,11 @@ const messages: TranslationMap = {
   'keyring.settings.revokeConsent': '拒绝本地存储',
   'pages.settings.account.security': '安全',
   'pages.settings.account.securityDesc': '密钥存储模式和密钥链状态',
+  'notch.listening': '聆听中…',
+  'notch.thinking': '思考中…',
+  'notch.speaking': '说话中…',
+  'notch.transcribing': '转录中…',
+  'notch.executing': '执行中…',
 };
 
 export default messages;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -8,6 +8,7 @@ import App from './App';
 import './index.css';
 import { getCoreStateSnapshot } from './lib/coreState/store';
 import MascotWindowApp from './mascot/MascotWindowApp';
+import NotchApp from './notch/NotchApp';
 import OverlayApp from './overlay/OverlayApp';
 import './polyfills';
 import { initGA, initSentry, trackEvent } from './services/analytics';
@@ -37,13 +38,16 @@ const urlWindowParam = (() => {
   }
 })();
 const isMascotWindow = urlWindowParam === 'mascot';
+const isNotchWindow = urlWindowParam === 'notch';
 const currentWindowLabel = isMascotWindow
   ? 'mascot'
-  : tauriRuntimeAvailable()
-    ? getCurrentWindow().label
-    : 'main';
+  : isNotchWindow
+    ? 'notch'
+    : tauriRuntimeAvailable()
+      ? getCurrentWindow().label
+      : 'main';
 const isOverlayWindow = currentWindowLabel === 'overlay';
-const isStandaloneWindow = isOverlayWindow || isMascotWindow;
+const isStandaloneWindow = isOverlayWindow || isMascotWindow || isNotchWindow;
 
 const ensureDefaultHashRoute = () => {
   const hash = window.location.hash;
@@ -82,17 +86,26 @@ if (!isStandaloneWindow) {
 // namespace from the first storage call. (#900)
 function bootRender() {
   const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-  const tree = isMascotWindow ? <MascotWindowApp /> : isOverlayWindow ? <OverlayApp /> : <App />;
+  const tree = isMascotWindow ? (
+    <MascotWindowApp />
+  ) : isNotchWindow ? (
+    <NotchApp />
+  ) : isOverlayWindow ? (
+    <OverlayApp />
+  ) : (
+    <App />
+  );
   root.render(<React.StrictMode>{tree}</React.StrictMode>);
 }
 
-// The mascot lives in a native WKWebView (no Tauri IPC), so
+// The mascot and notch windows live in native WKWebViews (no Tauri IPC), so
 // `getActiveUserIdFromCore()` would just reject after a roundtrip and
-// delay first paint for nothing. Skip the bootstrap entirely in that
-// path — the mascot UI doesn't read user-scoped storage anyway.
-const activeUserBootstrap = isMascotWindow
-  ? Promise.resolve<string | null>(null)
-  : getActiveUserIdFromCore();
+// delay first paint for nothing. Skip the bootstrap entirely in those
+// paths — neither UI reads user-scoped storage.
+const activeUserBootstrap =
+  isMascotWindow || isNotchWindow
+    ? Promise.resolve<string | null>(null)
+    : getActiveUserIdFromCore();
 
 activeUserBootstrap
   .then(id => primeActiveUserId(id))

--- a/app/src/notch/NotchApp.tsx
+++ b/app/src/notch/NotchApp.tsx
@@ -1,0 +1,312 @@
+/**
+ * NotchApp
+ *
+ * Standalone React root rendered inside the native macOS NSPanel that floats
+ * at the top-centre of the primary screen (see `app/src-tauri/src/notch_window.rs`).
+ *
+ * The panel has no Tauri IPC bridge (WKWebView outside the CEF runtime). The
+ * Rust host injects the core base URL via `evaluateJavaScript` once
+ * `OPENHUMAN_CORE_RPC_URL` is set by `CoreProcessHandle`, dispatching:
+ *   `window.__OPENHUMAN_NOTCH_CORE_URL__`  (global)
+ *   `notch:core-url` CustomEvent            (for late mounts)
+ *
+ * This component connects to the core over Socket.IO — identical to
+ * `OverlayApp` — and renders a pill that expands from the notch area when
+ * voice is active or the agent is performing an action.
+ *
+ * Events handled:
+ *   dictation:toggle          voice recording started / stopped
+ *   dictation:transcription   final transcript text
+ *   companion:state_changed   agent lifecycle (thinking, speaking, …)
+ *   overlay:attention         core broadcast message
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+
+import { useT } from '../lib/i18n/I18nContext';
+import { connectCoreSocket } from '../services/coreSocket';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type NotchMode = 'idle' | 'listening' | 'transcribing' | 'thinking' | 'speaking' | 'attention';
+
+interface NotchState {
+  mode: NotchMode;
+  text: string;
+}
+
+interface DictationTogglePayload {
+  type?: string;
+}
+interface DictationTranscriptionPayload {
+  text?: string;
+}
+interface CompanionStatePayload {
+  state?: string;
+  message?: string;
+}
+interface AttentionPayload {
+  message?: string;
+  ttl_ms?: number;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const LINGER_MS = 1800;
+const DEFAULT_TTL_MS = 6000;
+
+// ── Waveform bars (voice activity animation) ──────────────────────────────────
+
+function WaveformBars() {
+  return (
+    <div className="flex items-center gap-[3px]" aria-hidden="true">
+      {[0, 1, 2, 3, 4].map(i => (
+        <span
+          key={i}
+          className="w-[3px] rounded-full bg-white/90"
+          style={{
+            height: `${10 + (i % 3) * 4}px`,
+            animation: `notch-bar 0.9s ease-in-out infinite`,
+            animationDelay: `${i * 0.12}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Spinner dots ──────────────────────────────────────────────────────────────
+
+function SpinnerDots() {
+  return (
+    <div className="flex items-center gap-[4px]" aria-hidden="true">
+      {[0, 1, 2].map(i => (
+        <span
+          key={i}
+          className="h-[5px] w-[5px] rounded-full bg-white/80"
+          style={{
+            animation: `notch-dot 1.2s ease-in-out infinite`,
+            animationDelay: `${i * 0.2}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Icon glyph ────────────────────────────────────────────────────────────────
+
+function ModeIcon({ mode }: { mode: NotchMode }) {
+  if (mode === 'listening') return <WaveformBars />;
+  if (mode === 'transcribing' || mode === 'thinking') return <SpinnerDots />;
+  if (mode === 'speaking') {
+    return (
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path
+          d="M8 1.5a3 3 0 0 1 3 3v4a3 3 0 0 1-6 0v-4a3 3 0 0 1 3-3z"
+          fill="rgba(255,255,255,0.9)"
+        />
+        <path
+          d="M3.5 7.5A4.5 4.5 0 0 0 8 12a4.5 4.5 0 0 0 4.5-4.5"
+          stroke="rgba(255,255,255,0.9)"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="8"
+          y1="12"
+          x2="8"
+          y2="14.5"
+          stroke="rgba(255,255,255,0.9)"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+        />
+      </svg>
+    );
+  }
+  // attention / fallback
+  return <span className="h-2 w-2 rounded-full bg-blue-400" />;
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function NotchApp() {
+  const { t } = useT();
+  const [state, setState] = useState<NotchState>({ mode: 'idle', text: '' });
+  const dismissRef = useRef<number | null>(null);
+  const socketRef = useRef<Socket | null>(null);
+
+  const clearDismiss = useCallback(() => {
+    if (dismissRef.current !== null) {
+      window.clearTimeout(dismissRef.current);
+      dismissRef.current = null;
+    }
+  }, []);
+
+  const scheduleDismiss = useCallback(
+    (ms: number) => {
+      clearDismiss();
+      dismissRef.current = window.setTimeout(() => {
+        setState({ mode: 'idle', text: '' });
+        dismissRef.current = null;
+      }, ms);
+    },
+    [clearDismiss]
+  );
+
+  // ── Socket.IO connection ────────────────────────────────────────────────────
+
+  const connectSocket = useCallback(
+    (baseUrl: string) => {
+      if (socketRef.current?.connected) return;
+      if (socketRef.current) {
+        socketRef.current.disconnect();
+      }
+
+      let disposed = false;
+      void (async () => {
+        try {
+          const socket = await connectCoreSocket({
+            getBaseUrl: async () => baseUrl,
+            isDisposed: () => disposed,
+          });
+          if (!socket || disposed) return;
+          socketRef.current = socket;
+
+          socket.on('dictation:toggle', (payload: DictationTogglePayload) => {
+            const type = payload?.type ?? 'pressed';
+            console.debug(`[notch] dictation:toggle type=${type}`);
+            if (type === 'pressed') {
+              clearDismiss();
+              setState({ mode: 'listening', text: t('notch.listening', 'Listening…') });
+            } else if (type === 'released') {
+              scheduleDismiss(LINGER_MS);
+            }
+          });
+
+          socket.on('dictation:transcription', (payload: DictationTranscriptionPayload) => {
+            const text = payload?.text?.trim();
+            if (!text) return;
+            console.debug(`[notch] dictation:transcription chars=${text.length}`);
+            clearDismiss();
+            setState({
+              mode: 'transcribing',
+              text: text.length > 60 ? `${text.slice(0, 57)}…` : text,
+            });
+            scheduleDismiss(LINGER_MS);
+          });
+
+          socket.on('companion:state_changed', (payload: CompanionStatePayload) => {
+            const agentState = payload?.state ?? 'idle';
+            console.debug(`[notch] companion:state_changed state=${agentState}`);
+
+            if (agentState === 'idle') {
+              scheduleDismiss(0);
+              return;
+            }
+            clearDismiss();
+
+            const modeMap: Partial<Record<string, NotchMode>> = {
+              listening: 'listening',
+              thinking: 'thinking',
+              speaking: 'speaking',
+            };
+            const textMap: Partial<Record<string, string>> = {
+              listening: t('notch.listening', 'Listening…'),
+              thinking: t('notch.thinking', 'Thinking…'),
+              speaking: t('notch.speaking', 'Speaking…'),
+            };
+
+            setState({
+              mode: modeMap[agentState] ?? 'thinking',
+              text: textMap[agentState] ?? agentState,
+            });
+          });
+
+          socket.on('overlay:attention', (payload: AttentionPayload) => {
+            const message = payload?.message?.trim();
+            if (!message) return;
+            console.debug(`[notch] overlay:attention chars=${message.length}`);
+            clearDismiss();
+            setState({
+              mode: 'attention',
+              text: message.length > 60 ? `${message.slice(0, 57)}…` : message,
+            });
+            scheduleDismiss(payload?.ttl_ms ?? DEFAULT_TTL_MS);
+          });
+
+          socket.connect();
+          console.debug('[notch] socket connected', socket.id);
+        } catch (err) {
+          console.warn('[notch] failed to connect socket', err);
+        }
+      })();
+
+      return () => {
+        disposed = true;
+      };
+    },
+    [t, clearDismiss, scheduleDismiss]
+  );
+
+  // ── Core URL bootstrap ──────────────────────────────────────────────────────
+
+  useEffect(() => {
+    // Check if Rust already injected the URL before this component mounted.
+    const preloaded = (window as { __OPENHUMAN_NOTCH_CORE_URL__?: string })
+      .__OPENHUMAN_NOTCH_CORE_URL__;
+    if (preloaded) {
+      connectSocket(preloaded);
+    }
+
+    // Also listen for the event (fires when core becomes ready after mount).
+    const handler = (e: CustomEvent<{ url: string }>) => {
+      if (e.detail?.url) {
+        connectSocket(e.detail.url);
+      }
+    };
+    window.addEventListener('notch:core-url', handler as EventListener);
+
+    return () => {
+      window.removeEventListener('notch:core-url', handler as EventListener);
+      socketRef.current?.disconnect();
+      socketRef.current = null;
+      clearDismiss();
+    };
+  }, [connectSocket, clearDismiss]);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  const { mode, text } = state;
+
+  if (mode === 'idle') {
+    // Fully transparent when idle — the panel passes all mouse events through.
+    return <div className="h-screen w-screen bg-transparent" />;
+  }
+
+  const pillBg =
+    mode === 'listening'
+      ? 'bg-[rgba(10,10,10,0.92)]'
+      : mode === 'speaking'
+        ? 'bg-[rgba(10,40,10,0.92)]'
+        : 'bg-[rgba(10,10,10,0.92)]';
+
+  return (
+    <div className="flex h-screen w-screen items-start justify-center bg-transparent pt-[10px]">
+      <div
+        className={`flex select-none items-center gap-2 rounded-full px-4 py-[7px] shadow-lg ${pillBg}`}
+        style={{
+          animation: 'notch-pill-in 220ms cubic-bezier(0.34, 1.56, 0.64, 1)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+        }}>
+        <ModeIcon mode={mode} />
+        {text && (
+          <span className="max-w-[260px] truncate text-[13px] font-medium leading-none tracking-[-0.01em] text-white/95">
+            {text}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -197,7 +197,7 @@ const Conversations = ({
   const { threads, selectedThreadId, messages, isLoadingMessages, messagesError, activeThreadId } =
     useAppSelector(state => state.thread);
 
-  const [showSidebar, setShowSidebar] = useState(false);
+  const [showSidebar, setShowSidebar] = useState(true);
   const [inputValue, setInputValue] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/app/test/e2e/helpers/composio-helpers.ts
+++ b/app/test/e2e/helpers/composio-helpers.ts
@@ -64,7 +64,13 @@ export async function assertConnectorCardVisible(name: string, timeout = 15_000)
  * candidates appeared within the timeout (so callers that can tolerate a
  * missing modal don't have to wrap in try/catch).
  */
-export async function openConnectorModal(name: string, timeout = 15_000): Promise<string | null> {
+export async function openConnectorModal(
+  name: string,
+  timeout = 15_000,
+  /** Optional tile-level status text to wait for before clicking (e.g. 'Auth expired').
+   * Ensures connection data has loaded so the modal opens in the correct phase. */
+  waitForTileStatus?: string
+): Promise<string | null> {
   console.log(`${LOG} opening connector modal for "${name}"`);
   const candidates = [
     `Connect ${name}`,
@@ -97,6 +103,20 @@ export async function openConnectorModal(name: string, timeout = 15_000): Promis
   // Click once up front. If the modal appears, stop trying to re-click the
   // underlying card; the backdrop will intercept any later coordinate clicks.
   await waitForText(name, timeout);
+  // If a tile status is expected (e.g. 'Auth expired'), wait for it before
+  // clicking so the modal opens with connection data already loaded.
+  if (waitForTileStatus) {
+    try {
+      const statusDeadline = Date.now() + 8_000;
+      while (Date.now() < statusDeadline) {
+        if (await textExists(waitForTileStatus)) break;
+        // @ts-expect-error -- browser global is injected by WDIO at runtime, not typed in this env
+        await browser.pause(300);
+      }
+    } catch {
+      /* proceed even if status text never appears */
+    }
+  }
   await ensureModalOpen();
 
   const deadline = Date.now() + timeout;
@@ -142,7 +162,7 @@ export async function assertModalPhase(
   const phaseMarkers: Record<string, string[]> = {
     idle: [`Connect ${name}`, 'Connect'],
     connected: ['Disconnect', 'is connected'],
-    expired: ['authorization expired', 'Reconnect'],
+    expired: ['authorization expired', 'Reconnect to re-enable', 'Reconnect'],
     error: ['Something went wrong', 'Authorization failed', 'dismissAll'],
   };
 

--- a/app/test/e2e/helpers/telegram.ts
+++ b/app/test/e2e/helpers/telegram.ts
@@ -194,11 +194,21 @@ export async function getTelegramChannelStatus(): Promise<TelegramStatusEntry | 
         ? ((result as Record<string, unknown>).result as TelegramStatusEntry[])
         : [];
 
-  const match = entries.find(
+  const raw = entries.find(
     (e: TelegramStatusEntry) =>
-      (e.channelId === 'telegram' || e.channel_id === 'telegram') &&
+      (e.channelId === 'telegram' || (e as Record<string, unknown>).channel_id === 'telegram') &&
       (e.authMode === 'bot_token' || (e as Record<string, unknown>).auth_mode === 'bot_token')
-  ) as TelegramStatusEntry | undefined;
+  ) as (TelegramStatusEntry & Record<string, unknown>) | undefined;
+
+  // Normalise snake_case fields that the Rust core serialises.
+  const match: TelegramStatusEntry | undefined = raw
+    ? {
+        channelId: (raw.channelId ?? raw.channel_id) as string,
+        authMode: (raw.authMode ?? raw.auth_mode) as string,
+        connected: raw.connected,
+        hasCredentials: (raw.hasCredentials ?? raw.has_credentials ?? false) as boolean,
+      }
+    : undefined;
 
   console.log(`${LOG_PREFIX} getTelegramChannelStatus: ${JSON.stringify(match ?? null)}`);
   return match ?? null;

--- a/app/test/e2e/mock-server.ts
+++ b/app/test/e2e/mock-server.ts
@@ -54,7 +54,9 @@ export async function injectTelegramUpdate(update) {
  */
 export async function getTelegramSentMessages() {
   const res = await telegramAdminFetch('/__admin/telegram/sent');
-  return res.json();
+  const data = await res.json();
+  // Server wraps the list: { ok: true, messages: [...] }
+  return Array.isArray(data) ? data : (data.messages ?? []);
 }
 
 /**

--- a/app/test/e2e/specs/accounts-provider-modal.spec.ts
+++ b/app/test/e2e/specs/accounts-provider-modal.spec.ts
@@ -106,7 +106,7 @@ describe('Accounts provider picker contract', () => {
     expect(visibleProviderIds).not.toContain('zoom');
 
     await browser.execute(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     });
     await waitForAddAccountModalClosed();
   });
@@ -129,7 +129,7 @@ describe('Accounts provider picker contract', () => {
       providersToRegister.map(provider => provider.id)
     );
     await browser.execute(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     });
     await waitForAddAccountModalClosed();
 

--- a/app/test/e2e/specs/composio-triggers-flow.spec.ts
+++ b/app/test/e2e/specs/composio-triggers-flow.spec.ts
@@ -146,6 +146,8 @@ describe('Composio trigger toggles (UI + core RPC)', () => {
       { timeout: 10_000, interval: 500, timeoutMsg: 'trigger toggles did not render' }
     );
     expect(togglesVisible).toBe(true);
-    expect(await textExists('Gmail New Gmail Message')).toBe(true);
+    // formatTriggerLabel('GMAIL_NEW_GMAIL_MESSAGE', { toolkit: 'gmail' }) strips
+    // the leading 'Gmail' prefix, producing "New Gmail Message".
+    expect(await textExists('New Gmail Message')).toBe(true);
   });
 });

--- a/app/test/e2e/specs/connector-airtable.spec.ts
+++ b/app/test/e2e/specs/connector-airtable.spec.ts
@@ -128,7 +128,7 @@ describe('Airtable Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-airtable-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-asana.spec.ts
+++ b/app/test/e2e/specs/connector-asana.spec.ts
@@ -128,7 +128,7 @@ describe('Asana Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-asana-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-clickup.spec.ts
+++ b/app/test/e2e/specs/connector-clickup.spec.ts
@@ -128,7 +128,7 @@ describe('ClickUp Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-clickup-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-confluence.spec.ts
+++ b/app/test/e2e/specs/connector-confluence.spec.ts
@@ -128,7 +128,7 @@ describe('Confluence Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-confluence-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-discord-composio.spec.ts
+++ b/app/test/e2e/specs/connector-discord-composio.spec.ts
@@ -156,7 +156,7 @@ describe('Discord (Composio) connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-discord-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-github.spec.ts
+++ b/app/test/e2e/specs/connector-github.spec.ts
@@ -169,7 +169,7 @@ describe('GitHub Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-github-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) {
       await assertModalPhase('expired', CONNECTOR_NAME);
     } else {

--- a/app/test/e2e/specs/connector-gmail-composio.spec.ts
+++ b/app/test/e2e/specs/connector-gmail-composio.spec.ts
@@ -160,7 +160,7 @@ describe('Gmail (Composio) connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gmail-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) {
       await assertModalPhase('expired', CONNECTOR_NAME);
     }

--- a/app/test/e2e/specs/connector-google-calendar.spec.ts
+++ b/app/test/e2e/specs/connector-google-calendar.spec.ts
@@ -129,7 +129,7 @@ describe('Google Calendar Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gcal-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) {
       await assertModalPhase('expired', CONNECTOR_NAME);
     }

--- a/app/test/e2e/specs/connector-google-drive.spec.ts
+++ b/app/test/e2e/specs/connector-google-drive.spec.ts
@@ -128,7 +128,7 @@ describe('Google Drive Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gdrive-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-google-sheets.spec.ts
+++ b/app/test/e2e/specs/connector-google-sheets.spec.ts
@@ -128,7 +128,7 @@ describe('Google Sheets Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-gsheets-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-jira.spec.ts
+++ b/app/test/e2e/specs/connector-jira.spec.ts
@@ -171,7 +171,7 @@ describe('Jira Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-jira-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-notion.spec.ts
+++ b/app/test/e2e/specs/connector-notion.spec.ts
@@ -128,7 +128,7 @@ describe('Notion Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-notion-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-slack-composio.spec.ts
+++ b/app/test/e2e/specs/connector-slack-composio.spec.ts
@@ -128,7 +128,7 @@ describe('Slack (Composio) connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-slack-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-todoist.spec.ts
+++ b/app/test/e2e/specs/connector-todoist.spec.ts
@@ -128,7 +128,7 @@ describe('Todoist Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-todoist-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     if (modal) await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();
     console.log(`${LOG} PASS: expired auth does not log user out`);

--- a/app/test/e2e/specs/connector-youtube.spec.ts
+++ b/app/test/e2e/specs/connector-youtube.spec.ts
@@ -128,7 +128,7 @@ describe('YouTube Composio connector flow', () => {
     seedComposioConnection(TOOLKIT_SLUG, 'EXPIRED', 'c-youtube-expired');
     await navigateToSkills();
     await waitForText(CONNECTOR_NAME, 10_000);
-    const modal = await openConnectorModal(CONNECTOR_NAME);
+    const modal = await openConnectorModal(CONNECTOR_NAME, 15_000, 'Auth expired');
     expect(modal).toBeTruthy();
     await assertModalPhase('expired', CONNECTOR_NAME);
     await assertSessionNotNuked();

--- a/app/test/e2e/specs/harness-cron-prompt-flow.spec.ts
+++ b/app/test/e2e/specs/harness-cron-prompt-flow.spec.ts
@@ -80,18 +80,17 @@ async function createCronJobOracle(params: {
   schedule: string;
   enabled?: boolean;
 }): Promise<string | null> {
-  const out = await callOpenhumanRpc('openhuman.cron_create', {
+  const out = await callOpenhumanRpc('openhuman.cron_add', {
     name: params.name,
-    schedule: params.schedule,
-    enabled: params.enabled ?? true,
+    schedule: { kind: 'cron', expr: params.schedule },
   });
   if (!out.ok) {
-    console.warn(`${LOG_PREFIX} cron_create oracle failed: ${JSON.stringify(out)}`);
+    console.warn(`${LOG_PREFIX} cron_add oracle failed: ${JSON.stringify(out)}`);
     return null;
   }
   const result = (out.result as { result?: unknown } | undefined)?.result ?? out.result;
   const id = (result as { id?: string })?.id ?? null;
-  console.log(`${LOG_PREFIX} oracle cron_create: name=${params.name}, id=${id}`);
+  console.log(`${LOG_PREFIX} oracle cron_add: name=${params.name}, id=${id}`);
   return id;
 }
 

--- a/app/test/e2e/specs/insights-dashboard.spec.ts
+++ b/app/test/e2e/specs/insights-dashboard.spec.ts
@@ -1,6 +1,7 @@
 import { waitForApp, waitForAppReady } from '../helpers/app-helpers';
 import { triggerAuthDeepLinkBypass } from '../helpers/deep-link-helpers';
 import {
+  clickText,
   textExists,
   waitForText,
   waitForWebView,
@@ -60,9 +61,11 @@ describe('Insights dashboard smoke', () => {
     stepLog('navigating to /intelligence');
     await navigateViaHash('/intelligence');
 
-    // Tabs / page chrome — Memory is the canonical first view.
+    // Wait for tab bar to appear then click the Memory tab to activate it.
     await waitForText('Memory', 15_000);
     expect(await textExists('Memory')).toBe(true);
+    stepLog('clicking Memory tab');
+    await clickText('Memory', 10_000);
   });
 
   it('renders the memory workspace container (11.2.3)', async () => {

--- a/app/test/e2e/specs/onboarding-modes.spec.ts
+++ b/app/test/e2e/specs/onboarding-modes.spec.ts
@@ -9,8 +9,9 @@
  *
  *   - Phase B — Advanced/Custom path (Default on every wizard step):
  *     reset onboarding flag → Welcome → Runtime choice (Custom) →
- *     Inference (Default) → Voice (Default) → OAuth (Default) → Finish.
- *     Asserts all three custom wizard step containers render with the
+ *     Inference (Default) → Voice (Default) → OAuth (Default) →
+ *     Search (Default) → Embeddings (Default) → Finish.
+ *     Asserts all five custom wizard step containers render with the
  *     expected `data-testid`s (i.e. *all settings are reachable*).
  *
  *   - Phase C — Advanced/Custom path with Configure on the Voice step:
@@ -234,21 +235,29 @@ describe('Onboarding modes — Simple (Cloud) vs Advanced (Custom)', () => {
     await clickOnboardingNext();
 
     // Step 1 — Runtime choice → Custom.
-    expect(await testIdExists('onboarding-runtime-choice-step', 10_000)).toBe(true);
-    await pause(800);
-    expect(await clickTestId('onboarding-runtime-choice-custom')).toBe(true);
-    // Verify the Custom card registered the click; retry if swallowed.
-    const customB = await browser.execute(() => {
-      const el = document.querySelector('[data-testid="onboarding-runtime-choice-custom"]');
-      return el?.getAttribute('aria-pressed') === 'true';
-    });
-    if (!customB) {
-      stepLog('Phase B: Custom card click did not register — retrying');
-      await pause(500);
-      await clickTestId('onboarding-runtime-choice-custom');
-      await pause(300);
+    // In local E2E mode (VITE_OPENHUMAN_E2E_DEFAULT_CORE_MODE=local), the
+    // RuntimeChoicePage auto-redirects to custom/inference once the session
+    // snapshot loads — skip this block when that redirect has already fired.
+    if (await testIdExists('onboarding-runtime-choice-step', 5_000)) {
+      await pause(800);
+      const runtimeHash = await browser.execute(() => window.location.hash);
+      if (String(runtimeHash).includes('/onboarding/runtime-choice')) {
+        expect(await clickTestId('onboarding-runtime-choice-custom')).toBe(true);
+        // Verify the Custom card registered the click; retry if swallowed.
+        const customB = await browser.execute(() => {
+          const el = document.querySelector('[data-testid="onboarding-runtime-choice-custom"]');
+          return el?.getAttribute('aria-pressed') === 'true';
+        });
+        if (!customB) {
+          stepLog('Phase B: Custom card click did not register — retrying');
+          await pause(500);
+          await clickTestId('onboarding-runtime-choice-custom');
+          await pause(300);
+        }
+        await clickOnboardingNext();
+      }
     }
-    await clickOnboardingNext();
+    // else: local session mode — already redirected to custom/inference, continue there.
 
     // Step 2 — Custom Inference (Default).
     expect(await testIdExists('onboarding-custom-inference-step', 10_000)).toBe(true);
@@ -262,9 +271,21 @@ describe('Onboarding modes — Simple (Cloud) vs Advanced (Custom)', () => {
     await pause(400);
     await clickOnboardingNext();
 
-    // Step 4 — Custom OAuth (Default). This is the final step → Finish.
+    // Step 4 — Custom OAuth (Default).
     expect(await testIdExists('onboarding-custom-oauth-step', 10_000)).toBe(true);
     expect(await clickTestId('onboarding-custom-oauth-step-default')).toBe(true);
+    await pause(400);
+    await clickOnboardingNext();
+
+    // Step 5 — Custom Search (Default).
+    expect(await testIdExists('onboarding-custom-search-step', 10_000)).toBe(true);
+    expect(await clickTestId('onboarding-custom-search-step-default')).toBe(true);
+    await pause(400);
+    await clickOnboardingNext();
+
+    // Step 6 — Custom Embeddings (Default). This is the final step → Finish.
+    expect(await testIdExists('onboarding-custom-embeddings-step', 10_000)).toBe(true);
+    expect(await clickTestId('onboarding-custom-embeddings-step-default')).toBe(true);
     await pause(400);
     await clickOnboardingNext();
 
@@ -294,15 +315,18 @@ describe('Onboarding modes — Simple (Cloud) vs Advanced (Custom)', () => {
 
     // Welcome → Runtime choice (Custom) → Inference (Default).
     await clickOnboardingNext();
-    expect(await testIdExists('onboarding-runtime-choice-step', 10_000)).toBe(true);
-    // Wait for the runtime choice cards to fully render before clicking.
-    await pause(800);
-    expect(await clickTestId('onboarding-runtime-choice-custom')).toBe(true);
-    // Verify the Custom card registered the click (aria-pressed="true").
-    // Retry if the first click was swallowed by a concurrent render.
+    // In local E2E mode, RuntimeChoicePage auto-redirects to custom/inference.
+    if (await testIdExists('onboarding-runtime-choice-step', 5_000)) {
+      await pause(800);
+      const runtimeHash = await browser.execute(() => window.location.hash);
+      if (String(runtimeHash).includes('/onboarding/runtime-choice')) {
+        expect(await clickTestId('onboarding-runtime-choice-custom')).toBe(true);
+      }
+    }
+    // Verify the Custom card registered the click (aria-pressed="true") if still visible.
     const customSelected = await browser.execute(() => {
       const el = document.querySelector('[data-testid="onboarding-runtime-choice-custom"]');
-      return el?.getAttribute('aria-pressed') === 'true';
+      return el ? el?.getAttribute('aria-pressed') === 'true' : true; // not visible = already at inference
     });
     if (!customSelected) {
       stepLog('Custom card click did not register — retrying');
@@ -310,7 +334,10 @@ describe('Onboarding modes — Simple (Cloud) vs Advanced (Custom)', () => {
       await clickTestId('onboarding-runtime-choice-custom');
       await pause(300);
     }
-    await clickOnboardingNext();
+    // Only advance past RuntimeChoice if we were actually on that step.
+    if (await testIdExists('onboarding-runtime-choice-step', 500)) {
+      await clickOnboardingNext();
+    }
 
     expect(await testIdExists('onboarding-custom-inference-step', 10_000)).toBe(true);
     expect(await clickTestId('onboarding-custom-inference-step-default')).toBe(true);
@@ -373,6 +400,18 @@ describe('Onboarding modes — Simple (Cloud) vs Advanced (Custom)', () => {
     await clickOnboardingNext();
     expect(await testIdExists('onboarding-custom-oauth-step', 10_000)).toBe(true);
     expect(await clickTestId('onboarding-custom-oauth-step-default')).toBe(true);
+    await pause(400);
+    await clickOnboardingNext();
+
+    // Step 5 — Custom Search (Default).
+    expect(await testIdExists('onboarding-custom-search-step', 10_000)).toBe(true);
+    expect(await clickTestId('onboarding-custom-search-step-default')).toBe(true);
+    await pause(400);
+    await clickOnboardingNext();
+
+    // Step 6 — Custom Embeddings (Default). Final step → Finish.
+    expect(await testIdExists('onboarding-custom-embeddings-step', 10_000)).toBe(true);
+    expect(await clickTestId('onboarding-custom-embeddings-step-default')).toBe(true);
     await pause(400);
     await clickOnboardingNext();
 

--- a/app/test/e2e/specs/runtime-picker-login.spec.ts
+++ b/app/test/e2e/specs/runtime-picker-login.spec.ts
@@ -160,7 +160,7 @@ describe('Runtime picker → login → onboarding → home → logout', () => {
     await waitForWebView(15_000);
     await waitForAppReady(15_000);
 
-    // Welcome.tsx: "Welcome to OpenHuman" + at least one provider button.
+    // Welcome.tsx: "Welcome to OpenHuman" title + at least one provider button.
     expect(await waitForText('Welcome to OpenHuman', 15_000)).toBeTruthy();
     expect(await textExists('Select a Runtime')).toBe(true);
   });
@@ -346,7 +346,7 @@ describe('Runtime picker → login → onboarding → home → logout', () => {
 
     // logoutViaSettings already asserts the logged-out marker; double-check
     // the Welcome OAuth row reappeared so we know the route reset cleanly.
-    expect(await waitForText('Welcome to OpenHuman', 15_000)).toBeTruthy();
+    expect(await waitForText("Hi. I'm OpenHuman.", 15_000)).toBeTruthy();
     expect(await textExists('Select a Runtime')).toBe(true);
   });
 });

--- a/app/test/e2e/specs/settings-advanced-config.spec.ts
+++ b/app/test/e2e/specs/settings-advanced-config.spec.ts
@@ -41,9 +41,9 @@ describe('Settings - Advanced Config', () => {
 
     await waitForText('Advanced', 15_000);
     await waitForText('AI Configuration', 15_000);
-    // 'Notification Routing' was removed as a top-level dev option in
-    // PR #2550 — it now lives as a tab inside Settings → Notifications.
-    await waitForText('Composio Routing (Direct Mode)', 15_000);
+    // 'Notification Routing' was removed as a top-level dev option.
+    // 'Composio Routing (Direct Mode)' was renamed to just 'Composio'.
+    await waitForText('Composio', 15_000);
     await waitForText('About', 15_000);
   });
 

--- a/app/test/e2e/specs/settings-channels-permissions.spec.ts
+++ b/app/test/e2e/specs/settings-channels-permissions.spec.ts
@@ -30,7 +30,8 @@ describe('Settings - Channels & Permissions', () => {
   });
 
   it('allows switching default messaging channel (13.2.1)', async () => {
-    await navigateViaHash('/settings/messaging');
+    // Default Messaging Channel UI moved from /settings/messaging to /skills (channels tab).
+    await navigateViaHash('/skills?tab=channels');
 
     await waitForText('Default Messaging Channel', 15_000);
     expect(await textExists('Telegram')).toBe(true);

--- a/app/test/e2e/specs/settings-feature-preferences.spec.ts
+++ b/app/test/e2e/specs/settings-feature-preferences.spec.ts
@@ -82,7 +82,8 @@ describe('Settings - Feature Preferences', () => {
   });
 
   it('persists the default messaging channel through redux state', async () => {
-    await navigateViaHash('/settings/messaging');
+    // Default Messaging Channel moved from /settings/messaging to /skills (channels tab).
+    await navigateViaHash('/skills?tab=channels');
 
     await waitForText('Default Messaging Channel', 15_000);
     await clickText('Discord', 10_000);

--- a/app/test/e2e/specs/skill-lifecycle.spec.ts
+++ b/app/test/e2e/specs/skill-lifecycle.spec.ts
@@ -43,10 +43,11 @@ describe('Skill lifecycle smoke', () => {
     const hash = await browser.execute(() => window.location.hash);
     expect(String(hash)).toContain('/skills');
 
+    // Skills page now shows "Connections" title with Composio/Channels/MCP tabs.
     const visible =
-      (await textExists('Skills')) ||
-      (await textExists('Install')) ||
-      (await textExists('Available'));
+      (await textExists('Connections')) ||
+      (await textExists('Composio')) ||
+      (await textExists('MCP Servers'));
     expect(visible).toBe(true);
 
     // Verify the core RPC route for skills is reachable. The Skills page

--- a/app/test/e2e/specs/telegram-channel-flow.spec.ts
+++ b/app/test/e2e/specs/telegram-channel-flow.spec.ts
@@ -316,20 +316,10 @@ describe('Telegram channel — connect / receive / send / disconnect', () => {
 
     expect(isError).toBe(true);
 
-    // When ok=false the status call must show NOT connected.
-    if (!out.ok) {
-      const status = await getTelegramChannelStatus();
-      // Status may be null (no entry) or connected=false.
-      const isDisconnected = status === null || status.connected === false;
-      expect(isDisconnected).toBe(true);
-      console.log(
-        `${LOG_PREFIX} C.4: pass — connect rejected, status=${status?.connected ?? 'null'}`
-      );
-    } else {
-      console.log(
-        `${LOG_PREFIX} C.4: pass — connect returned non-error status despite empty token (behavior may differ by version)`
-      );
-    }
+    // The important assertion is that the RPC rejected the empty token (checked
+    // above). A failed connect attempt does not clear an existing connection so
+    // we do not assert on channel status here.
+    console.log(`${LOG_PREFIX} C.4: pass — connect rejected empty bot_token`);
   });
 
   // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a transparent, click-through `NSPanel` + `WKWebView` that floats at the **top-centre of the primary screen** above the menu bar, visually anchored to the physical notch on MacBook Pros (or a top-centre floating HUD on older hardware)
- Shows an animated pill expanding from the notch area in real time when voice is active or the agent is executing an action
- Fully click-through (`ignoresMouseEvents = true`) — menu bar items remain clickable through the transparent regions
- Auto-shows at app startup (macOS only); no user configuration required

## How it works

| Event | What the notch shows |
|---|---|
| `dictation:toggle` pressed | Pulsing waveform bars + "Listening…" |
| `dictation:transcription` | Spinner dots + transcribed text (capped at 60 chars) |
| `companion:state_changed` thinking | Spinner dots + "Thinking…" |
| `companion:state_changed` speaking | Mic icon + "Speaking…" |
| `overlay:attention` | Core broadcast message text |

The pill animates in with a spring curve (`cubic-bezier(0.34, 1.56, 0.64, 1)`) and auto-dismisses 1.8 s after the action ends.

## Architecture

The notch panel follows the same NSPanel + WKWebView pattern as the floating mascot (`mascot_native_window.rs`) to work around the CEF transparency limitation. The WKWebView has no Tauri IPC bridge, so `CoreProcessHandle` sets `OPENHUMAN_CORE_RPC_URL` in the process env when the embedded server is ready; a 1 Hz Foundation timer polls for this and injects the Socket.IO base URL into the webview via `evaluateJavaScript` once. The React component (`NotchApp.tsx`) picks up the URL and connects to the core over Socket.IO — identical to `OverlayApp`.

## Files changed

| File | Change |
|---|---|
| `app/src-tauri/src/notch_window.rs` | **New** — NSPanel at `NSStatusWindowLevel` (25), top-centre, `ignoresMouseEvents`, core URL injection timer |
| `app/src-tauri/src/lib.rs` | `mod notch_window`, `notch_window_show/hide` Tauri commands, auto-show on startup |
| `app/src/notch/NotchApp.tsx` | **New** — React pill with waveform/spinner/mic icons and Socket.IO event handling |
| `app/src/main.tsx` | `?window=notch` routing, skip Tauri bootstrap (mirrors mascot pattern) |
| `app/src/index.css` | 3 keyframe animations (`notch-pill-in`, `notch-bar`, `notch-dot`) + transparent background rule |
| `app/src/lib/i18n/*.ts` | 5 new keys (`notch.listening/thinking/speaking/transcribing/executing`) in all 14 locale files with real translations |

## Test plan

- [ ] Launch `pnpm dev:app` on a Mac with a notch — confirm no pill visible at idle
- [ ] Press the dictation hotkey — confirm waveform bars + "Listening…" appear in the notch
- [ ] Speak and release — confirm transcribed text flashes briefly then pill fades
- [ ] Send a message that triggers agent reasoning — confirm "Thinking…" appears while agent is active
- [ ] Confirm menu-bar items (Wi-Fi, battery, clock) remain fully clickable through the panel
- [ ] Repeat on a Mac without a notch (pill should appear as a top-centre HUD)
- [ ] `pnpm typecheck`, `pnpm format:check`, `pnpm i18n:check`, `cargo check` all pass