### PR TITLE
fix(agent): drop removed memory_tree modes from orchestrator prompt

### DIFF
--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.md
@@ -182,13 +182,14 @@ Reach for `memory_tree` when the user asks about prior context that's already be
 Modes:
 
 - `mode: "search_entities"` — resolve a name to a canonical id (e.g. "alice" → `email:alice@example.com`). Call this first when the user mentions someone by name *and* you've decided memory_tree is the right tool.
-- `mode: "query_topic"` — all cross-source mentions of an `entity_id` from `search_entities`.
 - `mode: "query_source"` — filter by `source_kind` (chat/email/document) and `time_window_days`. Use for retrospective "in my email last week…" intents — **not** for live "check my inbox" intents.
-- `mode: "query_global"` — cross-source daily digest over `time_window_days` (7-day digest is pre-loaded into context on session start — only call for a different window or to force refresh).
+- `mode: "smart_walk"` — multi-strategy retrieval (vector + keyword + entity lookup + tree browsing across raw files, wiki summaries, documents, and episodic memories). Best default for an open-ended natural-language question like "what did Alice and I decide on Q2".
+- `mode: "walk"` — agentic multi-turn walk: the LLM navigates summaries and returns a synthesized answer for a natural-language query. Use when you want a guided traversal rather than broad retrieval.
 - `mode: "drill_down"` — expand a coarse `node_id` summary one level.
 - `mode: "fetch_leaves"` — pull raw `chunk_ids` for citation.
+- `mode: "ingest_document"` — write a document into the tree for future retrieval.
 
-Start cheap (query_* summaries), only drill_down/fetch_leaves when you need verbatim content.
+Start cheap (`query_source` / `smart_walk` summaries), only drill_down/fetch_leaves when you need verbatim content.
 
 ## Citations
 

--- a/src/openhuman/memory/query/search_entities.rs
+++ b/src/openhuman/memory/query/search_entities.rs
@@ -18,7 +18,8 @@ impl Tool for MemoryTreeSearchEntitiesTool {
         "Free-text LIKE search over the entity index — resolve a name or \
          handle to a canonical id (e.g. \"alice\" -> \
          `email:alice@example.com`). ALWAYS call this first when the user \
-         mentions someone by name before calling `memory_tree_query_topic`."
+         mentions someone by name before a `memory_tree` retrieval \
+         (`query_source` / `smart_walk` / `walk`) keyed on that id."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {


### PR DESCRIPTION
## Summary

- Remove the `query_topic` and `query_global` modes from the orchestrator's `memory_tree` documentation — both were deleted when the global/topic trees were removed, but two LLM-facing strings still advertised them.
- Add the modes the prompt was missing: `walk`, `smart_walk`, and `ingest_document`.
- Fix the `memory_tree_search_entities` tool description, which pointed the model at a nonexistent `memory_tree_query_topic` tool.

## Problem

The `memory_tree` dispatcher (`src/openhuman/memory/query/mod.rs`) supports exactly: `search_entities`, `query_source`, `drill_down`, `fetch_leaves`, `ingest_document`, `walk`, `smart_walk`. The `query_topic` / `query_global` modes were removed with the global/topic trees (asserted gone in `mod.rs` tests), but two prompts the model actually reads were never updated:

- `orchestrator/prompt.md` still listed `mode: "query_topic"` and `mode: "query_global"` as valid, and the "Start cheap (query_* summaries)" line leaned on them. If the orchestrator followed its prompt it would emit a call the dispatcher rejects with `unknown mode`. The prompt also never mentioned the more capable `walk` / `smart_walk` retrieval paths, so the agent was blind to them.
- `memory_tree_search_entities`'s tool `description()` told the model to call a `memory_tree_query_topic` tool that does not exist.

## Solution

Align both LLM-facing strings with the dispatcher's real mode list — drop the two dead modes, document `smart_walk` (multi-strategy retrieval) and `walk` (agentic traversal) as the open-ended-query defaults, add `ingest_document`, and update `search_entities` to reference `memory_tree`'s real retrieval modes.

## Submission Checklist

- [x] `N/A`: prompt/description string-only change — no executable behaviour to unit-test. The dispatcher already asserts the removed modes are gone (`memory/query/mod.rs`).
- [x] `N/A: behaviour-only change` — no changed executable lines for `diff-cover`.
- [x] Coverage matrix updated — `N/A: behaviour-only change`
- [x] Affected feature IDs — `N/A`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist — `N/A`: does not touch release-cut surfaces
- [x] Linked issue — `N/A`: no tracking issue

## Impact

- Desktop/CLI agent runtime: the orchestrator and `search_entities` tool now describe only modes the tool actually accepts, eliminating a class of guaranteed-failing `memory_tree` calls and surfacing `smart_walk` / `walk`. No code-path or schema change.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: optional tidy-up of historical `query_topic` mentions in `memory_tree/retrieval/{drill_down,types}.rs` comments (non-LLM-facing).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/memory-tree-prompt-stale-modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded AI agent memory retrieval strategies with new search modes to improve context understanding.
  * Clarified tool usage instructions for better performance when searching by user name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->