### PR TITLE
perf(skill-registry): bound-concurrent catalog source fan-out

### DIFF
--- a/src/openhuman/skill_registry/ops.rs
+++ b/src/openhuman/skill_registry/ops.rs
@@ -132,6 +132,13 @@ async fn collect_catalogs(
     fetcher: &(dyn CatalogFetcher + Sync),
     enabled: &[&RegistrySource],
 ) -> (Vec<CatalogEntry>, Vec<String>) {
+    let source_ids: Vec<&str> = enabled.iter().map(|s| s.id.as_str()).collect();
+    tracing::debug!(
+        source_ids = ?source_ids,
+        concurrency = CATALOG_FETCH_CONCURRENCY,
+        "[skill_registry] collect_catalogs: fan-out start"
+    );
+
     // Materialize the per-source futures into a `Vec` before `stream::iter` — a
     // lazy `Map` adaptor trips the "implementation of `Send` is not general
     // enough" HRTB error.
@@ -168,6 +175,11 @@ async fn collect_catalogs(
             }
         }
     }
+    tracing::debug!(
+        total_count = all_entries.len(),
+        error_count = errors.len(),
+        "[skill_registry] collect_catalogs: fan-out complete"
+    );
     (all_entries, errors)
 }
 

--- a/src/openhuman/skill_registry/ops.rs
+++ b/src/openhuman/skill_registry/ops.rs
@@ -1,5 +1,7 @@
 //! Business logic for the skill registry: fetch catalogs, search, and install.
 
+use async_trait::async_trait;
+use futures::stream::StreamExt;
 use serde::Deserialize;
 
 use super::store;
@@ -7,6 +9,13 @@ use super::types::{CatalogEntry, RegistryKind, RegistrySource};
 
 const MAX_CATALOG_BYTES: usize = 5 * 1024 * 1024;
 const FETCH_TIMEOUT_SECS: u64 = 30;
