### PR TITLE
fix(inference): tolerate both reasoning and reasoning_content keys (#3547)

### DIFF
--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -2196,6 +2196,36 @@ fn reasoning_alias_captured_in_stream_delta() {
     );
 }
 
+/// Regression for Sentry TAURI-RUST-A5N: a provider that emits BOTH `reasoning`
+/// and `reasoning_content` in the same message object must not fail with
+/// `duplicate field \`reasoning_content\``. Both keys deserialize and fold into
+/// the canonical field, which wins when both are present.
+#[test]
+fn reasoning_and_reasoning_content_both_present_does_not_error() {
+    let json = r#"{"choices":[{"message":{"content":null,"reasoning":"alias cot","reasoning_content":"canonical cot"}}]}"#;
+    let resp: ApiChatResponse = serde_json::from_str(json)
+        .expect("both reasoning keys must parse without a duplicate-field error");
+    assert_eq!(
+        resp.choices[0].message.reasoning_content.as_deref(),
+        Some("canonical cot"),
+        "canonical reasoning_content wins when both keys are present"
+    );
+}
+
+/// Same regression on the streaming delta path (TAURI-RUST-A5N also hits the
+/// native stream parser at `compatible_stream_native.rs`).
+#[test]
+fn reasoning_and_reasoning_content_both_present_in_stream_delta_does_not_error() {
+    let json = r#"{"choices":[{"delta":{"reasoning":"alias cot","reasoning_content":"canonical cot"},"finish_reason":null}]}"#;
+    let chunk: StreamChunkResponse = serde_json::from_str(json)
+        .expect("both reasoning keys must parse without a duplicate-field error");
+    assert_eq!(
+        chunk.choices[0].delta.reasoning_content.as_deref(),
+        Some("canonical cot"),
+        "canonical reasoning_content wins when both keys are present"
+    );
+}
+
 /// End-to-end: a tool-call turn whose reasoning arrived under the `reasoning`
 /// alias must still be surfaced by `parse_native_response` so the agent loop
 /// can replay it on the follow-up request (the issue #3094 failure path).

--- a/src/openhuman/inference/provider/compatible_types.rs
+++ b/src/openhuman/inference/provider/compatible_types.rs
@@ -4,7 +4,7 @@
 //! as appropriate). External code only sees the public API on
 //! [`super::OpenAiCompatibleProvider`].
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 // ── Request bodies ────────────────────────────────────────────────────────────
 
