### PR TITLE
fix(composio): empty connections in direct mode without api key (TAURI-RUST-R4)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -233,7 +233,17 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if lower.contains("local ai is disabled") {
         return Some(ExpectedErrorKind::LocalAiDisabled);
     }
-    if lower.contains("api key not set") || lower.contains("missing api key") {
+    // `"no api key is configured"` covers the composio direct-mode factory
+    // bail (`client.rs`: "composio direct mode selected but no api key is
+    // configured"). `composio_list_connections` now short-circuits that
+    // state to an empty list, so the dominant 5 s-poll leak (TAURI-RUST-R4)
+    // no longer reaches here — but other direct-mode ops the user invokes
+    // explicitly (execute / authorize) can still surface it, and it is the
+    // same user-config state with no Sentry-actionable signal.
+    if lower.contains("api key not set")
+        || lower.contains("missing api key")
+        || lower.contains("no api key is configured")
+    {
         return Some(ExpectedErrorKind::ApiKeyMissing);
     }
     // Check `ChannelSupervisorRestart` BEFORE `is_loopback_unavailable` and
@@ -1953,6 +1963,33 @@ mod tests {
         );
         assert_eq!(
             expected_error_kind("ollama embed failed with status 500"),
+            None
+        );
+    }
+
+    /// Sentry TAURI-RUST-R4: the composio direct-mode factory bail must
+    /// classify as `ApiKeyMissing` so any residual emit (explicit
+    /// execute/authorize call with no key) stays out of Sentry. Uses the
+    /// verbatim wire shape from `client.rs`.
+    #[test]
+    fn classifies_composio_direct_no_api_key_as_api_key_missing() {
+        assert_eq!(
+            expected_error_kind(
+                "[composio] list_connections: composio direct mode selected but no api key \
+                 is configured (set via composio.set_api_key RPC or config.composio.api_key)"
+            ),
+            Some(ExpectedErrorKind::ApiKeyMissing)
+        );
+    }
+
+    /// Guard against over-suppression: a genuine BYO-key auth failure
+    /// (wrong/expired key the upstream rejected) is an actionable bug
+    /// shape and MUST still reach Sentry (stay `None`), not get demoted by
+    /// the new "no api key is configured" substring.
+    #[test]
+    fn does_not_classify_invalid_api_key_401_as_missing() {
+        assert_eq!(
+            expected_error_kind("OpenAI API error (401 Unauthorized): invalid_api_key"),
             None
         );
     }

--- a/src/openhuman/composio/ops.rs
+++ b/src/openhuman/composio/ops.rs
@@ -84,6 +84,40 @@ fn resolve_client(config: &Config) -> OpResult<ComposioClient> {
     })
 }
 
+/// True when the user has selected Composio **direct** mode but has not yet
+/// configured an API key (neither in the keychain nor `config.toml`).
+///
+/// This is a valid, user-controlled *setup* state — the user just flipped to
+/// direct mode and is about to paste their key — NOT an operation failure.
+/// Callers short-circuit to an empty result instead of letting the
+/// mode-aware factory bail with "composio direct mode selected but no api key
+/// is configured", which the desktop UI's 5 s poll would otherwise funnel to
+/// Sentry on every tick (TAURI-RUST-R4).
+///
+/// Key presence MUST mirror the factory's own resolution in
+/// [`create_composio_client`] (`client.rs`): a key counts if it is in the
+/// keychain (`credentials::get_composio_api_key`) **or** in `config.toml`
+/// (`config.composio.api_key`). Checking only the keychain would wrongly
+/// short-circuit to an empty list for a user who configured their key via
+/// `config.toml`, hiding their real connections.
+fn direct_mode_without_key(config: &Config) -> OpResult<bool> {
+    if config.composio.mode.trim() != crate::openhuman::config::schema::COMPOSIO_MODE_DIRECT {
+        return Ok(false);
+    }
+    let has_key = crate::openhuman::credentials::get_composio_api_key(config)
+        .map_err(|e| format!("[composio] get_composio_api_key failed: {e}"))?
+        .or_else(|| {
+            config
+                .composio
+                .api_key
+                .as_ref()
+                .map(|k| k.trim().to_string())
+                .filter(|k| !k.is_empty())
+        })
+        .is_some();
+    Ok(!has_key)
+}
+
 /// Defense-in-depth Sentry funnel for composio op-layer errors.
 ///
 /// The shared [`crate::openhuman::integrations::IntegrationClient`]
