### PR TITLE
fix(scripts): add --help to codex-pr-preflight

### DIFF
--- a/scripts/codex-pr-preflight.mjs
+++ b/scripts/codex-pr-preflight.mjs
@@ -29,6 +29,23 @@ function currentRepoRoot() {
   return physical;
 }
 
+function usage() {
+  return [
+    'Usage: node scripts/codex-pr-preflight.mjs [--lightweight] [--strict-path]',
+    '',
+    'Checks the current checkout for Codex PR preflight requirements and prints',
+    'recommended validation commands for the changed files.',
+    '',
+    'Options:',
+    '  --lightweight   Skip the heavier "pnpm debug rust" recommendation for Rust changes.',
+    '  --strict-path   Assert the checkout lives at the expected repo path.',
+    '  -h, --help      Show this help and exit.',
+    '',
+    'Environment:',
+    '  CODEX_EXPECT_REPO_PATH   Expected repo path for --strict-path (default /workspace/openhuman).',
+  ].join('\n');
+}
+
 function parseArgs(argv) {
   return {
     lightweight: argv.includes('--lightweight'),
@@ -85,7 +102,12 @@ function recommendations(changedFiles, lightweight) {
 }
 
 function main() {
-  const options = parseArgs(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log(usage());
+    process.exit(0);
+  }
+  const options = parseArgs(argv);
   const repoRoot = currentRepoRoot();
   const checks = [];
 


### PR DESCRIPTION
## What
Add `-h`/`--help` to `scripts/codex-pr-preflight.mjs`. It prints a `usage()` summary of the existing flags and the `CODEX_EXPECT_REPO_PATH` override, then exits 0 before running any checks.

## Why
The script already parsed `--lightweight` and `--strict-path` (and read `CODEX_EXPECT_REPO_PATH`), but had no `--help`, so there was no way to discover those flags without reading the source. This mirrors the `usage()` + `-h`/`--help` convention already used by `scripts/check-coverage-matrix.mjs`, `scripts/check-pr-checklist.mjs`, and `scripts/check-domain-e2e-coverage.mjs`.

No change to existing flag behavior — the help check runs only when `-h`/`--help` is passed.

## How to test
```
$ node scripts/codex-pr-preflight.mjs --help
Usage: node scripts/codex-pr-preflight.mjs [--lightweight] [--strict-path]
...
Options:
  --lightweight   Skip the heavier "pnpm debug rust" recommendation for Rust changes.
  --strict-path   Assert the checkout lives at the expected repo path.
  -h, --help      Show this help and exit.
...
$ echo $?
0

$ node scripts/codex-pr-preflight.mjs -h >/dev/null; echo $?
0

# no-arg behavior unchanged — still runs checks:
$ node scripts/codex-pr-preflight.mjs; echo $?
[PASS] working directory exists :: ...
...
0
```

## Platforms tested
- macOS (node, local checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added help documentation displaying invocation syntax, supported command-line flags, and required environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->