### PR TITLE
feat(settings): add Kimi API key affiliate link

### DIFF
--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -41,6 +41,7 @@ import {
   type TeamUsage,
 } from '../../../services/api/creditsApi';
 import { connectOpenRouterViaOAuth } from '../../../utils/openrouterOAuth';
+import { openUrl } from '../../../utils/openUrl';
 import {
   type AuthStyle,
   openhumanUpdateLocalAiSettings,
@@ -134,6 +135,7 @@ const BUILTIN_RESERVED_SLUGS = [
   'claude-code',
   ...BUILTIN_CLOUD_PROVIDER_SLUGS,
 ];
+const KIMI_PLATFORM_URL = 'https://platform.kimi.ai?aff=openhuman';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Static catalog
@@ -638,6 +640,7 @@ const ProviderKeyDialog = ({
   const helper = isLocalRuntime
     ? formatI18n(t('settings.ai.localRuntimeHelper'), { label })
     : t('settings.ai.apiKeyStoredEncrypted');
+  const platformLinkUrl = slug === 'moonshot' && !isLocalRuntime ? KIMI_PLATFORM_URL : null;
 
   const handleSave = async () => {
     const trimmed = value.trim();
@@ -700,8 +703,27 @@ const ProviderKeyDialog = ({
       aria-modal="true"
       aria-label={formatI18n(t('settings.ai.connectProviderDialog'), { label })}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
-      <div className="w-full max-w-md rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-6 shadow-soft">
-        <div className="mb-4">
+      <div className="relative w-full max-w-md rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-6 shadow-soft">
+        {platformLinkUrl ? (
+          <a
+            href={platformLinkUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ insetInlineEnd: '1.5rem' }}
+            onClick={event => {
+              event.preventDefault();
+              void openUrl(platformLinkUrl).catch(err => {
+                console.warn('[ai-settings] provider platform link open failed', {
+                  slug,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              });
+            }}
+            className="absolute top-6 text-xs font-medium leading-6 text-primary-600 hover:text-primary-700 dark:text-primary-300 dark:hover:text-primary-200">
+            {t('settings.ai.getProviderApiKey')}
+          </a>
+        ) : null}
+        <div className="mb-4" style={platformLinkUrl ? { paddingInlineEnd: '9rem' } : undefined}>
           <h3 className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{`${t('settings.ai.connectProvider')} ${label}`}</h3>
           <p className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">{helper}</p>
         </div>

--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { listConnections as listComposioConnections } from '../../../../lib/composio/composioApi';
+import { I18nProvider } from '../../../../lib/i18n/I18nContext';
 import {
   clearCloudProviderKey,
   completeOpenAiCodexOAuth,
@@ -430,6 +431,123 @@ describe('AIPanel', () => {
     expect(
       within(dialog).queryByRole('button', { name: /Sign in with ChatGPT \/ Codex/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('shows a localized Kimi platform link and opens the supported .ai platform', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+
+    renderWithProviders(
+      <I18nProvider>
+        <AIPanel />
+      </I18nProvider>
+    );
+
+    fireEvent.click(await screen.findByRole('switch', { name: /Kimi \(Moonshot\)/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Kimi \(Moonshot\)/i });
+    const link = within(dialog).getByRole('link', { name: /^Get API key$/i });
+
+    expect(link).toHaveAttribute('href', 'https://platform.kimi.ai?aff=openhuman');
+
+    fireEvent.click(link);
+
+    expect(openUrl).toHaveBeenCalledWith('https://platform.kimi.ai?aff=openhuman');
+  });
+
+  it('logs Kimi platform link open failures without changing the dialog', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+    vi.mocked(openUrl).mockRejectedValueOnce('blocked');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      renderWithProviders(
+        <I18nProvider>
+          <AIPanel />
+        </I18nProvider>
+      );
+
+      fireEvent.click(await screen.findByRole('switch', { name: /Kimi \(Moonshot\)/i }));
+      const dialog = await screen.findByRole('dialog', { name: /Kimi \(Moonshot\)/i });
+      fireEvent.click(within(dialog).getByRole('link', { name: /^Get API key$/i }));
+
+      await waitFor(() => {
+        expect(warnSpy).toHaveBeenCalledWith('[ai-settings] provider platform link open failed', {
+          slug: 'moonshot',
+          error: 'blocked',
+        });
+      });
+      expect(dialog).toBeInTheDocument();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('localizes the Kimi platform link text for Chinese', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+
+    renderWithProviders(
+      <I18nProvider>
+        <AIPanel />
+      </I18nProvider>,
+      { preloadedState: { locale: { current: 'zh-CN' } } }
+    );
+
+    fireEvent.click(await screen.findByRole('switch', { name: /Kimi \(Moonshot\)/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Kimi \(Moonshot\)/i });
+
+    expect(within(dialog).getByRole('link', { name: '获取 API Key' })).toBeInTheDocument();
+  });
+
+  it('reserves logical inline space for long translated Kimi link labels', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+
+    renderWithProviders(
+      <I18nProvider>
+        <AIPanel />
+      </I18nProvider>,
+      { preloadedState: { locale: { current: 'fr' } } }
+    );
+
+    fireEvent.click(await screen.findByRole('switch', { name: /Kimi \(Moonshot\)/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Kimi \(Moonshot\)/i });
+    const heading = within(dialog).getByRole('heading', {
+      name: /Connecter un fournisseur Kimi \(Moonshot\)/i,
+    });
+
+    expect(heading.parentElement).toHaveStyle({ paddingInlineEnd: '9rem' });
+  });
+
+  it('positions the Kimi link at the logical inline end for RTL locales', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+
+    renderWithProviders(
+      <I18nProvider>
+        <AIPanel />
+      </I18nProvider>,
+      { preloadedState: { locale: { current: 'ar' } } }
+    );
+
+    fireEvent.click(await screen.findByRole('switch', { name: /Kimi \(Moonshot\)/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Kimi \(Moonshot\)/i });
+    const link = within(dialog).getByRole('link', { name: 'احصل على مفتاح API' });
+
+    expect(document.documentElement).toHaveAttribute('dir', 'rtl');
+    expect(link).toHaveStyle({ insetInlineEnd: '1.5rem' });
+    expect(link).not.toHaveClass('right-6');
+  });
+
+  it('does not show the Kimi platform link for other providers', async () => {
+    vi.mocked(loadAISettings).mockResolvedValue({ ...baseSettings, cloudProviders: [] });
+
+    renderWithProviders(
+      <I18nProvider>
+        <AIPanel />
+      </I18nProvider>
+    );
+
+    fireEvent.click(await screen.findByRole('switch', { name: /Connect OpenAI/i }));
+    const dialog = await screen.findByRole('dialog', { name: /Connect OpenAI/i });
+
+    expect(within(dialog).queryByRole('link', { name: /^Get API key$/i })).not.toBeInTheDocument();
   });
 
   it('renders Phase 1 built-in provider chips including SumoPod', async () => {

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -3241,6 +3241,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'نقطة النهاية URL مطلوبة.',
   'settings.ai.endpointProtocolRequired': 'يجب أن تبدأ نقطة النهاية بـ http:// أو https://.',
   'settings.ai.connectProviderDialog': 'الاتصال {label}',
+  'settings.ai.getProviderApiKey': 'احصل على مفتاح API',
   'settings.ai.or': 'أو',
   'settings.ai.codexOauthMissingAuthUrl':
     'لم يُرجع Codex OAuth عنوان URL للتفويض. حاول تسجيل الدخول مرة أخرى.',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -3312,6 +3312,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'এন্ডপয়েন্ট URL প্রয়োজন।',
   'settings.ai.endpointProtocolRequired': 'সমাপ্তির তারিখ / http://wxqxqxkx/x উচিত',
   'settings.ai.connectProviderDialog': 'সংযোগ করুন {label}',
+  'settings.ai.getProviderApiKey': 'API Key নিন',
   'settings.ai.or': 'অথবা',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth কোনো অনুমোদন URL ফেরত দেয়নি। আবার সাইন ইন করার চেষ্টা করুন।',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -3391,6 +3391,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'Endpunkt URL ist erforderlich.',
   'settings.ai.endpointProtocolRequired': 'Endpunkt muss mit http:// oder https://. beginnen.',
   'settings.ai.connectProviderDialog': 'Verbinden Sie {label}',
+  'settings.ai.getProviderApiKey': 'API-Key erhalten',
   'settings.ai.or': 'Oder',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth hat keine Autorisierungs-URL zurückgegeben. Versuchen Sie, sich erneut anzumelden.',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -3853,6 +3853,7 @@ const en: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'Endpoint URL is required.',
   'settings.ai.endpointProtocolRequired': 'Endpoint must start with http:// or https://.',
   'settings.ai.connectProviderDialog': 'Connect {label}',
+  'settings.ai.getProviderApiKey': 'Get API key',
   'settings.ai.or': 'Or',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth did not return an authorization URL. Try signing in again.',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -3372,6 +3372,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'Se requiere el punto final URL.',
   'settings.ai.endpointProtocolRequired': 'El punto final debe comenzar con http:// o https://.',
   'settings.ai.connectProviderDialog': 'Conectar {label}',
+  'settings.ai.getProviderApiKey': 'Obtener API Key',
   'settings.ai.or': 'O',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth no devolvió una URL de autorización. Intenta iniciar sesión de nuevo.',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -3385,6 +3385,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointProtocolRequired':
     'Le point de terminaison doit commencer par http:// ou https://.',
   'settings.ai.connectProviderDialog': 'Connectez-vous {label}',
+  'settings.ai.getProviderApiKey': 'Obtenir une API Key',
   'settings.ai.or': 'Ou',
   'settings.ai.codexOauthMissingAuthUrl':
     "Codex OAuth n'a pas renvoyé d'URL d'autorisation. Essayez de vous reconnecter.",

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -3315,6 +3315,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'समापन बिंदु URL आवश्यक है.',
   'settings.ai.endpointProtocolRequired': 'समापन बिंदु http:// या https://. से शुरू होना चाहिए',
   'settings.ai.connectProviderDialog': 'कनेक्ट करें {label}',
+  'settings.ai.getProviderApiKey': 'API Key प्राप्त करें',
   'settings.ai.or': 'या',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth ने कोई प्राधिकरण URL नहीं लौटाया। फिर से साइन इन करने का प्रयास करें।',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -3319,6 +3319,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'Titik akhir URL diperlukan.',
   'settings.ai.endpointProtocolRequired': 'Titik akhir harus dimulai dengan http:// atau https://.',
   'settings.ai.connectProviderDialog': 'Hubungkan {label}',
+  'settings.ai.getProviderApiKey': 'Dapatkan API Key',
   'settings.ai.or': 'Atau',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth tidak mengembalikan URL otorisasi. Coba masuk lagi.',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -3364,6 +3364,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': "È richiesto l'endpoint URL.",
   'settings.ai.endpointProtocolRequired': "L'endpoint deve iniziare con http:// o https://.",
   'settings.ai.connectProviderDialog': 'Connetti {label}',
+  'settings.ai.getProviderApiKey': 'Ottieni API Key',
   'settings.ai.or': 'Oppure',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth non ha restituito un URL di autorizzazione. Prova ad accedere di nuovo.',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -3285,6 +3285,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': '엔드포인트 URL이(가) 필요합니다.',
   'settings.ai.endpointProtocolRequired': '엔드포인트는 http:// 또는 https://로 시작해야 합니다.',
   'settings.ai.connectProviderDialog': '{label}에 연결',
+  'settings.ai.getProviderApiKey': 'API Key 받기',
   'settings.ai.or': '또는',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth가 인증 URL을 반환하지 않았습니다. 다시 로그인해 보세요.',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -3363,6 +3363,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'URL endpointu jest wymagany.',
   'settings.ai.endpointProtocolRequired': 'Endpoint musi zaczynać się od http:// lub https://.',
   'settings.ai.connectProviderDialog': 'Połącz {label}',
+  'settings.ai.getProviderApiKey': 'Pobierz API Key',
   'settings.ai.or': 'lub',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth nie zwrócił adresu URL autoryzacji. Spróbuj zalogować się ponownie.',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -3368,6 +3368,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': 'Endpoint URL é necessário.',
   'settings.ai.endpointProtocolRequired': 'Endpoint deve começar com http:// ou https://.',
   'settings.ai.connectProviderDialog': 'Conectar {label}',
+  'settings.ai.getProviderApiKey': 'Obter API Key',
   'settings.ai.or': 'Ou',
   'settings.ai.codexOauthMissingAuthUrl':
     'O Codex OAuth não retornou uma URL de autorização. Tente entrar novamente.',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -3339,6 +3339,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointProtocolRequired':
     'Конечная точка должна начинаться с http:// или https://..',
   'settings.ai.connectProviderDialog': 'Подключиться {label}',
+  'settings.ai.getProviderApiKey': 'Получить API Key',
   'settings.ai.or': 'Или',
   'settings.ai.codexOauthMissingAuthUrl':
     'Codex OAuth не вернул URL авторизации. Попробуйте войти снова.',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -3151,6 +3151,7 @@ const messages: TranslationMap = {
   'settings.ai.endpointUrlRequired': '端点 URL 是必需的。',
   'settings.ai.endpointProtocolRequired': '端点必须以 http:// 或 https:// 开头。',
   'settings.ai.connectProviderDialog': '连接 {label}',
+  'settings.ai.getProviderApiKey': '获取 API Key',
   'settings.ai.or': '或者',
   'settings.ai.codexOauthMissingAuthUrl': 'Codex OAuth 未返回授权 URL。请重试登录。',
   'settings.ai.codexOauthMissingCallbackUrl': '登录后请粘贴浏览器中的重定向 URL。',


### PR DESCRIPTION
## Summary

- Adds a localized `Get API key` link to the Kimi (Moonshot) provider API key dialog.
- Opens `https://platform.kimi.ai?aff=openhuman` through the existing `openUrl` helper.
- Preserves the Moonshot API endpoint/provider setup behavior and only changes the user-clickable dialog CTA.
- Adds coverage for localization, non-Kimi provider exclusion, long translated labels, RTL placement, and link-open failure logging.

## Problem

- Users configuring Kimi (Moonshot) from OpenHuman setup/settings did not have a direct path to obtain a Kimi API key.
- The link must point to the currently supported Kimi platform host (`platform.kimi.ai`) with the OpenHuman affiliate parameter without changing model/API transport behavior.

## Solution

- Defines a dialog-scoped Kimi platform URL and renders it only for the non-local `moonshot` provider dialog.
- Uses logical inline positioning and reserved header inline space so long French/Russian labels and RTL Arabic layout do not overlap the dialog title.
- Adds a new `settings.ai.getProviderApiKey` i18n key with translations for every supported locale.
- Keeps `https://api.moonshot.ai/v1` and provider routing/configuration unchanged.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — local `pnpm test:coverage` passed and `diff-cover /tmp/openhuman-frontend-lcov.info --compare-branch=upstream/main --fail-under=80` reported 88% changed-line coverage; no Rust lines changed.
- [x] N/A: Coverage matrix updated — no feature row was added, removed, or renamed in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md).
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)); this adds only a user-clickable external link.
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — no release-cut smoke checklist flow changed.
- [x] N/A: Linked issue closed via `Closes #NNN` in the `## Related` section — task is tracked in the Kimi OSS CRM/Base, no GitHub issue was provided.

## Impact

- Desktop/settings/setup UI: Kimi (Moonshot) API key dialogs now show a localized `Get API key` CTA.
- Clicking the CTA opens `https://platform.kimi.ai?aff=openhuman` in the system browser.
- No API endpoints, provider definitions, request routing, credentials storage behavior, or model behavior changed.
- No migration, performance, or security impact beyond the new explicit external navigation.

## Related

- Closes: N/A — tracked in Kimi OSS CRM/Base: `https://moonshot.feishu.cn/base/NjQebfo6saiHS7s7RBMchSrDndh?table=tbli6MA5CO4PvhHL&view=vewHRkIkaw`
- Follow-up PR(s)/TODOs: None

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A — Kimi OSS CRM/Base task
- URL: N/A — `https://moonshot.feishu.cn/base/NjQebfo6saiHS7s7RBMchSrDndh?table=tbli6MA5CO4PvhHL&view=vewHRkIkaw`

### Commit & Branch

- Branch: `codex/OH-1-kimi-affiliate-api-key-link`
- Commit SHA: `1e8f7cfff71542b54e72c5ba8d938d91e4a5093e`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm --dir app exec vitest run src/components/settings/panels/__tests__/AIPanel.test.tsx --config test/vitest.config.ts` (46 passed)
- [x] Rust fmt/check (if changed): `GGML_NATIVE=OFF cargo check -p openhuman --lib` passed with existing warnings; Rust fmt also ran via `pnpm --filter openhuman-app format:check`
- [x] Tauri fmt/check (if changed): N/A no Tauri code changed; Tauri fmt check still ran via `pnpm --filter openhuman-app format:check`

Additional validation:

- `git fetch upstream main && git rebase upstream/main` — branch was up to date before PR submission.
- `git diff --check HEAD~1..HEAD`
- `pnpm i18n:check`
- `pnpm test:coverage` (561 files passed, 5947 tests passed, 4 skipped)
- `diff-cover /tmp/openhuman-frontend-lcov.info --compare-branch=upstream/main --fail-under=80` — 88% changed-line coverage
- Desktop shell smoke test via `pnpm --filter openhuman-app dev:app` before PR cleanup; setup/settings share the same provider dialog module.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Kimi (Moonshot) API key dialog shows a localized `Get API key` link to `https://platform.kimi.ai?aff=openhuman`.
- User-visible effect: Users can open the Kimi platform from the setup/settings provider dialog while provider API behavior remains unchanged.

### Parity Contract

- Legacy behavior preserved: provider selection, API key save flow, local runtime dialog behavior, OAuth actions, provider routing, and the Moonshot API endpoint remain unchanged.
- Guard/fallback/dispatch parity checks: link is gated to `slug === 'moonshot' && !isLocalRuntime`; non-Kimi providers are covered by regression tests.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found before submission.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Get API key" link in the Kimi provider settings panel, providing quick access to the provider's authentication platform without manual URL entry.

* **Chores**
  * Extended multilingual support across 14+ languages including English, Chinese, Spanish, French, German, Portuguese, Italian, Polish, Russian, Korean, Hindi, Bengali, Indonesian, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->