### PR TITLE
test(observability): cover updater GitHub 403 message events

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -4741,6 +4741,19 @@ mod tests {
     }
 
     #[test]
+    fn updater_github_403_message_only_shapes_are_dropped() {
+        for event in [
+            event_with_message("GitHub API error: 403 Forbidden"),
+            event_with_exception_value("GitHub API error: 403 Forbidden"),
+        ] {
+            assert!(
+                is_updater_transient_event(&event),
+                "message-only GitHub 403 updater failures must be filtered"
+            );
+        }
+    }
+
+    #[test]
     fn updater_transient_502_is_dropped() {
         let event = event_with_tags_and_message(
             &[


### PR DESCRIPTION
## Summary
- Add regression coverage for `GitHub API error: 403 Forbidden` when it arrives as a message-only or exception-value updater event.
- Complements the existing tagged `domain=update/status=403` test so both Sentry shapes stay filtered as transient rate-limit/region noise.
- Keeps real updater panics visible.

Fixes #3540

## Tests
- `cargo fmt --check`
- `git diff --check`
- `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test updater_github_403_message_only_shapes_are_dropped` *(blocked locally: missing system pkg-config files `alsa.pc` and `xi.pc`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for updater GitHub API error handling to ensure transient failures are properly identified and can be retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->