### PR TITLE
fix(rpc/credentials): preserve anyhow context chain in BackendOAuthClient call sites (TAURI-RUST-10)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1923,9 +1923,9 @@ pub fn is_session_expired_event(event: &sentry::protocol::Event<'_>) -> bool {
 /// RPC failures whose message body has been collapsed to just the bare
 /// HTTP method + path (`"GET /auth/me"`) with no underlying transport error.
 ///
-/// Pairs with the primary fix at `openhuman::credentials::ops::auth_get_me`
-/// (#458), which replaced `e.to_string()` with `format!("{e:#}")` so the
-/// full `anyhow` context chain reaches the rpc dispatcher. Before that
+/// Pairs with the primary fix at `openhuman::credentials::ops::auth_get_me`,
+/// which replaced `e.to_string()` with `format!("{e:#}")` so the full
+/// `anyhow` context chain reaches the rpc dispatcher. Before that
 /// fix, every transient network failure under this RPC — reqwest timeout,
 /// connection reset, TLS handshake EOF, DNS hiccup — fingerprinted to one
 /// opaque "GET /auth/me" Sentry group (TAURI-RUST-10, ~409 events / 17

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1919,6 +1919,54 @@ pub fn is_session_expired_event(event: &sentry::protocol::Event<'_>) -> bool {
     false
 }
 
+/// Defense-in-depth `before_send` filter for opaque `openhuman.auth_get_me`
+/// RPC failures whose message body has been collapsed to just the bare
+/// HTTP method + path (`"GET /auth/me"`) with no underlying transport error.
+///
+/// Pairs with the primary fix at `openhuman::credentials::ops::auth_get_me`
+/// (#458), which replaced `e.to_string()` with `format!("{e:#}")` so the
+/// full `anyhow` context chain reaches the rpc dispatcher. Before that
+/// fix, every transient network failure under this RPC — reqwest timeout,
+/// connection reset, TLS handshake EOF, DNS hiccup — fingerprinted to one
+/// opaque "GET /auth/me" Sentry group (TAURI-RUST-10, ~409 events / 17
+/// users) because `is_transient_message_failure` could not see the
+/// stripped transport phrases.
+///
+/// This filter is the catch-all if anyone re-introduces the same anyhow
+/// `.to_string()` collapse at another call site that eventually reaches
+/// `report_error_or_expected` with the same shape, OR if the existing fix
+/// regresses. Genuine `auth_get_me` errors that carry the underlying
+/// context chain (`"GET /auth/me: error sending request for url (...): …"`)
+/// still page — only the bare path-only body is dropped.
+///
+/// Match criteria (all required):
+/// - tag `domain == "rpc"`
+/// - tag `operation == "invoke_method"`
+/// - tag `method == "openhuman.auth_get_me"`
+/// - `event.message` (or last exception `value`) trims to **exactly**
+///   `"GET /auth/me"` — strict equality, not `contains`, so a body with
+///   the chain appended still surfaces.
+pub fn is_auth_get_me_opaque_transport_event(event: &sentry::protocol::Event<'_>) -> bool {
+    let tags = &event.tags;
+    if tags.get("domain").map(String::as_str) != Some("rpc") {
+        return false;
+    }
+    if tags.get("operation").map(String::as_str) != Some("invoke_method") {
+        return false;
+    }
+    if tags.get("method").map(String::as_str) != Some("openhuman.auth_get_me") {
+        return false;
+    }
+
+    const OPAQUE_BODY: &str = "GET /auth/me";
+    let direct = event.message.as_deref();
+    let from_exception = event.exception.last().and_then(|e| e.value.as_deref());
+    [direct, from_exception]
+        .into_iter()
+        .flatten()
+        .any(|body| body.trim() == OPAQUE_BODY)
+}
+
 pub fn is_transient_http_status(status: &str) -> bool {
     TRANSIENT_HTTP_STATUSES.contains(&status)
 }
@@ -5561,5 +5609,131 @@ mod tests {
             "operation timed out",
         );
         assert!(!is_transient_provider_transport_failure(&event));
+    }
+
+    // ── is_auth_get_me_opaque_transport_event ────────────────────────────
+    // Covers the TAURI-RUST-10 fingerprint shape: `domain=rpc`,
+    // `operation=invoke_method`, `method=openhuman.auth_get_me`, message
+    // body = exactly "GET /auth/me" (no underlying chain). See the
+    // function docstring + the `auth_get_me` fix in
+    // `openhuman::credentials::ops::auth_get_me` for the broader
+    // context.
+
+    fn auth_get_me_tags() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("domain", "rpc"),
+            ("operation", "invoke_method"),
+            ("method", "openhuman.auth_get_me"),
+            ("elapsed_ms", "5003"),
+        ]
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_drops_bare_method_path_message() {
+        let event = event_with_tags_and_message(&auth_get_me_tags(), "GET /auth/me");
+        assert!(
+            is_auth_get_me_opaque_transport_event(&event),
+            "bare 'GET /auth/me' message must be dropped (TAURI-RUST-10 shape)"
+        );
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_tolerates_surrounding_whitespace() {
+        let event = event_with_tags_and_message(&auth_get_me_tags(), "  GET /auth/me  ");
+        assert!(
+            is_auth_get_me_opaque_transport_event(&event),
+            "trimmed equality must still match the opaque shape"
+        );
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_keeps_full_anyhow_chain_message() {
+        // Post-fix shape from `auth_get_me` now using `format!("{e:#}")`.
+        let event = event_with_tags_and_message(
+            &auth_get_me_tags(),
+            "GET /auth/me: error sending request for url \
+             (https://api.tinyhumans.ai/auth/me): operation timed out",
+        );
+        assert!(
+            !is_auth_get_me_opaque_transport_event(&event),
+            "messages carrying the underlying transport chain must surface — \
+             the transient classifier handles those at the rpc dispatcher"
+        );
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_keeps_other_rpc_methods() {
+        // Same opaque shape but for a different RPC must NOT be dropped —
+        // we don't have evidence the same anti-pattern exists elsewhere,
+        // and a path-only body might be a legitimate distinct error for a
+        // future endpoint.
+        for method in [
+            "openhuman.consume_login_token",
+            "openhuman.auth_create_channel_link_token",
+            "openhuman.thread_list",
+        ] {
+            let mut tags = auth_get_me_tags();
+            // Replace the method tag.
+            if let Some(slot) = tags.iter_mut().find(|(k, _)| *k == "method") {
+                slot.1 = method;
+            }
+            let event = event_with_tags_and_message(&tags, "GET /auth/me");
+            assert!(
+                !is_auth_get_me_opaque_transport_event(&event),
+                "filter must be scoped strictly to method=openhuman.auth_get_me \
+                 — saw method={method}"
+            );
+        }
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_requires_rpc_invoke_method_domain() {
+        // Wrong domain → must surface.
+        let mut tags = auth_get_me_tags();
+        if let Some(slot) = tags.iter_mut().find(|(k, _)| *k == "domain") {
+            slot.1 = "backend_api";
+        }
+        let event = event_with_tags_and_message(&tags, "GET /auth/me");
+        assert!(!is_auth_get_me_opaque_transport_event(&event));
+
+        // Wrong operation → must surface.
+        let mut tags = auth_get_me_tags();
+        if let Some(slot) = tags.iter_mut().find(|(k, _)| *k == "operation") {
+            slot.1 = "post";
+        }
+        let event = event_with_tags_and_message(&tags, "GET /auth/me");
+        assert!(!is_auth_get_me_opaque_transport_event(&event));
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_matches_exception_value_path() {
+        // sentry-tracing path: message empty, exception last value carries
+        // the body. The filter must still match.
+        let mut event = event_with_tags(&auth_get_me_tags());
+        event.exception.values.push(sentry::protocol::Exception {
+            value: Some("GET /auth/me".to_string()),
+            ..Default::default()
+        });
+        assert!(
+            is_auth_get_me_opaque_transport_event(&event),
+            "must also catch the exception-value shape (sentry-tracing bridge)"
+        );
+    }
+
+    #[test]
+    fn auth_get_me_opaque_filter_ignores_empty_and_unrelated() {
+        // No message and no exception → false.
+        let event = event_with_tags(&auth_get_me_tags());
+        assert!(!is_auth_get_me_opaque_transport_event(&event));
+
+        // Unrelated message body with the right tags → false.
+        let event = event_with_tags_and_message(
+            &auth_get_me_tags(),
+            "session JWT verified via GET /auth/me on https://api.tinyhumans.ai",
+        );
+        assert!(
+            !is_auth_get_me_opaque_transport_event(&event),
+            "substring match must NOT trigger — strict equality only"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,21 @@ fn main() {
             // filter catches any future call site that re-emits the same
             // shape — keeping OPENHUMAN-TAURI-25 / -1Q / -27 / -1G off
             // Sentry permanently (~185 events/day combined).
+            // Defense-in-depth: drop opaque "GET /auth/me" events from the
+            // `openhuman.auth_get_me` RPC. The primary fix in
+            // `credentials::ops::auth_get_me` walks the full anyhow context
+            // chain so `is_transient_message_failure` can demote transient
+            // transport failures at the rpc dispatcher. This catches any
+            // future regression where a sibling call site collapses the
+            // chain via `e.to_string()` and reproduces TAURI-RUST-10
+            // (~409 events / 17 users).
+            if openhuman_core::core::observability::is_auth_get_me_opaque_transport_event(&event) {
+                log::debug!(
+                    "[sentry-auth-get-me-opaque-filter] dropping opaque transport event_id={:?}",
+                    event.event_id
+                );
+                return None;
+            }
             if openhuman_core::core::observability::is_session_expired_event(&event) {
                 // Metadata-only log shape — `event.message` carries the raw
                 // backend response body (often a JSON envelope with the

--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -455,7 +455,13 @@ pub async fn auth_get_me(config: &Config) -> Result<RpcOutcome<serde_json::Value
     let user = client
         .fetch_current_user(&token)
         .await
-        .map_err(|e| e.to_string())?;
+        // `{e:#}` walks the full anyhow context chain so the underlying
+        // reqwest transport error (timeout / connection reset / TLS / DNS)
+        // reaches `core::observability::is_transient_message_failure`. Bare
+        // `e.to_string()` only renders the top context layer
+        // ("GET /auth/me") and collapsed every transient transport failure
+        // into Sentry TAURI-RUST-10.
+        .map_err(|e| format!("{e:#}"))?;
 
     Ok(RpcOutcome::single_log(user, "current user fetched"))
 }
@@ -474,7 +480,8 @@ pub async fn consume_login_token(
     let jwt_token = client
         .consume_login_token(token)
         .await
-        .map_err(|e| e.to_string())?;
+        // See `auth_get_me` above for why we walk the full anyhow chain.
+        .map_err(|e| format!("{e:#}"))?;
 
     Ok(RpcOutcome::new(
         serde_json::json!({ "jwtToken": jwt_token }),
@@ -507,7 +514,8 @@ pub async fn auth_create_channel_link_token(
     let payload = client
         .create_channel_link_token(&channel, &token)
         .await
-        .map_err(|e| e.to_string())?;
+        // See `auth_get_me` above for why we walk the full anyhow chain.
+        .map_err(|e| format!("{e:#}"))?;
 
     Ok(RpcOutcome::single_log(
         payload,


### PR DESCRIPTION
## Summary

- Preserve the `anyhow` context chain in three `BackendOAuthClient` call sites in `credentials/ops` so the underlying transport error reaches the rpc dispatcher.
- Drops Sentry **TAURI-RUST-10** ("GET /auth/me", 409 events / 17 users / since 2026-05-19), which was an opaque transient-network noise group caused by `e.to_string()` collapsing the chain.
- Adds defense-in-depth `before_send` filter `is_auth_get_me_opaque_transport_event` so any future regression that re-emits the same opaque shape stays off Sentry.

## Problem

Sentry [TAURI-RUST-10](https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/98/) shows 409 events / 17 users since v0.54.0 with:

- `message`/`title`: literally `GET /auth/me`
- tags: `domain=rpc`, `operation=invoke_method`, `method=openhuman.auth_get_me`, `elapsed_ms≈5003`
- No exception, no stack, no status code, no underlying transport text.

Trace:

1. Frontend calls RPC `openhuman.auth_get_me` → `src/openhuman/credentials/ops.rs:451`.
2. `auth_get_me` calls `BackendOAuthClient::fetch_current_user` (`src/api/rest.rs:402`), which does `client.get(url).send().await.context("GET /auth/me")?`. This wraps the underlying `reqwest::Error` (`operation timed out`, `connection reset`, `tls handshake eof`, etc.) under the top context `"GET /auth/me"`.
3. Back in `auth_get_me`: `.map_err(|e| e.to_string())?`. **`anyhow::Error::to_string()` renders only the top-most context** — the underlying transport error is dropped. The string handed up the stack becomes exactly `"GET /auth/me"`.
4. The rpc dispatcher (`src/core/jsonrpc.rs:39`) runs its classifier ladder. `is_transient_message_failure("GET /auth/me")` returns false because `TRANSIENT_TRANSPORT_PHRASES` (`"timeout"`, `"connection reset"`, `"tls handshake eof"`, `"error sending request"`) were stripped in step 3.
5. The classifier misses → `report_error_or_expected("GET /auth/me", "rpc", "invoke_method", …)` → `sentry::capture_message("GET /auth/me", Error)`. Group fingerprint stabilizes on the bare literal → every transient network blip folds into one opaque high-traffic issue.

`elapsed_ms = 5003` + the 17-user / 26-day spread are consistent with episodic transient network failures (launch / resume / sleep-wake), not a real backend regression. The reqwest client has 15s connect / 120s total timeouts, so the ~5s timing is a fast network failure (DNS, refused, transient TLS) — exactly the class `is_transient_message_failure` is built to demote.

Same `.map_err(|e| e.to_string())` anti-pattern existed in sibling endpoints (`consume_login_token`, `auth_create_channel_link_token`) — fixing all three preemptively.

## Solution

**Primary fix** — preserve the error chain at the three sibling call sites in `src/openhuman/credentials/ops.rs`:

```diff
- .map_err(|e| e.to_string())?;
+ .map_err(|e| format!("{e:#}"))?;
```

`format!("{e:#}")` is `anyhow`'s alternate Display, which walks the full context chain. After the fix, a transient timeout surfaces as e.g. `"GET /auth/me: error sending request for url (https://api.tinyhumans.ai/auth/me): operation timed out"`. The existing skip-path at `core::jsonrpc::rpc_handler` (`is_transient_message_failure` → `tracing::warn!`, no Sentry) now matches and demotes to `warn`. Genuine non-transient backend errors still page, but with usable text instead of just the path.

**Defense in depth** — new classifier in `src/core/observability.rs`:

```rust
pub fn is_auth_get_me_opaque_transport_event(event: &sentry::protocol::Event<'_>) -> bool
```

Strictly matches the TAURI-RUST-10 fingerprint:

- tag `domain == "rpc"`
- tag `operation == "invoke_method"`
- tag `method == "openhuman.auth_get_me"`
- `event.message` (or last exception `value`) trims to **exactly** `"GET /auth/me"` (strict equality — chain-bearing messages still page).

Wired into the `before_send` chain in `src/main.rs` alongside `is_session_expired_event` / `is_max_iterations_event`. Pattern + docstring shape mirrors those siblings so the three layers can't drift.

**Tests** — 7 new unit tests in `core::observability::tests`:

- Drops bare `"GET /auth/me"` (TAURI-RUST-10 shape).
- Tolerates surrounding whitespace.
- Keeps the full-chain shape (`"GET /auth/me: error sending request …"`) — must reach Sentry.
- Strict-scoped to method=`openhuman.auth_get_me` (sibling methods `consume_login_token`, etc. surface).
- Strict-scoped to domain=`rpc` + operation=`invoke_method`.
- Matches the `sentry-tracing` exception-value path.
- Substring matches do NOT trigger (only strict equality).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — every changed line in the new filter is exercised by the 7 new unit tests; the three `format!("{e:#}")` lines are the existing tested error paths and the test surface covers the resulting body shapes.
- [x] Coverage matrix updated — N/A: pure noise-classifier addition, no new feature row; `auth_get_me` behavior is unchanged for callers.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: behaviour-only change to error string formatting + Sentry classifier.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut UI surface touched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: tracked only in Sentry (TAURI-RUST-10), no GitHub issue.

## Impact

- **Runtime**: desktop only. The three changed call sites are the desktop core's backend OAuth client.
- **Behavior change**: error strings returned by `auth_get_me` / `consume_login_token` / `auth_create_channel_link_token` now include the underlying transport context when the request fails — strictly more informative, never less. The frontend already surfaces these via `callCoreCommand` failure paths and treats them as opaque strings.
- **Performance**: zero (single Display invocation, same path).
- **Security**: no new PII risk. The reqwest errors include URLs, which are already in our scrub list (`scrub_secrets`/`sanitize_api_error`); the rpc dispatcher's existing `tracing::warn!` skip-path already redacts before logging.
- **Sentry volume**: drops ~400 events / month on TAURI-RUST-10. Genuine `auth_get_me` failures still report with actionable text.

## Related

- Closes: N/A (Sentry-tracked: TAURI-RUST-10)
- Follow-up PR(s)/TODOs: same `e.to_string()` anti-pattern likely exists at other anyhow boundaries in the credentials/integrations layer — sweep candidate, out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A (Sentry TAURI-RUST-10: https://sentry.tinyhumans.ai/organizations/tinyhumans/issues/98/)

### Commit & Branch

- Branch: `fix/sentry-tauri-rust-10-auth-get-me`
- Commit SHA: `58c4aa9e649f5b25864c5a2ab0698284daf9f709`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change, no TS/TSX touched.
- [x] `pnpm typecheck` — N/A: Rust-only change.
- [x] Focused tests: `cargo test --lib observability::tests::auth_get_me` → 7 passed; `cargo test --lib credentials::ops` → 37 passed; `cargo test --lib observability::` → 164 passed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --bin openhuman-core` clean (warnings only, all pre-existing and unrelated).
- [x] Tauri fmt/check (if changed): N/A: no tauri shell code touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `auth_get_me` (and two sibling RPCs) now propagate the full anyhow context chain on error, instead of collapsing to the top-most context string only.
- User-visible effect: when a backend auth call fails transiently, the user sees the same UI-level "couldn't reach backend" path, but the chain is no longer reported to Sentry as noise. On genuine non-transient errors, the actionable text is preserved (better debuggability).

### Parity Contract

- Legacy behavior preserved: success path is byte-identical. Error-path callers receive a strictly-longer error string (anyhow chain instead of top context). All call sites treat the error as an opaque `String` and either log or surface to UI — no callers parse the bytes for specific text.
- Guard/fallback/dispatch parity checks: the new `before_send` filter strictly matches the previously-leaked TAURI-RUST-10 shape only (bare path, no chain). Post-fix shape with the chain still routes through the existing `is_transient_message_failure` skip path at `rpc_handler`, unchanged. Real backend errors continue to page.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A — verified no open PR / local branch covers TAURI-RUST-10 / `auth_get_me`.
- Canonical PR: this one.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication-related error messages to include full context chains for clearer diagnosis when requests fail.
* **Monitoring**
  * Reduced Sentry noise by filtering out specific deterministic transport-related failures for the `auth_get_me` RPC, while preserving other events and errors for visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->