@@ -266,6 +300,30 @@ pub async fn composio_list_connections(
     config: &Config,
 ) -> OpResult<RpcOutcome<ComposioConnectionsResponse>> {
     tracing::debug!("[composio] rpc list_connections");
+    // [Sentry TAURI-RUST-R4] Direct mode with no API key yet is a valid,
+    // user-controlled *setup* state — not an operation failure. The desktop
+    // UI polls this RPC every 5 s; without this guard the mode-aware factory
+    // bails ("composio direct mode selected but no api key is configured") on
+    // every tick and the error funnels to Sentry until the user pastes a key
+    // (~3.2 k events, single user, release 0.57.5). Mirror `periodic.rs`'s
+    // graceful skip and return the truthful empty list (no key → no tenant →
+    // no connections). The Settings → Composio panel drives the "enter your
+    // key" prompt off the separate `api_key_set` status, so the user is still
+    // told what to do. We return BEFORE `create_composio_client` and
+    // `sync_cache_with_connections`, so no error is constructed and the
+    // integrations cache is left untouched.
+    if direct_mode_without_key(config)? {
+        tracing::debug!(
+            "[composio] list_connections: direct mode selected, no api key configured yet \
+             — returning empty connection list (valid setup state, not an error)"
+        );
+        return Ok(RpcOutcome::new(
+            ComposioConnectionsResponse {
+                connections: Vec::new(),
+            },
+            vec!["composio: direct mode — no api key configured yet, 0 connection(s)".to_string()],
+        ));
+    }
     // Route through the mode-aware factory so direct-mode users do NOT
     // accidentally see the tinyhumans-tenant connections from the
     // backend-proxied path. Mixing the two tenants is the bug behind the

--- a/src/openhuman/composio/ops_tests.rs
+++ b/src/openhuman/composio/ops_tests.rs
@@ -1838,6 +1838,82 @@ async fn composio_list_connections_routes_through_direct_mode() {
     }
 }
 
+// ── Direct mode with no API key yet (Sentry TAURI-RUST-R4) ────────
+//
+// Direct mode selected but no key configured is a valid user *setup*
+// state, not an operation failure. `composio_list_connections` must
+// return an empty list (no key → no tenant → no connections) instead of
+// erroring, so the desktop UI's 5 s poll stops funnelling the factory's
+// "no api key is configured" error to Sentry on every tick.
+
+/// Direct mode selected, but NO key in the keychain and none in
+/// `config.toml`. The mode-aware factory would bail here with
+/// "composio direct mode selected but no api key is configured".
+fn direct_mode_no_key_config(tmp: &tempfile::TempDir) -> Config {
+    let mut c = Config::default();
+    c.workspace_dir = tmp.path().join("workspace");
+    c.config_path = tmp.path().join("config.toml");
+    c.composio.mode = crate::openhuman::config::schema::COMPOSIO_MODE_DIRECT.into();
+    c
+}
+
+#[test]
+fn direct_mode_without_key_is_false_in_backend_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Default mode is backend — the guard must never fire there, or
+    // backend users would get a silent empty list.
+    let config = test_config(&tmp);
+    assert!(!direct_mode_without_key(&config).unwrap());
+}
+
+#[test]
+fn direct_mode_without_key_is_true_when_direct_and_no_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = direct_mode_no_key_config(&tmp);
+    assert!(direct_mode_without_key(&config).unwrap());
+}
+
+#[test]
+fn direct_mode_without_key_is_false_when_key_in_config_toml() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Key supplied via config.toml (not the keychain) still counts —
+    // the factory accepts it, so the guard must NOT short-circuit and
+    // hide the user's real connections.
+    let mut config = direct_mode_no_key_config(&tmp);
+    config.composio.api_key = Some("  ck_cfg_key  ".into());
+    assert!(!direct_mode_without_key(&config).unwrap());
+}
+
+#[test]
+fn direct_mode_without_key_is_false_when_key_in_keychain() {
+    let tmp = tempfile::tempdir().unwrap();
+    // `direct_mode_config` stores a key via the auth store — the guard
+    // must see it and report "has key".
+    let config = direct_mode_config(&tmp);
+    assert!(!direct_mode_without_key(&config).unwrap());
+}
+
+#[tokio::test]
+async fn composio_list_connections_returns_empty_when_direct_mode_no_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = direct_mode_no_key_config(&tmp);
+    // RC of TAURI-RUST-R4: this MUST be Ok(empty), not Err — no error is
+    // constructed, so nothing reaches Sentry and the 5 s poll stops
+    // churning.
+    let outcome = composio_list_connections(&config)
+        .await
+        .expect("direct mode with no key must return an empty list, not an error");
+    assert!(
+        outcome.value.connections.is_empty(),
+        "no key → no tenant → no connections"
+    );
+    assert!(
+        outcome.logs.iter().any(|l| l.contains("no api key")),
+        "log must explain the empty list is the no-key setup state, got {:?}",
+        outcome.logs
+    );
+}
+
 // ── Direct-mode authorize / list_tools / execute (commit 1, #1710) ─
 
 /// Direct-mode `composio_list_tools` now hits Composio v3 with the


### PR DESCRIPTION
## Summary

