### PR TITLE
Fix keyring backend env override

### DIFF
--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -191,7 +191,7 @@ fn run_sentry_test_command(args: &[String]) -> Result<()> {
 /// 1. Variables already set in the process environment are **not** overwritten.
 /// 2. If `OPENHUMAN_DOTENV_PATH` is set, that file is loaded.
 /// 3. Otherwise, it searches for `.env` in the current working directory.
-fn load_dotenv_for_cli() -> Result<()> {
+pub(crate) fn load_dotenv_for_cli() -> Result<()> {
     match std::env::var("OPENHUMAN_DOTENV_PATH") {
         Ok(path) if !path.trim().is_empty() => {
             dotenvy::from_path(&path).map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use openhuman::memory_store::{MemoryClient, MemoryState};
 ///
 /// Returns an error if command execution fails.
 pub fn run_core_from_args(args: &[String]) -> anyhow::Result<()> {
+    core::cli::load_dotenv_for_cli()?;
     openhuman::service::apply_startup_restart_delay_from_env();
     openhuman::keyring::init_master_key();
     core::cli::run_from_cli_args(args)

--- a/src/openhuman/keyring/encrypted_file_backend.rs
+++ b/src/openhuman/keyring/encrypted_file_backend.rs
@@ -18,6 +18,7 @@ use parking_lot::Mutex;
 use crate::openhuman::keyring::backend::KeyringBackend;
 use crate::openhuman::keyring::crypto::{self, KEY_LEN};
 use crate::openhuman::keyring::error::KeyringError;
+use crate::openhuman::keyring::store::BackendKind;
 
 const KEYCHAIN_SERVICE: &str = "openhuman";
 const KEYCHAIN_MASTER_KEY_USERNAME: &str = "app:master_key";
@@ -42,8 +43,11 @@ pub fn init_master_key() {
     crate::openhuman::keyring::init_workspace(&dir);
 
     MASTER_KEY.get_or_init(|| {
-        if !is_staging_or_production() {
-            log::debug!("[keyring:encrypted_file] skipping master key init (dev environment)");
+        let backend_kind = crate::openhuman::keyring::store::effective_backend_kind();
+        if backend_kind != BackendKind::EncryptedFile {
+            log::debug!(
+                "[keyring:encrypted_file] skipping master key init backend={backend_kind:?}"
+            );
             return None;
         }
 
@@ -66,13 +70,6 @@ pub fn init_master_key() {
             }
         }
     });
-}
-
-fn is_staging_or_production() -> bool {
-    matches!(
-        std::env::var("OPENHUMAN_APP_ENV").as_deref(),
-        Ok("staging") | Ok("production")
-    )
 }
 
 /// Returns `true` if the master key has been successfully loaded.

--- a/src/openhuman/keyring/store.rs
+++ b/src/openhuman/keyring/store.rs
@@ -9,6 +9,13 @@ use std::sync::OnceLock;
 
 use crate::openhuman::keyring::backend::{self, KeyringBackend};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum BackendKind {
+    Os,
+    File,
+    EncryptedFile,
+}
+
 // ── Global state ─────────────────────────────────────────────────────────────
 
 /// The workspace directory provided by the caller at startup.
@@ -42,12 +49,12 @@ pub(super) fn backend() -> &'static dyn KeyringBackend {
 pub(super) fn build_backend() -> Box<dyn KeyringBackend> {
     // Priority 1: explicit env var override.
     if let Ok(env_val) = std::env::var("OPENHUMAN_KEYRING_BACKEND") {
-        match env_val.trim() {
-            "os" => {
+        match backend_kind_from_env_value(&env_val) {
+            Some(BackendKind::Os) => {
                 log::info!("[keyring] backend=os (OPENHUMAN_KEYRING_BACKEND override)");
                 return Box::new(backend::OsBackend);
             }
-            "file" => {
+            Some(BackendKind::File) => {
                 let path = workspace_dir_for_file_backend();
                 log::info!(
                     "[keyring] backend=file path={} (OPENHUMAN_KEYRING_BACKEND override)",
@@ -55,7 +62,7 @@ pub(super) fn build_backend() -> Box<dyn KeyringBackend> {
                 );
                 return Box::new(backend::FileBackend::new(&path));
             }
-            "encrypted_file" => {
+            Some(BackendKind::EncryptedFile) => {
                 let path = workspace_dir_for_file_backend();
                 log::info!(
                     "[keyring] backend=encrypted_file path={} (OPENHUMAN_KEYRING_BACKEND override)",
@@ -65,9 +72,10 @@ pub(super) fn build_backend() -> Box<dyn KeyringBackend> {
                     &path,
                 ));
             }
-            other => {
+            None => {
                 log::warn!(
-                    "[keyring] unknown OPENHUMAN_KEYRING_BACKEND={other:?}; falling through to defaults"
+                    "[keyring] unknown OPENHUMAN_KEYRING_BACKEND={:?}; falling through to defaults",
+                    env_val.trim()
                 );
             }
         }
@@ -98,10 +106,46 @@ pub(super) fn build_backend() -> Box<dyn KeyringBackend> {
 }
 
 fn is_staging_or_production() -> bool {
-    matches!(
-        std::env::var("OPENHUMAN_APP_ENV").as_deref(),
-        Ok("staging") | Ok("production")
+    is_staging_or_production_value(std::env::var("OPENHUMAN_APP_ENV").as_deref().ok())
+}
+
+pub(super) fn effective_backend_kind() -> BackendKind {
+    effective_backend_kind_for(
+        std::env::var("OPENHUMAN_APP_ENV").as_deref().ok(),
+        std::env::var("OPENHUMAN_KEYRING_BACKEND").as_deref().ok(),
+        cfg!(test),
     )
+}
+
+fn effective_backend_kind_for(
+    app_env: Option<&str>,
+    backend_override: Option<&str>,
+    cfg_test: bool,
+) -> BackendKind {
+    if let Some(kind) = backend_override.and_then(backend_kind_from_env_value) {
+        return kind;
+    }
+    if cfg_test {
+        return BackendKind::File;
+    }
+    if is_staging_or_production_value(app_env) {
+        BackendKind::EncryptedFile
+    } else {
+        BackendKind::File
+    }
+}
+
+fn backend_kind_from_env_value(value: &str) -> Option<BackendKind> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "os" => Some(BackendKind::Os),
+        "file" => Some(BackendKind::File),
+        "encrypted_file" => Some(BackendKind::EncryptedFile),
+        _ => None,
+    }
+}
+
+fn is_staging_or_production_value(app_env: Option<&str>) -> bool {
+    matches!(app_env.map(str::trim), Some("staging") | Some("production"))
 }
 
 /// Derive the directory for keyring files (`secrets.enc`, `dev-keychain.json`).
@@ -126,4 +170,41 @@ pub fn workspace_dir_for_file_backend() -> PathBuf {
         _ => home.join(".openhuman"),
     };
     openhuman_dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{effective_backend_kind_for, BackendKind};
+
+    #[test]
+    fn explicit_file_backend_wins_over_staging_environment() {
+        assert_eq!(
+            effective_backend_kind_for(Some("staging"), Some("file"), false),
+            BackendKind::File
+        );
+    }
+
+    #[test]
+    fn explicit_encrypted_file_backend_wins_in_dev_environment() {
+        assert_eq!(
+            effective_backend_kind_for(Some("development"), Some("encrypted_file"), false),
+            BackendKind::EncryptedFile
+        );
+    }
+
+    #[test]
+    fn staging_defaults_to_encrypted_file_without_override() {
+        assert_eq!(
+            effective_backend_kind_for(Some(" staging "), None, false),
+            BackendKind::EncryptedFile
+        );
+    }
+
+    #[test]
+    fn unknown_backend_override_falls_back_to_environment_default() {
+        assert_eq!(
+            effective_backend_kind_for(Some("production"), Some("bogus"), false),
+            BackendKind::EncryptedFile
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Honors `OPENHUMAN_KEYRING_BACKEND=file` before keyring master-key startup, even when `OPENHUMAN_APP_ENV=staging` or `production` is set.
- Centralizes effective keyring backend selection so startup and backend construction share the same precedence rules.
- Loads CLI dotenv configuration before library startup initializes the keyring.
- Adds focused Rust unit coverage for backend override precedence.

## Problem

- `OPENHUMAN_KEYRING_BACKEND=file` could be set in `.env` or the process environment, but startup still used `OPENHUMAN_APP_ENV` to decide whether to initialize the encrypted-file master key.
- In staging/production environments this meant the process could touch the OS keychain before the explicit file backend override took effect.
- Library CLI startup also initialized keyring state before `OPENHUMAN_DOTENV_PATH` was loaded.

## Solution

- Introduce an effective backend decision helper in the keyring store with explicit override precedence: `OPENHUMAN_KEYRING_BACKEND` first, then test defaults, then app-environment defaults.
- Make `init_master_key()` load the OS-backed encrypted-file master key only when the effective backend is `encrypted_file`.
- Load CLI dotenv configuration at the beginning of `run_core_from_args()` so env-file overrides are visible to startup-time keyring initialization.
- Cover the staging-plus-file override and related fallback paths with unit tests.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Local focused Rust coverage added for changed decision logic; full diff coverage runs in CI.
- [x] Coverage matrix updated — N/A: internal startup/configuration behavior only; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID applies to this internal keyring startup fix.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release manual smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no GitHub issue was provided.

## Impact

- Runtime/platform impact: desktop and CLI startup keyring configuration.
- Security/compatibility: explicit file backend override now prevents unintended OS keychain access during startup; encrypted-file remains the default for staging/production when no override is set.
- Migration impact: none.

## Related

- Closes: N/A - no GitHub issue was provided.
- Follow-up PR(s)/TODOs: N/A.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix-keyring-backend-env`
- Commit SHA: `8e0e3dfd4`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` - via pre-push hook
- [x] `pnpm typecheck` - via pre-push hook (`pnpm compile`)
- [x] Focused tests: `cargo test --manifest-path Cargo.toml openhuman::keyring -- --nocapture`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --check`; `cargo check --manifest-path Cargo.toml`; pre-push `pnpm rust:check`
- [x] Tauri fmt/check (if changed): pre-push `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check`; `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `OPENHUMAN_KEYRING_BACKEND=file` is honored before OS keychain master-key initialization.
- User-visible effect: developers/operators using the file backend override avoid unexpected OS keychain access during startup.

### Parity Contract

- Legacy behavior preserved: staging/production still default to `encrypted_file`; dev/test still default to file-backed keyring when no explicit override is set.
- Guard/fallback/dispatch parity checks: backend construction and master-key initialization now use the same effective backend precedence.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A
