### PR TITLE
fix(memory): redact source tag debug identifiers

### DIFF
--- a/src/openhuman/memory_store/content/compose.rs
+++ b/src/openhuman/memory_store/content/compose.rs
@@ -142,8 +142,8 @@ fn build_front_matter(chunk: &Chunk) -> Vec<u8> {
     let source_scope = meta.path_scope.as_deref().unwrap_or(&meta.source_id);
     log::debug!(
         "[content_store::compose] seeding source tag source_id={} source_scope={} path_scope={}",
-        meta.source_id,
-        source_scope,
+        crate::openhuman::memory::util::redact::redact(&meta.source_id),
+        crate::openhuman::memory::util::redact::redact(source_scope),
         meta.path_scope.is_some()
     );
     let seeded_tags = with_source_tag(source_scope, &meta.tags);


### PR DESCRIPTION
## Summary

- Redacts memory source identifiers before writing the source-tag seeding debug log.
- Keeps the existing `path_scope` boolean in the log so scoped tag debugging still works.
- Follows up on the CodeRabbit privacy note from merged PR #3264.

## Problem

- PR #3264 fixed selector-based memory source identity, but its new debug log could print raw `source_id` / `source_scope` values.
- Some source identifiers can contain PII, such as Gmail email addresses, so debug output should not emit them unredacted.

## Solution

- Wrap `meta.source_id` and `source_scope` with the existing memory `redact()` helper before logging.
- Leave tag seeding behavior unchanged; only the debug output values are sanitized.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — N/A: log redaction only; existing scoped compose regression was rerun.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: logging-only privacy fix.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature row changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut/manual smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: follow-up to PR review, no standalone issue.

## Impact

- Security/privacy: reduces PII leakage risk in memory debug logs.
- Runtime behavior: no ingestion, tag, graph, archive, or migration behavior change.
- Compatibility: backwards compatible; only log argument formatting changed.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: Follows #3264

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/memory-redact-source-debug-log`
- Commit SHA: `60bed918`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — passed via pre-push hook
- [x] `pnpm typecheck` — passed via pre-push hook (`pnpm compile`)
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib openhuman::memory_store::content::compose::tests::compose_persists_path_scope_and_seeds_scoped_source_tag -- --nocapture`
- [x] Rust fmt/check (if changed): `git diff --check`; Rust fmt/check passed via pre-push hook
- [x] Tauri fmt/check (if changed): passed via pre-push hook

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: debug log source identifiers are redacted before emission.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: source tag seeding and `path_scope` fallback behavior are unchanged.
- Guard/fallback/dispatch parity checks: existing compose regression test still passes.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by redacting sensitive identifiers from debug logs to prevent exposure of sensitive data in log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->