### PR TITLE
fix(observability): skip SQLITE_FULL "database or disk is full" (Sentry TAURI-RUST-B6N)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -496,7 +496,19 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
 /// That string carries no "no space left on device" text, so anchor
 /// additionally on the cross-platform `StorageFull` ErrorKind token (std maps
 /// ENOSPC / `ERROR_DISK_FULL` / `ERROR_HANDLE_DISK_FULL` all to
-/// `ErrorKind::StorageFull`). This is defense-in-depth for the genuinely
+/// `ErrorKind::StorageFull`).
+///
+/// A fifth shape comes from SQLite itself. When the engine detects the
+/// disk-full condition during its own page bookkeeping (journal/WAL extension)
+/// before the next syscall surfaces an errno, rusqlite renders the `SQLITE_FULL`
+/// result code as `"database or disk is full"` (Sentry TAURI-RUST-B6N, hit at
+/// `memory_store::unified::documents::tx.commit()` during
+/// `openhuman.memory_doc_ingest`). `SQLITE_FULL` has only two causes:
+/// genuine ENOSPC/ERROR_DISK_FULL (always the case in practice — the same
+/// burst always produces an os-error-28/112 sibling event) or a
+/// `max_page_count` PRAGMA cap (we set none). Anchor on the exact
+/// `"database or disk is full"` phrase so unrelated "full" prose doesn't get
+/// silenced. This is defense-in-depth for the genuinely
 /// unpreventable **write** paths (a write can't succeed on a full disk); the
 /// read path no longer emits this error at all (it degrades to a lock-free
 /// read — see `AuthProfilesStore::load`).
@@ -504,6 +516,7 @@ fn is_disk_full_message(lower: &str) -> bool {
     lower.contains("no space left on device")
         || lower.contains("not enough space on the disk")
         || lower.contains("storagefull")
+        || lower.contains("database or disk is full")
 }
 
 /// Detect the literal `"Config loading timed out"` string produced by
