### PR TITLE
docs(env): document OPENHUMAN_BRAVE_API_KEY + OPENHUMAN_PARALLEL_API_KEY in .env.example (#3098 sub-issue 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,26 @@ OPENHUMAN_WEB_SEARCH_TIMEOUT_SECS=10
 # OPENHUMAN_QUERIT_API_KEY=
 
 # ---------------------------------------------------------------------------
+# Brave search (direct API — https://brave.com/search/api/)
+# ---------------------------------------------------------------------------
+# [optional] API key from https://api.search.brave.com. Select "Brave" in
+# Settings > Search engine, or set OPENHUMAN_SEARCH_ENGINE=brave. Powers
+# web_search_tool plus brave_news_search / brave_image_search /
+# brave_video_search. Engine silently falls back to "managed" if no key
+# is present, so the agent always has working search.
+# BRAVE_API_KEY=
+# OPENHUMAN_BRAVE_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Parallel search (direct API — https://parallel.ai)
+# ---------------------------------------------------------------------------
+# [optional] API key from https://parallel.ai. Select "Parallel" in
+# Settings > Search engine, or set OPENHUMAN_SEARCH_ENGINE=parallel.
+# Engine silently falls back to "managed" if no key is present.
+# PARALLEL_API_KEY=
+# OPENHUMAN_PARALLEL_API_KEY=
+
+# ---------------------------------------------------------------------------
 # SearXNG search (self-hosted — https://docs.searxng.org)
 # ---------------------------------------------------------------------------
 # [optional] Enable the searxng_search agent/MCP tool. Default: false.


### PR DESCRIPTION
## Summary

- `.env.example` now documents `OPENHUMAN_BRAVE_API_KEY` (and `OPENHUMAN_PARALLEL_API_KEY`, same root cause), matching the existing Querit / Seltz / SearXNG sections.
- Zero code change. The Brave Search code path is already fully wired — this PR closes the discoverability gap that most plausibly explains sub-issue 4 of #3098.

## Problem

Sub-issue 4 of #3098 reports "Brave Search not connecting — team noted this requires a Brave API key set in config or env vars." The Brave wiring is in fact complete end-to-end:

- **Config field**: `config.search.brave.api_key` (`src/openhuman/config/schema/types.rs`)
- **Env loader**: `OPENHUMAN_BRAVE_API_KEY` / `BRAVE_API_KEY` are read at `src/openhuman/config/schema/load.rs:1503-1507`
- **RPC**: `openhuman.config.update_search_settings { brave_api_key }` (`src/openhuman/config/ops.rs:1237-1241`)
- **UI**: `app/src/components/settings/panels/SearchPanel.tsx` has the Brave field + "configured" badge
- **Engine gate**: `SearchConfig::effective_engine()` returns `Brave` only when a key is present, otherwise silently falls back to `Managed` (`src/openhuman/config/schema/tools.rs:778-786`)
- **Tools**: `BraveWebSearchTool` / `BraveNewsSearchTool` / `BraveImageSearchTool` / `BraveVideoSearchTool` (`src/openhuman/search/tools/brave.rs`) error with a clear "no API key configured" message if blank

But `.env.example` documents Seltz, Querit, and SearXNG and has **no Brave section at all**. A user following the example file as the canonical reference for configurable env vars has no way to discover that `OPENHUMAN_BRAVE_API_KEY` exists without reading the Rust source. The same gap exists for `OPENHUMAN_PARALLEL_API_KEY`.

## Solution

Add two sections to `.env.example` (Brave first, since that's the reported issue; Parallel for symmetry — same env-var pattern, same gap). Each section follows the existing Querit template: optional, commented out, points at the upstream docs URL, names both `<NAME>_API_KEY` and `OPENHUMAN_<NAME>_API_KEY` (both are accepted by `env.get_any`).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `N/A: documentation-only change to .env.example. No code path touched. Existing tests in src/openhuman/search/tools/brave.rs and src/openhuman/config/schema/tools.rs already pin Brave loading + gating behavior.`
- [x] **Diff coverage ≥ 80%** — `N/A: documentation-only change (no executable lines changed).`
- [x] Coverage matrix updated — `N/A: documentation change; no feature row added or removed.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: documentation change.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no code change.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: not a release-cut surface.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — see below (#3098 has 4 sub-issues; this PR closes only sub-issue 4, so the issue stays open).

## Impact

- **Desktop / mobile / web / CLI**: no behavior change. The env vars were already loaded by the Rust core; this PR only changes what users see in `.env.example`.
- **Performance**: none.
- **Security**: none. Env-var path was already supported; this just documents it.
- **Migration**: none.

## Related

- Sub-issue 4 of #3098 (Brave Search not connecting).
- Sub-issue 1 of #3098 is addressed in PR #3217.
- Sub-issues 2 (Telegram file commits) and 3 (skills not running) remain open.
- Follow-up PR(s)/TODOs: if the issue reporter confirms they DID set a key and Brave still doesn't connect, the next steps would be (a) tool-registry refresh on config change so a running channel runtime picks up new keys without restart, or (b) an actual HTTP/auth investigation against `api.search.brave.com`. Out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3098-brave-search-env-docs`
- Commit SHA: `31634179f2588c2309410136f4bbac224876ef04`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: only .env.example touched.`
- [x] `pnpm typecheck` — `N/A: no TS/TSX touched.`
- [x] Focused tests: `N/A: documentation-only change. Brave loading + gating behavior already covered by src/openhuman/config/schema/tools.rs:830-839 (brave_requires_key) and src/openhuman/search/tools/brave.rs:644-697.`
- [x] Rust fmt/check (if changed): `N/A: no Rust touched.`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri touched.`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: None at runtime. Users see two new commented sections in `.env.example` describing how to provide a Brave or Parallel API key via env var.
- User-visible effect: Brave Search becomes a discoverable configuration option for users following `.env.example`.

### Parity Contract

- Legacy behavior preserved: Yes. `.env.example` is reference documentation only. The env-var loader is unchanged; the engine-selector gate is unchanged; the tool registry is unchanged. Users who set neither env var see identical behavior pre/post.
- Guard/fallback/dispatch parity checks: `SearchConfig::effective_engine()` already falls back to `Managed` when no key is present — that fallback is untouched.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found for sub-issue 4 of #3098.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A — first PR on this sub-issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Brave search engine is now available with optional API key configuration
  * Parallel search engine is now available with optional API key configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->