### PR TITLE
fix(scripts): add --help to agent-batch/launch

### DIFF
--- a/scripts/agent-batch/launch.mjs
+++ b/scripts/agent-batch/launch.mjs
@@ -59,8 +59,30 @@ Tracking: progress for this batch is reported on issue #${spec.tracking_issue}.
 `;
 }
 
+function usage() {
+  return [
+    'Usage: node scripts/agent-batch/launch.mjs <spec.json> [options]',
+    '',
+    'Print one launch comment per agent in the batch. The operator pastes each',
+    'into Cursor as the agent prompt.',
+    '',
+    'Arguments:',
+    '  <spec.json>     Path to the batch specification file.',
+    '',
+    'Options:',
+    '  --agent <id>    Print only the agent with this id (default: all agents).',
+    '  --print-only    Print launch comments (default and only mode currently).',
+    '  -h, --help      Show this help and exit.',
+  ].join('\n');
+}
+
 function main() {
-  const { positional, flags } = parseArgs(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log(usage());
+    process.exit(0);
+  }
+  const { positional, flags } = parseArgs(argv);
   const specPath = positional[0];
   if (!specPath) {
     process.stderr.write(

--- a/scripts/agent-batch/launch.mjs
+++ b/scripts/agent-batch/launch.mjs
@@ -59,6 +59,15 @@ Tracking: progress for this batch is reported on issue #${spec.tracking_issue}.
 `;
 }
 
+/**
+ * Returns formatted help text for the agent-batch launch CLI.
+ *
+ * Describes the script's purpose, required arguments, and available options.
+ * The operator uses this tool to generate launch comments that are pasted
+ * into Cursor as agent prompts.
+ *
+ * @returns {string} Multi-line help text describing usage, arguments, and flags.
+ */
 function usage() {
   return [
     'Usage: node scripts/agent-batch/launch.mjs <spec.json> [options]',


### PR DESCRIPTION
## What
Add `-h`/`--help` to `scripts/agent-batch/launch.mjs`. It prints a `usage()` summary of the required `<spec.json>` argument and the existing options (`--agent`, `--print-only`), then exits 0 before attempting to parse positional arguments.

## Why
The script already parsed `<spec.json>`, `--agent <id>`, and `--print-only`, but had no `--help`, so there was no way to discover those arguments and options without reading the source. This mirrors the `usage()` + `-h`/`--help` convention used by other scripts.

No change to existing argument parsing or the exit-2 path when `<spec.json>` is missing — the help check runs only when `-h`/`--help` is passed.

## How to test
```
$ node scripts/agent-batch/launch.mjs --help
Usage: node scripts/agent-batch/launch.mjs <spec.json> [options]

Print one launch comment per agent in the batch. The operator pastes each
into Cursor as the agent prompt.

Arguments:
  <spec.json>     Path to the batch specification file.

Options:
  --agent <id>    Print only the agent with this id (default: all agents).
  --print-only    Print launch comments (default and only mode currently).
  -h, --help      Show this help and exit.
$ echo $?
0

$ node scripts/agent-batch/launch.mjs -h >/dev/null; echo $?
0

# no-arg behavior unchanged — still exits 2 with the brief usage:
$ node scripts/agent-batch/launch.mjs; echo $?
usage: launch.mjs <spec.json> [--agent <id>] [--print-only]
2
```

## Platforms tested
- macOS (node, local checkout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved command-line help for batch processing: explicit handling of --help/-h now prints a clear usage message and exits before further argument parsing, ensuring users see guidance immediately and avoiding unnecessary validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->