### PR TITLE
fix(credentials): retry transient Windows FS errors when persisting auth-profiles.json (#3355)

### DIFF
--- a/src/openhuman/credentials/profiles.rs
+++ b/src/openhuman/credentials/profiles.rs
@@ -1,4 +1,5 @@
 use crate::openhuman::keyring::SecretStore;
+use crate::openhuman::util::retry_with_backoff;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -8,6 +9,11 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(test)]
+use std::sync::Arc;
 
 const CURRENT_SCHEMA_VERSION: u32 = 1;
 
@@ -50,6 +56,15 @@ const MALFORMED_LOCK_GRACE_MS: u64 = 2_000;
 /// Wait long enough for a fresh leaked lock to cross the stale threshold
 /// and be reclaimed before surfacing a lock timeout to the caller.
 const LOCK_TIMEOUT_MS: u64 = STALE_LOCK_AGE_MS + 5_000;
+
+/// Retry budget for the JSON write + rename in `write_persisted_locked`.
+/// Same shape as the lock-create call at the bottom of `acquire_lock` (which
+/// is what closed Sentry OPENHUMAN-TAURI-H1 / H8 in #1641 / #2085). 6 attempts
+/// at base 100ms doubles up to ~6.3s worst-case before surfacing. Sized to
+/// stay well inside `LOCK_TIMEOUT_MS` so concurrent acquire_lock callers
+/// never time out behind a single retry-loop owner.
+const PERSIST_RETRY_ATTEMPTS: u32 = 6;
+const PERSIST_RETRY_BASE_MS: u64 = 100;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -199,6 +214,13 @@ pub struct AuthProfilesStore {
     /// Whether the OS keychain is available on this machine.
     /// Cached at construction time to avoid repeated probes.
     use_keychain: bool,
+    /// `#[cfg(test)]` failure injection — when non-zero, the next retryable
+    /// FS call inside `write_persisted_locked` consumes one count and returns
+    /// a `__TEST_TRANSIENT__` error so the `is_transient_fs_error` classifier
+    /// treats it as retryable (`src/openhuman/util.rs:618`). Production
+    /// binaries never see this field.
+    #[cfg(test)]
+    force_transient_failures: Arc<AtomicUsize>,
 }
 
 impl AuthProfilesStore {
@@ -240,6 +262,8 @@ impl AuthProfilesStore {
             secret_store: SecretStore::new(state_dir, encrypt_secrets),
             user_id,
             use_keychain,
+            #[cfg(test)]
+            force_transient_failures: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -928,14 +952,41 @@ impl AuthProfilesStore {
         );
         let tmp_path = self.path.with_file_name(tmp_name);
 
-        fs::write(&tmp_path, &json).with_context(|| {
+        // Windows AV / Search-Indexer / Defender may briefly hold a handle on
+        // the destination, returning transient `ERROR_SHARING_VIOLATION (32)`,
+        // `ERROR_ACCESS_DENIED (5)`, or `ERROR_DELETE_PENDING (303)` —
+        // recognised as retryable by `is_transient_fs_error`. Mirror the
+        // lock-create retry budget at the bottom of `acquire_lock` so the
+        // JSON write+rename path absorbs the same transient family that
+        // closed Sentry OPENHUMAN-TAURI-H1 / H8 for the lock path. Outer
+        // `with_context` preserved so the Sentry fingerprint shape is stable
+        // across releases. (Sentry TAURI-RUST-92J / #3355.)
+        retry_with_backoff(
+            "write auth profile tmp",
+            PERSIST_RETRY_ATTEMPTS,
+            PERSIST_RETRY_BASE_MS,
+            || {
+                self.consume_test_transient_failure()?;
+                fs::write(&tmp_path, &json).context("write auth profile tmp")
+            },
+        )
+        .with_context(|| {
             format!(
                 "Failed to write temporary auth profile file at {}",
                 tmp_path.display()
             )
         })?;
 
-        fs::rename(&tmp_path, &self.path).with_context(|| {
+        retry_with_backoff(
+            "replace auth profile store",
+            PERSIST_RETRY_ATTEMPTS,
+            PERSIST_RETRY_BASE_MS,
+            || {
+                self.consume_test_transient_failure()?;
+                fs::rename(&tmp_path, &self.path).context("rename auth profile tmp -> store")
+            },
+        )
+        .with_context(|| {
             format!(
                 "Failed to replace auth profile store at {}",
                 self.path.display()
@@ -943,6 +994,42 @@ impl AuthProfilesStore {
         })?;
 
         Ok(())
+    }
+
+    /// Consume one test-injected transient FS failure if any are queued.
+    /// No-op in production builds.
+    #[cfg(test)]
+    fn consume_test_transient_failure(&self) -> Result<()> {
+        let remaining = self.force_transient_failures.load(Ordering::SeqCst);
+        if remaining == 0 {
+            return Ok(());
+        }
+        self.force_transient_failures.fetch_sub(1, Ordering::SeqCst);
+        Err(anyhow::anyhow!(
+            "__TEST_TRANSIENT__ injected transient FS failure"
+        ))
+    }
+
+    #[cfg(not(test))]
+    #[inline(always)]
+    fn consume_test_transient_failure(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Queue `n` test-only forced transient FS failures. The next `n`
+    /// retryable calls inside `write_persisted_locked` return a
+    /// `__TEST_TRANSIENT__` error before the underlying FS op runs; the
+    /// retry helper treats them as retryable.
+    #[cfg(test)]
+    pub(super) fn force_next_transient_failures(&self, n: usize) {
+        self.force_transient_failures.store(n, Ordering::SeqCst);
+    }
+
+    /// Test introspection: how many forced transient failures are still
+    /// queued. Lets tests verify the retry helper drained the queue.
+    #[cfg(test)]
+    pub(super) fn remaining_forced_failures(&self) -> usize {
+        self.force_transient_failures.load(Ordering::SeqCst)
     }
 
     fn encrypt_optional(&self, value: Option<&str>) -> Result<Option<String>> {

--- a/src/openhuman/credentials/profiles_tests.rs
+++ b/src/openhuman/credentials/profiles_tests.rs
@@ -689,3 +689,102 @@ fn auth_profile_kind_serde_roundtrip() {
     let json = serde_json::to_string(&AuthProfileKind::Token).unwrap();
     assert_eq!(json, "\"token\"");
 }
+
+// ── Regression coverage for Sentry TAURI-RUST-92J / #3355 ─────────────────
+//
+// `write_persisted_locked` retries transient Windows FS errors
+// (`is_transient_fs_error` family — `ERROR_SHARING_VIOLATION` (32),
+// `ERROR_ACCESS_DENIED` (5), `ERROR_DELETE_PENDING` (303), etc.) via
+// `retry_with_backoff`. Matches the sibling `.lock`-create retry that
+// already closed OPENHUMAN-TAURI-H1 / H8 — the JSON `fs::write` +
+// `fs::rename` path was the missing partial.
+//
+// `force_next_transient_failures` is the `#[cfg(test)]`-only injection point
+// — it consumes one queued failure per retry attempt and returns an error
+// whose chain contains `__TEST_TRANSIENT__`, which `is_transient_fs_error`
+// recognises as retryable on every platform (see `src/openhuman/util.rs`).
+
+#[test]
+fn write_persisted_locked_retries_one_shot_transient() {
+    let tmp = TempDir::new().unwrap();
+    let store = AuthProfilesStore::new(tmp.path(), false);
+
+    // Queue one forced transient FS failure — the first retry attempt
+    // returns `__TEST_TRANSIENT__`, the second runs the real `fs::write` and
+    // succeeds. `upsert_profile` therefore returns Ok and the queue drains.
+    store.force_next_transient_failures(1);
+
+    let profile = AuthProfile::new_token("anthropic", "default", "tok-1".into());
+    store
+        .upsert_profile(profile.clone(), true)
+        .expect("retry should absorb the single transient failure");
+
+    assert_eq!(
+        store.remaining_forced_failures(),
+        0,
+        "retry helper must have consumed the queued forced failure"
+    );
+
+    // Round-trip the profile to prove the store wrote real bytes after the retry.
+    let data = store.load().unwrap();
+    assert!(data.profiles.contains_key(&profile.id));
+}
+
+#[test]
+fn write_persisted_locked_absorbs_burst_of_transients() {
+    let tmp = TempDir::new().unwrap();
+    let store = AuthProfilesStore::new(tmp.path(), false);
+
+    // Queue 5 forced transient failures — fewer than the retry budget
+    // (PERSIST_RETRY_ATTEMPTS = 6) so the 6th attempt succeeds. Covers the
+    // common "AV holds destination for a few hundred ms" case which was the
+    // root cause of TAURI-RUST-92J — the file genuinely lands on disk after
+    // the helper waits out the transient.
+    store.force_next_transient_failures(5);
+
+    let profile = AuthProfile::new_token("anthropic", "default", "tok-burst".into());
+    store
+        .upsert_profile(profile.clone(), true)
+        .expect("retry must absorb a burst of transient failures within budget");
+
+    assert_eq!(
+        store.remaining_forced_failures(),
+        0,
+        "retry helper must drain every queued failure before succeeding"
+    );
+
+    let data = store.load().unwrap();
+    let loaded = data
+        .profiles
+        .get(&profile.id)
+        .expect("profile must round-trip after retry");
+    assert_eq!(loaded.token.as_deref(), Some("tok-burst"));
+}
+
+#[test]
+fn write_persisted_locked_exhausts_retries_on_persistent_transient() {
+    let tmp = TempDir::new().unwrap();
+    let store = AuthProfilesStore::new(tmp.path(), false);
+
+    // Queue more forced failures than the retry budget for the write stage
+    // (PERSIST_RETRY_ATTEMPTS = 6) — every retry returns the test sentinel,
+    // so `retry_with_backoff` ultimately surfaces the failed-after-N-attempts
+    // error. Genuinely unrecoverable failures still surface to Sentry as
+    // honest signal; this is not a noise-suppression layer.
+    store.force_next_transient_failures(6);
+
+    let profile = AuthProfile::new_token("anthropic", "default", "tok-2".into());
+    let err = store
+        .upsert_profile(profile, true)
+        .expect_err("persistent transient must exhaust retries and surface as Err");
+
+    let chain = format!("{err:?}");
+    assert!(
+        chain.contains("Failed to write temporary auth profile file"),
+        "outer with_context must be preserved for Sentry fingerprint stability: {chain}"
+    );
+    assert!(
+        chain.contains("write auth profile tmp failed after"),
+        "retry helper must annotate the exhausted attempts count: {chain}"
+    );
+}


### PR DESCRIPTION
## Summary

- Wrap the JSON `fs::write(tmp)` + `fs::rename(tmp → auth-profiles.json)` calls in `write_persisted_locked` with `retry_with_backoff`, matching the auth-profiles `.lock`-create retry budget that already closed the sibling Windows transient-FS bugs `OPENHUMAN-TAURI-H1` / `H8` in #1641 / #2085.
- 3 regression tests pinned to the failure mode via a `#[cfg(test)]`-only `__TEST_TRANSIENT__` injection point that the existing `is_transient_fs_error` classifier already recognises (`src/openhuman/util.rs:618`).
- Closes #3355 — Sentry `TAURI-RUST-92J`, 10,158 events / 24h, single Windows 11 24H2 user, release `openhuman@0.56.0+e8968077aeb5`.

## Problem

`AuthProfilesStore::write_persisted_locked` (`src/openhuman/credentials/profiles.rs:911-946`) serialised the persisted JSON to a tmp file and renamed it onto `auth-profiles.json` via raw `std::fs::write` + `std::fs::rename`. On Windows, AV / Search-Indexer / Defender briefly holding the destination handle returns `ERROR_SHARING_VIOLATION (32)`, `ERROR_ACCESS_DENIED (5)`, or `ERROR_DELETE_PENDING (303)` — exactly the family `crate::openhuman::util::retry_with_backoff` is built to absorb. The sibling `.lock`-create at `profiles.rs:987` was already routed through this helper (PR #1641 / #2085 / #2180); the `.json` write+rename path was the missing partial.

Result: any single transient AV hold flipped a normally-retry-safe operation into a permanent error. Compounding it, `load_locked` (`profiles.rs:744`) calls `write_persisted_locked` whenever its in-memory purge set is non-empty (`#3125`-class drops, legacy `kind` values per `#2439`, decrypt-failure recovery), and the frontend polls `openhuman.app_state_snapshot` every ~2s — so one persistent AV hold amplified into 10k+ identical Sentry events in 24h on `TAURI-RUST-92J`.

## Solution

`write_persisted_locked` now wraps both the tmp write and the rename in `retry_with_backoff("…", PERSIST_RETRY_ATTEMPTS, PERSIST_RETRY_BASE_MS, …)`. Constants are set to **6 attempts at base 100ms** (worst-case ≈ 6.3 s), matching the proven `.lock`-create budget and staying well inside `LOCK_TIMEOUT_MS` so concurrent `acquire_lock` callers never starve behind a single retry-loop owner. Outer `with_context` is preserved on both calls so the Sentry fingerprint shape stays stable across releases.

This is the real fix to the underlying file-system race — **not noise suppression**. Genuinely unrecoverable failures still propagate via `Err` and reach the RPC error path, so a user whose AV is permanently hostile remains visible in Sentry as honest signal.

Regression coverage uses a `#[cfg(test)]`-only injection counter on `AuthProfilesStore` (`force_next_transient_failures` + `consume_test_transient_failure`) that returns an error chain containing `__TEST_TRANSIENT__` — the test sentinel that `is_transient_fs_error` already accepts. Three tests exercise the retry semantics:
- one-shot transient is absorbed and the profile lands on disk,
- a burst of transients within the retry budget still resolves to a successful write,
- sustained failures beyond the budget still surface as `Err` with the outer `with_context` preserved.

Production binaries carry zero new surface area from the injection helpers (gated behind `#[cfg(test)]`).

## Submission Checklist

- N/A: no UI changes (Rust-only fix; no i18n keys touched, no React surface)
- [x] Tests added — three regression tests in `src/openhuman/credentials/profiles_tests.rs` exercising one-shot retry, retry-within-budget burst, and retry-exhaustion behaviour. `cargo test --lib openhuman::credentials::profiles` is green locally (38 passed, 0 failed).
- [x] `cargo check --manifest-path Cargo.toml` clean on the changed crate.
- [x] `cargo fmt` clean on the changed files.
- N/A: `cargo clippy -D warnings` — pre-existing lints elsewhere in the crate (`useless_vec` in `tokenjuice/text/process.rs`, `map_or` simplifications in this file at lines 1106 / 1205 / 1211, assertion-on-constant in `profiles_tests.rs` at 600 / 619 / 623) are unchanged by this PR and untouched on `main`.
- N/A: rustdoc / `gitbooks` — no architecture or contributor-facing behaviour change (internal retry semantics on an existing private method).
- N/A: feature flag / capability catalog — no user-visible feature added, removed, or renamed.

## Impact

- Windows users whose AV / Search-Indexer / Defender intermittently held a handle on `auth-profiles.json` no longer see `app_state_snapshot` fail on every poll once a profile gets dropped — the write retries and lands on disk as soon as the handle releases.
- Sentry `TAURI-RUST-92J` event volume drops sharply once the next release ships; the issue stays open until clean so any genuinely sustained AV interference still surfaces.
- No behaviour change on macOS / Linux: `is_transient_fs_error` only matches Windows raw OS codes (5 / 32 / 33 / 303 / 1224), so non-Windows callers see identical first-attempt semantics.
- No schema change, no migration, no RPC surface change, no public API surface change.

## Related

- Closes #3355
- Sentry-Issue: TAURI-RUST-92J
- Sibling retries on the same store: #1641, #2085, #2180 (`.lock`-create transient-FS retry — same helper, same Windows error family).
- Related load-driven drop paths whose persist this fix now covers: #2439 (legacy `kind` value tolerance), #3125 / #3180 (OAuth missing `access_token` drop).