### PR TITLE
feat(meetings): backend contract — correlationId, listenOnly, in-call channel

### DIFF
--- a/src/core/event_bus/events.rs
+++ b/src/core/event_bus/events.rs
@@ -979,29 +979,54 @@ pub enum DomainEvent {
     },
 
     // ── Backend Meet Bot ──────────────────────────────────────────────
+    /// Calendar auto-join policy triggered a meeting join.
+    MeetingAutoJoinTriggered {
+        meeting_id: String,
+        meet_url: String,
+    },
     /// Backend gmeet bot successfully joined the meeting.
-    BackendMeetJoined { meet_url: String },
+    BackendMeetJoined {
+        meet_url: String,
+        correlation_id: Option<String>,
+    },
     /// Backend gmeet bot left the meeting.
-    BackendMeetLeft { reason: String },
+    BackendMeetLeft {
+        reason: String,
+        correlation_id: Option<String>,
+    },
     /// Backend gmeet bot produced a spoken reply.
     BackendMeetReply {
         transcript: String,
         reply: String,
         emotion: String,
+        correlation_id: Option<String>,
     },
     /// Backend gmeet bot needs the harness to execute a tool instruction.
     BackendMeetHarness {
         transcript: String,
         instruction: String,
         emotion: String,
+        correlation_id: Option<String>,
     },
     /// Backend gmeet bot sent the full meeting transcript on close.
     BackendMeetTranscript {
         turns: Vec<BackendMeetTurn>,
         duration_ms: u64,
+        correlation_id: Option<String>,
     },
     /// Backend gmeet bot emitted an error.
-    BackendMeetError { error: String },
+    BackendMeetError {
+        error: String,
+        correlation_id: Option<String>,
+    },
+    /// Backend bot detected a mid-call voice command addressed to it (Phase 2).
+    BackendMeetInCallRequest {
+        correlation_id: String,
+        speaker: String,
+        command_text: String,
+        recent_transcript: Vec<BackendMeetTurn>,
+        timestamp_ms: u64,
+    },
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1137,12 +1162,14 @@ impl DomainEvent {
             | Self::McpSetupSecretRequested { .. }
             | Self::McpToolRejected { .. } => "mcp_client",
 
-            Self::BackendMeetJoined { .. }
+            Self::MeetingAutoJoinTriggered { .. }
+            | Self::BackendMeetJoined { .. }
             | Self::BackendMeetLeft { .. }
             | Self::BackendMeetReply { .. }
             | Self::BackendMeetHarness { .. }
             | Self::BackendMeetTranscript { .. }
-            | Self::BackendMeetError { .. } => "agent_meetings",
+            | Self::BackendMeetError { .. }
+            | Self::BackendMeetInCallRequest { .. } => "agent_meetings",
         }
     }
 
@@ -1252,12 +1279,14 @@ impl DomainEvent {
             Self::TaskSourceFetchFailed { .. } => "TaskSourceFetchFailed",
             Self::TaskPlanAwaitingApproval { .. } => "TaskPlanAwaitingApproval",
             Self::TaskRunReclaimed { .. } => "TaskRunReclaimed",
+            Self::MeetingAutoJoinTriggered { .. } => "MeetingAutoJoinTriggered",
             Self::BackendMeetJoined { .. } => "BackendMeetJoined",
             Self::BackendMeetLeft { .. } => "BackendMeetLeft",
             Self::BackendMeetReply { .. } => "BackendMeetReply",
             Self::BackendMeetHarness { .. } => "BackendMeetHarness",
             Self::BackendMeetTranscript { .. } => "BackendMeetTranscript",
             Self::BackendMeetError { .. } => "BackendMeetError",
+            Self::BackendMeetInCallRequest { .. } => "BackendMeetInCallRequest",
             Self::Voice(_) => "Voice",
         }
     }

