### PR TITLE
feat(agent_team): durable team coordination model + read/claim controllers (#3374)

### DIFF
--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -299,6 +299,9 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     // Durable dynamic workflow runs — definitions + read surface over the run ledger
     controllers
         .extend(crate::openhuman::agent_orchestration::all_workflow_run_registered_controllers());
+    // Durable agent-team coordination — teams, members, dependency-aware task claiming, messaging
+    controllers
+        .extend(crate::openhuman::agent_orchestration::all_agent_team_registered_controllers());
     controllers
 }
 
@@ -429,6 +432,8 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
     schemas.extend(crate::openhuman::agent_orchestration::all_command_center_controller_schemas());
     // Durable dynamic workflow runs
     schemas.extend(crate::openhuman::agent_orchestration::all_workflow_run_controller_schemas());
+    // Durable agent-team coordination
+    schemas.extend(crate::openhuman::agent_orchestration::all_agent_team_controller_schemas());
     schemas
 }
 
@@ -517,6 +522,9 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         ),
         "workflow_run" => Some(
             "Durable dynamic workflow runs — declarative multi-agent definitions and the read surface over persisted runs.",
+        ),
+        "agent_team" => Some(
+            "Durable agent-team coordination: teams, members, dependency-aware task claiming, and teammate messaging.",
         ),
         "billing" => Some("Subscription plan, payment links, and credit top-up via the backend."),
         "team" => Some("Team member management, invites, and role changes via the backend."),

--- a/src/openhuman/agent_orchestration/agent_teams/mod.rs
+++ b/src/openhuman/agent_orchestration/agent_teams/mod.rs
@@ -1,0 +1,32 @@
+//! Durable agent-team coordination (issue #3374).
+//!
+//! A first-class, restart-survivable model for a lead agent coordinating a team
+//! of worker agents: teams, members, dependency-aware tasks with race-safe
+//! atomic claiming, and teammate messaging. All durable state lives in
+//! `session_db::run_ledger` (the `agent_teams` / `agent_team_members` /
+//! `agent_team_tasks` tables, plus the shared run-event log for messages),
+//! never in the main chat context — so a coordination session can be listed,
+//! inspected, and resumed.
+//!
+//! PR1 scope (this module today): the durable model + 8 read/write controllers
+//! (`create`, `list`, `get`, `assign_task`, `claim_task`, `message_member`,
+//! `list_messages`, `close`), the atomic compare-and-swap claim primitive, and
+//! dependency validation (self / unknown / cycle). Live agent execution
+//! (spawning workers, driving the run loop) and the UI are follow-up PRs.
+//!
+//! Namespace note: `agent_team` is distinct from the existing `team` domain,
+//! which manages backend org/team membership.
+
+pub mod ops;
+mod schemas;
+pub mod types;
+
+pub use ops::{
+    assign_task, claim_task, close_team, create_team, get_team, list_messages, list_teams,
+    message_member, NewMember,
+};
+pub use schemas::{
+    all_controller_schemas as all_agent_team_controller_schemas,
+    all_registered_controllers as all_agent_team_registered_controllers,
+};
+pub use types::{TeamError, TeamView};

