### PR TITLE
fix(observability): classify web-channel prompt-injection wording as expected (TAURI-RUST-1J)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1164,9 +1164,15 @@ fn is_local_ai_capability_unavailable_message(lower: &str) -> bool {
 /// prefix that cannot appear in any other error path. Anchored to the exact
 /// strings emitted by `prompt_guard_user_message` in
 /// `src/openhuman/inference/local/ops.rs`.
+///
+/// A third variant is emitted by the web channel provider
+/// (`src/openhuman/channels/providers/web/ops.rs`) which uses the phrasing
+/// "message was flagged for security review" rather than "prompt flagged".
+/// See TAURI-RUST-1J.
 fn is_prompt_injection_blocked_message(lower: &str) -> bool {
     lower.contains("prompt flagged for security review")
         || lower.contains("prompt blocked by security policy")
+        || lower.contains("message was flagged for security review")
 }
 
 /// Detect an RPC-level filesystem path validation failure from user input.
@@ -2384,6 +2390,9 @@ mod tests {
         for raw in [
             "Prompt flagged for security review and was not processed. Please rephrase clearly.",
             "Prompt blocked by security policy. Please rephrase without instruction overrides or exfiltration requests.",
+            // TAURI-RUST-1J — web channel variant uses "message was flagged"
+            // rather than "prompt flagged".
+            "Your message was flagged for security review and was not processed. Please rephrase the request in a direct, task-focused way.",
         ] {
             assert_eq!(
                 expected_error_kind(raw),


### PR DESCRIPTION
## Summary
- **Sentry issue:** [TAURI-RUST-1J](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/116/) (~228 events)
- The web channel provider (`web/ops.rs`) emits `"Your message was flagged for security review"` but `is_prompt_injection_blocked_message` only matched `"prompt flagged for security review"` and `"prompt blocked by security policy"` — wording mismatch let events leak to Sentry
- Adds `"message was flagged for security review"` as a third pattern

## Changes
- `src/core/observability.rs` — add third pattern to `is_prompt_injection_blocked_message()` + doc comment update + test entry in `classifies_prompt_injection_blocked_errors`

## Test plan
- [x] `classifies_prompt_injection_blocked_errors` — now includes verbatim web-channel wording
- [x] `does_not_classify_unrelated_messages_as_prompt_injection_blocked` — unrelated messages still pass through
- [x] `cargo check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of security-related messages. The system now recognizes an additional warning variant that may appear when content is flagged for security review, improving accuracy in identifying security-related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->