### PR TITLE
feat(voice): expose always-on toggle + test-build logging for the always-on flow

### DIFF
--- a/app/src/components/settings/panels/VoicePanel.tsx
+++ b/app/src/components/settings/panels/VoicePanel.tsx
@@ -18,7 +18,6 @@ import {
   type VoiceProviderView,
   type VoiceSettings,
 } from '../../../services/api/voiceSettingsApi';
-import { IS_DEV_LIKE } from '../../../utils/config';
 import {
   openhumanGetVoiceServerSettings,
   openhumanUpdateVoiceServerSettings,
@@ -96,11 +95,6 @@ interface VoicePanelProps {
    *  inside the onboarding custom wizard). */
   embedded?: boolean;
 }
-
-/** Always-on listening toggle is hidden in production for now, but shown in
- *  dev/debug builds so the feature can be exercised. Set unconditionally to
- *  `true` to expose it everywhere. See docs/voice-system-actions.md. */
-const SHOW_ALWAYS_ON_TOGGLE = IS_DEV_LIKE;
 
 const VoicePanel = ({ embedded = false }: VoicePanelProps = {}) => {
   const { t } = useT();
@@ -504,8 +498,7 @@ const VoicePanel = ({ embedded = false }: VoicePanelProps = {}) => {
 
       <div className={embedded ? 'space-y-4' : 'p-4 space-y-4'}>
         {/* ─── Always-on listening (Phase 2) ──────────────────────────── */}
-        {/* Gated on SHOW_ALWAYS_ON_TOGGLE — shown in dev/debug builds, hidden in prod. */}
-        {SHOW_ALWAYS_ON_TOGGLE && settings && (
+        {settings && (
           <SettingsSection>
             <SettingsRow
               htmlFor="switch-always-on-main"

--- a/src/openhuman/config/schemas/controllers.rs
+++ b/src/openhuman/config/schemas/controllers.rs
@@ -764,7 +764,7 @@ fn handle_update_voice_server_settings(params: Map<String, Value>) -> Controller
         // silently wouldn't apply until the next launch.
         match config_rpc::load_config_with_timeout().await {
             Ok(config) => {
-                log::debug!("[config][rpc] voice settings saved; applying live always-on state");
+                log::info!("[config][rpc] voice settings saved; applying live always-on state");
                 crate::openhuman::voice::always_on::start_if_enabled(&config).await;
             }
             Err(error) => {

--- a/src/openhuman/voice/always_on.rs
+++ b/src/openhuman/voice/always_on.rs
@@ -248,12 +248,27 @@ pub async fn start_if_enabled(app_config: &Config) {
     // Privacy hook: pause capture while the screen is locked.
     spawn_lock_watcher();
 
+    let onset_threshold = vad.onset_threshold;
     tokio::spawn(async move {
         let mut seg = VadSegmenter::new(vad);
         let mut pending: Vec<f32> = Vec::new();
         let mut utterance: Vec<f32> = Vec::new();
+        // Test-build diagnostics: confirm audio actually flows from the mic and
+        // surface live input levels vs the onset threshold (every ~5s) so the VAD
+        // can be tuned per mic/room without guessing. Levels are loudness, not PII.
+        let mut first_chunk_logged = false;
+        let mut level_peak: f32 = 0.0;
+        let mut level_frames: u32 = 0;
+        let mut last_level_log = std::time::Instant::now();
 
         while let Some(chunk) = rx.recv().await {
+            if !first_chunk_logged {
+                first_chunk_logged = true;
+                log::info!(
+                    "{LOG_PREFIX} first audio chunk received from mic (samples={}) — capture pipeline live",
+                    chunk.len()
+                );
+            }
             // Drop audio and abandon any in-flight utterance while paused
             // (screen locked) or toggled off — nothing is captured or sent.
             if PAUSED.load(Ordering::Relaxed) || !ENABLED.load(Ordering::Relaxed) {
@@ -268,8 +283,26 @@ pub async fn start_if_enabled(app_config: &Config) {
             while pending.len() >= FRAME_SAMPLES {
                 let frame: Vec<f32> = pending.drain(..FRAME_SAMPLES).collect();
                 let rms = chunk_rms(&frame);
+                level_peak = level_peak.max(rms);
+                level_frames += 1;
+                if last_level_log.elapsed() >= std::time::Duration::from_secs(5) {
+                    log::info!(
+                        "{LOG_PREFIX} mic level peak_rms={level_peak:.4} onset={onset_threshold:.4} frames={level_frames} ({})",
+                        if level_peak >= onset_threshold {
+                            "speech would trigger"
+                        } else {
+                            "below onset — lower vad_onset_threshold or check mic gain"
+                        }
+                    );
+                    level_peak = 0.0;
+                    level_frames = 0;
+                    last_level_log = std::time::Instant::now();
+                }
                 match seg.push_frame(rms, FRAME_MS) {
                     Some(VadEvent::SpeechStart) => {
+                        log::info!(
+                            "{LOG_PREFIX} speech onset rms={rms:.4} (onset={onset_threshold:.4})"
+                        );
                         utterance.clear();
                         utterance.extend_from_slice(&frame);
                         notch_status("Listening", 2500); // pill: capturing speech
@@ -328,6 +361,7 @@ fn notch_status(status: &str, ttl_ms: u32) {
 /// hotkey dictation uses.
 async fn transcribe_and_deliver(config: &Config, samples_16k: Vec<f32>) {
     use base64::Engine as _;
+    let sample_count = samples_16k.len();
     let wav = match encode_wav_16k(&samples_16k) {
         Ok(w) => w,
         Err(e) => {
@@ -340,6 +374,12 @@ async fn transcribe_and_deliver(config: &Config, samples_16k: Vec<f32>) {
     // honors the user's choice instead of forcing local whisper.
     let provider_name = crate::openhuman::voice::effective_stt_provider(config);
     let model = crate::openhuman::voice::DEFAULT_WHISPER_MODEL.to_string();
+    // Which STT backend is doing the work matters when diagnosing slow/failed
+    // transcription across machines (local whisper download state vs cloud).
+    log::info!(
+        "{LOG_PREFIX} transcribing utterance: provider={provider_name} model={model} samples={sample_count} wav_bytes={}",
+        wav.len()
+    );
     let provider =
         match crate::openhuman::voice::create_stt_provider(&provider_name, &model, config) {
             Ok(p) => p,
@@ -349,6 +389,7 @@ async fn transcribe_and_deliver(config: &Config, samples_16k: Vec<f32>) {
             }
         };
     let audio_b64 = base64::engine::general_purpose::STANDARD.encode(&wav);
+    let stt_started = std::time::Instant::now();
     // Force English transcription. Auto-detect was rendering the English wake
     // word "Hey Tiny" in Hindi/Bengali/etc. script ("हे टाइनी"), which could never
     // match the Latin wake word. The wake word + commands here are English.
@@ -364,8 +405,13 @@ async fn transcribe_and_deliver(config: &Config, samples_16k: Vec<f32>) {
     {
         Ok(outcome) => {
             let text = outcome.value.text.trim().to_string();
+            log::info!(
+                "{LOG_PREFIX} transcription ok in {}ms (provider={provider_name}, chars={})",
+                stt_started.elapsed().as_millis(),
+                text.len()
+            );
             if text.is_empty() {
-                log::debug!("{LOG_PREFIX} empty transcript dropped");
+                log::info!("{LOG_PREFIX} empty transcript dropped");
                 return;
             }
             // Wake-word gate: only act on utterances addressed to the agent
@@ -387,7 +433,10 @@ async fn transcribe_and_deliver(config: &Config, samples_16k: Vec<f32>) {
                 }
             }
         }
-        Err(e) => log::warn!("{LOG_PREFIX} transcription failed ({provider_name}): {e}"),
+        Err(e) => log::warn!(
+            "{LOG_PREFIX} transcription failed ({provider_name}) after {}ms: {e}",
+            stt_started.elapsed().as_millis()
+        ),
     }
 }
 
@@ -613,14 +662,24 @@ fn capture_on_thread(
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
     use cpal::{SampleFormat, StreamConfig};
 
-    if matches!(detect_microphone_permission(), PermissionState::Denied) {
+    // Surface the mic permission state explicitly — a denied/Unknown state is the
+    // most common reason always-on "does nothing" and it differs per OS (macOS TCC
+    // prompt, Windows privacy settings), so log it on every test build.
+    let permission = detect_microphone_permission();
+    log::info!("{LOG_PREFIX} microphone permission: {permission:?}");
+    if matches!(permission, PermissionState::Denied) {
+        log::error!("{LOG_PREFIX} microphone permission denied — always-on cannot capture audio");
         return Err("microphone permission denied".to_string());
     }
 
     let host = cpal::default_host();
+    log::info!("{LOG_PREFIX} audio host: {:?}", host.id());
     let device = host
         .default_input_device()
         .ok_or_else(|| "no default audio input device".to_string())?;
+    let device_name = device
+        .name()
+        .unwrap_or_else(|e| format!("<unknown: {e}>"));
     let supported = device
         .default_input_config()
         .map_err(|e| format!("no default input config: {e}"))?;
@@ -628,8 +687,11 @@ fn capture_on_thread(
     let channels = supported.channels() as usize;
     let sample_format = supported.sample_format();
     let stream_config: StreamConfig = supported.into();
+    // Name + source rate/channels/format vary across M-chip, Intel, and Windows
+    // mics; capturing them makes a "wrong device" or "unsupported format" failure
+    // obvious from the log alone. We resample everything to 16 kHz mono downstream.
     log::info!(
-        "{LOG_PREFIX} capture device ready rate={source_rate} channels={channels} format={sample_format:?}"
+        "{LOG_PREFIX} capture device ready name='{device_name}' rate={source_rate}->{TARGET_SAMPLE_RATE} channels={channels} format={sample_format:?}"
     );
 
     // Forward one resampled-to-16k mono chunk per callback.
@@ -704,7 +766,7 @@ fn spawn_lock_watcher() {
     });
     #[cfg(not(target_os = "macos"))]
     {
-        log::debug!("{LOG_PREFIX} screen-lock watcher unavailable on this platform");
+        log::info!("{LOG_PREFIX} screen-lock watcher unavailable on this platform");
     }
 }
 


### PR DESCRIPTION
## Summary

- Surface the **always-on listening toggle** in all builds — removes the `IS_DEV_LIKE` dev/debug-only visibility gate in `VoicePanel` so testers can enable "voice on" in a production-flavoured test build.
- Add **verbose `info`-level diagnostics** across the always-on voice flow (`always_on.rs`) so a cross-platform test build (macOS M-chip / Intel, Windows) can trace the pipeline and capture errors without a debugger.
- All new logs are `info`/`warn`/`error` (no `debug`/`trace`) so they appear at default verbosity, and are **PII-safe** (loudness + lengths only — never the spoken command text).

## Problem

We're cutting a build to manually validate the always-on "voice on" feature across macOS (Apple Silicon + Intel) and Windows. Two blockers:
1. The Settings toggle was hidden outside dev/debug builds, so a release-flavoured test build couldn't turn the feature on.
2. The flow's failure-prone, platform-divergent points (mic permission, input device/format selection, VAD onset tuning, STT backend/latency) weren't observable at default log verbosity, making "voice on does nothing" hard to diagnose remotely.

## Solution

- **`VoicePanel.tsx`** — drop the `SHOW_ALWAYS_ON_TOGGLE`/`IS_DEV_LIKE` gate (and now-unused constant + import) so the toggle always renders (still waits for `settings` to load).
- **`always_on.rs`** — add info-level diagnostics at the highest-signal points:
  - mic **permission state** (explicit) + audio host + selected **input device name**, source rate→16k, channels, sample format;
  - one-time **"first audio chunk received"** capture-liveness confirmation;
  - **live mic-level heartbeat** (`peak_rms` vs `onset`, ~every 5s) with a tuning hint, so `vad_onset_threshold` can be set per mic/room;
  - **speech-onset RMS**;
  - **STT** provider/model/size at start + **transcription latency** on ok/fail.
- **`controllers.rs`** — bump the live always-on toggle-apply log to `info`.
- **Tradeoff / temporary:** these logs are intentionally chatty for the test cycle and are meant to be **removed afterward** — all grep-able by the `[voice::always_on]` prefix.

## Submission Checklist

- [ ] `N/A: logging + visibility-gate change only` — no behavioural logic added; existing `voice::always_on` unit tests (12) still pass. No new failure path to cover.
- [ ] `N/A` — diff is logging/UI-visibility lines only (no new logic branches to cover).
- [ ] `N/A: behaviour-only change` — no feature rows added/removed/renamed.
- [ ] `N/A` — no matrix feature IDs affected.
- [x] No new external network dependencies introduced.
- [ ] `N/A` — does not change a release-cut smoke surface beyond exposing an existing toggle.
- [ ] `N/A` — no linked issue.

## Impact

- **Platform:** desktop (macOS/Windows/Linux). Logging is cross-platform; macOS-only paths (screen-lock watcher, osascript media control) unchanged.
- **Performance:** negligible — the mic-level heartbeat logs at most once per ~5s; per-frame work is a single `max`/counter.
- **Security/PII:** logs never include transcript/command text — only loudness (RMS), byte/char counts, device metadata.
- **Cleanup:** logging is temporary for the test cycle; remove via the `[voice::always_on]` prefix once validation is done.

## Related

- Closes:
- Follow-up PR(s)/TODOs: remove the temporary `[voice::always_on]` test-build logging after cross-platform validation.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/new-work`
- Commit SHA: 8819a3f1d

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (prettier on changed TS — clean; `cargo fmt --check` — clean)
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib voice::always_on` — 12 passed
- [x] Rust fmt/check (if changed): `cargo check --lib` clean; `cargo fmt --check` clean
- [ ] Tauri fmt/check (if changed): N/A — no `app/src-tauri` changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: always-on listening toggle is now visible in all builds; new info-level diagnostic logs in the always-on flow.
- User-visible effect: the "Always-on listening" switch appears in Settings → Voice in non-dev builds.

### Parity Contract

- Legacy behavior preserved: VAD/STT/wake-word/routing logic unchanged; only added logging + removed a UI visibility gate.
- Guard/fallback/dispatch parity checks: pause/disable gating, wake-word gate, and command-router fallback paths untouched.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Always-on listening is now available to all users (previously limited to development builds)

* **Improvements**
  * Enhanced voice system diagnostics with detailed logging for audio capture, transcription timing, and performance metrics
  * Improved visibility into microphone status and audio processing details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->