### PR TITLE
fix(shell): demote per-poll CEF cache-held log to debug (TAURI-RUST-B7S)

### DIFF
--- a/app/src-tauri/src/cef_preflight.rs
+++ b/app/src-tauri/src/cef_preflight.rs
@@ -195,7 +195,16 @@ pub fn check_cef_cache_lock(cache_path: &Path) -> Result<(), CefLockError> {
     };
 
     if is_pid_alive(pid) {
-        log::error!(
+        // `debug!`, not `error!`: a live lock-holder is the *expected,
+        // self-healing* precondition the caller polls on, not a fault. This is a
+        // pure predicate — severity belongs to the loop, not here. #3337 wrapped
+        // this check in the `wait_for_cache_release` poll loop, so an `error!`
+        // here fired once *per poll* (~3 on a wait that clears, ~11 on one that
+        // times out), flooding Sentry (TAURI-RUST-B7S: 29k events from a single
+        // release). The loop already logs `warn!` per poll and a single `error!`
+        // on give-up, matching the Windows `cef_singleton_wait` sibling. Do not
+        // re-promote this to `error!`.
+        log::debug!(
             "[cef-preflight] CEF cache held by host={} pid={} at {}",
             host,
             pid,


### PR DESCRIPTION
## Summary

Demote the per-poll "CEF cache held" log in `cef_preflight::check_cef_cache_lock` from `error!` to `debug!`. This collapses Sentry **TAURI-RUST-B7S** — **29,188 events in ~1 day, all from a single release (0.57.18)** — back to at most one error event per genuinely-failed launch, with zero behavior change.

## Problem

`check_cef_cache_lock` is a pure `Result`-returning predicate, but it `log::error!`s every time it observes a live CEF lock-holder. The `log::error!` line itself is old (added in #864) and was harmless when the check was **one-shot** — see a held lock, log once, `exit(1)`.

#3337 (TAURI-RUST-F, shipped in 0.57.18) then wrapped that predicate in `wait_for_cache_release` — a 5s backoff **poll loop** — to gracefully ride out relaunch races, but left the per-detection `error!` intact. So the old one-shot error became per-poll:

- a wait that **succeeds** after the holder releases still emits ~3 error events before the lock clears;
- a wait that **times out** emits ~11.

`log::error!` is bridged (`tracing_log::LogTracer` → sentry-tracing layer, `Level::ERROR → Event` per `src/core/logging.rs`), so each poll became a Sentry **event** → the 29k flood. All 29,152 events are from release `openhuman@0.57.18`, confirming a clean single-release regression.

The cache-lock **behavior is correct** (it waits, then exits cleanly with code 0); only the telemetry severity is wrong. The Windows sibling `cef_singleton_wait.rs` (also #3337-era) already does this right — silent predicate, `warn!` while waiting, a single `error!` on give-up — which is why no equivalent Windows flood exists.

## Solution

Demote the held-branch log in `check_cef_cache_lock` from `error!` to `debug!` (+ a comment naming TAURI-RUST-B7S and the #3337 loop context so it is not re-promoted). `wait_for_cache_release` is unchanged: it already logs `warn!` per poll (breadcrumb) and a single `error!` on give-up (the one legitimate Sentry signal). Net result mirrors Windows exactly:

- successful wait → **0** error events (was ~3);
- genuine give-up → **1** error event (was ~11).

`CefLockError::Held` is still returned identically, so every caller and all existing tests are unaffected.

## Submission Checklist
- [x] Tests added or updated (happy path + at least one failure / edge case) — `N/A: severity-only change; existing `lock_held_by_live_pid_returns_err` / `check_default_cache_env_path_held_returns_err` already pin the `Err(Held)` return on the changed branch (13/13 pass)
- [x] **Diff coverage ≥ 80%** — the single changed executable line (`log::debug!`) sits in the held branch exercised by the above tests
- [x] Coverage matrix updated — `N/A: behaviour-only change`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature touched`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: log-severity only`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: Sentry-only fix (TAURI-RUST-B7S), no GH issue`

## Impact

- Eliminates the dominant noise source on the self-hosted Sentry `tauri-rust` project (TAURI-RUST-B7S, 29k+ events). Restores signal: a held-lock at process start is now a `debug!`/breadcrumb, and only a genuine "another instance still running after 5s" give-up raises an error event.
- No runtime behavior change: cache-lock wait/exit semantics, the actionable give-up message, and `CefLockError::Held` are all preserved.

## Related

Sentry-Issue: TAURI-RUST-B7S
Regression introduced by #3337 (post-merge follow-up).

**CI note:** `E2E (Playwright / web lane 2/4)` fails here from a pre-existing `main` bug, not this change — `mcp-tab-flow.spec.ts` hardcoded `APP_VERSION` mismatched the `0.57.19` build, blanking `#root`. Fixed by #3501 (lane 2/4 proven green there). This PR's lane 2/4 clears on rebase once #3501 merges. This change is one Rust log-level line and cannot affect a React-page E2E.

## AI Authored PR Metadata (required for Codex/Linear PRs)
### Linear Issue
N/A — Sentry-driven (TAURI-RUST-B7S).
### Commit & Branch
Branch `fix/cef-preflight-sentry-error-flood`; commit demoting the per-poll held log to `debug!`.
### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — green via CI "Frontend Quality (typecheck, lint, format)"
- [x] `pnpm typecheck` — green via CI "Frontend Quality (typecheck, lint, format)"
- [x] Focused tests: `cargo test --manifest-path app/src-tauri/Cargo.toml --lib cef_preflight` → 13 passed, 0 failed
- [x] Rust fmt/check (if changed): `N/A: core crate (src/) not changed`
- [x] Tauri fmt/check (if changed): `cargo clippy --manifest-path app/src-tauri/Cargo.toml --lib` → exit 0; `cargo fmt --check` clean
### Validation Blocked
None.
### Behavior Changes
None — log severity only. `CefLockError::Held` return, wait/exit semantics, and the give-up error log are unchanged.
