### PR TITLE
fix(test): feed multi_batch_volume_builds_full_tree past the 50k seal threshold (#3115)

### DIFF
--- a/src/openhuman/memory/sync_pipeline_e2e_tests.rs
+++ b/src/openhuman/memory/sync_pipeline_e2e_tests.rs
@@ -229,7 +229,6 @@ async fn single_batch_sync_to_tree() {
 // ── Test 2: high-volume → seal → digest → topic tree ────────────────────
 
 #[tokio::test]
-#[ignore = "pre-existing failure after #3059 refactor — tracked in #3115"]
 async fn multi_batch_volume_builds_full_tree() {
     let (_tmp, cfg) = test_config();
     ensure_event_bus();
@@ -240,8 +239,17 @@ async fn multi_batch_volume_builds_full_tree() {
     let base_ts = Utc::now().timestamp_millis() - 86_400_000;
 
     // Ingest 30 batches with large bodies to cross the 50k token seal threshold.
+    // Each large_body is ~302 tokens. 6 segments = ~1812 tokens per batch.
+    // 30 batches * 1812 tokens = 54,360 tokens (> 50,000 threshold).
+    // We vary each repetition slightly to ensure no content-based deduplication
+    // collapses the volume.
     for i in 0..30u32 {
-        let batch = mk_batch("gmail", "inbox", i, &large_body(i), base_ts);
+        let mut body = String::new();
+        for j in 0..6 {
+            body.push_str(&large_body(i));
+            body.push_str(&format!("\n\nRepeat marker: batch {i} / segment {j}\n\n"));
+        }
+        let batch = mk_batch("gmail", "inbox", i, &body, base_ts);
         let result = ingest_chat(&cfg, source_id, "alice", vec!["gmail".into()], batch)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

- Re-enable `multi_batch_volume_builds_full_tree` (drop `#[ignore]`) and feed it enough token volume to actually cross the L0 seal threshold.
- Root cause was **insufficient test input**, not a product regression: the seal pipeline is correct; the test simply never fed it past `INPUT_TOKEN_BUDGET`.

## Problem

The test ingested 30 batches of `large_body(i)` (~302 tokens each ≈ **9k total**), then asserted the source tree sealed to L1+ (`max_level >= 1`). The L0 seal fires only at `INPUT_TOKEN_BUDGET = 50_000` tokens (`src/openhuman/memory_store/trees/types.rs:188`), so `max_level=0` was the **correct** outcome — the assertion was unreachable and the test was `#[ignore]`'d as a "pre-existing failure after #3059".

The issue (#3115) hypothesized the `append_buffer → seal` chain broke in #3059. That is not the case: once the buffer is fed past 50k, the seal cascade fires and the tree reaches L1 as designed. The bug was in the test fixture's token volume, not the product.

## Solution

- Remove `#[ignore]` and grow each batch to 6 segments (~1,812 tokens/batch) → ~54,360 tokens across 30 batches, comfortably over the 50k seal threshold.
- Vary every segment with a `Repeat marker: batch {i} / segment {j}` suffix so no content-based dedup collapses the volume back under threshold.
- Assertions are unchanged from the #3059 source-tree model (`max_level >= 1`, non-empty L1 summaries, source retrieval, entity index). The test now exercises the real L0→L1 seal path instead of being skipped.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — re-enables and corrects the high-volume seal E2E (`sync_pipeline_e2e_tests::multi_batch_volume_builds_full_tree`); it now reaches the L1 seal it previously asserted.
- [x] **Diff coverage ≥ 80%** — N/A: test-only change, no production lines added.
- [x] Coverage matrix updated — N/A: no feature-ID behavior change; a skipped test is restored.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: test-only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Test coverage:** restores E2E coverage of the high-volume seal → L1 path; the suite no longer carries a silently-`#[ignore]`'d gap.
- **Runtime/CI:** none on production. Test runs in ~25s locally (real seal pipeline work).

## Related

- Closes #3115
- Context: #3059 (`refactor(memory): remove global+topic trees in favor of source trees`) rewrote this test's assertions to the source-tree model but left the feeder volume under threshold.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3115-multi-batch-volume`
- Commit SHA: `e3c19f0`
- Authored by Google Jules (session `86369401754696197`); committed + GPG-signed under oxoxDev.

### Validation Run

- [x] `cargo test -p openhuman --lib memory::sync_pipeline_e2e_tests::multi_batch_volume_builds_full_tree` → **1 passed** (24.53s), run against current `upstream/main` (`2a67e6ab`), not the stale Jules base.
- [x] Cherry-picked onto fresh `upstream/main` (40 commits ahead of the original Jules base) — clean, no conflict.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none in product. Test-only — restores a previously skipped seal E2E and feeds it enough tokens to fire the L0 seal.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: seal pipeline, thresholds, and assertions unchanged; only the test's input volume grows.
- Guard/fallback/dispatch parity checks: N/A — no production code touched.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A

### Verification

- Confirmed the seal chain is healthy: with ~54k tokens fed, `max_level` reaches ≥1 and L1 summaries are produced, disproving the suspected #3059 seal-chain regression. The earlier `max_level=0` was correct behavior for a ~9k-token feed below the 50k threshold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Activated previously skipped end-to-end test that comprehensively validates memory synchronization under high-volume scenarios, ensuring system stability and reliable performance at scale
* Enhanced test payload generation to create larger batch structures with improved deduplication simulation, providing better validation of token threshold handling and system behavior under demanding conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->