### PR TITLE
test(observability): cover custom_openai 502 transient shape

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -3164,6 +3164,7 @@ mod tests {
             "OpenHuman API error (408): request timeout",
             "OpenAI API error (429 Too Many Requests): rate limit",
             "Anthropic API error (502 Bad Gateway): upstream unhealthy",
+            "custom_openai API error (502 Bad Gateway): upstream gateway blip",
             "OpenHuman API error (503): service unavailable",
             "Provider API error (504): upstream timed out",
         ] {
@@ -4473,6 +4474,23 @@ mod tests {
                 "status {status} must be classified as transient and filtered"
             );
         }
+    }
+
+    #[test]
+    fn custom_openai_502_event_shape_is_transient_provider_http() {
+        let event = event_with_tags_and_message(
+            &[
+                ("domain", "llm_provider"),
+                ("provider", "custom_openai"),
+                ("failure", "non_2xx"),
+                ("status", "502"),
+            ],
+            "custom_openai API error (502 Bad Gateway): upstream gateway blip",
+        );
+        assert!(
+            is_transient_provider_http_failure(&event),
+            "custom_openai 502 attempts should be treated as transient provider HTTP noise"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a regression assertion for the exact `custom_openai API error (502 Bad Gateway): ...` Sentry shape from #3538.
- Cover both the message-level expected-error classifier and the `before_send` provider HTTP tag shape.
- Keeps final aggregate failures visible while documenting that per-attempt 502s are transient provider HTTP noise.

Fixes #3538

## Tests
- `cargo fmt --check`
- `git diff --check`
- `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test custom_openai_502_event_shape_is_transient_provider_http` *(blocked locally: missing system pkg-config files `alsa.pc` and `xi.pc`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for transient upstream HTTP failures (502 errors) from custom providers.
  * Added validation for proper error classification and handling in monitoring systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->