+
+/// Bound on how many registry sources are fetched concurrently.
+///
+/// The enabled-source set is tiny (3 bundled defaults + any custom), so this
+/// only needs to be large enough to overlap the typical handful of GitHub raw
+/// round-trips without opening an unbounded number of sockets.
+const CATALOG_FETCH_CONCURRENCY: usize = 4;
 
 /// Default registry sources shipped with the app.
 pub fn default_sources() -> Vec<RegistrySource> {
@@ -95,6 +104,73 @@ pub fn remove_source(id: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Narrow seam over the concrete `reqwest`-backed catalog fetch so the
+/// multi-source fan-out can be unit-tested with a fake fetcher (no network).
+#[async_trait]
+trait CatalogFetcher {
+    async fn fetch(&self, source: &RegistrySource) -> Result<Vec<CatalogEntry>, String>;
+}
+
+/// Real fetcher: one HTTP GET + parse per source via `fetch_source_catalog`.
+struct HttpCatalogFetcher {
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl CatalogFetcher for HttpCatalogFetcher {
+    async fn fetch(&self, source: &RegistrySource) -> Result<Vec<CatalogEntry>, String> {
+        fetch_source_catalog(&self.client, source).await
+    }
+}
+
+/// Fetch every enabled source with bounded concurrency, preserving the exact
+/// serial-loop result: `buffered(K)` yields per-source results in input order,
+/// so the accumulated entries and the diagnostic `errors` list are identical to
+/// the old one-at-a-time loop — only the wall-clock latency drops (from the sum
+/// of all fetches to roughly `ceil(N / K)` round-trips).
+async fn collect_catalogs(
+    fetcher: &(dyn CatalogFetcher + Sync),
+    enabled: &[&RegistrySource],
+) -> (Vec<CatalogEntry>, Vec<String>) {
+    // Materialize the per-source futures into a `Vec` before `stream::iter` — a
+    // lazy `Map` adaptor trips the "implementation of `Send` is not general
+    // enough" HRTB error.
+    let fetch_futs: Vec<_> = enabled
+        .iter()
+        .map(|source| async move { (source.id.clone(), fetcher.fetch(source).await) })
+        .collect();
+
+    let results: Vec<(String, Result<Vec<CatalogEntry>, String>)> =
+        futures::stream::iter(fetch_futs)
+            .buffered(CATALOG_FETCH_CONCURRENCY)
+            .collect()
+            .await;
+
+    let mut all_entries: Vec<CatalogEntry> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    for (source_id, result) in results {
+        match result {
+            Ok(entries) => {
+                tracing::debug!(
+                    source = %source_id,
+                    count = entries.len(),
+                    "[skill_registry] fetched catalog"
+                );
+                all_entries.extend(entries);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    source = %source_id,
+                    error = %e,
+                    "[skill_registry] failed to fetch catalog"
+                );
+                errors.push(format!("{source_id}: {e}"));
+            }
+        }
+    }
+    (all_entries, errors)
+}
+
 /// Fetch the full catalog from all enabled sources, using cache when fresh.
 pub async fn browse_catalog(force_refresh: bool) -> Result<Vec<CatalogEntry>, String> {
     if !force_refresh {
@@ -121,29 +197,8 @@ pub async fn browse_catalog(force_refresh: bool) -> Result<Vec<CatalogEntry>, St
         .build()
         .map_err(|e| format!("failed to build http client: {e}"))?;
 
-    let mut all_entries: Vec<CatalogEntry> = Vec::new();
-    let mut errors: Vec<String> = Vec::new();
-
-    for source in &enabled {
-        match fetch_source_catalog(&client, source).await {
-            Ok(entries) => {
-                tracing::debug!(
-                    source = %source.id,
-                    count = entries.len(),
-                    "[skill_registry] fetched catalog"
-                );
-                all_entries.extend(entries);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    source = %source.id,
-                    error = %e,
-                    "[skill_registry] failed to fetch catalog"
-                );
-                errors.push(format!("{}: {e}", source.id));
-            }
-        }
-    }
+    let fetcher = HttpCatalogFetcher { client };
+    let (mut all_entries, errors) = collect_catalogs(&fetcher, &enabled).await;
 
     all_entries.sort_by(|a, b| {
         b.stars
@@ -363,4 +418,143 @@ struct RawIndexEntry {
     star_count: Option<u32>,
     updated_at: Option<String>,
     last_updated: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn source(id: &str) -> RegistrySource {
+        RegistrySource {
+            id: id.to_string(),
+            name: id.to_string(),
+            url: format!("https://example.test/{id}.json"),
+            kind: RegistryKind::GithubIndex,
+            enabled: true,
+        }
+    }
+
+    fn entry(id: &str, source_id: &str) -> CatalogEntry {
+        CatalogEntry {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: String::new(),
+            format: "openhuman".to_string(),
+            author: None,
+            version: None,
+            tags: Vec::new(),
+            download_url: format!("https://example.test/{id}.md"),
+            source_id: source_id.to_string(),
+            stars: None,
+            updated_at: None,
+        }
+    }
+
+    /// Fake fetcher returning canned per-source results, tracking the observed
+    /// max in-flight concurrency so a test can assert the fan-out really overlaps.
+    struct FakeFetcher {
+        responses: HashMap<String, Result<Vec<CatalogEntry>, String>>,
+        inflight: Arc<AtomicUsize>,
+        max_inflight: Arc<AtomicUsize>,
+        delay_ms: u64,
+    }
+
+    impl FakeFetcher {
+        fn new(delay_ms: u64) -> Self {
+            Self {
+                responses: HashMap::new(),
+                inflight: Arc::new(AtomicUsize::new(0)),
+                max_inflight: Arc::new(AtomicUsize::new(0)),
+                delay_ms,
+            }
+        }
+
+        fn with(mut self, id: &str, result: Result<Vec<CatalogEntry>, String>) -> Self {
+            self.responses.insert(id.to_string(), result);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl CatalogFetcher for FakeFetcher {
+        async fn fetch(&self, source: &RegistrySource) -> Result<Vec<CatalogEntry>, String> {
+            let now = self.inflight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_inflight.fetch_max(now, Ordering::SeqCst);
+            if self.delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+            }
+            self.inflight.fetch_sub(1, Ordering::SeqCst);
+            self.responses
+                .get(&source.id)
+                .cloned()
+                .unwrap_or_else(|| Err("no canned response".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn collect_catalogs_preserves_source_order() {
+        let sources: Vec<RegistrySource> = (1..=5).map(|n| source(&format!("src-{n}"))).collect();
+        let enabled: Vec<&RegistrySource> = sources.iter().collect();
+
+        let mut fetcher = FakeFetcher::new(0);
+        for n in 1..=5 {
+            let id = format!("src-{n}");
+            fetcher = fetcher.with(&id, Ok(vec![entry(&format!("evt-{n}"), &id)]));
+        }
+
+        let (entries, errors) = collect_catalogs(&fetcher, &enabled).await;
+        let ids: Vec<String> = entries.into_iter().map(|e| e.id).collect();
+        assert_eq!(
+            ids,
+            vec!["evt-1", "evt-2", "evt-3", "evt-4", "evt-5"],
+            "buffered fan-out must preserve per-source input order"
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn collect_catalogs_runs_sources_concurrently() {
+        let sources: Vec<RegistrySource> = (1..=4).map(|n| source(&format!("src-{n}"))).collect();
+        let enabled: Vec<&RegistrySource> = sources.iter().collect();
+
+        let mut fetcher = FakeFetcher::new(30);
+        for n in 1..=4 {
+            let id = format!("src-{n}");
+            fetcher = fetcher.with(&id, Ok(vec![entry(&format!("evt-{n}"), &id)]));
+        }
+        let max_inflight = fetcher.max_inflight.clone();
+
+        let (entries, _errors) = collect_catalogs(&fetcher, &enabled).await;
+        assert_eq!(entries.len(), 4);
+        assert!(
+            max_inflight.load(Ordering::SeqCst) > 1,
+            "fan-out must overlap fetches (observed max in-flight = {})",
+            max_inflight.load(Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test]
+    async fn collect_catalogs_isolates_failed_source() {
+        let sources = vec![source("src-1"), source("src-2"), source("src-3")];
+        let enabled: Vec<&RegistrySource> = sources.iter().collect();
+
+        // Middle source errors — it must drop out without poisoning the
+        // surviving two, and surface in the diagnostic `errors` list.
+        let fetcher = FakeFetcher::new(0)
+            .with("src-1", Ok(vec![entry("evt-1", "src-1")]))
+            .with("src-2", Err("boom".to_string()))
+            .with("src-3", Ok(vec![entry("evt-3", "src-3")]));
+
+        let (entries, errors) = collect_catalogs(&fetcher, &enabled).await;
+        let ids: Vec<String> = entries.into_iter().map(|e| e.id).collect();
+        assert_eq!(
+            ids,
+            vec!["evt-1", "evt-3"],
+            "a failed source contributes no entries while order is preserved"
+        );
+        assert_eq!(errors, vec!["src-2: boom".to_string()]);
+    }
 }


### PR DESCRIPTION
## Summary

- `skill_registry::ops::browse_catalog` now fetches each enabled registry source's index JSON with a bounded-concurrent `buffered` fan-out (K=4) instead of one strictly-serial `await` per source.
- Output-identical to the old serial loop: `buffered` yields per-source results in input order, so the accumulated `CatalogEntry` list (sorted afterwards) and the diagnostic `errors` list match exactly, and a failing source still contributes zero entries while being recorded in `errors`.
- Cold catalog loads (cache miss / `force_refresh`) on the Skills browse UI now resolve all sources in ~`ceil(N/4)` round-trips instead of N. Cached loads are unaffected (early return before any fetch).

## Problem

`browse_catalog` builds a `reqwest::Client`, then awaits each enabled source one at a time:

```rust
for source in &enabled {
    match fetch_source_catalog(&client, source).await {
        Ok(entries) => all_entries.extend(entries),
        Err(e) => errors.push(format!("{}: {e}", source.id)),
    }
}
```

Each source is an independent GitHub raw HTTP GET. The enabled set is the 3 bundled defaults (all `enabled: true`) plus any user-added custom sources, so a cold load blocked for the **sum** of every source's round-trip before the catalog could render.

## Solution

Introduce a narrow, testable seam — a `CatalogFetcher` trait — over the concrete reqwest fetch, then drive the per-source fetches through a bounded `buffered`:

- `HttpCatalogFetcher` is the real impl (delegates to the unchanged `fetch_source_catalog`).
- `collect_catalogs` materializes the per-source futures into a `Vec`, runs them through `futures::stream::iter(..).buffered(CATALOG_FETCH_CONCURRENCY)`, and folds the in-order results into `(entries, errors)` — the same accumulation the serial loop did.

Key parity points:
- **Output-identical**: `buffered(K)` emits result[i] for input[i], so the pre-sort entry order and the `errors` order match the serial loop; `browse_catalog` then applies the same `sort_by(stars desc, name asc)` and the same "all sources failed" aggregation as before.
- **Error semantics preserved**: a failed source logs a warn and is pushed to `errors`; surviving sources are unaffected.
- **Bounded**: `CATALOG_FETCH_CONCURRENCY = 4` caps sockets; the enabled set is tiny (3 defaults + custom).
- **HRTB**: the futures are collected into a `Vec` before `stream::iter` — a lazy `Map` adaptor trips the "implementation of `Send` is not general enough" error.

## Submission Checklist

- [x] Tests added (happy path + edge cases): `collect_catalogs_preserves_source_order` (5 sources > K, asserts input order), `collect_catalogs_runs_sources_concurrently` (asserts observed max in-flight > 1, i.e. real overlap), `collect_catalogs_isolates_failed_source` (middle source errors → drops out, survivors keep order, error recorded). The module previously had no tests.
- [x] **Diff coverage ≥ 80%**: the fan-out driver and per-source success/failure aggregation are exercised by the fake-fetcher tests; only the ~3-line real reqwest `HttpCatalogFetcher::fetch` remains client-bound (untestable without a live HTTP endpoint).
- [x] No new external network dependencies (same `fetch_source_catalog`, just concurrent).
- [x] N/A: no linked issue — proactive performance improvement.

## Impact

- Runtime: Rust core skill registry (`browse_catalog`), user-facing Skills browse UI on cold loads.
- Latency: a cold catalog load over N sources now resolves in ~`ceil(N/4)` round-trips instead of N. No change for cache hits.
- No migration, security, or compatibility implications; per-source fetch, parse, sort, caching, and the "all failed" error path are untouched.

## Parity Contract

- Legacy behaviour preserved: each source goes through the identical `fetch_source_catalog` → parse path; the final sort, cache write, and "all registry sources failed" aggregation are unchanged.
- Guard/fallback parity: the cache short-circuit, the empty-enabled early return, and the per-source error isolation all run exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Skill catalogs now fetch concurrently from multiple sources, reducing load times.
* **Reliability**
  * Partial source failures are isolated—failed sources no longer block others and produce per-source error messages.
* **Behavior**
  * Catalog order and downstream sorting/cache behavior are preserved.
* **Tests**
  * Added tests validating concurrent fetching, order preservation, and failure isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->