### PR TITLE
fix(observability): classify inference errors on backend errorCode (F2/F3/F4/F6/F7/F8)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2181,6 +2181,31 @@ pub fn run() {
             {
                 return None;
             }
+            // Defense-in-depth: drop managed-backend `errorCode` events (#870)
+            // the backend owns (F2/F4). The shell links the core in-process,
+            // so a managed inference error captured here must be filtered
+            // identically to the core binary's main.rs chain. The malformed
+            // `BAD_REQUEST` carve-out (F8) is excluded by the underlying
+            // decision, so a client-built bad payload still pages.
+            if openhuman_core::core::observability::is_backend_error_code_event(&event) {
+                log::debug!(
+                    "[sentry-error-code-filter] dropping backend-owned errorCode event_id={:?}",
+                    event.event_id
+                );
+                return None;
+            }
+            // Defense-in-depth: drop transient streaming transport blips
+            // (domain=llm_provider, failure=transport) — flaky-network
+            // timeouts/resets recovered by retry/fallback (F7). Mirrors the
+            // core binary's main.rs filter.
+            if openhuman_core::core::observability::is_transient_provider_transport_failure(&event)
+            {
+                log::debug!(
+                    "[sentry-transport-filter] dropping transient provider transport event_id={:?}",
+                    event.event_id
+                );
+                return None;
+            }
             // Drop 401 "Session expired. Please log in again." bodies and
             // pre-flight "no session token stored" guards — mirrors the
             // core binary's before_send chain. Since #1061 the Tauri shell

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -1062,6 +1062,10 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       ['tool_error', 'A tool call failed during this request.'],
       ['provider_error', 'The AI provider returned an error.'],
       ['model_unavailable', 'The selected model is currently unavailable.'],
+      [
+        'payload_too_large',
+        'Your message or attachment is too large for this model. Shorten it or remove the attachment — or start a new thread.',
+      ],
     ] as const)('forwards server message for error_type %s', async (error_type, serverMessage) => {
       const listeners = renderProvider();
       const threadId = `t-${error_type}`;

--- a/app/src/services/chatService.ts
+++ b/app/src/services/chatService.ts
@@ -102,6 +102,7 @@ export interface ChatErrorEvent {
     | 'provider_error'
     | 'context_overflow'
     | 'model_unavailable'
+    | 'payload_too_large'
     | 'budget_exhausted';
   round: number | null;
 }

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -268,10 +268,37 @@ pub enum ExpectedErrorKind {
     /// — a genuine keyring/persist failure in `upsert_profile` carries neither
     /// anchor, so a real defect in the import code still reaches Sentry.
     CodexCliAuthUnavailable,
+    /// The managed backend (#870) stamped a stable `errorCode` on this
+    /// inference error response — so the backend **owns** it (it already paged
+    /// its own 5xx, or the code is expected user-state: rate limit, out of
+    /// credits, upstream unavailable, model/routing misconfig, payload too
+    /// large, context overflow, user-param rejection). The provider HTTP layer
+    /// (`api_error`) already demotes its own per-attempt event; this catches
+    /// the **re-report** when the same flattened error is raised again under
+    /// `domain=web_channel` / `agent` (the path
+    /// `channels::providers::web::run_chat_task` →
+    /// `report_error_or_expected`). The FE surfaces actionable copy via
+    /// `classify_inference_error`; Sentry must not double-report (F2/F4).
+    ///
+    /// The single exception — a backend-flagged **malformed** `BAD_REQUEST` —
+    /// is NOT classified here (it is a client-built payload the backend
+    /// couldn't parse, and the FE *does* page for it, F8). See
+    /// [`crate::openhuman::inference::provider::backend_error_code_skips_sentry`].
+    BackendErrorCodeOwned,
 }
 
 pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     let lower = message.to_ascii_lowercase();
+    // F2/F4: a managed-backend `errorCode` (#870) means the backend owns this
+    // error — it already paged its own 5xx, or the code is expected user-state.
+    // Trust it FIRST, before the substring matchers, so a managed 500
+    // `INTERNAL_ERROR` (which no substring matcher below would otherwise demote)
+    // stops double-reporting. The one exception — a backend-flagged malformed
+    // `BAD_REQUEST` — is excluded by `backend_error_code_skips_sentry` and
+    // falls through to the matchers / capture so the FE still pages (F8).
+    if crate::openhuman::inference::provider::backend_error_code_skips_sentry(message) {
+        return Some(ExpectedErrorKind::BackendErrorCodeOwned);
+    }
     // Check the Codex-CLI import envelope first: it is highly specific
     // (literal `codex cli auth` / `.codex/auth.json`) and carries no overlap
     // with the generic matchers below, so ordering is for clarity, not
@@ -1635,6 +1662,23 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 "[observability] {domain}.{operation} skipped expected codex-cli auth-unavailable error"
             );
         }
+        ExpectedErrorKind::BackendErrorCodeOwned => {
+            // Managed-backend `errorCode` (#870) re-report — the backend owns
+            // this error (already paged its own 5xx, or expected user-state).
+            // The FE surfaces actionable copy via `classify_inference_error`;
+            // Sentry must not double-report (F2/F4). Demote at `warn!` so the
+            // breadcrumb retains the code for triage without spawning an event.
+            let code =
+                crate::openhuman::inference::provider::extract_backend_error_code_token(message)
+                    .unwrap_or_default();
+            tracing::warn!(
+                domain = domain,
+                operation = operation,
+                kind = "backend_error_code",
+                error_code = %code,
+                "[observability] {domain}.{operation} skipped backend-owned errorCode={code} error: {message}"
+            );
+        }
     }
 }
 
@@ -1721,6 +1765,50 @@ pub fn is_transient_provider_http_failure(event: &sentry::protocol::Event<'_>) -
         return false;
     };
     TRANSIENT_PROVIDER_HTTP_STATUSES.contains(&status_u16)
+}
+
+/// Defense-in-depth `before_send` filter for managed-backend `errorCode`
+/// events (#870): drops any Sentry event whose message/exception text carries a
+/// backend `errorCode` that the backend owns (F2/F4) — *except* a backend-flagged
+/// malformed `BAD_REQUEST`, which the client caused and so still pages (F8).
+///
+/// Primary suppression lives at the emit sites (`api_error` /
+/// `compatible_*` streaming gates) and at the higher-layer re-report
+/// classifier (`expected_error_kind` → [`ExpectedErrorKind::BackendErrorCodeOwned`]).
+/// This catches any future call site that re-emits the same flattened error
+/// without routing through those funnels. Delegates the decision to the
+/// single-source [`crate::openhuman::inference::provider::backend_error_code_skips_sentry`]
+/// so the layers can't drift.
+pub fn is_backend_error_code_event(event: &sentry::protocol::Event<'_>) -> bool {
+    let direct = event.message.as_deref();
+    let from_logentry = event.logentry.as_ref().map(|log| log.message.as_str());
+    let from_exception = event.exception.last().and_then(|e| e.value.as_deref());
+    [direct, from_logentry, from_exception]
+        .into_iter()
+        .flatten()
+        .any(crate::openhuman::inference::provider::backend_error_code_skips_sentry)
+}
+
+/// Defense-in-depth `before_send` filter for transient streaming **transport**
+/// failures (F7): drops `domain=llm_provider, failure=transport` events whose
+/// body is a transient transport phrase (timeout / reset / TLS-handshake EOF /
+/// "error sending request"). Flaky-network blips on the streaming send are
+/// recovered by retry/fallback and carry no actionable Sentry signal; a
+/// non-transient transport failure (DNS misconfig, unexpected protocol error)
+/// is not matched and still pages.
+///
+/// Primary gate lives at the two streaming emit sites in
+/// `compatible_provider_impl.rs` (`stream_chat` / `stream_chat_history`); this
+/// catches any future site that reports the same shape without gating.
+pub fn is_transient_provider_transport_failure(event: &sentry::protocol::Event<'_>) -> bool {
+    let tags = &event.tags;
+    if tags.get("domain").map(String::as_str) != Some("llm_provider") {
+        return false;
+    }
+    if tags.get("failure").map(String::as_str) != Some("transport") {
+        return false;
+    }
+    event_has_transient_transport_phrase(event)
 }
 
 /// Returns true when a Sentry event's message/exception text contains the
@@ -5209,5 +5297,136 @@ mod tests {
             "supervised_listener",
             &[("channel", "discord")],
         );
