### PR TITLE
feat(skill_executor): reliable skill file I/O — sandboxed scratch dir + readable-location steering

### DIFF
--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -407,21 +407,40 @@ impl PromptSection for WorkspaceSection {
         // point agents at a directory the file tools are sandboxed *out of*,
         // causing write→read mismatches. Instead, tell the agent to discover
         // its real working directory at runtime and keep writes/reads there.
-        let scratch = crate::openhuman::security::openhuman_scratch_dir();
-        Ok(format!(
+        let mut out = String::from(
             "## Workspace\n\n\
              Run `pwd` to confirm your working directory — that is where `shell` runs and \
              where `file_read`/`file_write` resolve relative paths. Create files in that \
              directory and read them back from the same place (use the relative path, or \
-             confirm the absolute path with `pwd`). Reads and writes outside this directory \
-             are blocked by the security sandbox, so keep intermediate files inside it.\n\n\
+             confirm the absolute path with `pwd`). Writes and reads outside your granted \
+             locations (your working directory plus the scratch directory below) are blocked \
+             by the security sandbox.\n\n\
              Prefer printing results to stdout. Only when output is too large for stdout, \
-             write it to a file in your working directory and read that file back.\n\n\
-             For scratch or temporary files, use the directory `{}` (a granted scratch \
-             space) or your `$TMPDIR` / `%TEMP%` — never a hardcoded `/tmp/<name>` (Linux/macOS) \
-             or `C:\\Temp\\<name>` (Windows) path, which is blocked.",
-            scratch.display()
-        ))
+             write it to a file in your working directory and read that file back.\n\n",
+        );
+        // Only advertise a concrete scratch path when the dir is actually present
+        // and safe (real dir, not a symlink) — matching the policy grant in
+        // `SecurityPolicy::from_config`. Otherwise fall back to env-var/working-dir
+        // wording so we never point file I/O at a location the sandbox would block.
+        // Read-only check (no fs side effects in prompt rendering).
+        let scratch = crate::openhuman::security::openhuman_scratch_dir();
+        let scratch_granted = std::fs::symlink_metadata(&scratch)
+            .map(|m| !m.file_type().is_symlink() && m.is_dir())
+            .unwrap_or(false);
+        if scratch_granted {
+            let _ = write!(
+                out,
+                "For scratch or temporary files, use the directory `{}` (a granted scratch \
+                 space) or your `$TMPDIR` / `%TEMP%` — never a hardcoded `/tmp/<name>` path.",
+                scratch.display()
+            );
+        } else {
+            out.push_str(
+                "For scratch or temporary files, use `$TMPDIR` / `%TEMP%`, or create them in \
+                 your working directory — never a hardcoded `/tmp/<name>` path, which is blocked.",
+            );
+        }
+        Ok(out)
     }
 }
 

--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -400,10 +400,27 @@ impl PromptSection for WorkspaceSection {
         "workspace"
     }
 
-    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+    fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
+        // Intentionally does NOT print a hardcoded path: `shell` and the file
+        // tools resolve relative paths against the agent's *action directory*,
+        // which is not `workspace_dir`. Printing `workspace_dir` here used to
+        // point agents at a directory the file tools are sandboxed *out of*,
+        // causing write→read mismatches. Instead, tell the agent to discover
+        // its real working directory at runtime and keep writes/reads there.
+        let scratch = crate::openhuman::security::openhuman_scratch_dir();
         Ok(format!(
-            "## Workspace\n\nWorking directory: `{}`",
-            ctx.workspace_dir.display()
+            "## Workspace\n\n\
+             Run `pwd` to confirm your working directory — that is where `shell` runs and \
+             where `file_read`/`file_write` resolve relative paths. Create files in that \
+             directory and read them back from the same place (use the relative path, or \
+             confirm the absolute path with `pwd`). Reads and writes outside this directory \
+             are blocked by the security sandbox, so keep intermediate files inside it.\n\n\
+             Prefer printing results to stdout. Only when output is too large for stdout, \
+             write it to a file in your working directory and read that file back.\n\n\
+             For scratch or temporary files, use the directory `{}` (a granted scratch \
+             space) or your `$TMPDIR` / `%TEMP%` — never a hardcoded `/tmp/<name>` (Linux/macOS) \
+             or `C:\\Temp\\<name>` (Windows) path, which is blocked.",
+            scratch.display()
         ))
     }
 }

