### PR TITLE
perf(team): cache managed-tool budget probe behind a short TTL

### DIFF
--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -185,14 +185,22 @@ where
     Fut: std::future::Future<Output = Option<bool>>,
 {
     if let Some(hit) = cache.get(Instant::now(), ttl) {
+        tracing::debug!(exhausted = hit, "[team] budget probe cache hit");
         return hit;
     }
     match fetch().await {
         Some(exhausted) => {
+            tracing::debug!(
+                exhausted,
+                "[team] budget probe cache miss; caching fresh probe"
+            );
             cache.put(Instant::now(), exhausted);
             exhausted
         }
-        None => false,
+        None => {
+            tracing::debug!("[team] budget probe failed; deferring to backend gate (not cached)");
+            false
+        }
     }
 }
 

--- a/src/openhuman/team/ops.rs
+++ b/src/openhuman/team/ops.rs
@@ -9,6 +9,9 @@
 //! receive a backend 401/403 surfaced verbatim as an RPC error string.
 //! API keys / JWTs are never written to logs.
 
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
 use reqwest::{Method, Url};
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -110,16 +113,86 @@ pub fn usage_budget_exhausted(data: &Value) -> bool {
         && (cycle_budget > 0.01 || cycle_spent > 0.01 || cycle_limit_7day > 0.01)
 }
 
