### PR TITLE
test(e2e): update composer selectors for new placeholder + voice button

### DIFF
--- a/app/test/e2e/helpers/chat-harness.ts
+++ b/app/test/e2e/helpers/chat-harness.ts
@@ -6,7 +6,7 @@
  * needs:
  *
  *   - `button[title="New thread"]`       — icon-only button, no text
- *   - `textarea[placeholder="Type a message..."]` — React-controlled
+ *   - `textarea[placeholder="How can I help you today?"]` — React-controlled
  *     input that should be driven through WebDriver so React observes
  *     the same input events a user would produce
  *   - `button[aria-label="Send message"]` — icon-only button
@@ -39,7 +39,7 @@ export async function clickByTitle(title: string, timeoutMs = 6_000): Promise<bo
   return false;
 }
 
-const COMPOSER_SELECTOR = 'textarea[placeholder="Type a message..."]';
+const COMPOSER_SELECTOR = 'textarea[placeholder="How can I help you today?"]';
 
 /** Type into the chat composer through WebDriver so React's controlled
  *  input state and the DOM stay in sync. */

--- a/app/test/e2e/specs/chat-harness-cancel.spec.ts
+++ b/app/test/e2e/specs/chat-harness-cancel.spec.ts
@@ -162,7 +162,7 @@ describe('Chat harness — mid-stream cancel', () => {
     // The textarea must be re-enabled.
     const composerEnabled = await browser.execute(() => {
       const ta = document.querySelector(
-        'textarea[placeholder="Type a message..."]'
+        'textarea[placeholder="How can I help you today?"]'
       ) as HTMLTextAreaElement | null;
       return !!ta && !ta.disabled;
     });

--- a/app/test/e2e/specs/chat-harness-send-stream.spec.ts
+++ b/app/test/e2e/specs/chat-harness-send-stream.spec.ts
@@ -112,7 +112,7 @@ describe('Chat harness — send + stream', () => {
           'button[aria-label="Send message"]'
         ) as HTMLButtonElement;
         const ta = document.querySelector(
-          'textarea[placeholder*="Type a message"]'
+          'textarea[placeholder*="How can I help"]'
         ) as HTMLTextAreaElement;
         return {
           btnExists: !!btn,

--- a/app/test/e2e/specs/chat-tool-error-recovery.spec.ts
+++ b/app/test/e2e/specs/chat-tool-error-recovery.spec.ts
@@ -153,7 +153,7 @@ describe('Chat tool-error recovery', () => {
           'button[aria-label="Send message"]'
         ) as HTMLButtonElement | null;
         const ta = document.querySelector(
-          'textarea[placeholder="Type a message..."]'
+          'textarea[placeholder="How can I help you today?"]'
         ) as HTMLTextAreaElement | null;
         return (btn !== null && !btn.disabled) || (ta !== null && !ta.disabled);
       });

--- a/app/test/e2e/specs/composio-github-tools-tags.spec.ts
+++ b/app/test/e2e/specs/composio-github-tools-tags.spec.ts
@@ -86,7 +86,7 @@ async function navigateChatAndSend(prompt: string): Promise<void> {
     async () => {
       if (await getSelectedThreadId()) return true;
       if (await textExists('No messages yet')) return true;
-      return textExists('Type a message');
+      return textExists('How can I help');
     },
     { timeout: 15_000, timeoutMsg: 'Chat surface did not mount' }
   );

--- a/app/test/e2e/specs/conversations-web-channel-flow.spec.ts
+++ b/app/test/e2e/specs/conversations-web-channel-flow.spec.ts
@@ -74,7 +74,7 @@ suiteRunner('Conversations web channel flow', () => {
     // 'Message OpenHuman' button was removed from Home in a redesign — navigate directly.
     await navigateToConversations();
     // If navigating to /chat doesn't show threads, retry via direct hash.
-    const hasInput = await textExists('Type a message...');
+    const hasInput = await textExists('How can I help you today?');
     if (!hasInput) {
       await navigateViaHash('/chat');
       await browser.pause(2_000);

--- a/app/test/e2e/specs/harness-composio-tool-flow.spec.ts
+++ b/app/test/e2e/specs/harness-composio-tool-flow.spec.ts
@@ -81,7 +81,7 @@ async function navigateChatAndSend(prompt: string): Promise<void> {
     async () => {
       if (await getSelectedThreadId()) return true;
       if (await textExists('No messages yet')) return true;
-      return textExists('Type a message');
+      return textExists('How can I help');
     },
     { timeout: 15_000, timeoutMsg: 'Chat surface did not mount' }
   );

--- a/app/test/e2e/specs/skill-multi-round.spec.ts
+++ b/app/test/e2e/specs/skill-multi-round.spec.ts
@@ -38,7 +38,7 @@ describe('Multi-round tool conversation smoke', () => {
     const ok =
       (await textExists('Threads')) ||
       (await textExists('New')) ||
-      (await textExists('Type a message'));
+      (await textExists('How can I help'));
     expect(ok).toBe(true);
   });
 });

--- a/app/test/e2e/specs/voice-mode.spec.ts
+++ b/app/test/e2e/specs/voice-mode.spec.ts
@@ -96,10 +96,10 @@ describe.skip('Voice mode integration', () => {
     }
     expect(onHome).toBe(true);
 
-    const hasTextInput = await waitForAnyText(['Type a message', 'Threads', 'New'], 10_000);
+    const hasTextInput = await waitForAnyText(['How can I help', 'Threads', 'New'], 10_000);
     expect(hasTextInput).not.toBeNull();
 
-    await clickButton('Start recording', 10_000);
+    await clickButton('Voice mode', 10_000);
 
     const voiceStatusMessage = await waitForAnyText(
       [
@@ -116,18 +116,18 @@ describe.skip('Voice mode integration', () => {
     expect(voiceStatusMessage).not.toBeNull();
 
     await clickButton('Switch to text', 10_000);
-    const textRestored = await waitForAnyText(['Type a message', 'Threads', 'New'], 10_000);
+    const textRestored = await waitForAnyText(['How can I help', 'Threads', 'New'], 10_000);
     expect(textRestored).not.toBeNull();
   });
 
   it('surfaces a mic entry button from the text composer', async () => {
-    const onConversations = await waitForAnyText(['Type a message', 'Threads', 'New'], 10_000);
+    const onConversations = await waitForAnyText(['How can I help', 'Threads', 'New'], 10_000);
     if (!onConversations) {
       const tree = await dumpAccessibilityTree();
       console.log('[VoiceModeE2E] Conversations not ready. Tree:\n', tree.slice(0, 4000));
     }
     expect(onConversations).not.toBeNull();
-    expect(await textExists('Start recording')).toBe(true);
+    expect(await textExists('Voice mode')).toBe(true);
   });
 });
 

--- a/app/test/playwright/specs/chat-conversation-history.spec.ts
+++ b/app/test/playwright/specs/chat-conversation-history.spec.ts
@@ -115,7 +115,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-harness-cancel.spec.ts
+++ b/app/test/playwright/specs/chat-harness-cancel.spec.ts
@@ -109,7 +109,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();
@@ -134,7 +134,7 @@ test.describe('Chat Harness - Cancel', () => {
       await expect(page.getByText(piece, { exact: false })).toHaveCount(0);
     }
 
-    const composer = page.getByPlaceholder('Type a message...');
+    const composer = page.getByPlaceholder('How can I help you today?');
     await expect(composer).toBeEnabled();
     await composer.fill('post-cancel probe message');
     await expect(page.getByTestId('send-message-button')).toBeEnabled();

--- a/app/test/playwright/specs/chat-harness-scroll-render.spec.ts
+++ b/app/test/playwright/specs/chat-harness-scroll-render.spec.ts
@@ -117,7 +117,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-harness-send-stream.spec.ts
+++ b/app/test/playwright/specs/chat-harness-send-stream.spec.ts
@@ -113,7 +113,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-harness-subagent.spec.ts
+++ b/app/test/playwright/specs/chat-harness-subagent.spec.ts
@@ -126,7 +126,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-harness-wallet-flow.spec.ts
+++ b/app/test/playwright/specs/chat-harness-wallet-flow.spec.ts
@@ -151,7 +151,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-multi-tool-round.spec.ts
+++ b/app/test/playwright/specs/chat-multi-tool-round.spec.ts
@@ -134,7 +134,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-tool-call-flow.spec.ts
+++ b/app/test/playwright/specs/chat-tool-call-flow.spec.ts
@@ -124,7 +124,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/chat-tool-error-recovery.spec.ts
+++ b/app/test/playwright/specs/chat-tool-error-recovery.spec.ts
@@ -99,7 +99,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();
@@ -142,7 +142,7 @@ test.describe('Chat Tool Error Recovery', () => {
       })
       .toBeNull();
 
-    const composer = page.getByPlaceholder('Type a message...');
+    const composer = page.getByPlaceholder('How can I help you today?');
     await expect(composer).toBeEnabled();
 
     await setMockBehavior('llmStreamScript', '');

--- a/app/test/playwright/specs/conversations-web-channel-flow.spec.ts
+++ b/app/test/playwright/specs/conversations-web-channel-flow.spec.ts
@@ -112,7 +112,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/harness-channel-bridge-flow.spec.ts
+++ b/app/test/playwright/specs/harness-channel-bridge-flow.spec.ts
@@ -99,7 +99,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/harness-composio-tool-flow.spec.ts
+++ b/app/test/playwright/specs/harness-composio-tool-flow.spec.ts
@@ -124,7 +124,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/harness-cron-prompt-flow.spec.ts
+++ b/app/test/playwright/specs/harness-cron-prompt-flow.spec.ts
@@ -101,7 +101,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/harness-search-tool-flow.spec.ts
+++ b/app/test/playwright/specs/harness-search-tool-flow.spec.ts
@@ -110,7 +110,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/skill-multi-round.spec.ts
+++ b/app/test/playwright/specs/skill-multi-round.spec.ts
@@ -16,7 +16,7 @@ test.describe('Multi-round tool conversation smoke', () => {
 
     const text = await page.locator('#root').innerText();
     expect(
-      ['Threads', 'New thread', 'Type a message', 'Chat'].some(marker => text.includes(marker))
+      ['Threads', 'New thread', 'How can I help', 'Chat'].some(marker => text.includes(marker))
     ).toBe(true);
   });
 });

--- a/app/test/playwright/specs/user-journey-full-task.spec.ts
+++ b/app/test/playwright/specs/user-journey-full-task.spec.ts
@@ -101,7 +101,7 @@ async function waitForSocketConnected(page: Page): Promise<void> {
 async function sendMessage(page: Page, prompt: string): Promise<void> {
   await waitForSocketConnected(page);
   await dismissWalkthroughIfPresent(page);
-  await page.getByPlaceholder('Type a message...').fill(prompt);
+  await page.getByPlaceholder('How can I help you today?').fill(prompt);
   await dismissWalkthroughIfPresent(page);
   await expect(page.getByTestId('send-message-button')).toBeEnabled();
   await page.getByTestId('send-message-button').click();

--- a/app/test/playwright/specs/voice-mode.spec.ts
+++ b/app/test/playwright/specs/voice-mode.spec.ts
@@ -24,7 +24,7 @@ async function openChat(page: Page): Promise<void> {
     await skipButton.first().click({ force: true });
     await expect(skipButton.first()).toBeHidden();
   }
-  await expect(page.getByPlaceholder('Type a message...')).toBeVisible();
+  await expect(page.getByPlaceholder('How can I help you today?')).toBeVisible();
 }
 
 async function installGetUserMediaError(page: Page, name: string): Promise<void> {
@@ -61,7 +61,7 @@ async function restoreGetUserMedia(page: Page): Promise<void> {
 
 async function switchChatIntoMicComposer(page: Page): Promise<void> {
   await dismissWalkthroughIfPresent(page);
-  await page.getByRole('button', { name: 'Start recording' }).click({ force: true });
+  await page.getByRole('button', { name: 'Voice mode' }).click({ force: true });
   await expect(page.getByText(/Tap and speak|Waiting for agent/i)).toBeVisible();
   await expect(page.getByRole('button', { name: 'Switch to text' })).toBeVisible();
 }
@@ -77,7 +77,7 @@ test.describe('Voice mode integration', () => {
     await switchChatIntoMicComposer(page);
 
     await page.getByRole('button', { name: 'Switch to text' }).click();
-    await expect(page.getByPlaceholder('Type a message...')).toBeVisible();
+    await expect(page.getByPlaceholder('How can I help you today?')).toBeVisible();
     await expect(page.getByTestId('send-message-button')).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #3165 (composer redesign). That PR renamed the composer placeholder (`Type a message...` → `How can I help you today?`) and the mic-entry button (`Start recording` → `Voice mode`), and updated the Vitest tests — but the **Playwright + WDIO E2E specs** that select by those strings were missed and merged stale.

This updates all 26 affected spec files so the E2E specs match the shipped composer:
- `getByPlaceholder('Type a message...')` → `getByPlaceholder('How can I help you today?')`
- `textarea[placeholder="Type a message..."]` selector + harness docstring
- marker-array / `textExists` / `waitForAnyText` references
- mic-entry button: `Start recording` → `Voice mode` (MicComposer's own record button stays `Start recording`)

## Test plan

- [x] No stale `Type a message` references remain in `app/test/`
- [x] All 26 spec files reference the shipped placeholder
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] N/A: No app/Rust changes — test-only follow-up

Refs #3165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Updated test selectors across end-to-end and integration test suites to reflect changes to the chat input placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->