### PR TITLE
fix(rpc): suppress Sentry noise for JSON-RPC probes

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -103,6 +103,12 @@ pub async fn rpc_handler(State(state): State<AppState>, Json(req): Json<RpcReque
                     "[rpc] expected-user-state error — skipping Sentry: {}",
                     display_message
                 );
+            } else if is_jsonrpc_probe_unknown_method(method.as_str(), &display_message) {
+                tracing::info!(
+                    method = %method,
+                    elapsed_ms = ms as u64,
+                    "[rpc] JSON-RPC probe unknown-method noise (skip-report)"
+                );
             } else if is_param_validation_error(&display_message) {
                 tracing::info!(
                     method = %method,
@@ -320,6 +326,17 @@ fn is_param_validation_error(msg: &str) -> bool {
     msg.starts_with("unknown param '")
         || msg.starts_with("missing required param '")
         || msg.starts_with("invalid params: ")
+}
+
+/// Returns true for generic JSON-RPC discovery/auth/status probes that are
+/// expected to miss OpenHuman's method table. They should still return the
+/// normal JSON-RPC error to the caller, but they do not carry actionable
+/// product signal for Sentry.
+fn is_jsonrpc_probe_unknown_method(method: &str, msg: &str) -> bool {
+    matches!(
+        method,
+        "rpc.discover" | "list_methods" | "status" | "auth.status" | "config/get"
+    ) && msg == format!("unknown method: {method}")
 }
 
 /// Internal method invocation logic.

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -336,7 +336,9 @@ fn is_jsonrpc_probe_unknown_method(method: &str, msg: &str) -> bool {
     matches!(
         method,
         "rpc.discover" | "list_methods" | "status" | "auth.status" | "config/get"
-    ) && msg == format!("unknown method: {method}")
+    ) && msg
+        .strip_prefix("unknown method: ")
+        .is_some_and(|missing_method| missing_method == method)
 }
 
 /// Internal method invocation logic.

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    build_http_schema_dump, default_state, escape_html, invoke_method, is_param_validation_error,
-    is_session_expired_error, is_unconfirmed_unauthorized_error, params_to_object,
-    parse_json_params, rpc_handler, type_name,
+    build_http_schema_dump, default_state, escape_html, invoke_method,
+    is_jsonrpc_probe_unknown_method, is_param_validation_error, is_session_expired_error,
+    is_unconfirmed_unauthorized_error, params_to_object, parse_json_params, rpc_handler, type_name,
 };
 
 struct EnvVarGuard {

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -809,6 +809,35 @@ fn is_param_validation_error_does_not_match_unrelated_errors() {
 }
 
 #[test]
+fn is_jsonrpc_probe_unknown_method_matches_only_generic_probe_misses() {
+    for method in [
+        "rpc.discover",
+        "list_methods",
+        "status",
+        "auth.status",
+        "config/get",
+    ] {
+        assert!(
+            is_jsonrpc_probe_unknown_method(method, &format!("unknown method: {method}")),
+            "{method} should be treated as probe noise only for its exact unknown-method error"
+        );
+    }
+
+    assert!(!is_jsonrpc_probe_unknown_method(
+        "openhuman.totally_made_up_xyz",
+        "unknown method: openhuman.totally_made_up_xyz"
+    ));
+    assert!(!is_jsonrpc_probe_unknown_method(
+        "status",
+        "status handler failed"
+    ));
+    assert!(!is_jsonrpc_probe_unknown_method(
+        "rpc.discover",
+        "unknown method: auth.status"
+    ));
+}
+
+#[test]
 fn is_session_expired_error_matches_missing_backend_session_token() {
     // Composio / web search / billing / team / webhooks / referral all surface
     // a "no backend session token" variant when the auth profile is gone. Each
@@ -937,6 +966,35 @@ async fn thread_not_found_rpc_error_does_not_report_to_sentry() {
     assert!(
         transport.fetch_and_clear_events().is_empty(),
         "ThreadNotFound should not reach Sentry"
+    );
+
+    for method in [
+        "rpc.discover",
+        "list_methods",
+        "status",
+        "auth.status",
+        "config/get",
+    ] {
+        let probe_request = crate::core::types::RpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: json!(method),
+            method: method.to_string(),
+            params: json!({}),
+        };
+        let response = rpc_handler(State(default_state()), Json(probe_request)).await;
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("json response");
+        assert_eq!(
+            body["error"]["message"],
+            format!("unknown method: {method}"),
+            "{method} should still return the JSON-RPC unknown-method error"
+        );
+    }
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "generic JSON-RPC probes should not reach Sentry"
     );
 
     let unrelated_error_request = crate::core::types::RpcRequest {


### PR DESCRIPTION
## Summary

- Suppresses Sentry reporting for common JSON-RPC discovery/status/auth probe methods when they miss the OpenHuman RPC table.
- Keeps the wire behavior unchanged: probe callers still receive the normal JSON-RPC `unknown method` response.
- Adds regression coverage that known probe misses skip Sentry while unrelated unknown methods are still reported.

## Problem

- Generic clients and tooling can probe JSON-RPC servers with method names like `rpc.discover`, `list_methods`, `status`, `auth.status`, and `config/get`.
- OpenHuman does not implement those methods, so returning `unknown method` is correct.
- Reporting those expected probe misses to Sentry creates noise and obscures actionable unknown-method errors.

## Solution

- Added a small classifier for exact probe-method `unknown method: <method>` failures at the JSON-RPC transport boundary.
- Logs those probe misses at info level and skips Sentry reporting.
- Anchors the classifier on both method name and exact unknown-method message so real handler errors for similarly named methods still report normally.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Focused Rust tests were added; local execution is blocked by missing system pkg-config deps listed below.
- [x] Coverage matrix updated - N/A: behavior-only transport noise-classification change; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no feature ID applies to this transport noise-classification fix.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) - N/A: no release-cut smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime impact is limited to Sentry/error-reporting classification for exact generic JSON-RPC probe misses.
- No API response shape changes, no migration, no network dependency, and no frontend behavior change.
- Genuine unknown methods and non-probe errors continue through the existing Sentry reporting path.

## Related

- Closes #3567
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3567-rpc-probe-noise`
- Commit SHA: `6c38e96d`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` - N/A: Rust-only change
- [x] `pnpm typecheck` - N/A: Rust-only change
- [x] Focused tests: attempted `cargo test is_jsonrpc_probe_unknown_method_matches_only_generic_probe_misses --lib` and `cargo test thread_not_found_rpc_error_does_not_report_to_sentry --lib`
- [x] Rust fmt/check (if changed): `cargo fmt --check`
- [x] Tauri fmt/check (if changed): N/A: no Tauri config/plugin change

### Validation Blocked

- `command:` `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test is_jsonrpc_probe_unknown_method_matches_only_generic_probe_misses --lib`
- `error:` local system pkg-config deps are missing: `alsa.pc` and `xi.pc`
- `impact:` the focused tests did not execute locally; formatting and diff whitespace checks passed, and CI should run in an environment with the required system packages.

### Behavior Changes

- Intended behavior change: exact generic JSON-RPC probe unknown-method misses no longer report to Sentry.
- User-visible effect: none; callers still receive the same JSON-RPC unknown-method error.

### Parity Contract

- Legacy behavior preserved: JSON-RPC response body and status remain unchanged.
- Guard/fallback/dispatch parity checks: regression test keeps unrelated unknown methods on the Sentry path.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON-RPC error handling for expected discovery/auth/status probe requests, preventing routine “unknown method” cases from triggering false alerts.
  * Updated logging and reporting logic so probe-related failures are treated as non-actionable while real issues still surface normally.
* **Tests**
  * Added regression coverage to ensure probe “unknown method” detection only applies to the intended method set and exact error text, with no alerting emitted for these cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->