### PR TITLE
fix(review): use exec and interactive mode for agent CLI invocations

### DIFF
--- a/scripts/shortcuts/review/lib.sh
+++ b/scripts/shortcuts/review/lib.sh
@@ -42,23 +42,24 @@ agent_exec() {
   local prompt="$2"
   if [ "${REVIEW_AGENT_SAFE:-0}" = "1" ]; then
     case "$agent" in
-      codex) codex exec "$prompt" ;;
-      *) "$agent" "$prompt" ;;
+      codex) exec codex "$prompt" ;;
+      claude) exec claude "$prompt" ;;
+      *) exec "$agent" "$prompt" ;;
     esac
     return
   fi
   case "$agent" in
     claude)
-      claude --dangerously-skip-permissions "$prompt"
+      exec claude --dangerously-skip-permissions "$prompt"
       ;;
     codex)
-      codex exec --dangerously-bypass-approvals-and-sandbox "$prompt"
+      exec codex --dangerously-bypass-approvals-and-sandbox "$prompt"
       ;;
     cursor|cursor-agent)
-      cursor-agent --yolo "$prompt"
+      exec cursor-agent --yolo "$prompt"
       ;;
     *)
-      "$agent" "$prompt"
+      exec "$agent" "$prompt"
       ;;
   esac
 }


### PR DESCRIPTION
## Summary

- Fix Codex CLI opening raw terminal output instead of its interactive TUI when invoked via `pnpm review`.
- Replace `codex exec` (headless) with bare `codex` (interactive TUI) in `agent_exec`.
- Add `exec` prefix to all agent invocations so the agent binary inherits the terminal PTY directly, bypassing pnpm's pipe.

## Problem

- Running `pnpm review review <pr> --agent codex` launches `codex exec`, which is the non-interactive/headless mode — it dumps raw output instead of rendering the Codex TUI.
- Even for agents that support interactive mode (claude, codex), the process chain (pnpm → bash → agent) can strip PTY allocation, causing raw ANSI escape codes instead of a rendered TUI.

## Solution

- Changed `codex exec "$prompt"` → `exec codex "$prompt"` (safe mode) and `codex exec --dangerously-bypass-approvals-and-sandbox "$prompt"` → `exec codex --dangerously-bypass-approvals-and-sandbox "$prompt"` (yolo mode). The bare `codex` command opens the interactive TUI with the prompt pre-loaded.
- Added `exec` prefix to all `agent_exec` calls (claude, codex, cursor, generic) so the agent process replaces the shell and directly owns the terminal file descriptors.

## Submission Checklist

- [x] N/A: shell script change, no testable application code
- [x] N/A: no application code changed, coverage gate not applicable
- [x] N/A: behaviour-only change to a dev script
- [x] N/A: no feature IDs affected
- [x] N/A: no network dependencies
- [x] N/A: dev tooling only, no release surface
- [x] N/A: no linked issue

## Impact

- Dev tooling only — affects `pnpm review` workflow scripts.
- No runtime/platform/security impact.

## Related

- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/codex-tui-agent-exec
- Commit SHA: f76c8cb1b

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` (pre-push hook passed)
- [x] N/A: Focused tests — shell script, no unit tests
- [x] Rust fmt/check (pre-push hook passed)
- [x] N/A: Tauri fmt/check — no Tauri changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `pnpm review` with `--agent codex` now opens the Codex interactive TUI instead of raw headless output.
- User-visible effect: Codex sessions render their full TUI when launched from review scripts.

### Parity Contract

- Legacy behavior preserved: claude and cursor agents continue to work identically (exec prefix is transparent).
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A