### PR TITLE
ci(release): raise desktop build timeout 30→50m to survive cold-cache builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -98,7 +98,7 @@ jobs:
   build:
     name: "Desktop: ${{ matrix.settings.artifact_suffix }}"
     runs-on: ${{ matrix.settings.platform }}
-    timeout-minutes: 30
+    timeout-minutes: 50
     environment: Production
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What

Raise the per-job `timeout-minutes` for the desktop build matrix from **30 → 50** in `.github/workflows/build-desktop.yml`.

## Why

[Release Production run 27208216144](https://github.com/tinyhumansai/openhuman/actions/runs/27208216144) failed with all five desktop build jobs (macOS x2, Windows, Ubuntu x2) hitting `The job has exceeded the maximum execution time of 30m0s`. This was **not a compile error** — the Ubuntu job actually reached `Success` on the AppImage and was killed during the final re-signing step, right at the 30-minute wire.

Root cause: every Rust cache was a cold miss that run (cargo registry, CEF binary, vendored `tauri-cli` — keyed on `Cargo.lock`/`Cargo.toml` hashes). With no cache slack, the job had to rebuild the vendored `tauri-cli` (~4 min), re-download CEF, and compile the whole workspace from scratch — tipping every platform over the 30-minute ceiling simultaneously.

There has never been a `target/` build cache in this workflow, so cold compiles are always near the limit. Raising the timeout gives cold-cache runs headroom so they can't be killed mid-bundle.

## Scope

Single-line change. Does not touch caching or build logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased desktop build timeout threshold to accommodate longer build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->