### PR TITLE
revert(ci): restore release-production, keep 60min Docker timeout

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -35,14 +35,14 @@ concurrency:
 # ---------------------------------------------------------------------------
 # Job dependency graph
 #
-#   prepare-build  (pushes v###-preview tag when create_release=false)
+#   prepare-build
 #        │
-#        ├─── create-release   (always generates + previews release notes;
-#        │         │            draft GitHub Release only when create_release)
+#        ├─── create-release   (optional no-op when `create_release=false`)
+#        │         │
 #        │    ┌────┴───────────────┬────────────────┐
 #        │    │                    │                │
 #        │  build-desktop    build-cli-linux    build-docker
-#        │  (release-only)   (release-only)     (release-only)
+#        │  (reusable wf)    (Linux tarballs)   (GHCR image)
 #        │    │                    │                │
 #        │    └────────┬───────────┴────────────────┘
 #        │             │
@@ -52,8 +52,7 @@ concurrency:
 #        │             │
 #        │      record-sentry-deploy
 #        │
-#        ├─── cleanup-failed-release (on failure)
-#        └─── cleanup-preview-tag    (removes v###-preview when !create_release)
+#        └─── cleanup-failed-release (on failure)
 #
 # The actual desktop build / sign / Sentry / artifact-upload pipeline lives in
 # `.github/workflows/build-desktop.yml` and is shared with release-staging.yml.
@@ -93,7 +92,6 @@ jobs:
     outputs:
       version: ${{ steps.resolve.outputs.version }}
       tag: ${{ steps.resolve.outputs.tag }}
-      preview_tag: ${{ steps.resolve.outputs.preview_tag }}
       sha: ${{ steps.resolve.outputs.sha }}
       # First 12 chars of `sha` — matches the truncation done at runtime by
       # app/src/utils/config.ts, app/vite.config.ts, src/main.rs, and
@@ -190,10 +188,7 @@ jobs:
             git tag -a "$TAG" -m "Release $TAG"
             git push origin "$TAG"
           else
-            PREVIEW_TAG="${TAG}-preview"
-            git tag -a "$PREVIEW_TAG" -m "Preview $TAG"
-            git push origin "$PREVIEW_TAG"
-            echo "preview_tag=$PREVIEW_TAG" >> "$GITHUB_OUTPUT"
+            echo "Skipping tag creation (create_release=false)"
           fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -204,18 +199,16 @@ jobs:
           CREATE_RELEASE: ${{ inputs.create_release }}
           VERSION: ${{ steps.bump.outputs.version }}
           TAG: ${{ steps.bump.outputs.tag }}
-          PREVIEW_TAG: ${{ steps.push.outputs.preview_tag }}
           SHA: ${{ steps.push.outputs.sha }}
         run: |
           if [ "$CREATE_RELEASE" = "true" ]; then
             BUILD_REF="$TAG"
           else
-            BUILD_REF="$PREVIEW_TAG"
+            BUILD_REF="$SHA"
           fi
           SHORT_SHA="${SHA:0:12}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "preview_tag=$PREVIEW_TAG" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
           echo "build_ref=$BUILD_REF" >> "$GITHUB_OUTPUT"
@@ -241,45 +234,29 @@ jobs:
           echo "release_id=" >> "$GITHUB_OUTPUT"
           echo "upload_url=" >> "$GITHUB_OUTPUT"
       - name: Checkout release ref
