### PR TITLE
feat(agent): add update_task tool — move/update a task card by id from any thread

### DIFF
--- a/src/openhuman/agent/tools.rs
+++ b/src/openhuman/agent/tools.rs
@@ -6,6 +6,7 @@ pub mod remember_preference;
 mod run_skill;
 pub mod save_preference;
 mod todo;
+mod update_task;
 pub mod workflow_tools;
 
 pub use ask_clarification::AskClarificationTool;
@@ -16,4 +17,5 @@ pub use remember_preference::RememberPreferenceTool;
 pub use run_skill::{RunSkillTool, RUN_SKILL_TOOL_NAME};
 pub use save_preference::SavePreferenceTool;
 pub use todo::TodoTool;
+pub use update_task::UpdateTaskTool;
 pub use workflow_tools::{WorkflowLoadTool, WorkflowPhaseTool};

--- a/src/openhuman/agent/tools/update_task.rs
+++ b/src/openhuman/agent/tools/update_task.rs
@@ -1,0 +1,226 @@
+//! `update_task` — move or update a specific task card on a thread's board.
+//!
+//! `todo` only reaches the *current* thread's board. `update_task` addresses a
+//! card **by id** on a *target* board — defaulting to the proactive
+//! `task-sources` board — so the orchestrator (or an autonomous task run on its
+//! own thread) can advance the task it's working: move it to
+//! `in_progress`/`blocked`/`done`, or update its objective/notes/evidence/blocker.
+//!
+//! It is a thin wrapper over [`crate::openhuman::todos::ops::edit`], which
+//! applies the status move + field updates atomically, enforces the
+//! single-`in_progress` invariant, and emits the board-progress event that the
+//! Tasks board UI listens on.
+
+use crate::openhuman::task_sources::TASK_SOURCES_THREAD_ID;
+use crate::openhuman::todos::ops::{self, BoardLocation, CardPatch};
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use async_trait::async_trait;
+use serde_json::json;
+use std::path::PathBuf;
+
+pub struct UpdateTaskTool;
+
+impl UpdateTaskTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for UpdateTaskTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for UpdateTaskTool {
+    fn name(&self) -> &str {
+        "update_task"
+    }
+
+    fn description(&self) -> &str {
+        "Move or update a specific task card on a task board, addressed by `id`. \
+         Use this to advance the task you're working on: set `status` \
+         (`todo`/`in_progress`/`blocked`/`done`) to move it between columns, and/or \
+         update `objective`, `notes`, `evidence`, `blocker`, `plan`, \
+         `acceptanceCriteria`. When you finish, set `status: done` with `evidence`; \
+         if you cannot proceed, set `status: blocked` with a `blocker` reason. \
+         Targets the proactive `task-sources` board by default — pass `threadId` to \
+         target another thread's board. Returns the updated card list + a markdown \
+         rendering. At most one card may be `in_progress` at a time."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "Id of the card to move/update (required)." },
+                "status": {
+                    "type": "string",
+                    "enum": ["todo", "in_progress", "blocked", "done"],
+                    "description": "New status — moves the card to that column."
+                },
+                "objective": { "type": "string", "description": "Updated desired outcome for the task." },
+                "notes": { "type": "string", "description": "Progress notes / running summary." },
+                "blocker": { "type": "string", "description": "Why the task is blocked (set with status=blocked)." },
+                "evidence": {
+                    "type": "array",
+                    "description": "Links, output, or files proving the work (set with status=done).",
+                    "items": { "type": "string" }
+                },
+                "plan": {
+                    "type": "array",
+                    "description": "Updated ordered execution steps.",
+                    "items": { "type": "string" }
+                },
+                "acceptanceCriteria": {
+                    "type": "array",
+                    "description": "Updated checklist that must hold before the task is done.",
+                    "items": { "type": "string" }
+                },
+                "threadId": {
+                    "type": "string",
+                    "description": "Board to target; defaults to the `task-sources` board."
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::None
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let Some(id) = optional_string(&args, "id") else {
+            return Ok(ToolResult::error("missing required field `id`".to_string()));
+        };
+
+        let patch = match build_patch(&args) {
+            Ok(patch) => patch,
+            Err(err) => return Ok(ToolResult::error(err)),
+        };
+        if patch_is_empty(&patch) {
+            return Ok(ToolResult::error(
+                "nothing to update — provide `status` and/or a field \
+                 (objective/notes/evidence/blocker/plan/acceptanceCriteria)"
+                    .to_string(),
+            ));
+        }
+
+        let location = match resolve_location(&args).await {
+            Ok(location) => location,
+            Err(err) => return Ok(ToolResult::error(err)),
+        };
+
+        Ok(apply(&location, &id, patch))
+    }
+}
+
+/// Apply the move/update to the card and render the result. Split out from
+/// `execute` so the edit + response shaping is testable without a fork/thread
+/// context (which `resolve_location` needs).
+fn apply(location: &BoardLocation, id: &str, patch: CardPatch) -> ToolResult {
+    tracing::info!(
+        card_id = %id,
+        thread_id = ?location.thread_id(),
+        status = ?patch.status,
+        "[tool][update_task] move/update task card"
+    );
+    match ops::edit(location, id, patch) {
+        Ok(snap) => {
+            let payload = json!({
+                "threadId": snap.thread_id,
+                "cards": snap.cards,
+                "markdown": snap.markdown,
+            });
+            ToolResult::success(payload.to_string())
+        }
+        Err(err) => ToolResult::error(err),
+    }
+}
+
+/// Resolve the board to act on: the explicit `threadId` arg, else the proactive
+/// `task-sources` board. The workspace root comes from the running agent's fork
+/// context when present, otherwise from the loaded config.
+async fn resolve_location(args: &serde_json::Value) -> Result<BoardLocation, String> {
+    let thread_id =
+        optional_string(args, "threadId").unwrap_or_else(|| TASK_SOURCES_THREAD_ID.to_string());
+    Ok(BoardLocation::Thread {
+        workspace_dir: workspace_dir().await?,
+        thread_id,
+    })
+}
+
+async fn workspace_dir() -> Result<PathBuf, String> {
+    if let Some(parent) = crate::openhuman::agent::harness::fork_context::current_parent() {
+        return Ok(parent.workspace_dir.clone());
+    }
+    crate::openhuman::config::ops::load_config_with_timeout()
+        .await
+        .map(|config| config.workspace_dir)
+        .map_err(|e| format!("update_task: failed to load config for workspace dir: {e}"))
+}
+
+fn build_patch(args: &serde_json::Value) -> Result<CardPatch, String> {
+    let status = match args.get("status").and_then(|v| v.as_str()) {
+        Some(s) => Some(ops::parse_status(s)?),
+        None => None,
+    };
+    Ok(CardPatch {
+        status,
+        objective: optional_string(args, "objective"),
+        plan: optional_string_array(args, "plan")?,
+        acceptance_criteria: optional_string_array(args, "acceptanceCriteria")?,
+        evidence: optional_string_array(args, "evidence")?,
+        notes: optional_string(args, "notes"),
+        blocker: optional_string(args, "blocker"),
+        ..Default::default()
+    })
+}
+
+fn patch_is_empty(patch: &CardPatch) -> bool {
+    patch.status.is_none()
+        && patch.objective.is_none()
+        && patch.plan.is_none()
+        && patch.acceptance_criteria.is_none()
+        && patch.evidence.is_none()
+        && patch.notes.is_none()
+        && patch.blocker.is_none()
+}
+
+fn optional_string(args: &serde_json::Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn optional_string_array(
+    args: &serde_json::Value,
+    key: &str,
+) -> Result<Option<Vec<String>>, String> {
+    match args.get(key) {
+        None => Ok(None),
+        Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Array(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                let s = item
+                    .as_str()
+                    .ok_or_else(|| format!("`{key}` must be an array of strings"))?
+                    .trim();
+                if !s.is_empty() {
+                    out.push(s.to_string());
+                }
+            }
+            Ok(Some(out))
+        }
+        Some(_) => Err(format!("`{key}` must be an array of strings")),
+    }
+}
+
+#[cfg(test)]
+#[path = "update_task_tests.rs"]
+mod tests;

