### PR TITLE
fix(scripts): add --help to test-channel-receive

### DIFF
--- a/scripts/test-channel-receive.mjs
+++ b/scripts/test-channel-receive.mjs
@@ -20,7 +20,26 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 
+function usage() {
+  return [
+    'Usage: node scripts/test-channel-receive.mjs [options]',
+    '',
+    'Connects to the backend Socket.IO server, authenticates with the stored',
+    'session JWT, and listens for incoming channel messages.',
+    '',
+    'Options:',
+    '  --timeout N     Wait N seconds before timing out (default: 60).',
+    '  --debug         Enable verbose logging.',
+    '  --send-test     Also send a test message after connecting.',
+    '  -h, --help      Show this help and exit.',
+  ].join('\n');
+}
+
 const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(usage());
+  process.exit(0);
+}
 const DEBUG = args.includes('--debug');
 const SEND_TEST = args.includes('--send-test');
 


### PR DESCRIPTION
## What
Add `-h`/`--help` to `scripts/test-channel-receive.mjs`. It prints a `usage()` summary of the existing flags (`--timeout`, `--debug`, `--send-test`), then exits 0 before attempting any token or backend operations.

## Why
The script had a `// Usage:` comment block at the top describing its flags, but no `--help` flag to surface that usage at runtime without reading the source. This mirrors the `usage()` + `-h`/`--help` convention used by `scripts/check-coverage-matrix.mjs` and other scripts.

No change to existing flag behavior — the help check runs only when `-h`/`--help` is passed.

## How to test
```
$ node scripts/test-channel-receive.mjs --help
Usage: node scripts/test-channel-receive.mjs [options]

Connects to the backend Socket.IO server, authenticates with the stored
session JWT, and listens for incoming channel messages.

Options:
  --timeout N     Wait N seconds before timing out (default: 60).
  --debug         Enable verbose logging.
  --send-test     Also send a test message after connecting.
  -h, --help      Show this help and exit.
$ echo $?
0

$ node scripts/test-channel-receive.mjs -h >/dev/null; echo $?
0

# no-arg behavior unchanged — still attempts token fetch and connection:
$ node scripts/test-channel-receive.mjs
📡 Channel Receive Listener
────────────────────────────────────────────────
Backend:   https://staging-api.alphahuman.xyz
...
```

## Platforms tested
- macOS (node, local checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development tooling with improved command-line help documentation and argument handling for test scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->