- `composio_list_connections` now returns an **empty list** (not an error) when the user has selected Composio **direct mode** but not yet configured an API key — a valid setup state, not a failure.
- Stops the desktop UI's 5 s connection poll from funnelling the factory's "no api key is configured" error to Sentry on every tick (TAURI-RUST-R4: ~3.2k events, single user, release 0.57.5).
- Key-presence detection mirrors the mode-aware factory's own keychain-**or**-`config.toml` resolution, so a key supplied via `config.toml` is never wrongly treated as absent.
- Defense-in-depth: `expected_error_kind` now classifies "no api key is configured" as `ApiKeyMissing` for the direct-mode ops a user invokes explicitly (`execute`/`authorize`).

## Problem

When a user toggles Composio to direct mode but hasn't pasted their API key yet, the mode-aware factory (`composio/client.rs`) bails with `composio direct mode selected but no api key is configured`. The desktop UI polls `composio_list_connections` every 5 s, so this error was constructed on every tick and propagated through the central RPC dispatcher (`core/jsonrpc.rs`) into Sentry — until the user finally entered a key. The result was a single user generating thousands of error events for an expected, user-controlled configuration state with no actionable signal.

The background sync tick (`memory_sync/composio/periodic.rs`) already handled this gracefully (skip). The UI-poll path never got the symmetric treatment.

## Solution

- Add `direct_mode_without_key(config)` in `composio/ops.rs`: true only when `config.composio.mode == "direct"` **and** no key resolves from either the keychain (`credentials::get_composio_api_key`) **or** `config.composio.api_key`. This deliberately mirrors the factory's own resolution to avoid hiding a `config.toml`-supplied key.
- `composio_list_connections` short-circuits to `Ok(ComposioConnectionsResponse { connections: vec![] })` **before** the factory call and before `sync_cache_with_connections`, so no error is constructed and the integrations cache is left untouched.
- This is a fix to the **root cause** (mis-modelling a valid setup state as an operation failure), not suppression — the error simply no longer occurs. Genuine failures still error and reach Sentry: backend no-session, keychain read failure, and an actually-**invalid** key (the v3 `HTTP 401: Invalid API key` path, classified separately).
- The Settings → Composio panel continues to drive the "enter your key" prompt off the separate `api_key_set` status, so the user is still told exactly what to do — nothing is hidden.
- `expected_error_kind` gains a `"no api key is configured"` substring under the existing `ApiKeyMissing` arm, demoting any residual explicit-invoke emit to `warn!` (logged, not Sentry). A guard test pins that a genuine `invalid_api_key` 401 stays actionable.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — every changed product line is exercised: the guard helper (4 cases incl. backend-mode / config-key / keychain-key), the empty-list path (`composio_list_connections_returns_empty_when_direct_mode_no_key`), and the classifier arm (+ over-suppression guard).
- [x] N/A: behaviour-only fix to an existing feature — no added/removed/renamed coverage-matrix feature row.
- [x] N/A: no coverage-matrix feature IDs affected by this change.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut smoke surfaces (internal RPC error-handling only).
- [x] N/A: Sentry-only issue, no GitHub issue to close — `Sentry-Issue: TAURI-RUST-R4` (see Related).

## Impact

- **Desktop (CLI/core):** direct-mode users without a key see an empty connection list instead of a silent error churn; UX is unchanged (the not-connected state is already driven by `api_key_set`).
- **Observability:** removes the dominant 5 s-poll Sentry leak at its source; residual explicit-invoke emits are demoted, not dropped (still in logs).
- No migration, no schema change, no new dependency. No security implication — genuine auth failures (invalid key, no session) still surface.

## Related

- Closes: _N/A — Sentry-only_
- `Sentry-Issue: TAURI-RUST-R4`
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/tauri-rust-r4-composio-listconns-empty-on-no-key`
- Commit SHA: `50e1170e`, `d16fd54f`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend (`app/`) changes.
- [x] N/A: `pnpm typecheck` — no frontend changes.
- [x] Focused tests: `cargo test --lib openhuman::composio::ops` (74 passed), `cargo test --lib core::observability` (135 passed)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --workspace` clean; `cargo clippy --lib` no new findings
- [x] N/A: Tauri fmt/check — no `app/src-tauri` changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `composio_list_connections` returns an empty list instead of erroring when direct mode is selected with no API key configured.
- User-visible effect: none beyond the existing not-connected state; the error no longer churns to Sentry.

### Parity Contract

- Legacy behavior preserved: backend mode unchanged; genuine failures (no session, keychain error, invalid key) still error; a `config.toml`-supplied key is honoured (guard helper mirrors the factory's keychain-or-config resolution).
- Guard/fallback/dispatch parity checks: empty short-circuit runs before the factory and cache sync; `direct_mode_without_key` returns false for backend mode and for any present key.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (dedup ran against open + 30-day-merged upstream PRs)
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing API key configuration in Direct mode—now gracefully returns an empty list instead of failing.
  * Enhanced error classification for API key-related issues, recognizing multiple error message variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->