### PR TITLE
fix(api): suppress expected backend 401s from Sentry via typed-error flatten (#3297)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,7 +18,8 @@ pub use config::{
 };
 pub use jwt::{bearer_authorization_value, get_session_token};
 pub use rest::{
-    decrypt_handoff_blob, user_id_from_auth_me_payload, user_id_from_profile_payload,
-    BackendOAuthClient, ConnectResponse, IntegrationSummary, IntegrationTokensHandoff,
+    decrypt_handoff_blob, flatten_authed_error, user_id_from_auth_me_payload,
+    user_id_from_profile_payload, BackendApiError, BackendOAuthClient, ConnectResponse,
+    IntegrationSummary, IntegrationTokensHandoff,
 };
 pub use socket::websocket_url;

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -42,6 +42,35 @@ pub enum BackendApiError {
     },
 }
 
+/// Flatten an `authed_json` error onto the JSON-RPC `String` channel.
+///
+/// `BackendApiError::Unauthorized` is an expected backend session-lapse 401
+/// (token expired / revoked / rotated server-side), not a code bug — see the
+/// variant docs above. Callers used to flatten it with `format!("{e:#}")` /
+/// `e.to_string()`, producing `"backend rejected session token on {method}
+/// {path}"`, which matches none of the JSON-RPC session-expiry classifiers
+/// (`is_session_expired_error`, `is_session_expired_message`, the `before_send`
+/// net), so every lapsed-session 401 leaked to Sentry — TAURI-RUST-8WY
+/// (`/teams/me/usage`), TAURI-RUST-8WZ (`/payments/stripe/currentPlan`), and the
+/// rest of the authed-endpoint family (#3297).
+///
+/// Mapping `Unauthorized` onto the existing `SESSION_EXPIRED` sentinel makes the
+/// dispatcher (`core/jsonrpc.rs`) classify it as session expiry: it skips the
+/// Sentry report AND publishes `DomainEvent::SessionExpired` so the auth domain
+/// drives re-sign-in. This keys off the typed downcast — not the Display
+/// wording — so it stays correct if the `#[error(...)]` text changes, consistent
+/// with #2959's removal of brittle string-based suppression. Every other error
+/// (including `MessageNotFound`) keeps its full `{e:#}` chain so genuine
+/// failures still reach Sentry.
+pub fn flatten_authed_error(err: anyhow::Error) -> String {
+    match err.downcast_ref::<BackendApiError>() {
+        Some(BackendApiError::Unauthorized { method, path }) => {
+            format!("SESSION_EXPIRED: backend rejected session token on {method} {path}")
+        }
+        _ => format!("{err:#}"),
+    }
+}
+
 /// Extract `(provider, message_id)` from a backend channel path of the
 /// shape `…/channels/<provider>/messages/<id>`. Returns `None` for paths
 /// that do not contain this four-segment subsequence.

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    key_bytes_from_string, parse_message_path, sanitize_client_version, BackendApiError,
-    BackendOAuthClient,
+    flatten_authed_error, key_bytes_from_string, parse_message_path, sanitize_client_version,
+    BackendApiError, BackendOAuthClient,
 };
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -416,6 +416,68 @@ async fn authed_json_surfaces_unauthorized_on_401() {
     };
     assert_eq!(method, "GET");
     assert_eq!(path, "/referral/stats");
