### PR TITLE
fix(test): derive mcp-tab spec APP_VERSION from package.json

### DIFF
--- a/app/test/playwright/specs/mcp-tab-flow.spec.ts
+++ b/app/test/playwright/specs/mcp-tab-flow.spec.ts
@@ -8,7 +8,13 @@
  */
 import { expect, type Page, test } from '@playwright/test';
 
-const APP_VERSION = '0.57.18';
+import packageJson from '../../../package.json' with { type: 'json' };
+
+// Derive from the build's real version, never hardcode. `update_version` feeds
+// the bootCheck version-match gate; a stale literal makes the mock mismatch the
+// app build, leaving BootCheckGate in "outdated" so `#root` never renders and
+// the whole spec times out (the 0.57.18→0.57.19 bump blanked it this way).
+const APP_VERSION = packageJson.version;
 
 // ---------------------------------------------------------------------------
 // Mock data


### PR DESCRIPTION
## Summary

Derive `APP_VERSION` in `mcp-tab-flow.spec.ts` from `package.json` instead of hardcoding it, so a release version bump can never silently break the bootCheck version-match gate.

## Problem

`app/test/playwright/specs/mcp-tab-flow.spec.ts` hardcoded `const APP_VERSION = '0.57.18'` and fed it into the `openhuman.update_version` mock. The `v0.57.19` staging bump (`04629ea16`) left that literal stale, so the mock returned `0.57.18` while the app build was `0.57.19`. `bootCheck` compares running-core version to app-build version and reports `outdated` on mismatch — `BootCheckGate` then never renders the app, so `#root` stays empty and every test in the spec times out on `await page.waitForSelector('#root', { state: 'visible' })`.

Result: **E2E (Playwright / web lane 2/4)** is red on `main` (and on every branch cut from `0.57.19`) with all 16 `mcp-tab-flow` tests failing. Timeline confirms it: lane 2/4 passed at `e213afc45` (app `0.57.18`, mock matched) and broke at the version-bump-only commit `04629ea16`.

## Solution

Import the build's real version and use it for the mock:

```ts
import packageJson from '../../../package.json' with { type: 'json' };
const APP_VERSION = packageJson.version;
```

The `with { type: 'json' }` import attribute is required by Playwright's Node-ESM loader. Now the mock always matches the app build, so future release bumps cannot re-break the gate — the spec self-tracks the version.

## Submission Checklist
- [x] Tests added or updated (happy path + at least one failure / edge case) — `N/A: fixes the existing mcp-tab-flow spec so it runs at all; no behavior under test changes`
- [x] **Diff coverage ≥ 80%** — `N/A: test-only change (no product lines added)`
- [x] Coverage matrix updated — `N/A: test-infra fix`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature touched`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: test-only`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no GH issue; fixes pre-existing main breakage`

## Impact

- Un-reds **E2E web lane 2/4** on `main` and on every fork branch cut from `0.57.19`.
- Removes a recurring version-coupling footgun: the spec now derives its version, so the next release bump won't reintroduce this failure.

## Related

Regression source: #3480 (introduced the hardcoded `APP_VERSION` in the new `mcp-tab-flow.spec.ts`).
Surfaced by the `v0.57.19` staging bump (`04629ea16`).

## AI Authored PR Metadata (required for Codex/Linear PRs)
### Linear Issue
N/A — test-infra fix, no ticket.
### Commit & Branch
Branch `fix/mcp-tab-spec-version-coupling`; one commit deriving `APP_VERSION` from `package.json`.
### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — clean
- [x] `pnpm typecheck` — clean (`pnpm compile`)
- [x] Focused tests: `npx playwright test mcp-tab-flow.spec.ts --list` compiles + lists all 16 tests (JSON import resolves under Playwright's loader); eslint clean
- [x] Rust fmt/check (if changed): `N/A: no Rust changed` (pre-push `rust:check` ran green)
- [x] Tauri fmt/check (if changed): `N/A: no Tauri changed`
### Validation Blocked
Full Playwright web run is the lane CI itself — verified there on this PR.
### Behavior Changes
None — test-only. The spec now matches the app's real version instead of a stale literal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved version handling in integration tests to ensure accurate testing of version-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->