--- a/src/openhuman/agent_orchestration/agent_teams/ops.rs
+++ b/src/openhuman/agent_orchestration/agent_teams/ops.rs
@@ -1,0 +1,527 @@
+//! Business logic for durable agent-team coordination (#3374).
+//!
+//! Thin orchestration over `session_db::run_ledger`: create teams + members,
+//! assign dependency-aware tasks (with self/unknown/cycle validation reusing
+//! the same Kahn's-algorithm shape as `workflow_runs`), atomically claim tasks,
+//! and exchange teammate messages. Messaging rides the run-ledger event stream
+//! (`run_id = team_id`, `event_type = "team_message"`) — no new message table.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::openhuman::config::Config;
+use crate::openhuman::session_db::run_ledger::{
+    self, AgentTeam, AgentTeamListRequest, AgentTeamListResponse, AgentTeamMemberStatus,
+    AgentTeamMemberUpsert, AgentTeamStatus, AgentTeamTask, AgentTeamTaskStatus,
+    AgentTeamTaskUpsert, AgentTeamUpsert, ClaimOutcome, RunEvent, RunEventAppend,
+    RunEventListRequest,
+};
+
+use super::types::{TeamError, TeamView};
+
+const LOG_PREFIX: &str = "[agent_team]";
+const TEAM_MESSAGE_EVENT: &str = "team_message";
+
+/// One member to create at team-creation time.
+#[derive(Debug, Clone)]
+pub struct NewMember {
+    pub name: String,
+    pub agent_id: Option<String>,
+}
+
+/// Create a team and its initial members.
+///
+/// Rejects duplicate member names ([`TeamError::DuplicateMemberName`]).
+pub fn create_team(
+    config: &Config,
+    lead_agent_id: &str,
+    parent_thread_id: Option<&str>,
+    summary: Option<&str>,
+    members: &[NewMember],
+) -> Result<TeamView> {
+    log::debug!(
+        "{LOG_PREFIX} create_team.entry lead={lead_agent_id} members={}",
+        members.len()
+    );
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for member in members {
+        if !seen.insert(member.name.as_str()) {
+            return Err(anyhow!(TeamError::DuplicateMemberName {
+                name: member.name.clone(),
+            }));
+        }
+    }
+
+    let team_id = format!("team-{}", Uuid::new_v4().simple());
+    run_ledger::upsert_agent_team(
+        config,
+        AgentTeamUpsert {
+            id: team_id.clone(),
+            parent_thread_id: parent_thread_id.map(str::to_string),
+            lead_agent_id: lead_agent_id.to_string(),
+            status: AgentTeamStatus::Active,
+            summary: summary.map(str::to_string),
+            created_at: None,
+            closed_at: None,
+        },
+    )?;
+
+    for member in members {
+        run_ledger::upsert_agent_team_member(
+            config,
+            AgentTeamMemberUpsert {
+                id: format!("member-{}", Uuid::new_v4().simple()),
+                team_id: team_id.clone(),
+                name: member.name.clone(),
+                agent_id: member.agent_id.clone(),
+                member_status: AgentTeamMemberStatus::Pending,
+                current_task_id: None,
+                worker_thread_id: None,
+                run_id: None,
+                created_at: None,
+            },
+        )?;
+    }
+
+    let view = team_view(config, &team_id)?;
+    log::debug!("{LOG_PREFIX} create_team.exit id={team_id}");
+    Ok(view)
+}
+
+/// List teams (delegates to the run ledger).
+pub fn list_teams(
+    config: &Config,
+    request: &AgentTeamListRequest,
+) -> Result<AgentTeamListResponse> {
+    log::debug!("{LOG_PREFIX} list_teams.entry status={:?}", request.status);
+    run_ledger::list_agent_teams(config, request)
+}
+
+/// Build the aggregate [`TeamView`] for a team id; `None` if the team is absent.
+pub fn get_team(config: &Config, team_id: &str) -> Result<Option<TeamView>> {
+    log::debug!("{LOG_PREFIX} get_team.entry id={team_id}");
+    match run_ledger::get_agent_team(config, team_id)? {
+        Some(_) => Ok(Some(team_view(config, team_id)?)),
+        None => {
+            log::debug!("{LOG_PREFIX} get_team.exit id={team_id} found=false");
+            Ok(None)
+        }
+    }
+}
+
+/// Assign a new dependency-aware task to a team.
+///
+/// Validates `depends_on`: rejects self-dependency, unknown dependency ids, and
+/// dependency cycles (Kahn's algorithm over the team's existing tasks plus the
+/// new one). An optional `owner_member_id` must reference a real member.
+#[allow(clippy::too_many_arguments)]
+pub fn assign_task(
+    config: &Config,
+    team_id: &str,
+    title: &str,
+    objective: Option<&str>,
+    owner_member_id: Option<&str>,
+    depends_on: &[String],
+) -> Result<AgentTeamTask> {
+    log::debug!(
+        "{LOG_PREFIX} assign_task.entry team={team_id} deps={}",
+        depends_on.len()
+    );
+
+    let team = run_ledger::get_agent_team(config, team_id)?
+        .ok_or_else(|| anyhow!("unknown team: {team_id}"))?;
+    let _ = team;
+
+    let existing = run_ledger::list_agent_team_tasks(config, team_id)?;
+    let task_id = format!("task-{}", Uuid::new_v4().simple());
+
+    if let Some(owner) = owner_member_id {
+        let members = run_ledger::list_agent_team_members(config, team_id)?;
+        if !members.iter().any(|m| m.id == owner) {
+            return Err(anyhow!(TeamError::UnknownMember {
+                member_id: owner.to_string(),
+            }));
+        }
+    }
+
+    validate_dependencies(&task_id, depends_on, &existing)?;
+
+    let order_index = existing.len() as i64;
+    let task = run_ledger::upsert_agent_team_task(
+        config,
+        AgentTeamTaskUpsert {
+            id: task_id.clone(),
+            team_id: team_id.to_string(),
+            title: title.to_string(),
+            objective: objective.map(str::to_string),
+            status: AgentTeamTaskStatus::Todo,
+            owner_member_id: owner_member_id.map(str::to_string),
+            depends_on: depends_on.to_vec(),
+            gate_status: None,
+            gate_reason: None,
+            evidence: vec![],
+            source_run_id: None,
+            order_index,
+            created_at: None,
+        },
+    )?;
+    log::debug!("{LOG_PREFIX} assign_task.exit team={team_id} task={task_id}");
+    Ok(task)
+}
+
+/// Atomically claim a task for a member (delegates to the run-ledger CAS).
+pub fn claim_task(
+    config: &Config,
+    team_id: &str,
+    task_id: &str,
+    member_id: &str,
+    claim_token: &str,
+) -> Result<ClaimOutcome> {
+    log::debug!("{LOG_PREFIX} claim_task.entry team={team_id} task={task_id} member={member_id}");
+    let members = run_ledger::list_agent_team_members(config, team_id)?;
+    if !members.iter().any(|m| m.id == member_id) {
+        return Err(anyhow!(TeamError::UnknownMember {
+            member_id: member_id.to_string(),
+        }));
+    }
+    run_ledger::claim_agent_team_task(config, team_id, task_id, member_id, claim_token)
+}
+
+/// Send a message from one member to another (or broadcast).
+///
+/// Persisted as a run-ledger event keyed by `run_id = team_id`, so the messaging
+/// stream reuses the durable event log with no new table.
+pub fn message_member(
+    config: &Config,
+    team_id: &str,
+    from_member_id: &str,
+    to_member_id: Option<&str>,
+    content: &str,
+    visibility: Option<&str>,
+) -> Result<RunEvent> {
+    log::debug!(
+        "{LOG_PREFIX} message_member.entry team={team_id} from={from_member_id} to={:?}",
+        to_member_id
+    );
+
+    let members = run_ledger::list_agent_team_members(config, team_id)?;
+    if !members.iter().any(|m| m.id == from_member_id) {
+        return Err(anyhow!(TeamError::UnknownMember {
+            member_id: from_member_id.to_string(),
+        }));
+    }
+    if let Some(to) = to_member_id {
+        if !members.iter().any(|m| m.id == to) {
+            return Err(anyhow!(TeamError::UnknownMember {
+                member_id: to.to_string(),
+            }));
+        }
+    }
+
+    let event = run_ledger::append_run_event(
+        config,
+        RunEventAppend {
+            run_id: team_id.to_string(),
+            event_type: TEAM_MESSAGE_EVENT.to_string(),
+            payload: json!({
+                "from": from_member_id,
+                "to": to_member_id,
+                "content": content,
+                "visibility": visibility.unwrap_or("team"),
+            }),
+        },
+    )?;
+    log::debug!(
+        "{LOG_PREFIX} message_member.exit team={team_id} sequence={}",
+        event.sequence
+    );
+    Ok(event)
+}
+
+/// List the team's message events in sequence order.
+pub fn list_messages(config: &Config, team_id: &str, limit: Option<u32>) -> Result<Vec<RunEvent>> {
+    log::debug!("{LOG_PREFIX} list_messages.entry team={team_id}");
+    let response = run_ledger::list_recent_run_events(
+        config,
+        &RunEventListRequest {
+            run_id: team_id.to_string(),
+            after_sequence: None,
+            limit,
+        },
+    )?;
+    let messages: Vec<RunEvent> = response
+        .events
+        .into_iter()
+        .filter(|e| e.event_type == TEAM_MESSAGE_EVENT)
+        .collect();
+    log::debug!(
+        "{LOG_PREFIX} list_messages.exit team={team_id} count={}",
+        messages.len()
+    );
+    Ok(messages)
+}
+
+/// Mark a team closed.
+pub fn close_team(config: &Config, team_id: &str, summary: Option<&str>) -> Result<AgentTeam> {
+    log::debug!("{LOG_PREFIX} close_team.entry team={team_id}");
+    let existing = run_ledger::get_agent_team(config, team_id)?
+        .ok_or_else(|| anyhow!("unknown team: {team_id}"))?;
+    let team = run_ledger::upsert_agent_team(
+        config,
+        AgentTeamUpsert {
+            id: team_id.to_string(),
+            parent_thread_id: existing.parent_thread_id.clone(),
+            lead_agent_id: existing.lead_agent_id.clone(),
+            status: AgentTeamStatus::Closed,
+            summary: summary.map(str::to_string),
+            created_at: Some(existing.created_at),
+            closed_at: Some(Utc::now()),
+        },
+    )?;
+    log::debug!("{LOG_PREFIX} close_team.exit team={team_id}");
+    Ok(team)
+}
+
+fn team_view(config: &Config, team_id: &str) -> Result<TeamView> {
+    let team = run_ledger::get_agent_team(config, team_id)?
+        .ok_or_else(|| anyhow!("team missing after creation: {team_id}"))?;
+    let members = run_ledger::list_agent_team_members(config, team_id)?;
+    let tasks = run_ledger::list_agent_team_tasks(config, team_id)?;
+    Ok(TeamView {
+        team,
+        members,
+        tasks,
+    })
+}
+
+/// Validate a new task's dependency edges against the team's existing tasks.
+///
+/// Rejects self-dependency, unknown dependency ids, and any edge that would
+/// introduce a cycle. The cycle check builds the full graph (existing tasks +
+/// the new task with its proposed deps) and runs Kahn's algorithm — the same
+/// shape used for workflow phase graphs in `workflow_runs::ops::has_cycle`.
+fn validate_dependencies(
+    new_task_id: &str,
+    depends_on: &[String],
+    existing: &[AgentTeamTask],
+) -> Result<()> {
+    let known: HashSet<&str> = existing.iter().map(|t| t.id.as_str()).collect();
+
+    for dep in depends_on {
+        if dep == new_task_id {
+            return Err(anyhow!(TeamError::SelfDependency {
+                task_id: new_task_id.to_string(),
+            }));
+        }
+        if !known.contains(dep.as_str()) {
+            return Err(anyhow!(TeamError::UnknownDependency {
+                depends_on: dep.clone(),
+            }));
+        }
+    }
+
+    if has_task_cycle(new_task_id, depends_on, existing) {
+        return Err(anyhow!(TeamError::CyclicDependency));
+    }
+
+    Ok(())
+}
+
+/// Kahn's-algorithm cycle check over the task dependency graph (existing tasks
+/// plus the candidate new task). Edge `dep -> task` means `task` depends on
+/// `dep`. Edges pointing at unknown ids are ignored here (rejected separately).
+fn has_task_cycle(
+    new_task_id: &str,
+    new_depends_on: &[String],
+    existing: &[AgentTeamTask],
+) -> bool {
+    // Node set: every existing task id plus the new one.
+    let mut nodes: HashSet<&str> = existing.iter().map(|t| t.id.as_str()).collect();
+    nodes.insert(new_task_id);
+
+    let mut indegree: HashMap<&str, usize> = nodes.iter().map(|&n| (n, 0)).collect();
+    let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    // Existing edges.
+    for task in existing {
+        for dep in &task.depends_on {
+            let dep = dep.as_str();
+            if nodes.contains(dep) {
+                adjacency.entry(dep).or_default().push(task.id.as_str());
+                *indegree.entry(task.id.as_str()).or_insert(0) += 1;
+            }
+        }
+    }
+    // Candidate edges for the new task.
+    for dep in new_depends_on {
+        let dep = dep.as_str();
+        if nodes.contains(dep) {
+            adjacency.entry(dep).or_default().push(new_task_id);
+            *indegree.entry(new_task_id).or_insert(0) += 1;
+        }
+    }
+
+    let mut queue: VecDeque<&str> = indegree
+        .iter()
+        .filter(|(_, &d)| d == 0)
+        .map(|(&n, _)| n)
+        .collect();
+    let mut visited = 0usize;
+    while let Some(node) = queue.pop_front() {
+        visited += 1;
+        if let Some(children) = adjacency.get(node) {
+            for &child in children {
+                let entry = indegree.get_mut(child).expect("child in indegree");
+                *entry -= 1;
+                if *entry == 0 {
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+    visited != indegree.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_config(dir: &TempDir) -> Config {
+        let mut config = Config::default();
+        config.workspace_dir = dir.path().to_path_buf();
+        config.action_dir = dir.path().join("actions");
+        config
+    }
+
+    fn team_err(err: anyhow::Error) -> TeamError {
+        err.downcast::<TeamError>().expect("TeamError")
+    }
+
+    #[test]
+    fn create_team_rejects_duplicate_member_names() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        let err = create_team(
+            &config,
+            "lead",
+            None,
+            None,
+            &[
+                NewMember {
+                    name: "alice".into(),
+                    agent_id: None,
+                },
+                NewMember {
+                    name: "alice".into(),
+                    agent_id: None,
+                },
+            ],
+        )
+        .unwrap_err();
+        assert_eq!(
+            team_err(err),
+            TeamError::DuplicateMemberName {
+                name: "alice".into()
+            }
+        );
+    }
+
+    #[test]
+    fn assign_task_rejects_self_unknown_and_cycle() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        let view = create_team(
+            &config,
+            "lead",
+            None,
+            None,
+            &[NewMember {
+                name: "alice".into(),
+                agent_id: None,
+            }],
+        )
+        .unwrap();
+        let team_id = view.team.id.clone();
+
+        // Unknown dependency.
+        let err =
+            assign_task(&config, &team_id, "task one", None, None, &["ghost".into()]).unwrap_err();
+        assert_eq!(
+            team_err(err),
+            TeamError::UnknownDependency {
+                depends_on: "ghost".into()
+            }
+        );
+
+        // Seed A, then B depends_on A — fine.
+        let a = assign_task(&config, &team_id, "A", None, None, &[]).unwrap();
+        let b = assign_task(&config, &team_id, "B", None, None, &[a.id.clone()]).unwrap();
+
+        // Self-dependency.
+        let err = assign_task(&config, &team_id, "self", None, None, &["task-xyz".into()]);
+        // self id is generated, so simulate via an existing-task edit path instead:
+        // unknown id path already covered; ensure self check fires when dep == new id.
+        // We can't predict the new id; verify cycle path instead.
+        let _ = err;
+
+        // Cycle: try to make A depend_on B (A already an upstream of B).
+        // Re-upserting A with depends_on [B] would close the loop; assign_task
+        // only creates new tasks, so emulate the cycle check directly.
+        let existing = run_ledger::list_agent_team_tasks(&config, &team_id).unwrap();
+        assert!(has_task_cycle(&a.id, &[b.id.clone()], &existing));
+    }
+
+    #[test]
+    fn self_dependency_is_rejected() {
+        // Directly exercise validate_dependencies with a matching id.
+        let err = validate_dependencies("task-self", &["task-self".into()], &[]).unwrap_err();
+        assert_eq!(
+            team_err(err),
+            TeamError::SelfDependency {
+                task_id: "task-self".into()
+            }
+        );
+    }
+
+    #[test]
+    fn message_append_then_list_in_order() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        let view = create_team(
+            &config,
+            "lead",
+            None,
+            None,
+            &[
+                NewMember {
+                    name: "alice".into(),
+                    agent_id: None,
+                },
+                NewMember {
+                    name: "bob".into(),
+                    agent_id: None,
+                },
+            ],
+        )
+        .unwrap();
+        let team_id = view.team.id.clone();
+        let alice = view.members[0].id.clone();
+        let bob = view.members[1].id.clone();
+
+        message_member(&config, &team_id, &alice, Some(&bob), "first", None).unwrap();
+        message_member(&config, &team_id, &bob, Some(&alice), "second", None).unwrap();
+
+        let messages = list_messages(&config, &team_id, None).unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].sequence, 1);
+        assert_eq!(messages[1].sequence, 2);
+        assert_eq!(messages[0].payload["content"], "first");
+        assert_eq!(messages[1].payload["content"], "second");
+    }
+}

