### PR TITLE
Fix Python runtime PATH for skill shell commands

### DIFF
--- a/src/openhuman/runtime_python/bootstrap.rs
+++ b/src/openhuman/runtime_python/bootstrap.rs
@@ -27,6 +27,9 @@ pub enum PythonSource {
 /// Fully-resolved Python interpreter.
 #[derive(Debug, Clone)]
 pub struct ResolvedPython {
+    /// Directory that should be prepended to `PATH` for child processes so
+    /// `python`, `python3`, `pip`, and `pip3` resolve to the same toolchain.
+    pub bin_dir: std::path::PathBuf,
     /// Absolute path to the Python executable.
     pub python_bin: std::path::PathBuf,
     /// Normalized interpreter version, e.g. `3.12.4`.
@@ -187,6 +190,7 @@ fn resolve_from_system(system: SystemPython) -> ResolvedPython {
         "[runtime_python::bootstrap] reusing compatible system python"
     );
     ResolvedPython {
+        bin_dir: python_bin_dir(&system.path),
         python_bin: system.path,
         version: system.version,
         source: PythonSource::System,
@@ -207,10 +211,18 @@ fn probe_managed_install(install_dir: &Path) -> Option<ResolvedPython> {
     let version = super::resolver::probe_python_version_public(&python_bin)?;
     let version_info = super::resolver::parse_python_version(&version)?;
     Some(ResolvedPython {
+        bin_dir: python_bin_dir(&python_bin),
         python_bin,
         version: version_info.display(),
         source: PythonSource::Managed,
     })
+}
+
+fn python_bin_dir(python_bin: &Path) -> PathBuf {
+    python_bin
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
 }
 
 fn find_python_binary(install_dir: &Path) -> Option<PathBuf> {

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -1,5 +1,6 @@
 use crate::openhuman::agent::host_runtime::RuntimeAdapter;
 use crate::openhuman::javascript::NodeBootstrap;
+use crate::openhuman::runtime_python::PythonBootstrap;
 use crate::openhuman::security::{AuditLogger, CommandExecutionLog, GateDecision, SecurityPolicy};
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 use async_trait::async_trait;
@@ -50,6 +51,12 @@ pub struct ShellTool {
     /// toolchain. Non-blocking: never triggers a download for unrelated
     /// commands (we use `try_cached()`).
     node_bootstrap: Option<Arc<NodeBootstrap>>,
+    /// Optional managed Python bootstrap. Unlike Node PATH injection, Python
+    /// shell support is the primary execution surface for skills, so
+    /// Python-looking commands resolve this lazily before spawn. That keeps
+    /// `pip install foo` and `python3 -m foo` on one interpreter instead of
+    /// mixing arbitrary host `pip` and `python3` binaries.
+    python_bootstrap: Option<Arc<PythonBootstrap>>,
 }
 
 impl ShellTool {
@@ -63,6 +70,7 @@ impl ShellTool {
             runtime,
             audit,
             node_bootstrap: None,
+            python_bootstrap: None,
         }
     }
 
@@ -80,6 +88,27 @@ impl ShellTool {
             runtime,
             audit,
             node_bootstrap: Some(bootstrap),
+            python_bootstrap: None,
+        }
+    }
+
+    /// Attach managed language runtimes used by shell-invoked skills. Node is
+    /// injected only after a dedicated node/npm tool resolved it; Python is
+    /// resolved lazily for python/pip commands because shell is currently the
+    /// user-facing Python skill execution path.
+    pub fn with_language_bootstraps(
+        security: Arc<SecurityPolicy>,
+        runtime: Arc<dyn RuntimeAdapter>,
+        audit: Arc<AuditLogger>,
+        node_bootstrap: Option<Arc<NodeBootstrap>>,
+        python_bootstrap: Option<Arc<PythonBootstrap>>,
+    ) -> Self {
+        Self {
+            security,
+            runtime,
+            audit,
+            node_bootstrap,
+            python_bootstrap,
         }
     }
 
@@ -264,25 +293,17 @@ impl ShellTool {
             }
         }
 
-        // If a managed Node.js install has already been resolved, transparently
-        // prepend its bin dir to PATH so this shell sees the managed toolchain.
-        // `try_cached()` never blocks and never triggers a download — unrelated
-        // commands (e.g. `ls`) stay fast and byte-identical to before.
-        if let Some(bootstrap) = self.node_bootstrap.as_ref() {
-            if let Some(resolved) = bootstrap.try_cached() {
-                let host_path = std::env::var("PATH").unwrap_or_default();
-                let sep = if cfg!(windows) { ";" } else { ":" };
-                let prepended = if host_path.is_empty() {
-                    resolved.bin_dir.to_string_lossy().into_owned()
-                } else {
-                    format!("{}{}{}", resolved.bin_dir.display(), sep, host_path)
-                };
-                tracing::debug!(
-                    bin_dir = %resolved.bin_dir.display(),
-                    version = %resolved.version,
-                    "[shell] prepending managed node bin to PATH"
+        match self.runtime_path_for_command(command).await {
+            Ok(Some(path)) => {
+                tracing::debug!(path = %path, "[shell] applying managed runtime PATH");
+                cmd.env("PATH", path);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return (
+                    true,
+                    ToolResult::error(format!("Failed to resolve command runtime: {error}")),
                 );
-                cmd.env("PATH", prepended);
             }
         }
 
@@ -350,16 +371,16 @@ impl ShellTool {
         );
 
         let mut extra_env = std::collections::HashMap::new();
-        if let Some(bootstrap) = self.node_bootstrap.as_ref() {
-            if let Some(resolved) = bootstrap.try_cached() {
-                let host_path = std::env::var("PATH").unwrap_or_default();
-                let sep = if cfg!(windows) { ";" } else { ":" };
-                let prepended = if host_path.is_empty() {
-                    resolved.bin_dir.to_string_lossy().into_owned()
-                } else {
-                    format!("{}{}{}", resolved.bin_dir.display(), sep, host_path)
-                };
-                extra_env.insert("PATH".to_string(), prepended);
+        match self.runtime_path_for_command(command).await {
+            Ok(Some(path)) => {
+                extra_env.insert("PATH".to_string(), path);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return (
+                    true,
+                    ToolResult::error(format!("Failed to resolve command runtime: {error}")),
+                );
             }
         }
 
@@ -402,6 +423,109 @@ impl ShellTool {
             ),
         }
     }
+
+    async fn runtime_path_for_command(&self, command: &str) -> anyhow::Result<Option<String>> {
+        let mut prepend_dirs = Vec::new();
+
+        // Node injection preserves the existing contract: shell only sees the
+        // managed Node bin directory after a previous node/npm tool resolved it.
+        if let Some(bootstrap) = self.node_bootstrap.as_ref() {
+            if let Some(resolved) = bootstrap.try_cached() {
+                tracing::debug!(
+                    bin_dir = %resolved.bin_dir.display(),
+                    version = %resolved.version,
+                    "[shell] prepending managed node bin to PATH"
+                );
+                prepend_dirs.push(resolved.bin_dir);
+            }
+        }
+
+        if shell_command_needs_python_runtime(command) {
+            if let Some(bootstrap) = self.python_bootstrap.as_ref() {
+                let resolved = bootstrap.resolve().await?;
+                tracing::debug!(
+                    bin_dir = %resolved.bin_dir.display(),
+                    python_bin = %resolved.python_bin.display(),
+                    version = %resolved.version,
+                    source = ?resolved.source,
+                    "[shell] prepending python runtime bin to PATH"
+                );
+                prepend_dirs.push(resolved.bin_dir);
+            }
+        }
+
+        if prepend_dirs.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(prepend_path_dirs(
+                prepend_dirs.iter().map(|p| p.as_path()),
+                &std::env::var("PATH").unwrap_or_default(),
+            )))
+        }
+    }
+}
+
+fn prepend_path_dirs<'a>(
+    dirs: impl IntoIterator<Item = &'a std::path::Path>,
+    host_path: &str,
+) -> String {
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let mut parts: Vec<String> = dirs
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    if !host_path.is_empty() {
+        parts.push(host_path.to_string());
+    }
+    parts.join(sep)
+}
+
+fn shell_command_needs_python_runtime(command: &str) -> bool {
+    let lower = command.to_ascii_lowercase();
+    lower
+        .split(|ch| matches!(ch, ';' | '&' | '|' | '\n' | '\r'))
+        .any(segment_starts_with_python_command)
+}
+
+fn segment_starts_with_python_command(segment: &str) -> bool {
+    let mut tokens = segment.split_whitespace().peekable();
+    while let Some(token) = tokens.next() {
+        let token = token.trim_matches(|ch| matches!(ch, '(' | ')' | '<' | '>'));
+        if token.is_empty() {
+            continue;
+        }
+        if token.contains('=') && !token.starts_with('-') {
+            continue;
+        }
+        if matches!(token, "sudo" | "command" | "time" | "env") {
+            continue;
+        }
+        return is_python_executable_token(token);
+    }
+    false
+}
+
+fn is_python_executable_token(token: &str) -> bool {
+    let executable = token.rsplit('/').next().unwrap_or(token);
+    matches!(
+        executable,
+        "python"
+            | "python3"
+            | "py"
+            | "pip"
+            | "pip3"
+            | "python.exe"
+            | "python3.exe"
+            | "pip.exe"
+            | "pip3.exe"
+    ) || versioned_executable(executable, "python3.")
+        || versioned_executable(executable, "pip3.")
+}
+
+fn versioned_executable(executable: &str, prefix: &str) -> bool {
+    executable
+        .strip_prefix(prefix)
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()))
 }
 
 #[cfg(test)]