--- a/src/openhuman/agent/tools/update_task_tests.rs
+++ b/src/openhuman/agent/tools/update_task_tests.rs
@@ -1,0 +1,123 @@
+//! Tests for the `update_task` tool.
+
+use super::*;
+use crate::openhuman::agent::task_board::TaskCardStatus;
+use crate::openhuman::tools::traits::Tool;
+use serde_json::json;
+
+// ── build_patch ──────────────────────────────────────────────────────────────
+
+#[test]
+fn build_patch_maps_status_and_all_fields() {
+    let patch = build_patch(&json!({
+        "status": "in_progress",
+        "objective": "ship it",
+        "notes": "halfway",
+        "blocker": "",
+        "evidence": ["https://x/1", "  ", "note"],
+        "plan": ["a", "b"],
+        "acceptanceCriteria": ["covered"]
+    }))
+    .expect("valid patch");
+    assert_eq!(patch.status, Some(TaskCardStatus::InProgress));
+    assert_eq!(patch.objective.as_deref(), Some("ship it"));
+    assert_eq!(patch.notes.as_deref(), Some("halfway"));
+    // empty/blank array entries are dropped; blanks elsewhere become None via edit.
+    assert_eq!(
+        patch.evidence,
+        Some(vec!["https://x/1".to_string(), "note".to_string()])
+    );
+    assert_eq!(patch.plan, Some(vec!["a".to_string(), "b".to_string()]));
+    assert_eq!(patch.acceptance_criteria, Some(vec!["covered".to_string()]));
+}
+
+#[test]
+fn build_patch_empty_args_is_empty() {
+    let patch = build_patch(&json!({})).expect("ok");
+    assert!(patch_is_empty(&patch));
+}
+
+#[test]
+fn build_patch_with_only_status_is_not_empty() {
+    let patch = build_patch(&json!({ "status": "done" })).expect("ok");
+    assert!(!patch_is_empty(&patch));
+    assert_eq!(patch.status, Some(TaskCardStatus::Done));
+}
+
+#[test]
+fn build_patch_rejects_unknown_status() {
+    assert!(build_patch(&json!({ "status": "nonsense" })).is_err());
+}
+
+#[test]
+fn build_patch_rejects_non_string_array_item() {
+    assert!(build_patch(&json!({ "evidence": [1, 2] })).is_err());
+}
+
+// ── execute() guard rails (no board/workspace needed) ────────────────────────
+
+#[tokio::test]
+async fn execute_without_id_is_an_error() {
+    let res = UpdateTaskTool::new()
+        .execute(json!({ "status": "done" }))
+        .await
+        .unwrap();
+    assert!(res.is_error, "missing id must be a tool error");
+}
+
+#[tokio::test]
+async fn execute_with_id_but_no_changes_is_an_error() {
+    // id present but nothing to change → rejected before any board write.
+    let res = UpdateTaskTool::new()
+        .execute(json!({ "id": "task-1" }))
+        .await
+        .unwrap();
+    assert!(res.is_error, "empty update must be a tool error");
+}
+
+// ── the move + update applied through ops::edit (the tool's real effect) ─────
+
+#[test]
+fn apply_moves_and_updates_a_card_and_returns_success() {
+    let dir = tempfile::tempdir().unwrap();
+    let location = BoardLocation::Thread {
+        workspace_dir: dir.path().to_path_buf(),
+        thread_id: TASK_SOURCES_THREAD_ID.to_string(),
+    };
+    let id = ops::add(&location, "Review PR #5", CardPatch::default())
+        .unwrap()
+        .cards[0]
+        .id
+        .clone();
+
+    // Move to done + attach evidence — the exact shape the tool produces.
+    let patch = build_patch(&json!({
+        "status": "done",
+        "evidence": ["posted review on PR #5"]
+    }))
+    .unwrap();
+    let res = apply(&location, &id, patch);
+    assert!(!res.is_error, "successful move/update must not be an error");
+
+    // The board reflects the move + evidence.
+    let card = ops::list(&location)
+        .unwrap()
+        .cards
+        .into_iter()
+        .find(|c| c.id == id)
+        .unwrap();
+    assert_eq!(card.status, TaskCardStatus::Done);
+    assert!(card.evidence.iter().any(|e| e.contains("posted review")));
+}
+
+#[test]
+fn apply_on_unknown_id_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let location = BoardLocation::Thread {
+        workspace_dir: dir.path().to_path_buf(),
+        thread_id: TASK_SOURCES_THREAD_ID.to_string(),
+    };
+    let patch = build_patch(&json!({ "status": "blocked", "blocker": "no channel" })).unwrap();
+    let res = apply(&location, "task-does-not-exist", patch);
+    assert!(res.is_error, "missing card must surface as a tool error");
+}

