### PR TITLE
fix(tauri): gate cef_preflight to macOS/Linux to fix Windows build

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -6,6 +6,11 @@ compile_error!("src-tauri host supports desktop (Windows/macOS/Linux) only. Mobi
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod artifact_commands;
 mod cdp;
+// macOS/Linux only: depends on the `nix` crate (a `cfg(unix)` dependency) and
+// resolves a platform cache path that is only defined for those targets. On
+// Windows it must not be compiled — see issue: Windows release build failed
+// with E0433 (`nix` unresolved) + E0425 (`cache_path` undefined).
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 mod cef_preflight;
 mod cef_profile;
 mod companion_commands;


### PR DESCRIPTION
## Summary

- Restore the `#[cfg(any(target_os = "macos", target_os = "linux"))]` gate on `mod cef_preflight;` in `app/src-tauri/src/lib.rs` so the macOS/Linux-only module is no longer compiled on Windows.
- Fixes the **Release Production** Windows desktop build, which failed at *"Build and package Tauri app (CEF, vendored CLI)"* (run [26825937389](https://github.com/tinyhumansai/openhuman/actions/runs/26825937389/job/79093542122)).

## Problem

`cef_preflight` is a macOS/Linux-only module: it depends on the `nix` crate (declared under `[target.'cfg(unix)'.dependencies]`) and only defines `cache_path` under `#[cfg(target_os = "macos")]` / `#[cfg(target_os = "linux")]`.

On `main` the platform gate ended up on the wrong module — a `mod artifact_commands;` insertion left the `#[cfg]` attached to `artifact_commands` while `mod cef_preflight;` became **ungated**:

```rust
#[cfg(any(target_os = "macos", target_os = "linux"))]
mod artifact_commands;
mod cdp;
mod cef_preflight;   // ← ungated, wrongly compiled on Windows
```

As a result the Windows build compiled `cef_preflight.rs` and failed:

```
error[E0433]: unresolved module or unlinked crate `nix`   (cef_preflight.rs:28, 29)
error[E0425]: cannot find value `cache_path` in this scope (cef_preflight.rs:113, 114)
error: could not compile `OpenHuman` (lib) due to 4 previous errors
```

macOS, Linux, and ubuntu-arm64 all built fine because the module is valid there.

## Solution

Add the missing gate directly above `mod cef_preflight;` (keeping `artifact_commands` gated too — both need it), with a comment explaining why the module is platform-restricted. The call site in `lib.rs` (`check_default_cache()`) and the usages in `process_recovery.rs` were already gated, so no other changes are required.

## Submission Checklist

- [x] Tests added or updated — `N/A`: build-fix / conditional-compilation only; no runtime behavior change. The module is unchanged and its existing tests still run on macOS/Linux.
- [x] **Diff coverage ≥ 80%** — `N/A`: the only changed line is a `#[cfg]` attribute (a `mod` gate), which is not executable and not measurable by `diff-cover`.
- [x] Coverage matrix updated — `N/A`: behaviour-only change (no feature added/removed/renamed).
- [x] All affected feature IDs listed — `N/A`: no feature rows affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A`: restores existing platform gate; no smoke surface change.
- [x] Linked issue closed via `Closes #NNN` — `N/A`: no tracking issue; references the failed CI run instead.

## Impact

- **Windows desktop**: build no longer fails — `cef_preflight` is correctly excluded from compilation.
- **macOS / Linux**: no change — module still compiles and runs exactly as before.
- No performance, security, or migration implications.

## Related

- Closes:
- Follow-up PR(s)/TODOs: none. Failed CI run: https://github.com/tinyhumansai/openhuman/actions/runs/26825937389/job/79093542122

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/windows-cef-preflight-gate`
- Commit SHA: 2b0c9368d648c3883ddd1503b328b58f97cc4ea7

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change.
- [ ] `pnpm typecheck` — N/A: Rust-only change.
- [ ] Focused tests: N/A: conditional-compilation fix, no behavior change.
- [x] Rust fmt/check (if changed): pre-push hook ran on this branch.
- [x] Tauri fmt/check (if changed): cef_preflight tests run on macOS/Linux unchanged.

### Validation Blocked

- `command:` `cargo check --target x86_64-pc-windows-msvc` (full Windows build)
- `error:` no MSVC toolchain/linker on the macOS dev host
- `impact:` Windows compile verified by reasoning — the change restores the exact gate that already guards the call site and `process_recovery.rs`; CI Windows job is the authoritative check.

### Behavior Changes

- Intended behavior change: none (build-only).
- User-visible effect: Windows release artifacts can be produced again.

### Parity Contract

- Legacy behavior preserved: yes — macOS/Linux unaffected.
- Guard/fallback/dispatch parity checks: gate matches the already-gated `check_default_cache()` call site and `process_recovery.rs` usages.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-platform build compatibility issues on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->