### PR TITLE
fix(agent): create action_dir on boot + separator-correct tilde expansion (#3353)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -2002,7 +2002,7 @@ pub async fn bootstrap_core_runtime(host_kind: crate::core::types::HostKind) {
     // `embedded_core` derived from host_kind so the rest of the function (which
     // already keys behavior off the boolean) stays unchanged.
     let embedded_core = host_kind.is_desktop_shell();
-    let cfg = match crate::openhuman::config::Config::load_or_init().await {
+    let mut cfg = match crate::openhuman::config::Config::load_or_init().await {
         Ok(cfg) => cfg,
         Err(e) => {
             log::error!("[runtime] Failed to load config for socket manager: {e}");
@@ -2059,6 +2059,17 @@ pub async fn bootstrap_core_runtime(host_kind: crate::core::types::HostKind) {
              spawn_subagent will be unavailable until restart"
         );
     }
+
+    // --- Agent sandbox + projects dirs ---
+    // Create the action sandbox + default projects home and register the
+    // projects dir as a ReadWrite trusted root BEFORE building the live policy
+    // below (so the trusted root is reflected in `from_config`). This is the
+    // always-run boot for web-chat-only desktop cores; without it a fresh
+    // install with no messaging integrations leaves `~/OpenHuman/projects`
+    // uncreated and every shell-tool `current_dir` fails with ERROR_DIRECTORY
+    // (os error 267) on Windows / ENOENT on Unix (#3353, RC-A). Idempotent — a
+    // later `start_channels` calls the same helper.
+    crate::openhuman::config::ensure_agent_dirs(&mut cfg).await;
 
     // --- Live SecurityPolicy ---
     // Install the process-global live policy on the always-run serve boot, not

--- a/src/openhuman/agent/host_runtime.rs
+++ b/src/openhuman/agent/host_runtime.rs
@@ -93,6 +93,13 @@ impl RuntimeAdapter for NativeRuntime {
             c.arg("-lc").arg(command);
             c
         };
+        // Validate the CWD up front so a missing/bad action_dir produces an
+        // actionable message naming the path, instead of an opaque OS error 267
+        // (ERROR_DIRECTORY) from CreateProcessW on Windows / a raw ENOENT on
+        // Unix when the process is spawned. Covers all three shell-family tools
+        // (shell / node_exec / npm_exec) since they all route through here.
+        // (#3353, Fix 2)
+        crate::openhuman::config::ensure_usable_cwd(workspace_dir)?;
         cmd.current_dir(workspace_dir);
         Ok(cmd)
     }
@@ -323,5 +330,47 @@ mod tests {
         // A clean pipeline still succeeds.
         let mut ok = rt.build_shell_command("true | true", &dir).unwrap();
         assert!(ok.status().await.unwrap().success());
+    }
+
+    /// #3353: a CWD that can't be made usable (here: a path *under an existing
+    /// file*, which `create_dir_all` cannot create) must yield a descriptive,
+    /// path-naming error from `build_shell_command` instead of an opaque OS
+    /// error 267 (ERROR_DIRECTORY) at spawn time.
+    #[test]
+    fn native_shell_command_rejects_uncreatable_cwd_with_clear_error() {
+        let rt = NativeRuntime::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let parent_file = tmp.path().join("a-file");
+        std::fs::write(&parent_file, b"x").unwrap();
+        let bad_cwd = parent_file.join("child"); // parent is a file → uncreatable
+
+        let err = rt
+            .build_shell_command("echo hi", &bad_cwd)
+            .expect_err("an uncreatable CWD must be rejected up front");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("could not be created"),
+            "expected an actionable message, got: {msg}"
+        );
+        assert!(
+            msg.contains(&bad_cwd.to_string_lossy().to_string()),
+            "error should name the offending path: {msg}"
+        );
+    }
+
+    /// A valid-but-missing CWD is defensively created (covers a dir deleted
+    /// after launch), so the command builds successfully and runs there.
+    #[test]
+    fn native_shell_command_creates_missing_cwd() {
+        let rt = NativeRuntime::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nested").join("workdir");
+        assert!(!missing.exists());
+
+        let command = rt
+            .build_shell_command("echo hi", &missing)
+            .expect("missing CWD should be auto-created");
+        assert!(missing.is_dir(), "CWD should have been created");
+        assert_eq!(command.as_std().get_current_dir(), Some(missing.as_path()));
     }
 }