+}
+
+#[test]
+fn flatten_authed_error_maps_unauthorized_to_session_expired_sentinel() {
+    // #3297: the typed `Unauthorized` (expected session-lapse 401) must flatten
+    // onto a string that the JSON-RPC session-expiry classifiers recognise, so
+    // it is suppressed from Sentry (TAURI-RUST-8WY / 8WZ) instead of leaking.
+    let err = anyhow::Error::new(BackendApiError::Unauthorized {
+        method: "GET".to_string(),
+        path: "/teams/me/usage".to_string(),
+    });
+    let flat = flatten_authed_error(err);
+
+    // Carries the SESSION_EXPIRED sentinel + preserves method/path for logs.
+    assert!(
+        flat.contains("SESSION_EXPIRED"),
+        "expected sentinel, got: {flat}"
+    );
+    assert!(flat.contains("GET"), "method preserved: {flat}");
+    assert!(flat.contains("/teams/me/usage"), "path preserved: {flat}");
+
+    // Contract cross-check: the flattened string MUST classify as session
+    // expiry. This couples the mapping to the actual classifier — if either the
+    // sentinel or the classifier drifts, this fails instead of silently leaking.
+    assert!(
+        crate::core::observability::is_session_expired_message(&flat),
+        "flattened Unauthorized must classify as session expiry: {flat}"
+    );
+}
+
+#[test]
+fn flatten_authed_error_preserves_non_unauthorized_chain() {
+    // A non-Unauthorized failure (e.g. a transient network/timeout error) keeps
+    // its full `{e:#}` anyhow chain and must NOT be demoted to session expiry —
+    // genuine failures still reach Sentry.
+    let err = anyhow::anyhow!("connect timeout").context("backend request GET /teams/me/usage");
+    let flat = flatten_authed_error(err);
+
+    assert!(!flat.contains("SESSION_EXPIRED"), "must not map: {flat}");
+    assert!(flat.contains("connect timeout"), "cause preserved: {flat}");
+    assert!(
+        !crate::core::observability::is_session_expired_message(&flat),
+        "non-auth error must NOT classify as session expiry: {flat}"
+    );
+}
+
+#[test]
+fn flatten_authed_error_does_not_swallow_message_not_found() {
+    // `MessageNotFound` is a different expected state handled by its own callers
+    // (channel streaming/delete paths downcast it); it must not be collapsed
+    // into the session-expiry sentinel here.
+    let err = anyhow::Error::new(BackendApiError::MessageNotFound {
+        provider: "telegram".to_string(),
+        message_id: "1103".to_string(),
+    });
+    let flat = flatten_authed_error(err);
+
+    assert!(!flat.contains("SESSION_EXPIRED"), "must not map: {flat}");
+    assert!(
+        flat.contains("message not found"),
+        "display preserved: {flat}"
+    );
 }
 
 #[tokio::test]

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -592,6 +592,26 @@ fn is_session_expired_error_matches_backend_path_401() {
 }
 
 #[test]
