### PR TITLE
perf(mcp_registry): spawn installed MCP servers concurrently at boot

### DIFF
--- a/src/openhuman/mcp_registry/boot.rs
+++ b/src/openhuman/mcp_registry/boot.rs
@@ -10,9 +10,23 @@
 //! to spawn. Once the `InstalledServer` model grows a remote-transport
 //! variant this function will skip them (or call a remote "warm-up" path).
 
+use futures::stream::StreamExt;
+
 use crate::openhuman::config::Config;
 
+use super::types::InstalledServer;
 use super::{connections, store};
+
+/// How many installed MCP servers are brought up concurrently at boot.
+///
+/// Each `connect` spawns a stdio subprocess and does the MCP `initialize` +
+/// `tools/list` handshake, so the connects are independent network/process
+/// round-trips — serial spawning made boot latency the *sum* of every
+/// server's warmup. Bounded concurrency overlaps the handshakes while still
+/// capping the subprocess spawn burst (a user with dozens of servers
+/// shouldn't fork them all at once). The registry insert each `connect`
+/// performs is internally synchronized, so there is no shared-state hazard.
+const BOOT_SPAWN_CONCURRENCY: usize = 8;
 
 /// Spawn every locally-installed MCP server. Per-server failures are logged
 /// and swallowed.
@@ -35,29 +49,62 @@ pub async fn spawn_installed_servers(config: &Config) {
         servers.len()
     );
 
-    for server in servers {
+    spawn_servers_concurrently(servers, |server| async move {
+        connections::connect(config, &server)
+            .await
+            .map(|tools| tools.len())
+    })
+    .await;
+}
+
+/// Bring up `servers` with bounded concurrency, logging per-server outcomes.
+///
+/// Disabled servers are filtered (and logged) before fan-out. `connect_fn`
+/// takes the server **by value** (not `&InstalledServer`) so the returned
+/// future owns its input — borrowing the argument would force rustc into a
+/// higher-ranked `FnOnce` bound that fails to infer. Order is irrelevant:
+/// each connect's effect (registry insert) is independent, so this uses
+/// `for_each_concurrent` rather than an ordered combinator.
+async fn spawn_servers_concurrently<F, Fut>(servers: Vec<InstalledServer>, connect_fn: F)
+where
+    F: Fn(InstalledServer) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<usize>>,
+{
+    let enabled = servers.into_iter().filter(|server| {
         if !server.enabled {
             tracing::info!(
                 "[mcp-registry] boot: skipping disabled server_id={} qualified={}",
                 server.server_id,
                 server.qualified_name
             );
-            continue;
         }
-        let server_id = server.server_id.clone();
-        let qualified = server.qualified_name.clone();
-        match connections::connect(config, &server).await {
-            Ok(tools) => tracing::info!(
-                "[mcp-registry] boot: connected server_id={} qualified={} tools={}",
-                server_id,
-                qualified,
-                tools.len()
-            ),
-            Err(err) => tracing::warn!(
-                "[mcp-registry] boot: connect failed server_id={} qualified={} err={err}",
-                server_id,
-                qualified
-            ),
-        }
-    }
+        server.enabled
+    });
+
+    futures::stream::iter(enabled)
+        .for_each_concurrent(BOOT_SPAWN_CONCURRENCY, |server| {
+            let connect_fn = &connect_fn;
+            let server_id = server.server_id.clone();
+            let qualified = server.qualified_name.clone();
+            async move {
+                match connect_fn(server).await {
+                    Ok(tool_count) => tracing::info!(
+                        "[mcp-registry] boot: connected server_id={} qualified={} tools={}",
+                        server_id,
+                        qualified,
+                        tool_count
+                    ),
+                    Err(err) => tracing::warn!(
+                        "[mcp-registry] boot: connect failed server_id={} qualified={} err={err}",
+                        server_id,
+                        qualified
+                    ),
+                }
+            }
+        })
+        .await;
 }
+
+#[cfg(test)]
+#[path = "boot_tests.rs"]
+mod tests;

