### PR TITLE
fix(ci): key vendored tauri-cli cache by runner.arch to fix Linux x64 release build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -213,20 +213,27 @@ jobs:
       # Upstream @tauri-apps/cli doesn't bundle CEF framework files into the
       # produced installer. Only the fork at vendor/tauri-cef does. Build and
       # install that CLI so `cargo tauri build` invokes the cef-aware bundler.
+      #
+      # The cache key must include runner.arch, not just runner.os: cargo-tauri
+      # is a host-arch binary, and the Linux matrix runs on both x86_64
+      # (ubuntu-24.04) and aarch64 (ubuntu-24.04-arm) runners that share
+      # runner.os == 'Linux'. Keying on runner.os alone lets one arch restore
+      # the other arch's binary, which then fails to exec ("ELF ...: not found"
+      # / "Syntax error: word unexpected") when `cargo tauri build` runs it.
       - name: Cache vendored tauri-cli binary (unix)
         if: matrix.settings.platform != 'windows-latest'
         id: tauri-cli-cache-unix
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri
-          key: vendored-tauri-cli-${{ runner.os }}-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
+          key: vendored-tauri-cli-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
       - name: Cache vendored tauri-cli binary (windows)
         if: matrix.settings.platform == 'windows-latest'
         id: tauri-cli-cache-windows
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-tauri.exe
-          key: vendored-tauri-cli-${{ runner.os }}-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
+          key: vendored-tauri-cli-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('app/src-tauri/vendor/tauri-cef/crates/tauri-cli/Cargo.toml') }}
       - name: Install vendored tauri-cli (cef-aware bundler)
         if:
           (matrix.settings.platform == 'windows-latest' && steps.tauri-cli-cache-windows.outputs.cache-hit


### PR DESCRIPTION
## What

The v0.57.9 production release ([run 26831421143](https://github.com/tinyhumansai/openhuman/actions/runs/26831421143)) failed on **Desktop: ubuntu** (x86_64) with:

\`\`\`
/home/runner/.cargo/bin/cargo-tauri: 1: ELF...: not found
/home/runner/.cargo/bin/cargo-tauri: 2: Syntax error: word unexpected (expecting ")")
\`\`\`

## Root cause

The Linux desktop matrix runs on two different host architectures:

- \`ubuntu-24.04\` → \`x86_64-unknown-linux-gnu\`
- \`ubuntu-24.04-arm\` → \`aarch64-unknown-linux-gnu\`

Both report \`runner.os == 'Linux'\`. The vendored \`cargo-tauri\` cache in \`build-desktop.yml\` was keyed only on \`runner.os\`, so both jobs shared one cache entry. \`cargo-tauri\` is a **host-arch** binary: whichever Linux job populated the cache first won, and the other job restored the wrong-arch binary. Trying to exec an aarch64 \`cargo-tauri\` on an x86_64 runner (or vice versa) produces the \`ELF ...: not found\` / \`Syntax error: word unexpected\` shell error above, failing the build before any bundling.

macOS isn't affected because both mac targets run on the same arm64 \`macos-latest\` host (x86_64 is cross-compiled), so they share the same host arch. Windows is single-arch.

## Fix

Add \`runner.arch\` to the cache key so each host architecture gets its own \`cargo-tauri\` cache entry:

\`vendored-tauri-cli-\${{ runner.os }}-\${{ runner.arch }}-\${{ hashFiles(...) }}\`

This matches how the CEF distribution cache in the same workflow already keys per-target.

## Testing

- YAML validated.
- No-op for macOS/Windows keys (single host arch); changes the Linux key so x64 and arm64 stop colliding. New keys are cold on first run, which simply rebuilds \`cargo-tauri\` once per arch via the existing install step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved desktop build workflow reliability by refining binary caching behavior across different system architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->