### PR TITLE
test(e2e): restore chat-harness-subagent strong assertions + diagnostics

### DIFF
--- a/app/test/playwright/specs/chat-harness-subagent.spec.ts
+++ b/app/test/playwright/specs/chat-harness-subagent.spec.ts
@@ -135,8 +135,138 @@ async function sendMessage(page: Page, prompt: string): Promise<void> {
   await page.getByTestId('send-message-button').click();
 }
 
+async function llmCompletionRequests(): Promise<MockRequest[]> {
+  const log = await requests();
+  return log.filter(
+    entry => entry.method === 'POST' && entry.url.includes('/openai/v1/chat/completions')
+  );
+}
+
+async function completionRequestCount(): Promise<number> {
+  return (await llmCompletionRequests()).length;
+}
+
+interface DiagnosticsSnapshot {
+  completionRequests: Array<{ probe: string; index: number }>;
+  matchedKeywords: string[];
+  selectedThreadId: string | null;
+  runtime: {
+    phase: string | null;
+    toolTimelineNames: string[];
+    toolTimelineIds: string[];
+    messageCount: number;
+    lastAssistantText: string | null;
+  };
+}
+
+// Captures the harness state the moment a strong assertion is about to time
+// out so future CI failures expose request counts, consumed keyword matches,
+// the active thread, and the chat runtime — instead of just "element not
+// found." Required by issue #3469's RCA acceptance criteria.
+async function diagnosticsSnapshot(page: Page): Promise<DiagnosticsSnapshot> {
+  const llmRequests = await llmCompletionRequests();
+  const completionRequests = llmRequests.map((entry, index) => {
+    let probe = '';
+    try {
+      const parsed = JSON.parse(entry.body ?? '{}') as {
+        messages?: Array<{ role?: string; content?: unknown }>;
+      };
+      const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+      for (let i = messages.length - 1; i >= 0; i -= 1) {
+        const m = messages[i];
+        if (!m || (m.role !== 'user' && m.role !== 'tool')) continue;
+        if (typeof m.content === 'string') {
+          probe = m.content;
+          break;
+        }
+        if (Array.isArray(m.content)) {
+          probe = m.content
+            .filter(
+              (c): c is { type: 'text'; text: string } =>
+                !!c &&
+                typeof c === 'object' &&
+                (c as { type?: string }).type === 'text' &&
+                typeof (c as { text?: unknown }).text === 'string'
+            )
+            .map(c => c.text)
+            .join(' ');
+          break;
+        }
+      }
+    } catch {
+      probe = '';
+    }
+    return { probe: probe.slice(0, 240), index };
+  });
+
+  const matchedKeywords = completionRequests
+    .map(({ probe }) =>
+      KEYWORD_RESPONSES.find(rule => probe.toLowerCase().includes(rule.keyword.toLowerCase()))
+    )
+    .map(rule => (rule ? rule.keyword : '<no-match>'));
+
+  const threadId = await selectedThreadId(page);
+
+  const runtime = await page.evaluate(currentThreadId => {
+    const store = (
+      window as unknown as {
+        __OPENHUMAN_STORE__?: {
+          getState?: () => {
+            chatRuntime?: {
+              inferenceStatusByThread?: Record<string, { phase?: string }>;
+              toolTimelineByThread?: Record<string, Array<{ id?: string; name?: string }>>;
+            };
+            thread?: {
+              messagesByThread?: Record<string, Array<{ role?: string; content?: string }>>;
+            };
+          };
+        };
+      }
+    ).__OPENHUMAN_STORE__;
+    const state = store?.getState?.();
+    const phase =
+      currentThreadId && state?.chatRuntime?.inferenceStatusByThread?.[currentThreadId]?.phase
+        ? (state.chatRuntime.inferenceStatusByThread[currentThreadId].phase ?? null)
+        : null;
+    const timeline =
+      currentThreadId && state?.chatRuntime?.toolTimelineByThread?.[currentThreadId]
+        ? state.chatRuntime.toolTimelineByThread[currentThreadId]
+        : [];
+    const messages =
+      currentThreadId && state?.thread?.messagesByThread?.[currentThreadId]
+        ? state.thread.messagesByThread[currentThreadId]
+        : [];
+    const lastAssistant = [...messages].reverse().find(m => m?.role === 'assistant');
+    return {
+      phase,
+      toolTimelineNames: timeline.map(entry => entry?.name ?? ''),
+      toolTimelineIds: timeline.map(entry => entry?.id ?? ''),
+      messageCount: messages.length,
+      lastAssistantText:
+        typeof lastAssistant?.content === 'string' ? lastAssistant.content.slice(0, 240) : null,
+    };
+  }, threadId);
+
+  return { completionRequests, matchedKeywords, selectedThreadId: threadId, runtime };
+}
+
+function formatDiagnostics(snapshot: DiagnosticsSnapshot): string {
+  return [
+    `selectedThreadId=${snapshot.selectedThreadId ?? '<null>'}`,
+    `completionRequestCount=${snapshot.completionRequests.length}`,
+    `matchedKeywords=${JSON.stringify(snapshot.matchedKeywords)}`,
+    `runtime.phase=${snapshot.runtime.phase ?? '<null>'}`,
+    `runtime.toolTimelineNames=${JSON.stringify(snapshot.runtime.toolTimelineNames)}`,
+    `runtime.messageCount=${snapshot.runtime.messageCount}`,
+    `runtime.lastAssistantText=${JSON.stringify(snapshot.runtime.lastAssistantText)}`,
+    `completionProbes=${JSON.stringify(
+      snapshot.completionRequests.map(r => ({ i: r.index, probe: r.probe }))
+    )}`,
+  ].join('\n  ');
+}
+
 test.describe('Chat Harness - Subagent', () => {
-  test('delegates to a subagent through the harness', async ({ page }) => {
+  test('delegates to a subagent and persists the final orchestrator text', async ({ page }) => {
     test.setTimeout(150_000);
 
     await resetMock();
@@ -148,25 +278,44 @@ test.describe('Chat Harness - Subagent', () => {
     await createNewThread(page);
     await sendMessage(page, PROMPT);
 
-    await expect
-      .poll(
-        async () => {
-          const log = await requests();
-          const llmRequests = log.filter(
-            entry => entry.method === 'POST' && entry.url.includes('/openai/v1/chat/completions')
-          );
-          const bodies = llmRequests.map(entry => entry.body ?? '');
-          // The orchestrator no longer eagerly spawns the memory agent before
-          // the turn (memory retrieval is on-demand now), so we assert the
-          // harness delegated to the researcher sub-agent — its prompt reaching
-          // the LLM is the signal — rather than ordering it after a memory call.
-          const delegatedPromptIndex = bodies.findIndex(body =>
-            body.includes('Tell me a marker phrase')
-          );
-          return delegatedPromptIndex >= 0;
-        },
-        { timeout: 90_000 }
-      )
-      .toBe(true);
+    // Three LLM hits are expected: orchestrator-1 (delegates), researcher
+    // (returns RESEARCHER_REPLY), orchestrator-2 (returns CANARY_FINAL).
+    // The orchestrator no longer eagerly invokes the memory agent (PR #3521),
+    // so this is the full sequence — no extra calls should consume keyword
+    // rules out from under the next-expected matcher.
+    try {
+      await expect.poll(completionRequestCount, { timeout: 90_000 }).toBeGreaterThanOrEqual(3);
+    } catch (err) {
+      const snapshot = await diagnosticsSnapshot(page);
+      throw new Error(
+        `completionRequestCount stayed below 3 after 90s.\n  ${formatDiagnostics(snapshot)}\n` +
+          `Original error: ${(err as Error).message}`
+      );
+    }
+
+    try {
+      await expect(page.getByText(CANARY_FINAL)).toBeVisible({ timeout: 30_000 });
+    } catch (err) {
+      const snapshot = await diagnosticsSnapshot(page);
+      throw new Error(
+        `Final orchestrator canary "${CANARY_FINAL}" never rendered.\n  ${formatDiagnostics(
+          snapshot
+        )}\n` + `Original error: ${(err as Error).message}`
+      );
+    }
+
+    const runtimeSnapshot = await diagnosticsSnapshot(page);
+    expect(
+      runtimeSnapshot.runtime.phase === 'subagent' ||
+        runtimeSnapshot.runtime.toolTimelineNames.some(name => name.startsWith('subagent:')) ||
+        runtimeSnapshot.runtime.toolTimelineIds.some(id => id.includes(':subagent:')),
+      `expected runtime to show a subagent delegation, got:\n  ${formatDiagnostics(
+        runtimeSnapshot
+      )}`
+    ).toBe(true);
+
+    // Re-assert after the runtime probe so the persisted message survives the
+    // turn-completion store transition rather than only being visible mid-stream.
+    await expect(page.getByText(CANARY_FINAL)).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/app/test/playwright/specs/chat-harness-subagent.spec.ts
+++ b/app/test/playwright/specs/chat-harness-subagent.spec.ts
@@ -266,6 +266,31 @@ function formatDiagnostics(snapshot: DiagnosticsSnapshot): string {
 }
 
 test.describe('Chat Harness - Subagent', () => {
+  // On any test failure, attach the harness state (mock request log, matched
+  // keywords, selected thread, chat-runtime phase + tool timeline + last
+  // assistant text) as a Playwright artifact. Keeps the original Playwright
+  // assertion error intact while satisfying issue #3469's RCA requirement
+  // that future failures expose request counts, consumed forced/keyword
+  // responses, active thread id, and final chat-runtime state.
+  test.afterEach(async ({ page }, testInfo) => {
+    if (testInfo.status === 'passed' || testInfo.status === 'skipped') return;
+    if (page.isClosed()) return;
+    try {
+      const snapshot = await diagnosticsSnapshot(page);
+      await testInfo.attach('subagent-harness-diagnostics.txt', {
+        contentType: 'text/plain',
+        body: formatDiagnostics(snapshot),
+      });
+      await testInfo.attach('subagent-harness-diagnostics.json', {
+        contentType: 'application/json',
+        body: JSON.stringify(snapshot, null, 2),
+      });
+    } catch {
+      // Diagnostics are best-effort — never mask the real failure if the
+      // page/mock is already torn down (e.g. core crash mid-test).
+    }
+  });
+
   test('delegates to a subagent and persists the final orchestrator text', async ({ page }) => {
     test.setTimeout(150_000);
 
@@ -283,26 +308,8 @@ test.describe('Chat Harness - Subagent', () => {
     // The orchestrator no longer eagerly invokes the memory agent (PR #3521),
     // so this is the full sequence — no extra calls should consume keyword
     // rules out from under the next-expected matcher.
-    try {
-      await expect.poll(completionRequestCount, { timeout: 90_000 }).toBeGreaterThanOrEqual(3);
-    } catch (err) {
-      const snapshot = await diagnosticsSnapshot(page);
-      throw new Error(
-        `completionRequestCount stayed below 3 after 90s.\n  ${formatDiagnostics(snapshot)}\n` +
-          `Original error: ${(err as Error).message}`
-      );
-    }
-
-    try {
-      await expect(page.getByText(CANARY_FINAL)).toBeVisible({ timeout: 30_000 });
-    } catch (err) {
-      const snapshot = await diagnosticsSnapshot(page);
-      throw new Error(
-        `Final orchestrator canary "${CANARY_FINAL}" never rendered.\n  ${formatDiagnostics(
-          snapshot
-        )}\n` + `Original error: ${(err as Error).message}`
-      );
-    }
+    await expect.poll(completionRequestCount, { timeout: 90_000 }).toBeGreaterThanOrEqual(3);
+    await expect(page.getByText(CANARY_FINAL)).toBeVisible({ timeout: 30_000 });
 
     const runtimeSnapshot = await diagnosticsSnapshot(page);
     expect(


### PR DESCRIPTION
## Summary

- Restore the strong end-to-end assertions on `app/test/playwright/specs/chat-harness-subagent.spec.ts` so the spec actually exercises the original failure mode again.
- Add a `diagnosticsSnapshot` helper that, on any failure, attaches the harness state (mock request log, matched keyword rules, selected thread id, chat-runtime phase + tool timeline + last assistant text) as Playwright `testInfo` artifacts.
- Wire the diagnostics through an `afterEach` hook so the original Playwright assertion error is preserved (no try/catch wrapping).

## Problem

Issue #3469 reported a flake on `Chat Harness - Subagent › delegates to a subagent and persists the final orchestrator text` — `getByText('subagent-canary-final-7afe2')` timing out after 45s. The original spec asserted three things in sequence:

1. `completionRequestCount >= 3` (three LLM hits — orchestrator-1, researcher, orchestrator-2).
2. `getByText(CANARY_FINAL)` is visible (the orchestrator's final assistant text is rendered).
3. The chat-runtime store shows a subagent delegation occurred.

Between the issue being filed and today, follow-up PRs progressively removed every one of those assertions until the spec only checked that the researcher's prompt reached the LLM — which is a strict subset of the original contract and silently sidesteps the failing assertion rather than RCA'ing it. The issue's acceptance criteria explicitly require an RCA + a targeted fix, not a workaround.

## Solution

**Root cause.** The original spec drove the mock backend with `setMockBehavior('llmForcedResponses', JSON.stringify(FORCED_RESPONSES))` — a **queue** popped on every `/chat/completions` hit regardless of which agent/turn made the request. As soon as any extra LLM call fired between orchestrator turns (e.g. an eager memory-subagent invocation, a turn-loop retry, an autocomplete probe), it consumed a queued item meant for the orchestrator's third turn. The final response then fell through to the mock's `"Hello from e2e mock agent"` default and `CANARY_FINAL` never reached the UI.

**Underlying fix already on `main`.** A subsequent PR migrated the spec from `llmForcedResponses` to `llmKeywordRules`, which routes responses by content-matching the latest user/tool message instead of by queue position. Extra LLM calls now hit a no-match fallback rather than stealing a future response — the queue-consumption race cannot recur.

**What this PR does on top.** Restore the dropped strong assertions on the keyword-rules-based spec so we are once again testing the behaviour issue #3469 was about (orchestrator's final text rendering in the chat UI), and add diagnostics so the next flake — if it ever surfaces — exposes state, not just `element(s) not found`.

The diagnostics capture exactly the four things the issue asked for: per-request keyword-match decisions (so we can see which forced/keyword responses were consumed and in what order), request counts, the active thread id, and the final chat-runtime state (phase, tool timeline, message count, last assistant text).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — restored strong assertions cover the happy path; `afterEach` diagnostics handler covers the failure path.
- [x] **Diff coverage ≥ 80%** — changes are entirely inside a Playwright spec file, which is executed line-by-line on every run; no production code touched.
- [x] N/A: Coverage matrix updated — test-only change, no feature row added/removed/renamed.
- [x] N/A: All affected feature IDs from the matrix are listed — no matrix feature touched.
- [x] No new external network dependencies introduced — keyword-rules-driven local mock backend per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy).
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces — test-only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Runtime/platform impact: none — Playwright spec only, no production code or build paths changed.
- Performance: spec wall-clock unchanged (~4s steady-state after warm-up, matching pre-#3469 timings).
- Security/migration: none.

## Related

- Closes: #3469
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3469-flaky-subagent-final-response`
- Commit SHA: `f66c03bf9`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on the edited spec.
- [x] `pnpm typecheck` — `pnpm exec tsc --noEmit -p test/tsconfig.e2e.json` clean on `chat-harness-subagent.spec.ts` (pre-existing `@wdio/globals/types` error in unrelated WDIO specs unchanged).
- [x] Focused tests: 31 consecutive back-to-back local runs of `chat-harness-subagent.spec.ts` via `bash app/scripts/e2e-web-session.sh test/playwright/specs/chat-harness-subagent.spec.ts --repeat-each N` — all pass.
- [x] Full Playwright web suite: 225/257 passed (23 skipped) — the spec passes inside the full run; remaining failures are pre-existing on `main` and unrelated to this change.
- [x] Rust fmt/check (if changed): N/A — no Rust source touched. Pre-push `pnpm rust:check` passed.
- [x] Tauri fmt/check (if changed): N/A — no Tauri source touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none on the product. The spec now asserts the original contract (orchestrator final text rendered, three LLM hits, subagent delegation recorded) and dumps the harness state on failure.
- User-visible effect: none on shipped behavior. CI failures on this spec will now ship `subagent-harness-diagnostics.txt` + `.json` artifacts inside the HTML report.

### Parity Contract

- Legacy behavior preserved: the keyword-rules-driven mock routing introduced upstream is unchanged. The spec asserts a superset of the post-relaxation contract, so anything that passes the new assertions also passes the prior weaker check.
- Guard/fallback/dispatch parity checks: `afterEach` diagnostics is best-effort and swallows its own errors so a torn-down page or mock never masks the real assertion failure.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test diagnostics and failure reporting for subagent integration testing to improve debugging capabilities and reliability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->