--- a/src/openhuman/mcp_registry/boot_tests.rs
+++ b/src/openhuman/mcp_registry/boot_tests.rs
@@ -1,0 +1,136 @@
+//! Tests for boot-time concurrent MCP server spawn.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::spawn_servers_concurrently;
+use super::BOOT_SPAWN_CONCURRENCY;
+use crate::openhuman::mcp_registry::types::{CommandKind, InstalledServer, Transport};
+
+fn sample_server(id: &str, enabled: bool) -> InstalledServer {
+    InstalledServer {
+        server_id: id.to_string(),
+        qualified_name: format!("@test/{id}"),
+        display_name: "Test Server".to_string(),
+        description: None,
+        icon_url: None,
+        command_kind: CommandKind::Node,
+        command: "npx".to_string(),
+        args: vec!["-y".to_string()],
+        env_keys: Vec::new(),
+        config: None,
+        installed_at: 1_700_000_000_000,
+        last_connected_at: None,
+        transport: Transport::Stdio,
+        enabled,
+    }
+}
+
+/// Tracks how many `connect_fn` invocations overlap so the test can assert
+/// real concurrency (peak in-flight > 1) bounded by `BOOT_SPAWN_CONCURRENCY`.
+#[derive(Default)]
+struct ConcurrencyProbe {
+    in_flight: AtomicUsize,
+    peak: AtomicUsize,
+    calls: AtomicUsize,
+}
+
+impl ConcurrencyProbe {
+    async fn run(&self) {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak.fetch_max(now, Ordering::SeqCst);
+        // Hold the slot long enough that siblings pile up if run concurrently.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn spawns_enabled_servers_concurrently() {
+    let probe = Arc::new(ConcurrencyProbe::default());
+    let servers: Vec<InstalledServer> = (0..4)
+        .map(|i| sample_server(&format!("srv-{i}"), true))
+        .collect();
+
+    let probe_for_fn = probe.clone();
+    spawn_servers_concurrently(servers, move |_server| {
+        let probe = probe_for_fn.clone();
+        async move {
+            probe.run().await;
+            Ok(3usize)
+        }
+    })
+    .await;
+
+    assert_eq!(
+        probe.calls.load(Ordering::SeqCst),
+        4,
+        "all enabled servers connected"
+    );
+    let peak = probe.peak.load(Ordering::SeqCst);
+    assert!(
+        peak >= 2,
+        "expected overlapping connects, peak in-flight was {peak}"
+    );
+    assert!(
+        peak <= BOOT_SPAWN_CONCURRENCY,
+        "peak in-flight {peak} must not exceed BOOT_SPAWN_CONCURRENCY {BOOT_SPAWN_CONCURRENCY}"
+    );
+}
+
+#[tokio::test]
+async fn skips_disabled_servers() {
+    let probe = Arc::new(ConcurrencyProbe::default());
+    let servers = vec![
+        sample_server("on-1", true),
+        sample_server("off-1", false),
+        sample_server("on-2", true),
+        sample_server("off-2", false),
+    ];
+
+    let probe_for_fn = probe.clone();
+    spawn_servers_concurrently(servers, move |_server| {
+        let probe = probe_for_fn.clone();
+        async move {
+            probe.run().await;
+            Ok(0usize)
+        }
+    })
+    .await;
+
+    assert_eq!(
+        probe.calls.load(Ordering::SeqCst),
+        2,
+        "only the two enabled servers should be connected"
+    );
+}
+
+/// An error from one connect must not abort the others (boot is best-effort).
+#[tokio::test]
+async fn one_failure_does_not_abort_the_rest() {
+    let probe = Arc::new(ConcurrencyProbe::default());
+    let servers: Vec<InstalledServer> = (0..3)
+        .map(|i| sample_server(&format!("srv-{i}"), true))
+        .collect();
+
+    let probe_for_fn = probe.clone();
+    spawn_servers_concurrently(servers, move |server| {
+        let probe = probe_for_fn.clone();
+        async move {
+            probe.run().await;
+            if server.server_id == "srv-1" {
+                anyhow::bail!("boom");
+            }
+            Ok(1usize)
+        }
+    })
+    .await;
+
+    assert_eq!(
+        probe.calls.load(Ordering::SeqCst),
+        3,
+        "every server is attempted even when one fails"
+    );
+}


### PR DESCRIPTION
## Summary

- Bring up installed MCP servers concurrently at boot (bounded `for_each_concurrent(8)`) instead of one-at-a-time, overlapping their stdio-subprocess spawn + MCP handshake round-trips.
- Boot latency for a user with N servers drops from `N x handshake` toward `ceil(N/8) x handshake`; tools become available sooner.
- Per-server failures stay logged-and-swallowed (boot remains best-effort); disabled servers are still filtered (and logged).

## Problem

`spawn_installed_servers` (`src/openhuman/mcp_registry/boot.rs`) looped `connections::connect(config, &server).await` serially. Each `connect` spawns a stdio subprocess and performs the MCP `initialize` + `tools/list` handshake — independent network/process round-trips with no ordering dependency. Serial spawning made startup latency the **sum** of every server's warmup, which is directly user-visible (the agent's MCP tools appear only after the last server connects).