--- a/src/openhuman/agent_registry/agents/code_executor/prompt.md
+++ b/src/openhuman/agent_registry/agents/code_executor/prompt.md
@@ -48,6 +48,7 @@ Shell commands run through an approval gate under the user's access policy. Keep
 - **Creating new files is free; editing existing files prompts.** Prefer the file tools (`file_write` / `edit` / `apply_patch`) over shell redirection for writing files.
 - **No `sudo` / system package installs** unless the user explicitly granted it. If a dependency is missing and can't be installed here, don't loop on installers — say so and propose an alternative (e.g. a stdlib-only approach).
 - **If you create a virtualenv, use it.** After `python3 -m venv .venv`, install and run with `.venv/bin/pip` and `.venv/bin/python` — do **not** fall back to the system `pip` (it's frequently missing or externally-managed and will keep failing).
+- **Only stdout/stderr comes back to you.** `shell`, `node_exec`, and `npm_exec` return *only* what the process prints — exit code plus captured stdout/stderr. A script that computes a result but doesn't print it (or writes it only to a file) returns an *empty success*; you will not see the value. Always make scripts `print(...)` / `console.log(...)` the result you need, or follow up by reading the file they wrote. Treat an empty result as "no output captured", not as confirmation the work succeeded.
 
 ## Rules
 

--- a/src/openhuman/security/mod.rs
+++ b/src/openhuman/security/mod.rs
@@ -37,6 +37,7 @@ pub use policy::validate_path_within_root;
 pub use policy::AutonomyLevel;
 pub use policy::SecurityPolicy;
 pub use policy::ToolOperation;
+pub use policy::{ensure_openhuman_scratch_dir, openhuman_scratch_dir};
 #[allow(unused_imports)]
 pub use policy::{CommandClass, GateDecision};
 #[allow(unused_imports)]

--- a/src/openhuman/security/policy/enforcement.rs
+++ b/src/openhuman/security/policy/enforcement.rs
@@ -115,13 +115,29 @@ impl SecurityPolicy {
         // is ever trusted — never `/tmp` itself. Created here with restrictive
         // perms and refused if it exists as a symlink (TOCTOU hardening, since
         // `/tmp` is world-writable and the name is predictable).
-        if let Some(scratch) = ensure_openhuman_scratch_dir() {
-            let scratch_str = scratch.to_string_lossy().to_string();
-            if !trusted_roots.iter().any(|r| r.path == scratch_str) {
-                trusted_roots.push(TrustedRoot {
-                    path: scratch_str,
-                    access: TrustedAccess::ReadWrite,
-                });
+        match ensure_openhuman_scratch_dir() {
+            Some(scratch) => {
+                let scratch_str = scratch.to_string_lossy().to_string();
+                if trusted_roots.iter().any(|r| r.path == scratch_str) {
+                    tracing::debug!(
+                        path = %scratch_str,
+                        "[policy][scratch] scratch dir already a trusted root — skipping grant"
+                    );
+                } else {
+                    tracing::debug!(
+                        path = %scratch_str,
+                        "[policy][scratch] granting scratch dir as ReadWrite trusted root"
+                    );
+                    trusted_roots.push(TrustedRoot {
+                        path: scratch_str,
+                        access: TrustedAccess::ReadWrite,
+                    });
+                }
+            }
+            None => {
+                tracing::debug!(
+                    "[policy][scratch] scratch dir unavailable (create/validation failed) — not granting"
+                );
             }
         }
 
@@ -166,24 +182,38 @@ pub fn openhuman_scratch_dir() -> std::path::PathBuf {
 /// the name is predictable. Idempotent: safe to call on every policy build.
 pub fn ensure_openhuman_scratch_dir() -> Option<std::path::PathBuf> {
     let dir = openhuman_scratch_dir();
-    if let Ok(meta) = std::fs::symlink_metadata(&dir) {
-        if meta.file_type().is_symlink() {
-            tracing::warn!(
-                path = %dir.display(),
-                "[security] scratch dir exists as a symlink — refusing to grant it as a trusted root"
-            );
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(path = %dir.display(), error = %e, "[security][scratch] failed to create scratch dir");
+        return None;
+    }
+    // Re-validate AFTER creation, and fail closed. `/tmp` is world-writable, so a
+    // local user could have raced or pre-created `/tmp/openhuman` (e.g. as a
+    // symlink) before we got here; a pre-create check alone can still hand back
+    // an unsafe path. `symlink_metadata` does not follow the final component, so
+    // a symlink is detected here even if its target is a real directory.
+    let meta = match std::fs::symlink_metadata(&dir) {
+        Ok(meta) => meta,
+        Err(e) => {
+            tracing::warn!(path = %dir.display(), error = %e, "[security][scratch] failed to stat scratch dir — refusing to grant");
             return None;
         }
-    }
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        tracing::warn!(path = %dir.display(), error = %e, "[security] failed to create scratch dir");
+    };
+    if meta.file_type().is_symlink() || !meta.is_dir() {
+        tracing::warn!(
+            path = %dir.display(),
+            "[security][scratch] scratch path is a symlink or not a directory — refusing to grant it as a trusted root"
+        );
         return None;
     }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        if let Err(e) = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)) {
+            tracing::warn!(path = %dir.display(), error = %e, "[security][scratch] failed to harden scratch dir perms — refusing to grant");
+            return None;
+        }
     }
+    tracing::debug!(path = %dir.display(), "[security][scratch] scratch dir ensured (0700, real dir)");
     Some(dir)
 }
 

--- a/src/openhuman/security/policy/enforcement.rs
+++ b/src/openhuman/security/policy/enforcement.rs
@@ -109,6 +109,22 @@ impl SecurityPolicy {
             });
         }
 
