### PR TITLE
fix(release): extend OpenAI timeout to 5min and add non-AI fallback

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -241,7 +241,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Generate AI release notes
+        id: ai-notes
         if: ${{ inputs.create_release }}
+        continue-on-error: true
+        timeout-minutes: 5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -249,13 +252,27 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${OPENAI_API_KEY:-}" ]; then
-            echo "::error::secrets.OPENAI_API_KEY is required to generate production release notes."
+            echo "::warning::OPENAI_API_KEY is empty — skipping AI notes."
             exit 1
           fi
           node scripts/release/generate-release-notes.mjs \
             --from latest-release \
             --to "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
+            --output release-notes.md
+      - name: Fallback to non-AI release notes
+        if: ${{ inputs.create_release && steps.ai-notes.outcome != 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare-build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "::warning::AI release notes failed or timed out — using deterministic notes."
+          node scripts/release/generate-release-notes.mjs \
+            --from latest-release \
+            --to "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --no-ai \
             --output release-notes.md
       - name: Create draft release with generated notes
         if: ${{ inputs.create_release }}

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -446,8 +446,9 @@ async function summarizeWithOpenAi(request) {
     throw new Error('OPENAI_API_KEY is required unless --no-ai or --dry-run is used');
   }
 
+  const timeoutMs = 300_000;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 45_000);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   let response;
   try {
     response = await fetch('https://api.openai.com/v1/responses', {
@@ -461,7 +462,7 @@ async function summarizeWithOpenAi(request) {
     });
   } catch (error) {
     if (error?.name === 'AbortError') {
-      throw new Error('OpenAI Responses API timed out after 45000ms');
+      throw new Error(`OpenAI Responses API timed out after ${timeoutMs}ms`);
     }
     throw error;
   } finally {


### PR DESCRIPTION
## Summary

The `generate-release-notes.mjs` script had a hardcoded 45-second timeout for OpenAI API calls, which was too tight for larger changelogs and caused production release failures.

- Bumps the script-level OpenAI timeout from 45s to 5 minutes (300s)
- Adds `continue-on-error: true` to the AI release notes step in the production workflow
- Adds a fallback step that generates deterministic `--no-ai` release notes when the AI step fails or times out
- A flaky or slow OpenAI call no longer blocks a production release

## Test plan

- [x] Verified workflow YAML syntax is valid
- [x] Confirmed fallback step condition (`steps.ai-notes.outcome != 'success'`) fires on AI step failure
- [x] Confirmed `--no-ai` flag is already supported by the script

## Submission Checklist

- [x] I have performed a self-review of my code
- [x] N/A: I have added tests — workflow/CI-only change, no testable application code
- [x] N/A: I have updated documentation — no user-facing behavior change
- [x] N/A: I have verified my changes in the app — CI workflow change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release notes generation with automatic fallback when AI generation is unavailable
  * Increased API request timeout to improve reliability during release operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->