### PR TITLE
fix(cli): restore SIGPIPE default on Unix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5180,6 +5180,7 @@ dependencies = [
  "keyring",
  "landlock",
  "lettre",
+ "libc",
  "log",
  "mail-parser",
  "matrix-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { version = "1", features = ["full", "sync"] }
 once_cell = "1.19"
 parking_lot = "0.12"
 log = "0.4"
+libc = "0.2"
 nu-ansi-term = "0.46"
 env_logger = "0.11"
 base64 = "0.22"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use regex::Regex;
 /// information is redacted before being sent to the server. After setup, it
 /// delegates execution to the core library based on CLI arguments.
 fn main() {
+    restore_default_sigpipe();
+
     // Load `.env` before `sentry::init` so a DSN defined only in the dotenv
     // file is visible to the Sentry client at startup. `dotenvy::dotenv()` is
     // a no-op for variables already present in the process environment, and
@@ -179,6 +181,19 @@ fn main() {
         std::process::exit(1);
     }
 }
+
+#[cfg(unix)]
+fn restore_default_sigpipe() {
+    // Rust ignores SIGPIPE at startup. That makes writes to a closed pipe
+    // return EPIPE, which the print macros turn into a panic. CLI tools should
+    // instead terminate quietly when a downstream reader such as `head` exits.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn restore_default_sigpipe() {}
 
 // ---------------------------------------------------------------------------
 // Release / environment resolution for Sentry

--- a/tests/cli_sigpipe.rs
+++ b/tests/cli_sigpipe.rs
@@ -1,0 +1,26 @@
+#[cfg(unix)]
+#[test]
+fn help_output_closed_pipe_does_not_panic() {
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_openhuman-core"))
+        .arg("--help")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openhuman-core --help");
+
+    drop(child.stdout.take());
+
+    let output = child.wait_with_output().expect("wait for openhuman-core");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("Broken pipe"),
+        "stderr must not include a broken-pipe panic: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "stderr must not include a panic report: {stderr}"
+    );
+}

--- a/tests/cli_sigpipe.rs
+++ b/tests/cli_sigpipe.rs
@@ -1,6 +1,8 @@
 #[cfg(unix)]
 #[test]
 fn help_output_closed_pipe_does_not_panic() {
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::process::ExitStatusExt;
     use std::process::{Command, Stdio};
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_openhuman-core"))
@@ -10,7 +12,19 @@ fn help_output_closed_pipe_does_not_panic() {
         .spawn()
         .expect("spawn openhuman-core --help");
 
-    drop(child.stdout.take());
+    // Mirror the issue repro (`openhuman-core --help | head -n 1`): read a
+    // single line, then drop the read end mid-stream so the child's next write
+    // lands on a closed pipe. Closing before reading (as a naive test does)
+    // lets the child buffer its entire few-KB `--help` output in one successful
+    // write well under the 64 KB pipe buffer and exit cleanly, never exercising
+    // the broken-pipe path — a false green that passes even without the fix.
+    let stdout = child.stdout.take().expect("capture stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut first_line = String::new();
+    reader
+        .read_line(&mut first_line)
+        .expect("read first help line");
+    drop(reader);
 
     let output = child.wait_with_output().expect("wait for openhuman-core");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -22,5 +36,15 @@ fn help_output_closed_pipe_does_not_panic() {
     assert!(
         !stderr.contains("panicked"),
         "stderr must not include a panic report: {stderr}"
+    );
+
+    // Acceptance criterion #1: a closed downstream reader must yield a clean
+    // exit — either the child finished before the pipe closed, or the restored
+    // default disposition let SIGPIPE terminate it. A normal-code crash (e.g.
+    // the panic exit code 101) is precisely the regression this guards against.
+    assert!(
+        output.status.success() || output.status.signal() == Some(libc::SIGPIPE),
+        "process must exit cleanly or via SIGPIPE, got {:?}",
+        output.status
     );
 }


### PR DESCRIPTION
## Summary
- restore the default SIGPIPE disposition at process startup on Unix
- prevents Rust print macros from panicking on normal closed-pipe CLI usage like `openhuman-core --help | head`
- add a Unix integration test that closes the stdout pipe and verifies stderr does not contain a broken-pipe panic

Closes #3535

## Tests
- `cargo fmt --check`
- `git diff --check`

Attempted but blocked locally:
- `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test --test cli_sigpipe -- --nocapture`
  - blocked by missing system pkg-config deps: `alsa.pc` and `xi.pc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when the CLI's output pipe was closed before completion (e.g., when piping to commands like `head`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->