### PR TITLE
chore(ci): extend Docker timeout and always generate release notes

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -234,14 +234,12 @@ jobs:
           echo "release_id=" >> "$GITHUB_OUTPUT"
           echo "upload_url=" >> "$GITHUB_OUTPUT"
       - name: Checkout release ref
-        if: ${{ inputs.create_release }}
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Generate AI release notes
-        if: ${{ inputs.create_release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -257,6 +255,17 @@ jobs:
             --to "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --output release-notes.md
+      - name: Preview release notes
+        run: |
+          echo "::group::Release Notes Preview"
+          cat release-notes.md
+          echo "::endgroup::"
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes.md
+          retention-days: 30
       - name: Create draft release with generated notes
         if: ${{ inputs.create_release }}
         id: create
@@ -344,7 +353,7 @@ jobs:
     needs: [prepare-build, create-release]
     if: always() && needs.create-release.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: Production
     env:
       REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

- Extend `build-docker` job timeout from 30 to 60 minutes to prevent timeouts on cold cache builds.
- Make release notes generation unconditional so the changelog is always produced, even on dry runs (`create_release=false`).
- Print release notes in the job log and upload as an artifact for easy preview.

## Problem

- The Docker build can exceed 30 minutes on cache misses, causing the release workflow to fail.
- When running the release workflow with `create_release=false` (dry run), no changelog is generated, making it impossible to preview release notes before a real cut.

## Solution

- Bumped `timeout-minutes` from 30 to 60 on the `build-docker` job.
- Removed `if: inputs.create_release` guards from the checkout and release notes generation steps in the `create-release` job.
- Added a "Preview release notes" step that prints the changelog into a collapsible `::group::` block in the Actions log.
- Added an "Upload release notes artifact" step that uploads `release-notes.md` as a downloadable artifact (30-day retention).

## Submission Checklist

- [x] N/A: Tests added or updated — CI workflow-only change, no application code affected
- [x] N/A: Diff coverage ≥ 80% — no application source changed
- [x] N/A: Coverage matrix updated — no feature change
- [x] N/A: All affected feature IDs listed — no feature change
- [x] N/A: No new external network dependencies — uses existing `actions/upload-artifact@v4`
- [x] N/A: Manual smoke checklist — workflow change only, not a release-cut surface
- [x] N/A: Linked issue closed — no tracking issue

## Impact

- No runtime impact. Affects only the `release-production.yml` GitHub Actions workflow.
- Dry-run releases now produce a previewable changelog artifact.

## Related

- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: chore/release-production-tweaks
- Commit SHA: 411f38aeb

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no app source changed
- [x] N/A: `pnpm typecheck` — no app source changed
- [x] N/A: Focused tests — CI workflow only
- [x] N/A: Rust fmt/check — no Rust source changed
- [x] N/A: Tauri fmt/check — no Tauri source changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Release notes always generated; Docker build has more time.
- User-visible effect: Changelog artifact available on every release workflow run.

### Parity Contract

- Legacy behavior preserved: Yes — `create_release=true` path unchanged.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow reliability by increasing Docker build timeout capacity.
  * Improved release notes artifact handling with automated preview and 30-day retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->