### PR TITLE
fix(tools): root glob at action_dir + readable-scope search (#3357)

### DIFF
--- a/src/openhuman/tools/impl/filesystem/glob_search.rs
+++ b/src/openhuman/tools/impl/filesystem/glob_search.rs
@@ -1,8 +1,27 @@
 //! `glob` — find files by glob pattern.
 //!
 //! Coding-harness baseline tool (issue #1205): pure file discovery
-//! by pattern (e.g. `src/**/*.rs`). Path traversal is blocked the same
-//! way as `file_read`.
+//! by pattern (e.g. `src/**/*.rs`).
+//!
+//! ## Path-root contract (issue #3357)
+//!
+//! `glob` resolves its search root through the **same** seam the reader tools
+//! use — [`SecurityPolicy::validate_path`] — and filters every hit through
+//! [`SecurityPolicy::is_path_string_allowed`]. This guarantees the core
+//! invariant a discovery tool must hold: **every path `glob` returns is a path
+//! `file_read`/`grep`/`list` can open, and nothing else.**
+//!
+//! Previously `glob` walked `workspace_dir` (internal product state) and
+//! returned paths relative to it, while the readers resolve relative paths
+//! against `action_dir`. The two roots normally differ, so a path `glob`
+//! returned was meaningless to the readers — every follow-up read failed with
+//! "No such file or directory (os error 2)" (#3357). Walking `workspace_dir`
+//! also let the agent enumerate internal state (memory DBs, sessions, tokens).
+//!
+//! The optional `path` argument lets the agent search any location it is
+//! allowed to read (the action sandbox by default, or a granted `trusted_root`)
+//! — it is resolved through `validate_path`, so it can never widen access
+//! beyond what the readers already permit.
 
 use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
@@ -32,8 +51,11 @@ impl Tool for GlobTool {
     }
 
     fn description(&self) -> &str {
-        "Find files matching a glob pattern (e.g. `src/**/*.rs`). Returns matching paths \
-         relative to the workspace, sorted by modification time (newest first)."
+        "Find files matching a glob pattern (e.g. `src/**/*.rs`). Searches your working \
+         directory (the action sandbox) by default; pass `path` to search another folder \
+         you're allowed to read. Returns matching paths sorted by modification time \
+         (newest first) — relative to the working directory, or absolute when outside it — \
+         so each result can be passed straight to `file_read`/`grep`."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -42,7 +64,11 @@ impl Tool for GlobTool {
             "properties": {
                 "pattern": {
                     "type": "string",
-                    "description": "Glob pattern, e.g. `**/*.rs` or `src/**/*.{ts,tsx}` (single brace expansion not supported — list patterns separately)."
+                    "description": "Glob pattern, e.g. `**/*.rs` or `src/**/*.{ts,tsx}` (single brace expansion not supported — list patterns separately). Matched against paths relative to the search directory."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search within. Defaults to the working directory (action sandbox). Must be a location you're allowed to read; relative paths resolve against the working directory."
                 },
                 "max_results": {
                     "type": "integer",
@@ -68,6 +94,14 @@ impl Tool for GlobTool {
             .get("pattern")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' parameter"))?;
+        // Default the search root to "." — which `validate_path` resolves to the
+        // action sandbox (action_dir), the same root file_read/grep/list use.
+        let search_path = args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(".");
         let max_results = args
             .get("max_results")
             .and_then(|v| v.as_u64())
@@ -90,11 +124,32 @@ impl Tool for GlobTool {
             Err(e) => return Ok(ToolResult::error(format!("Invalid glob pattern: {e}"))),
         };
 
-        let workspace = self.security.workspace_dir.clone();
-        let result =
-            tokio::task::spawn_blocking(move || collect_matches(&workspace, &pattern, max_results))
-                .await
-                .map_err(|e| anyhow::anyhow!("scan task failed: {e}"))?;
+        // Resolve + authorize the search root through the readers' validation
+        // seam. A disallowed or missing root yields a clear, path-naming error
+        // instead of the opaque "No such file or directory" the old workspace_dir
+        // root produced (#3357).
+        let base = match self.security.validate_path(search_path).await {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(ToolResult::error(format!(
+                    "glob search path '{search_path}' is not accessible: {e}"
+                )))
+            }
+        };
+
+        // Canonical action sandbox, used to decide whether a hit is rendered
+        // relative (inside the sandbox → directly file_read-able by relative
+        // path) or absolute (in a granted trusted root → file_read-able as-is).
+        let action_root = tokio::fs::canonicalize(&self.security.action_dir)
+            .await
+            .unwrap_or_else(|_| self.security.action_dir.clone());
+
+        let security = self.security.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            collect_matches(&base, &action_root, &security, &pattern, max_results)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("scan task failed: {e}"))?;
 
         let (paths, truncated) = result;
         let header = if truncated {
@@ -113,10 +168,27 @@ impl Tool for GlobTool {
     }
 }
 
-fn collect_matches(workspace: &Path, pattern: &Pattern, max_results: usize) -> (Vec<String>, bool) {
+/// Walk `base`, returning glob matches as paths the reader tools can open.
+///
+/// - The pattern is matched against each file's path **relative to `base`**
+///   (the searched directory), the conventional glob behavior.
+/// - The returned string is **relative to `action_root`** when the hit lives
+///   inside the action sandbox (so `file_read("src/a.rs")` works), otherwise
+///   the **absolute** path (so `file_read` resolves it as-is via a trusted
+///   root).
+/// - Every hit is filtered through [`SecurityPolicy::is_path_string_allowed`]
+///   on that exact returned string, so `glob` never surfaces a path the readers
+///   would reject (internal state, forbidden trees, symlink escapes).
+fn collect_matches(
+    base: &Path,
+    action_root: &Path,
+    security: &SecurityPolicy,
+    pattern: &Pattern,
+    max_results: usize,
+) -> (Vec<String>, bool) {
     let mut hits: Vec<(std::time::SystemTime, String)> = Vec::new();
 
-    for entry in WalkDir::new(workspace)
+    for entry in WalkDir::new(base)
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| !is_skipped(e.file_name().to_string_lossy().as_ref()))
@@ -125,20 +197,35 @@ fn collect_matches(workspace: &Path, pattern: &Pattern, max_results: usize) -> (
         if !entry.file_type().is_file() {
             continue;
         }
-        let rel = match entry.path().strip_prefix(workspace) {
-            Ok(p) => p,
+        let abs = entry.path();
+
+        // Match the pattern against the path relative to the searched root.
+        let rel_to_base = match abs.strip_prefix(base) {
+            Ok(p) => p.to_string_lossy().replace('\\', "/"),
             Err(_) => continue,
         };
-        let rel_str = rel.to_string_lossy().replace('\\', "/");
-        if !pattern.matches(&rel_str) {
+        if !pattern.matches(&rel_to_base) {
             continue;
         }
+
+        // Render the path the way the agent should hand it to file_read:
+        // sandbox-relative when inside action_dir, absolute otherwise.
+        let display = match abs.strip_prefix(action_root) {
+            Ok(rel) => rel.to_string_lossy().replace('\\', "/"),
+            Err(_) => abs.to_string_lossy().to_string(),
+        };
+
+        // Fail-closed: only surface paths the readers would also accept.
+        if !security.is_path_string_allowed(&display) {
+            continue;
+        }
+
         let mtime = entry
             .metadata()
             .ok()
             .and_then(|m| m.modified().ok())
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        hits.push((mtime, rel_str));
+        hits.push((mtime, display));
     }
 
     // Newest first.
@@ -158,13 +245,44 @@ fn is_skipped(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::openhuman::security::{AutonomyLevel, SecurityPolicy};
+    use crate::openhuman::security::{AutonomyLevel, SecurityPolicy, TrustedAccess, TrustedRoot};
 
     fn test_security(workspace: std::path::PathBuf) -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
             action_dir: workspace.clone(),
-            workspace_dir: workspace,
+            workspace_dir: workspace.clone(),
+            // Mirror the production constructor, which registers the action
+            // sandbox as a ReadWrite trusted root so validate_path accepts it
+            // even under workspace_only.
+            trusted_roots: vec![TrustedRoot {
+                path: workspace.to_string_lossy().to_string(),
+                access: TrustedAccess::ReadWrite,
+            }],
+            ..SecurityPolicy::default()
+        })
+    }
+
+    /// Policy with a distinct action sandbox and internal workspace — the real
+    /// production shape, and the configuration that surfaced #3357.
+    fn test_security_split(
+        action_dir: std::path::PathBuf,
+        workspace_dir: std::path::PathBuf,
+        extra_roots: Vec<std::path::PathBuf>,
+    ) -> Arc<SecurityPolicy> {
+        let mut roots = vec![TrustedRoot {
+            path: action_dir.to_string_lossy().to_string(),
+            access: TrustedAccess::ReadWrite,
+        }];
+        roots.extend(extra_roots.into_iter().map(|p| TrustedRoot {
+            path: p.to_string_lossy().to_string(),
+            access: TrustedAccess::ReadWrite,
+        }));
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            action_dir,
+            workspace_dir,
+            trusted_roots: roots,
             ..SecurityPolicy::default()
         })
     }
@@ -232,5 +350,107 @@ mod tests {
         assert!(!output.contains("node_modules"));
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    /// Regression for #3357: glob roots at action_dir (so its hits are readable),
+    /// and never surfaces files living under the internal workspace_dir.
+    #[tokio::test]
+    async fn glob_roots_at_action_dir_and_excludes_workspace() {
+        let root = std::env::temp_dir().join("openhuman_test_glob_split");
+        let action = root.join("action");
+        let workspace = root.join("workspace");
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(&action).await.unwrap();
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(action.join("keep.txt"), "keep")
+            .await
+            .unwrap();
+        tokio::fs::write(workspace.join("secret.txt"), "secret")
+            .await
+            .unwrap();
+
+        let security = test_security_split(action.clone(), workspace.clone(), vec![]);
+        let tool = GlobTool::new(security.clone());
+        let result = tool.execute(json!({"pattern": "**/*.txt"})).await.unwrap();
+        assert!(!result.is_error, "{}", result.output());
+        let output = result.output();
+        // Action-sandbox file is found, rendered relative...
+        assert!(output.contains("keep.txt"), "missing keep.txt: {output}");
+        // ...and the internal workspace file is NOT enumerated.
+        assert!(
+            !output.contains("secret.txt"),
+            "leaked workspace file: {output}"
+        );
+
+        // The glob hit must be directly readable by the reader tools.
+        assert!(
+            security.validate_path("keep.txt").await.is_ok(),
+            "glob hit not resolvable by validate_path"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    /// "As wide as the readers": glob can search any granted trusted root via
+    /// the `path` arg, returning absolute paths that the readers accept as-is.
+    #[tokio::test]
+    async fn glob_searches_named_trusted_root() {
+        let root = std::env::temp_dir().join("openhuman_test_glob_trusted");
+        let action = root.join("action");
+        let workspace = root.join("workspace");
+        let granted = root.join("granted");
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(&action).await.unwrap();
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&granted).await.unwrap();
+        tokio::fs::write(granted.join("data.csv"), "x")
+            .await
+            .unwrap();
+
+        let security =
+            test_security_split(action.clone(), workspace.clone(), vec![granted.clone()]);
+        let tool = GlobTool::new(security.clone());
+        let granted_abs = granted.to_string_lossy().to_string();
+        let result = tool
+            .execute(json!({"pattern": "**/*.csv", "path": granted_abs}))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.output());
+        let output = result.output();
+        assert!(output.contains("data.csv"), "missing data.csv: {output}");
+        // Rendered absolute (outside the action sandbox).
+        assert!(
+            output.contains(&granted.to_string_lossy().to_string()),
+            "expected absolute path: {output}"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    /// A search root the policy disallows yields a clear error, not ENOENT.
+    #[tokio::test]
+    async fn glob_rejects_disallowed_search_path() {
+        let root = std::env::temp_dir().join("openhuman_test_glob_reject");
+        let action = root.join("action");
+        let workspace = root.join("workspace");
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(&action).await.unwrap();
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+
+        let security = test_security_split(action.clone(), workspace.clone(), vec![]);
+        let tool = GlobTool::new(security);
+        // Absolute path outside any trusted root, under workspace_only.
+        let result = tool
+            .execute(json!({"pattern": "**/*", "path": "/etc"}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(
+            result.output().contains("not accessible"),
+            "{}",
+            result.output()
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
     }
 }

--- a/src/openhuman/tools/impl/filesystem/glob_search.rs
+++ b/src/openhuman/tools/impl/filesystem/glob_search.rs
@@ -141,6 +141,27 @@ impl Tool for GlobTool {
                 )));
             }
         };
+        // `validate_path` can authorize a *file* as well as a directory. Walking a
+        // file root yields the file itself, whose path relative to `base` is empty,
+        // so the pattern never matches and the agent gets a misleading "0 match(es)"
+        // instead of a clear error. Reject non-directory roots explicitly.
+        match tokio::fs::metadata(&base).await {
+            Ok(meta) if meta.is_dir() => {}
+            Ok(_) => {
+                log::debug!("[tools:glob] search path is not a directory: path='{search_path}'");
+                return Ok(ToolResult::error(format!(
+                    "glob search path '{search_path}' is not a directory"
+                )));
+            }
+            Err(e) => {
+                log::debug!(
+                    "[tools:glob] search path not accessible: path='{search_path}' error={e}"
+                );
+                return Ok(ToolResult::error(format!(
+                    "glob search path '{search_path}' is not accessible: {e}"
+                )));
+            }
+        };
         log::debug!(
             "[tools:glob] resolved search root: '{}' (action_dir='{}')",
             base.display(),
@@ -152,7 +173,13 @@ impl Tool for GlobTool {
         // path) or absolute (in a granted trusted root → file_read-able as-is).
         let action_root = tokio::fs::canonicalize(&self.security.action_dir)
             .await
-            .unwrap_or_else(|_| self.security.action_dir.clone());
+            .unwrap_or_else(|e| {
+                log::trace!(
+                    "[tools:glob] action_dir canonicalize fallback: path='{}' error={e}",
+                    self.security.action_dir.display()
+                );
+                self.security.action_dir.clone()
+            });
 
         let security = self.security.clone();
         let result = tokio::task::spawn_blocking(move || {
@@ -468,5 +495,29 @@ mod tests {
         );
 
         let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    /// A `path` that resolves to a *file* (not a directory) yields a clear
+    /// "not a directory" error rather than a misleading "0 match(es)".
+    #[tokio::test]
+    async fn glob_rejects_file_search_path() {
+        let dir = std::env::temp_dir().join("openhuman_test_glob_file_root");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("file.txt"), "x").await.unwrap();
+
+        let tool = GlobTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({"pattern": "**/*", "path": "file.txt"}))
+            .await
+            .unwrap();
+        assert!(result.is_error, "{}", result.output());
+        assert!(
+            result.output().contains("not a directory"),
+            "{}",
+            result.output()
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 }

--- a/src/openhuman/tools/impl/filesystem/glob_search.rs
+++ b/src/openhuman/tools/impl/filesystem/glob_search.rs
@@ -171,6 +171,10 @@ impl Tool for GlobTool {
         // Canonical action sandbox, used to decide whether a hit is rendered
         // relative (inside the sandbox → directly file_read-able by relative
         // path) or absolute (in a granted trusted root → file_read-able as-is).
+        // `base` is already canonical (validate_path canonicalizes), so if this
+        // fallback fires the two roots become asymmetric and strip_prefix below
+        // may miss for an in-sandbox hit, rendering it absolute. Harmless: the
+        // absolute path is still readable and the per-hit filter still applies.
         let action_root = tokio::fs::canonicalize(&self.security.action_dir)
             .await
             .unwrap_or_else(|e| {
@@ -221,6 +225,10 @@ impl Tool for GlobTool {
 /// - Every hit is filtered through [`SecurityPolicy::is_path_string_allowed`]
 ///   on that exact returned string, so `glob` never surfaces a path the readers
 ///   would reject (internal state, forbidden trees, symlink escapes).
+///
+/// `max_results` bounds the returned list, not the walk: the full tree under
+/// `base` is always traversed and only the output is truncated (pre-existing
+/// behavior — the cap caps results, not work).
 fn collect_matches(
     base: &Path,
     action_root: &Path,
@@ -492,6 +500,60 @@ mod tests {
             result.output().contains("not accessible"),
             "{}",
             result.output()
+        );
+
+        let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    /// Security backstop: a symlink inside the sandbox pointing OUTSIDE it must
+    /// never leak the target. Two layers cover this and this test exercises
+    /// both: the walk runs with `follow_links(false)`, so the symlink entry is
+    /// dropped by the `is_file()` gate (a symlink is not a regular file) and is
+    /// never descended; and `is_path_string_allowed` is the fail-closed per-hit
+    /// backstop — assert directly that it rejects the escape's resolved string,
+    /// since that is the check `collect_matches` leans on if the walk gate is
+    /// ever bypassed. A legitimate in-sandbox file is still found.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn glob_does_not_leak_symlink_escape() {
+        let root = std::env::temp_dir().join("openhuman_test_glob_symlink");
+        let action = root.join("action");
+        let workspace = root.join("workspace");
+        let outside = root.join("outside");
+        let _ = tokio::fs::remove_dir_all(&root).await;
+        tokio::fs::create_dir_all(action.join("sub")).await.unwrap();
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&outside).await.unwrap();
+        tokio::fs::write(action.join("sub/ok.txt"), "ok")
+            .await
+            .unwrap();
+        tokio::fs::write(outside.join("secret.txt"), "secret")
+            .await
+            .unwrap();
+        // Symlink inside the sandbox pointing at the outside (untrusted) tree.
+        std::os::unix::fs::symlink(&outside, action.join("escape")).unwrap();
+
+        // `outside` is deliberately NOT registered as a trusted root.
+        let security = test_security_split(action.clone(), workspace.clone(), vec![]);
+        let tool = GlobTool::new(security.clone());
+        let result = tool.execute(json!({"pattern": "**/*.txt"})).await.unwrap();
+        assert!(!result.is_error, "{}", result.output());
+        let output = result.output();
+        // The in-sandbox file is found, the escape target is not enumerated.
+        assert!(
+            output.contains("ok.txt"),
+            "missing in-sandbox file: {output}"
+        );
+        assert!(
+            !output.contains("secret"),
+            "leaked symlink-escape target: {output}"
+        );
+        // The fail-closed backstop, exercised directly: the resolved escape
+        // path is rejected as a string regardless of how it was reached.
+        let escaped = outside.join("secret.txt").to_string_lossy().to_string();
+        assert!(
+            !security.is_path_string_allowed(&escaped),
+            "policy must reject the escape target string: {escaped}"
         );
 
         let _ = tokio::fs::remove_dir_all(&root).await;

--- a/src/openhuman/tools/impl/filesystem/glob_search.rs
+++ b/src/openhuman/tools/impl/filesystem/glob_search.rs
@@ -124,6 +124,10 @@ impl Tool for GlobTool {
             Err(e) => return Ok(ToolResult::error(format!("Invalid glob pattern: {e}"))),
         };
 
+        log::debug!(
+            "[tools:glob] search start: pattern='{pattern_str}' path='{search_path}' max_results={max_results}"
+        );
+
         // Resolve + authorize the search root through the readers' validation
         // seam. A disallowed or missing root yields a clear, path-naming error
         // instead of the opaque "No such file or directory" the old workspace_dir
@@ -131,11 +135,17 @@ impl Tool for GlobTool {
         let base = match self.security.validate_path(search_path).await {
             Ok(p) => p,
             Err(e) => {
+                log::debug!("[tools:glob] search path rejected: path='{search_path}' error={e}");
                 return Ok(ToolResult::error(format!(
                     "glob search path '{search_path}' is not accessible: {e}"
-                )))
+                )));
             }
         };
+        log::debug!(
+            "[tools:glob] resolved search root: '{}' (action_dir='{}')",
+            base.display(),
+            self.security.action_dir.display()
+        );
 
         // Canonical action sandbox, used to decide whether a hit is rendered
         // relative (inside the sandbox → directly file_read-able by relative
@@ -152,6 +162,11 @@ impl Tool for GlobTool {
         .map_err(|e| anyhow::anyhow!("scan task failed: {e}"))?;
 
         let (paths, truncated) = result;
+        log::debug!(
+            "[tools:glob] scan complete: {} match(es) truncated={}",
+            paths.len(),
+            truncated
+        );
         let header = if truncated {
             format!("{} match(es) (truncated at {max_results})", paths.len())
         } else {
@@ -217,6 +232,7 @@ fn collect_matches(
 
         // Fail-closed: only surface paths the readers would also accept.
         if !security.is_path_string_allowed(&display) {
+            log::trace!("[tools:glob] path filtered by policy: '{display}'");
             continue;
         }
 


### PR DESCRIPTION
## Summary

- `glob` now resolves its search root through the **same** security seam the reader tools use (`SecurityPolicy::validate_path`), defaulting to the action sandbox (`action_dir`) — so a path `glob` returns is directly readable by `file_read`/`grep`/`list`.
- Fixes the reported "No such file or directory (os error 2)" where `glob` found files but every follow-up read failed (#3357).
- Closes an internal-state enumeration leak: `glob` no longer walks `workspace_dir` (memory DBs, sessions, tokens).
- Adds an optional `path` argument so the agent can search any folder it is *allowed* to read (e.g. a granted `trusted_root`), validated through the same seam so it can never widen access.

## Problem

`glob` resolved relative paths against `workspace_dir` (internal product state) and returned `workspace`-relative strings, while `file_read`/`grep`/`list` resolve relative paths against `action_dir` (`validate_path`). The two roots normally differ (`action_dir` defaults to `~/OpenHuman/projects`; `workspace_dir` is `~/.openhuman/users/<id>/workspace`), so a path `glob` returned was meaningless to the readers — the agent would `glob` a file, then fail to open it with `os error 2` (#3357). Walking `workspace_dir` also let the agent enumerate internal state, independent of the read bug.

## Solution

- Resolve the search root via `validate_path` (default `"."` → `action_dir`); a disallowed/missing root yields a clear path-naming error instead of an opaque ENOENT.
- Optional `path` arg: search any location `validate_path` accepts (action sandbox or a granted `trusted_root`) — bounded by the readers' own allow-check, never wider.
- Render each hit the way it should be handed to `file_read`: **relative** when inside the action sandbox, **absolute** when in a trusted root. The pattern is matched against the path relative to the searched root.
- Fail-closed per-hit filter through `is_path_string_allowed` on the exact returned string, so `glob` can never surface internal-state, forbidden, or symlink-escape paths.
- This brings `glob` in line with the shell family (which already runs with `cwd = action_dir`) and the readers — `glob` was the lone tool pointed at `workspace_dir`.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines covered by 4 new tests (action_dir rooting, workspace-leak exclusion, trusted-root `path` search, disallowed-root rejection) plus the 3 existing tests; `cargo test --lib glob_search` → 7 passed. CI `diff-cover` will confirm the gate.
- [x] Coverage matrix updated — `N/A: behaviour fix to the existing `glob` tool; no feature row added/removed/renamed.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: behaviour-only change.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not touch release-cut surfaces.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop/CLI agent harness (Rust core). No frontend change.
- **Security:** strictly tightening — `glob` stops enumerating internal `workspace_dir` state and now honours the same denylist/trusted-root/symlink-escape checks as the readers.
- **Behaviour change:** an agent that relied on `glob` searching the internal workspace will now search the action sandbox (that reliance was the bug + a leak). Default-root output stays relative, as before.
- No migration; single-file change.

## Related

- Closes: #3357
- Follow-up PR(s)/TODOs: none. (Sibling of #3074/#3353, which split `action_dir`/`workspace_dir` and migrated the readers but not `glob`.)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3357-glob-readable-scope
- Commit SHA: 62c7568a2206e8325075dba03bcbe8b443edd211

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no app/ changes); `cargo fmt --check` on the file: clean
- [x] `pnpm typecheck` — N/A (no TypeScript changes)
- [x] Focused tests: `cargo test --lib glob_search` → 7 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; lib test build green
- [x] Tauri fmt/check (if changed): N/A (no app/src-tauri changes)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `glob` roots at `action_dir` (not `workspace_dir`); adds an `path` arg to search granted trusted roots; hits are returned relative (sandbox) or absolute (trusted root).
- User-visible effect: `glob` results are now openable by `file_read`/`grep`; #3357 ENOENT resolved; internal workspace files no longer listed.

### Parity Contract

- Legacy behavior preserved: default-root globbing still returns relative, mtime-sorted paths; `node_modules`/`.git`/etc. still skipped; invalid-pattern + rate-limit paths unchanged.
- Guard/fallback/dispatch parity checks: per-hit `is_path_string_allowed` mirrors the readers' allow-check; search-root via `validate_path` mirrors `file_read`/`grep`/`list`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Glob search now enforces security checks, fails-closed for disallowed roots, and returns clearer errors (e.g., "not accessible" for disallowed roots, "not a directory" when a path resolves to a file).

* **Improvements**
  * Optional path input (default ".") is trimmed and validated; scans are limited to the validated base. Matches are returned sandbox-relative or absolute as appropriate and filtered to avoid exposing inaccessible paths.

* **Tests**
  * Added tests covering sandbox vs trusted-root behavior, symlink escape protection, and rejection/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