--- a/src/openhuman/agent_orchestration/agent_teams/schemas.rs
+++ b/src/openhuman/agent_orchestration/agent_teams/schemas.rs
@@ -1,0 +1,472 @@
+//! Controller schemas + JSON-RPC dispatchers for durable agent-team
+//! coordination (#3374). Namespace `agent_team`.
+//!
+//! Surface (PR1): create a team with members, list/get teams, assign
+//! dependency-aware tasks, atomically claim a task, exchange teammate messages,
+//! list those messages, and close a team. Live agent execution is a follow-up.
+
+use serde_json::{Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use crate::openhuman::config::rpc as config_rpc;
+use crate::openhuman::session_db::run_ledger::AgentTeamListRequest;
+use crate::rpc::RpcOutcome;
+
+use super::ops::{self, NewMember};
+
+/// Controller schemas exposed by the agent-teams module.
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    vec![
+        schema_for("agent_team_create"),
+        schema_for("agent_team_list"),
+        schema_for("agent_team_get"),
+        schema_for("agent_team_assign_task"),
+        schema_for("agent_team_claim_task"),
+        schema_for("agent_team_message_member"),
+        schema_for("agent_team_list_messages"),
+        schema_for("agent_team_close"),
+    ]
+}
+
+/// Registered controllers (schema + handler) for agent teams.
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    vec![
+        RegisteredController {
+            schema: schema_for("agent_team_create"),
+            handler: handle_create,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_list"),
+            handler: handle_list,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_get"),
+            handler: handle_get,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_assign_task"),
+            handler: handle_assign_task,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_claim_task"),
+            handler: handle_claim_task,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_message_member"),
+            handler: handle_message_member,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_list_messages"),
+            handler: handle_list_messages,
+        },
+        RegisteredController {
+            schema: schema_for("agent_team_close"),
+            handler: handle_close,
+        },
+    ]
+}
+
+fn schema_for(function: &str) -> ControllerSchema {
+    match function {
+        "agent_team_create" => ControllerSchema {
+            namespace: "agent_team",
+            function: "create",
+            description: "Create an agent team with a lead and initial members.",
+            inputs: vec![
+                required_str("leadAgentId", "Lead agent id coordinating the team."),
+                optional_str("parentThreadId", "Originating chat thread id."),
+                optional_str("summary", "Short description of the team's goal."),
+                json_input(
+                    "members",
+                    "Array of { name, agentId? } members to seed the team.",
+                ),
+            ],
+            outputs: vec![json_output("result", "TeamView with team, members, tasks.")],
+        },
+        "agent_team_list" => ControllerSchema {
+            namespace: "agent_team",
+            function: "list",
+            description: "List durable agent teams with optional filters and pagination.",
+            inputs: vec![
+                optional_str("parentThreadId", "Filter by parent thread id."),
+                optional_str("status", "Filter by team status (active|closed)."),
+                optional_u64("limit", "Max teams to return (default 50, max 500)."),
+                optional_u64("offset", "Pagination offset."),
+            ],
+            outputs: vec![json_output(
+                "result",
+                "AgentTeamListResponse with teams array and count.",
+            )],
+        },
+        "agent_team_get" => ControllerSchema {
+            namespace: "agent_team",
+            function: "get",
+            description: "Get a team with its members and tasks.",
+            inputs: vec![required_str("teamId", "Team id.")],
+            outputs: vec![json_output("team", "TeamView payload or null.")],
+        },
+        "agent_team_assign_task" => ControllerSchema {
+            namespace: "agent_team",
+            function: "assign_task",
+            description: "Add a dependency-aware task to a team.",
+            inputs: vec![
+                required_str("teamId", "Team id."),
+                required_str("title", "Task title."),
+                optional_str("objective", "Task objective / acceptance summary."),
+                optional_str("ownerMemberId", "Member who owns the task."),
+                json_input("dependsOn", "Array of task ids this task depends on."),
+            ],
+            outputs: vec![json_output("task", "The created AgentTeamTask.")],
+        },
+        "agent_team_claim_task" => ControllerSchema {
+            namespace: "agent_team",
+            function: "claim_task",
+            description: "Atomically claim a task for a member (race-safe compare-and-swap).",
+            inputs: vec![
+                required_str("teamId", "Team id."),
+                required_str("taskId", "Task id to claim."),
+                required_str("memberId", "Member attempting the claim."),
+                required_str("claimToken", "Idempotency / ownership token for the claim."),
+            ],
+            outputs: vec![json_output(
+                "result",
+                "ClaimOutcome: claimed | alreadyClaimed | blocked | unknownTask.",
+            )],
+        },
+        "agent_team_message_member" => ControllerSchema {
+            namespace: "agent_team",
+            function: "message_member",
+            description: "Send a message from one member to another (or broadcast to the team).",
+            inputs: vec![
+                required_str("teamId", "Team id."),
+                required_str("fromMemberId", "Sender member id."),
+                optional_str("toMemberId", "Recipient member id (omit to broadcast)."),
+                required_str("content", "Message content."),
+                optional_str("visibility", "Message visibility (default team)."),
+            ],
+            outputs: vec![json_output("message", "The appended message event.")],
+        },
+        "agent_team_list_messages" => ControllerSchema {
+            namespace: "agent_team",
+            function: "list_messages",
+            description: "List the team's messages in order.",
+            inputs: vec![
+                required_str("teamId", "Team id."),
+                optional_u64("limit", "Max messages to return."),
+            ],
+            outputs: vec![json_output("messages", "Array of message events.")],
+        },
+        "agent_team_close" => ControllerSchema {
+            namespace: "agent_team",
+            function: "close",
+            description: "Close a team, recording an optional summary.",
+            inputs: vec![
+                required_str("teamId", "Team id."),
+                optional_str("summary", "Closing summary."),
+            ],
+            outputs: vec![json_output("team", "The closed AgentTeam.")],
+        },
+        other => unreachable!("unknown agent_team schema: {other}"),
+    }
+}
+
+fn handle_create(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] create.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] create.config_failed err={err}");
+        })?;
+        let lead = require_str(&params, "leadAgentId")?;
+        let parent_thread_id = opt_str(&params, "parentThreadId");
+        let summary = opt_str(&params, "summary");
+        let members = parse_members(&params)?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] create.parsed lead={lead} members={}", members.len());
+        let view = ops::create_team(
+            &config,
+            &lead,
+            parent_thread_id.as_deref(),
+            summary.as_deref(),
+            &members,
+        )
+        .map_err(|e| log_err(&cid, "create", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] create.success id={}", view.team.id);
+        to_json(view)
+    })
+}
+
+fn handle_list(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list.config_failed err={err}");
+        })?;
+        let request: AgentTeamListRequest = if params.is_empty() {
+            log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list.branch=default_request");
+            AgentTeamListRequest::default()
+        } else {
+            log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list.branch=parsed_params");
+            serde_json::from_value(Value::Object(params)).map_err(|e| {
+                let s = format!("invalid agent team list params: {e}");
+                log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list.bad_params err={s}");
+                s
+            })?
+        };
+        let response = ops::list_teams(&config, &request).map_err(|e| log_err(&cid, "list", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list.success count={}", response.count);
+        to_json(response)
+    })
+}
+
+fn handle_get(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] get.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] get.config_failed err={err}");
+        })?;
+        let team_id = require_str(&params, "teamId")?;
+        let view = ops::get_team(&config, &team_id).map_err(|e| log_err(&cid, "get", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] get.success id={team_id} found={}", view.is_some());
+        to_json(serde_json::json!({ "team": view }))
+    })
+}
+
+fn handle_assign_task(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] assign_task.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] assign_task.config_failed err={err}");
+        })?;
+        let team_id = require_str(&params, "teamId")?;
+        let title = require_str(&params, "title")?;
+        let objective = opt_str(&params, "objective");
+        let owner = opt_str(&params, "ownerMemberId");
+        let depends_on = opt_str_array(&params, "dependsOn");
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] assign_task.parsed team={team_id} deps={}", depends_on.len());
+        let task = ops::assign_task(
+            &config,
+            &team_id,
+            &title,
+            objective.as_deref(),
+            owner.as_deref(),
+            &depends_on,
+        )
+        .map_err(|e| log_err(&cid, "assign_task", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] assign_task.success task={}", task.id);
+        to_json(serde_json::json!({ "task": task }))
+    })
+}
+
+fn handle_claim_task(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] claim_task.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] claim_task.config_failed err={err}");
+        })?;
+        let team_id = require_str(&params, "teamId")?;
+        let task_id = require_str(&params, "taskId")?;
+        let member_id = require_str(&params, "memberId")?;
+        let claim_token = require_str(&params, "claimToken")?;
+        let outcome = ops::claim_task(&config, &team_id, &task_id, &member_id, &claim_token)
+            .map_err(|e| log_err(&cid, "claim_task", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] claim_task.success team={team_id} task={task_id}");
+        to_json(serde_json::json!({ "result": outcome }))
+    })
+}
+
+fn handle_message_member(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] message_member.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] message_member.config_failed err={err}");
+        })?;
+        let team_id = require_str(&params, "teamId")?;
+        let from = require_str(&params, "fromMemberId")?;
+        let to = opt_str(&params, "toMemberId");
+        let content = require_str(&params, "content")?;
+        let visibility = opt_str(&params, "visibility");
+        let event = ops::message_member(
+            &config,
+            &team_id,
+            &from,
+            to.as_deref(),
+            &content,
+            visibility.as_deref(),
+        )
+        .map_err(|e| log_err(&cid, "message_member", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] message_member.success team={team_id} sequence={}", event.sequence);
+        to_json(serde_json::json!({ "message": event }))
+    })
+}
+
+fn handle_list_messages(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list_messages.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list_messages.config_failed err={err}");
+        })?;
+        let team_id = require_str(&params, "teamId")?;
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|v| v as u32);
+        let messages = ops::list_messages(&config, &team_id, limit)
+            .map_err(|e| log_err(&cid, "list_messages", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] list_messages.success team={team_id} count={}", messages.len());
+        to_json(serde_json::json!({ "messages": messages }))
+    })
+}
+
+fn handle_close(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let cid = new_correlation_id();
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] close.entry");
+        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
+            log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] close.config_failed err={err}");
+        })?;
+        let team_id = require_str(&params, "teamId")?;
+        let summary = opt_str(&params, "summary");
+        let team = ops::close_team(&config, &team_id, summary.as_deref())
+            .map_err(|e| log_err(&cid, "close", e))?;
+        log::debug!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] close.success team={team_id}");
+        to_json(serde_json::json!({ "team": team }))
+    })
+}
+
+fn parse_members(params: &Map<String, Value>) -> Result<Vec<NewMember>, String> {
+    let raw = match params.get("members") {
+        Some(Value::Array(items)) => items,
+        Some(Value::Null) | None => return Ok(vec![]),
+        Some(_) => return Err("members must be an array".to_string()),
+    };
+    let mut members = Vec::with_capacity(raw.len());
+    for item in raw {
+        let name = item
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .ok_or_else(|| "each member requires a non-empty name".to_string())?;
+        let agent_id = item
+            .get("agentId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        members.push(NewMember {
+            name: name.to_string(),
+            agent_id,
+        });
+    }
+    Ok(members)
+}
+
+fn require_str(params: &Map<String, Value>, key: &str) -> Result<String, String> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("missing required param: {key}"))
+}
+
+fn opt_str(params: &Map<String, Value>, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn opt_str_array(params: &Map<String, Value>, key: &str) -> Vec<String> {
+    params
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn log_err(cid: &str, op: &str, err: anyhow::Error) -> String {
+    let s = err.to_string();
+    log::warn!(target: "agent_team_rpc", "[agent_team_rpc][{cid}] {op}.error err={s}");
+    s
+}
+
+fn to_json<T: serde::Serialize>(value: T) -> Result<Value, String> {
+    RpcOutcome::new(value, vec![]).into_cli_compatible_json()
+}
+
+fn new_correlation_id() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
+}
+
+fn required_str(name: &'static str, comment: &'static str) -> FieldSchema {
+    FieldSchema {
+        name,
+        ty: TypeSchema::String,
+        comment,
+        required: true,
+    }
+}
+
+fn optional_str(name: &'static str, comment: &'static str) -> FieldSchema {
+    FieldSchema {
+        name,
+        ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+        comment,
+        required: false,
+    }
+}
+
+fn optional_u64(name: &'static str, comment: &'static str) -> FieldSchema {
+    FieldSchema {
+        name,
+        ty: TypeSchema::Option(Box::new(TypeSchema::U64)),
+        comment,
+        required: false,
+    }
+}
+
+fn json_input(name: &'static str, comment: &'static str) -> FieldSchema {
+    FieldSchema {
+        name,
+        ty: TypeSchema::Json,
+        comment,
+        required: false,
+    }
+}
+
+fn json_output(name: &'static str, comment: &'static str) -> FieldSchema {
+    FieldSchema {
+        name,
+        ty: TypeSchema::Json,
+        comment,
+        required: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registered_controllers_match_schemas() {
+        let schemas = all_controller_schemas();
+        let registered = all_registered_controllers();
+        assert_eq!(schemas.len(), registered.len());
+        assert_eq!(schemas.len(), 8);
+        assert!(schemas.iter().all(|s| s.namespace == "agent_team"));
+        assert_eq!(schema_for("agent_team_claim_task").function, "claim_task");
+    }
+}

--- a/src/openhuman/agent_orchestration/agent_teams/types.rs
+++ b/src/openhuman/agent_orchestration/agent_teams/types.rs
@@ -1,0 +1,57 @@
+//! Aggregate + validation types for durable agent-team coordination (#3374).
+//!
+//! The durable row types ([`AgentTeam`], [`AgentTeamMember`], [`AgentTeamTask`],
+//! [`ClaimOutcome`]) live in `session_db::run_ledger`. This module adds the
+//! read-aggregate view returned by the controllers and the validation error
+//! surface used by `ops::assign_task`.
+
+use serde::Serialize;
+
+use crate::openhuman::session_db::run_ledger::{AgentTeam, AgentTeamMember, AgentTeamTask};
+
+/// A team plus its members and tasks — the shape returned by `get`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamView {
+    pub team: AgentTeam,
+    pub members: Vec<AgentTeamMember>,
+    pub tasks: Vec<AgentTeamTask>,
+}
+
+/// A validation / coordination problem surfaced by the agent-team ops.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind", content = "detail")]
+pub enum TeamError {
+    /// A member name collides with an existing member in the same team.
+    DuplicateMemberName { name: String },
+    /// A referenced member id is not part of the team.
+    UnknownMember { member_id: String },
+    /// A task declared itself as one of its own dependencies.
+    SelfDependency { task_id: String },
+    /// A dependency edge would introduce a cycle among the team's tasks.
+    CyclicDependency,
+    /// A dependency named a task id that does not exist in the team.
+    UnknownDependency { depends_on: String },
+}
+
+impl std::fmt::Display for TeamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TeamError::DuplicateMemberName { name } => {
+                write!(f, "duplicate member name: {name}")
+            }
+            TeamError::UnknownMember { member_id } => {
+                write!(f, "unknown member: {member_id}")
+            }
+            TeamError::SelfDependency { task_id } => {
+                write!(f, "task {task_id} cannot depend on itself")
+            }
+            TeamError::CyclicDependency => write!(f, "dependency cycle detected"),
+            TeamError::UnknownDependency { depends_on } => {
+                write!(f, "unknown dependency: {depends_on}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TeamError {}

--- a/src/openhuman/agent_orchestration/mod.rs
+++ b/src/openhuman/agent_orchestration/mod.rs
@@ -5,6 +5,7 @@
 //! [`crate::openhuman::agent::harness`] module remains responsible for prompt
 //! construction, tool filtering, and the actual sub-agent run loop.
 
+pub mod agent_teams;
 pub mod command_center;
 mod ops;
 pub mod tools;
@@ -14,6 +15,7 @@ pub mod workflow_runs;
 #[cfg(test)]
 mod ops_tests;
 
+pub use agent_teams::{all_agent_team_controller_schemas, all_agent_team_registered_controllers};
 pub use command_center::{
     all_command_center_controller_schemas, all_command_center_registered_controllers,
 };

--- a/src/openhuman/session_db/run_ledger/mod.rs
+++ b/src/openhuman/session_db/run_ledger/mod.rs
@@ -10,12 +10,18 @@ pub mod store;
 pub mod types;
 
 pub use ops::{
-    append_run_event, get_agent_run, get_workflow_run, list_agent_runs, list_recent_run_events,
-    list_workflow_runs, upsert_agent_run, upsert_run_telemetry, upsert_workflow_run,
+    append_run_event, claim_agent_team_task, get_agent_run, get_agent_team, get_agent_team_member,
+    get_agent_team_task, get_workflow_run, list_agent_runs, list_agent_team_members,
+    list_agent_team_tasks, list_agent_teams, list_recent_run_events, list_workflow_runs,
+    upsert_agent_run, upsert_agent_team, upsert_agent_team_member, upsert_agent_team_task,
+    upsert_run_telemetry, upsert_workflow_run,
 };
 pub use types::{
     AgentRun, AgentRunKind, AgentRunListRequest, AgentRunListResponse, AgentRunStatus,
-    AgentRunUpsert, RunEvent, RunEventAppend, RunEventListRequest, RunEventListResponse,
-    RunTelemetry, RunTelemetryUpsert, WorkflowRun, WorkflowRunListRequest, WorkflowRunListResponse,
-    WorkflowRunStatus, WorkflowRunUpsert,
+    AgentRunUpsert, AgentTeam, AgentTeamListRequest, AgentTeamListResponse, AgentTeamMember,
+    AgentTeamMemberStatus, AgentTeamMemberUpsert, AgentTeamStatus, AgentTeamTask,
+    AgentTeamTaskStatus, AgentTeamTaskUpsert, AgentTeamUpsert, ClaimOutcome, RunEvent,
+    RunEventAppend, RunEventListRequest, RunEventListResponse, RunTelemetry, RunTelemetryUpsert,
+    WorkflowRun, WorkflowRunListRequest, WorkflowRunListResponse, WorkflowRunStatus,
+    WorkflowRunUpsert,
 };

--- a/src/openhuman/session_db/run_ledger/ops.rs
+++ b/src/openhuman/session_db/run_ledger/ops.rs
@@ -7,9 +7,12 @@ use crate::openhuman::config::Config;
 
 use super::store::init_run_ledger_schema;
 use super::types::{
-    AgentRun, AgentRunListRequest, AgentRunListResponse, AgentRunStatus, AgentRunUpsert, RunEvent,
-    RunEventAppend, RunEventListRequest, RunEventListResponse, RunTelemetry, RunTelemetryUpsert,
-    WorkflowRun, WorkflowRunListRequest, WorkflowRunListResponse, WorkflowRunUpsert,
+    AgentRun, AgentRunListRequest, AgentRunListResponse, AgentRunStatus, AgentRunUpsert, AgentTeam,
+    AgentTeamListRequest, AgentTeamListResponse, AgentTeamMember, AgentTeamMemberStatus,
+    AgentTeamMemberUpsert, AgentTeamStatus, AgentTeamTask, AgentTeamTaskStatus,
+    AgentTeamTaskUpsert, AgentTeamUpsert, ClaimOutcome, RunEvent, RunEventAppend,
+    RunEventListRequest, RunEventListResponse, RunTelemetry, RunTelemetryUpsert, WorkflowRun,
+    WorkflowRunListRequest, WorkflowRunListResponse, WorkflowRunUpsert,
 };
 
 const LOG_PREFIX: &str = "[session_db:run_ledger]";
@@ -428,6 +431,516 @@ pub fn list_workflow_runs(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Agent-team coordination (issue #3374)
+// ---------------------------------------------------------------------------
+
+/// Insert or update a team row.
+pub fn upsert_agent_team(config: &Config, upsert: AgentTeamUpsert) -> Result<AgentTeam> {
+    let now = Utc::now();
+    let created_at = upsert.created_at.unwrap_or(now);
+    log::debug!(
+        "{LOG_PREFIX} upsert_agent_team.entry id={} lead={} status={}",
+        upsert.id,
+        upsert.lead_agent_id,
+        upsert.status.as_str()
+    );
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        conn.execute(
+            "INSERT INTO agent_teams (
+                id, parent_thread_id, lead_agent_id, status, summary,
+                created_at, updated_at, closed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(id) DO UPDATE SET
+                parent_thread_id = COALESCE(excluded.parent_thread_id, agent_teams.parent_thread_id),
+                lead_agent_id = excluded.lead_agent_id,
+                status = excluded.status,
+                summary = COALESCE(excluded.summary, agent_teams.summary),
+                updated_at = excluded.updated_at,
+                closed_at = COALESCE(excluded.closed_at, agent_teams.closed_at)",
+            params![
+                upsert.id,
+                upsert.parent_thread_id,
+                upsert.lead_agent_id,
+                upsert.status.as_str(),
+                upsert.summary,
+                created_at.to_rfc3339(),
+                now.to_rfc3339(),
+                upsert.closed_at.map(|dt| dt.to_rfc3339()),
+            ],
+        )
+        .context("upsert agent team")?;
+        Ok(())
+    })?;
+    let team = get_agent_team(config, &upsert.id)?.context("agent team missing after upsert")?;
+    log::debug!("{LOG_PREFIX} upsert_agent_team.exit id={}", team.id);
+    Ok(team)
+}
+
+/// Fetch a single team by id.
+pub fn get_agent_team(config: &Config, id: &str) -> Result<Option<AgentTeam>> {
+    log::debug!("{LOG_PREFIX} get_agent_team.entry id={id}");
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        let team = get_agent_team_inner(conn, id)?;
+        log::debug!(
+            "{LOG_PREFIX} get_agent_team.exit id={id} found={}",
+            team.is_some()
+        );
+        Ok(team)
+    })
+}
+
+/// List teams, most-recently-updated first, with optional thread/status filters.
+pub fn list_agent_teams(
+    config: &Config,
+    request: &AgentTeamListRequest,
+) -> Result<AgentTeamListResponse> {
+    log::debug!(
+        "{LOG_PREFIX} list_agent_teams.entry parent_thread={:?} status={:?} limit={:?} offset={:?}",
+        request.parent_thread_id,
+        request.status,
+        request.limit,
+        request.offset
+    );
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        let mut where_clauses = Vec::new();
+        let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(thread) = request
+            .parent_thread_id
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+        {
+            values.push(Box::new(thread.to_string()));
+            where_clauses.push(format!("parent_thread_id = ?{}", values.len()));
+        }
+        if let Some(status) = request.status.as_deref().filter(|s| !s.trim().is_empty()) {
+            values.push(Box::new(status.to_string()));
+            where_clauses.push(format!("status = ?{}", values.len()));
+        }
+
+        let where_sql = if where_clauses.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", where_clauses.join(" AND "))
+        };
+        let count_sql = format!("SELECT COUNT(*) FROM agent_teams {where_sql}");
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            values.iter().map(|v| v.as_ref()).collect();
+        let count = conn.query_row(&count_sql, params_ref.as_slice(), |row| {
+            row.get::<_, i64>(0)
+        })? as usize;
+
+        let limit = request.limit.unwrap_or(50).min(500) as i64;
+        // `offset` is `u64`; convert checked so a value > i64::MAX surfaces a
+        // clear error instead of wrapping negative and corrupting pagination.
+        let offset = i64::try_from(request.offset.unwrap_or(0))
+            .context("agent team list offset exceeds i64::MAX")?;
+        values.push(Box::new(limit));
+        let limit_idx = values.len();
+        values.push(Box::new(offset));
+        let offset_idx = values.len();
+
+        let query_sql = format!(
+            "SELECT id, parent_thread_id, lead_agent_id, status, summary,
+                    created_at, updated_at, closed_at
+             FROM agent_teams {where_sql}
+             ORDER BY updated_at DESC
+             LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+        );
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            values.iter().map(|v| v.as_ref()).collect();
+        let mut stmt = conn.prepare(&query_sql)?;
+        let rows = stmt.query_map(params_ref.as_slice(), map_agent_team_row)?;
+        let mut teams = Vec::new();
+        for row in rows {
+            teams.push(row?);
+        }
+        log::debug!(
+            "{LOG_PREFIX} list_agent_teams.exit count={count} returned={}",
+            teams.len()
+        );
+        Ok(AgentTeamListResponse { teams, count })
+    })
+}
+
+/// Insert or update a team member. `UNIQUE(team_id, name)` enforces unique names.
+pub fn upsert_agent_team_member(
+    config: &Config,
+    upsert: AgentTeamMemberUpsert,
+) -> Result<AgentTeamMember> {
+    let now = Utc::now();
+    let created_at = upsert.created_at.unwrap_or(now);
+    log::debug!(
+        "{LOG_PREFIX} upsert_agent_team_member.entry id={} team={} name={} status={}",
+        upsert.id,
+        upsert.team_id,
+        upsert.name,
+        upsert.member_status.as_str()
+    );
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        conn.execute(
+            "INSERT INTO agent_team_members (
+                id, team_id, name, agent_id, member_status,
+                current_task_id, worker_thread_id, run_id, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                agent_id = COALESCE(excluded.agent_id, agent_team_members.agent_id),
+                member_status = excluded.member_status,
+                current_task_id = COALESCE(excluded.current_task_id, agent_team_members.current_task_id),
+                worker_thread_id = COALESCE(excluded.worker_thread_id, agent_team_members.worker_thread_id),
+                run_id = COALESCE(excluded.run_id, agent_team_members.run_id),
+                updated_at = excluded.updated_at",
+            params![
+                upsert.id,
+                upsert.team_id,
+                upsert.name,
+                upsert.agent_id,
+                upsert.member_status.as_str(),
+                upsert.current_task_id,
+                upsert.worker_thread_id,
+                upsert.run_id,
+                created_at.to_rfc3339(),
+                now.to_rfc3339(),
+            ],
+        )
+        .context("upsert agent team member")?;
+        Ok(())
+    })?;
+    let member = get_agent_team_member(config, &upsert.id)?
+        .context("agent team member missing after upsert")?;
+    log::debug!(
+        "{LOG_PREFIX} upsert_agent_team_member.exit id={}",
+        member.id
+    );
+    Ok(member)
+}
+
+/// Fetch a single member by id.
+pub fn get_agent_team_member(config: &Config, id: &str) -> Result<Option<AgentTeamMember>> {
+    log::debug!("{LOG_PREFIX} get_agent_team_member.entry id={id}");
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        let member = get_agent_team_member_inner(conn, id)?;
+        log::debug!(
+            "{LOG_PREFIX} get_agent_team_member.exit id={id} found={}",
+            member.is_some()
+        );
+        Ok(member)
+    })
+}
+
+/// List all members of a team, by creation order.
+pub fn list_agent_team_members(config: &Config, team_id: &str) -> Result<Vec<AgentTeamMember>> {
+    log::debug!("{LOG_PREFIX} list_agent_team_members.entry team={team_id}");
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        let mut stmt = conn.prepare(
+            "SELECT id, team_id, name, agent_id, member_status,
+                    current_task_id, worker_thread_id, run_id, created_at, updated_at
+             FROM agent_team_members WHERE team_id = ?1
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![team_id], map_agent_team_member_row)?;
+        let mut members = Vec::new();
+        for row in rows {
+            members.push(row?);
+        }
+        log::debug!(
+            "{LOG_PREFIX} list_agent_team_members.exit team={team_id} count={}",
+            members.len()
+        );
+        Ok(members)
+    })
+}
+
+/// Insert or update a team task.
+pub fn upsert_agent_team_task(
+    config: &Config,
+    upsert: AgentTeamTaskUpsert,
+) -> Result<AgentTeamTask> {
+    let now = Utc::now();
+    let created_at = upsert.created_at.unwrap_or(now);
+    let depends_on_json =
+        serde_json::to_string(&upsert.depends_on).context("serialize task depends_on")?;
+    let evidence_json =
+        serde_json::to_string(&upsert.evidence).context("serialize task evidence")?;
+    let gate_status = upsert.gate_status.unwrap_or_else(|| "pending".to_string());
+    log::debug!(
+        "{LOG_PREFIX} upsert_agent_team_task.entry id={} team={} status={} deps={}",
+        upsert.id,
+        upsert.team_id,
+        upsert.status.as_str(),
+        upsert.depends_on.len()
+    );
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        conn.execute(
+            "INSERT INTO agent_team_tasks (
+                id, team_id, title, objective, status, owner_member_id,
+                claimed_by_member_id, claim_token, depends_on_json, gate_status,
+                gate_reason, evidence_json, source_run_id, order_index,
+                created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             ON CONFLICT(id) DO UPDATE SET
+                title = excluded.title,
+                objective = COALESCE(excluded.objective, agent_team_tasks.objective),
+                status = excluded.status,
+                owner_member_id = COALESCE(excluded.owner_member_id, agent_team_tasks.owner_member_id),
+                depends_on_json = excluded.depends_on_json,
+                gate_status = excluded.gate_status,
+                gate_reason = COALESCE(excluded.gate_reason, agent_team_tasks.gate_reason),
+                evidence_json = excluded.evidence_json,
+                source_run_id = COALESCE(excluded.source_run_id, agent_team_tasks.source_run_id),
+                order_index = excluded.order_index,
+                updated_at = excluded.updated_at",
+            params![
+                upsert.id,
+                upsert.team_id,
+                upsert.title,
+                upsert.objective,
+                upsert.status.as_str(),
+                upsert.owner_member_id,
+                depends_on_json,
+                gate_status,
+                upsert.gate_reason,
+                evidence_json,
+                upsert.source_run_id,
+                upsert.order_index,
+                created_at.to_rfc3339(),
+                now.to_rfc3339(),
+            ],
+        )
+        .context("upsert agent team task")?;
+        Ok(())
+    })?;
+    let task =
+        get_agent_team_task(config, &upsert.id)?.context("agent team task missing after upsert")?;
+    log::debug!("{LOG_PREFIX} upsert_agent_team_task.exit id={}", task.id);
+    Ok(task)
+}
+
+/// Fetch a single task by id.
+pub fn get_agent_team_task(config: &Config, id: &str) -> Result<Option<AgentTeamTask>> {
+    log::debug!("{LOG_PREFIX} get_agent_team_task.entry id={id}");
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        let task = get_agent_team_task_inner(conn, id)?;
+        log::debug!(
+            "{LOG_PREFIX} get_agent_team_task.exit id={id} found={}",
+            task.is_some()
+        );
+        Ok(task)
+    })
+}
+
+/// List all tasks of a team, by `order_index` then creation order.
+pub fn list_agent_team_tasks(config: &Config, team_id: &str) -> Result<Vec<AgentTeamTask>> {
+    log::debug!("{LOG_PREFIX} list_agent_team_tasks.entry team={team_id}");
+    crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+        let mut stmt = conn.prepare(
+            "SELECT id, team_id, title, objective, status, owner_member_id,
+                    claimed_by_member_id, claim_token, depends_on_json, gate_status,
+                    gate_reason, evidence_json, source_run_id, order_index,
+                    created_at, updated_at
+             FROM agent_team_tasks WHERE team_id = ?1
+             ORDER BY order_index ASC, created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![team_id], map_agent_team_task_row)?;
+        let mut tasks = Vec::new();
+        for row in rows {
+            tasks.push(row?);
+        }
+        log::debug!(
+            "{LOG_PREFIX} list_agent_team_tasks.exit team={team_id} count={}",
+            tasks.len()
+        );
+        Ok(tasks)
+    })
+}
+
+/// Atomically claim a task for a member.
+///
+/// All steps run inside a single `with_connection` transaction so that the
+/// dependency check and the compare-and-swap observe a consistent snapshot:
+/// 1. Resolve the task by `(id, team_id)`; absent → [`ClaimOutcome::UnknownTask`].
+/// 2. For every dependency id, look up its status; collect those not `done`
+///    into `unmet`. Non-empty → [`ClaimOutcome::Blocked`].
+/// 3. WHERE-guarded `UPDATE ... WHERE claimed_by_member_id IS NULL`: SQLite
+///    serializes writers, so exactly one concurrent claimer flips the row from
+///    unclaimed to claimed. `rows_affected == 0` → already taken
+///    ([`ClaimOutcome::AlreadyClaimed`]); otherwise re-fetch and return
+///    [`ClaimOutcome::Claimed`].
+pub fn claim_agent_team_task(
+    config: &Config,
+    team_id: &str,
+    task_id: &str,
+    member_id: &str,
+    claim_token: &str,
+) -> Result<ClaimOutcome> {
+    log::debug!(
+        "{LOG_PREFIX} claim_agent_team_task.entry team={team_id} task={task_id} member={member_id}"
+    );
+    let outcome = crate::openhuman::session_db::store::with_connection(config, |conn| {
+        init_run_ledger_schema(conn)?;
+
+        // 1. Resolve the task within this team.
+        let task = match get_agent_team_task_inner(conn, task_id)? {
+            Some(task) if task.team_id == team_id => task,
+            _ => {
+                log::debug!(
+                    "{LOG_PREFIX} claim_agent_team_task.unknown team={team_id} task={task_id}"
+                );
+                return Ok(ClaimOutcome::UnknownTask);
+            }
+        };
+
+        // 2. Dependency gate: every dep must be `done`.
+        let mut unmet = Vec::new();
+        for dep_id in &task.depends_on {
+            let dep_status: Option<String> = conn
+                .query_row(
+                    "SELECT status FROM agent_team_tasks WHERE id = ?1 AND team_id = ?2",
+                    params![dep_id, team_id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            let is_done = dep_status.as_deref() == Some(AgentTeamTaskStatus::Done.as_str());
+            if !is_done {
+                unmet.push(dep_id.clone());
+            }
+        }
+        if !unmet.is_empty() {
+            log::debug!(
+                "{LOG_PREFIX} claim_agent_team_task.blocked team={team_id} task={task_id} unmet={}",
+                unmet.len()
+            );
+            return Ok(ClaimOutcome::Blocked { unmet });
+        }
+
+        // 3. Compare-and-swap on the unclaimed guard.
+        let now = Utc::now();
+        let rows_affected = conn
+            .execute(
+                "UPDATE agent_team_tasks
+                 SET claimed_by_member_id = ?1, claim_token = ?2, status = 'in_progress', updated_at = ?3
+                 WHERE id = ?4 AND team_id = ?5 AND claimed_by_member_id IS NULL",
+                params![member_id, claim_token, now.to_rfc3339(), task_id, team_id],
+            )
+            .context("compare-and-swap claim agent team task")?;
+        if rows_affected == 0 {
+            log::debug!(
+                "{LOG_PREFIX} claim_agent_team_task.already_claimed team={team_id} task={task_id}"
+            );
+            return Ok(ClaimOutcome::AlreadyClaimed);
+        }
+
+        let claimed = get_agent_team_task_inner(conn, task_id)?
+            .context("claimed task missing after compare-and-swap")?;
+        Ok(ClaimOutcome::Claimed(Box::new(claimed)))
+    })?;
+    log::debug!(
+        "{LOG_PREFIX} claim_agent_team_task.exit team={team_id} task={task_id} outcome={}",
+        match &outcome {
+            ClaimOutcome::Claimed(_) => "claimed",
+            ClaimOutcome::AlreadyClaimed => "already_claimed",
+            ClaimOutcome::Blocked { .. } => "blocked",
+            ClaimOutcome::UnknownTask => "unknown",
+        }
+    );
+    Ok(outcome)
+}
+
+fn get_agent_team_inner(conn: &Connection, id: &str) -> Result<Option<AgentTeam>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, parent_thread_id, lead_agent_id, status, summary,
+                created_at, updated_at, closed_at
+         FROM agent_teams WHERE id = ?1",
+    )?;
+    stmt.query_row(params![id], map_agent_team_row)
+        .optional()
+        .map_err(Into::into)
+}
+
+fn get_agent_team_member_inner(conn: &Connection, id: &str) -> Result<Option<AgentTeamMember>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, team_id, name, agent_id, member_status,
+                current_task_id, worker_thread_id, run_id, created_at, updated_at
+         FROM agent_team_members WHERE id = ?1",
+    )?;
+    stmt.query_row(params![id], map_agent_team_member_row)
+        .optional()
+        .map_err(Into::into)
+}
+
+fn get_agent_team_task_inner(conn: &Connection, id: &str) -> Result<Option<AgentTeamTask>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, team_id, title, objective, status, owner_member_id,
+                claimed_by_member_id, claim_token, depends_on_json, gate_status,
+                gate_reason, evidence_json, source_run_id, order_index,
+                created_at, updated_at
+         FROM agent_team_tasks WHERE id = ?1",
+    )?;
+    stmt.query_row(params![id], map_agent_team_task_row)
+        .optional()
+        .map_err(Into::into)
+}
+
+fn map_agent_team_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentTeam> {
+    Ok(AgentTeam {
+        id: row.get(0)?,
+        parent_thread_id: row.get(1)?,
+        lead_agent_id: row.get(2)?,
+        status: AgentTeamStatus::parse(&row.get::<_, String>(3)?),
+        summary: row.get(4)?,
+        created_at: parse_rfc3339(&row.get::<_, String>(5)?)?,
+        updated_at: parse_rfc3339(&row.get::<_, String>(6)?)?,
+        closed_at: parse_rfc3339_opt(row.get(7)?)?,
+    })
+}
+
+fn map_agent_team_member_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentTeamMember> {
+    Ok(AgentTeamMember {
+        id: row.get(0)?,
+        team_id: row.get(1)?,
+        name: row.get(2)?,
+        agent_id: row.get(3)?,
+        member_status: AgentTeamMemberStatus::parse(&row.get::<_, String>(4)?),
+        current_task_id: row.get(5)?,
+        worker_thread_id: row.get(6)?,
+        run_id: row.get(7)?,
+        created_at: parse_rfc3339(&row.get::<_, String>(8)?)?,
+        updated_at: parse_rfc3339(&row.get::<_, String>(9)?)?,
+    })
+}
+
+fn map_agent_team_task_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AgentTeamTask> {
+    Ok(AgentTeamTask {
+        id: row.get(0)?,
+        team_id: row.get(1)?,
+        title: row.get(2)?,
+        objective: row.get(3)?,
+        status: AgentTeamTaskStatus::parse(&row.get::<_, String>(4)?),
+        owner_member_id: row.get(5)?,
+        claimed_by_member_id: row.get(6)?,
+        claim_token: row.get(7)?,
+        depends_on: serde_json::from_str(&row.get::<_, String>(8)?).unwrap_or_default(),
+        gate_status: row.get(9)?,
+        gate_reason: row.get(10)?,
+        evidence: serde_json::from_str(&row.get::<_, String>(11)?).unwrap_or_default(),
+        source_run_id: row.get(12)?,
+        order_index: row.get(13)?,
+        created_at: parse_rfc3339(&row.get::<_, String>(14)?)?,
+        updated_at: parse_rfc3339(&row.get::<_, String>(15)?)?,
+    })
+}
+
 fn get_agent_run_inner(conn: &Connection, id: &str) -> Result<Option<AgentRun>> {
     let mut stmt = conn.prepare(
         "SELECT id, kind, parent_run_id, parent_thread_id, agent_id, status,
@@ -640,5 +1153,148 @@ mod tests {
         .unwrap();
         assert_eq!(list.count, 1);
         assert_eq!(list.runs[0].worker_thread_id.as_deref(), Some("worker-1"));
+    }
+
+    fn seed_team(config: &Config, team_id: &str) {
+        upsert_agent_team(
+            config,
+            AgentTeamUpsert {
+                id: team_id.into(),
+                parent_thread_id: Some("thread-team".into()),
+                lead_agent_id: "lead".into(),
+                status: AgentTeamStatus::Active,
+                summary: None,
+                created_at: None,
+                closed_at: None,
+            },
+        )
+        .unwrap();
+    }
+
+    fn seed_task(config: &Config, team_id: &str, task_id: &str, depends_on: Vec<String>) {
+        upsert_agent_team_task(
+            config,
+            AgentTeamTaskUpsert {
+                id: task_id.into(),
+                team_id: team_id.into(),
+                title: format!("task {task_id}"),
+                objective: None,
+                status: AgentTeamTaskStatus::Todo,
+                owner_member_id: None,
+                depends_on,
+                gate_status: None,
+                gate_reason: None,
+                evidence: vec![],
+                source_run_id: None,
+                order_index: 0,
+                created_at: None,
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn claim_is_atomic_first_wins_then_already_claimed() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        seed_team(&config, "team-1");
+        seed_task(&config, "team-1", "task-a", vec![]);
+
+        let first = claim_agent_team_task(&config, "team-1", "task-a", "m1", "tok-1").unwrap();
+        match first {
+            ClaimOutcome::Claimed(task) => {
+                assert_eq!(task.claimed_by_member_id.as_deref(), Some("m1"));
+                assert_eq!(task.status, AgentTeamTaskStatus::InProgress);
+            }
+            other => panic!("expected Claimed, got {other:?}"),
+        }
+
+        let second = claim_agent_team_task(&config, "team-1", "task-a", "m2", "tok-2").unwrap();
+        assert_eq!(second, ClaimOutcome::AlreadyClaimed);
+    }
+
+    #[test]
+    fn claim_unknown_task_returns_unknown() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        seed_team(&config, "team-1");
+        let outcome = claim_agent_team_task(&config, "team-1", "ghost", "m1", "tok").unwrap();
+        assert_eq!(outcome, ClaimOutcome::UnknownTask);
+    }
+
+    #[test]
+    fn claim_blocked_until_dependency_done() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        seed_team(&config, "team-1");
+        seed_task(&config, "team-1", "task-a", vec![]);
+        seed_task(&config, "team-1", "task-b", vec!["task-a".into()]);
+
+        // B is blocked while A is still todo.
+        let blocked = claim_agent_team_task(&config, "team-1", "task-b", "m1", "tok").unwrap();
+        assert_eq!(
+            blocked,
+            ClaimOutcome::Blocked {
+                unmet: vec!["task-a".into()]
+            }
+        );
+
+        // Mark A done, then B claims fine.
+        upsert_agent_team_task(
+            &config,
+            AgentTeamTaskUpsert {
+                id: "task-a".into(),
+                team_id: "team-1".into(),
+                title: "task task-a".into(),
+                objective: None,
+                status: AgentTeamTaskStatus::Done,
+                owner_member_id: None,
+                depends_on: vec![],
+                gate_status: None,
+                gate_reason: None,
+                evidence: vec![],
+                source_run_id: None,
+                order_index: 0,
+                created_at: None,
+            },
+        )
+        .unwrap();
+
+        let ok = claim_agent_team_task(&config, "team-1", "task-b", "m1", "tok").unwrap();
+        assert!(matches!(ok, ClaimOutcome::Claimed(_)));
+    }
+
+    #[test]
+    fn team_members_and_tasks_list_back() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        seed_team(&config, "team-1");
+        upsert_agent_team_member(
+            &config,
+            AgentTeamMemberUpsert {
+                id: "mem-1".into(),
+                team_id: "team-1".into(),
+                name: "alice".into(),
+                agent_id: Some("researcher".into()),
+                member_status: AgentTeamMemberStatus::Active,
+                current_task_id: None,
+                worker_thread_id: None,
+                run_id: None,
+                created_at: None,
+            },
+        )
+        .unwrap();
+        seed_task(&config, "team-1", "task-a", vec![]);
+
+        let members = list_agent_team_members(&config, "team-1").unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].name, "alice");
+
+        let tasks = list_agent_team_tasks(&config, "team-1").unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, "task-a");
+
+        let teams = list_agent_teams(&config, &AgentTeamListRequest::default()).unwrap();
+        assert_eq!(teams.count, 1);
     }
 }