+    }
+
+    // ── #870 managed-backend errorCode Sentry ownership (F2/F4/F7/F8) ──
+
+    fn managed_body(status: &str, code: &str) -> String {
+        format!(
+            "OpenHuman API error ({status}): {{\"error\":{{\"errorCode\":\"{code}\",\"message\":\"x\"}}}}"
+        )
+    }
+
+    #[test]
+    fn expected_kind_demotes_every_backend_owned_error_code() {
+        for (status, code) in [
+            ("429", "RATE_LIMITED"),
+            ("402", "USER_INSUFFICIENT_CREDITS"),
+            ("503", "UPSTREAM_UNAVAILABLE"),
+            ("404", "MODEL_UNAVAILABLE"),
+            ("413", "PAYLOAD_TOO_LARGE"),
+            ("400", "CONTEXT_LENGTH_EXCEEDED"),
+            ("400", "BAD_REQUEST"),
+            ("500", "INTERNAL_ERROR"),
+        ] {
+            let body = managed_body(status, code);
+            assert_eq!(
+                expected_error_kind(&body),
+                Some(ExpectedErrorKind::BackendErrorCodeOwned),
+                "errorCode={code} must be backend-owned (no FE Sentry)"
+            );
+        }
+    }
+
+    #[test]
+    fn expected_kind_lets_malformed_bad_request_page() {
+        // F8: the one errorCode case that still pages — the backend flagged a
+        // client-built payload as unparseable. `expected_error_kind` must NOT
+        // classify it as expected, so capture proceeds.
+        let body = "OpenHuman API error (400 Bad Request): \
+             {\"error\":{\"errorCode\":\"BAD_REQUEST\",\"malformed\":true}}";
+        assert_eq!(expected_error_kind(body), None);
+    }
+
+    #[test]
+    fn expected_kind_ignores_byo_errors_with_no_code() {
+        // A BYO 401 carries no errorCode — it must NOT be swallowed by the
+        // backend-owned branch (it routes through its own matchers / capture).
+        let body = "openai API error (401 Unauthorized): \
+             {\"error\":{\"message\":\"Incorrect API key provided\"}}";
+        assert_ne!(
+            expected_error_kind(body),
+            Some(ExpectedErrorKind::BackendErrorCodeOwned)
+        );
+    }
+
+    #[test]
+    fn before_send_filter_drops_backend_owned_error_code_events() {
+        for code in [
+            "RATE_LIMITED",
+            "UPSTREAM_UNAVAILABLE",
+            "MODEL_UNAVAILABLE",
+            "PAYLOAD_TOO_LARGE",
+            "INTERNAL_ERROR",
+            "BAD_REQUEST",
+        ] {
+            let event = event_with_message(&managed_body("500", code));
+            assert!(
+                is_backend_error_code_event(&event),
+                "errorCode={code} event must be dropped by before_send"
+            );
+        }
+    }
+
+    #[test]
+    fn before_send_filter_keeps_malformed_bad_request_event() {
+        let event = event_with_message(
+            "OpenHuman API error (400 Bad Request): \
+             {\"error\":{\"errorCode\":\"BAD_REQUEST\",\"malformed\":true}}",
+        );
+        assert!(
+            !is_backend_error_code_event(&event),
+            "malformed BAD_REQUEST must survive before_send and page (F8)"
+        );
+    }
+
+    #[test]
+    fn before_send_filter_matches_error_code_in_exception_value() {
+        let event = event_with_exception_value(&managed_body("500", "INTERNAL_ERROR"));
+        assert!(is_backend_error_code_event(&event));
+    }
+
+    #[test]
+    fn transient_provider_transport_filter_drops_flaky_network_blips() {
+        // F7: a streaming transport timeout/reset under
+        // domain=llm_provider, failure=transport is recovered by
+        // retry/fallback — drop it.
+        for phrase in [
+            "error sending request for url (https://api.tinyhumans.ai/v1/chat): \
+             operation timed out",
+            "connection reset by peer",
+            "tls handshake eof",
+        ] {
+            let event = event_with_tags_and_message(
+                &[("domain", "llm_provider"), ("failure", "transport")],
+                phrase,
+            );
+            assert!(
+                is_transient_provider_transport_failure(&event),
+                "transient transport phrase must be dropped: {phrase}"
+            );
+        }
+    }
+
+    #[test]
+    fn transient_provider_transport_filter_keeps_non_transient_transport() {
+        // A genuine, non-transient transport failure (e.g. an unexpected
+        // protocol error) is NOT a flaky-network blip — keep paging.
+        let event = event_with_tags_and_message(
+            &[("domain", "llm_provider"), ("failure", "transport")],
+            "invalid URL scheme: unsupported protocol",
+        );
+        assert!(!is_transient_provider_transport_failure(&event));
+    }
+
+    #[test]
+    fn transient_provider_transport_filter_scoped_to_llm_provider() {
+        // Same shape under a different domain must not be claimed by this
+        // provider-scoped filter.
+        let event = event_with_tags_and_message(
+            &[("domain", "backend_api"), ("failure", "transport")],
+            "operation timed out",
+        );
+        assert!(!is_transient_provider_transport_failure(&event));
     }
 }

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -294,9 +294,12 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     // Trust it FIRST, before the substring matchers, so a managed 500
     // `INTERNAL_ERROR` (which no substring matcher below would otherwise demote)
     // stops double-reporting. The one exception — a backend-flagged malformed
