### PR TITLE
docs(config): refer to minimax/m3 in team model-pin example

### DIFF
--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -144,7 +144,7 @@ pub struct Config {
     /// Optional per-team model pins for delegated swarms.
     ///
     /// Example:
-    /// `[teams.research] lead_model = "minimax/m2" agent_model = "deepseek/v3.2"`.
+    /// `[teams.research] lead_model = "minimax/m3" agent_model = "deepseek/v3.2"`.
     #[serde(default)]
     pub teams: HashMap<String, TeamModelConfig>,
 
@@ -770,7 +770,7 @@ mod model_pin_tests {
                 model = "deepseek/deepseek-r2"
 
                 [teams.research]
-                lead_model = "minimax/m2"
+                lead_model = "minimax/m3"
                 agent_model = "deepseek/v3.2"
 
                 [teams.code]
@@ -789,7 +789,7 @@ mod model_pin_tests {
         );
         assert_eq!(
             config.configured_agent_model("researcher", true),
-            Some("minimax/m2")
+            Some("minimax/m3")
         );
         assert_eq!(
             config.configured_agent_model("code_executor", false),


### PR DESCRIPTION
## Summary

- Replace the deprecated `minimax/m2` model id used in the `TeamModelConfig` docstring example with `minimax/m3` (MiniMax-M3), the current default.
- Update the matching parser test (`config_parses_orchestrator_and_team_model_pins`) so docs and test agree.
- No runtime/behaviour change: the parser still accepts any `<provider>/<model>` string.

## Problem

The `[teams.research]` example shown in the docstring above `Config::teams` and asserted by the matching test fixture still references `minimax/m2`. That model id was retired by MiniMax in favour of newer M2.7 and M3 variants, so a contributor copying the example into their own config will pin a model the upstream provider no longer routes to. Keeping deprecated identifiers in front-and-centre docs invites avoidable user error and obscures what the current recommended model is for the provider.

## Solution

Bump the literal in three places (docstring, TOML fixture, and the matching `assert_eq!`) from `"minimax/m2"` to `"minimax/m3"`. The change is intentionally surgical: it is only the example/test fixture, not any runtime selection or routing code. `configured_agent_model` does not inspect the model string, so the assertion still exercises the exact same code path; the parser is value-agnostic by design.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — `config_parses_orchestrator_and_team_model_pins` is the test for this docstring example and is updated in lockstep so the doc and the test agree on the model id.
- [x] **Diff coverage ≥ 80%** — N/A: the change is limited to a docstring comment and the literal in an already-covered test fixture; no new executable lines are introduced.
- [x] Coverage matrix updated — N/A: docs/test-fixture-only refresh, no feature surface change.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix rows touched.
- [x] No new external network dependencies introduced — N/A: no runtime change.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no user-visible surface touched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: drive-by docs refresh, no tracking issue.

## Impact

- Runtime/platform impact: none. The change is confined to a docstring example and a string literal in a unit test fixture; the test continues to exercise the same TOML-parsing path with an equivalent assertion.
- Performance / security / migration: none.
- Compatibility: fully backward compatible — `minimax/m2` and any other `<provider>/<model>` string still parse and resolve identically; this is purely a recommendation/doc change.

## Related

N/A — drive-by documentation refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration example to reflect current model availability.

* **Tests**
  * Updated test fixtures and assertions to align with configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->