### PR TITLE
fix(scripts): add short help to GitHub test map

### DIFF
--- a/scripts/__tests__/build-github-test-map-help.test.mjs
+++ b/scripts/__tests__/build-github-test-map-help.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(HERE, '..', 'test-planning', 'build-github-test-map.mjs');
+
+function writeFailingStub(binDir, name) {
+  fs.writeFileSync(
+    join(binDir, name),
+    `#!/usr/bin/env sh\necho "${name} should not run for help" >&2\nexit 99\n`,
+    { mode: 0o755 },
+  );
+}
+
+function runHelp(flag) {
+  const binDir = fs.mkdtempSync(join(os.tmpdir(), 'openhuman-test-map-stub-'));
+  for (const name of ['gh', 'codex', 'claude']) {
+    writeFailingStub(binDir, name);
+  }
+
+  return spawnSync(process.execPath, [SCRIPT, flag], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`,
+    },
+  });
+}
+
+test('build-github-test-map help exits before fetch or synthesis work', () => {
+  for (const flag of ['--help', '-h']) {
+    const result = runHelp(flag);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage: build-github-test-map\.mjs \[options\]/);
+    assert.match(result.stdout, /-h, --help\s+Show this message/);
+    assert.equal(result.stderr, '');
+  }
+});

--- a/scripts/test-planning/build-github-test-map.mjs
+++ b/scripts/test-planning/build-github-test-map.mjs
@@ -29,7 +29,7 @@ Options:
   --prompt-body-chars <count>    Max body chars per item sent to the LLM (default: ${DEFAULT_PROMPT_BODY_CHARS})
   --llm <codex|claude>           Non-interactive CLI to use for synthesis (default: ${DEFAULT_LLM})
   --model <name>                 Optional model override for the LLM CLI
-  --help                         Show this message
+  -h, --help                     Show this message
 
 Examples:
   node scripts/test-planning/build-github-test-map.mjs --max-prs 50 --max-issues 50
@@ -63,7 +63,7 @@ function parseArgs(argv) {
     if (arg === '--') {
       continue;
     }
-    if (arg === '--help') {
+    if (arg === '--help' || arg === '-h') {
       printUsage();
       process.exit(0);
     }


### PR DESCRIPTION
## Summary

- Adds `-h` as a short help alias for `scripts/test-planning/build-github-test-map.mjs`.
- Updates usage text to document both `-h` and `--help`.
- Adds a focused Node test proving help exits before GitHub fetch or LLM synthesis work.

## Problem

- `build-github-test-map.mjs` is a contributor-facing planning helper, but it only accepted `--help`.
- Normal execution can call GitHub CLI and an LLM CLI, so help must remain local and side-effect-free.
- Adjacent helper scripts already support short help aliases, so this one was inconsistent.

## Solution

- Treat `-h` the same as `--help` before phase/include/LLM parsing work proceeds.
- Test both help aliases with temporary failing `gh`, `codex`, and `claude` stubs in `PATH`.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + failure guard: help exits 0 and fails if GitHub/LLM CLIs are invoked).
- [x] N/A: Diff coverage gate was not run because this is a root helper script change and local Rust tooling is unavailable.
- [x] N/A: Coverage matrix not affected; this does not add, remove, or rename a product feature.
- [x] N/A: No affected feature IDs; contributor planning script only.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist not affected; this does not touch release-cut surfaces.
- [x] N/A: Related to #2611 but does not close it by itself.

## Impact

- Runtime/platform impact: none.
- Developer impact: `node scripts/test-planning/build-github-test-map.mjs -h` now prints usage and exits without requiring GitHub or LLM CLI setup.

## Related

- Related: #2611
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `codex/OH-2611-test-map-short-help`
- Commit SHA: `40f3c3f`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (blocked after Prettier passed; see Validation Blocked)
- [x] `pnpm typecheck`: N/A, root Node helper-only change
- [x] Focused tests: `node --test scripts/__tests__/build-github-test-map-help.test.mjs`
- [x] Rust fmt/check (if changed): N/A, no Rust files changed
- [x] Tauri fmt/check (if changed): N/A, no Tauri files changed
- [x] `node scripts/codex-pr-preflight.mjs --lightweight`
- [x] `git diff --check`

### Validation Blocked

- `command:` `pnpm --filter openhuman-app format:check`
- `error:` `sh: cargo: command not found`
- `impact:` Prettier passed, but the Rust format phase cannot run in this local environment until Cargo is installed.

### Behavior Changes

- Intended behavior change: `-h` now prints usage and exits 0 for `build-github-test-map.mjs`.
- User-visible effect: contributor-facing planning CLI help is easier to discover.

### Parity Contract

- Legacy behavior preserved: `--help`, fetch/synthesize/all phases, include filtering, LLM selection, and invalid argument behavior are unchanged.
- Guard/fallback/dispatch parity checks: focused test verifies both help aliases exit before any `gh`, `codex`, or `claude` invocation.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found in the current open PR list during preflight.
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a short `-h` option alongside `--help` so the CLI prints usage immediately for faster access to help.

* **Tests**
  * Added tests verifying both help flags print usage, exit successfully without invoking external tools, and produce no error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->