### PR TITLE
fix(scripts): add short help to stale CI cleanup

### DIFF
--- a/scripts/__tests__/cancel-stale-pr-ci-help.test.mjs
+++ b/scripts/__tests__/cancel-stale-pr-ci-help.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(HERE, '..', 'cancel-stale-pr-ci.mjs');
+
+function runHelp(flag) {
+  const binDir = fs.mkdtempSync(join(os.tmpdir(), 'openhuman-gh-stub-'));
+  fs.writeFileSync(
+    join(binDir, 'gh'),
+    '#!/usr/bin/env sh\necho "gh should not run for help" >&2\nexit 99\n',
+    { mode: 0o755 },
+  );
+
+  return spawnSync(process.execPath, [SCRIPT, flag], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`,
+    },
+  });
+}
+
+test('cancel-stale-pr-ci help exits before invoking gh', () => {
+  for (const flag of ['--help', '-h']) {
+    const result = runHelp(flag);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage: cancel-stale-pr-ci\.mjs \[options\]/);
+    assert.match(result.stdout, /-h, --help\s+Show this message\./);
+    assert.equal(result.stderr, '');
+  }
+});

--- a/scripts/cancel-stale-pr-ci.mjs
+++ b/scripts/cancel-stale-pr-ci.mjs
@@ -21,7 +21,7 @@ Options:
   --exclude-workflow <pattern>  Case-insensitive substring/regex fragment to skip.
                                 May be passed multiple times. Default: ${DEFAULT_EXCLUDE_WORKFLOW_PATTERNS.join(', ')}
   --execute                     Actually cancel matching runs.
-  --help                        Show this message.
+  -h, --help                    Show this message.
 
 Examples:
   node scripts/cancel-stale-pr-ci.mjs
@@ -61,7 +61,7 @@ function parseArgs(argv) {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--help') {
+    if (arg === '--help' || arg === '-h') {
       printUsage();
       process.exit(0);
     }


### PR DESCRIPTION
## Summary

- Adds `-h` as a short help alias for `scripts/cancel-stale-pr-ci.mjs`.
- Updates the usage text to document both `-h` and `--help`.
- Adds a focused Node test proving help exits before invoking `gh`.

## Problem

- Adjacent contributor helper CLIs support both `--help` and `-h`, but `cancel-stale-pr-ci.mjs` only accepted `--help`.
- The script depends on GitHub CLI for normal operation, so help paths must remain side-effect-free and usable without GitHub access.

## Solution

- Treat `-h` the same as `--help` before parsing action flags or calling GitHub CLI.
- Test both aliases with a temporary failing `gh` stub in `PATH` so any accidental GitHub CLI invocation fails the test.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + failure guard: help exits 0 and fails if `gh` is invoked).
- [x] N/A: Diff coverage gate was not run because this is a root helper script change and local Rust tooling is unavailable.
- [x] N/A: Coverage matrix not affected; this does not add, remove, or rename a product feature.
- [x] N/A: No affected feature IDs; contributor maintenance script only.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist not affected; this does not touch release-cut surfaces.
- [x] N/A: Related to #2611 but does not close it by itself.

## Impact

- Runtime/platform impact: none.
- Developer impact: `node scripts/cancel-stale-pr-ci.mjs -h` now prints usage and exits without requiring `gh`.

## Related

- Related: #2611
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `codex/OH-2611-cancel-stale-ci-short-help`
- Commit SHA: `16b6ddb`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (blocked after Prettier passed; see Validation Blocked)
- [x] `pnpm typecheck`: N/A, root Node helper-only change
- [x] Focused tests: `node --test scripts/__tests__/cancel-stale-pr-ci-help.test.mjs`
- [x] Rust fmt/check (if changed): N/A, no Rust files changed
- [x] Tauri fmt/check (if changed): N/A, no Tauri files changed
- [x] `node scripts/codex-pr-preflight.mjs --lightweight`
- [x] `git diff --check --cached`

### Validation Blocked

- `command:` `pnpm --filter openhuman-app format:check`
- `error:` `sh: cargo: command not found`
- `impact:` Prettier passed, but the Rust format phase cannot run in this local environment until Cargo is installed.

### Behavior Changes

- Intended behavior change: `-h` now prints usage and exits 0 for `cancel-stale-pr-ci.mjs`.
- User-visible effect: contributor-facing maintenance CLI help is easier to discover.

### Parity Contract

- Legacy behavior preserved: `--help`, normal dry-run mode, `--execute`, and invalid argument behavior are unchanged.
- Guard/fallback/dispatch parity checks: focused test verifies both help aliases exit before any `gh` invocation.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found in the current open PR list during preflight.
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The script now supports `-h` as a shorthand alternative to `--help` for displaying usage and help information.

* **Tests**
  * Added comprehensive test coverage to verify that both `-h` and `--help` flags work correctly and that the script displays proper help information without unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->