### PR TITLE
test(observability): cover Composio list_connections 503 wrappers

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -4724,6 +4724,47 @@ mod tests {
     }
 
     #[test]
+    fn composio_list_connections_503_504_wrappers_stay_filtered() {
+        for (status, reason) in [("503", "Service Unavailable"), ("504", "Gateway Timeout")] {
+            let message = format!(
+                "[composio] list_connections failed: Backend returned {status} {reason} \
+                 for GET /agent-integrations/composio/connections"
+            );
+            let event = event_with_tags_and_message(
+                &[
+                    ("domain", "composio"),
+                    ("failure", "non_2xx"),
+                    ("status", status),
+                ],
+                &message,
+            );
+            assert!(
+                is_transient_integrations_failure(&event),
+                "wrapped composio list_connections {status} failures must be filtered"
+            );
+        }
+
+        for (status, reason) in [("503", "Service Unavailable"), ("504", "Gateway Timeout")] {
+            let message = format!(
+                "Backend returned {status} {reason} \
+                 for GET /agent-integrations/composio/connections"
+            );
+            let event = event_with_tags_and_message(
+                &[
+                    ("domain", "integrations"),
+                    ("failure", "non_2xx"),
+                    ("status", status),
+                ],
+                &message,
+            );
+            assert!(
+                is_transient_integrations_failure(&event),
+                "raw integrations list_connections {status} failures must be filtered"
+            );
+        }
+    }
+
+    #[test]
     fn updater_transient_403_is_dropped() {
         let event = event_with_tags_and_message(
             &[


### PR DESCRIPTION
## Summary
- Add a regression test for `[composio] list_connections failed: Backend returned 503/504 ...` wrapper events.
- Cover both `domain=composio` op-layer wrappers and the raw `domain=integrations` backend-proxy shape.
- Confirms the existing transient integrations classifier keeps these backend 503/504 events out of Sentry noise.

Fixes #3537

## Tests
- `cargo fmt --check`
- `git diff --check`
- `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test composio_list_connections_503_504_wrappers_stay_filtered` *(blocked locally: missing system pkg-config files `alsa.pc` and `xi.pc`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for transient failure detection, ensuring the system correctly identifies and handles temporary backend service unavailability (HTTP 503 and 504 errors).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->