-pub async fn managed_tool_budget_exhausted(config: &Config) -> bool {
-    match get_usage(config).await {
-        Ok(outcome) => usage_budget_exhausted(&outcome.value),
-        Err(err) => {
-            tracing::debug!(
-                error = %err,
-                "[budget-gate] usage probe failed; allowing managed tool to defer to backend"
-            );
-            false
+/// How long a managed-tool budget probe result is reused before re-fetching.
+///
+/// `ensure_budget_available` runs before **every** managed `post`/`get`, so a
+/// burst of managed tool calls in one agent turn would otherwise fire one
+/// `GET /teams/me/usage` round-trip *per call* — doubling the network cost of
+/// each managed integration request and re-fetching identical usage data. A
+/// short TTL collapses that burst to one probe while keeping the gate
+/// responsive: the backend remains the authoritative gate (it rejects spend
+/// once credits run out), so the worst case of a stale cache is a handful of
+/// extra calls within the window that the backend itself still blocks.
+const BUDGET_PROBE_TTL: Duration = Duration::from_secs(30);
+
+/// Process-global cache for the managed-tool budget probe.
+struct BudgetProbeCache {
+    /// `(fetched_at, exhausted)` of the last successful probe, if any.
+    inner: RwLock<Option<(Instant, bool)>>,
+}
+
+impl BudgetProbeCache {
+    const fn new() -> Self {
+        Self {
+            inner: RwLock::new(None),
         }
+    }
+
+    /// Cached `exhausted` flag if the last probe is still within `ttl`.
+    fn get(&self, now: Instant, ttl: Duration) -> Option<bool> {
+        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        guard.and_then(|(fetched_at, exhausted)| {
+            (now.duration_since(fetched_at) < ttl).then_some(exhausted)
+        })
+    }
+
+    /// Record a fresh probe result.
+    fn put(&self, now: Instant, exhausted: bool) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Some((now, exhausted));
+    }
+}
+
+static BUDGET_PROBE_CACHE: BudgetProbeCache = BudgetProbeCache::new();
+
+pub async fn managed_tool_budget_exhausted(config: &Config) -> bool {
+    budget_exhausted_with_cache(&BUDGET_PROBE_CACHE, BUDGET_PROBE_TTL, || async {
+        match get_usage(config).await {
+            Ok(outcome) => Some(usage_budget_exhausted(&outcome.value)),
+            Err(err) => {
+                tracing::debug!(
+                    error = %err,
+                    "[budget-gate] usage probe failed; allowing managed tool to defer to backend"
+                );
+                None
+            }
+        }
+    })
+    .await
+}
+
+/// Cache-aware budget gate. Returns the cached `exhausted` flag when fresh;
+/// otherwise calls `fetch` and caches a successful result. A failed probe
+/// (`fetch` returns `None`) is **not** cached and reports "not exhausted" so
+/// the call defers to the backend gate — identical to the pre-cache behaviour.
+async fn budget_exhausted_with_cache<F, Fut>(
+    cache: &BudgetProbeCache,
+    ttl: Duration,
+    fetch: F,
+) -> bool
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Option<bool>>,
+{
+    if let Some(hit) = cache.get(Instant::now(), ttl) {
+        return hit;
+    }
+    match fetch().await {
+        Some(exhausted) => {
+            cache.put(Instant::now(), exhausted);
+            exhausted
+        }
+        None => false,
     }
 }
 
@@ -312,6 +385,101 @@ pub async fn revoke_invite(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn budget_cache_get_returns_none_when_empty() {
+        let cache = BudgetProbeCache::new();
+        assert_eq!(cache.get(Instant::now(), Duration::from_secs(30)), None);
+    }
+
+    #[test]
+    fn budget_cache_returns_value_within_ttl_and_expires_after() {
+        let cache = BudgetProbeCache::new();
+        let base = Instant::now();
+        cache.put(base, true);
+        // Within TTL → cached value.
+        assert_eq!(
+            cache.get(base + Duration::from_secs(5), Duration::from_secs(30)),
+            Some(true)
+        );
+        // Past TTL → miss (caller must re-probe).
+        assert_eq!(
+            cache.get(base + Duration::from_secs(31), Duration::from_secs(30)),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_hit_skips_fetch() {
+        let cache = BudgetProbeCache::new();
+        cache.put(Instant::now(), true);
+        let calls = AtomicUsize::new(0);
+        let result = budget_exhausted_with_cache(&cache, Duration::from_secs(30), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Some(false) }
+        })
+        .await;
+        assert!(result, "fresh cache value should be returned");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "fetch must be skipped on cache hit"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_miss_fetches_and_caches() {
+        let cache = BudgetProbeCache::new();
+        let calls = AtomicUsize::new(0);
+        // First call: empty cache → fetch runs and result is cached.
+        let first = budget_exhausted_with_cache(&cache, Duration::from_secs(30), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Some(true) }
+        })
+        .await;
+        assert!(first);
+        // Second call: cache is now warm → fetch is skipped.
+        let second = budget_exhausted_with_cache(&cache, Duration::from_secs(30), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Some(false) }
+        })
+        .await;
+        assert!(
+            second,
+            "second call should return the cached true, not the fresh false"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "only the first call should fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_probe_is_not_cached_and_defers_to_backend() {
+        let cache = BudgetProbeCache::new();
+        let calls = AtomicUsize::new(0);
+        // Probe failure (None) → returns false (defer to backend) and does not cache.
+        let first = budget_exhausted_with_cache(&cache, Duration::from_secs(30), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { None }
+        })
+        .await;
+        assert!(!first, "failed probe defers to backend (not exhausted)");
+        // Next call must re-probe because the failure wasn't cached.
+        let second = budget_exhausted_with_cache(&cache, Duration::from_secs(30), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Some(true) }
+        })
+        .await;
+        assert!(second);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "failed probe is re-fetched next time"
+        );
+    }
 
     #[test]
     fn build_api_path_encodes_reserved_characters_in_segments() {


### PR DESCRIPTION
## Summary

- Cache the managed-tool budget probe (`GET /teams/me/usage`) behind a 30s TTL so a burst of managed tool calls in one turn does one probe instead of one per call.
- `managed_tool_budget_exhausted` returns the cached `exhausted` flag when fresh and only re-probes on a miss; the backend stays the authoritative spend gate.
- Failed probes are not cached and still defer to the backend (report "not exhausted") — identical to pre-cache behaviour.

## Problem

`IntegrationClient::ensure_budget_available` (`src/openhuman/integrations/client.rs`) runs before **every** managed `post`/`get` and called `team::managed_tool_budget_exhausted`, which did a fresh `GET /teams/me/usage` round-trip each time (`src/openhuman/team/ops.rs`). A burst of managed integration calls in a single agent turn therefore fired one usage probe **per call** — effectively doubling the network round-trips of each managed request and re-fetching identical usage data repeatedly, adding serial pre-flight latency to every call.

## Solution

- Add a process-global `BudgetProbeCache` (`RwLock<Option<(Instant, bool)>>`) with `BUDGET_PROBE_TTL = 30s`.
- `managed_tool_budget_exhausted` delegates to `budget_exhausted_with_cache(cache, ttl, fetch)`: returns the cached flag when within TTL, else calls `fetch` (the real `get_usage` probe) and caches a successful result.
- A failed probe (`fetch` → `None`) is **not** cached and returns `false` (defer to backend) — preserving the exact pre-cache fail-open semantics. The backend remains authoritative, so a stale cache can at worst let a few extra calls through within the 30s window, which the backend itself still rejects once credits are gone.
- The lock is never held across `.await` (the network fetch runs outside the critical section).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — empty-cache miss, within-TTL hit + post-TTL expiry, fetch-skipped-on-hit, fetch-and-cache-on-miss (happy), and failed-probe-not-cached (failure path).
- [x] **Diff coverage ≥ 80%** — cache logic is factored into `budget_exhausted_with_cache` + `BudgetProbeCache::get/put` (parameterised on `now`), all exercised by the new tests (`cargo test --lib team::ops::tests`, 35 passed).
- [x] Coverage matrix updated — N/A: internal performance change, no feature added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no feature IDs touched.
- [x] No new external network dependencies introduced — N/A: reduces network round-trips; no new deps; tests inject an in-process fetch closure.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no user-visible surface change.
- [x] Linked issue closed via `Closes #NNN` — N/A: no tracking issue.

## Impact

- **Runtime**: Rust core managed-integration request path. No desktop/mobile/web/CLI surface change.
- **Performance**: managed-tool-heavy turns drop from 2 round-trips/call toward 1, removing a serial pre-flight probe before each call.
- **Compatibility**: gate decisions unchanged within freshness; backend remains authoritative; fail-open-on-probe-error preserved. Staleness bounded to 30s.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: perf/managed-budget-probe-cache
- Commit SHA: 590542dd5f02830d7d3a21e1fbd542f6ae50f8b8

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only, no `app/` changes.
- [x] `pnpm typecheck` — N/A: no TypeScript changes.
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib team::ops::tests` → 35 passed.
- [x] Rust fmt/check (if changed): `cargo fmt` clean; lib test build exit 0.
- [x] Tauri fmt/check (if changed): N/A: no Tauri shell changes (pre-push `pnpm rust:check` passed).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: budget probe result is reused for up to 30s instead of re-fetched on every managed call.
- User-visible effect: faster managed tool calls; no change to gate decisions (backend authoritative).

### Parity Contract

- Legacy behavior preserved: failed probe defers to backend (not exhausted); gate decision identical within freshness window.
- Guard/fallback/dispatch parity checks: lock never held across await; failures not cached so they re-probe.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added a short-lived, process-level cache for budget status checks to reduce redundant API requests and improve responsiveness.

* **Tests**
  * Expanded test coverage for cache behavior, covering cache hits, misses, and handling of probe failures so transient errors don't block requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->