### PR TITLE
fix(composio): defer on_connection_created sync until onboarding completes

### DIFF
--- a/src/openhuman/memory_sync/composio/bus.rs
+++ b/src/openhuman/memory_sync/composio/bus.rs
@@ -582,32 +582,65 @@ impl EventHandler for ComposioConnectionCreatedSubscriber {
 
             // Optional provider-specific post-OAuth hook (e.g. gmail's
             // inbox ingest). Only fires for toolkits that registered a
-            // provider; the rest just got the cache refresh above and
-            // we're done.
-            let Some(provider) = get_provider(&toolkit) else {
-                tracing::debug!(
-                    toolkit = %toolkit,
-                    "[composio:bus] no provider registered for toolkit; cache refreshed, no provider hook to dispatch"
-                );
-                return;
-            };
-
-            if let Err(e) = provider.on_connection_created(&ctx).await {
-                tracing::warn!(
+            // provider, and only when the user has completed onboarding.
+            //
+            // Skip the initial sync when onboarding is still in progress
+            // (#3097). Connections made during the setup wizard would otherwise
+            // enqueue embedding/LLM jobs that drain cloud credits before the
+            // user has had a chance to choose their AI routing. The periodic
+            // scheduler (20-min tick) will fire the first real sync after
+            // onboarding completes. The memory_sources auto-register below
+            // still runs unconditionally so the source appears in the unified
+            // sources list immediately.
+            if !ctx.config.onboarding_completed {
+                tracing::info!(
                     toolkit = %toolkit,
                     connection_id = %connection_id,
-                    error = %e,
-                    "[composio:bus] provider on_connection_created failed"
+                    "[composio:bus] onboarding not yet complete — deferring initial sync to periodic scheduler"
                 );
             } else {
-                // Successful connection-created sync — record the
-                // timestamp so the periodic scheduler doesn't
-                // immediately re-fire for this connection.
-                super::periodic::record_sync_success(&toolkit, &connection_id);
+                let Some(provider) = get_provider(&toolkit) else {
+                    tracing::debug!(
+                        toolkit = %toolkit,
+                        "[composio:bus] no provider registered for toolkit; cache refreshed, no provider hook to dispatch"
+                    );
+                    // Still fall through to auto-register below.
+                    let label = format!("{toolkit} connection");
+                    if let Err(e) = crate::openhuman::memory_sources::upsert_composio_source(
+                        &toolkit,
+                        &connection_id,
+                        &label,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            toolkit = %toolkit,
+                            connection_id = %connection_id,
+                            error = %e,
+                            "[composio:bus] memory_sources auto-register failed (non-fatal)"
+                        );
+                    }
+                    return;
+                };
+
+                if let Err(e) = provider.on_connection_created(&ctx).await {
+                    tracing::warn!(
+                        toolkit = %toolkit,
+                        connection_id = %connection_id,
+                        error = %e,
+                        "[composio:bus] provider on_connection_created failed"
+                    );
+                } else {
+                    // Successful connection-created sync — record the
+                    // timestamp so the periodic scheduler doesn't
+                    // immediately re-fire for this connection.
+                    super::periodic::record_sync_success(&toolkit, &connection_id);
+                }
             }
 
-            // Auto-register this connection in the memory_sources
-            // registry so it appears in the unified sources list.
+            // Auto-register this connection in the memory_sources registry so
+            // it appears in the unified sources list regardless of whether the
+            // initial sync ran.
             let label = format!("{toolkit} connection");
             if let Err(e) = crate::openhuman::memory_sources::upsert_composio_source(
                 &toolkit,


### PR DESCRIPTION
## Summary

- Closes #3281
- Depends on / should be merged after #3278

Connects the `config.onboarding_completed` flag to the `ComposioConnectionCreatedSubscriber`. When a user connects Composio integrations during the onboarding wizard, the subscriber previously fired an immediate initial sync (profile fetch + inbox ingest), enqueuing embedding/LLM memory jobs before the user had chosen their AI routing or been shown any cost expectations. This drained cloud credits silently during setup.

**Change**: Before calling `provider.on_connection_created`, check `config.onboarding_completed`. If onboarding is still in progress, log a deferred-sync notice and skip the credit-consuming sync. The periodic scheduler (20-min tick) will run the first real sync after the user completes onboarding. The `memory_sources` auto-register runs unconditionally in both branches so the new connection still appears in Settings → Memory Sources immediately.

## What's preserved

- Cache invalidation + eager warm of the connected integrations cache still fires on every new connection (the ACTIVE-poll block above the guard is unchanged).
- Connections made during onboarding are auto-registered in memory_sources, so they show up in the Sources list as soon as OAuth completes.
- For connections added post-onboarding the behavior is identical to before — `on_connection_created` fires normally and records the sync timestamp so the 20-min scheduler doesn't redundantly re-fire.

## Test plan

- [x] Connect a Composio integration (e.g. Gmail) while the onboarding wizard is still open → confirm no memory embedding jobs fire immediately (log shows deferred notice; no credits consumed)
- [x] Complete onboarding → connect a new Composio integration → confirm initial sync fires normally
- [x] Verify the new connection appears in Settings → Memory Sources in both cases
- [x] `cargo check` passes (no new errors/warnings beyond pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth connection handling to properly defer initial data synchronization until onboarding is complete, with sync scheduled for later processing.
  * Enhanced automatic connection registration for memory sources across all onboarding states.
  * Fixed edge case handling when provider registration is unavailable during certain onboarding paths, ensuring proper registration completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->