### PR TITLE
fix(keyring): don't mint a new master key on keychain access-denied (#3311)

### DIFF
--- a/src/openhuman/keyring/encrypted_file_backend.rs
+++ b/src/openhuman/keyring/encrypted_file_backend.rs
@@ -53,10 +53,15 @@ pub fn init_master_key() {
                 Some(key)
             }
             Err(e) => {
-                log::warn!(
-                    "[keyring:encrypted_file] master key unavailable — secrets will be \
-                     inaccessible this session. Cause: {e}"
+                log::error!(
+                    "[keyring:encrypted_file] master key load FAILED — refusing to mint a \
+                     replacement (that would orphan existing secrets, #3311). Secrets are \
+                     inaccessible this session and recover once OS keychain access is \
+                     restored. Cause: {e}"
                 );
+                // Surface the denied state to the frontend instead of silently
+                // resetting — this is the "warn before reset" the issue asks for.
+                crate::openhuman::keyring_consent::policy::notify_master_key_unavailable(&e);
                 None
             }
         }
@@ -75,10 +80,49 @@ pub fn is_master_key_available() -> bool {
     MASTER_KEY.get().and_then(|k| k.as_ref()).is_some()
 }
 
+/// Abstraction over the OS-keychain entry that holds the master key.
+///
+/// Exists solely so the load-vs-mint decision in [`load_or_mint_master_key`]
+/// can be unit-tested against injected `keyring::Error` variants. A real
+/// `keyring::Entry` cannot be exercised non-interactively under `cargo test`
+/// (the first access blocks on a GUI permission prompt), so the decision logic
+/// is split out behind this trait and tested with a fake.
+trait MasterKeyEntry {
+    fn get_password(&self) -> Result<String, keyring::Error>;
+    fn set_password(&self, value: &str) -> Result<(), keyring::Error>;
+}
+
+impl MasterKeyEntry for keyring::Entry {
+    fn get_password(&self) -> Result<String, keyring::Error> {
+        keyring::Entry::get_password(self)
+    }
+    fn set_password(&self, value: &str) -> Result<(), keyring::Error> {
+        keyring::Entry::set_password(self, value)
+    }
+}
+
 fn try_load_master_key() -> Result<[u8; KEY_LEN], String> {
     let entry = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_MASTER_KEY_USERNAME)
         .map_err(|e| format!("keychain entry creation failed: {e}"))?;
+    load_or_mint_master_key(&entry)
+}
 
