### PR TITLE
fix(agent_prompts): anchor coding-agent prompts in action_dir, not workspace_dir

### DIFF
--- a/src/openhuman/agent_registry/agents/code_executor/prompt.md
+++ b/src/openhuman/agent_registry/agents/code_executor/prompt.md
@@ -1,6 +1,6 @@
 # Code Executor — Sandboxed Developer
 
-You are the **Code Executor** agent. You write, run, and debug code in a sandboxed environment.
+You are the **Code Executor** agent. You write, run, and debug code inside the **action sandbox** — `Config.action_dir` (defaults to `~/OpenHuman/projects`; override with `OPENHUMAN_ACTION_DIR`). Your `shell` / `node_exec` / `npm_exec` / `file_write` / `edit` / `apply_patch` / `git_operations` tools default their working directory and relative-path root to this directory. **Clone repos and write build artifacts under the action sandbox.** Internal product state under `Config.workspace_dir` (memory, sessions, vault, etc.) is denied to your tools — do not try to read or write there.
 
 ## Capabilities
 

--- a/src/openhuman/agent_registry/agents/loader.rs
+++ b/src/openhuman/agent_registry/agents/loader.rs
@@ -341,6 +341,41 @@ mod tests {
         }
     }
 
+    /// Regression guard for #3236.
+    ///
+    /// PR #3074 introduced the `Config.action_dir` / `Config.workspace_dir`
+    /// split: acting tools resolve to `action_dir` (default
+    /// `~/OpenHuman/projects`), and `workspace_dir` is reserved for
+    /// internal product state (memory / sessions / vault / etc.) that is
+    /// denied to agent tools. The coding-agent prompts must reflect that
+    /// split — saying "in a sandboxed environment" or "the workspace has
+    /// code …" without anchoring contradicts the new model and steers
+    /// the model toward paths that hit the internal-state denylist.
+    ///
+    /// If a future edit reintroduces stale phrasing, this assertion fires
+    /// at `cargo test` time before the bad prompt ships.
+    #[test]
+    fn coding_agent_prompts_reference_action_sandbox_not_stale_workspace() {
+        let code_executor = include_str!("code_executor/prompt.md");
+        assert!(
+            !code_executor.contains("sandboxed environment"),
+            "code_executor/prompt.md still says 'sandboxed environment' \
+             generically — anchor in the action sandbox path (see #3236)"
+        );
+        assert!(
+            code_executor.contains("action sandbox") || code_executor.contains("action_dir"),
+            "code_executor/prompt.md must reference the action sandbox or action_dir (see #3236)"
+        );
+
+        let planner = include_str!("planner/prompt.md");
+        assert!(
+            !planner.contains("the workspace has code"),
+            "planner/prompt.md still says 'the workspace has code …' — \
+             use 'the project tree' or similar to avoid colliding with \
+             `Config.workspace_dir` (internal product state). See #3236."
+        );
+    }
+
     #[test]
     fn every_builtin_has_a_prompt_body() {
         use crate::openhuman::context::prompt::{

--- a/src/openhuman/agent_registry/agents/planner/prompt.md
+++ b/src/openhuman/agent_registry/agents/planner/prompt.md
@@ -6,7 +6,7 @@ Before you plan, **gather context** so the plan is grounded in reality, not gues
 
 - Use `memory_recall` to search what we already know — past decisions, user preferences, project context, prior plans. Memory is cheap; planning blind is expensive.
 - Use `web_search_tool` when the goal involves external information you don't have — API docs, library comparisons, current best practices, pricing, compatibility matrices.
-- Use `file_read` to inspect relevant files when the workspace has code or config that constrains the plan.
+- Use `file_read` to inspect relevant files when the project tree has code or config that constrains the plan.
 
 Only produce the plan JSON **after** you have the context you need. A plan built on assumptions the memory or a quick search could have resolved is a bad plan.
 


### PR DESCRIPTION
## Summary

- Anchors the `code_executor` agent's opening sentence in `Config.action_dir` (default `~/OpenHuman/projects`, env override `OPENHUMAN_ACTION_DIR`) instead of saying "in a sandboxed environment" with no path reference.
- Replaces a stale "the workspace has code" line in the `planner` prompt with "the project tree has code" so the word "workspace" stops colliding with `Config.workspace_dir` (internal product state).
- Adds a regression-guard `cargo test` that `include_str!`s both prompts and asserts the stale phrasing cannot be reintroduced without test failure, plus a positive check that `code_executor` references "action sandbox" or "action_dir".

## Problem

PR #3074 introduced the `Config.action_dir` / `Config.workspace_dir` split: acting tools (`shell`, `node_exec`, `npm_exec`, `file_write`, `edit`, `apply_patch`, `git_operations`) resolve relative paths and CWD to `action_dir` (default `~/OpenHuman/projects`), while `Config.workspace_dir` (`~/.openhuman/users/<id>/workspace`) is reserved for internal product state — memory DBs, session transcripts, vault, approval store, etc. — and is fail-closed denied to agent tools via `SecurityPolicy::is_workspace_internal_path` (`src/openhuman/security/policy.rs:1097`).

PR #3074 changed the **code** but did not touch the **prompts**. Audit #3239 found:

- `src/openhuman/agent_registry/agents/code_executor/prompt.md:3` still said "in a sandboxed environment" — no path anchor, no mention of the action sandbox.
- `src/openhuman/agent_registry/agents/planner/prompt.md:9` said "the workspace has code or config that constrains the plan" — colloquial "workspace" that conflicts with the now-distinct `Config.workspace_dir` term.

Concrete effect on the agent: when asked to clone a repo or write build artifacts, the model has no reason to prefer `~/OpenHuman/projects`. It picks a "workspace" path and hits the internal-state denylist, generating avoidable approval prompts or outright denials. The fix is to put the canonical destination directly in the prompt so the model lands there on the first try.

## Solution

Three small edits:

1. **`code_executor/prompt.md`** — rewrite the opening sentence to name `Config.action_dir`, the default `~/OpenHuman/projects` path, the `OPENHUMAN_ACTION_DIR` env override, the list of acting tools that default their CWD to it, and the explicit rule that clones and build artifacts belong under the action sandbox while `Config.workspace_dir` is off-limits.
2. **`planner/prompt.md`** — replace `the workspace has code or config that constrains the plan` with `the project tree has code or config that constrains the plan` so the prompt no longer overloads "workspace".
3. **`agent_registry/agents/loader.rs#tests`** — new `coding_agent_prompts_reference_action_sandbox_not_stale_workspace` test that `include_str!`s both prompts and asserts:
   - `code_executor` does not contain `"sandboxed environment"`.
   - `code_executor` contains `"action sandbox"` or `"action_dir"`.
   - `planner` does not contain `"the workspace has code"`.

The test runs at `cargo test` time, so a future edit that reintroduces stale phrasing fails CI before merging. Test verified passing locally (`cargo test loader::tests::coding_agent_prompts_reference_action_sandbox_not_stale_workspace`).

`orchestrator/prompt.md` and `tool_maker/prompt.md` are intentionally untouched — `grep -i "workspace\|sandbox\|clone\|cwd"` returns zero hits in either.

### Out of scope (intentionally)

The dynamic `## Workspace` block emitted by `WorkspaceSection.build` (`src/openhuman/agent/prompts/mod.rs:680`) still reports `ctx.workspace_dir` as the agent's "Working directory" — which is the *internal* state dir, not where shell tools actually spawn. That's a deeper fix (plumbing `action_dir` through `PromptContext`) and belongs in its own PR; #3236's acceptance criteria are scoped to the static archetype prompts.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated — new `loader::tests::coding_agent_prompts_reference_action_sandbox_not_stale_workspace` regression-guard test in `src/openhuman/agent_registry/agents/loader.rs` (happy path = current prompts pass; failure-path coverage = the four assertions each fire if the stale phrasing reappears).
- [x] **Diff coverage ≥ 80%** — the only changed Rust lines are the new `#[test]` body, fully exercised by the test itself (the prompt.md edits are markdown and outside coverage scope).
- [x] Coverage matrix updated — N/A: no feature rows added, removed, or renamed; this is a prompt-wording correction.
- [x] All affected feature IDs from the matrix are listed — N/A: no matrix-tracked feature behavior changed.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: prompt-text and a unit test, no smoke surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Runtime/platform impact: agent prompts are bundled into the binary via `include_str!`. The next core build picks up the new wording — no runtime config or migration needed.
- Performance: prompt body grows by ~250 bytes for `code_executor`; negligible vs prefix-caching threshold.
- Security: improves containment — the model is more likely to keep writes inside `action_dir` instead of bouncing off the `workspace_dir` denylist.
- Migration / compatibility: none. Existing sessions pick up the new prompt on the next agent spawn.

## Related

- Closes: #3236
- Parent issue (audit punch list): #3051
- Implementing PR that shipped the code but not the prompts: #3074
- Sibling follow-ups from the same audit: #3235 (`cwd_jail` wiring), #3237 (live paths in `AgentAccessPanel`), #3238 (`pwd` tests), #3239 (`CLAUDE.md` docs — PR #3241), #3240 (Settings UI editor).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A — work is tracked in GitHub issue #3236, not Linear.
- URL: N/A

### Commit & Branch

- Branch: `followup/3236-coding-agent-prompts` (on fork `CodeGhost21/openhuman`)
- Commit SHA: `09eff91dde4309bf85b33f3c454be44d4b27901a`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no app/ files touched.
- [x] `pnpm typecheck` — N/A: no TypeScript touched.
- [x] Focused tests: `cargo test agent_registry::agents::loader::tests::coding_agent_prompts_reference_action_sandbox_not_stale_workspace` → 1 passed, 0 failed; `folder_ids_match_toml_ids` regression-check → passed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` → clean.
- [x] Tauri fmt/check (if changed): N/A — Tauri shell not touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: coding-agent prompts now anchor the model in `Config.action_dir` rather than a generic sandbox.
- User-visible effect: the `code_executor` agent should pick `~/OpenHuman/projects` (or the user's `OPENHUMAN_ACTION_DIR` override) for clones and build artifacts on the first try, reducing avoidable internal-state-denylist denials.

### Parity Contract

- Legacy behavior preserved: yes — only the static archetype text and a new test were changed; no executable agent code paths altered. The dynamic `## Workspace` block still emits as before.
- Guard/fallback/dispatch parity checks: covered by the new test plus `every_builtin_has_a_prompt_body` and `folder_ids_match_toml_ids` (unchanged).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Code Executor agent to enforce isolation within a designated action sandbox directory, improving security and resource management.
  * Clarified Planner agent instructions with explicit step numbering for improved guidance.

* **Tests**
  * Added regression tests to verify agents maintain proper sandbox isolation and current prompt standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->