### PR TITLE
fix(inference): point MiniMax at its OpenAI-compatible /v1 endpoint (#3401)

### DIFF
--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -427,7 +427,7 @@ describe('AIPanel', () => {
     );
   });
 
-  it('connects MiniMax with anthropic auth style', async () => {
+  it('connects MiniMax via its OpenAI-compatible /v1 endpoint with bearer auth', async () => {
     vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
 
     renderWithProviders(<AIPanel />);
@@ -445,13 +445,16 @@ describe('AIPanel', () => {
     await waitFor(() => expect(vi.mocked(saveAISettings)).toHaveBeenCalled());
 
     const [, nextSettings] = vi.mocked(saveAISettings).mock.calls[0];
+    // MiniMax speaks OpenAI on `/v1` (chat/completions + models). The old
+    // `/anthropic` base + anthropic auth pointed at its Messages API, which
+    // OpenHuman doesn't speak — both paths 404'd (Sentry TAURI-RUST-8X3).
     expect(nextSettings.cloudProviders).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           slug: 'minimax',
           label: 'MiniMax',
-          endpoint: 'https://api.minimax.io/anthropic',
-          auth_style: 'anthropic',
+          endpoint: 'https://api.minimax.io/v1',
+          auth_style: 'bearer',
         }),
       ])
     );

--- a/app/src/components/settings/panels/__tests__/builtinCloudProviders.test.ts
+++ b/app/src/components/settings/panels/__tests__/builtinCloudProviders.test.ts
@@ -15,7 +15,7 @@ describe('builtinCloudProviders', () => {
   it.each([
     ['groq', 'https://api.groq.com/openai/v1', 'bearer'],
     ['deepseek', 'https://api.deepseek.com/v1', 'bearer'],
-    ['minimax', 'https://api.minimax.io/anthropic', 'anthropic'],
+    ['minimax', 'https://api.minimax.io/v1', 'bearer'],
     ['sumopod', 'https://ai.sumopod.com/v1', 'bearer'],
   ] as const)('maps %s to its endpoint and auth style', (slug, endpoint, authStyle) => {
     expect(defaultEndpointForBuiltinCloudProvider(slug)).toBe(endpoint);

--- a/app/src/components/settings/panels/builtinCloudProviders.ts
+++ b/app/src/components/settings/panels/builtinCloudProviders.ts
@@ -158,8 +158,12 @@ export const BUILTIN_CLOUD_PROVIDERS: BuiltinCloudProvider[] = [
   {
     slug: 'minimax',
     label: 'MiniMax',
-    endpoint: 'https://api.minimax.io/anthropic',
-    authStyle: 'anthropic',
+    // OpenAI-compatible surface (`/v1/chat/completions`, `/v1/models`). The
+    // prior `/anthropic` base + anthropic auth hit MiniMax's Messages API,
+    // which OpenHuman doesn't speak — both chat and model-listing 404'd
+    // (Sentry TAURI-RUST-8X3). Keep in sync with the Rust catalog.
+    endpoint: 'https://api.minimax.io/v1',
+    authStyle: 'bearer',
     tone: TONE.rose,
   },
   {

--- a/src/openhuman/config/schema/cloud_providers.rs
+++ b/src/openhuman/config/schema/cloud_providers.rs
@@ -132,8 +132,16 @@ pub const BUILTIN_CLOUD_PROVIDERS: &[BuiltinCloudProvider] = &[
     BuiltinCloudProvider {
         slug: "minimax",
         label: "MiniMax",
-        endpoint: "https://api.minimax.io/anthropic",
-        auth_style: AuthStyle::Anthropic,
+        // MiniMax exposes a full OpenAI-compatible surface at `/v1`
+        // (`/v1/chat/completions`, `/v1/models`). The previous `/anthropic`
+        // base + Anthropic auth pointed at MiniMax's Messages-protocol API,
+        // which OpenHuman does not speak — it only builds OpenAI-style
+        // `/chat/completions` and `/models` — so both chat and model-listing
+        // 404'd (`/anthropic/chat/completions`, `/anthropic/models`). The
+        // 404 on model-listing was Sentry TAURI-RUST-8X3. Use the `/v1`
+        // OpenAI surface with Bearer auth so both paths resolve.
+        endpoint: "https://api.minimax.io/v1",
+        auth_style: AuthStyle::Bearer,
     },
     BuiltinCloudProvider {
         slug: "stepfun",
@@ -507,8 +515,8 @@ mod tests {
             (
                 "minimax",
                 "MiniMax",
-                "https://api.minimax.io/anthropic",
-                AuthStyle::Anthropic,
+                "https://api.minimax.io/v1",
+                AuthStyle::Bearer,
             ),
             (
                 "sumopod",

--- a/tests/config_auth_app_state_connectivity_e2e.rs
+++ b/tests/config_auth_app_state_connectivity_e2e.rs
@@ -669,8 +669,10 @@ fn config_schema_helpers_cover_provider_voice_agent_and_channel_defaults() {
     migrate_legacy_fields(&mut minimax_legacy);
     assert_eq!(minimax_legacy.slug, "minimax");
     assert_eq!(minimax_legacy.label, "MiniMax");
-    assert_eq!(minimax_legacy.endpoint, "https://api.minimax.io/anthropic");
-    assert_eq!(minimax_legacy.auth_style, AuthStyle::Anthropic);
+    // MiniMax uses its OpenAI-compatible /v1 surface + Bearer (TAURI-RUST-8X3);
+    // the legacy `type=minimax` migration fills from the corrected catalog.
+    assert_eq!(minimax_legacy.endpoint, "https://api.minimax.io/v1");
+    assert_eq!(minimax_legacy.auth_style, AuthStyle::Bearer);
     assert_eq!(AuthStyle::OpenhumanJwt.as_str(), "openhuman_jwt");
     assert_eq!(AuthStyle::Anthropic.as_str(), "anthropic");
     assert_eq!(AuthStyle::None.as_str(), "none");


### PR DESCRIPTION
## Summary

`openhuman.inference_list_models` fired `provider returned 404: 404 page not found` for the **MiniMax** builtin provider (Sentry TAURI-RUST-8X3: 236 events / 30 users, live on 0.57.13, all platforms). Root cause: MiniMax's catalog entry pointed at its **Anthropic Messages** base (`…/anthropic`) with Anthropic auth, but OpenHuman only speaks the OpenAI chat-completions dialect — so the probe built `…/anthropic/models`, a path MiniMax doesn't serve. Fix: point MiniMax at its **OpenAI-compatible `/v1`** surface with Bearer auth.

## Problem

`list_configured_models` (`src/openhuman/inference/provider/ops.rs`) builds `{endpoint}/models`, and the chat provider (`compatible.rs`) builds `{endpoint}/chat/completions` — both OpenAI-style paths. OpenHuman has **no Anthropic Messages provider**; `AuthStyle::Anthropic` only swaps the auth header, it still hits `/chat/completions` and `/models`.

MiniMax was added in #3062 with `endpoint = https://api.minimax.io/anthropic` + `AuthStyle::Anthropic`. That base only serves the Anthropic Messages protocol (`/anthropic/v1/messages`), so with OpenHuman's OpenAI paths **both** endpoints 404:

| URL OpenHuman builds | Result |
|---|---|
| `…/anthropic/models` (list_models) | **404 page not found** ← the Sentry bug |
| `…/anthropic/chat/completions` (chat) | **404 page not found** (chat was broken too) |

MiniMax's actual OpenAI-compatible surface (verified by live probe) does serve both:

| URL | Result (unauthenticated) |
|---|---|
| `https://api.minimax.io/v1/models` | `401` — exists, Bearer auth |
| `https://api.minimax.io/v1/chat/completions` | `401` — exists, Bearer auth |

This 404 is exactly the class of failure #2959 ("revert: remove all Sentry error suppression") intended to surface for a **root-cause fix**, not re-suppress — so the fix corrects the misconfiguration rather than swallowing the error.

## Solution

Correct the MiniMax catalog entry (Rust `BUILTIN_CLOUD_PROVIDERS` + the frontend mirror `builtinCloudProviders.ts`, kept in sync):

- `endpoint`: `https://api.minimax.io/anthropic` → `https://api.minimax.io/v1`
- `auth_style`: `Anthropic` → `Bearer`

Now `list_models` → `…/v1/models` ✓ and chat → `…/v1/chat/completions` ✓. No change to the probe's 404 handling: a genuine 404 from any provider still errors and reaches Sentry, per #2959.

No suppression, no probe-skipping, no synthetic empty result — the failing operation now actually succeeds.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — changed catalog lines are asserted by the Rust migration/preset tests and the frontend `builtinCloudProviders.test.ts` + `AIPanel.test.tsx` MiniMax-connect test
- [x] Coverage matrix updated — `N/A: configuration correction, no feature added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A (config correction)
- [x] No new external network dependencies introduced
- [x] N/A: Manual smoke checklist — release-cut surfaces untouched (catalog data correction only)
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- MiniMax model-listing now resolves (`/v1/models`) — AI-settings dropdown populates and save succeeds.
- MiniMax chat, also 404 before, now works (`/v1/chat/completions`).
- Sentry TAURI-RUST-8X3 stops firing — the endpoint is correct, not silenced. Genuine listing failures from other providers still error → Sentry → root-cause fix.
- Zero regression: MiniMax was fully non-functional before (both paths 404), so this can only fix it.
- Scope: data correction only — no code-path, schema, or error-handling change.

Note: a quick sweep of the other catalog providers found their `/models` endpoints resolve (401/200); MiniMax was the structural outlier. (`google`'s OpenAI-compat `/models` 404s unauthenticated but is key-gated — unconfirmed in this Sentry issue; left for separate verification.)

## Related

Closes #3401
Sentry-Issue: TAURI-RUST-8X3

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
N/A — GitHub issue #3401 (from Sentry TAURI-RUST-8X3).

### Commit & Branch
Branch `fix/3401-list-models-discovery`; single commit correcting the MiniMax catalog entry (Rust + frontend mirror) and updating the affected tests.

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` (prettier — changed files clean)
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib openhuman::config::schema::cloud_providers` (4 pass); Vitest `builtinCloudProviders.test.ts` + `AIPanel.test.tsx` (45 pass)
- [x] Rust fmt/check (changed): `cargo fmt --check`, `cargo check`, `cargo clippy` clean
- [x] N/A: Tauri fmt/check — shell unchanged

### Validation Blocked
None — pushed with the pre-push hook enabled (vendored submodules initialized in the worktree).

### Behavior Changes
- MiniMax provider now uses `https://api.minimax.io/v1` + Bearer; model-listing and chat resolve. No change to error handling for any other provider.

### Parity Contract
Rust catalog and the frontend `builtinCloudProviders.ts` mirror are updated together and asserted by tests on both sides.

### Duplicate / Superseded PR Handling
Supersedes this PR's own earlier approach (a 404-reclassification), which was withdrawn because PR #2959 explicitly reverted that style of Sentry-error suppression. This revision fixes the root-cause misconfiguration instead.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * MiniMax cloud provider configuration has been updated to use OpenAI-compatible API endpoints with bearer token authentication (`https://api.minimax.io/v1`). Replaces previous Anthropic-style endpoint. Improves API standardization and aligns provider integration with modern authentication patterns, ensuring better consistency across the platform's cloud provider ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->