@@ -892,6 +1016,54 @@ mod tests {
                 "{var} must be forwarded for Windows child processes"
             );
         }
+    }
+
+    #[test]
+    fn shell_detects_python_runtime_commands() {
+        for command in [
+            "python3 -m pyfiglet hello",
+            "python -m pip install pyfiglet",
+            "pip install pyfiglet",
+            "pip3.13 show pyfiglet",
+            "/opt/openhuman/python/bin/python3 script.py",
+            "echo hi && python3 -V",
+        ] {
+            assert!(
+                shell_command_needs_python_runtime(command),
+                "expected python runtime detection for {command}"
+            );
+        }
+
+        for command in [
+            "echo python3",
+            "ls",
+            "cat ./pipelines.txt",
+            "node script.js",
+        ] {
+            assert!(
+                !shell_command_needs_python_runtime(command),
+                "did not expect python runtime detection for {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_runtime_path_prepends_managed_dirs_before_host_path() {
+        let python = std::path::Path::new("/opt/openhuman/python/bin");
+        let node = std::path::Path::new("/opt/openhuman/node/bin");
+        let joined = prepend_path_dirs([python, node], "/usr/local/bin:/usr/bin");
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        assert_eq!(
+            joined,
+            format!(
+                "{}{}{}{}{}",
+                python.display(),
+                sep,
+                node.display(),
+                sep,
+                "/usr/local/bin:/usr/bin"
+            )
+        );
     }
 
     #[tokio::test]

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -4,6 +4,7 @@ use crate::openhuman::agent::host_runtime::{NativeRuntime, RuntimeAdapter};
 use crate::openhuman::config::{Config, DelegateAgentConfig};
 use crate::openhuman::javascript::NodeBootstrap;
 use crate::openhuman::memory::Memory;
+use crate::openhuman::runtime_python::PythonBootstrap;
 use crate::openhuman::security::{AuditLogger, SecurityPolicy};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -113,21 +114,29 @@ pub fn all_tools_with_runtime(
         );
         None
     };
-
-    let shell: Box<dyn Tool> = if let Some(bootstrap) = node_bootstrap.as_ref() {
-        Box::new(ShellTool::with_node_bootstrap(
-            security.clone(),
-            Arc::clone(&runtime),
-            Arc::clone(&audit),
-            Arc::clone(bootstrap),
-        ))
+    let python_bootstrap: Option<Arc<PythonBootstrap>> = if root_config.runtime_python.enabled {
+        tracing::debug!(
+            minimum_version = %root_config.runtime_python.minimum_version,
+            prefer_system = root_config.runtime_python.prefer_system,
+            "[tools::ops] python runtime enabled — constructing shared PythonBootstrap"
+        );
+        Some(Arc::new(PythonBootstrap::new(
+            root_config.runtime_python.clone(),
+        )))
     } else {
-        Box::new(ShellTool::new(
-            security.clone(),
-            Arc::clone(&runtime),
-            Arc::clone(&audit),
-        ))
+        tracing::debug!(
+            "[tools::ops] python runtime disabled — shell python/pip PATH injection suppressed"
+        );
+        None
     };
+
+    let shell: Box<dyn Tool> = Box::new(ShellTool::with_language_bootstraps(
+        security.clone(),
+        Arc::clone(&runtime),
+        Arc::clone(&audit),
+        node_bootstrap.as_ref().map(Arc::clone),
+        python_bootstrap.as_ref().map(Arc::clone),
+    ));
 
     let mut tools: Vec<Box<dyn Tool>> = vec![
         shell,


### PR DESCRIPTION
## Summary

- Adds `bin_dir` to resolved Python runtime metadata so callers can prepend the owning interpreter directory to `PATH`.
- Wires a shared `PythonBootstrap` into `ShellTool` for agent/skill shell execution.
- Lazily resolves Python only for python/pip-looking shell commands so ordinary shell calls do not trigger runtime downloads.
- Applies the same runtime PATH forwarding to sandboxed shell execution.

## Problem

- Skill execution can install Python packages with one `pip` binary and then execute `python3` from another host location.
- In the observed ascii-art flow, `pip install pyfiglet` appeared successful, but `/usr/local/bin/python3 -m pyfiglet` failed with `No module named pyfiglet`.
- The system prompt already tells skill executors to use OpenHuman Python runtimes, but the general shell tool did not inject that runtime for Python shell commands.

## Solution

- `ResolvedPython` now exposes `bin_dir`, derived from both managed and system interpreters.
- `ShellTool` accepts optional language bootstraps and builds a runtime-aware `PATH` before spawning commands.
- Python runtime resolution is command-aware: `python`, `python3`, versioned `python3.x`, `pip`, `pip3`, and versioned `pip3.x` at command positions trigger resolution; text arguments like `echo python3` do not.
- Added focused Rust tests for Python command detection and PATH ordering.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — N/A: did not run full diff coverage locally; focused Rust tests cover the changed shell heuristics and PATH composition.
- [x] Coverage matrix updated — N/A: runtime behavior fix, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release manual smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no issue provided.

## Impact

- Runtime/platform: affects agent shell execution on desktop/core when skills invoke Python or pip commands.
- Compatibility: preserves existing Node PATH injection behavior and keeps Python resolution lazy for unrelated shell commands.
- Security: continues to clear host env and forwards only the existing safe env allowlist; runtime PATH is rebuilt after env clearing.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/skill-python-runtime`
- Commit SHA: `6d9c04c90`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --manifest-path Cargo.toml shell_ --lib`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml`; `cargo check --manifest-path Cargo.toml`; pre-push `pnpm --filter openhuman-app rust:check`
- [x] Tauri fmt/check (if changed): pre-push `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check`; pre-push `pnpm --filter openhuman-app rust:check`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Python/pip shell commands in skill execution resolve through the OpenHuman Python runtime and prepend its bin directory to PATH.
- User-visible effect: skills like ascii-art can install and execute Python packages without crossing mismatched host pip/python binaries.

### Parity Contract

- Legacy behavior preserved: non-Python shell commands keep the existing environment flow; Node PATH injection remains cached-only.
- Guard/fallback/dispatch parity checks: native and sandboxed shell paths both call the same runtime PATH builder.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell commands now automatically detect and use the configured Python runtime for Python and pip operations, providing consistent managed runtime support alongside existing Node.js integration.

* **Tests**
  * Added test coverage for Python command detection and runtime management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->