--- a/src/openhuman/channels/runtime/startup.rs
+++ b/src/openhuman/channels/runtime/startup.rs
@@ -253,47 +253,11 @@ pub async fn start_channels(mut config: Config) -> Result<()> {
 
     let runtime: Arc<dyn host_runtime::RuntimeAdapter> =
         Arc::from(host_runtime::create_runtime(&config.runtime)?);
-    // Ensure the agent's default projects home (~/OpenHuman/projects) exists and
-    // is a read-write trusted root, so the coding agent creates/edits projects
-    // there freely — distinct from the hidden internal workspace dir. A user who
-    // has already granted it (or any other root) is left untouched.
-    {
-        use crate::openhuman::security::{TrustedAccess, TrustedRoot};
-        let projects_dir = crate::openhuman::config::default_projects_dir();
-        if let Err(e) = tokio::fs::create_dir_all(&projects_dir).await {
-            tracing::warn!(
-                dir = %projects_dir.display(),
-                error = %e,
-                "[startup] could not create default projects dir"
-            );
-        }
-        let projects_path = projects_dir.to_string_lossy().to_string();
-        if !config
-            .autonomy
-            .trusted_roots
-            .iter()
-            .any(|r| r.path == projects_path)
-        {
-            config.autonomy.trusted_roots.push(TrustedRoot {
-                path: projects_path,
-                access: TrustedAccess::ReadWrite,
-            });
-        }
-    }
-    // Ensure the action sandbox directory exists (defaults to ~/OpenHuman/projects).
-    let action_dir = config.action_dir.clone();
-    if let Err(e) = tokio::fs::create_dir_all(&action_dir).await {
-        tracing::warn!(
-            dir = %action_dir.display(),
-            error = %e,
-            "[startup] could not create action sandbox dir"
-        );
-    }
-    tracing::info!(
-        workspace = %config.workspace_dir.display(),
-        action = %action_dir.display(),
-        "[startup] workspace (internal state) and action sandbox (tool cwd) directories configured"
-    );
+    // Create the agent's action sandbox + default projects home and register the
+    // projects dir as a ReadWrite trusted root. Shared with the always-run
+    // `bootstrap_core_runtime` boot so a fresh install gets these dirs even with
+    // no messaging integrations connected (#3353, RC-A).
+    crate::openhuman::config::ensure_agent_dirs(&mut config).await;
     // Install as the process-global live policy so runtime autonomy changes
     // (config.update_autonomy_settings) are reflected by `live_policy::current()`
     // and picked up by the next session.
@@ -349,7 +313,7 @@ pub async fn start_channels(mut config: Config) -> Result<()> {
         Arc::clone(&mem),
         &config.browser,
         &config.http_request,
-        &action_dir,
+        &config.action_dir,
         &config.agents,
         &config,
     ));

--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -953,6 +953,23 @@ pub fn expand_tilde(path: &str) -> String {
     out.to_string_lossy().into_owned()
 }
 
+/// Redact a path for logging by replacing the user's home-directory prefix with
+/// `~`. Keeps the path *shape* (e.g. `~/OpenHuman/projects`) useful for
+/// diagnosis while not leaking the OS username / full home path (PII). Paths
+/// outside the home dir are returned unchanged.
+pub(crate) fn redact_home(path: &Path) -> String {
+    let s = path.to_string_lossy();
+    if let Some(home) = dirs::home_dir() {
+        let home = home.to_string_lossy();
+        if !home.is_empty() {
+            if let Some(rest) = s.strip_prefix(home.as_ref()) {
+                return format!("~{rest}");
+            }
+        }
+    }
+    s.into_owned()
+}
+
 /// Ensure the agent's action sandbox + default projects home exist and the
 /// projects dir is registered as a `ReadWrite` trusted root. Idempotent — safe
 /// to call from every boot path (web-chat-only `bootstrap_core_runtime` **and**
