### PR TITLE
fix(observability): drop [app-update] download decode/transport noise (TAURI-RUST-4JR)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1795,6 +1795,48 @@ fn event_has_updater_transient_message(event: &sentry::protocol::Event<'_>) -> b
         })
 }
 
+/// Matches Tauri-shell `[app-update]` failure log lines whose underlying cause
+/// is a transient reqwest body-decode or transport error. The shell logs at
+/// `log::error!` in `download_app_update` / `apply_app_update` /
+/// `install_app_update` (`app/src-tauri/src/lib.rs`); these events are
+/// captured by `sentry-log` and carry no `domain=update` tag, so the
+/// tag-based branch of [`is_updater_transient_event`] cannot reach them.
+///
+/// Anchored on both the `[app-update]` prefix AND a failure-line marker so
+/// arbitrary `[app-update]` info/debug lines never get silenced, and on a
+/// transient transport phrase or `error decoding response body` so signature
+/// / install / deserialize failures still reach Sentry (TAURI-RUST-4JR).
+pub fn is_app_update_shell_transient_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    if !lower.contains("[app-update]") {
+        return false;
+    }
+    let is_failure_line = lower.contains("download failed:")
+        || lower.contains("download/install failed:")
+        || lower.contains("install failed:");
+    if !is_failure_line {
+        return false;
+    }
+    lower.contains("error decoding response body") || contains_transient_transport_phrase(&lower)
+}
+
+fn event_has_app_update_shell_transient_message(event: &sentry::protocol::Event<'_>) -> bool {
+    event
+        .message
+        .as_deref()
+        .is_some_and(is_app_update_shell_transient_message)
+        || event
+            .logentry
+            .as_ref()
+            .is_some_and(|log| is_app_update_shell_transient_message(&log.message))
+        || event.exception.values.iter().any(|exception| {
+            exception
+                .value
+                .as_deref()
+                .is_some_and(is_app_update_shell_transient_message)
+        })
+}
+
 fn event_has_updater_domain(event: &sentry::protocol::Event<'_>) -> bool {
     matches!(
         event.tags.get("domain").map(String::as_str),
@@ -1847,10 +1889,19 @@ pub fn is_transient_integrations_failure(event: &sentry::protocol::Event<'_>) ->
 /// `operation=check_releases`, plus `failure/status`). Tauri's updater plugin
 /// can also emit message-only events such as
 /// `"failed to check for updates: error sending request for url (...latest.json)"`.
-/// Match both shapes, but never drop an arbitrary update-domain event unless
-/// it also has a transient status/transport marker.
+/// The Tauri shell itself logs `[app-update] download failed: ...` /
+/// `[app-update] install failed: ...` via `log::error!` (captured by
+/// `sentry-log`, no `domain` tag) when `tauri_plugin_updater::Update::download`
+/// returns a reqwest body-decode or transport error — that branch is matched
+/// by [`is_app_update_shell_transient_message`] (TAURI-RUST-4JR).
+/// Match all three shapes, but never drop an arbitrary update-domain event
+/// unless it also has a transient status/transport marker.
 pub fn is_updater_transient_event(event: &sentry::protocol::Event<'_>) -> bool {
     if event_has_updater_transient_message(event) {
+        return true;
+    }
+
+    if event_has_app_update_shell_transient_message(event) {
         return true;
     }
 
@@ -4542,6 +4593,72 @@ mod tests {
             assert!(
                 !is_updater_transient_event(&event),
                 "unrelated/actionable error must still reach Sentry: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn app_update_shell_transient_body_decode_is_dropped() {
+        // TAURI-RUST-4JR (~1.2k events / 8 days, win/macOS/linux):
+        // `app/src-tauri/src/lib.rs::download_app_update` logs
+        // `log::error!("[app-update] download failed: error decoding response body")`
+        // when `tauri_plugin_updater::Update::download()` surfaces a reqwest
+        // body-decode failure (truncated body / Content-Length mismatch /
+        // mid-stream connection drop). The event has no `domain=update` tag —
+        // sentry-log captures it from `log::error!` — so the message-only
+        // shell branch must catch it.
+        for msg in [
+            "[app-update] download failed: error decoding response body",
+            "[app-update] download/install failed: error decoding response body",
+            "[app-update] install failed: error decoding response body",
+        ] {
+            assert!(
+                is_app_update_shell_transient_message(msg),
+                "{msg} must be classified as transient app-update noise"
+            );
+            let event = event_with_tags_and_message(&[("logger", "log")], msg);
+            assert!(
+                is_updater_transient_event(&event),
+                "shell [app-update] body-decode failures must be filtered: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn app_update_shell_transient_transport_is_dropped() {
+        // The same shell error paths also surface plain reqwest transport
+        // failures (`error sending request`, `connection closed before
+        // message completed`, …). Those reuse `TRANSIENT_TRANSPORT_PHRASES`
+        // via `contains_transient_transport_phrase`.
+        let event = event_with_tags_and_message(
+            &[("logger", "log")],
+            "[app-update] download failed: error sending request for url (https://github.com/tinyhumansai/openhuman/releases/download/v0.57.5/openhuman_0.57.5_aarch64.app.tar.gz)",
+        );
+        assert!(
+            is_updater_transient_event(&event),
+            "shell [app-update] transport failures must be filtered"
+        );
+    }
+
+    #[test]
+    fn app_update_shell_actionable_failures_still_reported() {
+        // Signature verification / install failures / missing-asset errors
+        // are real bugs and must still reach Sentry even though they share
+        // the `[app-update] ... failed:` prefix. Pin the rejection contract.
+        for msg in [
+            "[app-update] download failed: signature verification failed",
+            "[app-update] install failed: failed to write to /Applications/OpenHuman.app (permission denied)",
+            "[app-update] download/install failed: invalid update manifest",
+            "[app-update] check requested (current: 0.57.5)", // info line, not a failure
+        ] {
+            assert!(
+                !is_app_update_shell_transient_message(msg),
+                "{msg} must NOT be classified as transient"
+            );
+            let event = event_with_tags_and_message(&[("logger", "log")], msg);
+            assert!(
+                !is_updater_transient_event(&event),
+                "actionable / non-failure shell log MUST still reach Sentry: {msg}"
             );
         }
     }


### PR DESCRIPTION
## Summary

- Filter Sentry TAURI-RUST-4JR: `[app-update] download failed: error decoding response body` and the transport-error variants emitted from `app/src-tauri/src/lib.rs`'s `download_app_update` / `apply_app_update` / `install_app_update`.
- Extend `is_updater_transient_event` (PR #1716) with a new shell-log branch `is_app_update_shell_transient_message` so message-only events that lack the `domain=update` tag are caught.
- Pin the rejection contract: signature verification, install / write-permission failures, invalid-manifest, and arbitrary `[app-update]` info/debug lines still reach Sentry.

## Problem

[TAURI-RUST-4JR](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5214/) — **1,175 events / 8 days, 10 users** (windows 684 / macOS 465 / linux 26). Same users repeatedly retry a flaky GitHub-releases download, each retry produces an error event. Pure transient noise; no actionable signal.

`tauri_plugin_updater::Update::download()` returns a reqwest `error decoding response body` when the response body decoding fails — truncated bytes / Content-Length mismatch / mid-stream connection drop. The shell logs the failure via `log::error!("[app-update] download failed: {e}")` (`app/src-tauri/src/lib.rs:648`), which `sentry-log` captures with `logger=log` and **no `domain=update` tag**.

The existing `is_updater_transient_event` filter from PR #1716 has two branches:
1. **Structured tags** — requires `domain=update*` plus `failure=non_2xx`/`transport` markers. Doesn't match here (no tag).
2. **Hardcoded message phrases** — four GitHub-API / `failed to check for updates` phrases. None match `[app-update] download failed: error decoding response body`.

So every flake reaches Sentry. The previous "resolution" on this issue (marked resolved in v0.57.5 on 2026-05-27, 4h after first-seen) had no accompanying code change and regressed on 2026-06-02 as expected.

## Solution

Add `is_app_update_shell_transient_message` and hook it into `is_updater_transient_event` as a third branch. Anchor the match on **three concurrent conditions** so it's narrow:

1. Message contains `[app-update]` (Tauri-shell origin)
2. AND a failure-line marker: `download failed:`, `download/install failed:`, or `install failed:` (only the three error log lines at `lib.rs:534`, `lib.rs:648`, `lib.rs:714` — never info / debug lines)
3. AND a transient marker: `error decoding response body` OR any `TRANSIENT_TRANSPORT_PHRASES` entry (reuses the shared transport-phrase list)

All three must match — a signature-verification failure has the prefix and failure-line but not the transient marker, so it still reaches Sentry. Three new tests pin the contract:

- `app_update_shell_transient_body_decode_is_dropped` — drops the verbatim TAURI-RUST-4JR message across all three error paths
- `app_update_shell_transient_transport_is_dropped` — drops `error sending request for url (https://github.com/...)` variants
- `app_update_shell_actionable_failures_still_reported` — keeps signature verification, install / write-permission, invalid manifest, and `[app-update] check requested` info line

No retry / UX change in this PR (deliberate — kept scope to the classifier; retry is the natural follow-up if download flakes prove user-visible).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — N/A: classifier-only change inside an existing observability filter; no new feature row.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature rows affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: changes only Sentry filtering; auto-update user flow is unaffected.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: tracked in Sentry (TAURI-RUST-4JR), not a GitHub issue.

## Impact

- **Runtime/platform**: Desktop only (Tauri shell logging path). No change to download / install user flow — Sentry capture is the only thing affected.
- **Performance**: Two extra substring scans (`contains("[app-update]")`, failure-marker, transient phrase) inside `before_send`. Negligible.
- **Security**: None. Only filters log strings, no data flow change.
- **Backward compat**: Additive — pure widening of `is_updater_transient_event` matching. Existing filtered events still filtered.

## Related

- Sentry: [TAURI-RUST-4JR](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/5214/) — 1,175 events / 8 days / 10 users at submission
- Related observability filters this builds on: PR #1716 (`Filter transient updater Sentry noise`), PR #1605 (`skip Sentry for transport-level update.check_releases failures`)
- Follow-up PR(s)/TODOs: None planned. If user-visible download flakes prove painful (which the 10-user / 1.2k-event ratio suggests they do), a separate PR could add a single retry around `Update::download()` with byte-0 restart — out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — Sentry-only triage
- URL: N/A

### Commit & Branch

- Branch: `fix/sentry-4jr-app-update-decode-noise`
- Commit SHA: `39c019f93`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change in `src/core/observability.rs`
- [x] `pnpm typecheck` — N/A: Rust-only change
- [x] Focused tests: `cargo test --lib core::observability::tests::app_update_shell` (3 passed) and full `core::observability::tests::` (140 passed) and `--test observability_smoke` (10 passed)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` clean (warnings pre-existing)
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri/` changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Sentry's `before_send` now drops the three `[app-update]` failure log lines when their payload contains `error decoding response body` or a known transient transport phrase. The Tauri shell still logs the failure locally (`log::error!`) and still surfaces the error status to the frontend.
- User-visible effect: None. Auto-update flow, retry button, and error toast are unchanged.

### Parity Contract

- Legacy behavior preserved: All previously filtered events still filtered (`event_has_updater_transient_message`, `event_has_updater_domain`, structured-tag branch all unchanged). New branch is additive.
- Guard/fallback/dispatch parity checks: The new helper requires `[app-update]` + failure-line + transient-marker all to match — actionable updater failures (signature verify, write-permission, invalid manifest) still reach Sentry. Pinned by `app_update_shell_actionable_failures_still_reported`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found (`gh pr list --search "5214 in:title,body"` empty; no `fix/sentry-*4jr*` branches on aniketh or upstream).
- Canonical PR: This one.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error filtering for the application updater to suppress transient, temporary failures in diagnostic reports, reducing noise while preserving critical errors that require attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->