### PR TITLE
fix(appimage): always replace bundled ld-linux from host system to prevent glibc mismatch crash

### DIFF
--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -265,9 +265,11 @@ ensure_sharun_interpreter() {
   fi
 
   local target="$appdir/lib/$loader_name"
-  if [ -e "$target" ]; then
-    return 1
-  fi
+  # Always replace — lib4bin may bundle an ld-linux from the CI runner
+  # that is incompatible with newer host glibc (#3224, #3099).
+  # The host_dynamic_loader source is the CI runner's own system ld-linux,
+  # which is guaranteed compatible with the binary compiled on the same runner.
+  rm -f "$target"
 
   local source
   if ! source="$(host_dynamic_loader "$loader_name")"; then


### PR DESCRIPTION
The lib4bin step in sharun-cef bundling copies the CI runner's
ld-linux-x86-64.so.2 into shared/lib/, which is glibc 2.39 on
Ubuntu 24.04. On newer glibc 2.42 systems (Fedora, rolling
distros) this causes an ABI mismatch and immediate `*** stack
smashing detected ***` crash.

Observed on Fedora Linux — distros shipping glibc ≥ 2.42 may be
affected.

`ensure_sharun_interpreter()` previously skipped replacement when
the bundled ld-linux already existed. Now it always replaces from
the CI host system, which is guaranteed compatible with the binary
compiled on the same runner.

This does not claim to resolve all of #3224; it fixes the ld-linux/glibc mismatch observed on Fedora.

## Change
- **File**: `scripts/release/strip-appimage-graphics-libs.sh` (+5/-3)
- **Function**: `ensure_sharun_interpreter()` — replace `[ -e "$target" ] && return 1` guard with `rm -f "$target"`
- **Effect**: CI runner's host `ld-linux-x86-64.so.2` (or `ld-linux-aarch64.so.1`) always replaces whatever `lib4bin` bundled

## Verified
1. **Negative control**: Original v0.57.40 AppImage on glibc 2.42 (Fedora) → `*** stack smashing detected ***: terminated`
2. **Positive control**: Same AppImage after fix applied → app launched, CEF initialized, RunEvent::Ready, zero crashes
3. **Syntax**: `bash -n` passes
4. **Return semantics**: No change to function return values (only one `return 1` remains — the non-sharun early exit)

Refs #3224
Closes #3099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release build process to ensure AppImage packages handle graphics library loaders more robustly, replacing any incompatible loaders with compatible host versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->