## Solution

- Extract `spawn_servers_concurrently(servers, connect_fn)`: filters disabled servers (logging each skip) and runs the rest through `futures::stream::iter(...).for_each_concurrent(BOOT_SPAWN_CONCURRENCY, ...)`.
- `BOOT_SPAWN_CONCURRENCY = 8` overlaps handshakes while capping the subprocess spawn burst (a user with dozens of servers shouldn't fork them all at once). The registry insert each `connect` performs is internally synchronized, so there's no shared-state hazard; ordering is irrelevant, hence the unordered combinator.
- The helper takes the server **by value** so each connect future owns its input — a borrowed `&InstalledServer` argument would force a higher-ranked `FnOnce` bound that fails to infer. It also accepts an injectable `connect_fn`, making the concurrency unit-testable without real subprocesses.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `boot_tests.rs`: concurrency probe (happy path) + disabled-skip + one-failure-does-not-abort edge cases.
- [x] **Diff coverage ≥ 80%** — changed lines are the helper + its three tests; all exercised by `cargo test --lib mcp_registry::boot` (3 passed).
- [x] Coverage matrix updated — N/A: internal performance change, no feature added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no feature IDs touched.
- [x] No new external network dependencies introduced — N/A: `futures` already a dependency; tests use an in-process probe, no network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no user-visible surface change.
- [x] Linked issue closed via `Closes #NNN` — N/A: no tracking issue.

## Impact

- **Runtime**: Rust core boot path only. No desktop/mobile/web/CLI surface change.
- **Performance**: faster core startup for users with multiple installed MCP servers.
- **Compatibility**: identical per-server outcomes and logging; only the spawn scheduling changed.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: perf/mcp-boot-parallel-spawn
- Commit SHA: b8983f5876a6d771bc689987575d33e713e705a1

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only, no `app/` changes.
- [x] `pnpm typecheck` — N/A: no TypeScript changes.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib mcp_registry::boot` → 3 passed.
- [x] Rust fmt/check (if changed): `cargo fmt` clean; lib test build exit 0.
- [x] Tauri fmt/check (if changed): N/A: no Tauri shell changes (pre-push `pnpm rust:check` passed).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: installed MCP servers spawn concurrently (bounded) at boot instead of serially.
- User-visible effect: faster startup; MCP tools available sooner. No change to which servers connect or their logged outcomes.

### Parity Contract

- Legacy behavior preserved: same enabled-filtering, same per-server connect/skip/error logging, same best-effort swallow.
- Guard/fallback/dispatch parity checks: errors remain per-server and non-fatal; bound caps spawn burst.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * MCP server initialization now uses concurrent spawning with bounded concurrency limits instead of sequential initialization.
  * Improved resilience: server startup failures no longer block other servers from initializing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->