### PR TITLE
fix(observability): classify ollama NaN-encoding 500 as expected user-state (TAURI-RUST-AZ)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -747,6 +747,14 @@ fn is_ollama_user_config_rejection(lower: &str) -> bool {
         return true;
     }
 
+    // TAURI-RUST-AZ — Ollama returns 500 with `unsupported value: NaN` when the
+    // model produces NaN for some input in the batch. The embed provider already
+    // recovers via per-text fallback; the initial batch-level error is upstream
+    // state (model bug / numerically degenerate input), not actionable in Sentry.
+    if lower.contains("ollama embed failed") && lower.contains("unsupported value: nan") {
+        return true;
+    }
+
     false
 }
 
@@ -2263,6 +2271,9 @@ mod tests {
             r#"ollama embed failed with status 501 Not Implemented: {"error":"this model does not support embeddings"}"#,
             // TAURI-RUST-3E — 401 unauthorized embed (auth required at ollama endpoint).
             r#"ollama embed failed with status 401 Unauthorized: {"error": "unauthorized"}"#,
+            // TAURI-RUST-AZ — Ollama 500 NaN-encoding error (model produces NaN
+            // for some input; embed provider already recovers via per-text fallback).
+            r#"ollama embed failed with status 500 Internal Server Error: {"error":"failed to encode response: json: unsupported value: NaN"}"#,
         ] {
             assert_eq!(
                 expected_error_kind(raw),


### PR DESCRIPTION
## Summary
- **Sentry issue:** [TAURI-RUST-AZ](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/464/) (~768 events, regressed)
- Ollama returns 500 `unsupported value: NaN` when a model produces NaN for some input in a batch — the embed provider already recovers via per-text fallback, but the initial batch-level error was not classified by `is_ollama_user_config_rejection` and leaked to Sentry
- Adds `"ollama embed failed" + "unsupported value: nan"` to the ollama user-config classifier

## Changes
- `src/core/observability.rs` — add NaN-encoding pattern to `is_ollama_user_config_rejection()` + test entry in `classifies_ollama_user_config_rejections`

## Test plan
- [x] `classifies_ollama_user_config_rejections` — now includes verbatim TAURI-RUST-AZ wire body
- [x] `does_not_classify_unrelated_ollama_errors_as_user_config` — bare 500 without NaN still reaches Sentry
- [x] `cargo check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Ollama embedding operations to recognize and properly classify a specific NaN value error case, ensuring consistent behavior when Ollama returns this configuration failure type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->