### PR TITLE
fix(inference/ollama): use prompt-guided tool calling so skills work on Ollama (#3098 sub-issue 3)

### DIFF
--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -80,6 +80,14 @@ pub struct OpenAiCompatibleProvider {
     /// carries an `@<temp>` suffix (e.g. `"openai:gpt-4o@0.2"`). The
     /// `temperature_unsupported_models` glob filter still applies after.
     pub(crate) temperature_override: Option<f64>,
+    /// Value reported by `capabilities().native_tool_calling`. Defaults to
+    /// `true` because most OpenAI-compatible providers (OpenAI, Anthropic
+    /// adapters, GLM, Groq, Mistral, OpenHuman backend, …) implement the
+    /// `tools` parameter correctly. The factory flips this to `false` for
+    /// Ollama (sub-issue 3 of #3098), whose OpenAI-compat endpoint returns
+    /// HTTP 400 on `tools` for many models — making prompt-guided text
+    /// tool specs the only path that works across the Ollama model zoo.
+    native_tool_calling: bool,
 }
 
 /// How the provider expects the API key to be sent.
@@ -195,7 +203,18 @@ impl OpenAiCompatibleProvider {
             emit_openhuman_thread_id: false,
             temperature_unsupported_models: Vec::new(),
             temperature_override: None,
+            native_tool_calling: true,
         }
+    }
+
+    /// Toggle whether this provider advertises native (OpenAI-style) tool
+    /// calling to the agent harness. The default is `true`; set to `false`
+    /// for providers whose `/v1/chat/completions` endpoint rejects the
+    /// `tools` parameter — the harness will then embed tool specs in the
+    /// system prompt and parse calls out of the response text instead.
+    pub fn with_native_tool_calling(mut self, enabled: bool) -> Self {
+        self.native_tool_calling = enabled;
+        self
     }
 
     /// Set the list of model glob patterns for which temperature must be