+        if: ${{ inputs.create_release }}
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Generate AI release notes
+        if: ${{ inputs.create_release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          CREATE_RELEASE: ${{ inputs.create_release }}
           TAG: ${{ needs.prepare-build.outputs.tag }}
-          PREVIEW_TAG: ${{ needs.prepare-build.outputs.preview_tag }}
         run: |
           set -euo pipefail
           if [ -z "${OPENAI_API_KEY:-}" ]; then
             echo "::error::secrets.OPENAI_API_KEY is required to generate production release notes."
             exit 1
           fi
-          if [ "$CREATE_RELEASE" = "true" ]; then
-            TO_REF="$TAG"
-          else
-            TO_REF="$PREVIEW_TAG"
-          fi
           node scripts/release/generate-release-notes.mjs \
             --from latest-release \
-            --to "$TO_REF" \
+            --to "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --output release-notes.md
-      - name: Preview release notes
-        run: |
-          echo "::group::Release Notes Preview"
-          cat release-notes.md
-          echo "::endgroup::"
-      - name: Upload release notes artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-notes
-          path: release-notes.md
-          retention-days: 30
       - name: Create draft release with generated notes
         if: ${{ inputs.create_release }}
         id: create
@@ -320,7 +297,7 @@ jobs:
   build-desktop:
     name: Build desktop matrix
     needs: [prepare-build, create-release]
-    if: ${{ inputs.create_release && always() && needs.create-release.result == 'success' }}
+    if: always() && needs.create-release.result == 'success'
     uses: ./.github/workflows/build-desktop.yml
     secrets: inherit
     with:
@@ -365,7 +342,7 @@ jobs:
   build-docker:
     name: "Docker: build and push"
     needs: [prepare-build, create-release]
-    if: ${{ inputs.create_release && always() && needs.create-release.result == 'success' }}
+    if: always() && needs.create-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: Production
@@ -805,39 +782,3 @@ jobs:
               echo "Tag ${IMAGE_TAG} not found or already deleted"
             fi
           done
-
-  # =========================================================================
-  # Cleanup: remove the temporary v###-preview tag after a dry run completes.
-  # The preview tag exists solely so the release notes script can resolve the
-  # --to ref; it has no downstream consumers and should not linger.
-  # =========================================================================
-  cleanup-preview-tag:
-    name: Remove preview tag
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs:
-      - prepare-build
-      - create-release
-    if: ${{ always() && !inputs.create_release && needs.prepare-build.result == 'success' }}
-    steps:
-      - name: Delete remote preview tag
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const previewTag = '${{ needs.prepare-build.outputs.preview_tag }}';
-            if (!previewTag) {
-              core.info('No preview tag to clean up');
-              return;
-            }
-            try {
-              await github.rest.git.deleteRef({ owner, repo, ref: `tags/${previewTag}` });
-              core.info(`Deleted remote preview tag ${previewTag}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Preview tag ${previewTag} already absent on remote`);
-              } else {
-                throw e;
-              }
-            }


### PR DESCRIPTION
## Summary

- Revert all preview tag, always-on release notes, and build gating changes from #3529, #3530, #3532.
- Keep only the Docker build timeout bump (30 → 60 minutes).

## Problem

The changes in #3529/#3530/#3532 introduced preview tags, unconditional release notes generation, and build gating that caused checkout failures and unintended behavior on dry runs. The approach needs rethinking.

## Solution

Restore the original `release-production.yml` with a single change: `build-docker` timeout increased from 30 to 60 minutes to prevent timeouts on cold cache builds.

## Submission Checklist

- [x] N/A: Tests added or updated — CI workflow revert, no application code affected
- [x] N/A: Diff coverage ≥ 80% — no application source changed
- [x] N/A: Coverage matrix updated — no feature change
- [x] N/A: All affected feature IDs listed — no feature change
- [x] N/A: No new external network dependencies — revert only
- [x] N/A: Manual smoke checklist — workflow change only
- [x] N/A: Linked issue closed — no tracking issue

## Impact

- No runtime impact. Restores original release workflow behavior with a longer Docker timeout.

## Related

- Reverts: #3529, #3530, #3532
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: revert/release-production-simplify
- Commit SHA: 5b3b2a59a

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no app source changed
- [x] N/A: `pnpm typecheck` — no app source changed
- [x] N/A: Focused tests — CI workflow only
- [x] N/A: Rust fmt/check — no Rust source changed
- [x] N/A: Tauri fmt/check — no Tauri source changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Revert to original release workflow; Docker timeout 60min.
- User-visible effect: Dry runs behave as they did before #3529.

### Parity Contract

- Legacy behavior preserved: Yes — this IS the revert to legacy.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this one
- Resolution: N/A