--- a/src/openhuman/session_db/run_ledger/store.rs
+++ b/src/openhuman/session_db/run_ledger/store.rs
@@ -69,7 +69,57 @@ pub(crate) fn init_run_ledger_schema(conn: &Connection) -> Result<()> {
             provider            TEXT,
             error               TEXT,
             updated_at          TEXT NOT NULL
-        );",
+        );
+
+        CREATE TABLE IF NOT EXISTS agent_teams (
+            id                 TEXT PRIMARY KEY,
+            parent_thread_id   TEXT,
+            lead_agent_id      TEXT NOT NULL,
+            status             TEXT NOT NULL,
+            summary            TEXT,
+            created_at         TEXT NOT NULL,
+            updated_at         TEXT NOT NULL,
+            closed_at          TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_teams_thread ON agent_teams(parent_thread_id);
+        CREATE INDEX IF NOT EXISTS idx_agent_teams_status ON agent_teams(status);
+
+        CREATE TABLE IF NOT EXISTS agent_team_members (
+            id                 TEXT PRIMARY KEY,
+            team_id            TEXT NOT NULL,
+            name               TEXT NOT NULL,
+            agent_id           TEXT,
+            member_status      TEXT NOT NULL,
+            current_task_id    TEXT,
+            worker_thread_id   TEXT,
+            run_id             TEXT,
+            created_at         TEXT NOT NULL,
+            updated_at         TEXT NOT NULL,
+            UNIQUE(team_id, name)
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_team_members_team ON agent_team_members(team_id);
+
+        CREATE TABLE IF NOT EXISTS agent_team_tasks (
+            id                  TEXT PRIMARY KEY,
+            team_id             TEXT NOT NULL,
+            title               TEXT NOT NULL,
+            objective           TEXT,
+            status              TEXT NOT NULL,
+            owner_member_id     TEXT,
+            claimed_by_member_id TEXT,
+            claim_token         TEXT,
+            depends_on_json     TEXT NOT NULL DEFAULT '[]',
+            gate_status         TEXT NOT NULL DEFAULT 'pending',
+            gate_reason         TEXT,
+            evidence_json       TEXT NOT NULL DEFAULT '[]',
+            source_run_id       TEXT,
+            order_index         INTEGER NOT NULL DEFAULT 0,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_team_tasks_team ON agent_team_tasks(team_id);
+        CREATE INDEX IF NOT EXISTS idx_agent_team_tasks_status ON agent_team_tasks(status);
+        CREATE INDEX IF NOT EXISTS idx_agent_team_tasks_claimed ON agent_team_tasks(claimed_by_member_id);",
     )
     .context("failed to initialize run ledger schema")
 }

--- a/src/openhuman/session_db/run_ledger/types.rs
+++ b/src/openhuman/session_db/run_ledger/types.rs
@@ -303,3 +303,224 @@ pub struct RunEventListResponse {
     pub events: Vec<RunEvent>,
     pub count: usize,
 }
+
+// ---------------------------------------------------------------------------
+// Agent-team coordination (issue #3374)
+// ---------------------------------------------------------------------------
+
+/// Lifecycle of an agent team.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTeamStatus {
+    Active,
+    Closed,
+}
+
+impl AgentTeamStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Closed => "closed",
+        }
+    }
+
+    /// Parse a stored status string (named `parse`, not `from_str`, to match the
+    /// run-ledger status-enum convention and avoid the `FromStr` clippy lint).
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "closed" => Self::Closed,
+            _ => Self::Active,
+        }
+    }
+}
+
+/// Lifecycle of a single team member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTeamMemberStatus {
+    Pending,
+    Active,
+    Idle,
+    Stopped,
+}
+
+impl AgentTeamMemberStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Active => "active",
+            Self::Idle => "idle",
+            Self::Stopped => "stopped",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "active" => Self::Active,
+            "idle" => Self::Idle,
+            "stopped" => Self::Stopped,
+            _ => Self::Pending,
+        }
+    }
+}
+
+/// Lifecycle of a coordination task within a team.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTeamTaskStatus {
+    Todo,
+    Ready,
+    InProgress,
+    Blocked,
+    Done,
+}
+
+impl AgentTeamTaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Todo => "todo",
+            Self::Ready => "ready",
+            Self::InProgress => "in_progress",
+            Self::Blocked => "blocked",
+            Self::Done => "done",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Self {
+        match raw {
+            "ready" => Self::Ready,
+            "in_progress" => Self::InProgress,
+            "blocked" => Self::Blocked,
+            "done" => Self::Done,
+            _ => Self::Todo,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTeam {
+    pub id: String,
+    pub parent_thread_id: Option<String>,
+    pub lead_agent_id: String,
+    pub status: AgentTeamStatus,
+    pub summary: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub closed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentTeamUpsert {
+    pub id: String,
+    pub parent_thread_id: Option<String>,
+    pub lead_agent_id: String,
+    pub status: AgentTeamStatus,
+    pub summary: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub closed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTeamMember {
+    pub id: String,
+    pub team_id: String,
+    pub name: String,
+    pub agent_id: Option<String>,
+    pub member_status: AgentTeamMemberStatus,
+    pub current_task_id: Option<String>,
+    pub worker_thread_id: Option<String>,
+    pub run_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentTeamMemberUpsert {
+    pub id: String,
+    pub team_id: String,
+    pub name: String,
+    pub agent_id: Option<String>,
+    pub member_status: AgentTeamMemberStatus,
+    pub current_task_id: Option<String>,
+    pub worker_thread_id: Option<String>,
+    pub run_id: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTeamTask {
+    pub id: String,
+    pub team_id: String,
+    pub title: String,
+    pub objective: Option<String>,
+    pub status: AgentTeamTaskStatus,
+    pub owner_member_id: Option<String>,
+    pub claimed_by_member_id: Option<String>,
+    pub claim_token: Option<String>,
+    pub depends_on: Vec<String>,
+    pub gate_status: String,
+    pub gate_reason: Option<String>,
+    pub evidence: Vec<String>,
+    pub source_run_id: Option<String>,
+    pub order_index: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentTeamTaskUpsert {
+    pub id: String,
+    pub team_id: String,
+    pub title: String,
+    pub objective: Option<String>,
+    pub status: AgentTeamTaskStatus,
+    pub owner_member_id: Option<String>,
+    pub depends_on: Vec<String>,
+    pub gate_status: Option<String>,
+    pub gate_reason: Option<String>,
+    pub evidence: Vec<String>,
+    pub source_run_id: Option<String>,
+    pub order_index: i64,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTeamListRequest {
+    #[serde(default)]
+    pub parent_thread_id: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    /// `u64` to match the `TypeSchema::U64` the controller advertises (the RPC
+    /// scalar-coercion layer only handles `U64`). Capped at 500 in
+    /// `list_agent_teams`.
+    #[serde(default)]
+    pub limit: Option<u64>,
+    #[serde(default)]
+    pub offset: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTeamListResponse {
+    pub teams: Vec<AgentTeam>,
+    pub count: usize,
+}
+
+/// Outcome of an atomic claim attempt on a team task.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ClaimOutcome {
+    /// The claim succeeded; carries the freshly-claimed task. Boxed to keep the
+    /// enum small (the task payload dwarfs the other variants).
+    Claimed(Box<AgentTeamTask>),
+    /// Another member already holds the claim.
+    AlreadyClaimed,
+    /// One or more dependency tasks are not yet `done`.
+    Blocked { unmet: Vec<String> },
+    /// No task matched the given team + task id.
+    UnknownTask,
+}

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -3196,6 +3196,252 @@ async fn json_rpc_workflow_run_definitions_and_runs_roundtrip() {
 }
 
 #[tokio::test]
+async fn json_rpc_agent_team_coordination_roundtrip() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_url_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+    let _api_url_guard = EnvVarGuard::unset("OPENHUMAN_API_URL");
+
+    let (api_addr, api_join) = serve_on_ephemeral(mock_upstream_router()).await;
+    let api_origin = format!("http://{api_addr}");
+    write_min_config(openhuman_home.as_path(), &api_origin);
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{rpc_addr}");
+
+    let config = openhuman_core::openhuman::config::Config::load_or_init()
+        .await
+        .expect("load config");
+
+    // Create a team with two members.
+    let created = post_json_rpc(
+        &rpc_base,
+        9341,
+        "openhuman.agent_team_create",
+        json!({
+            "leadAgentId": "lead",
+            "parentThreadId": "thread-team-e2e",
+            "summary": "ship feature",
+            "members": [
+                { "name": "alice", "agentId": "researcher" },
+                { "name": "bob", "agentId": "code_executor" }
+            ]
+        }),
+    )
+    .await;
+    let created_outer = assert_no_jsonrpc_error(&created, "agent_team_create");
+    let team_id = created_outer
+        .get("team")
+        .and_then(|t| t.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .expect("team id")
+        .to_string();
+    let members = created_outer
+        .get("members")
+        .and_then(serde_json::Value::as_array)
+        .expect("members array");
+    assert_eq!(members.len(), 2);
+    let alice_id = members[0]
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .expect("alice id")
+        .to_string();
+    let bob_id = members[1]
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .expect("bob id")
+        .to_string();
+
+    // Assign task A, then task B that depends on A.
+    let assign_a = post_json_rpc(
+        &rpc_base,
+        9342,
+        "openhuman.agent_team_assign_task",
+        json!({ "teamId": team_id, "title": "Task A", "dependsOn": [] }),
+    )
+    .await;
+    let assign_a_outer = assert_no_jsonrpc_error(&assign_a, "agent_team_assign_task A");
+    let task_a_id = assign_a_outer
+        .get("task")
+        .and_then(|t| t.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .expect("task A id")
+        .to_string();
+
+    let assign_b = post_json_rpc(
+        &rpc_base,
+        9343,
+        "openhuman.agent_team_assign_task",
+        json!({ "teamId": team_id, "title": "Task B", "dependsOn": [task_a_id.clone()] }),
+    )
+    .await;
+    let assign_b_outer = assert_no_jsonrpc_error(&assign_b, "agent_team_assign_task B");
+    let task_b_id = assign_b_outer
+        .get("task")
+        .and_then(|t| t.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .expect("task B id")
+        .to_string();
+
+    // Claim B while A is still todo → blocked on A.
+    let claim_b_blocked = post_json_rpc(
+        &rpc_base,
+        9344,
+        "openhuman.agent_team_claim_task",
+        json!({
+            "teamId": team_id,
+            "taskId": task_b_id,
+            "memberId": bob_id,
+            "claimToken": "tok-b"
+        }),
+    )
+    .await;
+    let claim_b_blocked_outer =
+        assert_no_jsonrpc_error(&claim_b_blocked, "agent_team_claim_task B blocked");
+    assert_eq!(
+        claim_b_blocked_outer
+            .get("result")
+            .and_then(|r| r.get("kind"))
+            .and_then(serde_json::Value::as_str),
+        Some("blocked")
+    );
+
+    // Claim A → ok.
+    let claim_a = post_json_rpc(
+        &rpc_base,
+        9345,
+        "openhuman.agent_team_claim_task",
+        json!({
+            "teamId": team_id,
+            "taskId": task_a_id,
+            "memberId": alice_id,
+            "claimToken": "tok-a"
+        }),
+    )
+    .await;
+    let claim_a_outer = assert_no_jsonrpc_error(&claim_a, "agent_team_claim_task A");
+    assert_eq!(
+        claim_a_outer
+            .get("result")
+            .and_then(|r| r.get("kind"))
+            .and_then(serde_json::Value::as_str),
+        Some("claimed")
+    );
+
+    // Mark A done directly via the run ledger, then B claims fine.
+    let task_a =
+        openhuman_core::openhuman::session_db::run_ledger::get_agent_team_task(&config, &task_a_id)
+            .expect("get task A")
+            .expect("task A present");
+    openhuman_core::openhuman::session_db::run_ledger::upsert_agent_team_task(
+        &config,
+        openhuman_core::openhuman::session_db::run_ledger::AgentTeamTaskUpsert {
+            id: task_a.id.clone(),
+            team_id: task_a.team_id.clone(),
+            title: task_a.title.clone(),
+            objective: task_a.objective.clone(),
+            status: openhuman_core::openhuman::session_db::run_ledger::AgentTeamTaskStatus::Done,
+            owner_member_id: task_a.owner_member_id.clone(),
+            depends_on: task_a.depends_on.clone(),
+            gate_status: Some(task_a.gate_status.clone()),
+            gate_reason: task_a.gate_reason.clone(),
+            evidence: task_a.evidence.clone(),
+            source_run_id: task_a.source_run_id.clone(),
+            order_index: task_a.order_index,
+            created_at: Some(task_a.created_at),
+        },
+    )
+    .expect("mark A done");
+
+    let claim_b_ok = post_json_rpc(
+        &rpc_base,
+        9346,
+        "openhuman.agent_team_claim_task",
+        json!({
+            "teamId": team_id,
+            "taskId": task_b_id,
+            "memberId": bob_id,
+            "claimToken": "tok-b2"
+        }),
+    )
+    .await;
+    let claim_b_ok_outer = assert_no_jsonrpc_error(&claim_b_ok, "agent_team_claim_task B ok");
+    assert_eq!(
+        claim_b_ok_outer
+            .get("result")
+            .and_then(|r| r.get("kind"))
+            .and_then(serde_json::Value::as_str),
+        Some("claimed")
+    );
+
+    // Message bob from alice, then list messages.
+    let message = post_json_rpc(
+        &rpc_base,
+        9347,
+        "openhuman.agent_team_message_member",
+        json!({
+            "teamId": team_id,
+            "fromMemberId": alice_id,
+            "toMemberId": bob_id,
+            "content": "task A done, you are unblocked"
+        }),
+    )
+    .await;
+    assert_no_jsonrpc_error(&message, "agent_team_message_member");
+
+    let messages = post_json_rpc(
+        &rpc_base,
+        9348,
+        "openhuman.agent_team_list_messages",
+        json!({ "teamId": team_id }),
+    )
+    .await;
+    let messages_outer = assert_no_jsonrpc_error(&messages, "agent_team_list_messages");
+    assert_eq!(
+        messages_outer
+            .get("messages")
+            .and_then(serde_json::Value::as_array)
+            .map(|m| m.len()),
+        Some(1)
+    );
+
+    // Get the team — 2 members, 2 tasks.
+    let get = post_json_rpc(
+        &rpc_base,
+        9349,
+        "openhuman.agent_team_get",
+        json!({ "teamId": team_id }),
+    )
+    .await;
+    let get_outer = assert_no_jsonrpc_error(&get, "agent_team_get");
+    assert_eq!(
+        get_outer
+            .get("team")
+            .and_then(|t| t.get("members"))
+            .and_then(serde_json::Value::as_array)
+            .map(|m| m.len()),
+        Some(2)
+    );
+    assert_eq!(
+        get_outer
+            .get("team")
+            .and_then(|t| t.get("tasks"))
+            .and_then(serde_json::Value::as_array)
+            .map(|t| t.len()),
+        Some(2)
+    );
+
+    api_join.abort();
+    rpc_join.abort();
+}
+
+#[tokio::test]
 async fn json_rpc_task_board_brief_roundtrips_across_todos_and_threads_rpc() {
     let _env_lock = json_rpc_e2e_env_lock();
     let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- First PR of the #3374 agent-team slice: a **durable team/member/task model** + **8 read/write JSON-RPC controllers** under the `agent_team` namespace, built on the existing `session_db::run_ledger` spine (no new persistence subsystem, no parallel task UI).
- **Race-safe task claiming** via a transactional compare-and-swap, and **dependency-aware** claiming (a task can only be claimed once all `depends_on` tasks are `done`).
- **Teammate messaging** reuses the existing `run_events` append-only timeline (event type `team_message`) — no new message table.
- Mirrors the just-merged `command_center` (#3497) and `workflow_runs` (#3500) module shape and durable-table conventions.
- No live agent execution and no UI in this PR — those are the follow-ups (see Related).

## Problem

`#3374` asks for an agent-team coordination model (lead + named teammates, shared tasks with ownership/dependencies/claiming, direct messaging, gates). The codebase had the *direction* but not the substance: `AgentRunKind::TeamMember` was reserved-but-unused, `AgentOrchestrationSession` is in-memory dead code, and the per-thread JSON task board (`TaskBoardCard`/`TaskRun`) cannot satisfy the issue's hard **race-safe claim** + **dependency-aware** requirements (no cross-member atomicity, no queryable dependency graph). A durable, queryable spine is required.

## Solution

- **Three durable tables** in `run_ledger` (`agent_teams`, `agent_team_members`, `agent_team_tasks`), mirroring the `workflow_runs` DDL style (TEXT PK, `*_json` columns, RFC3339 timestamps, indices; `UNIQUE(team_id, name)` on members).
- **`claim_agent_team_task`** — the centerpiece — runs inside one connection: resolve task → check every `depends_on` is `done` (else `Blocked{unmet}`) → atomic CAS `UPDATE … WHERE id=? AND team_id=? AND claimed_by_member_id IS NULL`; `rows_affected == 0` ⇒ `AlreadyClaimed`. SQLite serializes writers, so exactly one concurrent claimer wins the row.
- **Domain module** `agent_orchestration/agent_teams/` with 8 controllers: `create / list / get / assign_task / claim_task / message_member / list_messages / close`. `assign_task` validates dependencies (self-dependency, unknown id, and cycles via the same Kahn's-algorithm check used in `workflow_runs`).
- **Messaging** via `run_events` (`append_run_event`/`list_recent_run_events`, `run_id = team_id`).
- **Deferred to follow-ups** (kept strictly out of this PR): live teammate-session spawning, `shutdown_member`, quality-gate *enforcement* at completion (the `gate_status` field is stored but not yet evaluated), and the team-aware `TaskKanbanBoard` UI.
- Verified live: booted `openhuman-core` and exercised all 8 RPCs end-to-end (create → assign A → assign B dependsOn[A] → claim B = `blocked` → claim A = `claimed` → re-claim A = `alreadyClaimed` → message → list → get).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — 10 Rust unit tests (atomic claim race, dependency-unblock, self/cycle/unknown-dependency rejection, message ordering) + 1 JSON-RPC e2e roundtrip.
- [x] **Diff coverage ≥ 80%** — pure-logic module with direct unit + e2e coverage; verified by the Coverage Gate CI on changed lines.
- [x] N/A: no user-facing feature rows yet — coverage matrix tracks product surfaces; the UI lands in the follow-up PR, so no matrix row changes here.
- [x] N/A: no matrix feature IDs apply to this backend-only slice (see above).
- [x] No new external network dependencies introduced — backend-only, sqlite + existing config; no network calls.
- [x] N/A: not a release-cut surface — backend RPC only, no shipped UI/flow touched.
- [x] N/A: PR1 of 3 — `#3374` intentionally stays open until the UI + execution-engine PRs land; referenced (not closed) in Related.

## Impact

- **Platform:** desktop/CLI core only (Rust). No frontend, no mobile/web surface in this PR.
- **Migration:** additive `CREATE TABLE IF NOT EXISTS` only — no existing schema touched, safe on existing `session.db`.
- **Security/perf:** new RPCs are local sqlite reads/writes; claiming is a single transactional statement. No new external dependencies. Claim trusts the caller-supplied `member_id` (lead-orchestrated); caller-is-member authorization is noted as future hardening.

## Related

- Part of: #3374 (PR1 of 3 — does not close it)
- Parent epic: #3370
- Follow-up PR(s)/TODOs: PR2 team-aware `TaskKanbanBoard` UI; PR3 live teammate execution + quality-gate enforcement + `shutdown_member`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/3374-agent-teams`
- Commit SHA: `c1cd8339093ff8cc9415640995bb70ad07b7e99e`

### Validation Run

- [x] N/A: `format:check` — no frontend changed (Rust-only PR).
- [x] N/A: `typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test --lib openhuman::agent_orchestration::agent_teams` (5), `… session_db::run_ledger` (5), `cargo test --test json_rpc_e2e json_rpc_agent_team` (1) — all green.
- [x] Rust fmt/check: `cargo fmt --check` clean, `cargo check --lib` clean, `cargo clippy --lib` no new findings.
- [x] N/A: Tauri fmt/check — `app/src-tauri` not touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: adds the `openhuman.agent_team_*` JSON-RPC surface (durable team coordination); no existing behavior altered.
- User-visible effect: none yet — backend-only; user-facing surface arrives with the PR2 UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable agent-team coordination with persistent storage: create teams with members, assign dependency-aware tasks (with cycle validation), claim tasks atomically, and exchange messages between teammates.
  * Task claiming blocks on unmet dependencies; supports sequential message listing.

* **Tests**
  * Added end-to-end test validating team operations, task assignment, dependency blocking, atomic claiming, and messaging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->