@@ -1248,7 +1267,7 @@ impl OpenAiCompatibleProvider {
 impl Provider for OpenAiCompatibleProvider {
     fn capabilities(&self) -> crate::openhuman::inference::provider::traits::ProviderCapabilities {
         crate::openhuman::inference::provider::traits::ProviderCapabilities {
-            native_tool_calling: true,
+            native_tool_calling: self.native_tool_calling,
             vision: false,
         }
     }

--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -1959,7 +1959,12 @@ impl Provider for OpenAiCompatibleProvider {
     }
 
     fn supports_native_tools(&self) -> bool {
-        true
+        // Must mirror `capabilities().native_tool_calling`. Both signals are
+        // read by the agent harness (`traits.rs:415`) to decide between an
+        // OpenAI-style `tools` array and the prompt-guided text fallback;
+        // letting them disagree would defeat `with_native_tool_calling(false)`
+        // for the Ollama branch of sub-issue 3 of #3098.
+        self.native_tool_calling
     }
 
     fn supports_streaming(&self) -> bool {

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1336,6 +1336,36 @@ fn with_native_tool_calling_is_idempotent() {
     assert!(!caps.native_tool_calling);
 }
 
+/// `supports_native_tools()` is the gate the agent harness reads
+/// (`traits.rs:415`) when deciding whether to send tools natively or
+/// inject them into the prompt. It MUST agree with
+/// `capabilities().native_tool_calling`; otherwise
+/// `with_native_tool_calling(false)` silently fails to switch to
+/// prompt-guided and Ollama still receives a `tools` array (the exact
+/// regression sub-issue 3 of #3098 was meant to fix).
+#[test]
+fn supports_native_tools_mirrors_capabilities_flag() {
+    let default = make_provider("test", "https://example.com", None);
+    assert_eq!(
+        default.supports_native_tools(),
+        <OpenAiCompatibleProvider as Provider>::capabilities(&default).native_tool_calling,
+        "default provider: the two capability signals must match"
+    );
+    assert!(default.supports_native_tools(), "default must remain true");
+
+    let opted_out =
+        make_provider("test", "https://example.com", None).with_native_tool_calling(false);
+    assert_eq!(
+        opted_out.supports_native_tools(),
+        <OpenAiCompatibleProvider as Provider>::capabilities(&opted_out).native_tool_calling,
+        "after with_native_tool_calling(false): the two capability signals must match"
+    );
+    assert!(
+        !opted_out.supports_native_tools(),
+        "after with_native_tool_calling(false), supports_native_tools must report false so the harness picks the prompt-guided fallback"
+    );
+}
+
 #[test]
 fn tool_specs_convert_to_openai_format() {
     let specs = vec![crate::openhuman::tools::ToolSpec {

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1303,6 +1303,39 @@ fn capabilities_reports_native_tool_calling() {
     assert!(caps.native_tool_calling);
 }
 
+// Sub-issue 3 of #3098: Ollama's OpenAI-compat endpoint silently rejects the
+// `tools` parameter for many models, so we must let the factory opt the
+// Ollama provider out of native tool calling. The agent harness then falls
+// back to prompt-guided tool specs (embedded in the system prompt) which
+// any chat model can follow. The builder defaults to enabled so cloud
+// providers (OpenAI, BYOK slugs, OpenHuman backend) are unaffected.
+
+#[test]
+fn with_native_tool_calling_false_disables_capability() {
+    let p = make_provider("test", "https://example.com", None).with_native_tool_calling(false);
+    let caps = <OpenAiCompatibleProvider as Provider>::capabilities(&p);
+    assert!(
+        !caps.native_tool_calling,
+        "capabilities() must mirror the builder override; this is the gate the agent harness uses to decide between native vs prompt-guided tool specs"
+    );
+}
+
+#[test]
+fn with_native_tool_calling_true_preserves_default() {
+    let p = make_provider("test", "https://example.com", None).with_native_tool_calling(true);
+    let caps = <OpenAiCompatibleProvider as Provider>::capabilities(&p);
+    assert!(caps.native_tool_calling);
+}
+
+#[test]
+fn with_native_tool_calling_is_idempotent() {
+    let p = make_provider("test", "https://example.com", None)
+        .with_native_tool_calling(false)
+        .with_native_tool_calling(false);
+    let caps = <OpenAiCompatibleProvider as Provider>::capabilities(&p);
+    assert!(!caps.native_tool_calling);
+}
+
 #[test]
 fn tool_specs_convert_to_openai_format() {
     let specs = vec![crate::openhuman::tools::ToolSpec {

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -731,16 +731,24 @@ fn make_ollama_provider(
     // Ollama does not expose the Responses API (/v1/responses) — passing
     // `false` prevents a guaranteed-404 fallback attempt and the Sentry
     // noise it would generate (TAURI-RUST-59Y).
-    let p = make_openai_compatible_provider_with_config(
+    //
+    // Ollama also rejects the OpenAI-style `tools` parameter for many models
+    // (HTTP 400 "unsupported parameter: tools"), so we disable
+    // `native_tool_calling` on the provider directly. The agent harness
+    // then embeds tool specs in the system prompt and parses tool calls
+    // out of the response text — a format any chat model can follow.
+    // Skills that depend on tool invocations now work over Ollama
+    // (sub-issue 3 of #3098).
+    let provider = OpenAiCompatibleProvider::new_no_responses_fallback(
         "ollama",
         &endpoint,
-        "",
+        None,
         CompatAuthStyle::None,
-        &config.temperature_unsupported_models,
-        temperature_override,
-        false,
-    )?;
-    Ok((p, model.to_string()))
+    )
+    .with_temperature_unsupported_models(config.temperature_unsupported_models.clone())
+    .with_temperature_override(temperature_override)
+    .with_native_tool_calling(false);
+    Ok((Box::new(provider), model.to_string()))
 }
 
 /// Build an LM Studio local provider.

--- a/src/openhuman/inference/provider/factory_tests.rs
+++ b/src/openhuman/inference/provider/factory_tests.rs
@@ -211,6 +211,48 @@ fn ollama_prefix() {
 }
 
 #[test]
+fn ollama_provider_opts_out_of_native_tool_calling() {
+    // Sub-issue 3 of #3098: Ollama's OpenAI-compat endpoint returns HTTP 400
+    // for many models when a `tools` array is sent (the existing detection
+    // path matches "unsupported parameter: tools"). The retry logic strips
+    // tools entirely, which silently breaks any skill or workflow that
+    // depends on tool calls. The factory must build the Ollama provider
+    // with native tool calling disabled so the agent harness uses the
+    // prompt-guided text format from the first request.
+    let config = Config::default();
+    let (provider, _model) = create_chat_provider_from_string("chat", "ollama:llama3.2", &config)
+        .expect("ollama:<model> must build");
+    let caps = provider.capabilities();
+    assert!(
+        !caps.native_tool_calling,
+        "ollama provider must report native_tool_calling=false so the agent harness emits prompt-guided tool specs instead of an OpenAI-style `tools` array"
+    );
+}
+
+#[test]
+fn lmstudio_provider_keeps_native_tool_calling_enabled() {
+    // LM Studio's OpenAI-compat endpoint supports the `tools` parameter for
+    // models that expose function calling. Only Ollama gets opted out by
+    // default — the LM Studio path stays on the native schema.
+    let mut config = Config::default();
+    config.local_ai.base_url = Some("http://127.0.0.1:1234".to_string());
+    let (provider, _model) =
+        create_chat_provider_from_string("chat", "lmstudio:google/gemma-4-e4b", &config)
+            .expect("lmstudio:<model> must build");
+    assert!(
+        provider.capabilities().native_tool_calling,
+        "lmstudio provider must keep native_tool_calling=true; only the ollama branch opts out"
+    );
+}
+
+// Note: a BYOK-cloud regression test (e.g. `openai:gpt-4o` keeps
+// native_tool_calling=true) would need an `AuthService` with the slug's API
+// key seeded. The unit test
+// `with_native_tool_calling_true_preserves_default` in compatible_tests.rs
+// already pins that the builder leaves the default in place when not
+// called, which is what every non-Ollama factory path relies on.
+
+#[test]
 fn lmstudio_prefix() {
     let mut config = Config::default();
     config.local_ai.base_url = Some("http://127.0.0.1:1234".to_string());


### PR DESCRIPTION
## Summary

- Ollama provider now reports `native_tool_calling = false`. The agent harness embeds tool specs in the system prompt as text and parses tool calls out of the response (`ToolsPayload::PromptGuided`), which works across the Ollama model zoo.
- Adds `OpenAiCompatibleProvider::with_native_tool_calling(bool)` builder. Default stays `true` — every other provider (OpenAI, OpenHuman backend, BYOK slugs, LM Studio) is unchanged.
- 5 new tests pin the matrix: builder behavior + Ollama opts out + LM Studio keeps native.

## Problem

Sub-issue 3 of #3098 reports "Skills fail to execute" — most visibly when the user routes a channel (e.g. Telegram) through an Ollama model.

Trace:

1. Skills today are pure markdown instruction documents (the QuickJS skill runtime was removed). "Running a skill" means the agent reads the skill body and follows the instructions inside — many skills tell the model to "use the `file_read` tool" or "run `shell` X".
2. `OpenAiCompatibleProvider::capabilities()` previously hardcoded `native_tool_calling: true` for **every** OpenAI-compat endpoint, including Ollama (`compatible.rs:1248-1253`).
3. Ollama rejects the `tools` parameter with HTTP 400 ("unsupported parameter: tools") for many models.
4. The existing retry path (`compatible.rs:1748-1775`) detects this and retries with `tools: None` — i.e. strips tools entirely.
5. The model produces a natural-language reply but cannot invoke any tool. From the user's perspective, the skill "didn't run" — the model talks about doing the thing instead of doing it.

PR #3217 (sub-issue 1) makes this latent bug actively visible to Telegram users: Telegram now reliably routes to Ollama when `chat_provider = "ollama:…"` is set, so every skill-bearing turn hits this path.

## Solution

Stop pretending Ollama supports native tool schemas. Build the Ollama provider with `native_tool_calling = false` from the start so the agent harness uses prompt-guided text tool specs — embedded in the system prompt, parsed back out of the response. Works on every Ollama model with no upstream `tools` array, no 400, no silent retry-without-tools.

Concretely:

- Add `native_tool_calling: bool` field on `OpenAiCompatibleProvider` (defaults to `true`, preserving every existing construction path).
- Add `with_native_tool_calling(bool)` builder method.
- Change `capabilities()` to return the stored flag instead of hardcoded `true`.
- `factory::make_ollama_provider` now constructs the provider directly (no helper indirection) and chains `.with_native_tool_calling(false)`.

LM Studio, OpenHuman backend, BYOK cloud providers (`openai:…`, `anthropic:…`, etc.), and direct `OpenAiCompatibleProvider::new` callers are **untouched** — they keep the `true` default. Only the explicit Ollama factory branch opts out.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 3 unit tests in `compatible_tests.rs` (default true, override false, idempotent) + 2 factory tests (`ollama_provider_opts_out_of_native_tool_calling`, `lmstudio_provider_keeps_native_tool_calling_enabled`).
- [x] **Diff coverage ≥ 80%** — every changed line is exercised: the new `native_tool_calling` field is read by `capabilities()` (3 unit tests) and the Ollama factory branch is exercised by the new factory test; the LM Studio test is the regression guard.
- [x] Coverage matrix updated — `N/A: behavior fix on an existing capability (Ollama provider); no new feature row.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix row added or removed.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — all new tests construct providers in-process and inspect `capabilities()`; no network calls.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: not a release-cut surface; behaves identically for cloud users.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — see below (#3098 has 4 sub-issues; this PR closes sub-issue 3 only, issue stays open).

## Impact

- **Desktop**: zero change for the dominant cloud path. Users routing the chat / reasoning / agentic / etc. workload to Ollama see tool calls actually fire — skills, file operations, shell, schedule, etc.
- **Channels** (Telegram, Discord, Slack, iMessage, Mattermost — all share the same runtime via PR #3217): same gain. The "model replies in prose instead of executing the skill" bug stops happening over Ollama.
- **Performance**: marginal positive — eliminates one HTTP 400 + retry roundtrip per turn for every Ollama-routed call that previously tried `tools` and got rejected.
- **Security**: none. Same provider, same auth, same endpoint.
- **Migration**: none. Default field value preserves every non-Ollama path.

## Related

- Sub-issue 3 of #3098 (skills not running over Telegram / Ollama).
- Sub-issue 1 of #3098 → PR #3217 (Telegram model routing).
- Sub-issue 4 of #3098 → PR #3218 (Brave Search env docs).
- Sub-issue 2 of #3098 (Telegram file commits) — by-design question, not coded yet.
- Follow-up PR(s)/TODOs: with this fix and PR #3217 merged, the next plausible Ollama gap is the per-conversation `/model` override in `channels/routes.rs:get_or_create_provider` — it currently always rebuilds a cloud provider regardless of slug. Out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3098-ollama-prompt-guided-tools`
- Commit SHA: `6c504c7edd00ae84f74446a9b7b119f54207b67c`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: Rust-only change.`
- [x] `pnpm typecheck` — `N/A: no TS/TSX touched.`
- [x] Focused tests: `cargo test --lib -p openhuman inference::provider` → 386 passed, 0 failed, 2 ignored; `cargo test --lib -p openhuman channels:: agent::harness` → 1489 passed, 0 failed (regression suite). All five new tests pass.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` clean (pre-existing warnings only).
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched.`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Ollama provider stops sending the OpenAI-style `tools` array on outbound chat requests. The agent harness embeds tool specs in the system prompt as text and parses tool calls out of the response — the existing prompt-guided code path.
- User-visible effect: skills (and any workflow that depends on tool calls) actually execute when the user picks an Ollama model. Previously the model talked about the action without performing it.

### Parity Contract

- Legacy behavior preserved: Every non-Ollama provider construction site (OpenHuman backend, BYOK cloud slugs, LM Studio, direct `OpenAiCompatibleProvider::new` callers) inherits the `true` default for `native_tool_calling`. Behavior is byte-identical pre/post for those paths. Verified by the LM Studio regression test and by the unchanged `capabilities_reports_native_tool_calling` test.
- Guard/fallback/dispatch parity checks: The existing `err_supports_no_tools_retry` path (`compatible.rs:1748-1775`) and `is_native_tool_schema_unsupported` detector (`compatible.rs:780-795`) are untouched — they remain as a safety net for any other OpenAI-compat endpoint that rejects `tools`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found for sub-issue 3 of #3098.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A — first PR on this sub-issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Providers gain a configurable native tool-calling capability (opt-in/opt-out).

* **Bug Fixes**
  * Ollama provider now disables native tool calling to avoid compatibility issues with its API.

* **Tests**
  * Added tests verifying native tool-calling toggles and that providers report consistent capability state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->