### PR TITLE
feat(embeddings): auto-fall back managed cloud → local on session-expiry 401 (#3312)

### DIFF
--- a/src/openhuman/embeddings/README.md
+++ b/src/openhuman/embeddings/README.md
@@ -10,6 +10,7 @@ Embedding providers for the OpenHuman memory system. Converts text into numerica
 - Maintain the static provider/model catalog (slugs, labels, API-key/endpoint requirements, dimension presets) consumed by the frontend picker.
 - Throttle outbound cloud-embedding HTTP requests with a process-global, per-endpoint token bucket (loopback exempt).
 - Parse `Retry-After` and apply 429/503 exponential backoff in HTTP-based providers.
+- Auto-fall back from the managed cloud embedder to a local one when the backend session expires mid-run (#3312): latch confirmed 401/403 auth failures and, when a local embedder is preloaded at matching dimensions, persist a provider switch (no destructive wipe) so indexing survives without a restart.
 - Expose RPC handlers for settings, API-key management, embed, and connection testing; trigger memory wipe / re-embed backfill when the embedding signature changes.
 
 ## Key files
@@ -22,6 +23,7 @@ Embedding providers for the OpenHuman memory system. Converts text into numerica
 | `src/openhuman/embeddings/catalog.rs` | Static catalog of `EmbeddingProviderEntry` + `EmbeddingModelPreset`; slug constants; `all_providers` / `find_provider` / `find_model` / `default_model_for`. |
 | `src/openhuman/embeddings/cloud.rs` | `OpenHumanCloudEmbedding` — default provider; resolves session JWT + API URL per call, delegates HTTP to `OpenAiEmbedding` against `<api>/openai/v1`. `DEFAULT_CLOUD_EMBEDDING_MODEL` = `embedding-v1`, dims 1024. |
 | `src/openhuman/embeddings/openai.rs` | `OpenAiEmbedding` — OpenAI-compatible `POST /v1/embeddings`; URL inference, 429/503 retry, rate-limit gating, dimension/count validation. Used directly by cloud, voyage, and custom paths. |
+| `src/openhuman/embeddings/cloud_fallback.rs` | Process-global auth-failure latch + `maybe_switch_cloud_to_local` — on a confirmed cloud 401/403 with a reachable, dimension-matched local embedder, persists a managed-cloud → local switch (signature-safe, no wipe) so a session expiry can't permanently brick indexing (#3312). Consumed by the memory-queue worker each tick. |
 | `src/openhuman/embeddings/voyage.rs` | `VoyageEmbedding` — thin wrapper delegating to `OpenAiEmbedding` against `api.voyageai.com`. |
 | `src/openhuman/embeddings/cohere.rs` | `CohereEmbedding` — Cohere-native `POST /v2/embed` wire format (`texts`, `embedding_types`, nested `embeddings.float`) with its own 429/503 retry loop. |
 | `src/openhuman/embeddings/ollama.rs` | `OllamaEmbedding` — local Ollama `POST /api/embed`; base-url/model normalization, blank-input zero-vector preservation, NaN-encoding 500 per-text recovery (TAURI-RUST-AZ). Defaults `bge-m3`/1024. |

--- a/src/openhuman/embeddings/cloud_fallback.rs
+++ b/src/openhuman/embeddings/cloud_fallback.rs
@@ -29,7 +29,7 @@
 //! If any guard fails the gate is a no-op: the cloud failure stays surfaced
 //! (graceful skip) rather than switching into a dead provider or wiping memory.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use super::ollama::{DEFAULT_OLLAMA_DIMENSIONS, DEFAULT_OLLAMA_MODEL};
 use crate::openhuman::config::Config;
@@ -69,19 +69,43 @@ pub fn clear_embedding_auth_gate() {
     EMBEDDING_AUTH_FAILED.store(false, Ordering::SeqCst);
 }
 
+/// Process-global monotonic counter bumped whenever the embedding provider is
+/// switched and persisted by [`maybe_switch_cloud_to_local`]. Every memory-queue
+/// worker tracks the last generation it has reloaded; when this differs it
+/// reloads its `Config` from disk. This is what makes a persisted switch reach
+/// *all* workers (each owns its own `Config` clone), not just the one task that
+/// happened to perform the switch.
+static CONFIG_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Current config generation. Workers compare this against the generation they
+/// last reloaded at to decide whether to re-read `Config` from disk.
+pub fn config_generation() -> u64 {
+    CONFIG_GENERATION.load(Ordering::SeqCst)
+}
+
+/// Bump the config generation, signalling all workers to reload from disk.
+fn bump_config_generation() {
+    CONFIG_GENERATION.fetch_add(1, Ordering::SeqCst);
+}
+
 /// Pure decision core: should the active embedder be switched from managed
 /// cloud to local? Split out so the truth table is unit-testable without a
 /// live config, credential store, or Ollama daemon.
+///
+/// `local_available` must mean the target model is actually *usable* (daemon up
+/// **and** the model pulled), not merely that the daemon answered — switching
+/// onto a reachable daemon that lacks the model would just move indexing onto a
+/// provider that immediately fails with "model not found".
 fn should_switch(
     auth_failed: bool,
     current_provider: &str,
     current_dims: usize,
-    local_reachable: bool,
+    local_available: bool,
     local_dims: usize,
 ) -> bool {
     auth_failed
         && matches!(current_provider, "cloud" | "managed")
-        && local_reachable
+        && local_available
         && local_dims == current_dims
 }
 
@@ -93,9 +117,9 @@ fn should_switch(
 /// Idempotent and safe to call every worker tick: it returns immediately when
 /// the latch is clear, and clears the latch once a switch is applied so
 /// concurrent workers don't switch twice.
-pub async fn maybe_switch_cloud_to_local(config: &Config) -> Option<Config> {
+pub async fn maybe_switch_cloud_to_local(config: &Config) -> bool {
     if !embedding_auth_failed() {
-        return None;
+        return false;
     }
 
     let provider = config.memory.embedding_provider.as_str();
@@ -104,34 +128,41 @@ pub async fn maybe_switch_cloud_to_local(config: &Config) -> Option<Config> {
         // from a BYO 401 (or a switch already happened). Clear it; nothing to
         // do here.
         clear_embedding_auth_gate();
-        return None;
+        return false;
     }
 
     let current_dims = config.memory.embedding_dimensions;
     let base_url = crate::openhuman::inference::local::ollama_base_url();
-    let local_reachable =
-        crate::openhuman::memory_store::factories::probe_ollama_reachable(&base_url).await;
+    // Availability means the daemon is up AND the target model is pulled — a
+    // reachable daemon missing the model would just move indexing onto a
+    // provider that immediately fails with "model not found".
+    let local_available = crate::openhuman::memory_store::factories::probe_ollama_model_available(
+        &base_url,
+        DEFAULT_OLLAMA_MODEL,
+    )
+    .await;
 
     if !should_switch(
         true,
         provider,
         current_dims,
-        local_reachable,
+        local_available,
         DEFAULT_OLLAMA_DIMENSIONS,
     ) {
         log::debug!(
             "[embeddings::cloud_fallback] cloud embedding auth failing but local fallback \
-             unavailable (reachable={local_reachable}, local_dims={}, current_dims={current_dims}); \
-             leaving cloud provider in place — indexing degrades gracefully until re-auth (#3312)",
+             unavailable (model '{DEFAULT_OLLAMA_MODEL}' available={local_available}, \
+             local_dims={}, current_dims={current_dims}); leaving cloud provider in place — \
+             indexing degrades gracefully until re-auth (#3312)",
             DEFAULT_OLLAMA_DIMENSIONS
         );
-        return None;
+        return false;
     }
 
     log::warn!(
         "[embeddings::cloud_fallback] managed cloud session auth persistently failing and local \
-         embedder reachable at matching dims ({current_dims}); switching memory embeddings to \
-         local '{DEFAULT_OLLAMA_MODEL}' to keep indexing alive (#3312)"
+         model '{DEFAULT_OLLAMA_MODEL}' available at matching dims ({current_dims}); switching \
+         memory embeddings to local to keep indexing alive (#3312)"
     );
 
     match crate::openhuman::embeddings::rpc::update_settings(
@@ -145,28 +176,20 @@ pub async fn maybe_switch_cloud_to_local(config: &Config) -> Option<Config> {
     .await
     {
         Ok(_) => {
-            // Latch cleared only after the switch is durably persisted, so a
-            // mid-switch crash leaves the latch set for a retry next tick.
+            // The switch is now durably persisted to disk. Bump the generation
+            // so *every* worker reloads its `Config` from disk (each owns its
+            // own clone), then clear the latch. Clearing only after a successful
+            // persist means a failed persist (below) leaves the latch set for a
+            // retry on the next tick.
+            bump_config_generation();
             clear_embedding_auth_gate();
-            match crate::openhuman::config::ops::load_config_with_timeout().await {
-                Ok(fresh) => {
-                    log::info!(
-                        "[embeddings::cloud_fallback] switched memory embeddings to local \
-                         '{DEFAULT_OLLAMA_MODEL}'; re-embed backfill scheduled under new signature"
-                    );
-                    Some(fresh)
-                }
-                Err(e) => {
-                    // The switch persisted but reloading the config failed.
-                    // The on-disk change still takes effect on next restart;
-                    // surface it but don't crash the worker.
-                    log::warn!(
-                        "[embeddings::cloud_fallback] switch persisted but config reload failed: {e}; \
-                         worker keeps stale config until next restart"
-                    );
-                    None
-                }
-            }
+            log::info!(
+                "[embeddings::cloud_fallback] switched memory embeddings to local \
+                 '{DEFAULT_OLLAMA_MODEL}'; re-embed backfill scheduled under new signature; \
+                 workers will reload config (generation={})",
+                config_generation()
+            );
+            true
         }
         Err(e) => {
             // Persisting the switch is an unexpected system failure (config
@@ -178,7 +201,7 @@ pub async fn maybe_switch_cloud_to_local(config: &Config) -> Option<Config> {
                 "cloud_fallback_switch",
                 &[],
             );
-            None
+            false
         }
     }
 }
@@ -219,7 +242,7 @@ mod tests {
         clear_embedding_auth_gate();
         // Gate clear → returns immediately, no I/O, regardless of provider.
         let cfg = Config::default();
-        assert!(maybe_switch_cloud_to_local(&cfg).await.is_none());
+        assert!(!maybe_switch_cloud_to_local(&cfg).await);
     }
 
     #[tokio::test]
@@ -231,7 +254,7 @@ mod tests {
         note_embedding_auth_failure();
         let mut cfg = Config::default();
         cfg.memory.embedding_provider = "openai".to_string();
-        assert!(maybe_switch_cloud_to_local(&cfg).await.is_none());
+        assert!(!maybe_switch_cloud_to_local(&cfg).await);
         assert!(
             !embedding_auth_failed(),
             "non-cloud provider path must clear the stale latch"

--- a/src/openhuman/embeddings/cloud_fallback.rs
+++ b/src/openhuman/embeddings/cloud_fallback.rs
@@ -1,0 +1,274 @@
+//! Auto-fallback from the managed cloud embedder to a local embedder when the
+//! backend session expires mid-run (#3312).
+//!
+//! Background: a long-running headless deployment (e.g. Docker) authenticates
+//! to the OpenHuman backend with a session JWT that expires after a few hours.
+//! Once it expires every cloud embedding call returns `401 Invalid token`, and
+//! indexing fails hard with no recovery until a manual provider switch. This
+//! module watches for *confirmed* embedding auth failures (HTTP 401/403) and,
+//! when the active provider is the managed cloud embedder **and** a local
+//! embedder is actually preloaded and reachable at the **same dimensionality**
+//! (so no destructive memory wipe is required), persists a switch to the local
+//! provider.
+//!
+//! Persisting the switch via [`crate::openhuman::embeddings::rpc::update_settings`]
+//! moves the **active embedding signature** atomically with the provider, so
+//! new vectors are correctly labelled and the existing re-embed machinery
+//! back-fills the corpus under the local signature. This is the only safe way
+//! to fall back: returning local vectors under the cloud signature would
+//! silently mix two incomparable embedding spaces (#1574).
+//!
+//! Safety guards (all must hold before switching):
+//! - a confirmed auth failure is latched ([`embedding_auth_failed`]);
+//! - the *current* provider is the managed cloud embedder (`cloud`/`managed`) —
+//!   a 401 from a user's own OpenAI/custom key must never flip their provider;
+//! - a local embedder is reachable;
+//! - the local embedder's dimensionality equals the current one, so the switch
+//!   needs **no** destructive memory wipe.
+//!
+//! If any guard fails the gate is a no-op: the cloud failure stays surfaced
+//! (graceful skip) rather than switching into a dead provider or wiping memory.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use super::ollama::{DEFAULT_OLLAMA_DIMENSIONS, DEFAULT_OLLAMA_MODEL};
+use crate::openhuman::config::Config;
+
+/// Process-global latch: set when an embedding call is rejected with a
+/// confirmed auth error (HTTP 401/403). Set from the shared
+/// [`super::openai::OpenAiEmbedding::embed`] non-2xx path (which every cloud and
+/// BYO embed bottoms out in) and consumed by the memory-queue worker each tick.
+///
+/// The latch is intentionally generic ("an embedding auth call failed"); the
+/// cloud-specific interpretation lives entirely in [`maybe_switch_cloud_to_local`],
+/// which only acts when the *configured* provider is the managed cloud one. So
+/// a 401 from a user's own key may set the latch but can never switch their
+/// provider — it is simply cleared by the next successful embed.
+static EMBEDDING_AUTH_FAILED: AtomicBool = AtomicBool::new(false);
+
+/// Record a confirmed embedding auth failure (HTTP 401/403). Cheap and
+/// idempotent — logs once per transition into the failed state.
+pub fn note_embedding_auth_failure() {
+    if !EMBEDDING_AUTH_FAILED.swap(true, Ordering::SeqCst) {
+        log::warn!(
+            "[embeddings::cloud_fallback] embedding call rejected with auth error (401/403); \
+             will switch managed cloud → local if a local embedder is preloaded at matching dims (#3312)"
+        );
+    }
+}
+
+/// Whether a confirmed embedding auth failure is currently latched.
+pub fn embedding_auth_failed() -> bool {
+    EMBEDDING_AUTH_FAILED.load(Ordering::SeqCst)
+}
+
+/// Clear the latch — called after a successful switch, or after any successful
+/// embed (a success means the session is valid again, so we must not switch on
+/// a stale blip).
+pub fn clear_embedding_auth_gate() {
+    EMBEDDING_AUTH_FAILED.store(false, Ordering::SeqCst);
+}
+
+/// Pure decision core: should the active embedder be switched from managed
+/// cloud to local? Split out so the truth table is unit-testable without a
+/// live config, credential store, or Ollama daemon.
+fn should_switch(
+    auth_failed: bool,
+    current_provider: &str,
+    current_dims: usize,
+    local_reachable: bool,
+    local_dims: usize,
+) -> bool {
+    auth_failed
+        && matches!(current_provider, "cloud" | "managed")
+        && local_reachable
+        && local_dims == current_dims
+}
+
+/// If a cloud embedding auth failure is latched and a local embedder is
+/// available at matching dimensionality, persist a switch to the local
+/// provider and return the reloaded [`Config`] so the caller can adopt it
+/// immediately (no process restart). Returns `None` when no switch happened.
+///
+/// Idempotent and safe to call every worker tick: it returns immediately when
+/// the latch is clear, and clears the latch once a switch is applied so
+/// concurrent workers don't switch twice.
+pub async fn maybe_switch_cloud_to_local(config: &Config) -> Option<Config> {
+    if !embedding_auth_failed() {
+        return None;
+    }
+
+    let provider = config.memory.embedding_provider.as_str();
+    if !matches!(provider, "cloud" | "managed") {
+        // The active provider isn't the managed cloud one — the latch came
+        // from a BYO 401 (or a switch already happened). Clear it; nothing to
+        // do here.
+        clear_embedding_auth_gate();
+        return None;
+    }
+
+    let current_dims = config.memory.embedding_dimensions;
+    let base_url = crate::openhuman::inference::local::ollama_base_url();
+    let local_reachable =
+        crate::openhuman::memory_store::factories::probe_ollama_reachable(&base_url).await;
+
+    if !should_switch(
+        true,
+        provider,
+        current_dims,
+        local_reachable,
+        DEFAULT_OLLAMA_DIMENSIONS,
+    ) {
+        log::debug!(
+            "[embeddings::cloud_fallback] cloud embedding auth failing but local fallback \
+             unavailable (reachable={local_reachable}, local_dims={}, current_dims={current_dims}); \
+             leaving cloud provider in place — indexing degrades gracefully until re-auth (#3312)",
+            DEFAULT_OLLAMA_DIMENSIONS
+        );
+        return None;
+    }
+
+    log::warn!(
+        "[embeddings::cloud_fallback] managed cloud session auth persistently failing and local \
+         embedder reachable at matching dims ({current_dims}); switching memory embeddings to \
+         local '{DEFAULT_OLLAMA_MODEL}' to keep indexing alive (#3312)"
+    );
+
+    match crate::openhuman::embeddings::rpc::update_settings(
+        Some("ollama".to_string()),
+        Some(DEFAULT_OLLAMA_MODEL.to_string()),
+        Some(DEFAULT_OLLAMA_DIMENSIONS),
+        None,
+        None,
+        false,
+    )
+    .await
+    {
+        Ok(_) => {
+            // Latch cleared only after the switch is durably persisted, so a
+            // mid-switch crash leaves the latch set for a retry next tick.
+            clear_embedding_auth_gate();
+            match crate::openhuman::config::ops::load_config_with_timeout().await {
+                Ok(fresh) => {
+                    log::info!(
+                        "[embeddings::cloud_fallback] switched memory embeddings to local \
+                         '{DEFAULT_OLLAMA_MODEL}'; re-embed backfill scheduled under new signature"
+                    );
+                    Some(fresh)
+                }
+                Err(e) => {
+                    // The switch persisted but reloading the config failed.
+                    // The on-disk change still takes effect on next restart;
+                    // surface it but don't crash the worker.
+                    log::warn!(
+                        "[embeddings::cloud_fallback] switch persisted but config reload failed: {e}; \
+                         worker keeps stale config until next restart"
+                    );
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            // Persisting the switch is an unexpected system failure (config
+            // save / RPC error) — report it and leave the latch set so a later
+            // tick can retry rather than swallowing the failure.
+            crate::core::observability::report_error(
+                &format!("cloud_fallback: failed to persist embedding provider switch: {e}"),
+                "embeddings",
+                "cloud_fallback_switch",
+                &[],
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::openhuman::config::Config;
+
+    // The latch is process-global, so every test that touches it must serialize
+    // through this lock to stay race-free under cargo's parallel runner (the
+    // "no flakes" rule). The pure `should_switch` truth-table tests don't touch
+    // the global and so don't take the lock.
+    static GATE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn gate_set_clear_and_idempotency() {
+        let _guard = GATE_TEST_LOCK.lock().unwrap();
+        clear_embedding_auth_gate();
+        assert!(!embedding_auth_failed());
+
+        note_embedding_auth_failure();
+        assert!(embedding_auth_failed());
+
+        // Idempotent: a second note keeps it set, no panic.
+        note_embedding_auth_failure();
+        assert!(embedding_auth_failed());
+
+        clear_embedding_auth_gate();
+        assert!(!embedding_auth_failed());
+    }
+
+    #[tokio::test]
+    async fn maybe_switch_is_noop_when_gate_clear() {
+        let _guard = GATE_TEST_LOCK.lock().unwrap();
+        clear_embedding_auth_gate();
+        // Gate clear → returns immediately, no I/O, regardless of provider.
+        let cfg = Config::default();
+        assert!(maybe_switch_cloud_to_local(&cfg).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn maybe_switch_clears_gate_for_non_cloud_provider_without_switching() {
+        let _guard = GATE_TEST_LOCK.lock().unwrap();
+        // A 401 from a user's own key latches the gate, but the active provider
+        // is not the managed cloud one — must clear the latch and never switch
+        // (no network probe, no settings write).
+        note_embedding_auth_failure();
+        let mut cfg = Config::default();
+        cfg.memory.embedding_provider = "openai".to_string();
+        assert!(maybe_switch_cloud_to_local(&cfg).await.is_none());
+        assert!(
+            !embedding_auth_failed(),
+            "non-cloud provider path must clear the stale latch"
+        );
+    }
+
+    #[test]
+    fn switches_only_when_all_guards_hold() {
+        // Happy path: cloud provider, auth failed, local reachable, dims match.
+        assert!(should_switch(true, "cloud", 1024, true, 1024));
+        assert!(should_switch(true, "managed", 1024, true, 1024));
+    }
+
+    #[test]
+    fn no_switch_without_auth_failure() {
+        assert!(!should_switch(false, "cloud", 1024, true, 1024));
+    }
+
+    #[test]
+    fn no_switch_for_non_cloud_provider() {
+        // A 401 from a user's own OpenAI/custom/voyage key must never flip them.
+        assert!(!should_switch(true, "openai", 1024, true, 1024));
+        assert!(!should_switch(true, "voyage", 1024, true, 1024));
+        assert!(!should_switch(true, "custom:http://x", 1024, true, 1024));
+        assert!(!should_switch(true, "ollama", 1024, true, 1024));
+    }
+
+    #[test]
+    fn no_switch_when_local_unreachable() {
+        assert!(!should_switch(true, "cloud", 1024, false, 1024));
+    }
+
+    #[test]
+    fn no_switch_on_dimension_mismatch_never_auto_wipes() {
+        // Different dims would force a destructive memory wipe — never do that
+        // automatically on a transient auth failure.
+        assert!(!should_switch(true, "cloud", 1024, true, 768));
+        assert!(!should_switch(true, "cloud", 1536, true, 1024));
+    }
+}

--- a/src/openhuman/embeddings/mod.rs
+++ b/src/openhuman/embeddings/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod catalog;
 pub mod cloud;
+pub mod cloud_fallback;
 pub mod cohere;
 mod factory;
 pub mod noop;

--- a/src/openhuman/embeddings/openai.rs
+++ b/src/openhuman/embeddings/openai.rs
@@ -207,6 +207,15 @@ impl EmbeddingProvider for OpenAiEmbedding {
                     target: "openai::embed",
                     "[openai] embed error: status={status}, body={text}"
                 );
+                // Latch a confirmed embedding auth failure (#3312). This is the
+                // shared chokepoint every cloud and BYO embed bottoms out in, so
+                // detecting here covers both the embeddings RPC path and the
+                // memory-tree write path. The cloud→local switch is gated on the
+                // *configured* provider downstream, so a 401 from a user's own
+                // key sets the latch but can never flip their provider.
+                if status.as_u16() == 401 || status.as_u16() == 403 {
+                    super::cloud_fallback::note_embedding_auth_failure();
+                }
                 let message = format!("Embedding API error ({status}): {text}");
                 // Use `report_error_or_expected` so transient upstream HTTP
                 // failures (e.g. 429 Too Many Requests after retry cap) log a
@@ -275,6 +284,10 @@ impl EmbeddingProvider for OpenAiEmbedding {
                 self.model, embeddings.len(),
                 embeddings.first().map(|v| v.len()).unwrap_or(0)
             );
+
+            // A successful embed means the session is valid again — clear any
+            // stale auth latch so a transient 401 blip doesn't trigger a switch.
+            super::cloud_fallback::clear_embedding_auth_gate();
 
             return Ok(embeddings);
         }

--- a/src/openhuman/memory_queue/worker.rs
+++ b/src/openhuman/memory_queue/worker.rs
@@ -104,22 +104,45 @@ pub fn start(config: Config) {
         for idx in 0..WORKER_COUNT {
             let notify = notify.clone();
             let mut cfg = config.clone();
+            // Generation this worker last reloaded its `Config` at. When a cloud
+            // → local embedding switch is persisted (#3312) the global
+            // generation bumps; every worker — not just the one that performed
+            // the switch — then reloads from disk so the whole pool moves to the
+            // new provider instead of staying split across an expired cloud
+            // session and the new local one.
+            let mut cfg_generation =
+                crate::openhuman::embeddings::cloud_fallback::config_generation();
             tokio::spawn(async move {
                 loop {
-                    // #3312: if the managed cloud session has persistently
-                    // failed auth and a local embedder is preloaded at matching
-                    // dims, this persists a switch to local and returns the
-                    // reloaded config so subsequent jobs build the local
-                    // embedder live — no process restart. Cheap no-op when the
-                    // auth latch is clear.
-                    if let Some(fresh) =
-                        crate::openhuman::embeddings::cloud_fallback::maybe_switch_cloud_to_local(
-                            &cfg,
-                        )
-                        .await
-                    {
-                        cfg = fresh;
+                    // #3312: if the managed cloud session has persistently failed
+                    // auth and the local model is preloaded at matching dims,
+                    // this persists a switch to local and bumps the config
+                    // generation. Cheap no-op when the auth latch is clear.
+                    crate::openhuman::embeddings::cloud_fallback::maybe_switch_cloud_to_local(&cfg)
+                        .await;
+
+                    // Adopt a persisted config change (from this worker's switch
+                    // or another's) by reloading from disk. On reload failure we
+                    // leave `cfg_generation` unchanged so the next tick retries.
+                    let current_generation =
+                        crate::openhuman::embeddings::cloud_fallback::config_generation();
+                    if current_generation != cfg_generation {
+                        match crate::openhuman::config::ops::load_config_with_timeout().await {
+                            Ok(fresh) => {
+                                cfg = fresh;
+                                cfg_generation = current_generation;
+                                log::info!(
+                                    "[memory::jobs] worker {idx} reloaded config (generation={current_generation}) after embedding provider switch"
+                                );
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "[memory::jobs] worker {idx} config reload failed (generation={current_generation}); retrying next tick: {e}"
+                                );
+                            }
+                        }
                     }
+
                     match run_once(&cfg).await {
                         Ok(true) => continue,
                         Ok(false) => {

--- a/src/openhuman/memory_queue/worker.rs
+++ b/src/openhuman/memory_queue/worker.rs
@@ -103,9 +103,23 @@ pub fn start(config: Config) {
 
         for idx in 0..WORKER_COUNT {
             let notify = notify.clone();
-            let cfg = config.clone();
+            let mut cfg = config.clone();
             tokio::spawn(async move {
                 loop {
+                    // #3312: if the managed cloud session has persistently
+                    // failed auth and a local embedder is preloaded at matching
+                    // dims, this persists a switch to local and returns the
+                    // reloaded config so subsequent jobs build the local
+                    // embedder live — no process restart. Cheap no-op when the
+                    // auth latch is clear.
+                    if let Some(fresh) =
+                        crate::openhuman::embeddings::cloud_fallback::maybe_switch_cloud_to_local(
+                            &cfg,
+                        )
+                        .await
+                    {
+                        cfg = fresh;
+                    }
                     match run_once(&cfg).await {
                         Ok(true) => continue,
                         Ok(false) => {

--- a/src/openhuman/memory_store/factories.rs
+++ b/src/openhuman/memory_store/factories.rs
@@ -181,6 +181,75 @@ pub(crate) async fn probe_ollama_reachable(base_url: &str) -> bool {
     }
 }
 
+/// Stronger probe than [`probe_ollama_reachable`]: returns `true` only when the
+/// Ollama daemon answers `/api/tags` **and** the response lists `model` as a
+/// pulled model. A bare daemon-reachability check is not enough to switch the
+/// active embedder onto Ollama (#3312): a host where the daemon is up but the
+/// model was never pulled would otherwise move indexing onto a provider that
+/// immediately fails with "model not found".
+///
+/// Ollama tags are reported as `"<model>:<tag>"` (e.g. `bge-m3:latest`), so a
+/// configured model of `bge-m3` matches either an exact name or any `bge-m3:*`
+/// entry. 2s timeout mirrors [`probe_ollama_reachable`].
+pub(crate) async fn probe_ollama_model_available(base_url: &str, model: &str) -> bool {
+    let url = format!("{}/api/tags", base_url.trim_end_matches('/'));
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!(
+                "[memory::factory] probe_ollama_model_available: failed to build http client: {e}"
+            );
+            return false;
+        }
+    };
+    let resp = match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => resp,
+        Ok(resp) => {
+            log::debug!(
+                "[memory::factory] probe_ollama_model_available: {url} returned status {}",
+                resp.status()
+            );
+            return false;
+        }
+        Err(e) => {
+            log::debug!("[memory::factory] probe_ollama_model_available: {url} unreachable: {e}");
+            return false;
+        }
+    };
+    let json: serde_json::Value = match resp.json().await {
+        Ok(j) => j,
+        Err(e) => {
+            log::debug!("[memory::factory] probe_ollama_model_available: bad /api/tags body: {e}");
+            return false;
+        }
+    };
+    let Some(models) = json.get("models").and_then(|m| m.as_array()) else {
+        return false;
+    };
+    let available = models.iter().any(|entry| {
+        entry
+            .get("name")
+            .and_then(|n| n.as_str())
+            .is_some_and(|name| ollama_tag_matches_model(name, model))
+    });
+    if !available {
+        log::debug!(
+            "[memory::factory] probe_ollama_model_available: daemon up but model '{model}' not pulled"
+        );
+    }
+    available
+}
+
+/// Whether an Ollama `/api/tags` entry name (e.g. `bge-m3:latest`) satisfies a
+/// configured model id (e.g. `bge-m3`): exact match, or the same base before the
+/// `:<tag>` suffix. Pure so the matching rule is unit-tested directly.
+fn ollama_tag_matches_model(tag_name: &str, model: &str) -> bool {
+    tag_name == model || tag_name.split(':').next() == Some(model)
+}
+
 /// Returns the effective `(provider, model, dimensions)` triple for the
 /// embedding backend.
 ///
@@ -696,6 +765,52 @@ mod tests {
         });
         let url = format!("http://127.0.0.1:{}", addr.port());
         assert!(!probe_ollama_reachable(&url).await);
+    }
+
+    #[test]
+    fn ollama_tag_matches_model_handles_tag_suffixes() {
+        assert!(ollama_tag_matches_model("bge-m3", "bge-m3"));
+        assert!(ollama_tag_matches_model("bge-m3:latest", "bge-m3"));
+        assert!(ollama_tag_matches_model("bge-m3:f16", "bge-m3"));
+        assert!(!ollama_tag_matches_model("bge-large", "bge-m3"));
+        assert!(!ollama_tag_matches_model(
+            "nomic-embed-text:latest",
+            "bge-m3"
+        ));
+    }
+
+    /// Spin up a mock Ollama `/api/tags` returning the given model names.
+    async fn start_mock_ollama_with_models(names: &[&str]) -> String {
+        let models: Vec<serde_json::Value> = names
+            .iter()
+            .map(|n| serde_json::json!({ "name": n }))
+            .collect();
+        let body = serde_json::json!({ "models": models });
+        let app = Router::new().route("/api/tags", get(move || async move { Json(body) }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://127.0.0.1:{}", addr.port())
+    }
+
+    #[tokio::test]
+    async fn model_available_true_when_model_is_pulled() {
+        let url = start_mock_ollama_with_models(&["bge-m3:latest", "llama3:8b"]).await;
+        assert!(probe_ollama_model_available(&url, "bge-m3").await);
+    }
+
+    #[tokio::test]
+    async fn model_available_false_when_daemon_up_but_model_missing() {
+        // The #3312 hazard: daemon reachable, target model not pulled.
+        let url = start_mock_ollama_with_models(&["llama3:8b"]).await;
+        assert!(!probe_ollama_model_available(&url, "bge-m3").await);
+    }
+
+    #[tokio::test]
+    async fn model_available_false_when_unreachable() {
+        assert!(!probe_ollama_model_available("http://127.0.0.1:1", "bge-m3").await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- When the managed cloud (Voyage-backed) backend session JWT expires mid-run, every embedding call returns `401 Invalid token` and indexing fails hard until a manual provider switch. This adds an automatic, signature-safe fallback to a preloaded local embedder.
- Detection is a process-global auth-failure latch set at the shared `OpenAiEmbedding::embed` chokepoint; the memory-queue worker acts on it each tick.
- The switch is persisted via `update_settings`, moving the active embedding signature atomically with the provider, then adopted by the worker in-place — so it takes effect with **no process restart**.
- Addresses **1 of the 4** robustness gaps in #3312 (the "embedding fallback on 401" item). Does **not** close the issue.

## Problem

- On a long-running headless/Docker deployment the backend session expires after a few hours. From then on every managed-cloud embed returns 401 (every ~2 min), hard-failing indexing, with no automatic fallback even when a local embedder is preloaded. The original deployment needed a manual restart to recover.
- The constraint that makes this non-trivial: cloud (Voyage) and local (`bge-m3`) are **different embedding spaces**, and the vector store tags every vector by a **config-derived signature** (#1574). Naively returning local vectors on a 401 would write them under the cloud signature and silently corrupt semantic search.

## Solution

- **Detect** at `OpenAiEmbedding::embed` — the shared chokepoint both the embeddings RPC path and the memory-tree write path bottom out in. A confirmed 401/403 latches a process-global flag; any successful embed clears it (a transient blip can't trigger a switch).
- **Switch** in the memory-queue worker tick, only when **all** guards hold: configured provider is managed cloud (`cloud`/`managed`); a local embedder is reachable (`probe_ollama_reachable`); and local dimensionality **equals** the current one (`bge-m3` 1024 == cloud 1024) so **no destructive memory wipe** is required.
- Persisting the switch via the existing `update_settings` moves the active embedding signature **atomically** with the provider and schedules the existing re-embed backfill — vectors stay correctly labelled and the corpus re-indexes under the local signature. Local vectors are never written under the cloud signature.
- The worker **adopts the reloaded config in-place**, so the switch applies with no restart. If no local embedder is available, the latch is a **no-op**: the cloud failure stays surfaced (graceful degradation) rather than switching into a dead provider or auto-wiping memory.
- Design decision: settings-level switch + signature move, chosen over a per-call vector swap (would corrupt the established cloud corpus) and over a mere graceful-skip (wouldn't restore embeddings).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `should_switch` truth table incl. the dimension-mismatch never-auto-wipes case; gate set/clear/idempotency; no-I/O early-return branches (gate-clear, non-cloud provider). Serialized via a test lock to stay race-free.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. — Pure decision core + all early-return branches are unit-covered; the deep switch path (`probe_ollama_reachable` + `update_settings` + config reload) is genuine I/O integration and not unit-covered. Will confirm `diff-cover` in CI.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — `N/A: behaviour-only robustness change`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A (no matrix rows touched).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — reuses the existing Ollama reachability probe and embeddings RPC; no new deps.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A`: no release-cut UI surface, Rust core only.
- [x] N/A — linked issue intentionally NOT auto-closed: this is a partial fix (1 of 4 items in #3312); maintainer closes #3312 once all land.

## Impact

- Runtime/platform impact (desktop/mobile/web/CLI), if any. — Rust core (CLI/desktop/docker); no frontend changes.
- Performance, security, migration, or compatibility implications. — Per-tick cost is a single atomic load when the latch is clear (no-op). No memory wipe (dimension-matched), no migration. Switch only ever moves managed-cloud → local; BYO providers are never affected.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes: — none (partial fix; #3312 stays open until MCP auto-reconnect and granular health also land). Refs #3312 (embedding-fallback item), #3329 (scheduler auto-recovery, merged), #1574 (signature invariant).
- Follow-up PR(s)/TODOs: MCP server auto-reconnect; granular per-component health checks.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3312-embedding-cloud-local-fallback
- Commit SHA: eeb2c0f555af0b404b4838972587d784bf6c7211

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — passed via pre-push hook.
- [x] `pnpm typecheck` — passed via pre-push hook.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib embeddings::cloud_fallback` (8 passed); `embeddings::` suite (161 passed).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `GGML_NATIVE=OFF cargo check --bin openhuman-core` clean.
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: managed-cloud embedding auth expiry auto-switches to a preloaded, dimension-matched local embedder and re-indexes under the new signature; takes effect without a process restart.
- User-visible effect: indexing keeps working through a backend session expiry instead of stalling until a manual restart; no user action required.

### Parity Contract

- Legacy behavior preserved: when no local embedder is preloaded, or dims differ, behavior is unchanged (cloud failure surfaced, no wipe, no switch).
- Guard/fallback/dispatch parity checks: switch gated on configured provider == `cloud`/`managed`; a 401 from a BYO key can set the latch but never flips the user's provider.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic failover from managed cloud embeddings to a local embedder when repeated cloud auth failures occur, applied seamlessly at runtime.

* **Improvements**
  * Workers now detect and apply persisted provider changes without restart.
  * Stronger local embedder probe that verifies model availability before switching.

* **Tests**
  * Added unit tests covering latch behavior, switch eligibility, model-probing, and idempotent worker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