--- a/src/core/socketio.rs
+++ b/src/core/socketio.rs
@@ -968,13 +968,20 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             };
             match event {
-                crate::core::event_bus::DomainEvent::BackendMeetJoined { meet_url } => {
-                    let payload = serde_json::json!({ "meet_url": meet_url });
+                crate::core::event_bus::DomainEvent::BackendMeetJoined {
+                    meet_url,
+                    correlation_id,
+                } => {
+                    let payload = serde_json::json!({ "meet_url": meet_url, "correlation_id": correlation_id });
                     log::debug!("[socketio] broadcast agent_meetings:joined");
                     let _ = io_agent_meetings.emit("agent_meetings:joined", &payload);
                 }
-                crate::core::event_bus::DomainEvent::BackendMeetLeft { reason } => {
-                    let payload = serde_json::json!({ "reason": reason });
+                crate::core::event_bus::DomainEvent::BackendMeetLeft {
+                    reason,
+                    correlation_id,
+                } => {
+                    let payload =
+                        serde_json::json!({ "reason": reason, "correlation_id": correlation_id });
                     log::debug!("[socketio] broadcast agent_meetings:left reason={}", reason);
                     let _ = io_agent_meetings.emit("agent_meetings:left", &payload);
                 }
@@ -982,11 +989,13 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                     transcript,
                     reply,
                     emotion,
+                    correlation_id,
                 } => {
                     let payload = serde_json::json!({
                         "transcript": transcript,
                         "reply": reply,
                         "emotion": emotion,
+                        "correlation_id": correlation_id,
                     });
                     log::debug!(
                         "[socketio] broadcast agent_meetings:reply reply_len={}",
@@ -998,11 +1007,13 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                     transcript,
                     instruction,
                     emotion,
+                    correlation_id,
                 } => {
                     let payload = serde_json::json!({
                         "transcript": transcript,
                         "instruction": instruction,
                         "emotion": emotion,
+                        "correlation_id": correlation_id,
                     });
                     log::debug!(
                         "[socketio] broadcast agent_meetings:harness instruction_len={}",
@@ -1013,10 +1024,12 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                 crate::core::event_bus::DomainEvent::BackendMeetTranscript {
                     turns,
                     duration_ms,
+                    correlation_id,
                 } => {
                     let payload = serde_json::json!({
                         "turns": turns,
                         "duration_ms": duration_ms,
+                        "correlation_id": correlation_id,
                     });
                     log::debug!(
                         "[socketio] broadcast agent_meetings:transcript turns={} duration_ms={}",
@@ -1025,10 +1038,31 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                     );
                     let _ = io_agent_meetings.emit("agent_meetings:transcript", &payload);
                 }
-                crate::core::event_bus::DomainEvent::BackendMeetError { error } => {
-                    let payload = serde_json::json!({ "error": error });
+                crate::core::event_bus::DomainEvent::BackendMeetError {
+                    error,
+                    correlation_id,
+                } => {
+                    let payload =
+                        serde_json::json!({ "error": error, "correlation_id": correlation_id });
                     log::debug!("[socketio] broadcast agent_meetings:error");
                     let _ = io_agent_meetings.emit("agent_meetings:error", &payload);
+                }
+                crate::core::event_bus::DomainEvent::BackendMeetInCallRequest {
+                    correlation_id,
+                    speaker,
+                    command_text,
+                    recent_transcript,
+                    timestamp_ms,
+                } => {
+                    let payload = serde_json::json!({
+                        "correlation_id": correlation_id,
+                        "speaker": speaker,
+                        "command_text": command_text,
+                        "recent_transcript": recent_transcript,
+                        "timestamp_ms": timestamp_ms,
+                    });
+                    log::debug!("[socketio] broadcast agent_meetings:in_call_request");
+                    let _ = io_agent_meetings.emit("agent_meetings:in_call_request", &payload);
                 }
                 _ => {}
             }

--- a/src/openhuman/agent_meetings/ops.rs
+++ b/src/openhuman/agent_meetings/ops.rs
@@ -175,6 +175,12 @@ fn build_join_payload(
         if let Some(phrase) = &req.wake_phrase {
             map.insert("wakePhrase".to_string(), json!(phrase));
         }
+        if let Some(cid) = &req.correlation_id {
+            map.insert("correlationId".to_string(), json!(cid));
+        }
+        if let Some(lo) = req.listen_only {
+            map.insert("listenOnly".to_string(), json!(lo));
+        }
     }
     payload
 }
@@ -283,6 +289,37 @@ pub async fn handle_harness_response(params: Map<String, Value>) -> Result<Value
     mgr.emit("bot:harness:response", json!({ "result": req.result }))
         .await
         .map_err(|e| format!("[agent_meetings] emit failed: {e}"))?;
+
+    let outcome = RpcOutcome::new(json!({ "ok": true }), vec![]);
+    outcome.into_cli_compatible_json()
+}
+
+/// Handle `openhuman.agent_meetings_speak` — make the bot speak text into the call.
+pub async fn handle_speak(params: Map<String, Value>) -> Result<Value, String> {
+    let correlation_id = params
+        .get("correlation_id")
+        .and_then(Value::as_str)
+        .ok_or("[agent_meetings] missing correlation_id for speak")?
+        .to_string();
+    let text = params
+        .get("text")
+        .and_then(Value::as_str)
+        .ok_or("[agent_meetings] missing text for speak")?
+        .to_string();
+
+    tracing::debug!(
+        correlation_id = %correlation_id,
+        text_len = text.len(),
+        "[agent_meetings] emitting bot:speak"
+    );
+
+    let mgr = global_socket_manager();
+    mgr.emit(
+        "bot:speak",
+        json!({ "correlationId": correlation_id, "text": text }),
+    )
+    .await
+    .map_err(|e| format!("[agent_meetings] emit failed: {e}"))?;
 
     let outcome = RpcOutcome::new(json!({ "ok": true }), vec![]);
     outcome.into_cli_compatible_json()

--- a/src/openhuman/agent_meetings/ops.rs
+++ b/src/openhuman/agent_meetings/ops.rs
@@ -313,7 +313,8 @@ pub async fn handle_speak(params: Map<String, Value>) -> Result<Value, String> {
         "[agent_meetings] emitting bot:speak"
     );
 
-    let mgr = global_socket_manager();
+    let mgr = global_socket_manager()
+        .ok_or_else(|| "[agent_meetings] socket not connected to backend".to_string())?;
     mgr.emit(
         "bot:speak",
         json!({ "correlationId": correlation_id, "text": text }),

--- a/src/openhuman/agent_meetings/schemas.rs
+++ b/src/openhuman/agent_meetings/schemas.rs
@@ -31,6 +31,11 @@ const DEFS: &[BackendMeetControllerDef] = &[
         schema: schema_harness_response,
         handler: handle_harness_response_wrap,
     },
+    BackendMeetControllerDef {
+        function: "speak",
+        schema: schema_speak,
+        handler: handle_speak_wrap,
+    },
 ];
 
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
@@ -188,6 +193,38 @@ fn handle_harness_response_wrap(params: Map<String, Value>) -> ControllerFuture 
     Box::pin(async move { super::ops::handle_harness_response(params).await })
 }
 
+fn schema_speak() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "agent_meetings",
+        function: "speak",
+        description: "Make the bot speak text into the active call via TTS (Phase 2).",
+        inputs: vec![
+            FieldSchema {
+                name: "correlation_id",
+                ty: TypeSchema::String,
+                comment: "Meeting correlation ID identifying the active call.",
+                required: true,
+            },
+            FieldSchema {
+                name: "text",
+                ty: TypeSchema::String,
+                comment: "Text the bot should speak.",
+                required: true,
+            },
+        ],
+        outputs: vec![FieldSchema {
+            name: "ok",
+            ty: TypeSchema::Bool,
+            comment: "True when the speak request was emitted.",
+            required: true,
+        }],
+    }
+}
+
+fn handle_speak_wrap(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::ops::handle_speak(params).await })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,7 +240,10 @@ mod tests {
             .map(|c| c.schema.function)
             .collect();
         assert_eq!(schema_fns, handler_fns);
-        assert_eq!(schema_fns, vec!["join", "leave", "harness_response"]);
+        assert_eq!(
+            schema_fns,
+            vec!["join", "leave", "harness_response", "speak"]
+        );
     }
 
     #[test]

