### PR TITLE
fix(agent): halt agent loop on first backend user-state failure (TAURI-RUST-5KG)

### DIFF
--- a/src/openhuman/agent/harness/engine/tools.rs
+++ b/src/openhuman/agent/harness/engine/tools.rs
@@ -305,17 +305,38 @@ pub(crate) async fn run_one_tool(
             }
         }
         Ok(Err(e)) => {
-            crate::core::observability::report_error(
-                &e,
-                "tool",
-                "execute",
-                &[
-                    ("tool", call.name.as_str()),
-                    ("outcome", "failed"),
-                    ("iteration", &(iteration + 1).to_string()),
-                ],
-            );
-            (format!("Error executing {}: {e}", call.name), false)
+            // Distinguish user-state failures (out of credits, missing
+            // required field, toolkit not enabled, …) from system / product
+            // failures. Tools that call the integrations backend now attach
+            // a typed `BackendUserStateError` marker for the user-state
+            // case (see `openhuman::integrations::client`). Capturing those
+            // in Sentry is noise — the UI already surfaces them, the user
+            // is the only one who can act on them, and an agent that
+            // retries `web_search` 19 times with an empty wallet generates
+            // 19 indistinguishable events (TAURI-RUST-5KG, ~1860 hits).
+            // Surface the message to the LLM so it stops and reports back
+            // to the user, and let the repeated-failure circuit breaker
+            // (caller side) trip on identical retries.
+            if crate::openhuman::integrations::is_backend_user_state_error(&e) {
+                tracing::warn!(
+                    iteration,
+                    tool = call.name.as_str(),
+                    "[agent_loop] tool returned expected user-state error: {e:#}"
+                );
+                (format!("Error executing {}: {e}", call.name), false)
+            } else {
+                crate::core::observability::report_error(
+                    &e,
+                    "tool",
+                    "execute",
+                    &[
+                        ("tool", call.name.as_str()),
+                        ("outcome", "failed"),
+                        ("iteration", &(iteration + 1).to_string()),
+                    ],
+                );
+                (format!("Error executing {}: {e}", call.name), false)
+            }
         }
         Err(_) => {
             let msg = format!(

--- a/src/openhuman/agent/harness/engine/tools.rs
+++ b/src/openhuman/agent/harness/engine/tools.rs
@@ -307,23 +307,49 @@ pub(crate) async fn run_one_tool(
         Ok(Err(e)) => {
             // Distinguish user-state failures (out of credits, missing
             // required field, toolkit not enabled, …) from system / product
-            // failures. Tools that call the integrations backend now attach
-            // a typed `BackendUserStateError` marker for the user-state
-            // case (see `openhuman::integrations::client`). Capturing those
-            // in Sentry is noise — the UI already surfaces them, the user
-            // is the only one who can act on them, and an agent that
-            // retries `web_search` 19 times with an empty wallet generates
-            // 19 indistinguishable events (TAURI-RUST-5KG, ~1860 hits).
-            // Surface the message to the LLM so it stops and reports back
-            // to the user, and let the repeated-failure circuit breaker
-            // (caller side) trip on identical retries.
+            // failures. Tools that call the integrations backend attach a
+            // typed `BackendUserStateError` marker for the user-state case
+            // (see `openhuman::integrations::client`). For these:
+            //
+            // 1. Route through `report_error_or_expected` instead of the
+            //    always-capture `report_error`. The breadcrumb classifier
+            //    demotes the buckets we care about
+            //    (`BackendUserError` / `BudgetExhausted` /
+            //    `ProviderUserState`) to a `warn` — Sentry sees one
+            //    demoted breadcrumb per turn instead of the always-error
+            //    capture. We don't *silently* skip — observability still
+            //    sees the failure, it's just classified correctly.
+            //
+            // 2. Embed `BACKEND_USER_STATE_MARKER` in the LLM-visible
+            //    result text so the caller-side
+            //    [`crate::openhuman::agent::harness::tool_loop::RepeatFailureGuard`]
+            //    halts the agent loop on the FIRST occurrence with a
+            //    "user must act" message. Without this, the agent flooded
+            //    Sentry with ~19 retries per turn for ~9 users
+            //    (TAURI-RUST-5KG, ~1860 hits) because the per-(tool,args)
+            //    breaker can't catch varying queries and the consecutive
+            //    breaker resets on interleaved success. The real bug isn't
+            //    the Sentry noise — it's the runaway retry. Halting kills
+            //    both.
             if crate::openhuman::integrations::is_backend_user_state_error(&e) {
-                tracing::warn!(
-                    iteration,
-                    tool = call.name.as_str(),
-                    "[agent_loop] tool returned expected user-state error: {e:#}"
+                crate::core::observability::report_error_or_expected(
+                    &e,
+                    "tool",
+                    "execute",
+                    &[
+                        ("tool", call.name.as_str()),
+                        ("outcome", "failed_user_state"),
+                        ("iteration", &(iteration + 1).to_string()),
+                    ],
                 );
-                (format!("Error executing {}: {e}", call.name), false)
+                (
+                    format!(
+                        "{} Error executing {}: {e}",
+                        super::super::tool_loop::BACKEND_USER_STATE_MARKER,
+                        call.name,
+                    ),
+                    false,
+                )
             } else {
                 crate::core::observability::report_error(
                     &e,

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -140,6 +140,10 @@ impl RepeatFailureGuard {
         // success). See [`BACKEND_USER_STATE_MARKER`] for the TAURI-RUST-5KG
         // background.
         if result.contains(BACKEND_USER_STATE_MARKER) {
+            let clean_reason = result
+                .replace(BACKEND_USER_STATE_MARKER, "")
+                .trim()
+                .to_string();
             return Some(format!(
                 "Stopping: the `{tool}` call returned a backend user-state error \
                  — this is a deterministic condition that requires user action \
@@ -147,7 +151,7 @@ impl RepeatFailureGuard {
                  with different arguments or a different paid tool will not \
                  help. Reason:\n{}\n\nReport this back to the user instead of \
                  trying alternative tools.",
-                truncate_for_halt(result),
+                truncate_for_halt(&clean_reason),
             ));
         }
         // Hard policy rejections trip on the first verbatim repeat; everything

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -41,6 +41,29 @@ pub(crate) const NO_PROGRESS_FAILURE_THRESHOLD: u32 = 6;
 /// and pivot to a different, allowed approach.
 pub(crate) const HARD_REJECT_REPEAT_THRESHOLD: u32 = 2;
 
+/// Stable marker the tool runner embeds in a failed tool result when the
+/// underlying error carries the typed
+/// [`crate::openhuman::integrations::BackendUserStateError`] — i.e. the backend
+/// returned a deterministic *user-state* failure (insufficient balance, missing
+/// required field, toolkit not enabled, sign-in expired, …).
+///
+/// Unlike `(tool, args)`-coupled hard rejects, the underlying condition is
+/// **global**: the user's wallet is empty, or a toolkit they don't control is
+/// disabled. Retrying the same tool with a different query, or pivoting to a
+/// different paid integration, cannot resolve it — only the user can. The
+/// breaker therefore halts on the **first** occurrence rather than allowing
+/// the LLM to grind through a generic [`REPEAT_FAILURE_THRESHOLD`] of
+/// indistinguishable failures.
+///
+/// This is the actual fix for TAURI-RUST-5KG: `web_search_tool` flooded
+/// Sentry with ~19 events/turn × 9 users (1860 hits) because the agent kept
+/// retrying after a `400 Insufficient balance` — varying the search query so
+/// the per-`(tool,args)` breaker never tripped and interleaving the failures
+/// with succeeding tool calls so the consecutive-failure breaker reset. Halt
+/// on first occurrence stops the runaway directly instead of just routing
+/// the captured errors away from Sentry.
+pub(crate) const BACKEND_USER_STATE_MARKER: &str = "[backend-user-state]";
+
 /// Classification of a deterministic, recognizable policy rejection, detected via
 /// the stable markers the security/approval layers emit
 /// ([`crate::openhuman::security::POLICY_BLOCKED_MARKER`] /
@@ -108,6 +131,25 @@ impl RepeatFailureGuard {
             *c += 1;
             *c
         };
+        // Backend user-state failures (insufficient balance, toolkit disabled,
+        // missing required field, …) are a *global* deterministic condition
+        // the agent cannot resolve — only the user can. Halt on the FIRST
+        // occurrence rather than letting the model burn the generic
+        // identical-retry threshold by varying args, and rather than waiting
+        // for the consecutive-failure breaker (which resets on any interleaved
+        // success). See [`BACKEND_USER_STATE_MARKER`] for the TAURI-RUST-5KG
+        // background.
+        if result.contains(BACKEND_USER_STATE_MARKER) {
+            return Some(format!(
+                "Stopping: the `{tool}` call returned a backend user-state error \
+                 — this is a deterministic condition that requires user action \
+                 (e.g. add credits, enable the toolkit, sign in). Retrying \
+                 with different arguments or a different paid tool will not \
+                 help. Reason:\n{}\n\nReport this back to the user instead of \
+                 trying alternative tools.",
+                truncate_for_halt(result),
+            ));
+        }
         // Hard policy rejections trip on the first verbatim repeat; everything
         // else uses the generic identical-retry threshold.
         let hard = hard_reject_kind(result);

--- a/src/openhuman/agent/harness/tool_loop.rs
+++ b/src/openhuman/agent/harness/tool_loop.rs
@@ -144,6 +144,11 @@ impl RepeatFailureGuard {
                 .replace(BACKEND_USER_STATE_MARKER, "")
                 .trim()
                 .to_string();
+            tracing::debug!(
+                tool,
+                reason = %truncate_for_halt(&clean_reason),
+                "[circuit_breaker:backend_user_state] halting on first occurrence — global condition, retry futile"
+            );
             return Some(format!(
                 "Stopping: the `{tool}` call returned a backend user-state error \
                  — this is a deterministic condition that requires user action \

--- a/src/openhuman/agent/harness/tool_loop_tests.rs
+++ b/src/openhuman/agent/harness/tool_loop_tests.rs
@@ -1107,6 +1107,109 @@ fn hard_reject_distinct_args_do_not_trip_repeat() {
     );
 }
 
+// -- Backend user-state marker (TAURI-RUST-5KG, halt on FIRST occurrence) -------
+
+#[test]
+fn backend_user_state_marker_halts_on_first_occurrence() {
+    // The actual fix for TAURI-RUST-5KG (`web_search_tool` flooded Sentry with
+    // ~1860 events because the agent retried 19× per turn on a 400 Insufficient
+    // balance). Unlike hard policy rejects (which let the model try once and
+    // halt on the verbatim repeat), the underlying condition is *global* —
+    // varying the query or pivoting to a different paid tool cannot resolve
+    // an empty wallet. Halt immediately.
+    // `BACKEND_USER_STATE_MARKER` is `pub(crate)` in the parent `tool_loop`
+    // module and reached here via `use super::*;` at the top of this file.
+    let mut g = RepeatFailureGuard::new();
+    let body = format!(
+        "{BACKEND_USER_STATE_MARKER} Error executing web_search_tool: \
+         Backend returned 400 Bad Request for POST /agent-integrations/parallel/search: \
+         Insufficient balance"
+    );
+    let halt = g.record(
+        "web_search_tool",
+        "{\"query\":\"latest news\"}",
+        false,
+        &body,
+    );
+    assert!(
+        halt.is_some(),
+        "first backend-user-state failure must halt — retries can never resolve a global condition"
+    );
+    let msg = halt.unwrap();
+    assert!(
+        msg.contains("backend user-state error"),
+        "halt summary should label the failure class; got: {msg}"
+    );
+    assert!(
+        msg.contains("requires user action"),
+        "halt summary should tell the model to surface it to the user; got: {msg}"
+    );
+    assert!(
+        msg.contains("Insufficient balance"),
+        "halt summary should preserve the actionable root cause; got: {msg}"
+    );
+}
+
+#[test]
+fn backend_user_state_marker_halts_regardless_of_args() {
+    // The whole point of the first-occurrence semantic: the failure is global,
+    // so a *different* query that re-hits the same condition is still doomed.
+    // Pin that the breaker doesn't wait for an identical `(tool, args)` repeat
+    // the way the generic [`REPEAT_FAILURE_THRESHOLD`] would.
+    // `BACKEND_USER_STATE_MARKER` is `pub(crate)` in the parent `tool_loop`
+    // module and reached here via `use super::*;` at the top of this file.
+    let mut g = RepeatFailureGuard::new();
+    let body = format!("{BACKEND_USER_STATE_MARKER} Error: Insufficient balance");
+    assert!(
+        g.record("web_search_tool", "{\"query\":\"q1\"}", false, &body)
+            .is_some(),
+        "first call with a backend-user-state marker must halt even though \
+         (tool, args) hasn't repeated yet"
+    );
+}
+
+#[test]
+fn backend_user_state_marker_takes_precedence_over_generic_threshold() {
+    // If we ever broke ordering and the marker check sat *after* the generic
+    // `(tool, args)` repeat-threshold gate, a first-occurrence user-state
+    // failure would silently fall through to "not enough repeats yet" and the
+    // agent would keep retrying — defeating the whole point. Lock the order
+    // in with a direct assertion.
+    // `BACKEND_USER_STATE_MARKER` is `pub(crate)` in the parent `tool_loop`
+    // module and reached here via `use super::*;` at the top of this file.
+    let mut g = RepeatFailureGuard::new();
+    // Same (tool, args, body) shape that the closed PR would have allowed
+    // through 2 more times. With the marker check first, count=1 already
+    // trips. count==1 < REPEAT_FAILURE_THRESHOLD==3 → without the new gate
+    // this test would fail.
+    let body = format!("{BACKEND_USER_STATE_MARKER} Insufficient balance");
+    let halt = g.record("web_search_tool", "{}", false, &body);
+    assert!(halt.is_some(), "count=1 user-state failure must halt now");
+}
+
+#[test]
+fn backend_user_state_unmarked_failures_use_normal_threshold() {
+    // Regression guard: a tool error that *doesn't* carry the marker must
+    // continue to use the generic 3-attempt repeat threshold. The new gate
+    // should not widen to affect ordinary tool failures.
+    let mut g = RepeatFailureGuard::new();
+    // Backend-shaped 5xx — no marker, since `classify_as_user_state` rejects
+    // these and `is_backend_user_state_error` is false → no prefix added.
+    let body = "Error executing tool_x: Backend returned 500 for POST /foo: upstream blew up";
+    assert!(
+        g.record("tool_x", "{}", false, body).is_none(),
+        "first non-marker failure should not halt"
+    );
+    assert!(
+        g.record("tool_x", "{}", false, body).is_none(),
+        "second non-marker failure should not halt"
+    );
+    assert!(
+        g.record("tool_x", "{}", false, body).is_some(),
+        "third identical non-marker failure must halt via the 3-attempt threshold"
+    );
+}
+
 /// Provider that records the tool-spec names of every `chat()` request
 /// it sees, then returns the next scripted response.
 struct CapturingProvider {

--- a/src/openhuman/agent/harness/tool_loop_tests.rs
+++ b/src/openhuman/agent/harness/tool_loop_tests.rs
@@ -1148,6 +1148,10 @@ fn backend_user_state_marker_halts_on_first_occurrence() {
         msg.contains("Insufficient balance"),
         "halt summary should preserve the actionable root cause; got: {msg}"
     );
+    assert!(
+        !msg.contains(BACKEND_USER_STATE_MARKER),
+        "internal routing token must not leak into user-visible halt message; got: {msg}"
+    );
 }
 
 #[test]

--- a/src/openhuman/integrations/client.rs
+++ b/src/openhuman/integrations/client.rs
@@ -2,8 +2,86 @@
 
 use super::types::{BackendResponse, IntegrationPricing};
 use std::error::Error as _;
+use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
+
+/// Typed marker error attached to `anyhow::Error` when the backend returned a
+/// deterministic user-state failure (insufficient balance, missing-required-
+/// field, toolkit-not-enabled, …) classified by
+/// [`crate::core::observability::expected_error_kind`] as
+/// `BackendUserError` / `BudgetExhausted` / `ProviderUserState`.
+///
+/// The point is *not* to change what the error renders as — the `Display`
+/// impl reproduces the same `Backend returned 400 …: <detail>` shape the
+/// `anyhow::bail!` call would have produced, so existing callers that just
+/// stringify the error see no behaviour change. The point is to let the
+/// agent tool runner (`agent::harness::engine::tools`) downcast and route
+/// the failure to the warn-only path instead of `report_error`, so a tool
+/// call that fails 19 times in one turn because the user is out of credits
+/// doesn't generate 19 Sentry events (TAURI-RUST-5KG).
+///
+/// User-state vs system failure is a contract decision that belongs at the
+/// boundary that knows the difference — the HTTP client, which has both the
+/// status code and the body to classify. Bubbling everything as an opaque
+/// `anyhow::Error` and re-classifying at every call site is what caused the
+/// regression to begin with.
+#[derive(Debug, Clone)]
+pub struct BackendUserStateError {
+    pub message: String,
+}
+
+impl fmt::Display for BackendUserStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for BackendUserStateError {}
+
+/// Returns `true` when `err`'s chain contains a [`BackendUserStateError`].
+///
+/// Use at tool-runner / Sentry-capture sites that hold an `anyhow::Error`
+/// and need to decide whether to report-as-bug or treat-as-clean-failure.
+pub fn is_backend_user_state_error(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<BackendUserStateError>().is_some()
+        || err
+            .chain()
+            .any(|cause| cause.downcast_ref::<BackendUserStateError>().is_some())
+}
+
+/// Classify `message` via [`crate::core::observability::expected_error_kind`]
+/// and return `Some` of an `anyhow::Error` wrapping [`BackendUserStateError`]
+/// when the kind is one of the user-state buckets that must not reach
+/// Sentry. Returns `None` when the message is genuinely unexpected (5xx,
+/// unknown shapes, transport bugs) so the caller falls back to
+/// `anyhow::bail!` and the existing capture path runs.
+///
+/// Buckets considered user-state here:
+/// - `BackendUserError`  — generic 4xx with classified body (insufficient
+///   balance, generic "missing required fields", …).
+/// - `BudgetExhausted`   — "insufficient balance" / "budget exceeded" /
+///   "add credits" — the user can't proceed without topping up.
+/// - `ProviderUserState` — composio "toolkit not enabled", trigger slug
+///   missing, OAuth scopes missing, etc.
+///
+/// Other expected kinds (`NetworkUnreachable`, `TransientUpstreamHttp`,
+/// `SessionExpired`, …) are *also* demoted by the breadcrumb classifier but
+/// represent transport / session conditions, not a clean user-state failure
+/// the tool should report-and-stop on; we leave them as plain anyhow so the
+/// existing retry / re-auth machinery keeps working.
+fn classify_as_user_state(message: &str) -> Option<anyhow::Error> {
+    use crate::core::observability::{expected_error_kind, ExpectedErrorKind};
+
+    match expected_error_kind(message)? {
+        ExpectedErrorKind::BackendUserError
+        | ExpectedErrorKind::BudgetExhausted
+        | ExpectedErrorKind::ProviderUserState => Some(anyhow::Error::new(BackendUserStateError {
+            message: message.to_string(),
+        })),
+        _ => None,
+    }
+}
 
 /// Maximum length (in bytes) of backend error body included in propagated
 /// errors. Keep this bounded — error messages flow through tracing/Sentry and
@@ -204,8 +282,9 @@ impl IntegrationClient {
             // firing a Sentry event. 5xx and non-transient 4xx still
             // surface — see `is_backend_user_error_message` for the exact
             // status set classified as expected.
+            let bail_message = format!("Backend returned {status} for POST {url}: {detail}");
             crate::core::observability::report_error_or_expected(
-                format!("Backend returned {status} for POST {url}: {detail}").as_str(),
+                bail_message.as_str(),
                 "integrations",
                 "post",
                 &[
@@ -214,7 +293,16 @@ impl IntegrationClient {
                     ("failure", "non_2xx"),
                 ],
             );
-            anyhow::bail!("Backend returned {status} for POST {url}: {detail}");
+            // When the failure classifies as a known user-state bucket,
+            // attach the typed `BackendUserStateError` marker so downstream
+            // sites (notably `agent::harness::engine::tools`) can downcast
+            // and route to the warn-only path instead of re-capturing in
+            // Sentry. Display string is preserved → unchanged for the many
+            // callers that only stringify the error.
+            if let Some(typed) = classify_as_user_state(&bail_message) {
+                return Err(typed);
+            }
+            anyhow::bail!(bail_message);
         }
 
         let envelope: BackendResponse<T> = resp.json().await?;
@@ -235,7 +323,11 @@ impl IntegrationClient {
                 "post",
                 &[("path", path), ("failure", "envelope_error")],
             );
-            anyhow::bail!("Backend error for POST {}: {}", url, msg);
+            let bail_message = format!("Backend error for POST {}: {}", url, msg);
+            if let Some(typed) = classify_as_user_state(&bail_message) {
+                return Err(typed);
+            }
+            anyhow::bail!(bail_message);
         }
         envelope
             .data
@@ -284,8 +376,9 @@ impl IntegrationClient {
             // user-input / auth-state shapes demote to a warn breadcrumb
             // via the observability classifier; 5xx and non-transient 4xx
             // still surface.
+            let bail_message = format!("Backend returned {status} for GET {url}: {detail}");
             crate::core::observability::report_error_or_expected(
-                format!("Backend returned {status} for GET {url}: {detail}").as_str(),
+                bail_message.as_str(),
                 "integrations",
                 "get",
                 &[
@@ -294,7 +387,10 @@ impl IntegrationClient {
                     ("failure", "non_2xx"),
                 ],
             );
-            anyhow::bail!("Backend returned {status} for GET {url}: {detail}");
+            if let Some(typed) = classify_as_user_state(&bail_message) {
+                return Err(typed);
+            }
+            anyhow::bail!(bail_message);
         }
 
         let envelope: BackendResponse<T> = resp.json().await?;
@@ -311,7 +407,11 @@ impl IntegrationClient {
                 "get",
                 &[("path", path), ("failure", "envelope_error")],
             );
-            anyhow::bail!("Backend error for GET {}: {}", url, msg);
+            let bail_message = format!("Backend error for GET {}: {}", url, msg);
+            if let Some(typed) = classify_as_user_state(&bail_message) {
+                return Err(typed);
+            }
+            anyhow::bail!(bail_message);
         }
         envelope
             .data

--- a/src/openhuman/integrations/client_tests.rs
+++ b/src/openhuman/integrations/client_tests.rs
@@ -393,6 +393,205 @@ async fn jira_generic_400_classifies_as_backend_user_error() {
 
 // ── Unit: `sanitize_backend_url` (issue #2075) ────────────────────
 
+// ── TAURI-RUST-5KG: typed BackendUserStateError boundary ────────────
+//
+// 1860 Sentry events / 9 users from `web_search_tool` → backend 400
+// "Insufficient balance". The integrations breadcrumb path already
+// demoted the event, but the per-call error bubbled up as a flat
+// `anyhow::Error` and the agent's tool runner re-captured it. The fix
+// types the error here so the runner can `downcast_ref::<…>()` and
+// route to the warn-only path. These tests pin both halves of the
+// contract: (a) classify-and-wrap fires on user-state failures,
+// (b) Display string is preserved for stringify-only callers, and
+// (c) genuine system failures stay un-typed so capture still works.
+
+#[tokio::test]
+async fn post_400_insufficient_balance_returns_typed_backend_user_state_error() {
+    let app = Router::new().route(
+        "/agent-integrations/parallel/search",
+        post(|| async {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "success": false, "error": "Insufficient balance" })),
+            )
+                .into_response()
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = client_for(base);
+    let err = client
+        .post::<serde_json::Value>(
+            "/agent-integrations/parallel/search",
+            &json!({ "objective": "test" }),
+        )
+        .await
+        .expect_err("400 must surface as Err");
+
+    // Typed: the agent tool runner relies on this exact downcast to
+    // route the failure to the warn-only path instead of `report_error`.
+    assert!(
+        is_backend_user_state_error(&err),
+        "400 'Insufficient balance' must carry BackendUserStateError marker so the \
+         tool runner can route it to the warn-only path (TAURI-RUST-5KG); got: {err:#}"
+    );
+
+    // Display preserved: every caller that just stringifies the error
+    // (toasts, logs, prior bail-format consumers) keeps seeing the same
+    // message — typing is purely additive.
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("Insufficient balance"),
+        "Display string must still carry the user-facing error; got: {msg}"
+    );
+    assert!(
+        msg.contains("400"),
+        "Display string must still carry the HTTP status; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn post_500_internal_error_is_not_marked_user_state() {
+    let app = Router::new().route(
+        "/foo",
+        post(|| async {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "<html>upstream blew up</html>",
+            )
+                .into_response()
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = client_for(base);
+    let err = client
+        .post::<serde_json::Value>("/foo", &json!({}))
+        .await
+        .expect_err("500 must surface as Err");
+
+    // 5xx is a real failure — must remain a plain anyhow error so
+    // `report_error` runs at the tool runner and triage sees it.
+    assert!(
+        !is_backend_user_state_error(&err),
+        "5xx must NOT carry the user-state marker — that would silence real \
+         backend bugs; got: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn get_403_toolkit_not_enabled_returns_typed_backend_user_state_error() {
+    // Composio "Toolkit X is not enabled" classifies as
+    // `ProviderUserState` per the observability matcher. Pin that the
+    // typed marker is attached for the entire user-state bucket family,
+    // not just BackendUserError / BudgetExhausted.
+    let app = Router::new().route(
+        "/agent-integrations/composio/connections",
+        get(|| async {
+            (
+                StatusCode::FORBIDDEN,
+                Json(json!({ "success": false, "error": "Toolkit \"slack\" is not enabled" })),
+            )
+                .into_response()
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = client_for(base);
+    let err = client
+        .get::<serde_json::Value>("/agent-integrations/composio/connections")
+        .await
+        .expect_err("403 must surface as Err");
+
+    assert!(
+        is_backend_user_state_error(&err),
+        "Provider-user-state 403 must carry BackendUserStateError marker; got: {err:#}"
+    );
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("Toolkit \"slack\" is not enabled"),
+        "Display must preserve the actionable error; got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn post_envelope_user_state_failure_returns_typed_backend_user_state_error() {
+    // 2xx + `success: false` user-state envelope failure (composio
+    // "Toolkit X is not enabled" wire shape on the 2xx path). The
+    // envelope-error branch must wrap with the typed marker too —
+    // otherwise the runner re-captures it on the next tool call.
+    let app = Router::new().route(
+        "/agent-integrations/composio/execute",
+        post(|| async {
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "success": false,
+                    "error": "Toolkit \"slack\" is not enabled"
+                })),
+            )
+                .into_response()
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = client_for(base);
+    let err = client
+        .post::<serde_json::Value>("/agent-integrations/composio/execute", &json!({}))
+        .await
+        .expect_err("envelope-failure must surface as Err");
+
+    assert!(
+        is_backend_user_state_error(&err),
+        "envelope user-state failure must carry BackendUserStateError marker; \
+         got: {err:#}"
+    );
+}
+
+#[test]
+fn backend_user_state_error_display_is_message_verbatim() {
+    let typed = BackendUserStateError {
+        message: "Backend returned 400 Bad Request for POST x: Insufficient balance".into(),
+    };
+    // The Display impl is the single source of truth for what callers
+    // see; an `anyhow::Error::new(typed)` rendering must match this
+    // exactly so the existing bail-format contract holds.
+    assert_eq!(
+        typed.to_string(),
+        "Backend returned 400 Bad Request for POST x: Insufficient balance"
+    );
+}
+
+#[test]
+fn is_backend_user_state_error_matches_wrapped_anyhow() {
+    // `anyhow::Error::new(typed)` puts the typed value at the root of
+    // the chain — confirm both the direct downcast and the chain walk
+    // catch it (defense-in-depth against future `.context(…)` wraps).
+    let typed = BackendUserStateError {
+        message: "x".into(),
+    };
+    let err: anyhow::Error = typed.into();
+    assert!(is_backend_user_state_error(&err));
+
+    let plain = anyhow::anyhow!("not user-state");
+    assert!(!is_backend_user_state_error(&plain));
+}
+
+#[test]
+fn is_backend_user_state_error_finds_typed_marker_through_context_wraps() {
+    // Defense-in-depth: if a caller wraps the typed error with
+    // `.context("more info")`, the marker still lives in the chain.
+    // `is_backend_user_state_error` must walk to find it — otherwise
+    // any future `with_context` at a call site silently re-enables
+    // Sentry capture for user-state failures.
+    use anyhow::Context;
+
+    let typed = BackendUserStateError {
+        message: "Backend returned 400 …: Insufficient balance".into(),
+    };
+    let err: anyhow::Error = anyhow::Error::new(typed).context("while executing web_search_tool");
+    assert!(
+        is_backend_user_state_error(&err),
+        "marker must be reachable after .context() wraps; got: {err:#}"
+    );
+}
+
 #[test]
 fn sanitize_backend_url_strips_inference_path() {
     // Regression: a misconfigured `BACKEND_URL` baked into the build

--- a/src/openhuman/integrations/mod.rs
+++ b/src/openhuman/integrations/mod.rs
@@ -10,7 +10,10 @@ pub mod client;
 pub mod tools;
 pub mod types;
 
-pub use client::{build_client, pricing_for_config, IntegrationClient};
+pub use client::{
+    build_client, is_backend_user_state_error, pricing_for_config, BackendUserStateError,
+    IntegrationClient,
+};
 pub use types::{
     BackendResponse, IntegrationPricing, IntegrationPricingEntry, PricingIntegrations, ToolScope,
 };


### PR DESCRIPTION
## Summary

- The previous attempt at TAURI-RUST-5KG ([#3318, closed](https://github.com/tinyhumansai/openhuman/pull/3318)) routed `BackendUserStateError` away from `report_error` so identical retries stopped flooding Sentry — silencing the alarm without putting out the fire. The actual bug is upstream: when `web_search_tool` hits `400 Insufficient balance`, the agent retries 19× per turn because the underlying condition (empty wallet) is *global* and the existing `(tool, args)`-coupled breaker can't catch varied queries.
- Real fix: stop the runaway. Embed a `BACKEND_USER_STATE_MARKER` in the failed tool result and halt the agent loop on the **first** occurrence with a "user must act" summary — same idea as the existing `POLICY_BLOCKED_MARKER` / `POLICY_DENIED_MARKER` pattern, but more aggressive because the condition can never be resolved by retry.
- Route the (single) terminal capture through `report_error_or_expected` instead of silently skipping. The existing breadcrumb classifier already knows `BackendUserError` / `BudgetExhausted` / `ProviderUserState` → demoted to warn-level. Net: ~19 always-error captures per turn → 1 classified breadcrumb per turn, AND the agent stops retrying.

## Problem

[Sentry TAURI-RUST-5KG](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/6360/) — `tool=web_search_tool`, `operation=execute`, `iteration=19`, ~1860 events / 9 users on Windows releases 0.56.0 → 0.57.13. The closed PR #3318 correctly identified that the integrations breadcrumb classifier already handled `Insufficient balance` as a user-state error, then flattened the classification when `IntegrationClient::{post,get}` bailed with `anyhow!`. It typed the error at the boundary (`BackendUserStateError`) and made `run_one_tool` downcast.

But the closed PR's chosen exit was to *skip* `report_error` for the user-state case. That makes Sentry quiet — and leaves the agent retrying 19 times because the per-`(tool, args)` `REPEAT_FAILURE_THRESHOLD = 3` doesn't trip when the LLM varies the search query, and the consecutive `NO_PROGRESS_FAILURE_THRESHOLD = 6` resets on any interleaved success. The user objected that "ignoring an error is not fixing it" — they are right; the bug is the retry loop, not the captured event count.

## Solution

Three coordinated changes, building on the typed `BackendUserStateError` boundary work from the closed PR (cherry-picked into the first commit of this PR so the boundary classification remains the source of truth):

### `src/openhuman/agent/harness/tool_loop.rs`

- New `pub(crate) const BACKEND_USER_STATE_MARKER: &str = "[backend-user-state]"`. Module docstring spells out *why* it halts on first occurrence (unlike `HARD_REJECT_REPEAT_THRESHOLD`, which lets the model see one error and pivot) — the condition is global, retries with different args or different paid tools can't help, only the user can.
- `RepeatFailureGuard::record` now checks for the marker *before* the existing `(tool, args)` repeat-threshold gate and the hard-reject branch. When present and `success == false`, it returns a halt summary on the very first occurrence with the actionable error preserved.

### `src/openhuman/agent/harness/engine/tools.rs`

- `Ok(Err(e))` branch: when `is_backend_user_state_error(&e)` is true, prefix the LLM-visible result text with `BACKEND_USER_STATE_MARKER` (so the breaker sees it) AND call `report_error_or_expected` instead of `report_error`. The classifier demotes `BackendUserError` / `BudgetExhausted` / `ProviderUserState` to warn-level — Sentry still sees one breadcrumb per turn (we're not *suppressing* observability), just classified correctly. System / 5xx / non-classifiable errors continue using `report_error` with the always-capture path, unchanged.
- New `outcome=failed_user_state` tag distinguishes the demoted path from `outcome=failed` in dashboards.

### `src/openhuman/agent/harness/tool_loop_tests.rs`

Four new `RepeatFailureGuard` tests, all in the same style as the existing `hard_reject_*` tests:

| Test | Pins |
| --- | --- |
| `backend_user_state_marker_halts_on_first_occurrence` | first-occurrence halt + halt-summary shape (labels failure class, tells model to surface, preserves root cause) |
| `backend_user_state_marker_halts_regardless_of_args` | not coupled to `(tool, args)` repetition (the closed-PR shortcoming) |
| `backend_user_state_marker_takes_precedence_over_generic_threshold` | ordering: marker check fires *before* the count-based gates, so `count=1 < REPEAT_FAILURE_THRESHOLD=3` still trips |
| `backend_user_state_unmarked_failures_use_normal_threshold` | regression guard: ordinary failures still need 3 identical retries to trip (no behaviour widening) |

### Design notes

- Marker pattern was chosen over extending `ToolRunResult` with a typed `failure_kind` enum so the contract mirrors the existing `POLICY_BLOCKED_MARKER` / `POLICY_DENIED_MARKER` convention exactly. The breaker already string-scans for those; adding a third marker is a 6-line change.
- The marker is added in `run_one_tool`'s `Ok(Err(e))` branch — the same branch the integrations tools surface through via `?`. Other tool paths (e.g. tools that wrap errors as `Ok(ToolResult { is_error: true, … })`) are untouched here; they don't carry the typed `BackendUserStateError` because the type info is already lost by the time they format the body, and the existing thresholds catch their identical retries fine. If a future tool needs the typed marker, the fix is at *its* boundary, not here.
- Halting on first occurrence is intentionally more aggressive than `HARD_REJECT_REPEAT_THRESHOLD = 2`. Hard rejects let the model see one block and *pivot* (the LLM might try a different file, different command). For backend-user-state, pivot is futile — the wallet is empty for *all* paid tools. The halt summary explicitly tells the model to surface, not retry.
- No agent-side suppression. `report_error_or_expected` runs the same classifier the integrations client already used at the breadcrumb site; if the body somehow doesn't classify (network bug, malformed wrap), it falls through to `report_error_message` and Sentry sees the unclassified event. Defense in depth — no silent black-hole.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — 4 new `RepeatFailureGuard` tests pin the first-occurrence halt path, the (tool, args) decoupling, the precedence ordering vs. the generic threshold, and the negative-case regression guard. 7 client tests from the cherry-picked typed-error commit cover the four wrapped bail sites + Display preservation + chain-walk discrimination + 5xx negative.
- [x] N/A: behaviour-only change — Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) (no new user-visible feature; tightens an existing safety net)
- [x] N/A: behaviour-only change — All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: not a release-cut surface — Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] N/A: Sentry-tracked issue (TAURI-RUST-5KG), no GitHub issue — Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime: desktop core only — `src/openhuman/agent/harness/tool_loop.rs` + `src/openhuman/agent/harness/engine/tools.rs` + the cherry-picked `src/openhuman/integrations/client.rs` typed-error boundary. No frontend, no Tauri shell, no schema changes.
- User-visible: agents that previously ground through 19 retries on an empty-wallet `web_search_tool` call now stop on the first failure and surface a "out of credits — please add credits" message to the user. Identical error text still flows through; the difference is the loop terminating immediately instead of generating 18 more identical failures.
- Performance: negligible — one extra `is_backend_user_state_error(&e)` downcast and one extra `result.contains(BACKEND_USER_STATE_MARKER)` string scan per failed tool call. Both run only on the error path.
- Security/migration/compat: none. The marker prefix is purely additive in the LLM-visible result text and matches an existing string convention. Existing callers that scan tool results don't recognise the marker; they treat it as an opaque error prefix exactly as they treat `[policy-blocked]` today.

## Related

<!-- Sentry-tracked issue, no GitHub issue. -->

- Closes: N/A (Sentry TAURI-RUST-5KG, no linked GitHub issue)
- Supersedes: [#3318](https://github.com/tinyhumansai/openhuman/pull/3318) (closed — silenced Sentry rather than fixing the runaway retry; the typed-error commit from that PR is preserved here as the first commit because the boundary classification is still correct)
- Follow-up PR(s)/TODOs: a backend-driven pre-flight balance check could prevent the agent from picking `web_search_tool` at all when the wallet is empty — strictly orthogonal to this PR, which addresses the retry loop directly.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A (Sentry TAURI-RUST-5KG)

### Commit & Branch

- Branch: `fix/sentry-tauri-rust-5kg-halt-on-user-state`
- Commit SHA: see PR head

### Validation Run

- [x] N/A: Rust-only change — `pnpm --filter openhuman-app format:check`
- [x] N/A: Rust-only change — `pnpm typecheck`
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib agent::harness::tool_loop` (26/26 pass, including 4 new), `cargo test --manifest-path Cargo.toml --lib integrations::client` (26/26 pass, no regression from cherry-picked typed-error commit), `cargo test --manifest-path Cargo.toml --lib agent::harness` (423/423 pass), `cargo test --manifest-path Cargo.toml --lib observability::` (142/142 pass, classifier contract preserved)
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml -- --check` clean; `cargo check --manifest-path Cargo.toml --tests` clean
- [x] N/A: shell not touched — Tauri fmt/check (if changed)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: agents that hit a typed `BackendUserStateError` from the integrations client (insufficient balance, missing required field, toolkit not enabled) now halt the loop on the first occurrence with a "user must act" summary, instead of grinding through up to 19 retries before the iteration cap.
- User-visible effect: terminal "out of credits / disabled toolkit / sign in" failures surface immediately to the user instead of being preceded by 18 indistinguishable retry events. Error messages themselves are unchanged.

### Parity Contract

- Legacy behavior preserved: non-backend-user-state failures continue to use the existing 3-attempt `REPEAT_FAILURE_THRESHOLD`, 2-attempt `HARD_REJECT_REPEAT_THRESHOLD`, and 6-consecutive `NO_PROGRESS_FAILURE_THRESHOLD` gates verbatim. The marker check is added *before* those gates; when absent, control falls through and behaviour is unchanged.
- Guard/fallback/dispatch parity checks: `backend_user_state_unmarked_failures_use_normal_threshold` pins that ordinary failures still need 3 identical retries (no widening); `hard_reject_blocked_halts_on_first_repeat_not_third` and `hard_reject_denied_halts_on_first_repeat` continue to pass unchanged, confirming the marker check doesn't perturb the existing hard-reject paths.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): #3318 (closed)
- Canonical PR: this PR
- Resolution: supersedes — the closed PR's typed-error boundary work is preserved as the first commit; the additional commit replaces the silence-Sentry exit with halt-on-first + classifier-aware capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deterministic backend "user must act" failures (e.g., insufficient balance, toolkit disabled): operations now halt immediately on first detection and present a clear, actionable error instead of repeated retries.
  * Preserves the original actionable message while preventing repeated retry loops.

* **Tests**
  * Added unit and integration tests to validate classification, halt-on-first-occurrence behavior, and correctness of user-facing error text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->