+        // Dedicated, namespaced scratch dir (`/tmp/openhuman`) granted ReadWrite
+        // so the LLM's natural `/tmp/...` temp-file habit lands in a sandboxed,
+        // trusted location instead of the world-shared `/tmp`. Only this subdir
+        // is ever trusted — never `/tmp` itself. Created here with restrictive
+        // perms and refused if it exists as a symlink (TOCTOU hardening, since
+        // `/tmp` is world-writable and the name is predictable).
+        if let Some(scratch) = ensure_openhuman_scratch_dir() {
+            let scratch_str = scratch.to_string_lossy().to_string();
+            if !trusted_roots.iter().any(|r| r.path == scratch_str) {
+                trusted_roots.push(TrustedRoot {
+                    path: scratch_str,
+                    access: TrustedAccess::ReadWrite,
+                });
+            }
+        }
+
         Self {
             autonomy: autonomy_config.level,
             workspace_dir: workspace_dir.to_path_buf(),
@@ -127,6 +143,48 @@ impl SecurityPolicy {
             canonical_workspace: Arc::new(OnceCell::new()),
         }
     }
+}
+
+/// The dedicated, namespaced scratch directory granted to the agent so its
+/// natural `/tmp/...` temp-file habit lands in a sandboxed, trusted location
+/// rather than the world-shared `/tmp`. Only this subdir is ever trusted —
+/// never `/tmp` itself. On Windows, falls back to the per-user temp dir.
+pub fn openhuman_scratch_dir() -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        std::env::temp_dir().join("openhuman")
+    }
+    #[cfg(not(windows))]
+    {
+        std::path::PathBuf::from("/tmp/openhuman")
+    }
+}
+
+/// Create [`openhuman_scratch_dir`] with restrictive perms, best-effort.
+/// Returns `None` (and grants nothing) if the path already exists as a
+/// symlink — TOCTOU hardening, since the parent `/tmp` is world-writable and
+/// the name is predictable. Idempotent: safe to call on every policy build.
+pub fn ensure_openhuman_scratch_dir() -> Option<std::path::PathBuf> {
+    let dir = openhuman_scratch_dir();
+    if let Ok(meta) = std::fs::symlink_metadata(&dir) {
+        if meta.file_type().is_symlink() {
+            tracing::warn!(
+                path = %dir.display(),
+                "[security] scratch dir exists as a symlink — refusing to grant it as a trusted root"
+            );
+            return None;
+        }
+    }
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(path = %dir.display(), error = %e, "[security] failed to create scratch dir");
+        return None;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+    }
+    Some(dir)
 }
 
 /// Validate that a file path resolves within a given root directory.
