### PR TITLE
fix(observability): drop all-transient provider exhaustion events

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1842,6 +1842,46 @@ pub fn is_transient_provider_transport_failure(event: &sentry::protocol::Event<'
     event_has_transient_transport_phrase(event)
 }
 
+/// Defense-in-depth filter for aggregate provider exhaustion events where the
+/// aggregate only restates transient attempt failures.
+///
+/// Keep ordinary `failure=all_exhausted` events: they are the useful "every
+/// fallback failed" signal. Drop only the narrow shape observed in #3542,
+/// where the aggregate body starts with the reliable-provider exhaustion
+/// prefix and contains transient HTTP/transport wording already classified by
+/// [`is_transient_message_failure`].
+pub fn is_all_transient_provider_exhaustion_event(event: &sentry::protocol::Event<'_>) -> bool {
+    let tags = &event.tags;
+    if tags.get("domain").map(String::as_str) != Some("llm_provider") {
+        return false;
+    }
+    if tags.get("failure").map(String::as_str) != Some("all_exhausted") {
+        return false;
+    }
+
+    let direct = event.message.as_deref();
+    let from_logentry = event.logentry.as_ref().map(|log| log.message.as_str());
+    let from_exception = event.exception.last().and_then(|e| e.value.as_deref());
+    [direct, from_logentry, from_exception]
+        .into_iter()
+        .flatten()
+        .any(all_provider_attempts_are_transient)
+}
+
+fn all_provider_attempts_are_transient(message: &str) -> bool {
+    let Some(attempts) = message.strip_prefix("All providers/models failed. Attempts:") else {
+        return false;
+    };
+    let mut saw_attempt = false;
+    for attempt in attempts.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+        saw_attempt = true;
+        if !is_transient_message_failure(attempt) {
+            return false;
+        }
+    }
+    saw_attempt
+}
+
 /// Returns true when a Sentry event's message/exception text contains the
 /// canonical max-tool-iterations cap phrase (see
 /// `openhuman::agent::error::MAX_ITERATIONS_ERROR_PREFIX`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,11 @@ fn main() {
             if openhuman_core::core::observability::is_transient_provider_http_failure(&event) {
                 return None;
             }
+            if openhuman_core::core::observability::is_all_transient_provider_exhaustion_event(
+                &event,
+            ) {
+                return None;
+            }
             // Defense-in-depth: drop managed-backend `errorCode` events (#870)
             // the backend owns (F2/F4) — primary suppression lives in
             // `api_error` / the streaming gates and the `web_channel`

--- a/tests/observability_smoke.rs
+++ b/tests/observability_smoke.rs
@@ -9,9 +9,9 @@
 //! and aggregate `all_exhausted` events still surface.
 
 use openhuman_core::core::observability::{
-    is_budget_event, is_session_expired_event, is_transient_backend_api_failure,
-    is_transient_integrations_failure, is_transient_provider_http_failure,
-    is_updater_transient_event,
+    is_all_transient_provider_exhaustion_event, is_budget_event, is_session_expired_event,
+    is_transient_backend_api_failure, is_transient_integrations_failure,
+    is_transient_provider_http_failure, is_updater_transient_event,
 };
 use sentry::protocol::Event;
 use std::collections::BTreeMap;
@@ -58,6 +58,7 @@ fn count_captured(events: Vec<Event<'static>>) -> usize {
         // Same filter shape the real binary installs in main.rs.
         before_send: Some(Arc::new(|event| {
             if is_transient_provider_http_failure(&event)
+                || is_all_transient_provider_exhaustion_event(&event)
                 || is_transient_backend_api_failure(&event)
                 || is_transient_integrations_failure(&event)
                 || is_budget_event(&event)
@@ -240,6 +241,40 @@ fn keeps_aggregate_all_exhausted_event() {
         count_captured(vec![event]),
         1,
         "aggregate all_exhausted event must surface for genuine outages"
+    );
+}
+
+#[test]
+fn drops_aggregate_all_exhausted_when_attempts_are_transient() {
+    let event = event_with_tags_and_message(
+        &[
+            ("domain", "llm_provider"),
+            ("failure", "all_exhausted"),
+            ("attempts", "2"),
+        ],
+        "All providers/models failed. Attempts: openai API error (503 Service Unavailable); custom_openai API error (502 Bad Gateway)",
+    );
+    assert_eq!(
+        count_captured(vec![event]),
+        0,
+        "all-transient aggregate should not recreate per-attempt Sentry noise"
+    );
+}
+
+#[test]
+fn keeps_aggregate_all_exhausted_with_permanent_attempt() {
+    let event = event_with_tags_and_message(
+        &[
+            ("domain", "llm_provider"),
+            ("failure", "all_exhausted"),
+            ("attempts", "2"),
+        ],
+        "All providers/models failed. Attempts: openai API error (401 Unauthorized); custom_openai API error (503 Service Unavailable)",
+    );
+    assert_eq!(
+        count_captured(vec![event]),
+        1,
+        "mixed/permanent aggregate should remain actionable"
     );
 }
 


### PR DESCRIPTION
Fixes #3542

## Summary
- add a narrow before_send classifier for failure=all_exhausted provider events whose Attempts body contains only transient HTTP/transport failures
- keep ordinary all_exhausted events, including mixed/permanent attempts, visible in Sentry
- add smoke coverage for all-transient aggregate drop and mixed/permanent aggregate retention

## Tests
- cargo fmt --check
- git diff --check

Attempted but blocked locally:
- cargo test --test observability_smoke

The test build fails before this test runs because the local C linker rejects Rust's -m64 flag (`error: unknown option '-m64'`) while compiling dependency build scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error monitoring to better distinguish between temporary and permanent provider failures, reducing noise in error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->