### PR TITLE
fix(inference): preserve streaming tool_call id on empty continuation deltas

### DIFF
--- a/app/src/utils/config.ts
+++ b/app/src/utils/config.ts
@@ -91,11 +91,11 @@ export const CONSUMER_FIRST_SESSION_ENABLED =
   import.meta.env.VITE_CONSUMER_FIRST_SESSION === 'true';
 
 /**
- * Chat multimodal attachments (image + supported file markers). Enabled by
- * default — the attach affordance and file-picker path are on. Opt out for a
- * build by setting `VITE_CHAT_ATTACHMENTS=false`.
+ * Chat multimodal attachments (image + supported file markers). Disabled by
+ * default — the attach affordance and file-picker path are off. Opt in for a
+ * build by setting `VITE_CHAT_ATTACHMENTS=true`.
  */
-export const CHAT_ATTACHMENTS_ENABLED = import.meta.env.VITE_CHAT_ATTACHMENTS !== 'false';
+export const CHAT_ATTACHMENTS_ENABLED = import.meta.env.VITE_CHAT_ATTACHMENTS === 'true';
 
 export const SKILLS_GITHUB_REPO =
   import.meta.env.VITE_SKILLS_GITHUB_REPO || 'tinyhumansai/openhuman-skills';

--- a/src/openhuman/agent/harness/session/turn/core.rs
+++ b/src/openhuman/agent/harness/session/turn/core.rs
@@ -170,16 +170,29 @@ impl Agent {
         }
 
         if self.auto_save {
-            let _ = self
-                .memory
-                .store(
-                    "",
-                    "user_msg",
-                    user_message,
-                    MemoryCategory::Conversation,
-                    None,
-                )
-                .await;
+            // Fire-and-forget: persisting the user message to the memory store
+            // does an embedding round-trip (Voyage) + memory-tree write. Awaiting
+            // it here delayed the start of *every* turn before recall/LLM even
+            // began. Spawn it so the chat continues immediately. Recall for the
+            // current turn (below) intentionally does NOT need the just-sent
+            // message — recalling your own current message is undesirable — so
+            // letting the save race the turn is safe and actually cleaner.
+            let memory = self.memory.clone();
+            let user_msg = user_message.to_string();
+            tokio::spawn(async move {
+                if let Err(err) = memory
+                    .store(
+                        "",
+                        "user_msg",
+                        &user_msg,
+                        MemoryCategory::Conversation,
+                        None,
+                    )
+                    .await
+                {
+                    log::warn!("[agent_loop] async user-message memory autosave failed: {err}");
+                }
+            });
         }
 
         log::info!("[agent] loading memory context for user message");