@@ -154,4 +212,28 @@ pub fn validate_path_within_root(
         ));
     }
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod scratch_dir_tests {
+    use super::{ensure_openhuman_scratch_dir, openhuman_scratch_dir};
+
+    #[test]
+    fn scratch_dir_is_namespaced_on_every_platform() {
+        // Always the dedicated `openhuman` scratch namespace — never a bare
+        // temp root, so only this subdir is ever granted as a trusted root.
+        let dir = openhuman_scratch_dir();
+        assert_eq!(dir.file_name().and_then(|s| s.to_str()), Some("openhuman"));
+        #[cfg(not(windows))]
+        assert_eq!(dir, std::path::PathBuf::from("/tmp/openhuman"));
+    }
+
+    #[test]
+    fn ensure_scratch_dir_creates_and_returns_it() {
+        // Idempotent: creates the dir, returns its path, and it exists after.
+        let ensured = ensure_openhuman_scratch_dir();
+        let expected = openhuman_scratch_dir();
+        assert_eq!(ensured.as_deref(), Some(expected.as_path()));
+        assert!(expected.is_dir());
+    }
 }

--- a/src/openhuman/security/policy/mod.rs
+++ b/src/openhuman/security/policy/mod.rs
@@ -8,6 +8,7 @@ mod policy_command;
 mod types;
 
 pub use enforcement::validate_path_within_root;
+pub use enforcement::{ensure_openhuman_scratch_dir, openhuman_scratch_dir};
 pub use types::{
     ActionTracker, AutonomyLevel, CommandClass, CommandRiskLevel, GateDecision, SecurityPolicy,
     ToolOperation, TrustedAccess, TrustedRoot, POLICY_BLOCKED_MARKER, POLICY_DENIED_MARKER,

--- a/src/openhuman/skill_runtime/agent/skill_executor/prompt.md
+++ b/src/openhuman/skill_runtime/agent/skill_executor/prompt.md
@@ -15,6 +15,12 @@ You execute agent skills that have been installed on this system. Skills are def
    - Python scripts must use the OpenHuman Python runtime (`runtime_python`) rather than assuming the host PATH.
 6. **Report** results back to the user.
 
+> **Output contract:** only a command's stdout/stderr is captured back to you. A Python/Node
+> script that finishes without printing returns an *empty* result — that is "no output captured",
+> not proof of success. Ensure the skill's scripts print the result you need to stdout (e.g.
+> `print(...)` / `console.log(...)`); if a script only writes a file, read that file afterward with
+> `read_workflow_resource` or `file_read` to obtain its result.
+
 ## Important rules
 
 - Follow the skill's instructions precisely — they are the authoritative guide.

