### PR TITLE
fix(channels): presentation module private in release breaks the build (v0.57.16 release-blocker)

### DIFF
--- a/src/openhuman/channels/providers/mod.rs
+++ b/src/openhuman/channels/providers/mod.rs
@@ -10,9 +10,11 @@ pub mod linq;
 #[cfg(feature = "channel-matrix")]
 pub mod matrix;
 pub mod mattermost;
-#[cfg(not(any(test, debug_assertions)))]
-mod presentation;
-#[cfg(any(test, debug_assertions))]
+// Public (like every sibling provider module) so cross-module callers reach it
+// in *all* profiles. It was previously `pub` only under test/debug and private
+// in release, which compiled in debug but broke the release build once a
+// cross-module caller appeared (`agent::task_dispatcher` →
+// `presentation::deliver_response`): release-only `E0603: module is private`.
 pub mod presentation;
 pub mod qq;
 pub mod signal;


### PR DESCRIPTION
## Summary

Fixes the **v0.57.16 Release Production** failure — every build job (Docker image + all 5 desktop targets) failed with one **release-only** Rust error:

```
error[E0603]: module `presentation` is private
  --> src/openhuman/agent/task_dispatcher.rs:627
```

One-line fix: make `channels::providers::presentation` `pub mod` in **all** build profiles.

## Problem

`channels/providers/mod.rs` gated the module's *visibility* on build profile:

```rust
#[cfg(not(any(test, debug_assertions)))]
mod presentation;          // PRIVATE in release
#[cfg(any(test, debug_assertions))]
pub mod presentation;      // public only in test/debug
```

- The cfg gate (landed in #3023) made it `pub` in test/debug so an integration coverage test (`tests/channels_bus_presentation_raw_coverage_e2e.rs`, a separate crate) could reach `presentation::test_support`. It stayed **private in release**.
- #3380 then added an **unconditional, cross-module** call `presentation::deliver_response(...)` in `agent::task_dispatcher`. That compiles in debug (module is `pub` there) but is unreachable in **release** (module private) → `E0603`.

Because debug/test compiles all pass (local `cargo check`, PR CI, `pnpm test:rust`), nothing caught it until the release-profile production build ran.

## Solution

```rust
pub mod presentation;
```

- Consistent with every sibling provider module (`web`, `telegram`, `slack`, …) — `presentation` was the lone non-`pub` one.
- `pub` (not `pub(crate)`): the integration test is an external crate that needs full `pub`; `pub` also satisfies the in-crate release caller. `deliver_response` is already `pub fn`, so making the module visible is the entire fix.

Verified with `cargo check --release --bin openhuman-core` (the exact failing profile) — now compiles clean.

## Follow-up (separate)

PR CI compiles in **debug only**, which is why a release-only visibility break shipped. Recommend adding a `cargo check --release` job to catch this class of regression pre-release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module accessibility to ensure consistent compilation across all build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->