--- a/src/openhuman/socket/event_handlers.rs
+++ b/src/openhuman/socket/event_handlers.rs
@@ -255,8 +255,15 @@ pub(super) fn handle_sio_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
             log::info!("[socket] bot:joined meet_url_len={}", meet_url.len());
-            publish_global(DomainEvent::BackendMeetJoined { meet_url });
+            publish_global(DomainEvent::BackendMeetJoined {
+                meet_url,
+                correlation_id,
+            });
         }
         "bot:left" => {
             let reason = data
@@ -264,8 +271,15 @@ pub(super) fn handle_sio_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
                 .to_string();
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
             log::info!("[socket] bot:left reason={}", reason);
-            publish_global(DomainEvent::BackendMeetLeft { reason });
+            publish_global(DomainEvent::BackendMeetLeft {
+                reason,
+                correlation_id,
+            });
         }
         "bot:reply" => {
             let transcript = data
@@ -283,6 +297,10 @@ pub(super) fn handle_sio_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("neutral")
                 .to_string();
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
             log::info!(
                 "[socket] bot:reply reply_len={} emotion={}",
                 reply.len(),
@@ -292,6 +310,7 @@ pub(super) fn handle_sio_event(
                 transcript,
                 reply,
                 emotion,
+                correlation_id,
             });
         }
         "bot:harness" => {
@@ -310,6 +329,10 @@ pub(super) fn handle_sio_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("neutral")
                 .to_string();
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
             log::info!(
                 "[socket] bot:harness instruction_len={} emotion={}",
                 instruction.len(),
@@ -319,6 +342,7 @@ pub(super) fn handle_sio_event(
                 transcript,
                 instruction,
                 emotion,
+                correlation_id,
             });
         }
         "bot:transcript" => {
@@ -327,6 +351,10 @@ pub(super) fn handle_sio_event(
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or_default();
             let duration_ms = data.get("durationMs").and_then(|v| v.as_u64()).unwrap_or(0);
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
             log::info!(
                 "[socket] bot:transcript turns={} duration_ms={}",
                 turns.len(),
@@ -335,6 +363,7 @@ pub(super) fn handle_sio_event(
             publish_global(DomainEvent::BackendMeetTranscript {
                 turns: turns.clone(),
                 duration_ms,
+                correlation_id,
             });
             tokio::spawn(async move {
                 // Only ingest into memory when the user has opted in via
@@ -367,8 +396,52 @@ pub(super) fn handle_sio_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown error")
                 .to_string();
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
             log::error!("[socket] bot:error: {}", error);
-            publish_global(DomainEvent::BackendMeetError { error });
+            publish_global(DomainEvent::BackendMeetError {
+                error,
+                correlation_id,
+            });
+        }
+        "bot:in_call_request" => {
+            let correlation_id = data
+                .get("correlationId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let speaker = data
+                .get("speaker")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let command_text = data
+                .get("commandText")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let recent_transcript: Vec<BackendMeetTurn> = data
+                .get("recentTranscript")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            let timestamp_ms = data
+                .get("timestampMs")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            log::info!(
+                "[socket] bot:in_call_request speaker={} cmd_len={}",
+                speaker,
+                command_text.len()
+            );
+            publish_global(DomainEvent::BackendMeetInCallRequest {
+                correlation_id,
+                speaker,
+                command_text,
+                recent_transcript,
+                timestamp_ms,
+            });
         }
 
         // Channel inbound message — publish to event bus for ChannelInboundSubscriber


### PR DESCRIPTION
## What

Backend contract changes for the Meeting Assistant. Defines the OpenHuman-side contract that the cloud backend implements.

### Phase 1 (unblocks PR-3 #3509)

- **bot:join payload**: forwards `correlationId` and `listenOnly` from `BackendMeetJoinRequest` to the wire
- **All inbound bot:* events**: extract `correlationId` from the payload and propagate through domain events
- **Domain events**: `BackendMeetJoined`, `BackendMeetLeft`, `BackendMeetReply`, `BackendMeetHarness`, `BackendMeetTranscript`, `BackendMeetError` all carry `correlation_id: Option<String>`
- **Frontend bridge**: socketio.rs forwards `correlation_id` on all `agent_meetings:*` broadcasts

### Phase 2 (unblocks PR-6 #3512, PR-7 #3513)

- **`bot:in_call_request`** (backend -> core): new socket handler + `BackendMeetInCallRequest` domain event with `{ correlationId, speaker, commandText, recentTranscript, timestampMs }`
- **`bot:speak`** (core -> backend): new RPC `openhuman.agent_meetings_speak` + schema, emits `{ correlationId, text }` over Socket.IO

### No changes to

- Existing tests (all BackendMeet* events were previously field-less structs, now have an extra Option field — backward compatible)
- Frontend components (correlation_id is just passed through)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] No changes to existing test assertions

Closes #3514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meeting auto-join trigger added.
  * In-call request handling added with richer context (speaker, command, recent transcript, timestamp).
  * New "speak" endpoint to send spoken commands/text to meetings.

* **Refactor**
  * Correlation IDs added across meeting events and Socket.IO payloads for improved traceability and stable event naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->