### PR TITLE
test(observability): cover session-expired before_send events

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -5304,6 +5304,37 @@ mod tests {
     }
 
     #[test]
+    fn session_expired_before_send_matches_core_401_events() {
+        let msg = "SESSION_EXPIRED: backend session not active — sign in to resume LLM work";
+        for event in [
+            event_with_tags_and_message(&[("domain", "llm_provider"), ("status", "401")], msg),
+            {
+                let mut event = event_with_exception_value(msg);
+                event.tags.insert("domain".into(), "backend_api".into());
+                event.tags.insert("status".into(), "401".into());
+                event
+            },
+        ] {
+            assert!(
+                is_session_expired_event(&event),
+                "core/backend session-expired 401 events should be filtered"
+            );
+        }
+    }
+
+    #[test]
+    fn session_expired_before_send_stays_domain_scoped() {
+        let event = event_with_tags_and_message(
+            &[("domain", "composio"), ("status", "401")],
+            "SESSION_EXPIRED: backend session not active — sign in to resume LLM work",
+        );
+        assert!(
+            !is_session_expired_event(&event),
+            "non-core domains must not be filtered as backend session expiry"
+        );
+    }
+
+    #[test]
     fn max_iterations_filter_matches_message_path() {
         // `report_error_message` calls `sentry::capture_message`, which
         // populates `event.message`. The filter must see the canonical


### PR DESCRIPTION
## Summary
- Add before_send regression coverage for `SESSION_EXPIRED: backend session not active ...` events with core/backend 401 tags.
- Cover both direct message and exception-value Sentry payload paths.
- Add a non-core domain guard so unrelated 401s are not accidentally filtered.

Fixes #3541

## Tests
- `cargo fmt --check`
- `git diff --check`
- `env CC=/usr/bin/gcc CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc cargo test session_expired_before_send` *(blocked locally: missing system pkg-config files `alsa.pc` and `xi.pc`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for session-expired event filtering to ensure accurate detection and handling of authentication-related events, including correct matching for core namespace domains and excluding similar events from non-core domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->