--- a/src/openhuman/agent/harness/session/turn/core.rs
+++ b/src/openhuman/agent/harness/session/turn/core.rs
@@ -171,26 +171,41 @@ impl Agent {
 
         if self.auto_save {
             // Fire-and-forget: persisting the user message to the memory store
-            // does an embedding round-trip (Voyage) + memory-tree write. Awaiting
-            // it here delayed the start of *every* turn before recall/LLM even
-            // began. Spawn it so the chat continues immediately. Recall for the
-            // current turn (below) intentionally does NOT need the just-sent
-            // message — recalling your own current message is undesirable — so
-            // letting the save race the turn is safe and actually cleaner.
+            // does an embedding round-trip (Voyage) + memory-tree write that the
+            // in-flight turn never reads back. Awaiting it delayed the start of
+            // *every* turn before recall/LLM began, so spawn it and let the chat
+            // continue immediately.
+            //
+            // Use a UNIQUE per-message key: the old fixed `"user_msg"` key
+            // upserts a single document (`upsert_document` keys by namespace+key),
+            // so concurrent turns would race on — and overwrite — one shared slot.
+            // A unique key makes each user message its own conversation document,
+            // which both removes the race and stops the autosave from only ever
+            // retaining the latest message.
             let memory = self.memory.clone();
             let user_msg = user_message.to_string();
+            let autosave_key = format!("user_msg:{}", uuid::Uuid::new_v4());
+            let chars = user_msg.chars().count();
+            log::debug!(
+                "[agent_autosave] enqueue user-message store key={autosave_key} chars={chars}"
+            );
             tokio::spawn(async move {
-                if let Err(err) = memory
+                match memory
                     .store(
                         "",
-                        "user_msg",
+                        &autosave_key,
                         &user_msg,
                         MemoryCategory::Conversation,
                         None,
                     )
                     .await
                 {
-                    log::warn!("[agent_loop] async user-message memory autosave failed: {err}");
+                    Ok(()) => log::debug!(
+                        "[agent_autosave] stored user-message key={autosave_key} chars={chars}"
+                    ),
+                    Err(err) => log::warn!(
+                        "[agent_autosave] user-message memory autosave failed key={autosave_key} err={err}"
+                    ),
                 }
             });
         }

--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -435,7 +435,14 @@ impl Provider for OpenAiCompatibleProvider {
                 let name = function.name?;
                 let arguments = normalize_function_arguments(function.arguments);
                 Some(ProviderToolCall {
-                    id: tc.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                    // Treat an empty-string id like a missing one: some providers
+                    // (DashScope/GMI) return `""` rather than omitting it, and an
+                    // empty `tool_call_id` is rejected by the upstream tool-message
+                    // ordering check on the next turn.
+                    id: tc
+                        .id
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
                     name,
                     arguments,
                     // Non-streaming response: preserve Gemini's thought_signature

--- a/src/openhuman/inference/provider/compatible_stream_native.rs
+++ b/src/openhuman/inference/provider/compatible_stream_native.rs
@@ -282,16 +282,26 @@ impl OpenAiCompatibleProvider {
                                     }
                                 }
 
+                                // Only the FIRST delta for a tool-call index carries
+                                // the real id; argument-continuation deltas repeat the
+                                // index with an EMPTY id (`""`) on some providers
+                                // (DashScope/GMI) and omit it entirely on others
+                                // (DeepSeek). Guard against the empty string so a
+                                // continuation delta can't clobber the resolved id down
+                                // to `""` — which later trips the upstream tool-message
+                                // ordering check (empty `tool_call_id` → 400).
                                 if let Some(id) = tc.id.as_ref() {
-                                    if entry.id.is_none() {
-                                        log::debug!(
-                                            "[stream] {} tool_call[{}] id resolved: {}",
-                                            self.name,
-                                            idx,
-                                            id,
-                                        );
+                                    if !id.is_empty() {
+                                        if entry.id.is_none() {
+                                            log::debug!(
+                                                "[stream] {} tool_call[{}] id resolved: {}",
+                                                self.name,
+                                                idx,
+                                                id,
+                                            );
+                                        }
+                                        entry.id = Some(id.clone());
                                     }
-                                    entry.id = Some(id.clone());
                                 }
                                 if let Some(func) = tc.function.as_ref() {
                                     if let Some(name) = func.name.as_ref() {

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1524,13 +1524,13 @@ async fn streaming_parallel_tool_calls_preserve_ids_against_empty_continuations(
     assert_eq!(resp.tool_calls.len(), 2, "both parallel tool calls survive");
     // Order-independent: each id must be preserved AND mapped to the right tool
     // (no cross-index contamination).
-    let by_id: std::collections::HashMap<&str, &str> = resp
+    let by_id: std::collections::HashMap<&str, (&str, &str)> = resp
         .tool_calls
         .iter()
-        .map(|t| (t.id.as_str(), t.name.as_str()))
+        .map(|t| (t.id.as_str(), (t.name.as_str(), t.arguments.as_str())))
         .collect();
-    assert_eq!(by_id.get("call_a"), Some(&"get_weather"));
-    assert_eq!(by_id.get("call_b"), Some(&"get_time"));
+    assert_eq!(by_id.get("call_a"), Some(&("get_weather", "{}")));
+    assert_eq!(by_id.get("call_b"), Some(&("get_time", "{}")));
 }
 
 /// Counterpart to the DashScope cases: DeepSeek OMITS the `id` key on
@@ -1582,6 +1582,11 @@ async fn streaming_omitted_continuation_id_preserves_tool_call_id() {
     assert_eq!(resp.tool_calls.len(), 1);
     assert_eq!(resp.tool_calls[0].id.as_str(), "call_ds");
     assert_eq!(resp.tool_calls[0].name.as_str(), "get_weather");
+    assert_eq!(
+        resp.tool_calls[0].arguments.as_str(),
+        "{}",
+        "arguments must accumulate across the id-omitted continuation delta"
+    );
 }
 
 /// Helper: roles in serialized order.

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1475,6 +1475,115 @@ async fn streaming_empty_continuation_id_does_not_clobber_tool_call_id() {
     );
 }
 
+/// Regression: a single turn can emit MULTIPLE parallel tool calls. The
+/// per-`index` accumulator must keep each call's first-delta id even when the
+/// empty-id continuation deltas for both indices arrive together — neither may
+/// clobber the other (or itself) to `""`.
+#[tokio::test]
+async fn streaming_parallel_tool_calls_preserve_ids_against_empty_continuations() {
+    let mock_server = MockServer::start().await;
+    // Two parallel calls (index 0 + 1), then one continuation delta carrying
+    // BOTH indices with empty ids.
+    let body = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]}}]}\n\n\
+                data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_b\",\"type\":\"function\",\"function\":{\"name\":\"get_time\",\"arguments\":\"{}\"}}]}}]}\n\n\
+                data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"\"},{\"index\":1,\"id\":\"\"}]}}]}\n\n\
+                data: [DONE]\n\n";
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider =
+        OpenAiCompatibleProvider::new("dashscope", &mock_server.uri(), None, AuthStyle::None);
+    let request = NativeChatRequest {
+        model: "qwen3.7-plus".to_string(),
+        messages: vec![NativeMessage {
+            role: "user".to_string(),
+            content: Some("weather and time?".into()),
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_content: None,
+        }],
+        temperature: Some(0.7),
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        thread_id: None,
+        stream_options: Some(super::compatible_types::OpenAiStreamOptions {
+            include_usage: true,
+        }),
+        options: None,
+        frequency_penalty: None,
+    };
+    let (delta_tx, _delta_rx) = tokio::sync::mpsc::channel(64);
+    let resp = provider
+        .stream_native_chat(None, &request, &delta_tx, 0)
+        .await
+        .unwrap();
+    assert_eq!(resp.tool_calls.len(), 2, "both parallel tool calls survive");
+    // Order-independent: each id must be preserved AND mapped to the right tool
+    // (no cross-index contamination).
+    let by_id: std::collections::HashMap<&str, &str> = resp
+        .tool_calls
+        .iter()
+        .map(|t| (t.id.as_str(), t.name.as_str()))
+        .collect();
+    assert_eq!(by_id.get("call_a"), Some(&"get_weather"));
+    assert_eq!(by_id.get("call_b"), Some(&"get_time"));
+}
+
+/// Counterpart to the DashScope cases: DeepSeek OMITS the `id` key on
+/// argument-continuation deltas (rather than sending `""`). That deserializes
+/// to `None`, so the accumulator already leaves the resolved id alone — assert
+/// the contract holds for the key-absent shape too, and that args still
+/// accumulate across the continuation.
+#[tokio::test]
+async fn streaming_omitted_continuation_id_preserves_tool_call_id() {
+    let mock_server = MockServer::start().await;
+    // Delta 2 has NO `id` key at all (DeepSeek shape) and carries the rest of
+    // the arguments.
+    let body = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_ds\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\"}}]}}]}\n\n\
+                data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"}\"}}]}}]}\n\n\
+                data: [DONE]\n\n";
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider =
+        OpenAiCompatibleProvider::new("deepseek", &mock_server.uri(), None, AuthStyle::None);
+    let request = NativeChatRequest {
+        model: "deepseek-v4-flash".to_string(),
+        messages: vec![NativeMessage {
+            role: "user".to_string(),
+            content: Some("weather?".into()),
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_content: None,
+        }],
+        temperature: Some(0.7),
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        thread_id: None,
+        stream_options: Some(super::compatible_types::OpenAiStreamOptions {
+            include_usage: true,
+        }),
+        options: None,
+        frequency_penalty: None,
+    };
+    let (delta_tx, _delta_rx) = tokio::sync::mpsc::channel(64);
+    let resp = provider
+        .stream_native_chat(None, &request, &delta_tx, 0)
+        .await
+        .unwrap();
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.tool_calls[0].id.as_str(), "call_ds");
+    assert_eq!(resp.tool_calls[0].name.as_str(), "get_weather");
+}
+
 /// Helper: roles in serialized order.
 fn roles(messages: &[NativeMessage]) -> Vec<&str> {
     messages.iter().map(|m| m.role.as_str()).collect()

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1419,6 +1419,62 @@ async fn streaming_tool_call_captures_extra_content() {
     );
 }
 
