### PR TITLE
feat(agent): persist oversized tool outputs

### DIFF
--- a/src/openhuman/agent/harness/engine/core.rs
+++ b/src/openhuman/agent/harness/engine/core.rs
@@ -465,15 +465,17 @@ pub(crate) async fn run_turn_engine(
                 }
             }
             history.push(ChatMessage::assistant(response_text.clone()));
-            observer.on_assistant(
-                &final_out,
-                &response_text,
-                reasoning_content.as_deref(),
-                &[],
-                &[],
-                iteration,
-                true,
-            );
+            observer
+                .on_assistant(
+                    &final_out,
+                    &response_text,
+                    reasoning_content.as_deref(),
+                    &[],
+                    &[],
+                    iteration,
+                    true,
+                )
+                .await;
             observer.after_iteration(history, iteration);
             log::info!(
                 "[agent_loop] turn complete: iters={} provider_calls={} tokens_in={} tokens_out={} cached_in={} usd={:.4}",
@@ -579,15 +581,17 @@ pub(crate) async fn run_turn_engine(
         // reconstruct OpenAI-format tool_calls + tool result messages. Prompt
         // mode: XML-based text format.
         history.push(ChatMessage::assistant(assistant_history_content));
-        observer.on_assistant(
-            &display_text,
-            &response_text,
-            reasoning_content.as_deref(),
-            &native_tool_calls,
-            &tool_calls,
-            iteration,
-            false,
-        );
+        observer
+            .on_assistant(
+                &display_text,
+                &response_text,
+                reasoning_content.as_deref(),
+                &native_tool_calls,
+                &tool_calls,
+                iteration,
+                false,
+            )
+            .await;
         if native_tool_calls.is_empty() {
             let content = format!("[Tool results]\n{tool_results}");
             observer.on_results_batch(&content, iteration);

--- a/src/openhuman/agent/harness/engine/state.rs
+++ b/src/openhuman/agent/harness/engine/state.rs
@@ -49,7 +49,7 @@ pub(crate) trait TurnObserver: Send {
     /// typed `ConversationMessage` history; the subagent mirrors to its worker
     /// thread.
     #[allow(clippy::too_many_arguments)]
-    fn on_assistant(
+    async fn on_assistant(
         &mut self,
         _display_text: &str,
         _response_text: &str,

--- a/src/openhuman/agent/harness/mod.rs
+++ b/src/openhuman/agent/harness/mod.rs
@@ -42,6 +42,7 @@ pub mod subagent_runner;
 mod token_budget;
 pub(crate) mod tool_filter;
 mod tool_loop;
+pub(crate) mod tool_result_artifacts;
 
 pub use definition::{
     AgentDefinition, AgentDefinitionRegistry, DefinitionSource, ModelSpec, PromptSource,

--- a/src/openhuman/agent/harness/session/agent_tool_exec.rs
+++ b/src/openhuman/agent/harness/session/agent_tool_exec.rs
@@ -14,6 +14,9 @@ use crate::core::event_bus::{publish_global, DomainEvent};
 use crate::openhuman::agent::dispatcher::{ParsedToolCall, ToolExecutionResult};
 use crate::openhuman::agent::harness::engine::ProgressReporter;
 use crate::openhuman::agent::harness::payload_summarizer::PayloadSummarizer;
+use crate::openhuman::agent::harness::tool_result_artifacts::{
+    apply_per_result_persistence, ToolResultArtifactStore,
+};
 use crate::openhuman::agent::hooks::{self, ToolCallRecord};
 use crate::openhuman::agent::tool_policy::{
     ToolCallContext, ToolPolicy, ToolPolicyDecision, ToolPolicyRequest,
@@ -35,6 +38,7 @@ pub(super) struct AgentToolExecCtx<'a> {
     pub agent_definition_id: &'a str,
     pub prefer_markdown: bool,
     pub budget_bytes: usize,
+    pub artifact_store: Option<&'a ToolResultArtifactStore>,
 }
 
 /// Execute one parsed tool call end-to-end with the Agent's semantics, emitting
@@ -222,11 +226,25 @@ pub(super) async fn run_agent_tool_call(
         (format!("Unknown tool: {}", call.name), false)
     };
 
-    // Per-result byte budget — the only cache-safe reduction stage (the
-    // truncated body has never been sent to the backend).
-    let (result, budget_outcome) =
-        crate::openhuman::context::apply_tool_result_budget(raw_result, ctx.budget_bytes);
-    if budget_outcome.truncated {
+    // Per-result byte budget — the only cache-safe reduction stage (the full
+    // body has never been sent to the backend). Oversized outputs are persisted
+    // into the action workspace when possible, with truncation as fallback.
+    let (result, budget_outcome) = apply_per_result_persistence(
+        raw_result,
+        ctx.artifact_store,
+        &call.name,
+        Some(&call_id),
+        ctx.budget_bytes,
+    )
+    .await;
+    if budget_outcome.persisted {
+        log::info!(
+            "[agent_loop] tool_result_artifact applied name={} original_bytes={} final_bytes={}",
+            call.name,
+            budget_outcome.original_bytes,
+            budget_outcome.final_bytes,
+        );
+    } else if budget_outcome.original_bytes != budget_outcome.final_bytes {
         log::info!(
             "[agent_loop] tool_result_budget applied name={} original_bytes={} final_bytes={} dropped_bytes={}",
             call.name,

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -545,6 +545,11 @@ impl AgentBuilder {
             prompt_builder,
         );
 
+        let workspace_dir = self
+            .workspace_dir
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let action_dir = self.action_dir.unwrap_or_else(|| workspace_dir.clone());
+
         Ok(Agent {
             provider,
             tools: Arc::new(tools),
@@ -565,12 +570,8 @@ impl AgentBuilder {
             config,
             model_name,
             temperature: self.temperature.unwrap_or(0.7),
-            workspace_dir: self
-                .workspace_dir
-                .unwrap_or_else(|| std::path::PathBuf::from(".")),
-            action_dir: self
-                .action_dir
-                .unwrap_or_else(|| std::path::PathBuf::from(".")),
+            workspace_dir,
+            action_dir,
             skills: self.skills.unwrap_or_default(),
             workflows: self.workflows.unwrap_or_default(),
             auto_save: self.auto_save.unwrap_or(false),

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -93,6 +93,7 @@ impl AgentBuilder {
             model_name: None,
             temperature: None,
             workspace_dir: None,
+            action_dir: None,
             skills: None,
             workflows: None,
             auto_save: None,
@@ -197,6 +198,11 @@ impl AgentBuilder {
     /// Sets the workspace directory for the agent.
     pub fn workspace_dir(mut self, workspace_dir: std::path::PathBuf) -> Self {
         self.workspace_dir = Some(workspace_dir);
+        self
+    }
+
+    pub fn action_dir(mut self, action_dir: std::path::PathBuf) -> Self {
+        self.action_dir = Some(action_dir);
         self
     }
 
@@ -561,6 +567,9 @@ impl AgentBuilder {
             temperature: self.temperature.unwrap_or(0.7),
             workspace_dir: self
                 .workspace_dir
+                .unwrap_or_else(|| std::path::PathBuf::from(".")),
+            action_dir: self
+                .action_dir
                 .unwrap_or_else(|| std::path::PathBuf::from(".")),
             skills: self.skills.unwrap_or_default(),
             workflows: self.workflows.unwrap_or_default(),
@@ -1570,6 +1579,7 @@ impl Agent {
             .model_name(model_name)
             .temperature(effective_temperature)
             .workspace_dir(config.workspace_dir.clone())
+            .action_dir(config.action_dir.clone())
             .skills(crate::openhuman::skills::load_skills(&config.workspace_dir))
             .workflows({
                 let wf = crate::openhuman::agent_workflows::load_workflows(&config.workspace_dir);

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -496,6 +496,12 @@ impl Agent {
                 agent_definition_id: self.agent_definition_id.clone(),
                 prefer_markdown: self.context.prefer_markdown_tool_output(),
                 budget_bytes: self.context.tool_result_budget_bytes(),
+                artifact_store: Some(
+                    crate::openhuman::agent::harness::tool_result_artifacts::ToolResultArtifactStore::new(
+                        self.action_dir.clone(),
+                        self.session_key.clone(),
+                    ),
+                ),
                 should_send_specs: self.tool_dispatcher.should_send_tool_specs(),
                 advertised_specs: self.visible_tool_specs.as_ref().clone(),
                 records: Vec::new(),
@@ -750,6 +756,11 @@ impl Agent {
         // `TurnProgress` over this agent's sink. Legacy `run_skill`-wrapped
         // built-in cron tool calls are normalized to direct calls first.
         let progress = super::super::engine::TurnProgress::new(self.on_progress.clone());
+        let artifact_store =
+            crate::openhuman::agent::harness::tool_result_artifacts::ToolResultArtifactStore::new(
+                self.action_dir.clone(),
+                self.session_key.clone(),
+            );
         let ctx = super::agent_tool_exec::AgentToolExecCtx {
             tools: &self.tools,
             visible_tool_names: &self.visible_tool_names,
@@ -761,6 +772,7 @@ impl Agent {
             agent_definition_id: &self.agent_definition_id,
             prefer_markdown: self.context.prefer_markdown_tool_output(),
             budget_bytes: self.context.tool_result_budget_bytes(),
+            artifact_store: Some(&artifact_store),
         };
         super::agent_tool_exec::run_agent_tool_call(&ctx, &progress, call, iteration).await
     }

--- a/src/openhuman/agent/harness/session/turn.rs
+++ b/src/openhuman/agent/harness/session/turn.rs
@@ -485,6 +485,12 @@ impl Agent {
                 .as_ref()
                 .map(|c| c.multimodal_files.clone())
                 .unwrap_or_default();
+            let artifact_store = Some(
+                crate::openhuman::agent::harness::tool_result_artifacts::ToolResultArtifactStore::new(
+                    self.action_dir.clone(),
+                    self.session_key.clone(),
+                ),
+            );
             let mut tool_source = AgentToolSource {
                 tools: self.tools.clone(),
                 visible_tool_names: self.visible_tool_names.clone(),
@@ -496,12 +502,7 @@ impl Agent {
                 agent_definition_id: self.agent_definition_id.clone(),
                 prefer_markdown: self.context.prefer_markdown_tool_output(),
                 budget_bytes: self.context.tool_result_budget_bytes(),
-                artifact_store: Some(
-                    crate::openhuman::agent::harness::tool_result_artifacts::ToolResultArtifactStore::new(
-                        self.action_dir.clone(),
-                        self.session_key.clone(),
-                    ),
-                ),
+                artifact_store: artifact_store.clone(),
                 should_send_specs: self.tool_dispatcher.should_send_tool_specs(),
                 advertised_specs: self.visible_tool_specs.as_ref().clone(),
                 records: Vec::new(),
@@ -523,6 +524,7 @@ impl Agent {
             let cached_prefix = self.cached_transcript_messages.take();
             let mut observer = AgentObserver {
                 agent: self,
+                artifact_store,
                 effective_model: effective_model.clone(),
                 cumulative_input: 0,
                 cumulative_output: 0,

--- a/src/openhuman/agent/harness/session/turn_engine_adapter.rs
+++ b/src/openhuman/agent/harness/session/turn_engine_adapter.rs
@@ -36,6 +36,9 @@ use crate::openhuman::agent::harness::engine::{
 };
 use crate::openhuman::agent::harness::parse::ParsedToolCall;
 use crate::openhuman::agent::harness::payload_summarizer::PayloadSummarizer;
+use crate::openhuman::agent::harness::tool_result_artifacts::{
+    spill_aggregate_tool_results, ToolResultArtifactStore,
+};
 use crate::openhuman::agent::hooks::ToolCallRecord;
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::agent::tool_policy::ToolPolicy;
@@ -94,6 +97,7 @@ pub(super) struct AgentToolSource {
     pub agent_definition_id: String,
     pub prefer_markdown: bool,
     pub budget_bytes: usize,
+    pub artifact_store: Option<ToolResultArtifactStore>,
     pub should_send_specs: bool,
     pub advertised_specs: Vec<ToolSpec>,
     /// Collected per-call records, drained by the post-loop epilogue for hooks.
@@ -135,6 +139,7 @@ impl ToolSource for AgentToolSource {
             agent_definition_id: &self.agent_definition_id,
             prefer_markdown: self.prefer_markdown,
             budget_bytes: self.budget_bytes,
+            artifact_store: self.artifact_store.as_ref(),
         };
         let (exec_result, record) =
             run_agent_tool_call(&ctx, progress, &dispatcher_call, iteration).await;
@@ -307,7 +312,7 @@ impl TurnObserver for AgentObserver<'_> {
         });
     }
 
-    fn on_assistant(
+    async fn on_assistant(
         &mut self,
         display_text: &str,
         _response_text: &str,
@@ -361,7 +366,17 @@ impl TurnObserver for AgentObserver<'_> {
                     .filter(|s| !s.is_empty())
                     .map(ToString::to_string),
             });
-        let results = std::mem::take(&mut self.pending_results);
+        let mut results = std::mem::take(&mut self.pending_results);
+        let artifact_store = ToolResultArtifactStore::new(
+            self.agent.action_dir.clone(),
+            self.agent.session_key.clone(),
+        );
+        spill_aggregate_tool_results(
+            &mut results,
+            Some(&artifact_store),
+            self.agent.context.tool_result_budget_bytes(),
+        )
+        .await;
         let formatted = self.agent.tool_dispatcher.format_results(&results);
         self.agent.history.push(formatted);
         self.agent.trim_history();

--- a/src/openhuman/agent/harness/session/turn_engine_adapter.rs
+++ b/src/openhuman/agent/harness/session/turn_engine_adapter.rs
@@ -176,6 +176,7 @@ impl ToolSource for AgentToolSource {
 /// management, usage accounting, and transcript persistence.
 pub(super) struct AgentObserver<'a> {
     pub agent: &'a mut Agent,
+    pub artifact_store: Option<ToolResultArtifactStore>,
     pub effective_model: String,
     pub cumulative_input: u64,
     pub cumulative_output: u64,
@@ -367,13 +368,9 @@ impl TurnObserver for AgentObserver<'_> {
                     .map(ToString::to_string),
             });
         let mut results = std::mem::take(&mut self.pending_results);
-        let artifact_store = ToolResultArtifactStore::new(
-            self.agent.action_dir.clone(),
-            self.agent.session_key.clone(),
-        );
         spill_aggregate_tool_results(
             &mut results,
-            Some(&artifact_store),
+            self.artifact_store.as_ref(),
             self.agent.context.tool_result_budget_bytes(),
         )
         .await;

--- a/src/openhuman/agent/harness/session/types.rs
+++ b/src/openhuman/agent/harness/session/types.rs
@@ -54,6 +54,7 @@ pub struct Agent {
     pub(super) model_name: String,
     pub(super) temperature: f64,
     pub(super) workspace_dir: std::path::PathBuf,
+    pub(super) action_dir: std::path::PathBuf,
     pub(super) skills: Vec<crate::openhuman::skills::Skill>,
     /// Agent workflows discovered at session start.
     pub(super) workflows: Vec<crate::openhuman::agent_workflows::Workflow>,
@@ -269,6 +270,7 @@ pub struct AgentBuilder {
     pub(super) model_name: Option<String>,
     pub(super) temperature: Option<f64>,
     pub(super) workspace_dir: Option<std::path::PathBuf>,
+    pub(super) action_dir: Option<std::path::PathBuf>,
     pub(super) skills: Option<Vec<crate::openhuman::skills::Skill>>,
     /// Agent workflows to surface in the prompt. Populated from `load_workflows`
     /// at session start; defaults to empty when not explicitly set.

--- a/src/openhuman/agent/harness/subagent_runner/ops.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops.rs
@@ -1756,7 +1756,7 @@ impl super::super::engine::TurnObserver for SubagentObserver {
         self.usage.charged_amount_usd += usage.charged_amount_usd;
     }
 
-    fn on_assistant(
+    async fn on_assistant(
         &mut self,
         _display_text: &str,
         response_text: &str,

--- a/src/openhuman/agent/harness/tool_result_artifacts/mod.rs
+++ b/src/openhuman/agent/harness/tool_result_artifacts/mod.rs
@@ -13,7 +13,6 @@ use crate::openhuman::context::{apply_tool_result_budget, BudgetOutcome};
 use crate::openhuman::memory_store::safety::{sanitize_text, SanitizationReport};
 
 const ARTIFACT_ROOT: &str = "artifacts/tool-results";
-const MIN_PREVIEW_BUDGET_BYTES: usize = 256;
 const AGGREGATE_PREVIEW_BUDGET_BYTES: usize = 512;
 
 #[derive(Debug, Clone)]
@@ -86,9 +85,8 @@ impl ToolResultArtifactStore {
         }
         tokio::fs::write(&absolute_path, sanitized.value.as_bytes()).await?;
 
-        let preview_budget = preview_budget_bytes.max(MIN_PREVIEW_BUDGET_BYTES);
         let (preview, preview_outcome) =
-            apply_tool_result_budget(sanitized.value.clone(), preview_budget);
+            apply_tool_result_budget(sanitized.value.clone(), preview_budget_bytes);
         let redaction_note = if sanitized.report.changed() {
             " Credential/PII redaction was applied before storage and preview exposure."
         } else {
@@ -154,6 +152,16 @@ pub(crate) async fn apply_per_result_persistence(
             .await
         {
             Ok(persisted) => {
+                let (output, final_bytes) = bound_text_to_budget(persisted.output, budget_bytes);
+                if final_bytes >= original_bytes {
+                    log::debug!(
+                        "[agent][tool-result-artifacts] persisted envelope too large tool={} original_bytes={} final_bytes={} budget_bytes={} -- falling back to inline truncation",
+                        tool_name,
+                        original_bytes,
+                        final_bytes,
+                        budget_bytes
+                    );
+                }
                 log::info!(
                     "[agent][tool-result-artifacts] persisted oversized tool result tool={} original_bytes={} stored_bytes={} path={} redacted={}",
                     tool_name,
@@ -162,9 +170,8 @@ pub(crate) async fn apply_per_result_persistence(
                     persisted.path,
                     persisted.redactions.changed()
                 );
-                let final_bytes = persisted.output.len();
                 return (
-                    persisted.output,
+                    output,
                     ToolResultArtifactOutcome {
                         original_bytes,
                         final_bytes,
@@ -219,50 +226,56 @@ pub(crate) async fn spill_aggregate_tool_results(
         if total <= budget_bytes {
             break;
         }
-        if looks_like_preview_envelope(&results[idx].output) {
-            continue;
-        }
         let original = results[idx].output.clone();
-        match store
-            .persist(
-                &results[idx].name,
-                results[idx].tool_call_id.as_deref(),
-                &original,
-                AGGREGATE_PREVIEW_BUDGET_BYTES,
-                "aggregate tool-result budget exceeded",
-            )
-            .await
-        {
+        let original_len = original.len();
+        let allowed_len = budget_bytes.saturating_sub(total.saturating_sub(original_len));
+        let persisted_output = if looks_like_preview_envelope(&original) {
+            Ok(PersistedToolResult {
+                output: original.clone(),
+                path: "<existing-preview>".to_string(),
+                original_bytes: original_len,
+                stored_bytes: original_len,
+                redactions: SanitizationReport::default(),
+            })
+        } else {
+            store
+                .persist(
+                    &results[idx].name,
+                    results[idx].tool_call_id.as_deref(),
+                    &original,
+                    allowed_len.min(AGGREGATE_PREVIEW_BUDGET_BYTES),
+                    "aggregate tool-result budget exceeded",
+                )
+                .await
+        };
+        match persisted_output {
             Ok(persisted) => {
-                if persisted.output.len() >= original.len() {
-                    log::debug!(
-                        "[agent][tool-result-artifacts] aggregate spill skipped tool={} original_bytes={} envelope_bytes={} reason=no-savings",
-                        results[idx].name,
-                        original.len(),
-                        persisted.output.len()
-                    );
-                    continue;
-                }
+                let (output, final_bytes) = bound_text_to_budget(persisted.output, allowed_len);
                 total = total
-                    .saturating_sub(original.len())
-                    .saturating_add(persisted.output.len());
+                    .saturating_sub(original_len)
+                    .saturating_add(final_bytes);
                 log::info!(
                     "[agent][tool-result-artifacts] aggregate spill tool={} original_bytes={} final_bytes={} total_bytes={} path={}",
                     results[idx].name,
-                    original.len(),
-                    persisted.output.len(),
+                    original_len,
+                    final_bytes,
                     total,
                     persisted.path
                 );
-                results[idx].output = persisted.output;
+                results[idx].output = output;
             }
             Err(err) => {
                 log::warn!(
-                    "[agent][tool-result-artifacts] aggregate spill failed tool={} bytes={} err={}",
+                    "[agent][tool-result-artifacts] aggregate spill failed tool={} bytes={} err={} -- falling back to inline budget trim",
                     results[idx].name,
-                    original.len(),
+                    original_len,
                     err
                 );
+                let (output, final_bytes) = bound_text_to_budget(original, allowed_len);
+                total = total
+                    .saturating_sub(original_len)
+                    .saturating_add(final_bytes);
+                results[idx].output = output;
             }
         }
     }
@@ -270,6 +283,21 @@ pub(crate) async fn spill_aggregate_tool_results(
 
 fn looks_like_preview_envelope(value: &str) -> bool {
     value.starts_with("[tool_result_preview]\n")
+}
+
+fn bound_text_to_budget(content: String, budget_bytes: usize) -> (String, usize) {
+    if budget_bytes == 0 {
+        return (String::new(), 0);
+    }
+    let (mut output, BudgetOutcome { final_bytes, .. }) =
+        apply_tool_result_budget(content, budget_bytes);
+    if final_bytes <= budget_bytes {
+        return (output, final_bytes);
+    }
+    let cut = crate::openhuman::util::floor_char_boundary(&output, budget_bytes);
+    output.truncate(cut);
+    let final_bytes = output.len();
+    (output, final_bytes)
 }
 
 fn sanitize_component(value: &str) -> String {
@@ -356,6 +384,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn persisted_preview_is_bounded_for_small_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ToolResultArtifactStore::new(tmp.path().to_path_buf(), "session");
+        let raw = "x".repeat(800);
+
+        let (out, outcome) =
+            apply_per_result_persistence(raw, Some(&store), "shell", Some("call"), 320).await;
+
+        assert!(outcome.persisted);
+        assert!(outcome.final_bytes <= 320, "final={}", outcome.final_bytes);
+        assert_eq!(out.len(), outcome.final_bytes);
+        assert!(out.contains("[tool_result_preview]"));
+        assert!(tmp
+            .path()
+            .join("artifacts/tool-results/session/shell/call.txt")
+            .exists());
+    }
+
+    #[tokio::test]
     async fn aggregate_spills_largest_until_under_budget() {
         let tmp = tempfile::tempdir().unwrap();
         let store = ToolResultArtifactStore::new(tmp.path().to_path_buf(), "session");
@@ -389,6 +436,41 @@ mod tests {
         assert!(tmp
             .path()
             .join("artifacts/tool-results/session/largest/largest.txt")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn aggregate_forces_budget_when_envelope_has_no_savings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ToolResultArtifactStore::new(tmp.path().to_path_buf(), "session");
+        let mut results = vec![
+            ToolExecutionResult {
+                name: "one".into(),
+                output: "a".repeat(350),
+                success: true,
+                tool_call_id: Some("one".into()),
+            },
+            ToolExecutionResult {
+                name: "two".into(),
+                output: "b".repeat(350),
+                success: true,
+                tool_call_id: Some("two".into()),
+            },
+            ToolExecutionResult {
+                name: "three".into(),
+                output: "c".repeat(350),
+                success: true,
+                tool_call_id: Some("three".into()),
+            },
+        ];
+
+        spill_aggregate_tool_results(&mut results, Some(&store), 500).await;
+
+        let total: usize = results.iter().map(|result| result.output.len()).sum();
+        assert!(total <= 500, "total={total}");
+        assert!(tmp
+            .path()
+            .join("artifacts/tool-results/session/one/one.txt")
             .exists());
     }
 }

--- a/src/openhuman/agent/harness/tool_result_artifacts/mod.rs
+++ b/src/openhuman/agent/harness/tool_result_artifacts/mod.rs
@@ -1,0 +1,394 @@
+//! Persist oversized tool outputs as action-workspace artifacts.
+//!
+//! Tool results enter the model context before the provider has seen them, so
+//! this is the last cheap point to replace large raw output with a bounded
+//! preview. The full, scrubbed body is written under `action_dir` so normal
+//! file-reading tools can inspect it later without exposing internal workspace
+//! state.
+
+use std::path::{Path, PathBuf};
+
+use crate::openhuman::agent::dispatcher::ToolExecutionResult;
+use crate::openhuman::context::{apply_tool_result_budget, BudgetOutcome};
+use crate::openhuman::memory_store::safety::{sanitize_text, SanitizationReport};
+
+const ARTIFACT_ROOT: &str = "artifacts/tool-results";
+const MIN_PREVIEW_BUDGET_BYTES: usize = 256;
+const AGGREGATE_PREVIEW_BUDGET_BYTES: usize = 512;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ToolResultArtifactStore {
+    action_dir: PathBuf,
+    session_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PersistedToolResult {
+    pub output: String,
+    pub path: String,
+    pub original_bytes: usize,
+    pub stored_bytes: usize,
+    pub redactions: SanitizationReport,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ToolResultArtifactOutcome {
+    pub original_bytes: usize,
+    pub final_bytes: usize,
+    pub persisted: bool,
+}
+
+impl ToolResultArtifactOutcome {
+    pub fn unchanged(len: usize) -> Self {
+        Self {
+            original_bytes: len,
+            final_bytes: len,
+            persisted: false,
+        }
+    }
+}
+
+impl ToolResultArtifactStore {
+    pub(crate) fn new(action_dir: PathBuf, session_key: impl Into<String>) -> Self {
+        Self {
+            action_dir,
+            session_key: sanitize_component(&session_key.into()),
+        }
+    }
+
+    pub(crate) fn path_for_read_tool(&self, tool_name: &str, call_id: Option<&str>) -> String {
+        let call = call_id
+            .map(sanitize_component)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string());
+        format!(
+            "{ARTIFACT_ROOT}/{}/{}/{}.txt",
+            self.session_key,
+            sanitize_component(tool_name),
+            call
+        )
+    }
+
+    async fn persist(
+        &self,
+        tool_name: &str,
+        call_id: Option<&str>,
+        content: &str,
+        preview_budget_bytes: usize,
+        reason: &str,
+    ) -> anyhow::Result<PersistedToolResult> {
+        let sanitized = sanitize_text(content);
+        let relative_path = self.path_for_read_tool(tool_name, call_id);
+        let absolute_path = self.action_dir.join(&relative_path);
+        assert_within_action_dir(&self.action_dir, &absolute_path)?;
+        if let Some(parent) = absolute_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&absolute_path, sanitized.value.as_bytes()).await?;
+
+        let preview_budget = preview_budget_bytes.max(MIN_PREVIEW_BUDGET_BYTES);
+        let (preview, preview_outcome) =
+            apply_tool_result_budget(sanitized.value.clone(), preview_budget);
+        let redaction_note = if sanitized.report.changed() {
+            " Credential/PII redaction was applied before storage and preview exposure."
+        } else {
+            ""
+        };
+        let truncation_note = if preview_outcome.truncated {
+            format!(
+                " Preview is bounded; {} stored bytes are available via file_read.",
+                sanitized.value.len()
+            )
+        } else {
+            String::new()
+        };
+
+        let envelope = format!(
+            "[tool_result_preview]\n\
+             tool: {tool_name}\n\
+             reason: {reason}\n\
+             original_bytes: {}\n\
+             stored_bytes: {}\n\
+             artifact_path: {relative_path}\n\
+             read_with: file_read {{\"path\":\"{relative_path}\"}}\n\
+             notes: Full scrubbed output was persisted under the action workspace.{redaction_note}{truncation_note}\n\n\
+             [preview]\n{preview}",
+            content.len(),
+            sanitized.value.len(),
+        );
+
+        Ok(PersistedToolResult {
+            output: envelope,
+            path: relative_path,
+            original_bytes: content.len(),
+            stored_bytes: sanitized.value.len(),
+            redactions: sanitized.report,
+        })
+    }
+}
+
+pub(crate) async fn apply_per_result_persistence(
+    content: String,
+    store: Option<&ToolResultArtifactStore>,
+    tool_name: &str,
+    call_id: Option<&str>,
+    budget_bytes: usize,
+) -> (String, ToolResultArtifactOutcome) {
+    let original_bytes = content.len();
+    if budget_bytes == 0 || original_bytes <= budget_bytes {
+        return (
+            content,
+            ToolResultArtifactOutcome::unchanged(original_bytes),
+        );
+    }
+
+    if let Some(store) = store {
+        match store
+            .persist(
+                tool_name,
+                call_id,
+                &content,
+                budget_bytes,
+                "per-result budget exceeded",
+            )
+            .await
+        {
+            Ok(persisted) => {
+                log::info!(
+                    "[agent][tool-result-artifacts] persisted oversized tool result tool={} original_bytes={} stored_bytes={} path={} redacted={}",
+                    tool_name,
+                    persisted.original_bytes,
+                    persisted.stored_bytes,
+                    persisted.path,
+                    persisted.redactions.changed()
+                );
+                let final_bytes = persisted.output.len();
+                return (
+                    persisted.output,
+                    ToolResultArtifactOutcome {
+                        original_bytes,
+                        final_bytes,
+                        persisted: true,
+                    },
+                );
+            }
+            Err(err) => {
+                log::warn!(
+                    "[agent][tool-result-artifacts] persist failed tool={} original_bytes={} err={} — falling back to inline truncation",
+                    tool_name,
+                    original_bytes,
+                    err
+                );
+            }
+        }
+    }
+
+    let (output, BudgetOutcome { final_bytes, .. }) =
+        apply_tool_result_budget(content, budget_bytes);
+    (
+        output,
+        ToolResultArtifactOutcome {
+            original_bytes,
+            final_bytes,
+            persisted: false,
+        },
+    )
+}
+
+pub(crate) async fn spill_aggregate_tool_results(
+    results: &mut [ToolExecutionResult],
+    store: Option<&ToolResultArtifactStore>,
+    budget_bytes: usize,
+) {
+    if budget_bytes == 0 {
+        return;
+    }
+    let Some(store) = store else {
+        return;
+    };
+
+    let mut total: usize = results.iter().map(|result| result.output.len()).sum();
+    if total <= budget_bytes {
+        return;
+    }
+
+    let mut indexes: Vec<usize> = (0..results.len()).collect();
+    indexes.sort_by_key(|idx| std::cmp::Reverse(results[*idx].output.len()));
+
+    for idx in indexes {
+        if total <= budget_bytes {
+            break;
+        }
+        if looks_like_preview_envelope(&results[idx].output) {
+            continue;
+        }
+        let original = results[idx].output.clone();
+        match store
+            .persist(
+                &results[idx].name,
+                results[idx].tool_call_id.as_deref(),
+                &original,
+                AGGREGATE_PREVIEW_BUDGET_BYTES,
+                "aggregate tool-result budget exceeded",
+            )
+            .await
+        {
+            Ok(persisted) => {
+                if persisted.output.len() >= original.len() {
+                    log::debug!(
+                        "[agent][tool-result-artifacts] aggregate spill skipped tool={} original_bytes={} envelope_bytes={} reason=no-savings",
+                        results[idx].name,
+                        original.len(),
+                        persisted.output.len()
+                    );
+                    continue;
+                }
+                total = total
+                    .saturating_sub(original.len())
+                    .saturating_add(persisted.output.len());
+                log::info!(
+                    "[agent][tool-result-artifacts] aggregate spill tool={} original_bytes={} final_bytes={} total_bytes={} path={}",
+                    results[idx].name,
+                    original.len(),
+                    persisted.output.len(),
+                    total,
+                    persisted.path
+                );
+                results[idx].output = persisted.output;
+            }
+            Err(err) => {
+                log::warn!(
+                    "[agent][tool-result-artifacts] aggregate spill failed tool={} bytes={} err={}",
+                    results[idx].name,
+                    original.len(),
+                    err
+                );
+            }
+        }
+    }
+}
+
+fn looks_like_preview_envelope(value: &str) -> bool {
+    value.starts_with("[tool_result_preview]\n")
+}
+
+fn sanitize_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len().min(80));
+    for ch in value.chars().take(80) {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "unknown".to_string()
+    } else {
+        out
+    }
+}
+
+fn assert_within_action_dir(action_dir: &Path, path: &Path) -> anyhow::Result<()> {
+    if path.starts_with(action_dir) {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "tool-result artifact path escaped action_dir: {}",
+        path.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::security::{AutonomyLevel, SecurityPolicy};
+    use crate::openhuman::tools::traits::Tool;
+    use crate::openhuman::tools::FileReadTool;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn threshold_persists_preview_and_readable_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ToolResultArtifactStore::new(tmp.path().to_path_buf(), "session/one");
+        let raw = format!(
+            "{} {}",
+            "x".repeat(4096),
+            "ghp_abcdefghijklmnopqrstuvwxyz123456"
+        );
+
+        let (out, outcome) =
+            apply_per_result_persistence(raw.clone(), Some(&store), "shell", Some("call-1"), 1024)
+                .await;
+
+        assert!(outcome.persisted);
+        assert!(out.contains("artifact_path: artifacts/tool-results/session_one/shell/call-1.txt"));
+        assert!(out.contains("original_bytes:"));
+        assert!(out.contains("[preview]"));
+        assert!(!out.contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+
+        let policy = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::ReadOnly,
+            action_dir: tmp.path().to_path_buf(),
+            workspace_dir: tmp.path().to_path_buf(),
+            ..SecurityPolicy::default()
+        });
+        let reader = FileReadTool::new(policy);
+        let read = reader
+            .execute(json!({"path": "artifacts/tool-results/session_one/shell/call-1.txt"}))
+            .await
+            .unwrap();
+        assert!(!read.is_error, "{}", read.output());
+        assert!(read.output().contains("xxxx"));
+        assert!(!read
+            .output()
+            .contains("ghp_abcdefghijklmnopqrstuvwxyz123456"));
+    }
+
+    #[tokio::test]
+    async fn fallback_truncates_when_store_missing() {
+        let raw = "z".repeat(4096);
+        let (out, outcome) =
+            apply_per_result_persistence(raw, None, "shell", Some("call"), 512).await;
+        assert!(!outcome.persisted);
+        assert!(out.contains("truncated by tool_result_budget"));
+        assert!(out.len() < 4096);
+    }
+
+    #[tokio::test]
+    async fn aggregate_spills_largest_until_under_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ToolResultArtifactStore::new(tmp.path().to_path_buf(), "session");
+        let mut results = vec![
+            ToolExecutionResult {
+                name: "small".into(),
+                output: "a".repeat(100),
+                success: true,
+                tool_call_id: Some("small".into()),
+            },
+            ToolExecutionResult {
+                name: "largest".into(),
+                output: "b".repeat(2000),
+                success: true,
+                tool_call_id: Some("largest".into()),
+            },
+            ToolExecutionResult {
+                name: "medium".into(),
+                output: "c".repeat(900),
+                success: true,
+                tool_call_id: Some("medium".into()),
+            },
+        ];
+
+        spill_aggregate_tool_results(&mut results, Some(&store), 1800).await;
+
+        assert!(results[1].output.starts_with("[tool_result_preview]\n"));
+        let total: usize = results.iter().map(|result| result.output.len()).sum();
+        assert!(total <= 1800, "total={total}");
+        assert!(!results[0].output.starts_with("[tool_result_preview]\n"));
+        assert!(tmp
+            .path()
+            .join("artifacts/tool-results/session/largest/largest.txt")
+            .exists());
+    }
+}


### PR DESCRIPTION
## Summary

- Persist oversized tool outputs under the agent action workspace as run/session-scoped `artifacts/tool-results/...` files.
- Replace oversized in-context tool results with a bounded `[tool_result_preview]` envelope that includes original size, stored size, and a `file_read` path.
- Add aggregate spilling so batches with many medium tool outputs spill largest results until the total payload fits the existing tool-result budget when possible.
- Apply existing credential/PII scrubbing before storing and previewing persisted outputs, with truncation fallback when artifact persistence is unavailable.

## Problem

- Large logs, reports, search results, and integration payloads can exceed the harness tool-result budget.
- Hard truncation preserves context size but loses exact identifiers and late-output details that the agent may need to inspect later.
- Existing summarization remains useful for compression, but some outputs need a retrievable exact scrubbed body.

## Solution

- Added an agent-harness `tool_result_artifacts` module that writes scrubbed oversized outputs below `action_dir/artifacts/tool-results/<session>/<tool>/<call>.txt`.
- Threaded the artifact store through the shared tool executor so per-result budget overflow persists before history insertion.
- Made the turn observer assistant hook async so aggregate result spilling can persist files immediately before dispatcher formatting.
- Added unit coverage for threshold persistence, truncation fallback, aggregate spilling, and `file_read` read-back behavior.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — CI coverage gate will enforce final merged Vitest + cargo-llvm-cov diff coverage; focused Rust tests were added for changed harness behavior.
- [x] Coverage matrix updated — N/A: core harness behavior change, no feature matrix row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature matrix row applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release manual smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust core agent harness only; no UI, JSON-RPC, CLI controller, or Tauri command surface added.
- Security: persisted files contain scrubbed output and expose only action-workspace-relative paths usable by existing file tools.
- Compatibility: existing hard truncation remains the fallback when artifact persistence fails or no store is configured.

## Related

- Closes: #3254
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `issue/3254-persist-oversized-tool-outputs-with-prev`
- Commit SHA: `072ddb82c06b8b2eeb095bc4c5537e9248c6ee84`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — passed during pre-push hook.
- [x] `pnpm typecheck` — attempted; blocked by unrelated pre-existing frontend dependency/type errors listed below.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml tool_result_artifacts --lib` — passed, 3 tests.
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml`; `cargo check --manifest-path Cargo.toml` — passed with existing warnings.
- [x] Tauri fmt/check (if changed): Tauri not changed; pre-push `cargo check --manifest-path app/src-tauri/Cargo.toml` was attempted and blocked by missing system `glib-2.0.pc`.

### Validation Blocked

- `command: pnpm typecheck` / pre-push `pnpm compile`
- `error: TypeScript compile fails in existing intelligence graph files due missing modules/types: d3-force, pixi.js, and SimNode/WNode simulation fields.`
- `impact: Unrelated to this Rust-only agent harness change; no app/src files were modified.`

- `command: cargo check --manifest-path app/src-tauri/Cargo.toml` / pre-push `pnpm rust:check`
- `error: glib-sys build failed because system package glib-2.0 was not available via pkg-config (missing glib-2.0.pc / PKG_CONFIG_PATH).`
- `impact: Environment dependency blocker for Tauri shell check; app/src-tauri was not modified.`

### Behavior Changes

- Intended behavior change: oversized successful tool outputs are preserved as scrubbed files and replaced in model context with bounded preview/reference envelopes.
- User-visible effect: the agent can later inspect full persisted tool output via existing `file_read` paths instead of losing data to truncation.

### Parity Contract

- Legacy behavior preserved: payload summarizer still runs before the tool-result budget, and hard truncation remains the fallback when persistence is unavailable or fails.
- Guard/fallback/dispatch parity checks: shared executor path handles both normal `Agent::turn` and direct `execute_tool_call`; aggregate spill runs immediately before dispatcher formatting.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results exceeding size limits are now persisted to disk with a brief preview displayed, rather than being truncated in-place.
  * Added configurable action directory option for organizing tool result artifacts.

* **Tests**
  * Comprehensive test coverage added for artifact persistence and result aggregation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->