### PR TITLE
fix(scripts): add short help to PR main sync

### DIFF
--- a/scripts/__tests__/merge-main-into-open-prs-help.test.mjs
+++ b/scripts/__tests__/merge-main-into-open-prs-help.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(HERE, '..', 'merge-main-into-open-prs.mjs');
+
+function writeFailingStub(binDir, name) {
+  fs.writeFileSync(
+    join(binDir, name),
+    `#!/usr/bin/env sh\necho "${name} should not run for help" >&2\nexit 99\n`,
+    { mode: 0o755 },
+  );
+}
+
+function runHelp(flag) {
+  const binDir = fs.mkdtempSync(join(os.tmpdir(), 'openhuman-git-gh-stub-'));
+  writeFailingStub(binDir, 'git');
+  writeFailingStub(binDir, 'gh');
+
+  return spawnSync(process.execPath, [SCRIPT, flag], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`,
+    },
+  });
+}
+
+test('merge-main-into-open-prs help exits before invoking git or gh', () => {
+  for (const flag of ['--help', '-h']) {
+    const result = runHelp(flag);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage: merge-main-into-open-prs\.mjs \[options\]/);
+    assert.match(result.stdout, /-h, --help\s+Show this message\./);
+    assert.equal(result.stderr, '');
+  }
+});

--- a/scripts/merge-main-into-open-prs.mjs
+++ b/scripts/merge-main-into-open-prs.mjs
@@ -23,7 +23,7 @@ Options:
   --pr <number>               Restrict to one PR number. May be passed multiple times.
   --include-drafts            Include draft PRs (default: false)
   --execute                   Actually merge and push. Dry-run by default.
-  --help                      Show this message.
+  -h, --help                  Show this message.
 
 Examples:
   node scripts/merge-main-into-open-prs.mjs
@@ -79,7 +79,7 @@ function parseArgs(argv) {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--help') {
+    if (arg === '--help' || arg === '-h') {
       printUsage();
       process.exit(0);
     }


### PR DESCRIPTION
## Summary

- Adds `-h` as a short help alias for `scripts/merge-main-into-open-prs.mjs`.
- Updates usage text to document both `-h` and `--help`.
- Adds a focused Node test proving help exits before invoking `git` or `gh`.

## Problem

- `merge-main-into-open-prs.mjs` is a PR maintenance helper with GitHub and git side effects in normal execution.
- It accepted `--help` but not the short `-h` alias used by adjacent helper scripts.
- Help should be inspectable without a configured Git remote, temporary clone setup, or GitHub CLI access.

## Solution

- Treat `-h` the same as `--help` before any repository or GitHub-dependent work.
- Test both help aliases with temporary failing `git` and `gh` stubs in `PATH`.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + failure guard: help exits 0 and fails if `git` or `gh` is invoked).
- [x] N/A: Diff coverage gate was not run because this is a root helper script change and local Rust tooling is unavailable.
- [x] N/A: Coverage matrix not affected; this does not add, remove, or rename a product feature.
- [x] N/A: No affected feature IDs; contributor maintenance script only.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist not affected; this does not touch release-cut surfaces.
- [x] N/A: Related to #2611 but does not close it by itself.

## Impact

- Runtime/platform impact: none.
- Developer impact: `node scripts/merge-main-into-open-prs.mjs -h` now prints usage and exits without requiring git or GitHub CLI setup.

## Related

- Related: #2611
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `codex/OH-2611-merge-main-short-help`
- Commit SHA: `00d52b5`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (blocked after Prettier passed; see Validation Blocked)
- [x] `pnpm typecheck`: N/A, root Node helper-only change
- [x] Focused tests: `node --test scripts/__tests__/merge-main-into-open-prs-help.test.mjs`
- [x] Rust fmt/check (if changed): N/A, no Rust files changed
- [x] Tauri fmt/check (if changed): N/A, no Tauri files changed
- [x] `node scripts/codex-pr-preflight.mjs --lightweight`
- [x] `git diff --check`

### Validation Blocked

- `command:` `pnpm --filter openhuman-app format:check`
- `error:` `sh: cargo: command not found`
- `impact:` Prettier passed, but the Rust format phase cannot run in this local environment until Cargo is installed.

### Behavior Changes

- Intended behavior change: `-h` now prints usage and exits 0 for `merge-main-into-open-prs.mjs`.
- User-visible effect: contributor-facing maintenance CLI help is easier to discover.

### Parity Contract

- Legacy behavior preserved: `--help`, dry-run mode, `--execute`, draft filtering, PR filtering, and invalid argument behavior are unchanged.
- Guard/fallback/dispatch parity checks: focused test verifies both help aliases exit before any `git` or `gh` invocation.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found in the current open PR list during preflight.
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-h` shorthand flag as an alternative to `--help` for displaying command help.

* **Tests**
  * Added test coverage for help command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->