-    // `BAD_REQUEST` — is excluded by `backend_error_code_skips_sentry` and
-    // falls through to the matchers / capture so the FE still pages (F8).
-    if crate::openhuman::inference::provider::backend_error_code_skips_sentry(message) {
+    // `BAD_REQUEST` — is excluded by `managed_error_skips_sentry` and falls
+    // through to the matchers / capture so the FE still pages (F8). The
+    // decision is gated on the managed-backend envelope so a BYO payload
+    // carrying an `errorCode`-shaped field is not wrongly suppressed
+    // (CodeRabbit).
+    if crate::openhuman::inference::provider::managed_error_skips_sentry(message) {
         return Some(ExpectedErrorKind::BackendErrorCodeOwned);
     }
     // Check the Codex-CLI import envelope first: it is highly specific
@@ -1777,8 +1780,9 @@ pub fn is_transient_provider_http_failure(event: &sentry::protocol::Event<'_>) -
 /// classifier (`expected_error_kind` → [`ExpectedErrorKind::BackendErrorCodeOwned`]).
 /// This catches any future call site that re-emits the same flattened error
 /// without routing through those funnels. Delegates the decision to the
-/// single-source [`crate::openhuman::inference::provider::backend_error_code_skips_sentry`]
-/// so the layers can't drift.
+/// single-source [`crate::openhuman::inference::provider::managed_error_skips_sentry`]
+/// (managed-envelope gated, so a BYO payload carrying an `errorCode`-shaped
+/// field is not wrongly dropped) so the layers can't drift.
 pub fn is_backend_error_code_event(event: &sentry::protocol::Event<'_>) -> bool {
     let direct = event.message.as_deref();
     let from_logentry = event.logentry.as_ref().map(|log| log.message.as_str());
@@ -1786,7 +1790,7 @@ pub fn is_backend_error_code_event(event: &sentry::protocol::Event<'_>) -> bool 
     [direct, from_logentry, from_exception]
         .into_iter()
         .flatten()
-        .any(crate::openhuman::inference::provider::backend_error_code_skips_sentry)
+        .any(crate::openhuman::inference::provider::managed_error_skips_sentry)
 }
 
 /// Defense-in-depth `before_send` filter for transient streaming **transport**
@@ -1800,12 +1804,24 @@ pub fn is_backend_error_code_event(event: &sentry::protocol::Event<'_>) -> bool 
 /// Primary gate lives at the two streaming emit sites in
 /// `compatible_provider_impl.rs` (`stream_chat` / `stream_chat_history`); this
 /// catches any future site that reports the same shape without gating.
+///
+/// Scoped to the **streaming** operations on purpose (CodeRabbit): only the
+/// `stream_chat` / `stream_chat_history` transport emits are meant to be
+/// suppressed. A non-streaming `domain=llm_provider, failure=transport` event
+/// carries a different `operation` tag and must keep paging, so the
+/// observability blind spot stays as narrow as F7 intends.
 pub fn is_transient_provider_transport_failure(event: &sentry::protocol::Event<'_>) -> bool {
     let tags = &event.tags;
     if tags.get("domain").map(String::as_str) != Some("llm_provider") {
         return false;
     }
     if tags.get("failure").map(String::as_str) != Some("transport") {
+        return false;
+    }
+    if !matches!(
+        tags.get("operation").map(String::as_str),
+        Some("stream_chat") | Some("stream_chat_history")
+    ) {
         return false;
     }
     event_has_transient_transport_phrase(event)
@@ -5351,6 +5367,24 @@ mod tests {
     }
 
     #[test]
+    fn expected_kind_ignores_byo_errors_that_carry_an_error_code_token() {
+        // CodeRabbit: a BYO / direct-provider envelope whose body happens to
+        // carry an `errorCode`-shaped field must NOT be demoted — the
+        // managed-envelope gate keeps it reaching Sentry.
+        let body = "custom_openai API error (500 Internal Server Error): \
+             {\"error\":{\"errorCode\":\"INTERNAL_ERROR\"}}";
+        assert_ne!(
+            expected_error_kind(body),
+            Some(ExpectedErrorKind::BackendErrorCodeOwned)
+        );
+        let event = event_with_message(body);
+        assert!(
+            !is_backend_error_code_event(&event),
+            "BYO body with an errorCode token must not be dropped by before_send"
+        );
+    }
+
+    #[test]
     fn before_send_filter_drops_backend_owned_error_code_events() {
         for code in [
             "RATE_LIMITED",
@@ -5397,14 +5431,20 @@ mod tests {
             "connection reset by peer",
             "tls handshake eof",
         ] {
-            let event = event_with_tags_and_message(
-                &[("domain", "llm_provider"), ("failure", "transport")],
-                phrase,
-            );
-            assert!(
-                is_transient_provider_transport_failure(&event),
-                "transient transport phrase must be dropped: {phrase}"
-            );
+            for operation in ["stream_chat", "stream_chat_history"] {
+                let event = event_with_tags_and_message(
+                    &[
+                        ("domain", "llm_provider"),
+                        ("failure", "transport"),
+                        ("operation", operation),
+                    ],
+                    phrase,
+                );
+                assert!(
+                    is_transient_provider_transport_failure(&event),
+                    "transient transport phrase must be dropped: {phrase} ({operation})"
+                );
+            }
         }
     }
 
@@ -5413,10 +5453,40 @@ mod tests {
         // A genuine, non-transient transport failure (e.g. an unexpected
         // protocol error) is NOT a flaky-network blip — keep paging.
         let event = event_with_tags_and_message(
-            &[("domain", "llm_provider"), ("failure", "transport")],
+            &[
+                ("domain", "llm_provider"),
+                ("failure", "transport"),
+                ("operation", "stream_chat"),
+            ],
             "invalid URL scheme: unsupported protocol",
         );
         assert!(!is_transient_provider_transport_failure(&event));
+    }
+
+    #[test]
+    fn transient_provider_transport_filter_scoped_to_streaming_operations() {
+        // CodeRabbit: a NON-streaming llm_provider transport failure with the
+        // same domain/failure tags but a different operation must keep paging
+        // — the filter is intentionally scoped to the streaming emits.
+        let event = event_with_tags_and_message(
+            &[
+                ("domain", "llm_provider"),
+                ("failure", "transport"),
+                ("operation", "chat_completions"),
+            ],
+            "operation timed out",
+        );
+        assert!(
+            !is_transient_provider_transport_failure(&event),
+            "non-streaming llm_provider transport must not be suppressed"
+        );
+
+        // And with no operation tag at all (older/foreign emit) — keep paging.
+        let no_op = event_with_tags_and_message(
+            &[("domain", "llm_provider"), ("failure", "transport")],
+            "operation timed out",
+        );
+        assert!(!is_transient_provider_transport_failure(&no_op));
     }
 
     #[test]
@@ -5424,7 +5494,11 @@ mod tests {
         // Same shape under a different domain must not be claimed by this
         // provider-scoped filter.
         let event = event_with_tags_and_message(
-            &[("domain", "backend_api"), ("failure", "transport")],
+            &[
+                ("domain", "backend_api"),
+                ("failure", "transport"),
+                ("operation", "stream_chat"),
+            ],
             "operation timed out",
         );
         assert!(!is_transient_provider_transport_failure(&event));

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,24 @@ fn main() {
             if openhuman_core::core::observability::is_transient_provider_http_failure(&event) {
                 return None;
             }
+            // Defense-in-depth: drop managed-backend `errorCode` events (#870)
+            // the backend owns (F2/F4) — primary suppression lives in
+            // `api_error` / the streaming gates and the `web_channel`
+            // re-report classifier. The malformed `BAD_REQUEST` carve-out
+            // (F8) is excluded by the underlying decision, so a client-built
+            // bad payload still pages.
+            if openhuman_core::core::observability::is_backend_error_code_event(&event) {
+                return None;
+            }
+            // Defense-in-depth: drop transient streaming transport blips
+            // (domain=llm_provider, failure=transport) — flaky-network
+            // timeouts/resets recovered by retry/fallback (F7). The primary
+            // gate lives at the `stream_chat` / `stream_chat_history` emit
+            // sites.
+            if openhuman_core::core::observability::is_transient_provider_transport_failure(&event)
+            {
+                return None;
+            }
             // Defense-in-depth for budget-exhausted 400s. Emit sites demote the
             // known backend responses before they hit Sentry; this catches any
             // future non_2xx/status=400 event that carries the same tight body

--- a/src/openhuman/channels/providers/web_errors.rs
+++ b/src/openhuman/channels/providers/web_errors.rs
@@ -133,7 +133,8 @@ pub(crate) struct ClassifiedError {
     /// Stable token: `rate_limited`, `action_budget_exceeded`,
     /// `max_iterations`, `timeout`, `auth_error`, `budget_exhausted`,
     /// `provider_error`, `context_overflow`, `model_unavailable`,
-    /// `inference`.
+    /// `payload_too_large`, `provider_request_rejected`,
+    /// `capability_unsupported`, `empty_response`, `inference`.
     pub(crate) error_type: &'static str,
     /// User-facing copy (already includes provider detail block and the
     /// retry-after countdown sentence when available).
@@ -232,6 +233,13 @@ pub(crate) fn parse_retry_after_secs_from_str(err: &str) -> Option<u64> {
         "retry_after:",
         "retry-after ",
         "retry_after ",
+        // Managed backend (#870) emits the structured `retryAfter` field
+        // (camelCase). After lower-casing + quote-stripping above it
+        // collapses to `retryafter: 30` / `retryafter 30`, so the
+        // separator-bearing prefixes here let the same parser surface the
+        // structured field the spec asks us to prefer (F5).
+        "retryafter:",
+        "retryafter ",
     ] {
         if let Some(pos) = normalized.find(prefix) {
             let after = &normalized[pos + prefix.len()..];
@@ -290,6 +298,153 @@ pub(crate) fn is_action_budget_exhausted(err_lower: &str) -> bool {
         || err_lower.contains("action blocked: rate limit exceeded")
 }
 
+/// Classify a managed-backend error by its stable `errorCode` (#870).
+///
+/// Returns `Some` only when the flattened error string carries a *recognised*
+/// backend `errorCode`. Because an `errorCode` is present **only** when the
+/// error came through the managed backend, branching on it here lets us trust
+/// the backend's verdict (operator faults route to the calm "temporarily
+/// unavailable — we've been notified" copy, no user-blaming) instead of the
+/// substring heuristics, which are tuned for the BYO / direct-provider path
+/// (where no `errorCode` exists and "check your API key / model settings" is
+/// the correct, user-actionable copy). See [`classify_inference_error`] (F2).
+///
+/// `None` falls through to the substring ladder, covering both the BYO path
+/// (no code) and any future/unrecognised managed code we don't yet map.
+fn classify_by_backend_error_code(
+    err: &str,
+    provider: Option<String>,
+    fallback_available: Option<bool>,
+) -> Option<ClassifiedError> {
+    use crate::openhuman::inference::provider::{
+        body_flags_malformed, extract_backend_error_code, BackendErrorCode,
+    };
+
+    let code = extract_backend_error_code(err)?;
+
+    // Verbose diagnostics on the new managed-code branch (per CLAUDE.md).
+    // Low-cardinality only — the raw `err` may carry a provider payload / PII
+    // and is logged at the caller, not here.
+    log::debug!(
+        "[chat-error][classify][errorCode] code={:?} provider={:?}",
+        code,
+        provider,
+    );
+
+    let classified = match code {
+        BackendErrorCode::RateLimited => {
+            let retry_secs = parse_retry_after_secs_from_str(err);
+            ClassifiedError {
+                error_type: "rate_limited",
+                message: format!(
+                    "Your AI provider is rate-limiting requests. You can retry in this thread.{}",
+                    retry_after_hint(retry_secs)
+                ),
+                source: "provider",
+                retryable: true,
+                retry_after_ms: retry_secs.map(|s| s.saturating_mul(1000)),
+                provider,
+                fallback_available,
+            }
+        }
+        BackendErrorCode::UserInsufficientCredits => ClassifiedError {
+            error_type: "budget_exhausted",
+            message: "You're out of credits. Top up, or switch to 'Use Your Own Models' \
+                 in Settings."
+                .to_string(),
+            source: "openhuman_billing",
+            retryable: false,
+            retry_after_ms: None,
+            provider,
+            fallback_available: None,
+        },
+        // Operator fault (our key/account/quota/5xx) OR operator registry /
+        // routing misconfig — NOT user-actionable. Both route to the same
+        // calm "we've been notified" copy; the backend already paged. We
+        // deliberately DROP the "check your API key" (F4) and "pick a
+        // different model" (F6) copy the BYO substring arms would emit.
+        BackendErrorCode::UpstreamUnavailable | BackendErrorCode::ModelUnavailable => {
+            ClassifiedError {
+                error_type: "provider_error",
+                message: "The AI service is temporarily unavailable — we've been notified. \
+                     Please try again shortly."
+                    .to_string(),
+                source: "provider",
+                retryable: true,
+                retry_after_ms: None,
+                provider,
+                fallback_available,
+            }
+        }
+        BackendErrorCode::PayloadTooLarge => ClassifiedError {
+            error_type: "payload_too_large",
+            message: "Your message or attachment is too large for this model. Shorten it \
+                 or remove the attachment — or start a new thread."
+                .to_string(),
+            source: "config",
+            retryable: false,
+            retry_after_ms: None,
+            provider,
+            fallback_available: None,
+        },
+        BackendErrorCode::ContextLengthExceeded => ClassifiedError {
+            error_type: "context_overflow",
+            message: "The conversation is too long. Please start a new chat.".to_string(),
+            source: "config",
+            retryable: false,
+            retry_after_ms: None,
+            provider,
+            fallback_available: None,
+        },
+        BackendErrorCode::BadRequest => {
+            // Same code, two shapes (B8/F8): a backend-flagged *malformed*
+            // payload is a client bug (the request was built wrong — it pages
+            // Sentry at the FE layer, gated elsewhere), while a plain
+            // user-parameter rejection is a model/param mismatch the user can
+            // fix. The copy differs: don't tell the user to abandon the thread
+            // for a one-off malformation (only this turn failed).
+            if body_flags_malformed(err) {
+                ClassifiedError {
+                    error_type: "provider_request_rejected",
+                    message: "Something went wrong with this message. Try rephrasing it — \
+                         or start a new thread if it keeps happening."
+                        .to_string(),
+                    source: "provider",
+                    retryable: false,
+                    retry_after_ms: None,
+                    provider,
+                    fallback_available: None,
+                }
+            } else {
+                ClassifiedError {
+                    error_type: "provider_request_rejected",
+                    message: "The request was rejected — usually a model or parameter \
+                         mismatch. Try a different model in Settings → AI → LLM."
+                        .to_string(),
+                    source: "provider",
+                    retryable: false,
+                    retry_after_ms: None,
+                    provider,
+                    fallback_available: None,
+                }
+            }
+        }
+        BackendErrorCode::InternalError => ClassifiedError {
+            error_type: "inference",
+            // Backend already paged its own 500; the FE must not double-report
+            // (gated in the Sentry classifier) and the user just retries.
+            message: "Something went wrong — we've been notified. Please try again.".to_string(),
+            source: "provider",
+            retryable: true,
+            retry_after_ms: None,
+            provider,
+            fallback_available,
+        },
+    };
+
+    Some(classified)
+}
+
 pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
     let lower = err.to_lowercase();
     let provider = extract_provider_name(err);
@@ -298,6 +453,25 @@ pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
     } else {
         None
     };
+
+    // F2: when the managed backend stamped a stable `errorCode` on the body,
+    // trust it and branch on it FIRST — ignoring the substring heuristics
+    // below, which are tuned for the BYO / direct-provider path (no
+    // `errorCode`). Only a recognised code short-circuits; an absent or
+    // unrecognised code falls through to the substring ladder unchanged, so
+    // the BYO "check your API key / model settings" copy stays intact.
+    if let Some(classified) =
+        classify_by_backend_error_code(err, provider.clone(), fallback_available)
+    {
+        log::debug!(
+            "[chat-error][classify] error_type={} source={} retryable={} provider={:?} (via errorCode)",
+            classified.error_type,
+            classified.source,
+            classified.retryable,
+            classified.provider,
+        );
+        return classified;
+    }
 
     // Order matters: the SecurityPolicy hourly cap and the
     // agent-loop max-iterations error both surface as strings that

--- a/src/openhuman/channels/providers/web_errors.rs
+++ b/src/openhuman/channels/providers/web_errors.rs
@@ -317,8 +317,17 @@ fn classify_by_backend_error_code(
     fallback_available: Option<bool>,
 ) -> Option<ClassifiedError> {
     use crate::openhuman::inference::provider::{
-        body_flags_malformed, extract_backend_error_code, BackendErrorCode,
+        body_flags_malformed, extract_backend_error_code, is_managed_backend_envelope,
+        BackendErrorCode,
     };
+
+    // Managed-vs-BYO gate: an `errorCode` is only trustworthy on a
+    // managed-backend envelope. A BYO / direct-provider body that merely
+    // contains an `errorCode`-shaped field must fall through to the substring
+    // ladder (CodeRabbit), keeping its user-actionable copy intact.
+    if !is_managed_backend_envelope(err) {
+        return None;
+    }
 
     let code = extract_backend_error_code(err)?;
 

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -1052,6 +1052,226 @@ fn classify_inference_error_model_not_found_404_stays_model_unavailable() {
     );
 }
 
+// ── #870 managed-backend errorCode classification (F2/F3/F4/F6/F8) ──
+
+/// Build a flattened managed-backend error string the way it reaches
+/// `classify_inference_error` after the typed provider error is collapsed
+/// to a `String` (the `"OpenHuman API error (<status>): <body>"` envelope
+/// from `inference::provider::ops::api_error`).
+fn managed_error(status: &str, body: &str) -> String {
+    format!("OpenHuman API error ({status}): {body}")
+}
+
+#[test]
+fn classify_inference_error_rate_limited_code_branches_first() {
+    // F2: a managed RATE_LIMITED carries the structured `retryAfter`, which
+    // the classifier must prefer and surface as a countdown hint.
+    let raw = managed_error(
+        "429 Too Many Requests",
+        r#"{"error":{"message":"slow down","errorCode":"RATE_LIMITED","retryAfter":30}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "rate_limited");
+    assert!(classified.retryable, "rate limit is retryable in-thread");
+    assert_eq!(
+        classified.retry_after_ms,
+        Some(30_000),
+        "structured retryAfter must drive retry_after_ms"
+    );
+    assert!(
+        classified.message.contains("retry in this thread"),
+        "must use the in-thread retry copy: {}",
+        classified.message
+    );
+    assert!(
+        classified.message.contains("30 seconds"),
+        "must surface the retry countdown: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_user_insufficient_credits_is_the_only_top_up_case() {
+    let raw = managed_error(
+        "402 Payment Required",
+        r#"{"error":{"errorCode":"USER_INSUFFICIENT_CREDITS","message":"no credits"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "budget_exhausted");
+    assert!(!classified.retryable, "out of credits is non-retryable");
+    assert_eq!(classified.source, "openhuman_billing");
+    assert!(
+        classified.message.contains("out of credits")
+            && classified.message.contains("Use Your Own Models"),
+        "must offer top-up or BYO switch: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_upstream_unavailable_drops_user_blaming_copy() {
+    // F4: operator fault → "temporarily unavailable — we've been notified",
+    // never "check your API key".
+    let raw = managed_error(
+        "503 Service Unavailable",
+        r#"{"error":{"errorCode":"UPSTREAM_UNAVAILABLE","message":"upstream 5xx"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "provider_error");
+    assert!(classified.retryable);
+    assert!(
+        classified.message.contains("temporarily unavailable")
+            && classified.message.contains("we've been notified"),
+        "must use the operator-fault copy: {}",
+        classified.message
+    );
+    assert!(
+        !classified.message.to_lowercase().contains("api key"),
+        "must NOT blame the user's API key: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_model_unavailable_code_is_operator_fault_not_user_pick() {
+    // F6: a managed MODEL_UNAVAILABLE is an operator registry/routing
+    // misconfig — route to provider_error, NOT the user "pick a different
+    // model" copy.
+    let raw = managed_error(
+        "404 Not Found",
+        r#"{"error":{"errorCode":"MODEL_UNAVAILABLE","message":"no route for model"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(
+        classified.error_type, "provider_error",
+        "managed MODEL_UNAVAILABLE is provider_error, not model_unavailable"
+    );
+    assert!(classified.retryable);
+    assert!(
+        classified.message.contains("temporarily unavailable"),
+        "must use the operator-fault copy: {}",
+        classified.message
+    );
+    assert!(
+        !classified
+            .message
+            .to_lowercase()
+            .contains("check your model"),
+        "must NOT tell the user to pick a model: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_payload_too_large_is_new_non_retryable_bucket() {
+    // F3.
+    let raw = managed_error(
+        "413 Payload Too Large",
+        r#"{"error":{"errorCode":"PAYLOAD_TOO_LARGE","message":"too big"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "payload_too_large");
+    assert!(!classified.retryable, "payload too large is non-retryable");
+    assert!(
+        classified.message.contains("too large") && classified.message.contains("attachment"),
+        "must use the shorten/remove-attachment copy: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_context_length_exceeded_reuses_context_overflow() {
+    let raw = managed_error(
+        "400 Bad Request",
+        r#"{"error":{"errorCode":"CONTEXT_LENGTH_EXCEEDED","message":"too long"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "context_overflow");
+    assert!(!classified.retryable);
+    assert!(
+        classified.message.contains("start a new chat"),
+        "must use the start-a-new-chat copy: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_user_param_bad_request_is_actionable() {
+    let raw = managed_error(
+        "400 Bad Request",
+        r#"{"error":{"errorCode":"BAD_REQUEST","message":"unsupported parameter"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "provider_request_rejected");
+    assert!(!classified.retryable);
+    assert!(
+        classified.message.contains("Settings → AI → LLM"),
+        "user-param rejection points at Settings: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_malformed_bad_request_uses_rephrase_copy() {
+    // F8: malformed (backend-flagged) → "rephrase, or new thread if it
+    // persists" — NOT an outright "start a new thread".
+    let raw = managed_error(
+        "400 Bad Request",
+        r#"{"error":{"errorCode":"BAD_REQUEST","malformed":true,"message":"unparseable"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "provider_request_rejected");
+    assert!(!classified.retryable);
+    assert!(
+        classified.message.contains("Try rephrasing it"),
+        "malformed must use the rephrase copy: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_internal_error_is_generic_retryable() {
+    let raw = managed_error(
+        "500 Internal Server Error",
+        r#"{"error":{"errorCode":"INTERNAL_ERROR","message":"boom"}}"#,
+    );
+    let classified = classify_inference_error(&raw);
+    assert_eq!(classified.error_type, "inference");
+    assert!(classified.retryable);
+    assert!(
+        classified.message.contains("we've been notified"),
+        "must reassure the user it was reported: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_byo_no_code_keeps_user_actionable_copy() {
+    // Managed-vs-BYO: a BYO provider key bad (direct 401, no errorCode) must
+    // STILL get the user-actionable "check your API key" copy via the
+    // substring fallback — the errorCode branch must not steal it.
+    let auth = r#"openai API error (401 Unauthorized): {"error":{"message":"Incorrect API key provided"}}"#;
+    let classified = classify_inference_error(auth);
+    assert_eq!(classified.error_type, "auth_error");
+    assert!(
+        classified.message.contains("check your API key"),
+        "BYO no-code 401 keeps the actionable copy: {}",
+        classified.message
+    );
+
+    // BYO model misconfig (no errorCode) stays `model_unavailable` with the
+    // "check your model settings" copy — distinct from the managed
+    // MODEL_UNAVAILABLE provider_error route above (F6).
+    let model = r#"custom_openai API error (404 Not Found): {"error":{"message":"model unavailable on this endpoint"}}"#;
+    let classified = classify_inference_error(model);
+    assert_eq!(classified.error_type, "model_unavailable");
+    assert!(
+        classified.message.contains("model settings"),
+        "BYO no-code model error keeps the actionable copy: {}",
+        classified.message
+    );
+}
+
 // ── Schema catalog ────────────────────────────────────────────
 
 #[test]

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -1272,6 +1272,26 @@ fn classify_inference_error_byo_no_code_keeps_user_actionable_copy() {
     );
 }
 
+#[test]
+fn classify_inference_error_byo_with_error_code_token_is_not_managed() {
+    // CodeRabbit: a BYO / direct-provider error whose body happens to carry an
+    // `errorCode`-shaped field must NOT be classified on the managed-code
+    // branch — the managed-envelope gate keeps it on the substring ladder so
+    // the user-actionable BYO copy is preserved (and FE Sentry is unaffected).
+    let raw = r#"custom_openai API error (429 Too Many Requests): {"error":{"errorCode":"RATE_LIMITED","message":"slow down"}}"#;
+    let classified = classify_inference_error(raw);
+    // Still classified as rate_limited via the substring ladder, but through
+    // the BYO path: the message uses the existing substring-arm copy ("This is
+    // a transient upstream limit"), NOT the managed errorCode copy ("You can
+    // retry in this thread.").
+    assert_eq!(classified.error_type, "rate_limited");
+    assert!(
+        classified.message.contains("transient upstream limit"),
+        "BYO 429 must use the substring-arm copy, not the managed errorCode copy: {}",
+        classified.message
+    );
+}
+
 // ── Schema catalog ────────────────────────────────────────────
 
 #[test]

--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -836,16 +836,33 @@ impl Provider for OpenAiCompatibleProvider {
             let response = match req_builder.send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    crate::core::observability::report_error(
-                        e.to_string().as_str(),
-                        "llm_provider",
-                        "stream_chat",
-                        &[
-                            ("provider", provider_name.as_str()),
-                            ("model", model_owned.as_str()),
-                            ("failure", "transport"),
-                        ],
-                    );
+                    let detail = e.to_string();
+                    // F7: a flaky-network timeout / reset / TLS-handshake EOF on
+                    // the streaming send is transient transport noise the
+                    // socket layer recovers from — gate it so those blips stop
+                    // paging Sentry. A non-transient transport failure (DNS
+                    // misconfig, unexpected protocol error) still reports.
+                    if crate::core::observability::contains_transient_transport_phrase(&detail) {
+                        tracing::debug!(
+                            domain = "llm_provider",
+                            operation = "stream_chat",
+                            provider = provider_name.as_str(),
+                            model = model_owned.as_str(),
+                            failure = "transport",
+                            "[llm_provider] stream_chat transient transport error — not reporting to Sentry: {detail}"
+                        );
+                    } else {
+                        crate::core::observability::report_error(
+                            detail.as_str(),
+                            "llm_provider",
+                            "stream_chat",
+                            &[
+                                ("provider", provider_name.as_str()),
+                                ("model", model_owned.as_str()),
+                                ("failure", "transport"),
+                            ],
+                        );
+                    }
                     let _ = tx.send(Err(StreamError::Http(e))).await;
                     return;
                 }
@@ -901,6 +918,19 @@ impl Provider for OpenAiCompatibleProvider {
                         provider_name.as_str(),
                         Some(model_owned.as_str()),
                         status,
+                    );
+                } else if crate::openhuman::inference::provider::is_backend_error_code_owned(
+                    &raw_error,
+                ) {
+                    // F4/F2: managed-backend errorCode (#870) — backend-owned;
+                    // the FE must not double-report. Malformed BAD_REQUEST is
+                    // excluded and reaches the status gate (it pages — F8).
+                    crate::openhuman::inference::provider::log_backend_error_code_owned(
+                        "stream_chat",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                        &raw_error,
                     );
                 } else if crate::openhuman::inference::provider::should_report_provider_http_failure(
                     status,
@@ -1012,16 +1042,32 @@ impl Provider for OpenAiCompatibleProvider {
             let response = match req_builder.send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    crate::core::observability::report_error(
-                        error.to_string().as_str(),
-                        "llm_provider",
-                        "stream_chat_history",
-                        &[
-                            ("provider", provider_name.as_str()),
-                            ("model", model_owned.as_str()),
-                            ("failure", "transport"),
-                        ],
-                    );
+                    let detail = error.to_string();
+                    // F7: gate transient transport blips (timeout / reset / TLS
+                    // handshake EOF) so flaky-network failures on the streaming
+                    // send stop paging Sentry; non-transient transport errors
+                    // still report.
+                    if crate::core::observability::contains_transient_transport_phrase(&detail) {
+                        tracing::debug!(
+                            domain = "llm_provider",
+                            operation = "stream_chat_history",
+                            provider = provider_name.as_str(),
+                            model = model_owned.as_str(),
+                            failure = "transport",
+                            "[llm_provider] stream_chat_history transient transport error — not reporting to Sentry: {detail}"
+                        );
+                    } else {
+                        crate::core::observability::report_error(
+                            detail.as_str(),
+                            "llm_provider",
+                            "stream_chat_history",
+                            &[
+                                ("provider", provider_name.as_str()),
+                                ("model", model_owned.as_str()),
+                                ("failure", "transport"),
+                            ],
+                        );
+                    }
                     let _ = tx.send(Err(StreamError::Http(error))).await;
                     return;
                 }
@@ -1077,6 +1123,19 @@ impl Provider for OpenAiCompatibleProvider {
                         provider_name.as_str(),
                         Some(model_owned.as_str()),
                         status,
+                    );
+                } else if crate::openhuman::inference::provider::is_backend_error_code_owned(
+                    &raw_error,
+                ) {
+                    // F4/F2: managed-backend errorCode (#870) — backend-owned;
+                    // the FE must not double-report. Malformed BAD_REQUEST is
+                    // excluded and reaches the status gate (it pages — F8).
+                    crate::openhuman::inference::provider::log_backend_error_code_owned(
+                        "stream_chat_history",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                        &raw_error,
                     );
                 } else if crate::openhuman::inference::provider::should_report_provider_http_failure(
                     status,

--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -920,6 +920,7 @@ impl Provider for OpenAiCompatibleProvider {
                         status,
                     );
                 } else if crate::openhuman::inference::provider::is_backend_error_code_owned(
+                    provider_name.as_str(),
                     &raw_error,
                 ) {
                     // F4/F2: managed-backend errorCode (#870) — backend-owned;
@@ -1125,6 +1126,7 @@ impl Provider for OpenAiCompatibleProvider {
                         status,
                     );
                 } else if crate::openhuman::inference::provider::is_backend_error_code_owned(
+                    provider_name.as_str(),
                     &raw_error,
                 ) {
                     // F4/F2: managed-backend errorCode (#870) — backend-owned;

--- a/src/openhuman/inference/provider/compatible_stream_native.rs
+++ b/src/openhuman/inference/provider/compatible_stream_native.rs
@@ -94,7 +94,7 @@ impl OpenAiCompatibleProvider {
                     self.name,
                     status,
                 );
-            } else if super::super::is_backend_error_code_owned(&body) {
+            } else if super::super::is_backend_error_code_owned(self.name.as_str(), &body) {
                 // F4/F2: managed-backend errorCode (#870) — backend-owned, FE
                 // must not double-report. Malformed BAD_REQUEST is excluded and
                 // falls through to the status gate below.

--- a/src/openhuman/inference/provider/compatible_stream_native.rs
+++ b/src/openhuman/inference/provider/compatible_stream_native.rs
@@ -94,6 +94,17 @@ impl OpenAiCompatibleProvider {
                     self.name,
                     status,
                 );
+            } else if super::super::is_backend_error_code_owned(&body) {
+                // F4/F2: managed-backend errorCode (#870) — backend-owned, FE
+                // must not double-report. Malformed BAD_REQUEST is excluded and
+                // falls through to the status gate below.
+                super::super::log_backend_error_code_owned(
+                    "streaming_chat",
+                    self.name.as_str(),
+                    Some(native_request.model.as_str()),
+                    status,
+                    &body,
+                );
             } else if super::super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),

--- a/src/openhuman/inference/provider/error_code.rs
+++ b/src/openhuman/inference/provider/error_code.rs
@@ -31,6 +31,8 @@
 //! error is collapsed to a `String` at the native-bus boundary before it
 //! reaches the channel classifier or the higher-layer re-report sites.
 
+use super::openhuman_backend;
+
 /// A recognised backend `errorCode` token (PR #870).
 ///
 /// Unknown / future tokens are intentionally NOT represented here — they are
@@ -89,8 +91,14 @@ pub fn extract_backend_error_code_token(err: &str) -> Option<String> {
     const KEY: &str = "\"errorcode\"";
     let key_idx = lower.find(KEY)?;
     let after_key = &err[key_idx + KEY.len()..];
-    // Skip the colon + whitespace to the opening quote of the value.
-    let after_colon = after_key.trim_start_matches(|c: char| c != '"');
+    // Skip ONLY the JSON separators (whitespace + the colon) and then require a
+    // quoted string value. A non-string value (`"errorCode":null` / a number)
+    // must NOT be treated as a present code — otherwise the old
+    // `trim_start_matches(|c| c != '"')` skipped past the `null` and latched
+    // onto the *next* key's opening quote, returning a bogus token and wrongly
+    // marking the error backend-owned (CodeRabbit). `strip_prefix('"')` returns
+    // `None` for a non-string value, so we bail correctly.
+    let after_colon = after_key.trim_start_matches(|c: char| c.is_ascii_whitespace() || c == ':');
     let stripped = after_colon.strip_prefix('"')?;
     let end = stripped.find('"')?;
     let token = stripped[..end].trim().to_ascii_uppercase();
@@ -99,6 +107,33 @@ pub fn extract_backend_error_code_token(err: &str) -> Option<String> {
     } else {
         Some(token)
     }
+}
+
+/// Whether the flattened error string is a **managed-backend** envelope (the
+/// `errorCode` contract only holds for errors that came through the OpenHuman
+/// managed backend, `"OpenHuman API error (...)"` /
+/// `"OpenHuman streaming API error (...)"`).
+///
+/// Load-bearing for the managed-vs-BYO distinction: a BYO / direct-provider
+/// body that merely happens to carry an `errorCode`-shaped field must NOT be
+/// treated as backend-owned (CodeRabbit). The provider HTTP emit sites gate on
+/// the known `provider` value instead; this helper is for the string-only
+/// downstream sites (`expected_error_kind`, `before_send`) that no longer carry
+/// the typed provider.
+pub fn is_managed_backend_envelope(err: &str) -> bool {
+    let label = openhuman_backend::PROVIDER_LABEL.to_ascii_lowercase();
+    let lower = err.to_ascii_lowercase();
+    lower.contains(&format!("{label} api error"))
+        || lower.contains(&format!("{label} streaming api error"))
+}
+
+/// Managed-backend Sentry-ownership decision for **string-only** call sites:
+/// the error must both be a managed-backend envelope AND carry a backend
+/// `errorCode` the backend owns. Wraps [`backend_error_code_skips_sentry`] with
+/// the [`is_managed_backend_envelope`] gate so a BYO payload that contains an
+/// `errorCode` token can't suppress FE Sentry.
+pub fn managed_error_skips_sentry(err: &str) -> bool {
+    is_managed_backend_envelope(err) && backend_error_code_skips_sentry(err)
 }
 
 /// Parse a recognised [`BackendErrorCode`] out of a flattened error string.
@@ -118,7 +153,16 @@ pub fn extract_backend_error_code(err: &str) -> Option<BackendErrorCode> {
 /// double-report.
 pub fn body_flags_malformed(err: &str) -> bool {
     let lower = err.to_ascii_lowercase();
-    lower.contains("\"malformed\":true") || lower.contains("\"malformed\": true")
+    const KEY: &str = "\"malformed\"";
+    let Some(key_idx) = lower.find(KEY) else {
+        return false;
+    };
+    // Whitespace-tolerant: accept `"malformed":true`, `"malformed": true`, and
+    // pretty-printed `"malformed" : true` (CodeRabbit) — skip arbitrary
+    // whitespace and the colon before matching the boolean literal.
+    let after_key = &lower[key_idx + KEY.len()..];
+    let after_colon = after_key.trim_start_matches(|c: char| c.is_ascii_whitespace() || c == ':');
+    after_colon.starts_with("true")
 }
 
 /// Whether the error is a backend-flagged malformed `BAD_REQUEST` — the single
@@ -212,5 +256,43 @@ mod tests {
         let body = r#"{"errorCode":"INTERNAL_ERROR","malformed":true}"#;
         assert!(!is_backend_malformed_bad_request(body));
         assert!(backend_error_code_skips_sentry(body));
+    }
+
+    #[test]
+    fn non_string_error_code_is_not_treated_as_present_code() {
+        // `"errorCode":null` (or a numeric value) must NOT latch onto the next
+        // quoted key and return a bogus token (CodeRabbit).
+        let body = r#"{"error":{"errorCode":null,"message":"x"}}"#;
+        assert_eq!(extract_backend_error_code_token(body), None);
+        assert!(!backend_error_code_skips_sentry(body));
+    }
+
+    #[test]
+    fn malformed_flag_with_spaced_colon_is_detected() {
+        // Pretty-printed JSON `"malformed" : true` must still flag malformed.
+        let body = r#"OpenHuman API error (400 Bad Request): {"errorCode":"BAD_REQUEST","malformed" : true}"#;
+        assert!(is_backend_malformed_bad_request(body));
+        assert!(!managed_error_skips_sentry(body));
+    }
+
+    #[test]
+    fn managed_envelope_gate_rejects_byo_payload_carrying_error_code() {
+        // A BYO / direct-provider envelope that merely contains an
+        // `errorCode`-shaped field must NOT be treated as backend-owned —
+        // otherwise it would wrongly suppress FE Sentry.
+        let byo = r#"custom_openai API error (429 Too Many Requests): {"error":{"errorCode":"RATE_LIMITED"}}"#;
+        assert!(!is_managed_backend_envelope(byo));
+        assert!(!managed_error_skips_sentry(byo));
+
+        // The same body under the managed envelope IS backend-owned.
+        let managed = r#"OpenHuman API error (429 Too Many Requests): {"error":{"errorCode":"RATE_LIMITED"}}"#;
+        assert!(is_managed_backend_envelope(managed));
+        assert!(managed_error_skips_sentry(managed));
+
+        // The streaming envelope variant is also recognised.
+        let managed_stream =
+            r#"OpenHuman streaming API error (500): {"errorCode":"INTERNAL_ERROR"}"#;
+        assert!(is_managed_backend_envelope(managed_stream));
+        assert!(managed_error_skips_sentry(managed_stream));
     }
 }

--- a/src/openhuman/inference/provider/error_code.rs
+++ b/src/openhuman/inference/provider/error_code.rs
@@ -1,0 +1,216 @@
+//! Backend `errorCode` extraction + Sentry-ownership decision.
+//!
+//! The OpenHuman **managed backend** (PR #870 / backend `tinyhumansai/backend#870`)
+//! stamps every inference error response with a stable machine-readable
+//! `errorCode` field in the JSON body, e.g.
+//!
+//! ```json
+//! {"error":{"message":"Rate limited","errorCode":"RATE_LIMITED","retryAfter":30}}
+//! ```
+//!
+//! That body is the only thing that distinguishes a **managed** failure (our
+//! operator key / account / quota / routing) from a **BYO** failure (the user
+//! runs their own provider key, no `errorCode` is present). The presence of an
+//! `errorCode` is therefore the single load-bearing signal for two decisions:
+//!
+//! 1. **Classification** ([`super::super::super::channels::providers::web_errors::classify_inference_error`]):
+//!    when an `errorCode` is present, branch on it FIRST and ignore the
+//!    substring heuristics; when it is absent, fall back to the substring
+//!    ladder (the BYO / direct-provider path, whose "check your API key" /
+//!    "check your model settings" copy is correct there).
+//! 2. **Sentry ownership** (`api_error` / `before_send` / `expected_error_kind`):
+//!    any response carrying an `errorCode` is owned by the backend (it already
+//!    paged, or it is expected user-state) so the FE must **not** double-report
+//!    — with the single exception of a backend-flagged **malformed**
+//!    `BAD_REQUEST`, which means the client built a payload the backend
+//!    couldn't parse (a client bug worth paging). See the spec's "golden rule"
+//!    (F2) and the malformed-`BAD_REQUEST` carve-out (F8/B8).
+//!
+//! Everything in this module operates on the **already-flattened error string**
+//! (`"OpenHuman API error (429 …): {…errorCode…}"`) because the typed provider
+//! error is collapsed to a `String` at the native-bus boundary before it
+//! reaches the channel classifier or the higher-layer re-report sites.
+
+/// A recognised backend `errorCode` token (PR #870).
+///
+/// Unknown / future tokens are intentionally NOT represented here — they are
+/// still detected as "an `errorCode` is present" by
+/// [`extract_backend_error_code_token`] (so the Sentry golden rule still
+/// applies), but they fall through to the substring ladder for *display*
+/// classification rather than guessing a bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendErrorCode {
+    RateLimited,
+    UserInsufficientCredits,
+    UpstreamUnavailable,
+    ModelUnavailable,
+    PayloadTooLarge,
+    ContextLengthExceeded,
+    BadRequest,
+    InternalError,
+}
+
+impl BackendErrorCode {
+    /// Parse a canonical (upper-cased) token into a known variant.
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "RATE_LIMITED" => Some(Self::RateLimited),
+            "USER_INSUFFICIENT_CREDITS" => Some(Self::UserInsufficientCredits),
+            "UPSTREAM_UNAVAILABLE" => Some(Self::UpstreamUnavailable),
+            "MODEL_UNAVAILABLE" => Some(Self::ModelUnavailable),
+            "PAYLOAD_TOO_LARGE" => Some(Self::PayloadTooLarge),
+            "CONTEXT_LENGTH_EXCEEDED" => Some(Self::ContextLengthExceeded),
+            "BAD_REQUEST" => Some(Self::BadRequest),
+            "INTERNAL_ERROR" => Some(Self::InternalError),
+            _ => None,
+        }
+    }
+}
+
+/// Extract the raw (upper-cased) `errorCode` token from a flattened error
+/// string, or `None` when the body carries no `errorCode` field.
+///
+/// Returns the token **even if it is not a recognised [`BackendErrorCode`]** —
+/// the mere presence of an `errorCode` means the error came through the managed
+/// backend, which is what the Sentry golden rule keys on. Display
+/// classification narrows further via [`BackendErrorCode::from_token`].
+///
+/// The key match is case-insensitive (`"errorCode"` / `"errorcode"` /
+/// `"ERRORCODE"`) so a re-cased or re-serialised body still resolves; the
+/// extracted **value** is upper-cased before return so callers can compare
+/// against the canonical tokens regardless of how the backend cased them.
+pub fn extract_backend_error_code_token(err: &str) -> Option<String> {
+    // `to_ascii_lowercase` is byte-length preserving (it only remaps ASCII
+    // bytes in place), so a byte index found in `lower` is also valid in the
+    // original `err` — we search the lowercased copy for the key but read the
+    // value out of the original to keep the token's casing intact for the
+    // (defensive) upper-casing below.
+    let lower = err.to_ascii_lowercase();
+    const KEY: &str = "\"errorcode\"";
+    let key_idx = lower.find(KEY)?;
+    let after_key = &err[key_idx + KEY.len()..];
+    // Skip the colon + whitespace to the opening quote of the value.
+    let after_colon = after_key.trim_start_matches(|c: char| c != '"');
+    let stripped = after_colon.strip_prefix('"')?;
+    let end = stripped.find('"')?;
+    let token = stripped[..end].trim().to_ascii_uppercase();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+/// Parse a recognised [`BackendErrorCode`] out of a flattened error string.
+pub fn extract_backend_error_code(err: &str) -> Option<BackendErrorCode> {
+    extract_backend_error_code_token(err).and_then(|t| BackendErrorCode::from_token(&t))
+}
+
+/// Whether the managed backend explicitly flagged this `BAD_REQUEST` as a
+/// **malformed** payload (the client built a request the backend couldn't
+/// parse), as opposed to a user-parameter rejection (an unsupported model /
+/// parameter combination the user can fix).
+///
+/// Contract consumed from backend PR #870: the malformed variant carries a
+/// `"malformed": true` flag alongside `"errorCode":"BAD_REQUEST"`. Only this
+/// variant keeps paging the FE Sentry (F8/B8) — every other `errorCode` (the
+/// user-param `BAD_REQUEST` included) is owned by the backend and must not
+/// double-report.
+pub fn body_flags_malformed(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("\"malformed\":true") || lower.contains("\"malformed\": true")
+}
+
+/// Whether the error is a backend-flagged malformed `BAD_REQUEST` — the single
+/// `errorCode` case the FE *does* page (a client-built payload the backend
+/// rejected as unparseable).
+pub fn is_backend_malformed_bad_request(err: &str) -> bool {
+    matches!(
+        extract_backend_error_code(err),
+        Some(BackendErrorCode::BadRequest)
+    ) && body_flags_malformed(err)
+}
+
+/// Sentry-ownership decision (F2 golden rule): a response carrying any backend
+/// `errorCode` must **not** page the FE — the backend owns it (it already
+/// paged) or it is expected user-state — *except* a backend-flagged malformed
+/// `BAD_REQUEST`, which the client caused and so still pages.
+///
+/// Shared by the provider HTTP layer (`api_error`), the higher-layer re-report
+/// classifier (`observability::expected_error_kind`), and the Sentry
+/// `before_send` defense-in-depth filter so the three layers can't drift.
+pub fn backend_error_code_skips_sentry(err: &str) -> bool {
+    extract_backend_error_code_token(err).is_some() && !is_backend_malformed_bad_request(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_known_tokens() {
+        let body = r#"OpenHuman API error (429 Too Many Requests): {"error":{"message":"slow down","errorCode":"RATE_LIMITED","retryAfter":30}}"#;
+        assert_eq!(
+            extract_backend_error_code_token(body).as_deref(),
+            Some("RATE_LIMITED")
+        );
+        assert_eq!(
+            extract_backend_error_code(body),
+            Some(BackendErrorCode::RateLimited)
+        );
+    }
+
+    #[test]
+    fn extraction_is_case_insensitive_on_key_and_normalises_value() {
+        let body = r#"{"ErrorCode":"rate_limited"}"#;
+        assert_eq!(
+            extract_backend_error_code_token(body).as_deref(),
+            Some("RATE_LIMITED")
+        );
+    }
+
+    #[test]
+    fn unknown_token_is_present_but_not_recognised() {
+        let body = r#"{"errorCode":"SOME_FUTURE_CODE"}"#;
+        assert_eq!(
+            extract_backend_error_code_token(body).as_deref(),
+            Some("SOME_FUTURE_CODE")
+        );
+        assert_eq!(extract_backend_error_code(body), None);
+        // Golden rule still applies: an unknown code is a managed error.
+        assert!(backend_error_code_skips_sentry(body));
+    }
+
+    #[test]
+    fn no_error_code_means_byo_path() {
+        let body = r#"custom_openai API error (401 Unauthorized): {"error":{"message":"invalid api key"}}"#;
+        assert_eq!(extract_backend_error_code_token(body), None);
+        assert!(!backend_error_code_skips_sentry(body));
+    }
+
+    #[test]
+    fn malformed_bad_request_is_the_one_paging_exception() {
+        let malformed = r#"OpenHuman API error (400 Bad Request): {"error":{"errorCode":"BAD_REQUEST","malformed":true}}"#;
+        assert!(is_backend_malformed_bad_request(malformed));
+        assert!(!backend_error_code_skips_sentry(malformed));
+
+        let malformed_spaced = r#"{"errorCode":"BAD_REQUEST","malformed": true,"message":"bad"}"#;
+        assert!(is_backend_malformed_bad_request(malformed_spaced));
+    }
+
+    #[test]
+    fn user_param_bad_request_does_not_page() {
+        let user_param = r#"OpenHuman API error (400 Bad Request): {"error":{"errorCode":"BAD_REQUEST","message":"unsupported parameter"}}"#;
+        assert!(!is_backend_malformed_bad_request(user_param));
+        assert!(backend_error_code_skips_sentry(user_param));
+    }
+
+    #[test]
+    fn malformed_flag_without_bad_request_is_ignored() {
+        // A stray `malformed` flag on a non-BAD_REQUEST code must not turn a
+        // backend-owned error into a paging one.
+        let body = r#"{"errorCode":"INTERNAL_ERROR","malformed":true}"#;
+        assert!(!is_backend_malformed_bad_request(body));
+        assert!(backend_error_code_skips_sentry(body));
+    }
+}

--- a/src/openhuman/inference/provider/mod.rs
+++ b/src/openhuman/inference/provider/mod.rs
@@ -13,6 +13,7 @@ pub mod compatible_parse;
 pub mod compatible_stream;
 pub mod compatible_types;
 pub mod config_rejection;
+pub mod error_code;
 pub mod factory;
 mod openai_codex;
 pub mod openhuman_backend;
@@ -33,6 +34,10 @@ pub use traits::{
 pub use billing_error::is_budget_exhausted_message;
 pub use config_rejection::{
     is_openai_compatible_unknown_model_message, is_provider_config_rejection_message,
+};
+pub use error_code::{
+    backend_error_code_skips_sentry, body_flags_malformed, extract_backend_error_code,
+    extract_backend_error_code_token, is_backend_malformed_bad_request, BackendErrorCode,
 };
 pub use factory::{create_chat_provider, provider_for_role, BYOK_INCOMPLETE_SENTINEL};
 pub use ops::*;

--- a/src/openhuman/inference/provider/mod.rs
+++ b/src/openhuman/inference/provider/mod.rs
@@ -37,7 +37,8 @@ pub use config_rejection::{
 };
 pub use error_code::{
     backend_error_code_skips_sentry, body_flags_malformed, extract_backend_error_code,
-    extract_backend_error_code_token, is_backend_malformed_bad_request, BackendErrorCode,
+    extract_backend_error_code_token, is_backend_malformed_bad_request,
+    is_managed_backend_envelope, managed_error_skips_sentry, BackendErrorCode,
 };
 pub use factory::{create_chat_provider, provider_for_role, BYOK_INCOMPLETE_SENTINEL};
 pub use ops::*;

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -95,6 +95,42 @@ pub fn log_custom_openai_upstream_bad_request_http_400(
     );
 }
 
+/// Whether this provider response carries a managed-backend `errorCode` (#870)
+/// that the backend already owns — so the FE must not double-report (F2/F4).
+///
+/// Returns `false` for a backend-flagged **malformed** `BAD_REQUEST`: that one
+/// `errorCode` case is a client-built payload the backend couldn't parse, and
+/// the FE *does* page for it (F8). Delegates to the single-source decision in
+/// [`crate::openhuman::inference::provider::backend_error_code_skips_sentry`]
+/// so the provider layer, the higher-layer re-report classifier, and the
+/// Sentry `before_send` filter can't drift.
+pub fn is_backend_error_code_owned(body: &str) -> bool {
+    crate::openhuman::inference::provider::backend_error_code_skips_sentry(body)
+}
+
+pub fn log_backend_error_code_owned(
+    operation: &str,
+    provider: &str,
+    model: Option<&str>,
+    status: reqwest::StatusCode,
+    body: &str,
+) {
+    let code = crate::openhuman::inference::provider::extract_backend_error_code_token(body)
+        .unwrap_or_default();
+    tracing::info!(
+        domain = "llm_provider",
+        operation = operation,
+        provider = provider,
+        model = model.unwrap_or(""),
+        status = status.as_u16(),
+        failure = "non_2xx",
+        kind = "backend_error_code",
+        error_code = %code,
+        "[llm_provider] {operation} backend errorCode={code} ({status}) — backend owns \
+         this error, not reporting to Sentry"
+    );
+}
+
 pub fn log_provider_access_policy_denied_http_403(
     operation: &str,
     provider: &str,
@@ -370,6 +406,12 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     // custom gateways mis-report it as 500 — TAURI-RUST-501 — so a status
     // gate would let those through to `should_report_provider_http_failure`).
     let is_context_window_exceeded = is_context_window_exceeded_message(&body);
+    // F4/F2: any managed-backend response carrying a stable `errorCode` is
+    // backend-owned — it already paged or is expected user-state — so the FE
+    // must not double-report. The one exception (malformed `BAD_REQUEST`) is
+    // excluded by `is_backend_error_code_owned` and falls through to the
+    // status gate below, which reports it (status 400 is non-transient) — F8.
+    let is_backend_error_code_owned = is_backend_error_code_owned(&body);
 
     if is_auth_failure && is_backend {
         // Single source of truth for backend session-expiry handling (warn +
@@ -386,6 +428,8 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
         log_provider_config_rejection("api_error", provider, None, status);
     } else if is_context_window_exceeded {
         log_context_window_exceeded("api_error", provider, None, status);
+    } else if is_backend_error_code_owned {
+        log_backend_error_code_owned("api_error", provider, None, status, &body);
     } else if should_report_provider_http_failure(status) {
         crate::core::observability::report_error(
             message.as_str(),

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -98,14 +98,20 @@ pub fn log_custom_openai_upstream_bad_request_http_400(
 /// Whether this provider response carries a managed-backend `errorCode` (#870)
 /// that the backend already owns — so the FE must not double-report (F2/F4).
 ///
+/// Gated on `provider == `[`openhuman_backend::PROVIDER_LABEL`]: an `errorCode`
+/// is only trustworthy on the **managed backend**. A BYO / direct-provider body
+/// that merely contains an `errorCode`-shaped field must NOT be treated as
+/// backend-owned (CodeRabbit) — those keep reaching Sentry via the status gate.
+///
 /// Returns `false` for a backend-flagged **malformed** `BAD_REQUEST`: that one
 /// `errorCode` case is a client-built payload the backend couldn't parse, and
 /// the FE *does* page for it (F8). Delegates to the single-source decision in
 /// [`crate::openhuman::inference::provider::backend_error_code_skips_sentry`]
 /// so the provider layer, the higher-layer re-report classifier, and the
 /// Sentry `before_send` filter can't drift.
-pub fn is_backend_error_code_owned(body: &str) -> bool {
-    crate::openhuman::inference::provider::backend_error_code_skips_sentry(body)
+pub fn is_backend_error_code_owned(provider: &str, body: &str) -> bool {
+    provider == openhuman_backend::PROVIDER_LABEL
+        && crate::openhuman::inference::provider::backend_error_code_skips_sentry(body)
 }
 
 pub fn log_backend_error_code_owned(
@@ -411,7 +417,7 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     // must not double-report. The one exception (malformed `BAD_REQUEST`) is
     // excluded by `is_backend_error_code_owned` and falls through to the
     // status gate below, which reports it (status 400 is non-transient) — F8.
-    let is_backend_error_code_owned = is_backend_error_code_owned(&body);
+    let is_backend_error_code_owned = is_backend_error_code_owned(provider, &body);
 
     if is_auth_failure && is_backend {
         // Single source of truth for backend session-expiry handling (warn +

--- a/src/openhuman/inference/provider/ops/mod.rs
+++ b/src/openhuman/inference/provider/ops/mod.rs
@@ -19,10 +19,10 @@ pub use sanitize::{
 };
 
 pub use http_error::{
-    api_error, is_backend_auth_failure, is_budget_exhausted_http_400,
+    api_error, is_backend_auth_failure, is_backend_error_code_owned, is_budget_exhausted_http_400,
     is_context_window_exceeded_message, is_custom_openai_upstream_bad_request_http_400,
     is_provider_access_policy_denied_http_403, is_provider_config_rejection_http,
-    log_budget_exhausted_http_400, log_context_window_exceeded,
+    log_backend_error_code_owned, log_budget_exhausted_http_400, log_context_window_exceeded,
     log_custom_openai_upstream_bad_request_http_400, log_provider_access_policy_denied_http_403,
     log_provider_config_rejection, publish_backend_session_expired,
     should_report_provider_http_failure,

--- a/src/openhuman/inference/provider/ops_tests.rs
+++ b/src/openhuman/inference/provider/ops_tests.rs
@@ -334,6 +334,45 @@ fn skips_sentry_report_for_transient_upstream_statuses() {
     }
 }
 
+#[test]
+fn backend_error_code_owned_gates_managed_errors_except_malformed_bad_request() {
+    // F2/F4: any managed-backend body carrying an errorCode is backend-owned
+    // and must NOT page the provider HTTP layer.
+    for code in [
+        "RATE_LIMITED",
+        "USER_INSUFFICIENT_CREDITS",
+        "UPSTREAM_UNAVAILABLE",
+        "MODEL_UNAVAILABLE",
+        "PAYLOAD_TOO_LARGE",
+        "CONTEXT_LENGTH_EXCEEDED",
+        "INTERNAL_ERROR",
+    ] {
+        let body = format!("{{\"error\":{{\"errorCode\":\"{code}\",\"message\":\"x\"}}}}");
+        assert!(
+            is_backend_error_code_owned(&body),
+            "errorCode={code} must be backend-owned (no provider-layer Sentry)"
+        );
+    }
+
+    // A user-param BAD_REQUEST is still backend-owned (F8 only carves out the
+    // malformed variant).
+    assert!(is_backend_error_code_owned(
+        "{\"error\":{\"errorCode\":\"BAD_REQUEST\",\"message\":\"bad param\"}}"
+    ));
+
+    // F8: a backend-flagged malformed BAD_REQUEST is the one case the FE still
+    // pages — the gate must NOT claim it.
+    assert!(!is_backend_error_code_owned(
+        "{\"error\":{\"errorCode\":\"BAD_REQUEST\",\"malformed\":true}}"
+    ));
+
+    // BYO (no errorCode) is never claimed by this gate — it falls through to
+    // the status-based decision.
+    assert!(!is_backend_error_code_owned(
+        "{\"error\":{\"message\":\"Incorrect API key provided\"}}"
+    ));
+}
+
 // Confirm the budget-exhausted suppression predicate is scoped correctly.
 // These tests exercise the real production function, not a duplicate.
 mod budget_exhausted_suppression {

--- a/src/openhuman/inference/provider/ops_tests.rs
+++ b/src/openhuman/inference/provider/ops_tests.rs
@@ -336,6 +336,8 @@ fn skips_sentry_report_for_transient_upstream_statuses() {
 
 #[test]
 fn backend_error_code_owned_gates_managed_errors_except_malformed_bad_request() {
+    use crate::openhuman::inference::provider::openhuman_backend::PROVIDER_LABEL;
+
     // F2/F4: any managed-backend body carrying an errorCode is backend-owned
     // and must NOT page the provider HTTP layer.
     for code in [
@@ -349,7 +351,7 @@ fn backend_error_code_owned_gates_managed_errors_except_malformed_bad_request() 
     ] {
         let body = format!("{{\"error\":{{\"errorCode\":\"{code}\",\"message\":\"x\"}}}}");
         assert!(
-            is_backend_error_code_owned(&body),
+            is_backend_error_code_owned(PROVIDER_LABEL, &body),
             "errorCode={code} must be backend-owned (no provider-layer Sentry)"
         );
     }
@@ -357,19 +359,30 @@ fn backend_error_code_owned_gates_managed_errors_except_malformed_bad_request() 
     // A user-param BAD_REQUEST is still backend-owned (F8 only carves out the
     // malformed variant).
     assert!(is_backend_error_code_owned(
+        PROVIDER_LABEL,
         "{\"error\":{\"errorCode\":\"BAD_REQUEST\",\"message\":\"bad param\"}}"
     ));
 
     // F8: a backend-flagged malformed BAD_REQUEST is the one case the FE still
     // pages — the gate must NOT claim it.
     assert!(!is_backend_error_code_owned(
+        PROVIDER_LABEL,
         "{\"error\":{\"errorCode\":\"BAD_REQUEST\",\"malformed\":true}}"
     ));
 
     // BYO (no errorCode) is never claimed by this gate — it falls through to
     // the status-based decision.
     assert!(!is_backend_error_code_owned(
+        PROVIDER_LABEL,
         "{\"error\":{\"message\":\"Incorrect API key provided\"}}"
+    ));
+
+    // CodeRabbit: a BYO / direct provider whose body merely contains an
+    // `errorCode`-shaped field must NOT be claimed as backend-owned — the
+    // provider gate keeps it reaching Sentry via the status decision.
+    assert!(!is_backend_error_code_owned(
+        "custom_openai",
+        "{\"error\":{\"errorCode\":\"RATE_LIMITED\"}}"
     ));
 }
 


### PR DESCRIPTION
## Summary

- Consume the stable backend `errorCode` (backend [#870](https://github.com/tinyhumansai/backend/pull/870)) on managed-backend inference errors and classify on it **first**, before the substring heuristics — which now serve only as the BYO / direct-provider fallback (F2).
- An `errorCode` is present **only** for managed-backend errors, so its presence is the load-bearing managed-vs-BYO signal: managed errors are backend-owned (operator fault or expected user-state) and the FE stops double-paging Sentry; BYO (no code) keeps the existing user-actionable copy ("check your API key / model settings").
- New non-retryable `payload_too_large` bucket + copy, surfaced through the `ChatErrorEvent.error_type` union (F3).
- Operator-fault routing: `UPSTREAM_UNAVAILABLE` and managed `MODEL_UNAVAILABLE` → `provider_error` "temporarily unavailable — we've been notified", dropping the user-blaming "check your API key" / "pick a different model" copy and the FE Sentry page (F4/F6).
- Streaming transport errors gated with `contains_transient_transport_phrase` so flaky-network timeouts/resets stop paging Sentry (F7); user-param `BAD_REQUEST` demoted from FE Sentry while a backend-flagged **malformed** `BAD_REQUEST` keeps paging (F8).

This is the **F-item slice** (F2/F3/F4/F6/F7/F8) consuming the backend `errorCode` from backend PR #870. The R-item thread-recovery / poison-rollback work (R1/R2/R3/R5) is a separate effort and is **not** included here; only the malformed-vs-poison copy guidance was adopted where a bucket already existed.

## Problem

`classify_inference_error` matched purely on substrings of the flattened error string, so it could not distinguish a managed operator fault (our key/account/quota/5xx, which the backend already paged) from a user's own BYO-key problem. The result: user-blaming copy on operator faults ("check your API key" for our outage), a missing bucket for oversize payloads, and the FE double-reporting to Sentry errors the backend already owns. Backend #870 now emits a stable `errorCode` on every managed error, giving us a reliable signal to fix all of this.

## Solution

- New `inference::provider::error_code` module: extracts the `errorCode` token (case-insensitive key, normalised value), detects the backend-flagged malformed `BAD_REQUEST` (`"malformed": true`), and exposes the single-source Sentry-ownership decision `backend_error_code_skips_sentry` (skip for any code **except** malformed `BAD_REQUEST`).
- `classify_inference_error` branches on a recognised `errorCode` first and maps each code to the spec's bucket / message / retryable per Section 1; an absent or unrecognised code falls through to the unchanged substring ladder.
- The same ownership decision is reused by the provider HTTP gate (`api_error` + the two streaming non-2xx emit sites), the higher-layer re-report classifier (`expected_error_kind` → new `BackendErrorCodeOwned` kind), and the Sentry `before_send` filters in both `src/main.rs` (core binary) and the Tauri shell `lib.rs` (the in-process core's Sentry surface) so the layers can't drift.
- Streaming transport (`domain=llm_provider, failure=transport`) emit sites and a `before_send` defense-in-depth filter gate on `contains_transient_transport_phrase` (F7).
- i18n: messages stay as core-side English literals in `web_errors.rs`, matching the existing pattern. No i18n keys introduced (a separate, larger refactor noted in the spec §6).

**Backward-compatible**: with no `errorCode` present the classifier degrades to today's substring behaviour, so BYO / direct-provider errors are unchanged.

**Dependency note**: most streamed managed errors arrive instantly before any token, so the streamed-chat path additionally needs the backend **defer-flush** change to return them as normal HTTP errors (status + `errorCode` body) on `stream:true`. That backend change is separate; without it, those streamed errors are still masked as "empty response" client-side. The non-streaming path and the Sentry gates land fully with this PR.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — per-`errorCode` bucket/message/retryable/Sentry assertions, BYO no-code path, malformed-vs-user-param `BAD_REQUEST`, transport gating, and the `payload_too_large` Vitest case.
- [x] **Diff coverage ≥ 80%** — new branches in `error_code.rs`, `web_errors.rs`, `http_error.rs`, and `observability.rs` are covered by unit tests (`pnpm test`, `cargo test` for the affected modules).
- [x] Coverage matrix updated — N/A: behaviour-only change (no feature rows added/removed/renamed).
- [x] All affected feature IDs listed under `## Related`.
- [x] No new external network dependencies introduced (classification is pure; tests use literal error strings / the mock backend).
- [x] Manual smoke checklist updated — N/A: no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` — N/A: no tracking issue (spec-driven F-item slice; backend dep #870 linked in Related).

## Impact

- **Platform**: desktop (Tauri shell + core). Chat error surface only.
- **User-visible**: calmer, accurate copy on operator outages ("temporarily unavailable — we've been notified") instead of blaming the user's API key/model; a clear oversize-payload message; unchanged copy for BYO-key users.
- **Observability**: managed-backend errors stop double-paging FE Sentry (the backend owns them); flaky-network streaming transport blips stop paging; a backend-flagged malformed `BAD_REQUEST` still pages so genuine client-built-payload bugs remain visible.
- **Compatibility**: fully backward-compatible — degrades to substring classification when no `errorCode` is present.

## Related

- Backend dependency: tinyhumansai/backend#870 (emits `errorCode`)
- Follow-up PR(s)/TODOs: backend **defer-flush** for streamed errors (separate); R1/R2/R3/R5 thread-recovery / poison-rollback (separate); i18n key migration for `web_errors.rs` copy (spec §6).
- Closes:

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/inference-errorcode-classification`
- Commit SHA: cc176b082 (+ fmt amend)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test` (error_code / classify_inference_error / backend_error_code / expected_kind / before_send / transport) all pass; `pnpm test` full Vitest 5273 passed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check` (core) clean.
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml` clean.

### Validation Blocked

- `command:` `pnpm test:rust` (full `--lib` run)
- `error:` ~22 pre-existing failures in `memory_tree` / `memory` / `search` / `delegate` modules — cloud-embedding `401 Invalid token` and search-registry/config setup, unrelated to this change (none of the touched files are in those modules).
- `impact:` None on this PR's behaviour; all tests for the changed code pass.

### Behavior Changes

- Intended behavior change: classify managed inference errors on backend `errorCode` first; route operator faults to calm "we've been notified" copy; stop FE Sentry double-reporting for backend-owned errors; gate streaming transport noise.
- User-visible effect: accurate, non-blaming chat error copy on operator outages; new oversize-payload message; BYO-key copy unchanged.

### Parity Contract

- Legacy behavior preserved: no-`errorCode` (BYO / direct-provider) errors degrade to the existing substring classification unchanged.
- Guard/fallback/dispatch parity checks: the Sentry-ownership decision is single-sourced (`backend_error_code_skips_sentry`) and reused by `api_error`, the streaming gates, `expected_error_kind`, and both `before_send` filters; malformed `BAD_REQUEST` is the one carve-out that still pages.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for backend-generated errors with error codes, reducing redundant error reports to monitoring systems.
  * Enhanced handling of transient streaming network failures to prevent false error alerts.
  * Better distinction between managed and user-provided errors to ensure appropriate error messaging.

* **New Features**
  * Added support for "payload too large" error type to properly handle oversized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->