+/// Load the existing master key, mint a fresh one, or fail safe.
+///
+/// **Only a genuine absence (`NoEntry`) may mint a new key.** Every other error
+/// — access denied, keychain locked, platform failure — returns `Err` WITHOUT
+/// minting or calling `set_password`, leaving the keychain entry untouched.
+///
+/// This is the fix for #3311. A macOS app update can change the binary's
+/// code-signing identity (or the keychain item's ACL trust), so reading the
+/// *existing* master key fails with an access error rather than `NoEntry`. The
+/// previous code conflated the two and minted a brand-new key on access
+/// denial, orphaning every secret encrypted under the old key — a silent
+/// API-key wipe plus disconnected connectors, with no warning. Failing safe
+/// keeps the ciphertext intact so it recovers on the next launch once keychain
+/// access is restored. The catch-all `Err(e)` arm makes this independent of
+/// which exact `keyring` error variant macOS returns on the denial.
+fn load_or_mint_master_key<E: MasterKeyEntry>(entry: &E) -> Result<[u8; KEY_LEN], String> {
     match entry.get_password() {
         Ok(hex_str) => {
             let bytes = crypto::hex_decode(hex_str.trim())?;
@@ -92,7 +136,7 @@ fn try_load_master_key() -> Result<[u8; KEY_LEN], String> {
             key.copy_from_slice(&bytes);
             Ok(key)
         }
-        Err(keyring::Error::NoEntry) | Err(keyring::Error::NoStorageAccess(_)) => {
+        Err(keyring::Error::NoEntry) => {
             let key_bytes = crypto::generate_random_bytes(KEY_LEN);
             let hex_value = crypto::hex_encode(&key_bytes);
             entry
@@ -109,11 +153,14 @@ fn try_load_master_key() -> Result<[u8; KEY_LEN], String> {
             let mut key = [0u8; KEY_LEN];
             key.copy_from_slice(&key_bytes);
             log::info!(
-                "[keyring:encrypted_file] generated and stored new master key in OS keychain"
+                "[keyring:encrypted_file] no existing master key — generated and stored a new one"
             );
             Ok(key)
         }
-        Err(e) => Err(format!("OS keychain access denied or failed: {e}")),
+        Err(e) => Err(format!(
+            "OS keychain access unavailable; refusing to mint a replacement master key so \
+             existing secrets are preserved (#3311): {e}"
+        )),
     }
 }
 
@@ -320,5 +367,126 @@ impl KeyringBackend for EncryptedFileBackend {
 
     fn name(&self) -> &'static str {
         "encrypted_file"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+
+    /// In-memory fake of the keychain entry, so [`load_or_mint_master_key`] can
+    /// be exercised without a real OS keychain. `absent_error` is a fn pointer
+    /// because `keyring::Error` is not `Clone` — we mint a fresh error per call.
+    /// These tests touch no process-wide state (`load_or_mint_master_key` never
+    /// reads `MASTER_KEY`), so no OnceLock reset seam is needed.
+    struct FakeEntry {
+        stored: RefCell<Option<String>>,
+        absent_error: fn() -> keyring::Error,
+        set_calls: Cell<usize>,
+    }
+
+    impl FakeEntry {
+        fn with_stored(value: &str) -> Self {
+            Self {
+                stored: RefCell::new(Some(value.to_string())),
+                absent_error: || keyring::Error::NoEntry,
+                set_calls: Cell::new(0),
+            }
+        }
+        fn absent(err: fn() -> keyring::Error) -> Self {
+            Self {
+                stored: RefCell::new(None),
+                absent_error: err,
+                set_calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl MasterKeyEntry for FakeEntry {
+        fn get_password(&self) -> Result<String, keyring::Error> {
+            match &*self.stored.borrow() {
+                Some(v) => Ok(v.clone()),
+                None => Err((self.absent_error)()),
+            }
+        }
+        fn set_password(&self, value: &str) -> Result<(), keyring::Error> {
+            self.set_calls.set(self.set_calls.get() + 1);
+            *self.stored.borrow_mut() = Some(value.to_string());
+            Ok(())
+        }
+    }
+
+    fn access_denied() -> keyring::Error {
+        keyring::Error::NoStorageAccess(Box::new(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "keychain access denied",
+        )))
+    }
+
+    fn platform_failure() -> keyring::Error {
+        keyring::Error::PlatformFailure(Box::new(std::io::Error::other("platform boom")))
+    }
+
+    #[test]
+    fn loads_existing_key_without_minting() {
+        let hex = "ab".repeat(KEY_LEN); // 32 bytes of 0xab
+        let entry = FakeEntry::with_stored(&hex);
+        let key = load_or_mint_master_key(&entry).expect("should load existing key");
+        assert_eq!(key, [0xabu8; KEY_LEN]);
+        assert_eq!(entry.set_calls.get(), 0, "must not overwrite existing key");
+    }
+
+    #[test]
+    fn mints_only_on_no_entry() {
+        let entry = FakeEntry::absent(|| keyring::Error::NoEntry);
+        let key = load_or_mint_master_key(&entry).expect("should mint when genuinely absent");
+        assert_ne!(key, [0u8; KEY_LEN], "minted key should be random, not zero");
+        assert_eq!(
+            entry.set_calls.get(),
+            1,
+            "should store the freshly minted key"
+        );
+        // The key is now persisted, so a second load returns the same one.
+        assert!(entry.stored.borrow().is_some());
+    }
+
+    #[test]
+    fn does_not_mint_on_access_denied() {
+        // The #3311 case: existing key unreadable due to post-update ACL change.
+        let entry = FakeEntry::absent(access_denied);
+        let result = load_or_mint_master_key(&entry);
+        assert!(result.is_err(), "access denial must NOT mint a new key");
+        assert_eq!(
+            entry.set_calls.get(),
+            0,
+            "must never call set_password on access denial — that orphans existing secrets"
+        );
+        assert!(
+            entry.stored.borrow().is_none(),
+            "keychain entry left untouched"
+        );
+    }
+
+    #[test]
+    fn does_not_mint_on_platform_failure() {
+        // Variant-independence: any non-NoEntry error fails safe, not just
+        // NoStorageAccess (the exact macOS denial variant is unconfirmed).
+        let entry = FakeEntry::absent(platform_failure);
+        let result = load_or_mint_master_key(&entry);
+        assert!(result.is_err(), "platform failure must NOT mint a new key");
+        assert_eq!(entry.set_calls.get(), 0);
+    }
+
+    #[test]
+    fn rejects_wrong_length_key_without_minting() {
+        let entry = FakeEntry::with_stored("abcd"); // 2 bytes, not KEY_LEN
+        let result = load_or_mint_master_key(&entry);
+        assert!(result.is_err(), "wrong-length stored key is an error");
+        assert_eq!(
+            entry.set_calls.get(),
+            0,
+            "must not overwrite on length mismatch"
+        );
     }
 }

--- a/src/openhuman/keyring_consent/policy.rs
+++ b/src/openhuman/keyring_consent/policy.rs
@@ -141,6 +141,25 @@ pub fn retry_probe() -> KeyringStatus {
     current_status()
 }
 
+/// Surface a master-key load failure (e.g. OS keychain access denied after an
+/// app update) to the frontend by publishing the consent-required event.
+///
+/// Unlike [`check_secret_access`], this is called proactively at core startup
+/// when the encrypted-file backend cannot load its master key — so the user is
+/// warned *before* any secret read silently returns empty, rather than letting
+/// the failure pass unnoticed (the #3311 symptom: keys "wiped" with no warning).
+/// It reuses the same `CONSENT_EVENT_PUBLISHED` dedup flag as the lazy gate so
+/// we never double-publish if a secret op also hits the gate this session.
+pub fn notify_master_key_unavailable(reason: &str) {
+    warn!("{LOG_PREFIX} master key unavailable: {reason}");
+    if !CONSENT_EVENT_PUBLISHED.swap(true, Ordering::SeqCst) {
+        info!("{LOG_PREFIX} publishing KeyringConsentRequired event (master key unavailable)");
+        crate::core::event_bus::publish_global(
+            crate::core::event_bus::DomainEvent::KeyringConsentRequired,
+        );
+    }
+}
+
 /// Publish a decrypt-failure event for frontend notification.
 pub fn notify_decrypt_failure(field_name: &str, reason: &str) {
     warn!("{LOG_PREFIX} decrypt failure field={field_name} reason={reason}");


### PR DESCRIPTION
## Summary

- Stop the encrypted-file keyring backend from minting a **new** master key when the OS keychain denies access to the **existing** one.
- Root cause of #3311: on a macOS app update, a code-signing / keychain-ACL change makes the existing master key unreadable (`NoStorageAccess`, not `NoEntry`). The old code conflated the two and minted a replacement — orphaning every secret encrypted under the old key (silent API-key wipe + disconnected connectors, no warning).
- Only a genuine `NoEntry` may now mint; every other error fails safe (no mint, no `set_password` overwrite), so existing ciphertext survives and recovers on the next launch once access is restored.
- On failure, startup now logs at `error` and publishes `KeyringConsentRequired` so the frontend can warn instead of silently resetting — the "warn before reset" the issue asks for.
- Decision logic extracted behind a `MasterKeyEntry` trait and covered by unit tests for each error arm.

## Problem

Secrets (API keys, connector tokens) are encrypted in a file whose single master key lives in the OS keychain (introduced in #2660). In `try_load_master_key`, the mint-new branch matched **both** `keyring::Error::NoEntry` **and** `keyring::Error::NoStorageAccess(_)`:

```rust
Err(keyring::Error::NoEntry) | Err(keyring::Error::NoStorageAccess(_)) => {
    // generate a NEW random master key and set_password(new)
}
```

`NoEntry` means "no key was ever stored" — minting is correct. `NoStorageAccess` means "a key exists but I can't read it right now" (locked keychain, or — the #3311 trigger — an app update changed the binary's code-signing identity / the keychain item's ACL trust). Minting there overwrites the only key that can decrypt the user's secrets. Every secret is then undecryptable: API keys appear wiped, connectors disconnect, and the only log line was an `info!`. This matches the report exactly — "after update", "all at once" (single master key gates everything), "no warning".

This path only runs in staging/production (`OPENHUMAN_APP_ENV`), so dev never hit it — consistent with it only surfacing in shipped builds.

## Solution

- Split the match so **only `NoEntry` mints**. A catch-all `Err(e)` arm returns an error without minting or calling `set_password`. This is deliberately **variant-independent**: whatever variant macOS actually returns on a post-update denial, anything that isn't `NoEntry` fails safe.
- `init_master_key` now logs the failure at `error` and calls a new `keyring_consent::policy::notify_master_key_unavailable`, which publishes the existing `DomainEvent::KeyringConsentRequired` (reusing the consent-gate dedup flag so it never double-publishes).
- Extracted the get/mint decision into `load_or_mint_master_key<E: MasterKeyEntry>` behind a small trait. A real `keyring::Entry` can't be exercised under `cargo test` (first access blocks on a GUI prompt), so the trait lets a fake inject each `keyring::Error` variant. The pure decision fn touches no `MASTER_KEY` `OnceLock` state, so the tests need no global reset seam.
- **Trade-off:** a genuinely corrupted/missing entry now needs a user action (re-grant or explicit reset) instead of auto-minting. Auto-minting is exactly what destroyed the data, so failing safe is the correct default.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — `cargo test --lib openhuman::keyring` green (92 tests); the new `load_or_mint_master_key` arms are unit-tested. The 2-line event-publish glue in `init_master_key` is not unit-covered (it drives the global event bus); CI `diff-cover` is the gate.
- [x] N/A: behaviour-only bug fix — no feature row added/removed/renamed in the coverage matrix.
- [x] N/A: bug fix, no feature IDs from the matrix are affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: no release-cut smoke surface changed (the trigger — a code-signing/ACL change across an update — cannot be reproduced locally; see Impact).
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop only (staging/production keyring path). No mobile/web/CLI impact.
- **Security:** strictly safer — removes a silent destructive overwrite of the master key under access denial. No secret is logged.
- **Compatibility:** no data migration. Users whose secrets were previously *orphaned* by the old mint are not auto-recovered by this PR (the old key is already gone); this prevents *future* occurrences and surfaces the denied state instead.
- **Repro caveat (honest):** the trigger is an OS-keychain access denial caused by a code-signing/ACL change across an app update, which cannot be deterministically reproduced in a local/dev build. Confidence rests on unit tests for the branch logic, a `keyring`-crate error-variant audit, and the variant-independent catch-all design — **not** on a live end-to-end repro.

## Related

- Closes: #3311
- Follow-up PR(s)/TODOs: optional — on `NoEntry` *with* an existing non-empty `secrets.enc`, surface a "secrets locked / master key missing" state rather than minting over real data (minting still orphans data in that narrow case).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (tracked as GitHub issue #3311)
- URL: https://github.com/tinyhumansai/openhuman/issues/3311

### Commit & Branch

- Branch: `fix/3311-keyring-no-mint-on-access-denied`
- Commit SHA: `239c4c2f865972bdf0c72be9deacc460de618d99`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed
- [x] N/A: `pnpm typecheck` — no frontend files changed
- [x] Focused tests: `cargo test --lib openhuman::keyring` — 92 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` clean; `cargo clippy --lib` no new lints in changed files
- [x] N/A: Tauri fmt/check — no `app/src-tauri` files changed

### Validation Blocked

- `command:` live end-to-end repro of post-update keychain access denial
- `error:` cannot fake a code-signing / keychain-ACL change in a local build
- `impact:` branch logic verified by unit tests + crate audit instead; catch-all design is variant-independent

### Behavior Changes

- Intended behavior change: keychain access denial no longer mints/overwrites the master key; it fails safe and warns.
- User-visible effect: after an update that denies keychain access, secrets stay intact (recover once access is restored) instead of being silently wiped; the app surfaces a keyring-consent/warning signal.

### Parity Contract

- Legacy behavior preserved: genuine first-run (`NoEntry`) still mints + stores a master key exactly as before; successful load path unchanged.
- Guard/fallback/dispatch parity checks: only the access-denied/error path changed (mint → fail-safe + warn).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (verified open + 30d-merged on api-key/connector/credential/persist/migrat/secret keywords)
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for master key access failures with explicit status notifications to the frontend.

* **New Features**
  * Improved data preservation when master key access is unavailable, preventing accidental overwrite of existing encrypted secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->