@@ -2782,6 +2795,13 @@ mod tests {
             // only the `ErrorKind` debug + os_code survive — no "no space left
             // on device" text. Must still classify via the StorageFull anchor.
             "Failed to create auth profile lock (kind=Some(StorageFull), os_code=Some(28))",
+            // SQLITE_FULL rendering from rusqlite — engine-level disk-full
+            // detection during page-bookkeeping (journal/WAL extension) that
+            // beats the next syscall to the errno. Production hit at
+            // `memory_store::unified::documents::tx.commit()` during
+            // `openhuman.memory_doc_ingest`, in the same burst that emits
+            // os-error-112 siblings (Sentry TAURI-RUST-B6N).
+            "commit tx: database or disk is full",
         ] {
             assert_eq!(
                 expected_error_kind(raw),
@@ -2802,6 +2822,18 @@ mod tests {
         );
         assert_eq!(
             expected_error_kind("not enough memory to allocate buffer"),
+            None
+        );
+        // The SQLite anchor pins to the exact `"database or disk is full"`
+        // phrase. Generic prose that mentions a full database for unrelated
+        // reasons (e.g. duplicate-row complaints, application-level capacity
+        // talk) must not be silenced.
+        assert_eq!(
+            expected_error_kind("upsert failed: database is full of duplicates"),
+            None
+        );
+        assert_eq!(
+            expected_error_kind("user quota: database is full for this tier"),
             None
         );
     }

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -506,17 +506,45 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
 /// `openhuman.memory_doc_ingest`). `SQLITE_FULL` has only two causes:
 /// genuine ENOSPC/ERROR_DISK_FULL (always the case in practice — the same
 /// burst always produces an os-error-28/112 sibling event) or a
-/// `max_page_count` PRAGMA cap (we set none). Anchor on the exact
-/// `"database or disk is full"` phrase so unrelated "full" prose doesn't get
-/// silenced. This is defense-in-depth for the genuinely
+/// `max_page_count` PRAGMA cap (we set none).
+///
+/// The rusqlite `Display` for `SQLITE_FULL` is exactly the five words
+/// `"database or disk is full"` — no preamble, no trailing context. Our local
+/// memory-store write call-sites wrap it with `format!("<verb>: {e}")`
+/// (e.g. `"commit tx: ..."` / `"clear_namespace commit tx: ..."` in
+/// `memory_store::unified::documents`), so the phrase always lands as the
+/// **suffix** of the local emit. Anchor on suffix, not `contains`, so the
+/// silencer does not match a non-2xx backend response body whose payload
+/// happens to mention the same phrase (e.g. an `api.tinyhumans.ai` 5xx whose
+/// server-side SQLite is full). Non-2xx backend bodies are framed by
+/// `integrations::client::post` / `composio::client` as `"Backend returned
+/// <status> <reason> for <METHOD> <url>: <detail>"` — an operator-actionable
+/// server/storage failure that must still surface to Sentry. As
+/// defense-in-depth for the edge case where the backend body itself ends with
+/// the phrase, reject any message that also carries the `"backend returned "`
+/// envelope prefix (codex CR on #3672, mirrors the precedent set by
+/// [`is_backend_user_error_message`]).
+///
+/// This is defense-in-depth for the genuinely
 /// unpreventable **write** paths (a write can't succeed on a full disk); the
 /// read path no longer emits this error at all (it degrades to a lock-free
 /// read — see `AuthProfilesStore::load`).
 fn is_disk_full_message(lower: &str) -> bool {
-    lower.contains("no space left on device")
+    if lower.contains("no space left on device")
         || lower.contains("not enough space on the disk")
         || lower.contains("storagefull")
-        || lower.contains("database or disk is full")
+    {
+        return true;
+    }
+    // SQLITE_FULL — see the fifth-shape section above for the scoping
+    // rationale. Suffix anchor (after trimming trailing whitespace and
+    // punctuation that closures / JSON wrappers commonly append) pins to the
+    // local-emit shape; the negative `"backend returned "` guard rejects the
+    // remote envelope as a second line of defense.
+    let trimmed = lower.trim_end_matches(|c: char| {
+        c.is_ascii_whitespace() || matches!(c, '.' | ',' | ';' | ':' | '"' | '\'')
+    });
+    trimmed.ends_with("database or disk is full") && !lower.contains("backend returned ")
 }
 
 /// Detect the literal `"Config loading timed out"` string produced by
@@ -2835,6 +2863,43 @@ mod tests {
         assert_eq!(
             expected_error_kind("user quota: database is full for this tier"),
             None
+        );
+        // A non-2xx backend body whose payload contains the SQLITE_FULL phrase
+        // (e.g. `api.tinyhumans.ai` server-side SQLite is full) is an
+        // operator-actionable storage failure, not the user's local disk —
+        // must still surface to Sentry. `integrations::client::post` frames
+        // these as `"Backend returned <status> <reason> for POST <url>:
+        // <detail>"` (codex CR on #3672). The suffix anchor excludes the
+        // embedded-in-JSON case; the negative `"backend returned "` guard
+        // covers the rare case where the body itself ends with the phrase.
+        assert_eq!(
+            expected_error_kind(
+                "Backend returned 500 Internal Server Error for POST \
+                 https://api.tinyhumans.ai/agent-integrations/composio/list: \
+                 {\"error\":\"database or disk is full\"}"
+            ),
+            None,
+            "remote-backend body must surface"
+        );
+        assert_eq!(
+            expected_error_kind(
+                "Backend returned 500 Internal Server Error for POST \
+                 https://api.tinyhumans.ai/agent-integrations/composio/list: \
+                 database or disk is full"
+            ),
+            None,
+            "remote-backend body must surface even when the body itself ends with the phrase"
+        );
+        // Non-suffix occurrences in other body framings (no `"Backend
+        // returned"` prefix) are also excluded by the suffix anchor — locks
+        // in the primary defense layer.
+        assert_eq!(
+            expected_error_kind(
+                "Embedding API error (500 Internal Server Error): \
+                 {\"error\":\"database or disk is full\",\"retry\":true}"
+            ),
+            None,
+            "embedded-in-JSON body must surface"
         );
     }
 


### PR DESCRIPTION
## Summary

- Extend `is_disk_full_message` in `src/core/observability.rs` to recognize SQLite's `SQLITE_FULL` text (`"database or disk is full"`), so the disk-full classifier silences the SQLite-emitted variant the same way it already silences the OS-emitted variants.
- Drops Sentry **TAURI-RUST-B6N** (issue 12541) — 3085 events / 3 users in 0.57.18..0.57.40, all from `openhuman.memory_doc_ingest` on Windows hosts whose disks are genuinely full.

## Problem

The classifier already maps three disk-full renderings to `ExpectedErrorKind::DiskFull`:

- POSIX ENOSPC — `"No space left on device (os error 28)"`
- Windows ERROR_DISK_FULL — `"There is not enough space on the disk. (os error 112)"`
- The `io::ErrorKind` debug-name shape used by the auth-profile lock annotation — `"... (kind=Some(StorageFull), os_code=Some(28))"` (PR #3409, Sentry TAURI-RUST-4SZ).

Production breadcrumbs for issue 12541 show hundreds of OS-level `os error 112` events from the same telegram-scanner burst that ARE correctly skipped, and one SQLite-level variant `"commit tx: database or disk is full"` from `memory_store::unified::documents.rs:155` that is NOT skipped. That last variant is what produces the Sentry group.

`SQLITE_FULL` (rusqlite text: `"database or disk is full"`) has only two possible causes:

1. Real disk-full — always the case in practice; the same event burst always carries os-error-28/112 siblings, confirming the host disk is full.
2. A `max_page_count` PRAGMA cap — we set none on the memory store.

So the SQLite-emitted variant is the same condition as the OS-emitted variant, just surfaced from a different layer. The classifier-skip decision that PR #3409 made for the `StorageFull` debug-name shape applies identically here.

## Solution

1. Add `"database or disk is full"` as a fourth substring to `is_disk_full_message`. Anchor on the exact SQLite phrase (no looser "database … full" wildcard) so unrelated prose that mentions a full database for other reasons still reaches Sentry.
2. Update the function doc-comment with a "fifth shape" section documenting the SQLITE_FULL rationale, the call site (`memory_store::unified::documents::tx.commit()` during `openhuman.memory_doc_ingest`), and the two-causes argument for why this is safe.
3. Extend the positive `classifies_disk_full_errors` test with the production wire string `"commit tx: database or disk is full"`.
4. Extend the negative `does_not_classify_unrelated_space_messages` test with two prose-with-"database is full" cases (`"upsert failed: database is full of duplicates"`, `"user quota: database is full for this tier"`) to lock in that the anchor is the exact SQLite phrasing, not generic "database" + "full".

Rejected alternatives:

- **Pre-flight disk-space check before `tx.commit()`** — racy, wasteful, and cannot fix the user's full disk; the telegram scanner already handles the failure correctly by logging a warning at `src/telegram_scanner/mod.rs:255` and moving on.
- **New typed error variant in `documents.rs`** — heavier surgery for a one-line classifier gap that mirrors a precedent (#3409) already set in this codebase.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — positive case added to `classifies_disk_full_errors`, two negative cases added to `does_not_classify_unrelated_space_messages`
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). The only behavioral diff (the new substring branch in `is_disk_full_message`) is directly covered by the new test row in `classifies_disk_full_errors`; the rest of the diff is doc-comment text.
- [x] Coverage matrix updated — N/A: behaviour-only change (Sentry-side suppression of an existing unfixable user-environment error; no feature added, removed, or renamed)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: behaviour-only change, no matrix rows touched
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure in-process classifier change
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: does not touch any release-cut surface
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: Sentry-issue fix; no GitHub issue exists. Sentry issue ID called out in `## Related` instead.

## Impact

- **Runtime/platform:** desktop only (Windows hits the production wire string; Linux/macOS already covered by the existing POSIX ENOSPC anchor). No code path other than the Sentry-emission decision is affected — the user-facing error still propagates through the telegram scanner / memory ingestion as before; the only change is that the disk-full state stops being re-reported to Sentry from the SQLite-emitted variant.
- **Performance:** one extra substring check on already-classified-as-error wire strings; negligible.
- **Security / migration / compatibility:** none.

## Related

- Closes: Sentry **TAURI-RUST-B6N** (issue 12541) — `https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/12541/`
- Precedent: PR #3409 (auth-profile `StorageFull` debug-name variant — same one-line classifier extension pattern for a different disk-full stringification)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A — Sentry-issue fix, not Linear-tracked
- URL: N/A

### Commit & Branch

- Branch: `fix/sentry-b6n-sqlite-disk-full`
- Commit SHA: `dad4d8986`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change, no app/ file touched
- [x] `pnpm typecheck` — N/A: Rust-only change, no TypeScript touched
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib core::observability::tests::` → 152 passed, 0 failed; `classifies_disk_full_errors` and `does_not_classify_unrelated_space_messages` both green standalone
- [x] Rust fmt/check (if changed): `cargo fmt --check -- src/core/observability.rs` → clean
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri/` file touched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: the SQLITE_FULL Sentry-emit path is demoted to `ExpectedErrorKind::DiskFull` and silenced like the OS-level disk-full variants already are. No change to user-facing error propagation, retry logic, or any other code path.
- User-visible effect: none on the affected users themselves (they still see the underlying write failure surfaced through telegram-scanner warnings as before). The change suppresses a noisy, unfixable Sentry group that we cannot act on from code.

### Parity Contract

- Legacy behavior preserved: the OS-level disk-full variants (`os error 28`, `os error 112`, `StorageFull` debug-name) classify identically to before this PR; the existing positive test cases for those phrasings are unchanged.
- Guard/fallback/dispatch parity checks: the new anchor is the literal SQLite text `"database or disk is full"`; negative tests pin to the fact that unrelated `"database is full"` prose must still surface to Sentry, so this matcher cannot grow into a generic "anything mentioning a full database" silencer.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — searched open + closed PRs for `12541`, `TAURI-RUST-B6N`, `"commit tx"`, `"disk is full"`; no existing PR addresses this Sentry group.
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A — net-new


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of disk-full errors by recognizing SQLite’s “database or disk is full” wording more reliably.
  * Added stricter safeguards to avoid misclassifying unrelated “database is full” and remote/back-end framed error messages.
  * Expanded coverage to ensure the correct disk-full error kind is returned for SQLite-style messages while other similar phrases are correctly ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->