+/// Regression: some providers (DashScope/Qwen, GMI) emit the tool-call `id`
+/// ONLY on the first delta for an index, then send `"id": ""` (empty string,
+/// not omitted) on every argument-continuation delta. The streaming accumulator
+/// must not let those empty continuation ids clobber the resolved id down to
+/// `""` — an empty `tool_call_id` is rejected by the upstream tool-message
+/// ordering check on the next turn (400), dead-ending the conversation.
+#[tokio::test]
+async fn streaming_empty_continuation_id_does_not_clobber_tool_call_id() {
+    let mock_server = MockServer::start().await;
+    // Delta 1 carries the real id + name; deltas 2-3 are arg continuations that
+    // repeat index 0 with an EMPTY id (the DashScope/GMI wire shape).
+    let body = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_real\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{}\"}}]}}]}\n\n\
+                data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"\",\"function\":{\"arguments\":\"\"}}]}}]}\n\n\
+                data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"\"}]}}]}\n\n\
+                data: [DONE]\n\n";
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&mock_server)
+        .await;
+
+    let provider =
+        OpenAiCompatibleProvider::new("dashscope", &mock_server.uri(), None, AuthStyle::None);
+    let request = NativeChatRequest {
+        model: "qwen3.7-plus".to_string(),
+        messages: vec![NativeMessage {
+            role: "user".to_string(),
+            content: Some("weather in paris?".into()),
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_content: None,
+        }],
+        temperature: Some(0.7),
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        thread_id: None,
+        stream_options: Some(super::compatible_types::OpenAiStreamOptions {
+            include_usage: true,
+        }),
+        options: None,
+        frequency_penalty: None,
+    };
+    let (delta_tx, _delta_rx) = tokio::sync::mpsc::channel(64);
+    let resp = provider
+        .stream_native_chat(None, &request, &delta_tx, 0)
+        .await
+        .unwrap();
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(
+        resp.tool_calls[0].id.as_str(),
+        "call_real",
+        "empty-string id on continuation deltas must not clobber the resolved tool_call id"
+    );
+}
+
 /// Helper: roles in serialized order.
 fn roles(messages: &[NativeMessage]) -> Vec<&str> {
     messages.iter().map(|m| m.role.as_str()).collect()

--- a/tests/inference_agent_raw_coverage_e2e.rs
+++ b/tests/inference_agent_raw_coverage_e2e.rs
@@ -4641,6 +4641,7 @@ async fn agent_subagent_public_types_cover_task_local_and_error_display_paths() 
         worker_thread_id: Some("thread-1".to_string()),
         initial_history: None,
         checkpoint_dir: None,
+        worktree_action_dir: None,
     };
     assert_eq!(options.skill_filter_override.as_deref(), Some("docs"));
     assert_eq!(options.toolkit_override.as_deref(), Some("github"));


