### PR TITLE
Persist thread sidebar visibility

### DIFF
--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -57,6 +57,7 @@ import {
   persistReaction,
   setActiveThread,
   setSelectedThread,
+  setThreadSidebarVisible,
   THREAD_NOT_FOUND_MESSAGE,
   updateThreadTitle,
 } from '../store/threadSlice';
@@ -187,10 +188,16 @@ const Conversations = ({
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
-  const { threads, selectedThreadId, messages, isLoadingMessages, messagesError, activeThreadId } =
-    useAppSelector(state => state.thread);
+  const {
+    threads,
+    selectedThreadId,
+    threadSidebarVisible = false,
+    messages,
+    isLoadingMessages,
+    messagesError,
+    activeThreadId,
+  } = useAppSelector(state => state.thread);
 
-  const [showSidebar, setShowSidebar] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1224,7 +1231,7 @@ const Conversations = ({
     labelTabs.find(tab => tab.value === selectedLabel)?.label ?? selectedLabel;
 
   const isSidebar = variant === 'sidebar';
-  const effectiveShowSidebar = showSidebar;
+  const effectiveShowSidebar = threadSidebarVisible;
 
   // Stable title resolver used by both the sidebar thread list and the header.
   const resolveThreadDisplayTitle = (threadId: string | null): string => {
@@ -1405,7 +1412,7 @@ const Conversations = ({
             <button
               type="button"
               data-analytics-id="chat-header-toggle-sidebar"
-              onClick={() => setShowSidebar(prev => !prev)}
+              onClick={() => dispatch(setThreadSidebarVisible(!effectiveShowSidebar))}
               className="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-stone-100 dark:hover:bg-neutral-800 dark:bg-neutral-800 dark:hover:bg-neutral-800/60 text-stone-500 dark:text-neutral-400 hover:text-stone-700 dark:hover:text-neutral-200 dark:text-neutral-200 dark:hover:text-neutral-200 transition-colors"
               title={effectiveShowSidebar ? t('chat.hideSidebar') : t('chat.showSidebar')}>
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -206,8 +206,7 @@ async function renderConversations(preload: Record<string, unknown> = {}) {
   return store;
 }
 
-/** Click the sidebar toggle so the thread list becomes visible.
- *  The sidebar starts hidden (showSidebar=false) in this PR. */
+/** Click the sidebar toggle so the thread list becomes visible. */
 async function openSidebar() {
   const toggleBtn = screen.getByTitle('Show sidebar');
   await act(async () => {
@@ -219,6 +218,7 @@ async function openSidebar() {
 const emptyThreadState = {
   threads: [],
   selectedThreadId: null,
+  threadSidebarVisible: false,
   activeThreadId: null,
   welcomeThreadId: null,
   messagesByThreadId: {},
@@ -312,7 +312,7 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
     });
   });
 
-  // Covers line 906: const effectiveShowSidebar = showSidebar;
+  // Covers line 906: const effectiveShowSidebar = threadSidebarVisible;
   // Covers line 941: <div className="flex-1 overflow-y-auto"> (always rendered in page mode)
   it('renders the Threads sidebar header in page mode', async () => {
     await act(async () => {
@@ -324,6 +324,26 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
 
     // The "Threads" header is always rendered in page mode (sidebar guard removed)
     expect(screen.getByText('Threads')).toBeInTheDocument();
+  });
+
+  it('restores and updates the persisted thread sidebar visibility', async () => {
+    let renderedStore: ReturnType<typeof buildStore> | undefined;
+    await act(async () => {
+      renderedStore = await renderConversations({
+        thread: { ...emptyThreadState, threadSidebarVisible: true },
+      });
+    });
+
+    expect(screen.getByText('Threads')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTitle('Hide sidebar'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Threads')).not.toBeInTheDocument();
+    });
+    expect(renderedStore?.getState().thread.threadSidebarVisible).toBe(false);
   });
 
   // Covers line 941 empty branch

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -138,7 +138,11 @@ const persistedNotificationReducer = persistReducer(notificationPersistConfig, n
 // they were instead of falling through to "create a new thread". The
 // thread list and per-thread message caches are re-fetched from the core
 // on boot, so we deliberately don't persist them.
-const threadPersistConfig = { key: 'thread', storage, whitelist: ['selectedThreadId'] };
+const threadPersistConfig = {
+  key: 'thread',
+  storage,
+  whitelist: ['selectedThreadId', 'threadSidebarVisible'],
+};
 const persistedThreadReducer = persistReducer(threadPersistConfig, threadReducer);
 
 // Persist only previously persisted mascot appearance fields plus the custom

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -11,6 +11,7 @@ export const THREAD_NOT_FOUND_MESSAGE = 'This thread is no longer available.';
 interface ThreadState {
   threads: Thread[];
   selectedThreadId: string | null;
+  threadSidebarVisible: boolean;
   activeThreadId: string | null;
   /**
    * @deprecated — welcome-agent replaced by Joyride walkthrough. Always null
@@ -27,6 +28,7 @@ interface ThreadState {
 const initialState: ThreadState = {
   threads: [],
   selectedThreadId: null,
+  threadSidebarVisible: false,
   activeThreadId: null,
   welcomeThreadId: null,
   messagesByThreadId: {},
@@ -337,6 +339,9 @@ const threadSlice = createSlice({
     setActiveThread: (state, action: { payload: string | null }) => {
       state.activeThreadId = action.payload;
     },
+    setThreadSidebarVisible: (state, action: PayloadAction<boolean>) => {
+      state.threadSidebarVisible = action.payload;
+    },
     clearStaleThread: (state, action: PayloadAction<string>) => {
       const threadId = action.payload;
       state.threads = state.threads.filter(thread => thread.id !== threadId);
@@ -459,6 +464,7 @@ export const {
   setSelectedThread,
   clearSelectedThread,
   setActiveThread,
+  setThreadSidebarVisible,
   clearStaleThread,
   clearAllThreads,
   resetThreadCachesPreservingSelection,


### PR DESCRIPTION
## Summary

- Persist the chat thread sidebar visibility in the existing `thread` Redux slice.
- Add `threadSidebarVisible` to the redux-persist whitelist alongside `selectedThreadId`.
- Replace the local `showSidebar` component state in `Conversations` with the persisted Redux value.
- Add focused render coverage that restores the visible state and verifies toggling hides it again.

## Problem

- The thread sidebar toggle always reset to hidden after remount or reload because it lived only in component state.
- Users who intentionally showed or hid the thread button/sidebar had to repeat that choice each session.

## Solution

- Store the visibility bit as `thread.threadSidebarVisible`, defaulting to `false` to preserve current first-run behavior.
- Persist only that UI preference and the existing last selected thread id, while continuing to refetch thread lists and messages from core.
- Dispatch `setThreadSidebarVisible` from the existing header toggle.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. Focused changed-line Vitest coverage added; CI coverage gate will enforce final merged diff coverage.
- [x] Coverage matrix updated — N/A: behavior-only chat UI preference persistence, no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: narrow persisted UI preference, no release smoke checklist change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no GitHub or Linear issue was provided for this request.

## Impact

- Desktop app UI only.
- No backend, Rust core, network, or migration impact.
- Existing users without the persisted field keep the previous default hidden sidebar state.

## Related

- Closes: N/A, no issue provided.
- Follow-up PR(s)/TODOs: N/A.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A, no Linear issue was provided.
- URL: N/A, no Linear issue was provided.

### Commit & Branch

- Branch: `persist-thread-button-visibility`
- Commit SHA: `5abdea63c48167540ff78b3a846f511ef5c557e8`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — passed via pre-push hook.
- [x] `pnpm typecheck` — passed; warning only for local Node v22.22.3 while app wants >=24.
- [x] Focused tests: `pnpm debug unit src/pages/__tests__/Conversations.render.test.tsx --verbose` — passed, 49 tests.
- [x] Rust fmt/check (if changed): N/A, no Rust files changed; root cargo fmt check still passed via pre-push hook.
- [x] Tauri fmt/check (if changed): N/A, no Tauri files changed; Tauri cargo fmt/check still passed via pre-push hook with existing warnings.

### Validation Blocked

- `command:` N/A.
- `error:` N/A.
- `impact:` N/A.

### Behavior Changes

- Intended behavior change: The thread sidebar visibility choice now survives remount/reload.
- User-visible effect: If the user hides it, it stays hidden; if the user shows it, it stays shown.

### Parity Contract

- Legacy behavior preserved: First-run/default sidebar state remains hidden.
- Guard/fallback/dispatch parity checks: Thread list/message caches remain non-persisted and continue to refetch from core.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found for `senamakel:persist-thread-button-visibility`.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.