--- a/src/openhuman/agent_registry/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent_registry/agents/orchestrator/agent.toml
@@ -148,6 +148,12 @@ named = [
     # downstream agents — the orchestrator coordinates, it doesn't
     # touch files itself.
     "todowrite",
+    # `update_task` moves/updates a specific task card by id on a target board
+    # (defaults to the proactive `task-sources` board) — so the orchestrator can
+    # advance the task it's working: → in_progress when it starts, → done with
+    # evidence when finished, or → blocked with a reason when stuck. Complements
+    # `todowrite`, which only touches the current thread's board.
+    "update_task",
     "plan_exit",
     # Skill chaining: let an in-flight autonomous skill (e.g.
     # `github-issue-crusher` after the draft PR is open) spawn another

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -158,6 +158,11 @@ pub fn all_tools_with_runtime(
         // build-mode pass. The plan→build mode switch itself is a
         // follow-up; the tool emits a stable marker today.
         Box::new(TodoTool::new()),
+        // Move/update a specific task card by id on a target board (defaults to
+        // the proactive `task-sources` board) — lets the agent advance the task
+        // it's working (in_progress / done+evidence / blocked+reason) from any
+        // thread, complementing `todo` which only touches the current thread.
+        Box::new(UpdateTaskTool::new()),
         Box::new(PlanExitTool::new()),
         // Skill chaining: let an in-flight autonomous skill (e.g.
         // `github-issue-crusher`) kick off another bundled skill_run as a


### PR DESCRIPTION
## Summary

- Adds an `update_task` agent tool that **moves or updates a specific task card by `id`** — set `status` (todo/in_progress/blocked/done) to move it between columns, and/or update `objective` / `notes` / `evidence` / `blocker` / `plan` / `acceptanceCriteria`.
- Targets the proactive **`task-sources`** board by default; `threadId` overrides to any thread's board.
- Wired into the tool registry and the orchestrator's `named` tool list.

## Problem

The existing `todo`/`todowrite` tool only reaches the **current thread's** board. So an agent working a proactive task — the orchestrator, or an autonomous task run on its own `task-default-*` thread — cannot advance the originating **task-source card**: it can't move it to `in_progress` when it starts, attach `evidence` when it finishes, or mark it `blocked` with a reason when it's stuck. The card's lifecycle is invisible to the agent doing the work.

## Solution

`update_task` addresses a card by `id` on a target board (default `task-sources`) and applies the change through a single `todos::ops::edit`, which:
- applies the status move + field updates atomically,
- enforces the single-`in_progress` invariant,
- emits the board-progress event the Tasks board UI listens on, so updates surface live.

`execute()` validates (`id` required, non-empty update, known status) then delegates to a small `apply(location, id, patch)` seam (extracted so the edit + response shaping is unit-testable without a fork/thread context). Thin wrapper over existing `todos::ops` — no new persistence or board logic.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — `update_task_tests.rs`: build_patch mapping/validation, missing-id / empty-update / unknown-status guards, and the move+update (done+evidence) / unknown-id-error paths through `apply`.
- [x] **Diff coverage ≥ 80%** — Rust-only change; the new tool's logic + `apply` are covered by unit tests. (Only the async `resolve_location`/`workspace_dir` context-plumbing lines are not directly unit-tested.)
- [x] Coverage matrix updated — N/A: adds an agent tool, no feature-matrix row added/removed/renamed.
- [x] All affected feature IDs listed under `## Related` — N/A: no matrix feature ID.
- [x] No new external network dependencies introduced — N/A: no network; thin wrapper over local `todos::ops`.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: not a release-cut smoke surface.
- [x] Linked issue closed via `Closes #NNN` — N/A: no issue filed for this change.

## Impact

- Runtime: a new agent tool available to the orchestrator (and any agent in the registry default set). No migration, no compatibility impact. `PermissionLevel::None` (board write, no external effect).
- Lets the proactive task-source lifecycle become agent-driven and observable (live board updates via the existing progress event).

## Related

- Closes:
- Follow-up PR(s)/TODOs: surface the same capability to the autonomous task-run executor's prompt so a run reliably marks its card done/blocked.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/update-task-tool`
- Commit SHA: `7eb2286e`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` changes.
- [x] `pnpm typecheck` — N/A: no frontend changes.
- [x] Focused tests: `cargo test --lib update_task` (9 passed); `cargo test --lib tools::ops::tests` (58 passed).
- [x] Rust fmt/check (if changed): `cargo fmt --check`; `cargo check --lib` — clean.
- [x] Tauri fmt/check (if changed): N/A: no Tauri-shell changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: agents can move/update a task card by id on any board (default task-sources).
- User-visible effect: task cards advance (column + fields) live as the agent works them.

### Parity Contract

- Legacy behavior preserved: `todo`/`todowrite` (current-thread board CRUD) is unchanged; this is additive.
- Guard/fallback/dispatch parity checks: `update_task` reuses `todos::ops::edit` (same single-in-progress enforcement + progress event as `todo`).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New task card update tool allows users to modify specific task cards by ID. Supports updating status, objectives, notes, evidence, blockers, plans, and acceptance criteria with intelligent board selection.

* **Tests**
  * Added comprehensive test coverage for the task update feature, including validation and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
