### PR TITLE
test(observability): cover custom_openai Ollama timeout chain

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -2974,6 +2974,20 @@ mod tests {
     }
 
     #[test]
+    fn custom_openai_ollama_timeout_fallback_chain_is_network_unreachable() {
+        let chain =
+            "custom_openai chat completions transport error: error sending request for url \
+                     (http://localhost:11434/v1/chat/completions): operation timed out \
+                     (responses fallback failed: custom_openai API error (404 Not Found): \
+                     {\"error\":\"not found\"})";
+        assert_eq!(
+            expected_error_kind(chain),
+            Some(ExpectedErrorKind::NetworkUnreachable),
+            "local Ollama timeout plus responses fallback failure must not page Sentry"
+        );
+    }
+
+    #[test]
     fn does_not_classify_unrelated_provider_errors_as_network() {
         // Status-bearing provider failures (404, 500, …) are surfaced via
         // their HTTP status path and must NOT be silenced by the


### PR DESCRIPTION
## Summary
- Add a regression test for the #3539 local Ollama timeout shape: `custom_openai chat completions transport error ... localhost:11434 ... responses fallback failed`.
- Confirms the existing expected-error classifier treats this as `NetworkUnreachable`, keeping local-service downtime out of error-level Sentry.
- Leaves provider HTTP/status failures unchanged.

Fixes #3539

## Tests
- `cargo fmt --check`
- `git diff --check`
- `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test custom_openai_ollama_timeout_fallback_chain_is_network_unreachable` *(blocked locally: missing system pkg-config files `alsa.pc` and `xi.pc`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error classification chain validation, ensuring network-related errors are properly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->