--- a/src/openhuman/tools/impl/filesystem/file_read.rs
+++ b/src/openhuman/tools/impl/filesystem/file_read.rs
@@ -25,7 +25,10 @@ impl Tool for FileReadTool {
     }
 
     fn description(&self) -> &str {
-        "Read the contents of a file in the workspace"
+        "Read the contents of a file in your working directory (the action sandbox). \
+         Relative paths resolve against that directory; paths outside it are blocked. \
+         To read a file written by `shell`, confirm its location with `pwd` and use the \
+         same relative path."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/filesystem/file_write.rs
+++ b/src/openhuman/tools/impl/filesystem/file_write.rs
@@ -23,7 +23,9 @@ impl Tool for FileWriteTool {
     }
 
     fn description(&self) -> &str {
-        "Write contents to a file in the workspace"
+        "Write contents to a file in your working directory (the action sandbox). \
+         Relative paths resolve against that directory; writes outside it are blocked. \
+         Reference the file later by the same relative path so `file_read` resolves to it."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -92,7 +92,7 @@ impl Tool for NodeExecTool {
     }
 
     fn description(&self) -> &str {
-        "Execute JavaScript through Node.js. Pass either `inline_code` (runs via `node -e`) or `script_path` (runs a file in the workspace). Optional `args` forwards positional arguments to the script. Only the program's stdout/stderr is captured and returned to you — a value you do not `console.log` is invisible, and a script that exits 0 without printing returns an empty result. Always print the output you need (e.g. `console.log(JSON.stringify(result))`)."
+        "Execute JavaScript through Node.js. Pass either `inline_code` (runs via `node -e`) or `script_path` (runs a file in your working directory, the action sandbox). Optional `args` forwards positional arguments to the script. Only the program's stdout/stderr is captured and returned to you — a value you do not `console.log` is invisible, and a script that exits 0 without printing returns an empty result. Always print the output you need (e.g. `console.log(JSON.stringify(result))`)."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -92,7 +92,7 @@ impl Tool for NodeExecTool {
     }
 
     fn description(&self) -> &str {
-        "Execute JavaScript through Node.js. Pass either `inline_code` (runs via `node -e`) or `script_path` (runs a file in the workspace). Optional `args` forwards positional arguments to the script."
+        "Execute JavaScript through Node.js. Pass either `inline_code` (runs via `node -e`) or `script_path` (runs a file in the workspace). Optional `args` forwards positional arguments to the script. Only the program's stdout/stderr is captured and returned to you — a value you do not `console.log` is invisible, and a script that exits 0 without printing returns an empty result. Always print the output you need (e.g. `console.log(JSON.stringify(result))`)."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -303,9 +303,18 @@ impl ShellTool {
         // in a sandboxed, readable location instead of the world-shared /tmp.
         let scratch_dir = crate::openhuman::security::openhuman_scratch_dir();
         if scratch_dir.is_dir() {
+            tracing::debug!(
+                scratch_dir = %scratch_dir.display(),
+                "[shell] overriding TMPDIR/TMP/TEMP to the openhuman scratch dir"
+            );
             cmd.env("TMPDIR", scratch_dir.as_os_str());
             cmd.env("TMP", scratch_dir.as_os_str());
             cmd.env("TEMP", scratch_dir.as_os_str());
+        } else {
+            tracing::debug!(
+                scratch_dir = %scratch_dir.display(),
+                "[shell] scratch dir missing — leaving TMPDIR/TMP/TEMP as inherited"
+            );
         }
 
         match self.runtime_path_for_command(command).await {

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -151,7 +151,11 @@ impl Tool for ShellTool {
     fn description(&self) -> &str {
         "Execute a shell command. Use this to run code, manipulate files in the workspace, \
          or perform system actions on the user's machine — including launching applications \
-         (e.g. `open -a Music` on macOS, `xdg-open music://` on Linux)."
+         (e.g. `open -a Music` on macOS, `xdg-open music://` on Linux). Only the command's \
+         stdout/stderr is captured and returned to you — a program that prints nothing \
+         (e.g. a `python`/`node` script that computes silently or only writes a file) returns \
+         an empty result, so make scripts print the output you need (e.g. `print(...)`), or \
+         follow up by reading any file they wrote."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -291,6 +295,17 @@ impl ShellTool {
             if let Ok(val) = std::env::var(var) {
                 cmd.env(var, val);
             }
+        }
+
+        // Point the child's temp dir at the agent's granted scratch dir
+        // (`/tmp/openhuman`, a ReadWrite trusted root — see SecurityPolicy
+        // `from_config`) so `python3 tempfile` / `mktemp` / `$TMPDIR` writes land
+        // in a sandboxed, readable location instead of the world-shared /tmp.
+        let scratch_dir = crate::openhuman::security::openhuman_scratch_dir();
+        if scratch_dir.is_dir() {
+            cmd.env("TMPDIR", scratch_dir.as_os_str());
+            cmd.env("TMP", scratch_dir.as_os_str());
+            cmd.env("TEMP", scratch_dir.as_os_str());
         }
 
         match self.runtime_path_for_command(command).await {
@@ -1063,6 +1078,48 @@ mod tests {
                 sep,
                 "/usr/local/bin:/usr/bin"
             )
+        );
+    }
+
+    /// Empirical answer to "does `shell` resolve/install managed Node on its
+    /// own?" — NO. The shell path consults the managed Node bootstrap only via
+    /// `try_cached()`, which never calls `resolve()` and therefore never
+    /// downloads/installs anything. So without a prior `node_exec` / `npm_exec`
+    /// (the tools that DO call `resolve()` and share this bootstrap instance),
+    /// `runtime_path_for_command` injects nothing for a node command. On a host
+    /// with no Node in the login PATH, the command then fails — the managed
+    /// runtime is never reached on the shell path. (Python, by contrast, IS
+    /// self-resolved in `runtime_path_for_command` — see the python branch.)
+    #[tokio::test]
+    async fn shell_does_not_resolve_or_install_node_on_its_own() {
+        let node = Arc::new(NodeBootstrap::new(
+            crate::openhuman::config::schema::NodeConfig {
+                enabled: true,
+                version: "v22.11.0".to_string(),
+                cache_dir: String::new(),
+                prefer_system: true,
+            },
+            std::env::temp_dir(),
+            reqwest::Client::new(),
+        ));
+        let tool = ShellTool::with_language_bootstraps(
+            test_security(AutonomyLevel::Full),
+            test_runtime(),
+            test_audit(),
+            Some(node),
+            None,
+        );
+
+        // Unprimed (no prior node_exec/npm_exec resolve): shell injects NO
+        // managed node bin onto PATH — it does not auto-resolve or install.
+        let injected = tool
+            .runtime_path_for_command("node --version")
+            .await
+            .expect("runtime path resolves");
+        assert!(
+            injected.is_none(),
+            "shell injected a managed node bin without any prior node_exec/npm_exec \
+             resolve — it must not auto-resolve/install on the shell path: {injected:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Grant agents a dedicated, namespaced **scratch directory** (`/tmp/openhuman` on Linux/macOS, `%LOCALAPPDATA%\Temp\openhuman` on Windows) so the model's natural "write a temp file then read it back" habit lands in an allowed, sandboxed location — without ever trusting world-shared `/tmp`.
- Secure-create it (`0700`; refuse if it already exists as a symlink — TOCTOU hardening under world-writable `/tmp`), grant it as a ReadWrite `trusted_root`, and point `TMPDIR`/`TMP`/`TEMP` at it for shell subprocesses.
- Steer agents (shared, platform-aware `WorkspaceSection` + `file_read`/`file_write`/`shell`/`node_exec` tool descriptions): prefer stdout, keep files in the working/scratch dir, confirm the dir with `pwd`; never hardcode a bare `/tmp/<name>` path.
- Correct `file_read`/`file_write` descriptions to say *action sandbox* (the real read/write root) instead of the inaccurate *"workspace"*.

## Problem

Agents frequently shell out a scratch file (e.g. `python3 parse.py > /tmp/out.txt`) and then `file_read` it. This repeatedly fails for two reasons, both observed running the bundled `arxiv` skill end-to-end:

1. **Base-dir mismatch** — `shell`'s cwd and `file_read`'s relative-path base (`action_dir`) can diverge (especially with `OPENHUMAN_WORKSPACE` overrides), so the file is written one place and looked up in another → "Failed to resolve path".
2. **Hardcoded `/tmp`** — the model writes a literal `/tmp/<name>`, which the path sandbox **correctly blocks** (`/tmp` is outside the allowlist), producing a `[policy-blocked]` error.

The agent recovers, but with wasted iterations and confusing errors. The fix must keep the sandbox strict (untrusted community skills must not read `/etc`, SSH keys, credentials, other apps' `/tmp` data) while giving the agent a temp location its file tools *can* read.

## Solution

- Add `openhuman_scratch_dir()` / `ensure_openhuman_scratch_dir()` in `security/policy/enforcement.rs` — platform-aware path, idempotent secure creation, symlink refusal.
- Inject the scratch dir as a ReadWrite `TrustedRoot` at the single `SecurityPolicy::from_config` chokepoint (mirrors the existing `default_projects_dir` injection). **Only the dedicated subdir is granted — never `/tmp` itself.**
- Override `TMPDIR`/`TMP`/`TEMP` in `ShellTool` so `tempfile`/`mktemp`/`$TMPDIR` resolve into the granted dir on every platform.
- Prompt/description guidance lives in the right layers: the universal "keep files in your readable working/scratch dir, prefer stdout" rule in the shared `WorkspaceSection` (reaches every agent in one place); contract accuracy in the tool descriptions.

Verified end-to-end on macOS against the `arxiv` skill: before, the run wrote `/tmp/arxiv_output.txt` → policy-blocked → recovered with friction; after, it wrote `/tmp/openhuman/arxiv_results.txt` → allowed, clean write+read, real papers returned, no block.

## Submission Checklist

- [x] Tests added or updated — unit tests for `openhuman_scratch_dir` / `ensure_openhuman_scratch_dir` (namespacing + idempotent create). Behaviour-only prompt/description changes otherwise.
- [x] **Diff coverage ≥ 80%** — Rust unit tests added for the new functions; prompt/description string changes are not independently coverable. Full diff-cover left to CI.
- [x] Coverage matrix updated — N/A: no new matrix feature row (security/prompt hardening of existing file-I/O surface).
- [x] All affected feature IDs listed under `## Related` — N/A: no matrix feature ID.
- [x] No new external network dependencies — N/A: none introduced.
- [x] Manual smoke checklist — N/A: no release-cut surface changed.
- [x] Linked issue closed — N/A: contributes to skill-execution reliability (#3489) but does not close it.

## Impact

- **Platform:** Desktop/CLI/standalone core (all share the Rust core). Cross-platform: scratch path + steer are platform-aware (Linux/macOS `/tmp/openhuman`, Windows per-user temp).
- **Security:** Sandbox boundary unchanged in strictness — only one dedicated, secure-created subdir is granted; world-shared `/tmp` and credential/system dirs remain blocked. Windows uses per-user `%LOCALAPPDATA%\Temp` (not world-writable), so the symlink/perms concern barely applies (`0700` is Unix-only by design).
- **Compatibility:** Additive; no config migration. Existing `trusted_roots` are preserved.

## Related

- Closes: N/A
- Related: #3489 (SkillMD skill execution reliability) — this removes one concrete file-I/O friction surfaced while testing it.
- Follow-up PR(s)/TODOs: optional — route "run a skill by name" to the capable `run_workflow` path; make `shell` self-resolve managed Node like Python.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/exec-stdout-guidance`
- Commit SHA: see head

### Validation Run

- [x] Rust fmt/check: `cargo fmt`; `GGML_NATIVE=OFF cargo check --lib` (clean)
- [x] Focused tests: `cargo test --lib scratch_dir_tests` (2 passed)
- [x] `pnpm typecheck`: N/A — no frontend changes
- [x] `pnpm --filter openhuman-app format:check`: N/A — no frontend changes
- [x] Manual: rebuilt desktop dev app, verified `/tmp/openhuman` secure-created (`0700`) and the `arxiv` skill writes+reads there with no policy block.

### Behavior Changes

- Intended: agents get a granted, sandboxed scratch dir; their temp-file writes land somewhere the file tools can read; prompts steer toward stdout / the working dir.
- User-visible: skills that produce intermediate files (e.g. `arxiv`) complete cleanly instead of hitting and recovering from sandbox path errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified agent sandbox behavior, file path resolution, and output capture expectations
  * Explicitly documented that only stdout/stderr is returned to agents
  * Enhanced descriptions for file read/write, shell execution, and Node.js tools

* **Bug Fixes**
  * Improved sandbox security with dedicated scratch directory isolation
  * Enhanced path validation and symlink detection for safer file operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->