### PR TITLE
refactor(agents): make memory-agent retrieval on-demand, not pre-emptive

### DIFF
--- a/app/test/playwright/specs/chat-conversation-history.spec.ts
+++ b/app/test/playwright/specs/chat-conversation-history.spec.ts
@@ -13,7 +13,6 @@ const SECRET_WORD = 'XYZZY';
 const FIRST_PROMPT = `Remember: the secret word is ${SECRET_WORD}`;
 const SECOND_PROMPT = 'What was the secret word?';
 const TURN_TWO_CANARY = `canary-memory-m1n2o3-${SECRET_WORD}`;
-const MEMORY_TRIGGER_RESPONSE = 'No relevant memory context.';
 const FIRST_RESPONSE = `Got it! I will remember that the secret word is ${SECRET_WORD}.`;
 
 interface MockRequest {
@@ -128,10 +127,7 @@ test.describe('Chat Conversation History', () => {
     page,
   }) => {
     await resetMock();
-    await setMockBehavior(
-      'llmForcedResponses',
-      JSON.stringify([{ content: MEMORY_TRIGGER_RESPONSE }, { content: FIRST_RESPONSE }])
-    );
+    await setMockBehavior('llmForcedResponses', JSON.stringify([{ content: FIRST_RESPONSE }]));
     await setMockBehavior('llmStreamChunkDelayMs', '10');
 
     await openChat(page);
@@ -146,7 +142,6 @@ test.describe('Chat Conversation History', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        { content: MEMORY_TRIGGER_RESPONSE },
         {
           content: `The secret word you told me was ${SECRET_WORD}. Here is the confirmation: ${TURN_TWO_CANARY}`,
         },
@@ -156,6 +151,9 @@ test.describe('Chat Conversation History', () => {
     await sendMessage(page, SECOND_PROMPT);
     await expect(page.getByText(TURN_TWO_CANARY)).toBeVisible({ timeout: 30_000 });
 
+    // One chat-completion POST for the second turn: the orchestrator no longer
+    // eagerly spawns the memory agent before the turn (memory is on-demand now),
+    // so there is a single LLM call rather than the prior memory+main pair.
     const llmLog = await expect
       .poll(async () => {
         const log = await requests();
@@ -163,7 +161,7 @@ test.describe('Chat Conversation History', () => {
           entry => entry.method === 'POST' && entry.url.includes('/openai/v1/chat/completions')
         );
       })
-      .toHaveLength(2);
+      .toHaveLength(1);
 
     void llmLog;
 

--- a/app/test/playwright/specs/chat-harness-subagent.spec.ts
+++ b/app/test/playwright/specs/chat-harness-subagent.spec.ts
@@ -156,15 +156,14 @@ test.describe('Chat Harness - Subagent', () => {
             entry => entry.method === 'POST' && entry.url.includes('/openai/v1/chat/completions')
           );
           const bodies = llmRequests.map(entry => entry.body ?? '');
-          const memoryIndex = bodies.findIndex(body =>
-            body.includes(
-              "Search the user's memory tree and return only context relevant to the next agent turn."
-            )
-          );
+          // The orchestrator no longer eagerly spawns the memory agent before
+          // the turn (memory retrieval is on-demand now), so we assert the
+          // harness delegated to the researcher sub-agent — its prompt reaching
+          // the LLM is the signal — rather than ordering it after a memory call.
           const delegatedPromptIndex = bodies.findIndex(body =>
             body.includes('Tell me a marker phrase')
           );
-          return memoryIndex >= 0 && delegatedPromptIndex > memoryIndex;
+          return delegatedPromptIndex >= 0;
         },
         { timeout: 90_000 }
       )

--- a/app/test/playwright/specs/chat-harness-wallet-flow.spec.ts
+++ b/app/test/playwright/specs/chat-harness-wallet-flow.spec.ts
@@ -12,9 +12,7 @@ const USER_ID = 'pw-chat-wallet-flow';
 const CANARY = 'wallet-quote-canary-8d13';
 const JOHN_ADDRESS = '0x00000000000000000000000000000000000000aa';
 const WALLET_PROMPT = `Send John $5 on EVM at ${JOHN_ADDRESS} and tell me ${CANARY}.`;
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 const FORCED_RESPONSES = [
-  MEMORY_TRIGGER_RESPONSE,
   {
     content: '',
     toolCalls: [

--- a/app/test/playwright/specs/chat-management-functional.spec.ts
+++ b/app/test/playwright/specs/chat-management-functional.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '../helpers/core-rpc';
 
 const MOCK_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 async function setMockBehavior(behavior: Record<string, unknown>): Promise<void> {
   await fetch(`${MOCK_BASE}/__admin/behavior`, {
@@ -77,10 +76,7 @@ test.describe('Chat management functional coverage', () => {
   }) => {
     await resetMock();
     await setMockBehavior({
-      llmForcedResponses: JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
-        { content: 'Attachment received by the assistant.' },
-      ]),
+      llmForcedResponses: JSON.stringify([{ content: 'Attachment received by the assistant.' }]),
       llmStreamChunkDelayMs: '5',
     });
     await openChat(page, 'pw-chat-attachments');

--- a/app/test/playwright/specs/chat-multi-tool-round.spec.ts
+++ b/app/test/playwright/specs/chat-multi-tool-round.spec.ts
@@ -10,9 +10,7 @@ const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'
 const USER_ID = 'pw-chat-multi-tool';
 const PROMPT = 'Read the config file and search for the relevant setting.';
 const CANARY_FINAL = 'canary-multi-tool-d4e5f6';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 const FORCED_RESPONSES = [
-  MEMORY_TRIGGER_RESPONSE,
   {
     content: '',
     toolCalls: [

--- a/app/test/playwright/specs/chat-tool-call-flow.spec.ts
+++ b/app/test/playwright/specs/chat-tool-call-flow.spec.ts
@@ -10,9 +10,7 @@ const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'
 const USER_ID = 'pw-chat-tool-call';
 const PROMPT = 'Fetch the contents of https://example.com for me.';
 const CANARY_FINAL = 'canary-tool-call-fetched-a1b2c3';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 const FORCED_RESPONSES = [
-  MEMORY_TRIGGER_RESPONSE,
   {
     content: '',
     toolCalls: [

--- a/app/test/playwright/specs/chat-tool-error-recovery.spec.ts
+++ b/app/test/playwright/specs/chat-tool-error-recovery.spec.ts
@@ -9,7 +9,6 @@ import {
 const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-chat-error-recovery';
 const RECOVERY_CANARY = 'canary-recovery-7g8h9i';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 async function resetMock(): Promise<void> {
   await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
@@ -155,10 +154,7 @@ test.describe('Chat Tool Error Recovery', () => {
     await setMockBehavior('llmStreamScript', '');
     await setMockBehavior(
       'llmForcedResponses',
-      JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
-        { content: `Recovery successful: ${RECOVERY_CANARY}` },
-      ])
+      JSON.stringify([{ content: `Recovery successful: ${RECOVERY_CANARY}` }])
     );
     await setMockBehavior('llmStreamChunkDelayMs', '10');
 

--- a/app/test/playwright/specs/harness-channel-bridge-flow.spec.ts
+++ b/app/test/playwright/specs/harness-channel-bridge-flow.spec.ts
@@ -9,7 +9,6 @@ import {
 const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-harness-channel-bridge';
 const CANARY = 'canary-cb1-cron-standup';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 async function resetMock(): Promise<void> {
   await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
@@ -112,7 +111,6 @@ test.describe('Harness - Cross-channel bridge flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [

--- a/app/test/playwright/specs/harness-composio-tool-flow.spec.ts
+++ b/app/test/playwright/specs/harness-composio-tool-flow.spec.ts
@@ -8,7 +8,6 @@ import {
 
 const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-harness-composio-tool-flow';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 interface MockRequest {
   method: string;
@@ -153,7 +152,6 @@ test.describe('Harness - Composio tool-call prompt flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [
@@ -196,7 +194,6 @@ test.describe('Harness - Composio tool-call prompt flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [
@@ -229,7 +226,6 @@ test.describe('Harness - Composio tool-call prompt flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [
@@ -268,7 +264,6 @@ test.describe('Harness - Composio tool-call prompt flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [

--- a/app/test/playwright/specs/harness-cron-prompt-flow.spec.ts
+++ b/app/test/playwright/specs/harness-cron-prompt-flow.spec.ts
@@ -8,7 +8,6 @@ import {
 
 const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-harness-cron-prompt-flow';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 interface MockRequest {
   method: string;
@@ -122,7 +121,6 @@ test.describe('Harness - Cron prompt-flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [
@@ -158,7 +156,6 @@ test.describe('Harness - Cron prompt-flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: `You have 2 scheduled tasks: daily_standup (weekdays 9am) and weekly_review (Fridays 10am). ${CANARY}`,
         },
@@ -176,7 +173,6 @@ test.describe('Harness - Cron prompt-flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [
@@ -205,7 +201,6 @@ test.describe('Harness - Cron prompt-flow', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [

--- a/app/test/playwright/specs/harness-search-tool-flow.spec.ts
+++ b/app/test/playwright/specs/harness-search-tool-flow.spec.ts
@@ -8,7 +8,6 @@ import {
 
 const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-harness-search-tool-flow';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 interface MockRequest {
   method: string;
@@ -137,7 +136,6 @@ test.describe('Harness - Search tool-flow', () => {
   test('memory_recall prompt completes the two-turn sequence', async ({ page }) => {
     const CANARY = 'canary-memory-recall-a1b2';
     const forced = [
-      MEMORY_TRIGGER_RESPONSE,
       {
         content: '',
         toolCalls: [
@@ -170,7 +168,6 @@ test.describe('Harness - Search tool-flow', () => {
   test('web_search_tool prompt completes the two-turn sequence', async ({ page }) => {
     const CANARY = 'canary-web-search-c3d4';
     const forced = [
-      MEMORY_TRIGGER_RESPONSE,
       {
         content: '',
         toolCalls: [
@@ -206,7 +203,6 @@ test.describe('Harness - Search tool-flow', () => {
     const CANARY = 'canary-file-read-e5f6';
     const FILE_SNIPPET = 'OpenHuman is an AI assistant for communities';
     const forced = [
-      MEMORY_TRIGGER_RESPONSE,
       {
         content: '',
         toolCalls: [

--- a/app/test/playwright/specs/user-journey-full-task.spec.ts
+++ b/app/test/playwright/specs/user-journey-full-task.spec.ts
@@ -11,7 +11,6 @@ const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'
 const USER_ID = 'pw-user-journey-full-task';
 const PROMPT = 'Fetch the contents of example.com for me';
 const CANARY_FINAL = 'canary-journey-fetch-j1k2l3';
-const MEMORY_TRIGGER_RESPONSE = { content: 'No relevant memory context.' };
 
 async function resetMock(): Promise<void> {
   await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
@@ -116,7 +115,6 @@ test.describe('User journey - full research task', () => {
     await setMockBehavior(
       'llmForcedResponses',
       JSON.stringify([
-        MEMORY_TRIGGER_RESPONSE,
         {
           content: '',
           toolCalls: [

--- a/src/openhuman/agent_registry/agents/crypto_agent/agent.toml
+++ b/src/openhuman/agent_registry/agents/crypto_agent/agent.toml
@@ -14,7 +14,9 @@ omit_identity = true
 omit_memory_context = true
 omit_safety_preamble = false
 omit_skills_catalog = true
-trigger_memory_agent = "always"
+# No eager memory pre-fetch. A pure-function wallet/market specialist with
+# `omit_memory_context = true`; the orchestrator hands it a focused, already-
+# grounded request, so it never needed the per-turn memory-tree walk.
 
 [model]
 hint = "agentic"

--- a/src/openhuman/agent_registry/agents/help/agent.toml
+++ b/src/openhuman/agent_registry/agents/help/agent.toml
@@ -16,7 +16,9 @@ omit_safety_preamble = true
 omit_skills_catalog = true
 omit_profile = false
 omit_memory_md = false
-trigger_memory_agent = "always"
+# No eager memory pre-fetch. `omit_memory_context = false` keeps the cheap
+# per-turn recall so help can still personalise ("you mentioned earlier…");
+# the deep memory-tree walk is the orchestrator's on-demand concern.
 
 [model]
 hint = "agentic"

--- a/src/openhuman/agent_registry/agents/loader.rs
+++ b/src/openhuman/agent_registry/agents/loader.rs
@@ -544,7 +544,18 @@ mod tests {
             ToolScope::Wildcard => panic!("orchestrator must have named tool allowlist"),
         }
         assert_eq!(def.max_iterations, 15);
-        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Always);
+        // Memory retrieval is on-demand (via the `agent_memory` subagent,
+        // surfaced as `delegate_retrieve_memory`), not an eager pre-turn
+        // pre-fetch. The allowlist entry is what makes that route reachable
+        // (see the `agent_memory::tools` allowlist gate).
+        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Never);
+        assert!(
+            def.subagents.iter().any(|entry| matches!(
+                entry,
+                SubagentEntry::AgentId(id) if id == "agent_memory"
+            )),
+            "orchestrator must allow `agent_memory` for on-demand retrieval"
+        );
     }
 
     #[test]
@@ -669,10 +680,9 @@ mod tests {
             }
             other => panic!("presentation_agent must use Named tool scope, got {other:?}"),
         }
-        assert_eq!(
-            presentation.trigger_memory_agent,
-            TriggerMemoryAgent::Always
-        );
+        // Memory pre-fetch is no longer eager; `omit_memory_context = false`
+        // still gives the deck builder the cheap per-turn recall.
+        assert_eq!(presentation.trigger_memory_agent, TriggerMemoryAgent::Never);
 
         let desktop = find("desktop_control_agent");
         match &desktop.tools {
@@ -736,7 +746,9 @@ mod tests {
         assert!(def.omit_identity);
         assert!(def.omit_safety_preamble);
         assert!(!def.omit_memory_context);
-        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Always);
+        // Help personalises from the cheap per-turn recall (memory_context on),
+        // so it no longer pre-fetches the full memory agent before every turn.
+        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Never);
     }
 
     #[test]
@@ -850,8 +862,9 @@ mod tests {
                     tools.iter().any(|t| t == "ask_user_clarification"),
                     "crypto_agent needs ask_user_clarification to gate write ops"
                 );
-                // Market grounding + time helpers. Memory grounding is
-                // configured via `trigger_memory_agent = "always"`.
+                // Market grounding + time helpers. Memory retrieval is the
+                // orchestrator's on-demand concern — this specialist gets a
+                // grounded request and does not pre-fetch memory itself.
                 for required in [
                     "stock_quote",
                     "stock_exchange_rate",
@@ -900,7 +913,9 @@ mod tests {
         assert!(def.omit_identity);
         assert!(def.omit_memory_context);
         assert!(def.omit_skills_catalog);
-        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Always);
+        // Pure-function specialist (omit_memory_context = true) — no eager
+        // memory pre-fetch; the orchestrator hands it a grounded request.
+        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Never);
     }
 
     /// Routing: the orchestrator must list `crypto_agent` in its
@@ -949,8 +964,9 @@ mod tests {
                     tools.iter().any(|t| t == "ask_user_clarification"),
                     "markets_agent needs ask_user_clarification to gate write ops"
                 );
-                // Time grounding stays as a tool; memory grounding is
-                // configured via `trigger_memory_agent = "always"`.
+                // Time grounding stays as a tool; memory retrieval is the
+                // orchestrator's on-demand concern — this specialist gets a
+                // grounded request and does not pre-fetch memory itself.
                 for required in ["current_time"] {
                     assert!(
                         tools.iter().any(|t| t == required),
@@ -998,7 +1014,9 @@ mod tests {
         assert!(def.omit_identity);
         assert!(def.omit_memory_context);
         assert!(def.omit_skills_catalog);
-        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Always);
+        // Pure-function specialist (omit_memory_context = true) — no eager
+        // memory pre-fetch; the orchestrator hands it a grounded request.
+        assert_eq!(def.trigger_memory_agent, TriggerMemoryAgent::Never);
         // Delegate name must be the stable, chat-friendly slug — the
         // orchestrator surfaces it as `delegate_do_prediction_markets`.
         assert_eq!(

--- a/src/openhuman/agent_registry/agents/markets_agent/agent.toml
+++ b/src/openhuman/agent_registry/agents/markets_agent/agent.toml
@@ -14,7 +14,9 @@ omit_identity = true
 omit_memory_context = true
 omit_safety_preamble = false
 omit_skills_catalog = true
-trigger_memory_agent = "always"
+# No eager memory pre-fetch. A pure-function prediction-market specialist with
+# `omit_memory_context = true`; the orchestrator hands it a focused, already-
+# grounded request, so it never needed the per-turn memory-tree walk.
 
 [model]
 hint = "agentic"

--- a/src/openhuman/agent_registry/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent_registry/agents/orchestrator/agent.toml
@@ -23,7 +23,15 @@ omit_profile = false
 # prior conversations and distilled user preferences. Frozen per
 # session (KV-cache contract on `AgentDefinition::omit_memory_md`).
 omit_memory_md = false
-trigger_memory_agent = "always"
+# Memory retrieval is ON-DEMAND, not pre-emptive. The orchestrator used to
+# run `agent_memory` eagerly before every turn (`trigger_memory_agent =
+# "always"`), spawning a full ≤15-iteration memory subagent on every
+# message — including trivial ones — before it had even read the user's
+# intent. That cost a blocking agentic round-trip per turn for a guarantee
+# the model rarely needed. Instead, `agent_memory` is listed in the
+# `[subagents]` allowlist below, which synthesises a `delegate_retrieve_memory`
+# tool the orchestrator calls only when a message actually needs the deep
+# memory-tree walk. (The frozen MEMORY.md digest still anchors every turn.)
 
 # Delegation surface. The `collect_orchestrator_tools` helper reads this
 # at agent-build time and synthesises one `delegate_*` tool per entry:
@@ -61,6 +69,11 @@ allowlist = [
     # "forget", profile/persona edits, learned facets, and people alias
     # management here.
     "profile_memory_agent",
+    # On-demand memory retrieval. Synthesised into a `delegate_retrieve_memory`
+    # tool (from agent_memory's `delegate_name`). Replaces the old eager
+    # `trigger_memory_agent = "always"` pre-fetch — the orchestrator now walks
+    # the memory tree only when a message needs it, not before every turn.
+    "agent_memory",
     # Account/admin specialist. Route billing, team membership/invites/roles,
     # OAuth/credential/session, and referral requests here.
     "account_admin_agent",

--- a/src/openhuman/agent_registry/agents/planner/agent.toml
+++ b/src/openhuman/agent_registry/agents/planner/agent.toml
@@ -11,7 +11,11 @@ omit_identity = true
 omit_memory_context = false
 omit_safety_preamble = true
 omit_skills_catalog = true
-trigger_memory_agent = "always"
+# Memory is no longer pre-fetched eagerly before every turn. The planner
+# keeps `omit_memory_context = false`, so it still receives the cheap
+# per-turn memory recall; deep memory-tree walks are the orchestrator's
+# on-demand concern (`delegate_retrieve_memory`), and the orchestrator
+# hands the planner grounded context in the delegation prompt.
 
 # Spawn hierarchy: this is the deep-thinking tier (reasoning model hint).
 # The planner produces a DAG of leaf tasks for downstream workers; it

--- a/src/openhuman/agent_registry/agents/presentation_agent/agent.toml
+++ b/src/openhuman/agent_registry/agents/presentation_agent/agent.toml
@@ -11,7 +11,9 @@ omit_safety_preamble = false
 omit_skills_catalog = true
 omit_profile = true
 omit_memory_md = true
-trigger_memory_agent = "always"
+# No eager memory pre-fetch. `omit_memory_context = false` keeps the cheap
+# per-turn recall for grounding decks in prior context; the deep memory-tree
+# walk is the orchestrator's on-demand concern (`delegate_retrieve_memory`).
 
 [model]
 hint = "agentic"

--- a/src/openhuman/agent_registry/agents/researcher/agent.toml
+++ b/src/openhuman/agent_registry/agents/researcher/agent.toml
@@ -11,7 +11,9 @@ omit_identity = true
 omit_memory_context = true
 omit_safety_preamble = true
 omit_skills_catalog = true
-trigger_memory_agent = "always"
+# No eager memory pre-fetch. The researcher is a pure-function web/docs
+# specialist with `omit_memory_context = true`; the orchestrator passes it
+# the focused task to research, so it never needed the memory-tree walk.
 
 [model]
 hint = "agentic"

--- a/tests/agent_retrieval_e2e.rs
+++ b/tests/agent_retrieval_e2e.rs
@@ -145,30 +145,46 @@ fn alice_phoenix_thread() -> EmailThread {
     }
 }
 
-/// The orchestrator definition must trigger `agent_memory` automatically so
-/// memory queries route through the dedicated memory subagent before the main
-/// provider prompt.
+/// The orchestrator reaches `agent_memory` ON-DEMAND, not via an eager
+/// pre-turn pre-fetch. `agent_memory` is listed in the `[subagents]` allowlist
+/// (synthesised into a `delegate_retrieve_memory` tool), so the orchestrator
+/// walks the memory tree only when a message needs it — instead of spawning a
+/// full memory subagent before every turn.
 ///
 /// History: #1141 consolidated 6 `memory_tree_*` tools into `memory_tree`;
 /// the agent_memory domain then unified `memory_tree` + `query_memory`
-/// behind `call_memory_agent`. The current contract removes that explicit tool
-/// and makes the memory agent a declarative TOML trigger.
+/// behind `call_memory_agent`; a later revision made it an eager
+/// `trigger_memory_agent = "always"` pre-fetch. This contract reverts the
+/// eager pre-fetch to an on-demand delegation (the memory agent is heavy and
+/// most turns don't need a deep tree walk).
 #[test]
-fn orchestrator_lists_memory_tree_tools() {
+fn orchestrator_reaches_memory_agent_on_demand() {
     let toml = include_str!("../src/openhuman/agent_registry/agents/orchestrator/agent.toml");
+    // Eager pre-fetch must be gone.
+    assert!(
+        !toml
+            .lines()
+            .map(str::trim)
+            .any(|line| line == "trigger_memory_agent = \"always\""),
+        "orchestrator must NOT eagerly pre-fetch the memory agent — retrieval is on-demand"
+    );
+    // The on-demand route: `agent_memory` in the subagents allowlist.
     assert!(
         toml.lines()
             .map(str::trim)
-            .any(|line| line == "trigger_memory_agent = \"always\""),
-        "orchestrator agent.toml must trigger the memory agent automatically"
+            .any(|line| line == "\"agent_memory\"" || line == "\"agent_memory\","),
+        "orchestrator must list `agent_memory` in its subagents allowlist for on-demand retrieval"
     );
+    // The orchestrator reaches the memory agent through delegation, not the
+    // direct `call_memory_agent` tool (that tool is forbidden on the
+    // orchestrator — see loader::tests::orchestrator_has_chat_hint_and_named_tools).
     let has_call_memory_agent = toml
         .lines()
         .map(str::trim)
         .any(|line| line == "\"call_memory_agent\"" || line == "\"call_memory_agent\",");
     assert!(
         !has_call_memory_agent,
-        "orchestrator agent.toml must not expose the removed 'call_memory_agent' tool"
+        "orchestrator agent.toml must not expose the 'call_memory_agent' tool"
     );
     // Verify all superseded tool names are gone.
     for old_name in [

--- a/tests/orchestrator_presentation_wiring.rs
+++ b/tests/orchestrator_presentation_wiring.rs
@@ -56,8 +56,9 @@ fn presentation_agent_lists_generate_presentation_and_grounding_tools() {
         );
     }
     assert!(
-        PRESENTATION_AGENT_TOML.contains("trigger_memory_agent = \"always\""),
-        "presentation_agent must use the configured automatic memory trigger"
+        !PRESENTATION_AGENT_TOML.contains("trigger_memory_agent = \"always\""),
+        "presentation_agent must NOT eagerly pre-fetch memory; with memory_context on it \
+         relies on the cheap per-turn recall (refactor/memory-agent-on-demand)"
     );
     assert!(
         !lists_named_tool(PRESENTATION_AGENT_TOML, "call_memory_agent"),


### PR DESCRIPTION
## Summary

- Memory retrieval is now **on-demand instead of pre-emptive** for the orchestrator and 6 specialist agents.
- Previously these agents ran the full `agent_memory` subagent **eagerly before every turn** (`trigger_memory_agent = "always"`) — a blocking ≤15-iteration memory-tree walk on every message, including trivial ones.
- The orchestrator (the universal chat entry point) now reaches `agent_memory` via a synthesised `delegate_retrieve_memory` tool, walking the tree only when a turn needs it.
- Pure-function specialists keep the cheap per-turn recall or receive grounded context from the orchestrator; `profile_memory_agent` and `trigger_reactor` intentionally stay eager.
- Loader/wiring tests and the agent e2e harness specs are updated to the on-demand contract.

## Problem

Every user chat turn starts in the **orchestrator** (`channels/runtime/dispatch/routing.rs` hardcodes `target_id = "orchestrator"`); all other agents are reached only as its delegated sub-agents. With `trigger_memory_agent = "always"`, the harness spawned a full `agent_memory` subagent **before the model even read the message** (`agent/harness/session/turn/core.rs` `inject_triggered_memory_agent_context`). Because the orchestrator delegates to the specialists, an eager trigger fired the deep walk **redundantly** — once in the orchestrator and again in each specialist it delegated to — for a guarantee the model rarely needed (a lightweight per-turn recall already runs in `memory_loader`, and the model can escalate on demand).

## Solution

Per-agent, the eager trigger is replaced by the right on-demand mechanism:

| Agent | `mem_context` | Before | After |
|---|---|---|---|
| **orchestrator** | off | eager `agent_memory` | **on-demand** via `delegate_retrieve_memory` (agent_memory added to subagents allowlist) + frozen `MEMORY.md` |
| **planner** | on | eager + cheap recall | cheap per-turn recall (kept) |
| **help** | on | eager + cheap recall | cheap per-turn recall (kept) |
| **presentation_agent** | on | eager + cheap recall | cheap per-turn recall (kept) |
| **researcher** | off | eager | context passed by orchestrator |
| **crypto_agent** | off | eager | context passed by orchestrator |
| **markets_agent** | off | eager | context passed by orchestrator |
| **profile_memory_agent** | — | eager | **eager (unchanged)** — memory is its job |
| **trigger_reactor** | — | eager | **eager (unchanged)** — background entry, not orchestrator-fed |

The orchestrator has `omit_memory_context = true`, so the `delegate_retrieve_memory` route is its *replacement* for the eager trigger (without it the orchestrator would lose all runtime memory and keep only the frozen `MEMORY.md`). `call_memory_agent` stays forbidden on the orchestrator (it delegates rather than calling the tool directly).

**Test impact.** Removing the eager memory call changes the orchestrator's LLM-call sequence, which the Playwright agent-harness specs encoded: each seeded a leading `"No relevant memory context."` forced response to absorb the eager memory call. 11 specs are updated to drop that leading entry; `chat-conversation-history` drops its second-turn LLM-call count from 2 to 1; and `chat-harness-subagent` now asserts delegation directly instead of ordering it after the (now absent) memory call. All 21 affected Playwright tests pass locally against the mock backend.

### Entry topology

```mermaid
flowchart LR
    U([User chat]) --> O[orchestrator<br/>always entry]
    BG([background triggers]) --> TT[trigger_triage]
    TT --> TR[trigger_reactor]
    TT -. escalate .-> O
    O -. delegates .-> S["planner · researcher · help · crypto_agent<br/>markets_agent · presentation_agent<br/>profile_memory_agent · agent_memory"]
    classDef entry fill:#b2f2bb,stroke:#2f9e44,color:#1b5e20;
    classDef bg fill:#ffc9c9,stroke:#e03131,color:#a61e4d;
    class O entry;
    class TR bg;
```

### Memory access — before vs after

```mermaid
flowchart TB
    subgraph BEFORE["BEFORE — every agent eager"]
        AMB["agent_memory (deep walk)"]:::eager -->|EAGER · blocking · every turn| ALL["all 9 agents"]
    end
    subgraph AFTER["AFTER — on-demand / kept-cheap"]
        AMA["agent_memory (deep walk)"]:::ondemand -->|on-demand delegate| ORCH[orchestrator]
        AMK["agent_memory (deep walk)"]:::eager -. eager kept .-> EXC["profile_memory_agent<br/>trigger_reactor"]
        ML[memory_loader]:::cheap -->|cheap per-turn recall · kept| KEPT["planner · help · presentation_agent"]
        ORCH -->|passes grounded context| PURE["researcher · crypto_agent · markets_agent"]
    end
    classDef eager fill:#ffc9c9,stroke:#e03131;
    classDef ondemand fill:#b2f2bb,stroke:#2f9e44;
    classDef cheap fill:#a5d8ff,stroke:#1971c2;
```

> The editable source for these diagrams is an Excalidraw file (`memory-flow-before-after.excalidraw`) kept in the author's workspace; the Mermaid above mirrors it for inline rendering.

## Submission Checklist

- [x] Tests added or updated — loader assertions flipped to `Never` + a new orchestrator-allowlist assertion; `orchestrator_lists_memory_tree_tools` → `orchestrator_reaches_memory_agent_on_demand`; `orchestrator_presentation_wiring` flipped to the on-demand contract; 12 Playwright harness specs updated to the on-demand LLM-call sequence.
- [x] **Diff coverage ≥ 80%** — changed lines are agent `*.toml` config (not instrumented), Rust **test** assertions, and Playwright **spec** code (all executed). `cargo test --lib agent_registry::agents::loader::tests` → 39 passed; `orchestrator_presentation_wiring` 3/3; `monitor_agent_e2e` 5/5; 21/21 affected Playwright tests pass locally.
- [x] Coverage matrix updated — N/A: behaviour-only change (no new feature row).
- [x] All affected feature IDs listed — N/A: no matrix feature touched.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — N/A: does not touch a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` — N/A: no associated issue (self-initiated refactor).

## Impact

- **Runtime**: removes a blocking ≤15-iteration `agent_memory` subagent round-trip from every turn of the 7 affected agents — notably the orchestrator, which fronts all chat. Lower per-turn latency and token cost; deep retrieval now fires only when needed.
- **Behaviour**: agents that lost the eager deep walk still have lighter memory (cheap per-turn recall where `memory_context` is on, or orchestrator-passed context). No change to `profile_memory_agent` / `trigger_reactor`.
- **Security/migration**: none. Config + test-only changes; no schema or persistence changes.

## Related

- Closes: N/A (no associated issue)
- Follow-up PR(s)/TODOs: optionally wire `call_memory_agent` into planner/help/presentation for explicit deep-retrieval-on-demand in those specialists.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `refactor/memory-agent-on-demand`
- Commit SHA: `efaf63f54`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on the 12 edited specs
- [x] `pnpm typecheck` — ESLint clean on the 12 edited specs
- [x] Focused tests: `loader::tests` (39), `orchestrator_presentation_wiring` (3), `monitor_agent_e2e` (5), and 21/21 affected Playwright specs — all pass locally
- [x] Rust fmt/check: `cargo fmt --check` clean; pre-push `pnpm rust:check` passed
- [x] Tauri fmt/check (if changed): N/A — no Tauri changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: deep `agent_memory` retrieval becomes on-demand for the orchestrator + 6 specialists instead of an eager per-turn pre-fetch.
- User-visible effect: faster/cheaper turns; memory recall still occurs when relevant.

### Parity Contract

- Legacy behavior preserved: `profile_memory_agent` and `trigger_reactor` keep eager retrieval; frozen `MEMORY.md` and cheap per-turn recall paths unchanged.
- Guard/fallback/dispatch parity checks: loader still enforces eager-agents-don't-expose-`call_memory_agent`; `call_memory_agent` remains forbidden on the orchestrator; tier validation passes with `agent_memory` (worker) as an orchestrator delegate.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory retrieval across agents from eager pre-fetching to on-demand delegation, reducing unnecessary memory lookups during conversation turns.
  * Updated agent configurations to clarify that memory access now occurs only when needed rather than before every turn.

* **Tests**
  * Updated test suites to verify on-demand memory behavior and validate that eager pre-fetching is no longer triggered automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->