### PR DESCRIPTION
## Summary

- **fix(inference):** stop empty-string `id` on streaming tool-call *continuation* deltas from clobbering the resolved `tool_call_id` (DashScope/Qwen + GMI emit `id:""` on arg-continuation deltas; DeepSeek omits it). An empty `tool_call_id` was rejected by the backend tool-message-ordering check on the next turn (400), dead-ending the conversation.
- **perf(agent):** fire-and-forget the per-turn user-message memory autosave instead of blocking every turn on an embedding round-trip + memory-tree write.
- **feat(chat):** multimodal attachments are now **opt-in** (`VITE_CHAT_ATTACHMENTS=true`) rather than on by default.

## Problem

- A reasoning-v1 (DashScope/GMI) turn that calls a tool would execute the tool fine, then **die on the next provider call** with `400 — Message at index N has role 'tool' with tool_call_id '' that does not match any tool_call`. Root cause: the streaming accumulator (`compatible_stream_native.rs`) overwrote `entry.id` on *every* delta whose `id` field was `Some(_)`, including the `Some("")` that DashScope/GMI send on argument-continuation deltas — clobbering the good first-delta id to `""`. The sibling `name` field was already guarded with `!is_empty()`; `id` was not. DeepSeek was unaffected only because it *omits* the key on continuation deltas.
- Separately, the per-turn user-message autosave `await`ed a Voyage embed + memory-tree write before recall/LLM even started — latency the in-flight turn never benefits from (it never reads that write back).

