### PR TITLE
chore(chat): disable chat attachments by default

### DIFF
--- a/app/src/utils/config.ts
+++ b/app/src/utils/config.ts
@@ -91,11 +91,13 @@ export const CONSUMER_FIRST_SESSION_ENABLED =
   import.meta.env.VITE_CONSUMER_FIRST_SESSION === 'true';
 
 /**
- * Chat multimodal attachments (image + supported file markers). Enabled by
- * default now that core parses `[IMAGE:…]` / `[FILE:…]` payloads and the
- * renderer runs a lossless compression pass before sending.
+ * Chat multimodal attachments (image + supported file markers). Disabled by
+ * default — the attach affordance is hidden and the file-picker path is gated
+ * off (a bare `<textarea>` already ignores pasted/dropped files). Opt back in
+ * for a build by setting `VITE_CHAT_ATTACHMENTS=true` (e.g. the e2e web build
+ * in `app/scripts/e2e-web-build.sh`, which exercises the attachment specs).
  */
-export const CHAT_ATTACHMENTS_ENABLED = import.meta.env.VITE_CHAT_ATTACHMENTS !== 'false';
+export const CHAT_ATTACHMENTS_ENABLED = import.meta.env.VITE_CHAT_ATTACHMENTS === 'true';
 
 export const SKILLS_GITHUB_REPO =
   import.meta.env.VITE_SKILLS_GITHUB_REPO || 'tinyhumansai/openhuman-skills';


### PR DESCRIPTION
## Summary

- Default the chat multimodal attachment flag **off**: `CHAT_ATTACHMENTS_ENABLED` now evaluates `VITE_CHAT_ATTACHMENTS === 'true'` instead of `!== 'false'`.
- Hides the attach affordance in the chat composer — the hidden file `<input>`, the `+` attach button, and the attachment preview strip are all gated behind this flag in `ChatComposer.tsx`.
- No paste/drop path exists to disable: the composer `<textarea>` has no `onPaste`/`onDrop` handler and there is no document-level clipboard listener, so a plain textarea already ignores pasted/dropped files.
- Opt back in per build with `VITE_CHAT_ATTACHMENTS=true` — the e2e web build (`app/scripts/e2e-web-build.sh`) already sets this, so the attachment specs keep exercising the enabled path.

## Problem

We want to ship with chat attachments hidden and ensure no attachment can be added through the composer (button or paste), without ripping out the feature.

## Solution

- One-line flip of the default in the centralized frontend config (`app/src/utils/config.ts`); the existing `attachmentsEnabled` prop wiring in `Conversations.tsx` → `ChatComposer.tsx` already gates every attachment UI element, so flipping the default removes the entire affordance.
- Kept an explicit `=== 'true'` opt-in (matching the sibling `CONSUMER_FIRST_SESSION_ENABLED` flag) rather than a literal `false`, so the e2e attachment build/specs stay green and the feature is trivially re-enablable.

## Submission Checklist

- [x] Tests added or updated — `N/A: behaviour-only default flip`. The config module is fully mocked in the Vitest harness (`app/src/test/setup.ts` `vi.mock('../utils/config', …)`), which force-sets `CHAT_ATTACHMENTS_ENABLED: true`; the default value in `config.ts` is not unit-observable. Existing attachment specs (`Conversations.attachments.test.tsx`) continue to exercise the enabled path.
- [x] **Diff coverage ≥ 80%** — `N/A: config.ts is fully mocked in the test harness and never instrumented, so the changed line carries no diff-cover data.`
- [x] Coverage matrix updated — `N/A: behaviour-only change, no new/removed feature row.`
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix rows affected.`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: hides an existing optional affordance; no new release-cut surface.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue.`

## Impact

- Desktop/web: chat composer no longer shows the attach button, file input, or preview strip by default. Builds that set `VITE_CHAT_ATTACHMENTS=true` (e.g. e2e web build) are unchanged.
- No security/migration/perf implications; no API or core changes.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `chore/disable-chat-attachments`
- Commit SHA: 0702e6811

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (single-line config change, Prettier-clean)
- [x] `pnpm typecheck` — passed (`tsc --noEmit`)
- [ ] Focused tests: not run (config module fully mocked; default not unit-observable)
- [x] Rust fmt/check (if changed): N/A (no Rust changed)
- [x] Tauri fmt/check (if changed): N/A (no Tauri changed)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: chat attachments hidden by default.
- User-visible effect: no attach button / file picker / preview strip in the chat composer unless `VITE_CHAT_ATTACHMENTS=true`.

### Parity Contract

- Legacy behavior preserved: yes, behind `VITE_CHAT_ATTACHMENTS=true` opt-in.
- Guard/fallback/dispatch parity checks: `attachmentsEnabled` prop still gates all three UI elements in `ChatComposer.tsx`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Chat attachments are now **disabled by default**. Users must explicitly enable this feature to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->