@@ -973,7 +990,7 @@ pub async fn ensure_agent_dirs(config: &mut Config) {
     let projects_dir = crate::openhuman::config::default_projects_dir();
     if let Err(e) = tokio::fs::create_dir_all(&projects_dir).await {
         tracing::warn!(
-            dir = %projects_dir.display(),
+            dir = %redact_home(&projects_dir),
             error = %e,
             "[startup] could not create default projects dir"
         );
@@ -995,14 +1012,14 @@ pub async fn ensure_agent_dirs(config: &mut Config) {
     let action_dir = config.action_dir.clone();
     if let Err(e) = tokio::fs::create_dir_all(&action_dir).await {
         tracing::warn!(
-            dir = %action_dir.display(),
+            dir = %redact_home(&action_dir),
             error = %e,
             "[startup] could not create action sandbox dir"
         );
     }
     tracing::info!(
-        workspace = %config.workspace_dir.display(),
-        action = %action_dir.display(),
+        workspace = %redact_home(&config.workspace_dir),
+        action = %redact_home(&action_dir),
         "[startup] workspace (internal state) and action sandbox (tool cwd) directories configured"
     );
 }

--- a/src/openhuman/config/ops.rs
+++ b/src/openhuman/config/ops.rs
@@ -926,15 +926,113 @@ pub struct AgentPathsPatch {
     pub action_dir: Option<String>,
 }
 
-/// Expand a leading `~/` to the user's home directory. Mirrors
-/// `SecurityPolicy::expand_tilde` so UI-entered paths behave consistently.
-fn expand_tilde_path(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return format!("{}/{rest}", home.display());
+/// Expand a leading `~/` to the user's home directory, building the path
+/// component-by-component so the result uses the platform-native separator
+/// throughout. A naive `format!("{}/{rest}", home)` — or even `home.join(rest)`
+/// — leaves the embedded `/` inside `rest`, yielding a mixed-separator path like
+/// `C:\Users\Harry/OpenHuman/projects` on Windows, which `CreateProcessW`
+/// rejects with `ERROR_DIRECTORY` (os error 267) when used as a process CWD.
+/// See issue #3353 (RC-B).
+///
+/// This is the single source of truth for `~/` expansion; `SecurityPolicy::
+/// expand_tilde` delegates here so policy and config stay byte-for-byte
+/// consistent.
+pub fn expand_tilde(path: &str) -> String {
+    let Some(rest) = path.strip_prefix("~/") else {
+        return path.to_string();
+    };
+    let Some(home) = dirs::home_dir() else {
+        return path.to_string();
+    };
+    let mut out = home;
+    for part in rest.split('/') {
+        if !part.is_empty() {
+            out.push(part);
         }
     }
-    path.to_string()
+    out.to_string_lossy().into_owned()
+}
+
+/// Ensure the agent's action sandbox + default projects home exist and the
+/// projects dir is registered as a `ReadWrite` trusted root. Idempotent — safe
+/// to call from every boot path (web-chat-only `bootstrap_core_runtime` **and**
+/// `start_channels`).
+///
+/// Without this on the always-run boot, a fresh desktop install with no
+/// messaging integrations leaves `~/OpenHuman/projects` uncreated (the only
+/// other creation lived inside the integration-gated `start_channels`), so the
+/// shell tool's `current_dir` fails with `ERROR_DIRECTORY` (os error 267) on
+/// Windows / `ENOENT` on Unix. See issue #3353 (RC-A).
+pub async fn ensure_agent_dirs(config: &mut Config) {
+    use crate::openhuman::security::{TrustedAccess, TrustedRoot};
+
+    // Ensure the agent's default projects home (~/OpenHuman/projects) exists and
+    // is a read-write trusted root, so the coding agent creates/edits projects
+    // there freely — distinct from the hidden internal workspace dir. A user who
+    // has already granted it (or any other root) is left untouched.
+    let projects_dir = crate::openhuman::config::default_projects_dir();
+    if let Err(e) = tokio::fs::create_dir_all(&projects_dir).await {
+        tracing::warn!(
+            dir = %projects_dir.display(),
+            error = %e,
+            "[startup] could not create default projects dir"
+        );
+    }
+    let projects_path = projects_dir.to_string_lossy().to_string();
+    if !config
+        .autonomy
+        .trusted_roots
+        .iter()
+        .any(|r| r.path == projects_path)
+    {
+        config.autonomy.trusted_roots.push(TrustedRoot {
+            path: projects_path,
+            access: TrustedAccess::ReadWrite,
+        });
+    }
+
+    // Ensure the action sandbox directory exists (defaults to ~/OpenHuman/projects).
+    let action_dir = config.action_dir.clone();
+    if let Err(e) = tokio::fs::create_dir_all(&action_dir).await {
+        tracing::warn!(
+            dir = %action_dir.display(),
+            error = %e,
+            "[startup] could not create action sandbox dir"
+        );
+    }
+    tracing::info!(
+        workspace = %config.workspace_dir.display(),
+        action = %action_dir.display(),
+        "[startup] workspace (internal state) and action sandbox (tool cwd) directories configured"
+    );
+}
+
+/// Ensure `dir` is usable as a process working directory: it must exist (we
+/// attempt to create it if missing — covers a dir deleted after launch) and
+/// resolve to a directory. Returns a descriptive error naming the path and the
+/// Settings location to fix it, instead of letting the OS surface an opaque
+/// `ERROR_DIRECTORY` (os error 267) from `CreateProcessW`. See issue #3353
+/// (Fix 2). Cheap stat-only calls on the happy path.
+pub fn ensure_usable_cwd(dir: &Path) -> anyhow::Result<()> {
+    if !dir.exists() {
+        // Defensive auto-create (mirrors startup) — covers a dir deleted after
+        // launch or an override whose parent later disappeared.
+        std::fs::create_dir_all(dir).map_err(|e| {
+            anyhow::anyhow!(
+                "Working directory '{}' does not exist and could not be created: {e}. \
+                 Set a valid path in Settings → Agent access → Working directory.",
+                dir.display()
+            )
+        })?;
+    }
+    if !dir.is_dir() {
+        anyhow::bail!(
+            "Working directory '{}' is not a directory. \
+             Set a valid path in Settings → Agent access → Working directory.",
+            dir.display()
+        );
+    }
+    Ok(())
 }
 
 /// Source of the currently-effective `action_dir`, so the UI can gate
@@ -1001,7 +1099,7 @@ pub async fn apply_agent_paths_settings(
             config.action_dir_override = None;
             notes.push("action_dir override cleared (reverted to default)".to_string());
         } else {
-            let expanded = expand_tilde_path(trimmed);
+            let expanded = expand_tilde(trimmed);
             let candidate = PathBuf::from(&expanded);
 
             if !candidate.is_absolute() {

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -1724,3 +1724,129 @@ async fn apply_agent_paths_env_set_reports_source_env() {
         std::env::remove_var("OPENHUMAN_ACTION_DIR");
     }
 }
+
+// --- #3353 regression tests -------------------------------------------------
+
+#[test]
+fn expand_tilde_happy_path_uses_home() {
+    // `~/OpenHuman/projects` resolves to the home dir joined component-wise.
+    let expanded = expand_tilde("~/OpenHuman/projects");
+    let expected = dirs::home_dir()
+        .expect("home dir resolvable in test env")
+        .join("OpenHuman")
+        .join("projects");
+    assert_eq!(expanded, expected.to_string_lossy());
+}
+
+#[test]
+fn expand_tilde_without_prefix_is_unchanged() {
+    // Absolute paths and a bare `~` (no trailing slash) pass through verbatim.
+    assert_eq!(expand_tilde("/abs/path"), "/abs/path");
+    assert_eq!(expand_tilde("~"), "~");
+    assert_eq!(expand_tilde("relative/path"), "relative/path");
+}
+
+#[cfg(windows)]
+#[test]
+fn expand_tilde_has_no_mixed_separators_on_windows() {
+    // The whole point of the component-wise build: the result must be a pure
+    // backslash path with no embedded forward slash, so CreateProcessW accepts
+    // it as a CWD instead of failing with ERROR_DIRECTORY (os error 267).
+    let expanded = expand_tilde("~/OpenHuman/projects");
+    assert!(
+        !expanded.contains('/'),
+        "expected no forward slashes on Windows, got: {expanded}"
+    );
+}
+
+#[tokio::test]
+async fn ensure_agent_dirs_creates_missing_action_dir_and_trusted_root() {
+    use crate::openhuman::security::TrustedAccess;
+
+    let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempdir().unwrap();
+    // Point the default projects home at the tempdir so the helper doesn't touch
+    // the real `~/OpenHuman/projects`.
+    let projects_dir = tmp.path().join("projects-home");
+    unsafe {
+        std::env::set_var("OPENHUMAN_PROJECTS_DIR", &projects_dir);
+    }
+
+    let mut cfg = tmp_config(&tmp);
+    let action_dir = tmp.path().join("fresh-action-dir");
+    cfg.action_dir = action_dir.clone();
+    assert!(!action_dir.exists(), "precondition: action_dir is missing");
+
+    crate::openhuman::config::ensure_agent_dirs(&mut cfg).await;
+
+    // Both the action_dir and the projects home now exist.
+    assert!(action_dir.is_dir(), "action_dir should be created");
+    assert!(projects_dir.is_dir(), "projects home should be created");
+
+    // The projects home is registered exactly once as a ReadWrite trusted root.
+    let projects_path = projects_dir.to_string_lossy().to_string();
+    let matching: Vec<_> = cfg
+        .autonomy
+        .trusted_roots
+        .iter()
+        .filter(|r| r.path == projects_path)
+        .collect();
+    assert_eq!(matching.len(), 1, "trusted root registered exactly once");
+    assert!(matches!(matching[0].access, TrustedAccess::ReadWrite));
+
+    // Idempotent: a second call neither errors nor duplicates the trusted root.
+    crate::openhuman::config::ensure_agent_dirs(&mut cfg).await;
+    let count = cfg
+        .autonomy
+        .trusted_roots
+        .iter()
+        .filter(|r| r.path == projects_path)
+        .count();
+    assert_eq!(count, 1, "second call must not duplicate the trusted root");
+
+    unsafe {
+        std::env::remove_var("OPENHUMAN_PROJECTS_DIR");
+    }
+}
+
+#[test]
+fn ensure_usable_cwd_creates_missing_dir() {
+    let tmp = tempdir().unwrap();
+    let dir = tmp.path().join("not-yet-here");
+    assert!(!dir.exists());
+    crate::openhuman::config::ensure_usable_cwd(&dir).expect("missing dir is created");
+    assert!(dir.is_dir());
+}
+
+#[test]
+fn ensure_usable_cwd_rejects_a_file_with_descriptive_error() {
+    let tmp = tempdir().unwrap();
+    let file = tmp.path().join("a-file");
+    std::fs::write(&file, b"x").unwrap();
+    let err = crate::openhuman::config::ensure_usable_cwd(&file)
+        .expect_err("an existing file is not a usable working directory");
+    let msg = err.to_string();
+    assert!(msg.contains("not a directory"), "unexpected error: {msg}");
+    // The error names the offending path so the message is actionable.
+    assert!(
+        msg.contains(&file.to_string_lossy().to_string()),
+        "error should name the path: {msg}"
+    );
+}
+
+#[test]
+fn ensure_usable_cwd_errors_when_uncreatable() {
+    // A directory whose parent is an existing *file* can't be created; the
+    // helper must surface the descriptive, path-naming error rather than panic.
+    let tmp = tempdir().unwrap();
+    let parent_file = tmp.path().join("parent-file");
+    std::fs::write(&parent_file, b"x").unwrap();
+    let target = parent_file.join("child");
+    let err = crate::openhuman::config::ensure_usable_cwd(&target)
+        .expect_err("cannot create a dir under a file");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("could not be created"),
+        "unexpected error: {msg}"
+    );
+}

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -1759,6 +1759,32 @@ fn expand_tilde_has_no_mixed_separators_on_windows() {
     );
 }
 
+#[test]
+fn redact_home_replaces_home_prefix_and_passes_through_others() {
+    let home = dirs::home_dir().expect("home dir resolvable in test env");
+
+    // A path under home is redacted to `~/...` — the username/home prefix is
+    // stripped but the diagnostic suffix is preserved.
+    let under_home = home.join("OpenHuman").join("projects");
+    let redacted = redact_home(&under_home);
+    assert!(
+        redacted.starts_with('~'),
+        "expected a `~`-prefixed path, got: {redacted}"
+    );
+    assert!(
+        !redacted.contains(&*home.to_string_lossy()),
+        "redacted path must not contain the raw home dir: {redacted}"
+    );
+    assert!(
+        redacted.contains("OpenHuman"),
+        "diagnostic suffix should be preserved: {redacted}"
+    );
+
+    // A path outside the home dir is returned unchanged.
+    let outside = std::path::Path::new("/var/lib/openhuman/action");
+    assert_eq!(redact_home(outside), "/var/lib/openhuman/action");
+}
+
 #[tokio::test]
 async fn ensure_agent_dirs_creates_missing_action_dir_and_trusted_root() {
     use crate::openhuman::security::TrustedAccess;
@@ -1768,6 +1794,7 @@ async fn ensure_agent_dirs_creates_missing_action_dir_and_trusted_root() {
     // Point the default projects home at the tempdir so the helper doesn't touch
     // the real `~/OpenHuman/projects`.
     let projects_dir = tmp.path().join("projects-home");
+    let prev_projects_dir = std::env::var_os("OPENHUMAN_PROJECTS_DIR");
     unsafe {
         std::env::set_var("OPENHUMAN_PROJECTS_DIR", &projects_dir);
     }
@@ -1804,8 +1831,12 @@ async fn ensure_agent_dirs_creates_missing_action_dir_and_trusted_root() {
         .count();
     assert_eq!(count, 1, "second call must not duplicate the trusted root");
 
+    // Restore the prior env state so later tests observe the real environment.
     unsafe {
-        std::env::remove_var("OPENHUMAN_PROJECTS_DIR");
+        match prev_projects_dir {
+            Some(v) => std::env::set_var("OPENHUMAN_PROJECTS_DIR", v),
+            None => std::env::remove_var("OPENHUMAN_PROJECTS_DIR"),
+        }
     }
 }
 

--- a/src/openhuman/sandbox/ops.rs
+++ b/src/openhuman/sandbox/ops.rs
@@ -126,17 +126,24 @@ pub async fn execute_in_sandbox(
     // Validate the working directory up front so a missing/bad action_dir
     // surfaces an actionable, path-naming error here rather than an opaque OS
     // error 267 (ERROR_DIRECTORY) at spawn time — parity with the unsandboxed
-    // `NativeRuntime::build_shell_command` guard. Applies to every backend.
-    // (#3353, Fix 2)
-    crate::openhuman::config::ensure_usable_cwd(working_dir)?;
+    // `NativeRuntime::build_shell_command` guard. (#3353, Fix 2)
+    //
+    // The validation is host-side, so it is applied per-backend: for None/Local
+    // `working_dir` *is* a host path; for Docker `working_dir` is the
+    // container-side mount target (e.g. `/workspace`) which must NOT be
+    // stat'd/created on the host — there we validate the host-side mount source
+    // (`policy.workspace_root`) instead.
     match policy.backend {
         SandboxBackendKind::None => {
+            crate::openhuman::config::ensure_usable_cwd(working_dir)?;
             execute_unsandboxed(command, working_dir, &extra_env, timeout).await
         }
         SandboxBackendKind::Local => {
+            crate::openhuman::config::ensure_usable_cwd(working_dir)?;
             execute_local_jail(policy, command, working_dir, &extra_env, timeout).await
         }
         SandboxBackendKind::Docker => {
+            crate::openhuman::config::ensure_usable_cwd(&policy.workspace_root)?;
             let request = SandboxExecRequest {
                 command: command.to_string(),
                 working_dir: working_dir.to_path_buf(),

--- a/src/openhuman/sandbox/ops.rs
+++ b/src/openhuman/sandbox/ops.rs
@@ -123,6 +123,12 @@ pub async fn execute_in_sandbox(
     extra_env: HashMap<String, String>,
     timeout: Duration,
 ) -> anyhow::Result<SandboxExecResult> {
+    // Validate the working directory up front so a missing/bad action_dir
+    // surfaces an actionable, path-naming error here rather than an opaque OS
+    // error 267 (ERROR_DIRECTORY) at spawn time — parity with the unsandboxed
+    // `NativeRuntime::build_shell_command` guard. Applies to every backend.
+    // (#3353, Fix 2)
+    crate::openhuman::config::ensure_usable_cwd(working_dir)?;
     match policy.backend {
         SandboxBackendKind::None => {
             execute_unsandboxed(command, working_dir, &extra_env, timeout).await

--- a/src/openhuman/security/policy.rs
+++ b/src/openhuman/security/policy.rs
@@ -799,13 +799,12 @@ impl SecurityPolicy {
         }
     }
 
+    /// Expand a leading `~/` to the user's home directory. Delegates to
+    /// [`crate::openhuman::config::expand_tilde`] — the single source of truth —
+    /// so policy and config expand paths byte-for-byte identically (and both
+    /// produce platform-native separators; see issue #3353).
     fn expand_tilde(&self, path: &str) -> String {
-        if let Some(rest) = path.strip_prefix("~/") {
-            if let Some(home) = dirs::home_dir() {
-                return format!("{}/{rest}", home.display());
-            }
-        }
-        path.to_string()
+        crate::openhuman::config::expand_tilde(path)
     }
 
     /// String-only path check. Does NOT resolve symlinks.

--- a/src/openhuman/security/policy_tests.rs
+++ b/src/openhuman/security/policy_tests.rs
@@ -1423,6 +1423,20 @@ fn path_home_tilde_ssh() {
 }
 
 #[test]
+fn expand_tilde_delegates_to_config_single_source_of_truth() {
+    // The policy method must stay byte-for-byte identical to the canonical
+    // config helper so path checks and config expansion never diverge (#3353).
+    let p = SecurityPolicy::default();
+    let input = "~/OpenHuman/projects";
+    assert_eq!(
+        p.expand_tilde(input),
+        crate::openhuman::config::expand_tilde(input)
+    );
+    // Non-tilde inputs are returned unchanged on both sides.
+    assert_eq!(p.expand_tilde("/abs"), "/abs");
+}
+
+#[test]
 fn path_var_run_blocked() {
     let p = SecurityPolicy {
         workspace_only: false,


### PR DESCRIPTION
## Summary

- Create the agent's **action sandbox + default projects home** (`~/OpenHuman/projects`) on the *always-run* `bootstrap_core_runtime` boot, not just inside the integration-gated `start_channels` — fixes web-chat-only desktop cores (fresh installs with no messaging integrations) that never had a working directory created (#3353, RC-A).
- Make `~/` expansion **separator-correct**: build the path component-by-component so Windows gets `C:\Users\Harry\OpenHuman\projects`, not the mixed-separator `C:\Users\Harry/OpenHuman/projects` that `CreateProcessW` rejects with `ERROR_DIRECTORY` (os error 267) (#3353, RC-B).
- Add a **CWD guard** (`config::ensure_usable_cwd`) wired into both the unsandboxed `NativeRuntime::build_shell_command` and `sandbox::execute_in_sandbox`, so a missing/bad `action_dir` surfaces an actionable, path-naming error instead of an opaque OS error at spawn time.
- Make `SecurityPolicy::expand_tilde` delegate to the new `config::expand_tilde` so policy and config expand paths byte-for-byte identically (single source of truth).
- New unit tests cover both root causes and all three fixes (tilde expansion, dir creation + trusted root, CWD guard happy/edge paths).

## Problem

On Windows, a fresh desktop install where the user only uses **web chat** (no messaging integrations connected) could not run any agent shell-family tool (`shell` / `node_exec` / `npm_exec`). Two independent root causes:

**RC-A — `action_dir` never created on the web-chat-only boot.** The default projects home / action sandbox (`~/OpenHuman/projects`) was created only inside `start_channels`, which is gated on having messaging integrations. The always-run `bootstrap_core_runtime` path (used by web-chat-only desktop cores) skipped it entirely, so the directory the shell tool sets as `current_dir` never existed. Spawning a process with a non-existent CWD fails with `ERROR_DIRECTORY` (os error 267) on Windows / `ENOENT` on Unix.

**RC-B — mixed-separator `~/` expansion.** `expand_tilde` used `format!("{}/{rest}", home.display())`. With `rest = "OpenHuman/projects"`, on Windows this produced `C:\Users\Harry/OpenHuman/projects` — a path mixing `\` (from `home`) and `/` (literal in the format string and inside `rest`). `CreateProcessW` rejects such a path as a working directory with `ERROR_DIRECTORY` (os error 267). Note `home.join(rest)` would *not* fix this either, since the embedded `/` inside `rest` is preserved verbatim — the path has to be assembled component-by-component.

Together these meant the very first agent shell command on a clean Windows install failed with an opaque OS error and no actionable message.

## Solution

**Fix 0 — idempotent `config::ensure_agent_dirs`.** Extracted the projects-dir / action-dir creation + trusted-root registration out of `start_channels` into a single idempotent `ensure_agent_dirs(&mut Config)`. It is now called from **both** boot paths: `bootstrap_core_runtime` (always-run, before the live `SecurityPolicy` is built so the trusted root is reflected in `from_config`) and `start_channels` (unchanged behavior; the helper is a no-op the second time). This closes RC-A for web-chat-only cores.

**Fix 1 — component-wise `config::expand_tilde`.** Rewrote expansion to push each `/`-split component onto the home `PathBuf`, so the result uses the platform-native separator throughout. This is now the single source of truth; `SecurityPolicy::expand_tilde` delegates to it. Closes RC-B.

**Fix 2 — `config::ensure_usable_cwd` CWD guard.** A small stat-only (happy path) helper that verifies the working directory exists (defensively `create_dir_all` if missing — covers a dir deleted after launch) and resolves to a directory, otherwise returns a descriptive error naming the offending path and pointing at *Settings → Agent access → Working directory*. Wired into `NativeRuntime::build_shell_command` (covers all three shell-family tools, which route through it) and `sandbox::execute_in_sandbox` (parity across every sandbox backend). This converts opaque OS error 267 / ENOENT at spawn time into an actionable message — defense-in-depth on top of Fix 0/1.

### Verification note

The Windows-specific repro (mixed-separator path → `ERROR_DIRECTORY`) is **verified by reasoning**, not by CI: CI runs on Linux, where `/` is the native separator and the mixed-separator path is still valid, so the failure does not reproduce there. The new tests assert the separator-correctness invariant (`expand_tilde_has_no_mixed_separators_on_windows`) and the dir/CWD behavior in a platform-portable way. **@-reporter: please confirm the fix on a real Windows machine** — a fresh web-chat-only install should now run agent shell commands without the os error 267.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — new tilde-expansion, `ensure_agent_dirs`, and `ensure_usable_cwd` tests cover happy + edge/failure paths (uncreatable CWD, file-as-dir).
- [x] **Diff coverage ≥ 80%** — changed Rust lines are exercised by the new unit tests in `config/ops_tests.rs`, `security/policy_tests.rs`, and `agent/host_runtime.rs` test module.
- [x] Coverage matrix updated — `N/A: behaviour-only / bug-fix change`, no new feature row.
- [x] All affected feature IDs from the matrix are listed — `N/A`, no matrix feature touched.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist — no release-cut UI surface; behavior is core boot/dir creation.
- [x] Linked issue closed via `Closes #3353` in `## Related`.

## Impact

- **Platform:** Desktop. The user-visible bug was **Windows-only** (mixed-separator path + uncreated dir); the `action_dir`-creation fix (RC-A) also benefits Linux/macOS web-chat-only cores, which previously relied on `start_channels` for the dir.
- **Security:** No change to the path-hardening / workspace-internal denylist. `ensure_agent_dirs` registers `~/OpenHuman/projects` as a `ReadWrite` trusted root exactly as `start_channels` did before — same grant, just reachable from both boot paths. The internal workspace denylist is untouched.
- **Performance:** Negligible — idempotent `create_dir_all` at boot and a stat-only check on the shell happy path.
- **Migration/compat:** None. Idempotent; existing installs with the dir already present and the trusted root already granted are left untouched.

## Related

- Closes: #3353
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3353-windows-action-dir-tilde`
- Commit SHA: `4695ae92b397fcdd3c33a33191d14c6a6fee8b73`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no `app/` TS changes.
- [x] N/A: `pnpm typecheck` — no `app/` TS changes.
- [x] Focused tests: `cargo test` for `config::ops`, `security::policy`, `agent::host_runtime` modules.
- [x] Rust fmt/check (if changed): `cargo fmt` + `cargo check --manifest-path Cargo.toml`.
- [x] N/A: Tauri fmt/check — no `app/src-tauri` changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` Windows repro not reproducible on Linux CI — see Verification note; reporter confirmation requested.

### Behavior Changes

- Intended behavior change: agent shell tools work on fresh web-chat-only desktop installs (esp. Windows); bad `action_dir` yields an actionable error.
- User-visible effect: no more opaque `ERROR_DIRECTORY` (os error 267) on first agent shell command; descriptive message pointing at Settings when the working dir is unusable.

### Parity Contract

- Legacy behavior preserved: `start_channels` still creates the same dirs + trusted root (now via the shared helper); `SecurityPolicy::expand_tilde` semantics preserved (delegates to the single source of truth).
- Guard/fallback/dispatch parity checks: CWD guard applied identically in the unsandboxed and sandboxed execution paths.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent directories (projects/sandbox) are now auto-created at startup, preventing failures from missing folders.
  * Working-directory checks now give clearer, descriptive errors and auto-create valid-but-missing dirs.
  * Path/tilde expansion is now consistent across the app.
* **Tests**
  * Added regression tests covering tilde expansion, directory setup, and working-directory validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->