### PR TITLE
fix(dev): dynamically set Tauri devUrl from OPENHUMAN_DEV_PORT

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "vite",
     "dev:web": "vite",
-    "dev:app": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && bash ../scripts/setup-chromium-safe-storage.sh && source ../scripts/load-dotenv.sh && APPLE_SIGNING_IDENTITY='OpenHuman Dev Signer' cargo tauri dev",
+    "dev:app": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && bash ../scripts/setup-chromium-safe-storage.sh && source ../scripts/load-dotenv.sh && APPLE_SIGNING_IDENTITY='OpenHuman Dev Signer' cargo tauri dev --config '{\"build\":{\"devUrl\":\"http://localhost:'\"${OPENHUMAN_DEV_PORT:-1420}\"'\"}}' ",
     "dev:app:win": "\"C:/Program Files/Git/bin/bash.exe\" ../scripts/run-dev-win.sh",
     "dev:cef": "pnpm dev:app",
     "dev:wry": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && source ../scripts/load-dotenv.sh && cargo tauri dev --no-default-features --features wry",


### PR DESCRIPTION
## Summary

- Tauri's `devUrl` was hardcoded to `http://localhost:1420` in `tauri.conf.json`, but Vite reads `OPENHUMAN_DEV_PORT` (defaulting to 1420). When `OPENHUMAN_DEV_PORT` is set to a different port (e.g. 1421 for running multiple instances), Vite binds to that port while Tauri waits on 1420, timing out after 180s.
- The `dev:app` script now passes a `--config` override to `cargo tauri dev` so `devUrl` dynamically matches the same port Vite uses.

## Problem

- Running multiple Tauri dev instances requires different ports via `OPENHUMAN_DEV_PORT`, but the `dev:app` script on macOS/Linux didn't propagate the port to Tauri's `devUrl`. The Windows `run-dev-win.sh` already handled this correctly.

## Solution

- Added `--config '{"build":{"devUrl":"http://localhost:${OPENHUMAN_DEV_PORT:-1420}"}}'` to the `cargo tauri dev` invocation in `app/package.json`'s `dev:app` script.
- Falls back to port 1420 when `OPENHUMAN_DEV_PORT` is unset, preserving existing behavior.
- Mirrors the approach already used in `scripts/run-dev-win.sh` (lines 707-709).

## Submission Checklist

- [x] N/A: Tests added or updated — this is a one-line dev script change with no testable logic; the Windows equivalent is already in production without dedicated tests
- [x] N/A: Diff coverage ≥ 80% — change is in `package.json` (JSON, not covered by Vitest/cargo-llvm-cov)
- [x] N/A: Coverage matrix updated — no feature change, dev tooling only
- [x] N/A: All affected feature IDs listed — no feature IDs affected
- [x] N/A: No new external network dependencies — no network changes
- [x] N/A: Manual smoke checklist — not a release-cut surface
- [x] N/A: Linked issue closed — no tracking issue

## Impact

- Desktop dev workflow only (`pnpm dev:app`). No runtime, build, or production impact.
- Enables running multiple Tauri dev instances on different ports without the 180s timeout.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/dynamic-dev-port
- Commit SHA: 6e865df17

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — JSON only, no formatting delta
- [x] N/A: `pnpm typecheck` — no TypeScript changes
- [x] N/A: Focused tests — no testable code
- [x] N/A: Rust fmt/check — no Rust changes
- [x] N/A: Tauri fmt/check — no Rust changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `dev:app` now reads `OPENHUMAN_DEV_PORT` for Tauri's devUrl
- User-visible effect: `pnpm dev:app` works when `OPENHUMAN_DEV_PORT` is set to a non-default port

### Parity Contract

- Legacy behavior preserved: defaults to port 1420 when env var is unset
- Guard/fallback/dispatch parity checks: mirrors existing `run-dev-win.sh` logic

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A