## Solution

- Guard the id accumulation with `!id.is_empty()` in the streaming path, and treat an empty id as missing in the non-streaming parse (`tc.id.filter(|s| !s.is_empty()).unwrap_or_else(uuid)`). Added a regression test feeding a first-delta-id + empty-`""`-continuation stream and asserting the id survives.
- Move the autosave into a `tokio::spawn` (the store is `Arc<dyn Memory>`, `Send + Sync`); log failures instead of swallowing them.
- Flip `CHAT_ATTACHMENTS_ENABLED` to `=== 'true'`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — regression test `streaming_empty_continuation_id_does_not_clobber_tool_call_id` (passes locally).
- [x] **Diff coverage ≥ 80%** — Rust changes exercised by the new regression test + existing turn/auto_save tests; enforced independently by the Rust/Frontend Coverage jobs on this PR.
- [x] Coverage matrix updated — `N/A: bug-fix + perf + flag flip, no new feature rows.`
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature IDs touched.`
- [x] No new external network dependencies — `N/A: none added; test uses the existing wiremock MockServer.`
- [x] Manual smoke checklist updated if release-cut surfaces touched — `N/A: no release-cut surface change.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue.`

## Impact

- **Desktop/web chat.** Fixes a hard dead-end for tool-using turns on DashScope/GMI-served reasoning models (the current `reasoning-v1` routing). Faster turn start from the async autosave. Attachments now hidden unless explicitly enabled.
- No migrations; no new deps; backwards compatible (attachments re-enabled via env flag).

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: optional — same fire-and-forget for the channels path (`channels/runtime/dispatch/processor.rs:220`); optional backend-side `tool_call_id` mint as defense-in-depth.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/streaming-tool-call-id-clobber

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or missing tool-call IDs from overwriting valid identifiers in streaming chat, preserving correct tool-call ordering and arguments.

* **Changes**
  * Chat attachments are now opt-in and must be explicitly enabled.
  * User message persistence now runs in the background so saving does not delay chat responses.

* **Tests**
  * Added regression tests covering streaming tool-call ID handling and aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->