+fn is_session_expired_error_matches_flattened_backend_unauthorized() {
+    // #3297: after #2781 the backend 401 is a typed `BackendApiError::Unauthorized`
+    // that team/billing ops flatten via `api::flatten_authed_error`. The dispatcher
+    // classifier MUST recognise that flattened string as session expiry, so the
+    // 401 is suppressed from Sentry (TAURI-RUST-8WY on `/teams/me/usage`,
+    // TAURI-RUST-8WZ on `/payments/stripe/currentPlan`) AND triggers the
+    // `SessionExpired` publish. End-to-end: build the typed error → flatten → classify.
+    let flat = crate::api::flatten_authed_error(anyhow::Error::new(
+        crate::api::BackendApiError::Unauthorized {
+            method: "GET".to_string(),
+            path: "/teams/me/usage".to_string(),
+        },
+    ));
+    assert!(
+        is_session_expired_error(&flat),
+        "flattened backend Unauthorized must classify as session expiry: {flat}"
+    );
+}
+
+#[test]
 fn is_session_expired_error_does_not_match_generic_401_unauthorized() {
     // Generic 401+unauthorized strings without HTTP-method prefix must NOT match.
     assert!(!is_session_expired_error(

--- a/src/openhuman/billing/ops.rs
+++ b/src/openhuman/billing/ops.rs
@@ -41,10 +41,15 @@ async fn get_authed_value(
     let token = require_token(config)?;
     let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| e.to_string())?;
+    // `flatten_authed_error` maps the typed `BackendApiError::Unauthorized`
+    // (expected session-lapse 401) onto the `SESSION_EXPIRED` sentinel so the
+    // JSON-RPC layer classifies it as session expiry and skips Sentry (#3297,
+    // TAURI-RUST-8WZ on `/payments/stripe/currentPlan`); every other error keeps
+    // its full `{e:#}` anyhow chain.
     client
         .authed_json(&token, method, path, body)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(crate::api::flatten_authed_error)
 }
 
 pub async fn get_current_plan(config: &Config) -> Result<RpcOutcome<Value>, String> {

--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -64,21 +64,24 @@ async fn get_authed_value(
     let token = require_token(config)?;
     let api_url = effective_backend_api_url(&config.api_url);
     let client = BackendOAuthClient::new(&api_url).map_err(|e| format!("{e:#}"))?;
-    // `{e:#}` renders the full anyhow chain. `authed_json` wraps the
-    // underlying reqwest error with `.context(format!("backend request {} {}", …))`
-    // (`api/rest.rs::authed_json`), so plain `e.to_string()` only emits
-    // the outer "backend request GET /teams" label and drops the cause
-    // (connect timeout, DNS failure, TLS handshake, non-2xx status, …)
-    // before the JSON-RPC layer reports it to Sentry. OPENHUMAN-TAURI-AD
-    // is the canonical instance: 2 events on `0.53.35` from a Russia
-    // user, all with the truncated label and elapsed_ms=49 — far too
-    // short for a real timeout, so the underlying cause is the only
-    // signal worth surfacing. Same failure mode the `report_error`
-    // doc-string in `core/observability.rs` calls out (TAURI-B2).
+    // `flatten_authed_error` maps the typed `BackendApiError::Unauthorized`
+    // (expected session-lapse 401) onto the `SESSION_EXPIRED` sentinel so the
+    // JSON-RPC layer classifies it as session expiry and skips Sentry (#3297,
+    // TAURI-RUST-8WY on `/teams/me/usage`); every other error keeps its full
+    // `{e:#}` anyhow chain. `authed_json` wraps the underlying reqwest error
+    // with `.context(format!("backend request {} {}", …))`
+    // (`api/rest.rs::authed_json`), so `{e:#}` (not `e.to_string()`) is required
+    // to surface the cause (connect timeout, DNS failure, TLS handshake, non-2xx
+    // status, …) before the JSON-RPC layer reports it to Sentry.
+    // OPENHUMAN-TAURI-AD is the canonical instance: 2 events on `0.53.35` from a
+    // Russia user, all with the truncated label and elapsed_ms=49 — far too
+    // short for a real timeout, so the underlying cause is the only signal worth
+    // surfacing. Same failure mode the `report_error` doc-string in
+    // `core/observability.rs` calls out (TAURI-B2).
     client
         .authed_json(&token, method, path, body)
         .await
-        .map_err(|e| format!("{e:#}"))
+        .map_err(crate::api::flatten_authed_error)
 }
 
 pub async fn get_usage(config: &Config) -> Result<RpcOutcome<Value>, String> {


### PR DESCRIPTION
## Summary

- After #2781 the backend 401 became a typed `BackendApiError::Unauthorized` (Display `"backend rejected session token on {method} {path}"`), but the team/billing ops flatten it to a `String` before the JSON-RPC dispatcher — and that string matches none of the session-expiry classifiers, so expected session-lapse 401s leak to Sentry.
- Add `api::flatten_authed_error`, which downcasts the typed error and maps `Unauthorized` onto the existing `SESSION_EXPIRED` sentinel (every other error keeps its full `{e:#}` chain).
- Route `team::ops` and `billing::ops` `authed_json` errors through the helper.
- Suppresses TAURI-RUST-8WY (`/teams/me/usage`, 32 users) and TAURI-RUST-8WZ (`/payments/stripe/currentPlan`, 27 users), and the rest of the authed-endpoint family, without a brittle global string match.

## Problem

`BackendApiError::Unauthorized` is an expected user-session state (token expired / revoked / rotated server-side), not a code bug — the REST layer intentionally skips `report_error` for it. But callers flatten it to a `String` (`format!("{e:#}")` / `e.to_string()`) before it reaches the JSON-RPC dispatcher (`jsonrpc.rs`). There, all three session-expiry classifiers — `is_session_expired_error` (`jsonrpc.rs`), `is_session_expired_message` (`observability.rs`), and the `before_send` net `is_session_expired_event` (`observability.rs`) — still match the *old* `"401" + "unauthorized" + "GET /"` wording. The new Display string matches none, so expected session-lapse 401s flow to Sentry on every `authed_json` caller once a session lapses.

Background: #2924 added a matching arm for `"backend rejected session token"`, but #2959 deliberately reverted all string-based Sentry suppression. So re-adding a global prose arm is the wrong direction.

## Solution

Fix it at the **ops boundary** — the last place the typed error still exists and is downcastable:

- New `api::flatten_authed_error(err: anyhow::Error) -> String`:
  - `downcast_ref::<BackendApiError>()`; on `Unauthorized { method, path }` returns `"SESSION_EXPIRED: backend rejected session token on {method} {path}"`.
  - everything else (including `MessageNotFound`) → unchanged `format!("{e:#}")`.
- The `SESSION_EXPIRED` sentinel is already recognised by `is_session_expired_message`, so the dispatcher both **suppresses the Sentry report** and **publishes `DomainEvent::SessionExpired`** (auth domain drives re-sign-in) — no new behavior wiring needed.
- `team::ops` and `billing::ops` route their `authed_json` errors through the helper (single seam → endpoint-agnostic for current and future callers).

Design decision: the mapping keys off the **typed downcast**, not the Display wording, so it stays correct if the `#[error(...)]` text changes. The sentinel is minted deterministically from the type — not a match on upstream prose — which is consistent with #2959's intent (kill brittle string matches), unlike the reverted #2924 arm. A fully-typed end-to-end channel (changing the RPC `Result<Value, String>` error type) was considered and rejected as too large for this fix.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed logic covered by 4 new focused tests (the two one-line `.map_err(flatten_authed_error)` seams in team/billing ops are exercised through the helper's own unit tests); enforced by the Rust Core Coverage CI gate.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature added/removed/renamed; internal error-routing refinement).
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: behaviour-only change`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface touched (internal Sentry error routing).`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop (staging/production) Rust core only. No UI, no schema, no migration.
- Reduces Sentry noise: expected session-lapse 401s on `authed_json` endpoints stop reporting as errors and instead drive the existing `SessionExpired` re-auth path.
- No change to genuine failures (timeouts, DNS, non-401 status, `MessageNotFound`) — they keep their full anyhow chain and still reach Sentry.
- Security: no secrets logged; sentinel carries only method + path (already non-sensitive).

## Related

- Closes: Closes #3297
- Follow-up PR(s)/TODOs: none

Sentry-Issue: TAURI-RUST-8WY
Sentry-Issue: TAURI-RUST-8WZ

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3297-backend-401-sentry-suppress`
- Commit SHA: `c585a3239bcc932a96238e58e3e488d3f60e1ccc`

### Validation Run

- [x] `N/A: no frontend changes` — `pnpm --filter openhuman-app format:check`
- [x] `N/A: no frontend changes` — `pnpm typecheck`
- [x] Focused tests: `cargo test --lib -- api::rest::key_bytes_from_string_tests::flatten core::jsonrpc::tests::is_session_expired_error_matches_flattened_backend_unauthorized` → 4 passed
- [x] Rust fmt/check (if changed): `cargo fmt` + `cargo check` (exit 0) + `cargo clippy --lib` (exit 0, no new warnings)
- [x] `N/A: Tauri shell untouched` — Tauri fmt/check

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: expected backend 401s on `team`/`billing` `authed_json` calls are classified as session expiry (suppressed from Sentry, drive `SessionExpired`).
- User-visible effect: none directly; fewer false-error reports, consistent re-auth on session lapse.

### Parity Contract

- Legacy behavior preserved: non-401 errors keep full `{e:#}` chain and still report; `MessageNotFound` not swallowed; 403 still reported.
- Guard/fallback/dispatch parity checks: covered by `flatten_authed_error_preserves_non_unauthorized_chain` and `flatten_authed_error_does_not_swallow_message_not_found`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of session expiration errors to properly detect and classify unauthorized backend responses as session expirations, enabling more accurate error messaging and session recovery.

* **Tests**
  * Added comprehensive test coverage for session expiration error classification and flattening logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
