### PR TITLE
fix: disable storage for Codex responses requests

### DIFF
--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -269,6 +269,7 @@ impl OpenAiCompatibleProvider {
             input,
             instructions,
             stream: Some(false),
+            store: Some(false),
         };
 
         let url = self.responses_url();

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use sentry::test::TestTransport;
 use std::sync::Arc;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn make_provider(name: &str, url: &str, key: Option<&str>) -> OpenAiCompatibleProvider {
@@ -354,6 +354,15 @@ async fn responses_api_primary_posts_directly_to_responses() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/backend-api/codex/responses"))
+        .and(body_json(serde_json::json!({
+            "model": "gpt-5.5",
+            "input": [{
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}]
+            }],
+            "stream": false,
+            "store": false
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "output_text": "hello from responses",
             "output": []

--- a/src/openhuman/inference/provider/compatible_types.rs
+++ b/src/openhuman/inference/provider/compatible_types.rs
@@ -93,6 +93,8 @@ pub(crate) struct ResponsesRequest {
     pub(crate) instructions: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) store: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary
- Send `store: false` on OpenAI/Codex Responses API requests.
- Extend the existing Codex Responses API test to assert the outbound JSON body includes `store: false`.

## Why
Codex OAuth routes through the ChatGPT backend Responses API. That path expects requests not to create stored responses, so explicitly setting `store: false` keeps the request shape aligned with Codex/ChatGPT account usage.

## Test Plan
- RED: strengthened `responses_api_primary_posts_directly_to_responses` to require `store: false`; before the implementation change, the mock did not match and the focused test failed with `openai Responses API error`.
- GREEN: `RUSTC="$(rustup which --toolchain 1.93.0 rustc)" rustup run 1.93.0 cargo test responses_api_primary_posts_directly_to_responses --manifest-path Cargo.toml --lib -- --nocapture` → 1 passed, 0 failed.
- `RUSTC="$(rustup which --toolchain 1.93.0 rustc)" rustup run 1.93.0 cargo test openai_oauth --manifest-path Cargo.toml --lib -- --nocapture` → 32 passed, 0 failed.
- `rustup run 1.93.0 cargo fmt --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended API request configuration capabilities to support explicit control of server-side storage behavior for OpenAI-compatible provider endpoints, enabling management of data retention preferences

* **Tests**
  * Updated test suite to validate that storage configuration settings are correctly included and serialized in outbound request payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->