### PR TITLE
fix(cron): halt agent-job retry on backend session-expired (TAURI-RUST-N)

### DIFF
--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -192,6 +192,55 @@ pub async fn execute_job_now(config: &Config, job: &CronJob) -> (bool, String) {
     execute_job_with_retry(config, &security, job).await
 }
 
+/// Did this failed agent-job attempt hit the backend session-expired state?
+///
+/// When the OpenHuman backend returns 401 because the user's app JWT has
+/// lapsed, [`inference::provider::ops::api_error`] already publishes
+/// [`crate::core::event_bus::DomainEvent::SessionExpired`] (via
+/// `publish_backend_session_expired`) and the credentials subscriber clears
+/// the stored session + flips the scheduler-gate `signed_out` override. The
+/// gate then halts downstream LLM work until the user re-auths.
+///
+/// The cron retry loop pre-dates that gate handshake: it sleeps with
+/// exponential backoff and retries the same job N times, every attempt
+/// hitting the same global 401, then calls `report_error` with
+/// `failure=retries_exhausted`. That generated TAURI-RUST-N (7,038 events /
+/// 5 users): a cron-fired `morning_briefing` agent grinding through retries
+/// after a single JWT lapse, every retries-exhausted capture pointing at a
+/// problem the user can only fix from the UI.
+///
+/// The right move is the same halt-on-first-occurrence pattern as
+/// `agent::harness::tool_loop::BACKEND_USER_STATE_MARKER` (#3334): the
+/// condition is global and retries can't recover it, so we stop after the
+/// first attempt. Skipping the `report_error` call too is correct because
+/// the existing classifier
+/// [`crate::core::observability::is_session_expired_message`] already
+/// considers this expected user state (`observability.rs` — anchored on
+/// `OpenHuman API error (401` + `"error":"Invalid token"`).
+///
+/// We match on `last_agent_error` first because cron's `run_agent_job`
+/// routes the raw anyhow chain there (containing the provider's wire
+/// message), while `last_output` only carries the canned user-facing
+/// notification (`AGENT_JOB_USER_FAILURE_MESSAGE` / per-variant copy). For
+/// the canned-message branch we still fall back to `last_output` so a
+/// future code path that surfaces the raw error there isn't a silent miss.
+///
+/// Restricted to `JobType::Agent`: shell jobs that happen to echo a
+/// 401-shaped string don't go through the inference layer's
+/// `SessionExpired` publish, so halting them based on stdout would skip
+/// retries the operator may want.
+fn is_session_expired_failure(
+    job_type: &JobType,
+    last_agent_error: Option<&str>,
+    last_output: &str,
+) -> bool {
+    if !matches!(job_type, JobType::Agent) {
+        return false;
+    }
+    let signal = last_agent_error.unwrap_or(last_output);
+    crate::core::observability::is_session_expired_message(signal)
+}
+
 async fn execute_job_with_retry(
     config: &Config,
     security: &SecurityPolicy,
@@ -201,6 +250,7 @@ async fn execute_job_with_retry(
     let mut last_agent_error: Option<String> = None;
     let retries = config.reliability.scheduler_retries;
     let mut backoff_ms = config.reliability.provider_backoff_ms.max(200);
+    let mut session_expired = false;
 
     for attempt in 0..=retries {
         let (success, output, agent_error) = match job.job_type {
@@ -224,6 +274,20 @@ async fn execute_job_with_retry(
             return (false, last_output);
         }
 
+        if is_session_expired_failure(
+            &job.job_type,
+            last_agent_error.as_deref(),
+            last_output.as_str(),
+        ) {
+            // Halt on the first occurrence — the inference layer already
+            // published `SessionExpired`, retries cannot recover until the
+            // user re-auths, and the classifier considers this expected
+            // user state (TAURI-RUST-N). See `is_session_expired_failure`
+            // for the full rationale.
+            session_expired = true;
+            break;
+        }
+
         if attempt < retries {
             let jitter_ms = u64::from(Utc::now().timestamp_subsec_millis() % 250);
             time::sleep(Duration::from_millis(backoff_ms + jitter_ms)).await;
@@ -231,7 +295,7 @@ async fn execute_job_with_retry(
         }
     }
 
-    if matches!(job.job_type, JobType::Agent) {
+    if matches!(job.job_type, JobType::Agent) && !session_expired {
         let report_message = last_agent_error
             .as_deref()
             .unwrap_or_else(|| last_output.as_str());

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -302,6 +302,87 @@ async fn execute_job_with_retry_exhausts_attempts() {
     assert!(output.contains("always_missing_for_retry_test"));
 }
 
+// TAURI-RUST-N — backend 401 ("Invalid token") leaks from a cron-fired agent
+// job through `last_agent_error` and the existing classifier in
+// `core::observability::is_session_expired_message` matches it (the
+// `OpenHuman API error (401` + `"error":"Invalid token"` conjunction was added
+// for OPENHUMAN-TAURI-4P0). `is_session_expired_failure` MUST consult that
+// classifier so the cron retry loop halts on the first occurrence instead of
+// retrying N times and reporting `failure=retries_exhausted` to Sentry.
+#[test]
+fn is_session_expired_failure_matches_openhuman_backend_401_in_agent_error() {
+    let wire =
+        r#"OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#;
+    assert!(
+        is_session_expired_failure(&JobType::Agent, Some(wire), AGENT_JOB_USER_FAILURE_MESSAGE),
+        "raw agent error carrying the 401 wire shape must trip the halt"
+    );
+}
+
+// Defense-in-depth: if a future code path ever surfaces the raw error in
+// `last_output` instead of `last_agent_error` (currently `run_agent_job`
+// keeps the canned user message in `last_output`), the predicate should
+// still classify. Falling back to `last_output` when `last_agent_error` is
+// `None` is what guards against that silent-miss case.
+#[test]
+fn is_session_expired_failure_matches_when_only_output_carries_signal() {
+    let wire =
+        r#"OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#;
+    assert!(is_session_expired_failure(&JobType::Agent, None, wire));
+}
+
+// Negative guard: the canned user-facing message that `run_agent_job`
+// routes into `last_output` today carries no session signal. The predicate
+// must NOT trip on it — otherwise every generic agent failure (provider
+// keys missing, tool error, network blip) would halt after one attempt and
+// stop reporting to Sentry, defeating the retry semantics for non-401
+// failures.
+#[test]
+fn is_session_expired_failure_does_not_match_canned_user_message() {
+    assert!(!is_session_expired_failure(
+        &JobType::Agent,
+        Some(AGENT_JOB_USER_FAILURE_MESSAGE),
+        AGENT_JOB_USER_FAILURE_MESSAGE,
+    ));
+}
+
+// Negative guard: ordinary provider-error wire text (e.g. a third-party
+// model rejecting a request as 400 / 500 / 429) must not be misclassified
+// as session expiry. Those failures are exactly what the retry loop +
+// `failure=retries_exhausted` capture exist for.
+#[test]
+fn is_session_expired_failure_does_not_match_ordinary_provider_error() {
+    let wire =
+        r#"OpenHuman API error (500 Internal Server Error): {"error":"Internal server error"}"#;
+    assert!(!is_session_expired_failure(&JobType::Agent, Some(wire), ""));
+
+    let byo_key = r#"OpenAI API error (401 Unauthorized): {"error":{"message":"Invalid API key","type":"invalid_request_error"}}"#;
+    assert!(
+        !is_session_expired_failure(&JobType::Agent, Some(byo_key), ""),
+        "third-party BYO-key 401 is actionable (user misconfigured their key) — must NOT classify as backend session expiry"
+    );
+}
+
+// Scope guard: the halt is restricted to `JobType::Agent` because the
+// `SessionExpired` publish + scheduler-gate handshake only fires from the
+// inference layer. A shell job that happens to echo the 401-shaped string
+// (e.g. an operator's curl wrapper printing the backend response verbatim)
+// MUST keep its existing retry semantics — the operator may want those
+// retries, and the gate has no reason to be flipped from a shell exit.
+#[test]
+fn is_session_expired_failure_does_not_halt_shell_jobs() {
+    let wire =
+        r#"OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}"#;
+    assert!(
+        !is_session_expired_failure(&JobType::Shell, None, wire),
+        "shell jobs must retain retry semantics regardless of stdout content"
+    );
+    assert!(
+        !is_session_expired_failure(&JobType::Shell, Some(wire), wire),
+        "shell jobs never populate last_agent_error — but even if a future path did, scope stays Agent-only"
+    );
+}
+
 #[tokio::test]
 async fn run_agent_job_returns_error_without_provider_key() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- **Sentry [TAURI-RUST-N](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/81/)** — 7,038 events / 5 users on `openhuman@0.57.13` (and earlier). Tags: `domain=cron`, `operation=agent_job`, `agent_id=morning_briefing`, `failure=retries_exhausted`. Title: `OpenHuman API error (401 Unauthorized): {"success":false,"error":"Invalid token"}`.
- After the user's OpenHuman backend JWT lapses, `inference::provider::ops::api_error` already publishes `DomainEvent::SessionExpired` for the 401 and intentionally skips its own `report_error`. But the cron retry loop in `cron::scheduler::execute_job_with_retry` doesn't consult that signal — it sleeps with exponential backoff, retries the same job N times (every attempt hitting the same global 401), then unconditionally calls `report_error` with `failure=retries_exhausted`.
- Fix mirrors [#3334](https://github.com/tinyhumansai/openhuman/pull/3334)'s halt-on-first-occurrence pattern (`BACKEND_USER_STATE_MARKER` in `agent::harness::tool_loop`) but at the cron retry layer: detect the session-expired wire shape via the existing `core::observability::is_session_expired_message` classifier, halt the loop on the first failed attempt, and skip the `retries_exhausted` Sentry capture (the classifier already considers this expected user state, the `SessionExpired` event already drives the credentials + scheduler-gate handshake).

## Problem

[`inference/provider/ops.rs::api_error`](https://github.com/tinyhumansai/openhuman/blob/main/src/openhuman/inference/provider/ops.rs#L935) treats backend 401/403 as expected session-lapse user state — it publishes `DomainEvent::SessionExpired` via `publish_backend_session_expired` so the credentials subscriber clears the stored session and the scheduler-gate `signed_out` override halts downstream LLM work — and deliberately does **not** call `report_error` at that site.

That handshake leaves a gap in [`cron/scheduler.rs::execute_job_with_retry`](https://github.com/tinyhumansai/openhuman/blob/main/src/openhuman/cron/scheduler.rs#L195):

```rust
for attempt in 0..=retries {
    let (success, output, agent_error) = ...;     // hits 401, fails
    last_output = output;
    if agent_error.is_some() { last_agent_error = agent_error; }
    if success { return ...; }
    if attempt < retries {
        time::sleep(...).await;                   // backoff and retry the same global-401 call
        backoff_ms = (backoff_ms * 2).min(30_000);
    }
}
if matches!(job.job_type, JobType::Agent) {
    crate::core::observability::report_error(    // → Sentry as failure=retries_exhausted
        report_message, "cron", "agent_job", &[("failure", "retries_exhausted"), ...],
    );
}
```

The retry can't recover until the user re-auths, but the loop runs to exhaustion and the final `report_error` captures a 401 wire shape the existing classifier already knows is expected user state. The 7,038-event volume is one Windows user's cron-fired `morning_briefing` agent grinding through retries every poll for ~16 days.

The classifier `core::observability::is_session_expired_message` was already extended for [OPENHUMAN-TAURI-4P0](https://sentry.tinyhumans.ai/) (`observability.rs:615`):

```rust
|| (msg.contains("OpenHuman API error (401")
    && msg.contains("\"error\":\"Invalid token\""))
```

so the predicate to consult is already there — the cron retry just never asks.

## Solution

Two coordinated changes in `src/openhuman/cron/scheduler.rs`:

### New `is_session_expired_failure` predicate

```rust
fn is_session_expired_failure(
    job_type: &JobType,
    last_agent_error: Option<&str>,
    last_output: &str,
) -> bool {
    if !matches!(job_type, JobType::Agent) {
        return false;
    }
    let signal = last_agent_error.unwrap_or(last_output);
    crate::core::observability::is_session_expired_message(signal)
}
```

- Matches on `last_agent_error` first because `run_agent_job` routes the raw `anyhow::Error::to_string()` chain there (containing the provider's wire message), while `last_output` only carries the canned user-facing notification (`AGENT_JOB_USER_FAILURE_MESSAGE` / per-variant copy).
- Falls back to `last_output` as defense-in-depth so a future code path that surfaces the raw error there isn't a silent miss.
- Restricted to `JobType::Agent` because the `SessionExpired` publish + scheduler-gate handshake only fires from the inference layer; halting a shell job because its stdout happens to echo a 401-shaped string would skip retries the operator may want.

### Halt on first occurrence in `execute_job_with_retry`

```rust
if is_session_expired_failure(
    &job.job_type,
    last_agent_error.as_deref(),
    last_output.as_str(),
) {
    session_expired = true;
    break;
}
// ...
if matches!(job.job_type, JobType::Agent) && !session_expired {
    crate::core::observability::report_error(...);  // unchanged
}
```

When `session_expired == true` we skip the `retries_exhausted` capture entirely, since the classifier already considers it expected user state.

### Why halt on first (not the standard `REPEAT_FAILURE_THRESHOLD = 3`)

Same reasoning as [#3334](https://github.com/tinyhumansai/openhuman/pull/3334)'s `BACKEND_USER_STATE_MARKER`: the condition is **global** — every paid LLM call will hit the same 401 until the user re-auths. Pivoting query / model / args can't help, so the standard retry budget is wasted attempts. Halting on first matches the `tool_loop` precedent and stops the backoff-sleep storm too.

### Why not just swap `report_error` → `report_error_or_expected`

That would quiet Sentry but leave the agent burning N×(300ms..30s exponential backoff) per cron tick on a 401 that can never recover. Per the project's `feedback-sentry-skip-vs-real-fix` convention, fix the bug (the wasted retry) rather than just demote the symptom.

## Tests

Five focused unit tests pin the predicate behaviour:

| Test | Pins |
| --- | --- |
| `..._matches_openhuman_backend_401_in_agent_error` | 401 wire shape in `last_agent_error` trips the halt |
| `..._matches_when_only_output_carries_signal` | defense-in-depth fallback when `last_agent_error == None` |
| `..._does_not_match_canned_user_message` | `AGENT_JOB_USER_FAILURE_MESSAGE` doesn't false-positive (non-401 agent failures keep normal retry semantics) |
| `..._does_not_match_ordinary_provider_error` | 500s and third-party BYO-key 401s (`OpenAI API error (401 ...) Invalid API key`) stay on the retry path (those are actionable) |
| `..._does_not_halt_shell_jobs` | scope guard — `JobType::Shell` always returns `false` regardless of stdout content |

```
$ cargo test --manifest-path Cargo.toml --lib -- openhuman::cron::scheduler::tests::is_session_expired_failure
running 5 tests
test ..._does_not_halt_shell_jobs ... ok
test ..._matches_openhuman_backend_401_in_agent_error ... ok
test ..._matches_when_only_output_carries_signal ... ok
test ..._does_not_match_ordinary_provider_error ... ok
test ..._does_not_match_canned_user_message ... ok
test result: ok. 5 passed; 0 failed; 0 ignored

$ cargo test --manifest-path Cargo.toml --lib -- openhuman::cron::scheduler
test result: ok. 55 passed; 0 failed; 0 ignored
```

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — 5 new tests cover the new predicate's match arm (positive via `last_agent_error` and via `last_output` fallback), both negative arms (canned message, ordinary provider error / BYO-key 401), and the `JobType::Shell` scope guard. The 3-line call-site change in `execute_job_with_retry` is exercised through the predicate (no separate behaviour beyond `break`).
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature added/removed/renamed; tightens an existing safety net inside the cron retry loop).
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: behaviour-only change`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal cron error routing, no release-cut surface touched.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: Sentry-tracked issue (TAURI-RUST-N), no GitHub issue.`

## Impact

- Desktop Rust core only (`src/openhuman/cron/scheduler.rs`). No UI, no schema, no migration.
- **Sentry**: stops the `failure=retries_exhausted` capture stream from cron-fired agent jobs hitting backend 401. The inference layer already publishes `SessionExpired` so the credentials/scheduler-gate handshake continues to drive re-auth.
- **Resource**: agent cron jobs no longer waste N×(300ms..30s exponential backoff) per tick on a 401 they can't recover. The morning_briefing user case dropped from ~5 attempts per poll to 1.
- **No change to genuine failures**: non-401 agent failures (provider down, tool error, network blip, third-party BYO-key 401) keep their full `REPEAT_FAILURE_THRESHOLD = scheduler_retries` retry budget and still surface `failure=retries_exhausted` to Sentry — that's what the BYO-key negative-guard test pins.
- **Security**: no secrets logged; the predicate is a string scan with conjunctive anchors already audited for cross-provider false-positives in [OPENHUMAN-TAURI-4P0](https://sentry.tinyhumans.ai/).

## Related

<!-- Sentry-tracked issue, no GitHub issue. -->

- Closes: N/A (Sentry TAURI-RUST-N, no linked GitHub issue)
- Pattern peer: [#3334](https://github.com/tinyhumansai/openhuman/pull/3334) (halt-on-first user-state failure in the agent tool loop) — same convention, different layer.
- Adjacent surface: [#3336](https://github.com/tinyhumansai/openhuman/pull/3336) (typed-error flatten for `team`/`billing` `authed_json` 401s) — covers a different code path (RPC ops), no overlap with cron retries.
- Follow-up PR(s)/TODOs: none. A `AgentError::ProviderSessionExpired` variant could give the user-visible notification more actionable copy than the current generic "Something went wrong" — strictly orthogonal, the user-visible behaviour today is already governed by `classify_agent_anyhow_for_user`.

Sentry-Issue: TAURI-RUST-N

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A (Sentry TAURI-RUST-N)

### Commit & Branch

- Branch: `fix/cron-401-session-expired-halt`
- Commit SHA: see PR head

### Validation Run

- [x] `N/A: Rust-only change` — `pnpm --filter openhuman-app format:check`
- [x] `N/A: Rust-only change` — `pnpm typecheck`
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib -- openhuman::cron::scheduler::tests::is_session_expired_failure` → 5 passed; `cargo test --manifest-path Cargo.toml --lib -- openhuman::cron::scheduler` → 55 passed (no regression)
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml -- --check` clean; `cargo check --manifest-path Cargo.toml --tests` exit 0
- [x] `N/A: Tauri shell untouched` — Tauri fmt/check

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: cron-fired agent jobs that hit a backend session-expired 401 now halt the retry loop on the first occurrence and skip the `failure=retries_exhausted` Sentry capture, instead of running through `scheduler_retries` attempts before reporting.
- User-visible effect: same canned failure notification surfaces to the user, but immediately (after ~one attempt) rather than after N×backoff sleeps. Other failure shapes unchanged.

### Parity Contract

- Legacy behavior preserved: every non-`JobType::Agent` job keeps existing retry semantics; agent jobs whose failure does not match `is_session_expired_message` keep the full `scheduler_retries` budget and still emit `failure=retries_exhausted` to Sentry. Shell jobs always return early from the predicate (no behavioural change to the shell branch).
- Guard/fallback/dispatch parity checks: covered by `..._does_not_match_canned_user_message`, `..._does_not_match_ordinary_provider_error`, `..._does_not_halt_shell_jobs`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (verified — no open PR on `cron 401`/`scheduler retry session`/`TAURI-RUST-N` keywords or `execute_job_with_retry` surface)
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session expiration handling improved—when authentication tokens become invalid, the system now immediately halts retry attempts instead of exhausting the retry queue, preventing misleading "retries exhausted" error messages.

* **Tests**
  * Added comprehensive test coverage for session expiration detection and retry halt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->