### PR TITLE
feat(agent): ground spoken time-relative statements in the clock

### DIFF
--- a/src/openhuman/agent/prompts/mod_tests.rs
+++ b/src/openhuman/agent/prompts/mod_tests.rs
@@ -222,18 +222,26 @@ fn datetime_section_includes_timestamp_and_timezone() {
     assert!(rendered.starts_with("## Current Date & Time\n\n"));
 
     let payload = rendered.trim_start_matches("## Current Date & Time\n\n");
-    assert!(payload.chars().any(|c| c.is_ascii_digit()));
-    assert!(payload.contains(" ("));
-    assert!(payload.ends_with(')'));
+    // The timestamp is the first line; the #3602 grounding rule follows it.
+    let stamp = payload.lines().next().unwrap();
+    assert!(stamp.chars().any(|c| c.is_ascii_digit()));
+    assert!(stamp.contains(" ("));
+    assert!(stamp.ends_with(')'));
     // IANA zone is included so agents can reason about the host's
     // timezone without parsing a locale-dependent abbreviation. Either
     // a slashed zone (`America/Los_Angeles`) or the `UTC` fallback for
     // hosts where `iana-time-zone` can't resolve one.
     assert!(
-        payload.contains('/') || payload.contains(" UTC "),
-        "rendered payload missing IANA timezone: {payload}"
+        stamp.contains('/') || stamp.contains(" UTC "),
+        "rendered payload missing IANA timezone: {stamp}"
     );
-    assert!(payload.contains("UTC"), "missing UTC offset: {payload}");
+    assert!(stamp.contains("UTC"), "missing UTC offset: {stamp}");
+    // #3602: the spoken-time grounding rule always ships under the clock so
+    // greetings are bound to the rendered time, not guessed.
+    assert!(
+        payload.contains("Before any time-relative statement") && payload.contains("never guess"),
+        "datetime section must carry the #3602 spoken-time grounding rule; got:\n{payload}"
+    );
 }
 
 #[test]

--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -606,6 +606,20 @@ impl PromptSection for DateTimeSection {
             now.format("%Z"),
             now.format("%:z"),
         );
+        // #3602: ground spoken time-relative statements in the clock above.
+        // The exact local time is already rendered here, yet agents would
+        // still guess the time of day ("good morning" at 20:00). This binds
+        // greetings and relative-time phrasing to the timestamp with no tool
+        // call — zero added latency — and sits right under the time block so
+        // the two are read together. Always rendered (not tool-gated): it only
+        // asks the agent to read what's already in front of it.
+        out.push_str(
+            "\n\n> Before any time-relative statement to the user — greetings \
+             (\"good morning/afternoon/evening\"), \"today/tonight/tomorrow\", \
+             \"earlier/just now\", relative ages — read the date & time above \
+             and match it. The exact local time is right here, so never guess \
+             the time of day: a \"good morning\" at 20:00 local is a bug.",
+        );
         // Time-discipline rule, gated on the agent actually having the
         // `resolve_time` tool. LLMs are unreliable at epoch arithmetic — a
         // real incident had an agent compute "24h ago" ~10 months off, then


### PR DESCRIPTION
## Summary

Closes #3602.

The agent made time-relative statements ("good morning", "here's your morning briefing") without checking the current time — even though the exact local timestamp is already rendered in the `## Current Date & Time` header — leading to wrong greetings (e.g. "good morning" at 8 PM).

**Root cause:** the datetime section already prints the live clock, and it already carries a time-discipline rule — but that rule only covers **tool arguments** (`oldest`/`latest`/`since`/`after`, cron times). Nothing bound the agent's *spoken* time-relative statements to the timestamp, so greetings were left to guesswork.

**Fix (issue option 1 — prompt hardening):** add an always-rendered directive immediately under the timestamp that binds any time-relative statement — greetings, "today/tonight/tomorrow", "earlier/just now", relative ages — to the clock already in front of the agent.

## Why option 1 (not 2 or 3)

| Option | Verdict |
| --- | --- |
| **1. Prompt hardening** | ✅ Reads the timestamp already in context — **zero tool calls, zero added latency**, directly satisfies the acceptance criteria. |
| 2. `resolve_time` pre-step every turn | ❌ The time is **already** in the header; forcing a call per turn adds latency, which the issue explicitly forbids ("must not regress response speed"). |
| 3. UI: surface time more prominently | ❌ Surfaces the discrepancy but doesn't *ground* the statement — the agent could still say "good morning" at 8 PM. |

## Placement

The directive lives in `DateTimeSection` right under the rendered clock (not in `SOUL.md`), so the rule and the data it references are read together — mirroring the existing tool-argument time-discipline rule that already sits there. It is **unconditional** (not tool-gated): it only asks the agent to read what's already present.

## Acceptance criteria

- [x] Agent no longer says "good morning" at 8 PM — the rule explicitly calls that out as a bug.
- [x] Time-relative statements grounded in an explicit time check (the rendered `## Current Date & Time`).
- [x] Minimal, no speed regression — prompt-only, no tool call, no code path change.

## Tests

- Extended `datetime_section_includes_timestamp_and_timezone` to assert the grounding rule ships under the timestamp (timestamp assertions now target the first line; the rule follows).
- `agent::prompts` suite passes.
- Prompt text is English-only (system prompt, not user-facing UI copy), so locale files do not apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Strengthened test coverage for timestamp and timezone validation to ensure accurate time-based assertions.

* **Improvements**
  * Enhanced agent guidance to ground time-relative statements and user greetings to the current timestamp, preventing incorrect time-of-day inferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->