@@ -316,23 +316,56 @@ pub(crate) struct OpenHumanBilling {
     pub(crate) charged_amount_usd: f64,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct ResponseMessage {
-    #[serde(default)]
     pub(crate) content: Option<String>,
     /// Reasoning/thinking models may return their chain-of-thought in a
     /// dedicated field instead of (or alongside) `content`. DeepSeek, Qwen3 and
     /// GLM-4 name it `reasoning_content`; OpenRouter and vLLM/SGLang-backed
-    /// OpenAI-compatible proxies emit it as `reasoning`. Accept both so the CoT
-    /// is captured regardless of the (third-party) provider's field name — it
+    /// OpenAI-compatible proxies emit it as `reasoning`. Both names fold into
+    /// this single field (see the manual `Deserialize` impl below) — the CoT
     /// must be echoed back verbatim on tool-call turns or thinking models reject
     /// the follow-up request with HTTP 400.
-    #[serde(default, alias = "reasoning")]
     pub(crate) reasoning_content: Option<String>,
-    #[serde(default)]
     pub(crate) tool_calls: Option<Vec<ToolCall>>,
-    #[serde(default)]
     pub(crate) function_call: Option<Function>,
+}
+
+// Manual `Deserialize` so that `reasoning` and `reasoning_content` are accepted
+// as DISTINCT wire keys and then folded into the single canonical field.
+//
+// A serde `alias` maps both names onto one field slot, which makes a provider
+// that emits BOTH keys in the same object (some OpenRouter / vLLM-SGLang
+// proxies do) fail with `duplicate field \`reasoning_content\``, dropping the
+// entire response. Deserializing them as separate optional fields tolerates
+// any combination; the canonical `reasoning_content` wins when both are present.
+impl<'de> Deserialize<'de> for ResponseMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Shadow {
+            #[serde(default)]
+            content: Option<String>,
+            #[serde(default)]
+            reasoning_content: Option<String>,
+            #[serde(default)]
+            reasoning: Option<String>,
+            #[serde(default)]
+            tool_calls: Option<Vec<ToolCall>>,
+            #[serde(default)]
+            function_call: Option<Function>,
+        }
+
+        let shadow = Shadow::deserialize(deserializer)?;
+        Ok(ResponseMessage {
+            content: shadow.content,
+            reasoning_content: shadow.reasoning_content.or(shadow.reasoning),
+            tool_calls: shadow.tool_calls,
+            function_call: shadow.function_call,
+        })
+    }
 }
 
 impl ResponseMessage {
@@ -426,20 +459,48 @@ pub(crate) struct StreamChoice {
     pub(crate) finish_reason: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub(crate) struct StreamDelta {
-    #[serde(default)]
     pub(crate) content: Option<String>,
     /// Reasoning/thinking models may stream their chain-of-thought via
     /// `reasoning_content` (DeepSeek/Qwen3/GLM-4) or `reasoning`
-    /// (OpenRouter, vLLM/SGLang proxies). Accept both delta field names.
-    #[serde(default, alias = "reasoning")]
+    /// (OpenRouter, vLLM/SGLang proxies). Both delta field names fold into
+    /// this single field (see the manual `Deserialize` impl below).
     pub(crate) reasoning_content: Option<String>,
     /// Native tool-call chunks. Each entry is keyed by `index`; the first
     /// chunk for a given index carries `id`/`type`/`function.name`, later
     /// chunks only carry fragments of `function.arguments`.
-    #[serde(default)]
     pub(crate) tool_calls: Option<Vec<StreamToolCallDelta>>,
+}
+
+// Manual `Deserialize` for the same reason as `ResponseMessage`: a streaming
+// delta that carries both `reasoning` and `reasoning_content` must not fail
+// with `duplicate field`. They deserialize as distinct keys and fold into the
+// canonical `reasoning_content` (canonical wins when both are present).
+impl<'de> Deserialize<'de> for StreamDelta {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Shadow {
+            #[serde(default)]
+            content: Option<String>,
+            #[serde(default)]
+            reasoning_content: Option<String>,
+            #[serde(default)]
+            reasoning: Option<String>,
+            #[serde(default)]
+            tool_calls: Option<Vec<StreamToolCallDelta>>,
+        }
+
+        let shadow = Shadow::deserialize(deserializer)?;
+        Ok(StreamDelta {
+            content: shadow.content,
+            reasoning_content: shadow.reasoning_content.or(shadow.reasoning),
+            tool_calls: shadow.tool_calls,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

- Custom OpenAI-compatible providers that emit **both** `reasoning` and `reasoning_content` in the same message no longer fail to parse.
- Replaces the serde `alias = "reasoning"` on `ResponseMessage` and `StreamDelta` with a manual `Deserialize` that folds the two wire keys into the single canonical field.
- Restores response delivery for affected providers (the model's entire reply was being dropped).

## Problem

`ResponseMessage` and `StreamDelta` in `src/openhuman/inference/provider/compatible_types.rs` declared:

```rust
#[serde(default, alias = "reasoning")]
pub(crate) reasoning_content: Option<String>,
```

serde's `alias` maps both `reasoning` and `reasoning_content` onto the **same** field slot. When a provider (some OpenRouter / vLLM-SGLang proxies) sends both keys in one object, the derived visitor sets the slot on the first key and returns `duplicate field \`reasoning_content\`` on the second — failing the whole response parse and surfacing as `custom response parse error: duplicate field \`reasoning_content\``. The user's turn errors out with no reply.

Regression from the alias added in #3124; before that an extra `reasoning` key was an unknown field and silently ignored.

## Solution

- Drop the alias; add a manual `impl Deserialize` on both structs backed by a private shadow struct that reads `reasoning` and `reasoning_content` as **distinct** optional fields.
- Fold to the single public field via `reasoning_content.or(reasoning)` — canonical wins when both are present, alias-only still folds in, neither stays `None`.
- All existing readers and the tool-call echo-back path are unchanged (still one `reasoning_content` field); `Serialize` on `ResponseMessage` is untouched.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — verified by CI (Coverage Gate green); changed lines are the manual `Deserialize` impls, both exercised by the added tests.
- [x] N/A: behaviour-only change — no feature rows added/removed/renamed in the coverage matrix
- [x] N/A: bug fix, no matrix feature IDs affected
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: parsing-only change, does not touch release-cut smoke surfaces
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop/CLI inference path for OpenAI-compatible custom providers. Restores responses from thinking-model proxies that echo both reasoning keys.
- No performance, migration, or security implications. No API or wire-format change (deserialize is strictly more tolerant; serialize unchanged).

## Related

- Closes: #3547
- Sentry-Issue: TAURI-RUST-A5N
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3547-reasoning-content-duplicate-field
- Commit SHA: 2bc0f6d71be9cd4a6b226662e1684baf7275df30

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend changes
- [x] N/A: `pnpm typecheck` — no frontend changes
- [x] Focused tests: `cargo test --lib openhuman::inference::provider::compatible` (159 passed); `cargo test --lib both_present` (new regression tests pass)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo clippy --lib` clean on changed files
- [x] N/A: Tauri fmt/check — `app/src-tauri` not changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: responses carrying both reasoning keys parse instead of erroring.
- User-visible effect: affected custom providers return replies again instead of a parse error.

### Parity Contract

- Legacy behavior preserved: reasoning-only (`reasoning`) and canonical-only (`reasoning_content`) inputs behave exactly as under #3124.
- Guard/fallback/dispatch parity checks: canonical-wins ordering covered by tests on both chat and stream-delta paths.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with provider responses that include reasoning fields in alternate formats. The system now gracefully handles both field variants without parsing errors.

* **Tests**
  * Added regression tests to verify robust handling of reasoning content in both streaming and non-streaming response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
