### PR TITLE
fix(memory): thread BYO embedding credential — stop Cohere empty-key 401 flood (#3354)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -263,9 +263,17 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     // no longer reaches here — but other direct-mode ops the user invokes
     // explicitly (execute / authorize) can still surface it, and it is the
     // same user-config state with no Sentry-actionable signal.
+    //
+    // `"no api key supplied"` is Cohere's exact 401 body wording when the
+    // hosted `/v2/embed` endpoint is called with an empty bearer (the BYO-key
+    // embedding path with no key configured). The `CohereEmbedding::embed`
+    // guard now fast-fails before issuing that request, but this arm demotes
+    // any residual 401 of that shape — older clients, or a present-but-rejected
+    // key — so the flood (TAURI-RUST-52S) stays out of Sentry either way.
     if lower.contains("api key not set")
         || lower.contains("missing api key")
         || lower.contains("no api key is configured")
+        || lower.contains("no api key supplied")
     {
         return Some(ExpectedErrorKind::ApiKeyMissing);
     }
@@ -2043,6 +2051,23 @@ mod tests {
             expected_error_kind(
                 "[composio] list_connections: composio direct mode selected but no api key \
                  is configured (set via composio.set_api_key RPC or config.composio.api_key)"
+            ),
+            Some(ExpectedErrorKind::ApiKeyMissing)
+        );
+    }
+
+    /// Sentry TAURI-RUST-52S: Cohere's hosted `/v2/embed` returns a 401 with
+    /// body `"no api key supplied"` when called with an empty bearer (BYO-key
+    /// embedding path, no key configured). Verbatim wire shape from the embed
+    /// client must classify as `ApiKeyMissing` so the 8.7k-event flood stays
+    /// out of Sentry even from clients that predate the call-site guard.
+    #[test]
+    fn classifies_cohere_missing_api_key_401_as_api_key_missing() {
+        assert_eq!(
+            expected_error_kind(
+                "Cohere embed API error (401 Unauthorized): \
+                 {\"id\":\"3176e92f-d18e-4019-bd43-314821504a61\",\
+                 \"message\":\"no api key supplied\"}"
             ),
             Some(ExpectedErrorKind::ApiKeyMissing)
         );

--- a/src/openhuman/agent/harness/session/builder.rs
+++ b/src/openhuman/agent/harness/session/builder.rs
@@ -864,9 +864,14 @@ impl Agent {
         )?;
 
         let local_embedding = config.workload_local_model("embeddings");
+        let embedding_api_key = crate::openhuman::embeddings::resolve_api_key(
+            config,
+            &config.memory.embedding_provider,
+        );
         let memory: Arc<dyn Memory> = Arc::from(memory_store::create_memory_with_local_ai(
             &config.memory,
             local_embedding.as_deref(),
+            &embedding_api_key,
             &config.embedding_routes,
             Some(&config.storage.provider.config),
             &config.workspace_dir,

--- a/src/openhuman/channels/runtime/startup.rs
+++ b/src/openhuman/channels/runtime/startup.rs
@@ -329,9 +329,12 @@ pub async fn start_channels(mut config: Config) -> Result<()> {
     )?;
     let temperature = config.default_temperature;
     let local_embedding = config.workload_local_model("embeddings");
+    let embedding_api_key =
+        crate::openhuman::embeddings::resolve_api_key(&config, &config.memory.embedding_provider);
     let mem: Arc<dyn Memory> = Arc::from(memory_store::create_memory_with_local_ai(
         &config.memory,
         local_embedding.as_deref(),
+        &embedding_api_key,
         &[],
         Some(&config.storage.provider.config),
         &config.workspace_dir,

--- a/src/openhuman/embeddings/cohere.rs
+++ b/src/openhuman/embeddings/cohere.rs
@@ -95,6 +95,25 @@ impl EmbeddingProvider for CohereEmbedding {
             return Ok(Vec::new());
         }
 
+        // Fast-fail when no API key is configured. Cohere's hosted `/v2/embed`
+        // always requires a bearer token; without this guard we POST
+        // `Authorization: Bearer ` (empty) and Cohere returns a 401 "no api key
+        // supplied" on every call. That 401 is not retryable, so each embed
+        // attempt bails and reports an error — the memory pipeline re-embeds per
+        // document and floods Sentry (TAURI-RUST-52S: 8.7k events from a single
+        // misconfigured user). Bailing here skips the wasted request entirely,
+        // and the "API key not set" wording is demoted to a breadcrumb by the
+        // `ApiKeyMissing` classifier in
+        // `core::observability::expected_error_kind` instead of surfacing as a
+        // Sentry event. Scoped to Cohere on purpose: the OpenAI-compatible
+        // provider legitimately supports keyless local/custom endpoints, so it
+        // omits the header rather than bailing.
+        if self.api_key.trim().is_empty() {
+            anyhow::bail!(
+                "Cohere API key not set. Configure via the web UI or set the appropriate env var."
+            );
+        }
+
         let url = format!("{}/v2/embed", self.base_url);
 
         tracing::debug!(
@@ -251,6 +270,24 @@ mod tests {
     async fn embed_empty_returns_empty() {
         let p = CohereEmbedding::new("k", "", 0);
         assert!(p.embed(&[]).await.unwrap().is_empty());
+    }
+
+    /// Missing / whitespace-only API key bails before any HTTP request with the
+    /// classifiable "API key not set" wording (TAURI-RUST-52S). `with_base_url`
+    /// points at an address nothing is listening on, so the assertion that the
+    /// error is the key-guard message — not a connection error — proves no
+    /// request was attempted.
+    #[tokio::test]
+    async fn embed_missing_api_key_bails_without_request() {
+        for key in ["", "   "] {
+            let p = CohereEmbedding::new(key, "embed-english-v3.0", 1024)
+                .with_base_url("http://127.0.0.1:1");
+            let err = p.embed(&["hello"]).await.unwrap_err().to_string();
+            assert!(
+                err.contains("API key not set"),
+                "expected key-guard message for key {key:?}, got: {err}"
+            );
+        }
     }
 
     // ── 429 backoff tests ──────────────────────────────────────

--- a/src/openhuman/embeddings/rpc.rs
+++ b/src/openhuman/embeddings/rpc.rs
@@ -414,3 +414,67 @@ pub(crate) fn resolve_api_key(config: &Config, provider_name: &str) -> String {
         .flatten()
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// The seam the memory factory depends on (TAURI-RUST-52S fix): the three
+    /// `create_memory_with_local_ai` call sites resolve the user's stored BYO
+    /// embedding credential via `resolve_api_key` and thread it into the
+    /// provider. If this lookup silently returns "" for a configured key —
+    /// wrong cred slug, encryption mismatch, profile-store regression — the
+    /// memory pipeline reverts to sending an empty bearer and Cohere 401s on
+    /// every embed. Lock the round-trip: store under `embeddings:<slug>`, read
+    /// it back; an unrelated provider must stay empty (no cross-bleed).
+    #[test]
+    fn resolve_api_key_returns_stored_embeddings_credential() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.config_path = tmp.path().join("config.toml");
+
+        // Nothing stored yet → empty (the empty-key guard's "" input).
+        assert_eq!(resolve_api_key(&config, "cohere"), "");
+
+        // Store a Cohere embeddings key exactly as `set_api_key` does.
+        AuthService::from_config(&config)
+            .store_provider_token(
+                "embeddings:cohere",
+                "default",
+                "sk-cohere-test",
+                HashMap::new(),
+                true,
+            )
+            .unwrap();
+
+        // Resolve returns it; a provider with no stored key stays empty.
+        assert_eq!(resolve_api_key(&config, "cohere"), "sk-cohere-test");
+        assert_eq!(resolve_api_key(&config, "voyage"), "");
+    }
+
+    /// `custom:<url>` providers must look up under the `embeddings:custom`
+    /// slug (the inline URL is not part of the credential key), mirroring the
+    /// slug normalization in `embed`/`set_api_key`.
+    #[test]
+    fn resolve_api_key_normalizes_custom_prefix_to_custom_slug() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.config_path = tmp.path().join("config.toml");
+
+        AuthService::from_config(&config)
+            .store_provider_token(
+                "embeddings:custom",
+                "default",
+                "sk-custom-test",
+                HashMap::new(),
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            resolve_api_key(&config, "custom:http://localhost:1234"),
+            "sk-custom-test"
+        );
+    }
+}

--- a/src/openhuman/memory_store/factories.rs
+++ b/src/openhuman/memory_store/factories.rs
@@ -298,7 +298,10 @@ pub fn create_memory(
     config: &MemoryConfig,
     workspace_dir: &Path,
 ) -> anyhow::Result<Box<dyn Memory>> {
-    create_memory_full(config, &[], None, None, workspace_dir)
+    // No `Config` in scope here (tests + migration), so no credential store to
+    // read — pass an empty key. Callers that select a keyed BYO provider must
+    // use `create_memory_with_local_ai`, which resolves the stored credential.
+    create_memory_full(config, &[], None, None, "", workspace_dir)
 }
 
 /// Create a memory instance honouring the unified per-workload embedding
@@ -309,9 +312,17 @@ pub fn create_memory(
 /// `None`. Used by top-level entry points (agent harness, channels runtime)
 /// that have the full `Config` in scope. The local-AI opt-in flips the
 /// embedder to Ollama when `Some`.
+///
+/// `embedding_api_key` is the user's stored credential for the selected BYO
+/// embedding provider, resolved by the caller via
+/// [`crate::openhuman::embeddings::resolve_api_key`] (empty string when none is
+/// configured). It is threaded into the keyed providers (cohere/openai/voyage/
+/// custom) so they authenticate instead of sending an empty bearer; cloud /
+/// managed / ollama / none ignore it.
 pub fn create_memory_with_local_ai(
     memory: &MemoryConfig,
     local_embedding_model: Option<&str>,
+    embedding_api_key: &str,
     embedding_routes: &[EmbeddingRouteConfig],
     storage_provider: Option<&StorageProviderConfig>,
     workspace_dir: &Path,
@@ -321,6 +332,7 @@ pub fn create_memory_with_local_ai(
         embedding_routes,
         storage_provider,
         local_embedding_model,
+        embedding_api_key,
         workspace_dir,
     )
 }
@@ -370,6 +382,7 @@ fn create_memory_full(
     _embedding_routes: &[EmbeddingRouteConfig],
     _storage_provider: Option<&StorageProviderConfig>,
     local_embedding_model: Option<&str>,
+    embedding_api_key: &str,
     workspace_dir: &Path,
 ) -> anyhow::Result<Box<dyn Memory>> {
     // 1. Resolve the intended provider from config.
@@ -413,11 +426,29 @@ fn create_memory_full(
          (local_ai_opt_in={local_ai_opt_in} gate_triggered={gate_triggered})",
     );
 
-    // 3. Create the embedding provider.
+    // 3. Create the embedding provider, threading the user's stored BYO
+    //    credential. The keyless `create_embedding_provider` left the API key
+    //    empty for *every* provider, so a user who selected Cohere — even with
+    //    a valid key configured — sent an empty `Bearer ` and got a guaranteed
+    //    401 "no api key supplied" on every embed (TAURI-RUST-52S), and the
+    //    same gap silently broke BYO OpenAI / Voyage memory embeddings.
+    //    cloud/managed/ollama/none ignore the key; the keyed providers now
+    //    actually receive it. `embedding_api_key` is "" when no credential is
+    //    stored, which the per-provider guards reject fast. A `custom:<url>`
+    //    provider keeps its inline endpoint (the factory's `custom:` arm strips
+    //    the prefix), so `custom_endpoint` stays `None` here. The key is never
+    //    logged — the warning carries only provider/model/dims.
     let embedder: Arc<dyn EmbeddingProvider> = Arc::from(
-        embeddings::create_embedding_provider(&provider, &model, dims).inspect_err(|err| {
+        embeddings::create_embedding_provider_with_credentials(
+            &provider,
+            &model,
+            dims,
+            embedding_api_key,
+            None,
+        )
+        .inspect_err(|err| {
             log::warn!(
-                "[memory::factory] create_embedding_provider failed provider={provider} model={model} dims={dims}: {err}",
+                "[memory::factory] create_embedding_provider_with_credentials failed provider={provider} model={model} dims={dims}: {err}",
             );
         })?,
     );

--- a/src/openhuman/runtime_node/ops.rs
+++ b/src/openhuman/runtime_node/ops.rs
@@ -48,11 +48,14 @@ fn build_runtime_tools(config: &Config) -> Result<Vec<Box<dyn Tool>>, String> {
     .map_err(|e| e.to_string())?;
     let runtime: Arc<dyn RuntimeAdapter> = Arc::new(NativeRuntime::new());
     let local_embedding = config.workload_local_model("embeddings");
+    let embedding_api_key =
+        crate::openhuman::embeddings::resolve_api_key(config, &config.memory.embedding_provider);
     trace!("[runtime_node::ops] build_runtime_tools: create_memory_with_local_ai");
     let memory: Arc<dyn Memory> = Arc::from(
         crate::openhuman::memory_store::create_memory_with_local_ai(
             &config.memory,
             local_embedding.as_deref(),
+            &embedding_api_key,
             &config.embedding_routes,
             Some(&config.storage.provider.config),
             &config.workspace_dir,


### PR DESCRIPTION
## Summary

- **Root-cause fix:** the memory pipeline never passed the user's embedding API key — it built the embedder with the keyless factory, so a BYO provider (Cohere/OpenAI/Voyage) always sent an empty bearer. Now the stored credential is resolved and threaded through.
- **Safety net:** fast-fail `CohereEmbedding::embed()` on an empty key (no wasted request), and classify Cohere's `"no api key supplied"` 401 as `ApiKeyMissing` so any residual event is demoted.
- Fixes Sentry TAURI-RUST-52S (8.7k events, 1 user). Also silently un-breaks BYO OpenAI/Voyage memory embeddings.

## Problem

A user selected Cohere as their embedding provider. Every memory embed produced `401 "no api key supplied"`; not retryable, so each call reported an error and the per-document memory pipeline flooded Sentry.

The real cause: `memory_store/factories.rs` built the embedder via `create_embedding_provider(provider, model, dims)` — the **keyless** factory. The user's configured key (stored under `embeddings:<slug>`) was **never resolved or passed**, for *any* provider. The RPC "test embed" path (`embeddings/rpc.rs`) did it correctly via `resolve_api_key` + `create_embedding_provider_with_credentials`; the memory pipeline did not. So even a *correctly-keyed* Cohere setup got empty-bearer 401s.

The Sentry event escaped demotion because `expected_error_kind()` only matched `"api key not set"` / `"missing api key"` / `"no api key is configured"` — Cohere's `"no api key supplied"` wording matched none.

## Solution

**Real fix — thread the credential (`memory_store/factories.rs` + 3 call sites):**
- `create_memory_full` / `create_memory_with_local_ai` take an `embedding_api_key: &str` and build via `create_embedding_provider_with_credentials`.
- The three production callers that hold the full `Config` — `runtime_node::ops`, `agent::harness::session::builder`, `channels::runtime::startup` — resolve it with `resolve_api_key(config, &config.memory.embedding_provider)`.
- cloud/managed/ollama/none ignore the key; keyed providers now authenticate. `create_memory` (tests + migration, no `Config` in scope) passes `""`, preserving prior behavior. The key is never logged.

**Safety net (defense-in-depth):**
- `embeddings/cohere.rs`: bail before the request when the key is empty/whitespace, with a classifiable `"API key not set"` message — covers genuinely-unconfigured setups without a wasted round-trip or a Sentry event.
- `core/observability.rs`: add `"no api key supplied"` to the `ApiKeyMissing` arm for any residual 401 (older clients without the guard, or a present-but-rejected key).

Sibling: #2898 (429 embed-flood fix, same class).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `resolve_api_key` credential round-trip + custom-slug normalization; empty/whitespace Cohere key guard; verbatim Cohere 401-body classification; existing over-suppression guard still green
- [x] **Diff coverage ≥ 80%** — new/changed lines exercised by the new unit tests plus existing memory-creation tests that drive `create_memory_full`
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature row added/removed/renamed)
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature touched`
- [x] No new external network dependencies introduced — fix removes wasted calls; tests use the in-process credential store + axum mock
- [x] Manual smoke checklist updated — `N/A: no release-cut surface touched`
- [x] Linked issue closed via `Closes #NNN` in `## Related`

## Impact

- Desktop Rust core (embeddings + memory factory + observability). No UI, RPC, or schema change.
- BYO embedding providers (Cohere/OpenAI/Voyage) in the **memory pipeline** now actually authenticate — previously dead without a network-visible cause. Managed/cloud/ollama paths unchanged.
- A genuinely keyless setup fails fast instead of looping 401s; Sentry signal stays honest.
- No migration/compat impact.

## Related

- Closes: #3354
- Sentry-Issue: TAURI-RUST-52S
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3354-cohere-empty-key-flood`
- Commit SHA: `9eabd86e7`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no `app/` files changed
- [x] N/A: `pnpm typecheck` — no TypeScript changed
- [x] Focused tests: `embeddings::rpc::tests` (2 ok), `embeddings::cohere` (7 ok), `memory_store::factories` (16 ok), `core::observability::tests::classif*` (46 ok)
- [x] Rust fmt/check (if changed): `cargo fmt --check` + `cargo check` (exit 0)
- [x] N/A: Tauri fmt/check (if changed) — no `app/src-tauri` files changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: memory-pipeline BYO embeddings now use the stored API key; unconfigured Cohere fails fast instead of flooding.
- User-visible effect: Cohere/OpenAI/Voyage memory embeddings work when a key is configured; previously silently broken.

### Parity Contract

- Legacy behavior preserved: cloud/managed/ollama/none unchanged; `create_memory` (tests/migration) keeps empty-key path; correctly-keyed providers' 429 backoff tests still pass.
- Guard/fallback/dispatch parity checks: `create_embedding_provider_with_credentials` covers the same provider arms as the keyless factory; `custom:<url>` prefix self-stripped (custom_endpoint stays None).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (dedup vs open + 30d-merged clean)
- Canonical PR: this
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detect and classify Cohere "no api key supplied" 401 responses as missing API key to reduce noisy error reports and retries.
  * Fast-fail when an embeddings API key is blank to avoid unnecessary failed requests.

* **Improvements**
  * Ensure user-supplied embedding keys are honored when initializing local memory/embedding backends, reducing misconfigured-provider failures.

* **Tests**
  * Added tests to validate API-key resolution and missing-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
