### PR TITLE
fix(chat): only deliver proactive messages to a fresh thread (#3713)

### DIFF
--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -65,6 +65,23 @@ const MAX_SEGMENT_DELIVERIES = 100;
 
 type SegmentDelivery = { segments: Map<number, string>; createdAt: number; lastSeenAt: number };
 
+type ThreadSliceState = ReturnType<typeof store.getState>['thread'];
+
+/**
+ * A thread is a valid proactive-delivery target only when it is "fresh" —
+ * i.e. holds no messages. We check both the in-memory message cache and the
+ * persisted `messageCount` snapshot, so a thread that already has a
+ * conversation server-side (but whose messages aren't loaded into the cache
+ * yet) is still treated as occupied and never reused. See #3713.
+ */
+function threadHasMessages(state: ThreadSliceState, threadId: string): boolean {
+  const cached = state.messagesByThreadId[threadId];
+  if (cached && cached.length > 0) return true;
+  if (threadId === state.selectedThreadId && state.messages.length > 0) return true;
+  const thread = state.threads.find(t => t.id === threadId);
+  return (thread?.messageCount ?? 0) > 0;
+}
+
 function rtLog(message: string, fields?: Record<string, string | number | null | undefined>) {
   if (IS_PROD) return;
   if (fields && Object.keys(fields).length > 0) {
@@ -262,14 +279,18 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       const state = store.getState().thread;
-      // Resolution priority: selected > any in-flight inference thread > first
-      // thread. With parallel inference there may be several active threads;
-      // any one is an acceptable proactive target when nothing is selected.
-      const firstActiveThreadId = Object.keys(state.activeThreadIds)[0] ?? null;
-      const targetFromState =
-        state.selectedThreadId ?? firstActiveThreadId ?? state.threads[0]?.id ?? null;
-      if (targetFromState) {
-        return targetFromState;
+      // Reuse an existing thread for proactive delivery ONLY when it is
+      // fresh (no messages). Injecting a morning brief / subconscious
+      // update into a thread that already holds a conversation interrupts
+      // the active chat flow (#3713). Candidate priority is selected >
+      // first thread; if the candidate already has messages we fall
+      // through and open a dedicated new thread instead. An in-flight
+      // inference thread always has at least the user's message, so it is
+      // never considered fresh — that is why `activeThreadIds` is no
+      // longer used as a target here.
+      const candidateThreadId = state.selectedThreadId ?? state.threads[0]?.id ?? null;
+      if (candidateThreadId && !threadHasMessages(state, candidateThreadId)) {
+        return candidateThreadId;
       }
 
       if (proactiveThreadCreationPromiseRef.current) {

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -68,18 +68,29 @@ type SegmentDelivery = { segments: Map<number, string>; createdAt: number; lastS
 type ThreadSliceState = ReturnType<typeof store.getState>['thread'];
 
 /**
- * A thread is a valid proactive-delivery target only when it is "fresh" —
- * i.e. holds no messages. We check both the in-memory message cache and the
- * persisted `messageCount` snapshot, so a thread that already has a
- * conversation server-side (but whose messages aren't loaded into the cache
- * yet) is still treated as occupied and never reused. See #3713.
+ * Whether a thread should be treated as occupied for proactive delivery — a
+ * thread is only a valid target when it is provably "fresh" (holds no
+ * messages). We check the in-memory message cache and the persisted
+ * `messageCount` snapshot, so a thread that already has a conversation
+ * server-side (but whose messages aren't loaded into the cache yet) is still
+ * treated as occupied and never reused.
+ *
+ * Crucially, *unknown* thread metadata counts as occupied: when only a
+ * rehydrated `selectedThreadId` is present (e.g. before `loadThreads`
+ * resolves, or after caches were reset while selection was preserved),
+ * `state.threads.find` returns `undefined`. Treating that as fresh would let
+ * a proactive event append into a conversation we simply haven't loaded yet.
+ * We fail closed and open a new thread instead. See #3713.
  */
 function threadHasMessages(state: ThreadSliceState, threadId: string): boolean {
   const cached = state.messagesByThreadId[threadId];
   if (cached && cached.length > 0) return true;
   if (threadId === state.selectedThreadId && state.messages.length > 0) return true;
   const thread = state.threads.find(t => t.id === threadId);
-  return (thread?.messageCount ?? 0) > 0;
+  // Unknown metadata → fail closed (occupied) rather than risk interrupting an
+  // unloaded conversation.
+  if (!thread) return true;
+  return thread.messageCount > 0;
 }
 
 function rtLog(message: string, fields?: Record<string, string | number | null | undefined>) {

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -491,6 +491,41 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       expect(threadApi.appendMessage).not.toHaveBeenCalledWith('busy-thread', expect.anything());
     });
 
+    it('treats a selected thread with unknown metadata as occupied and opens a new thread', async () => {
+      vi.mocked(threadApi.createNewThread).mockResolvedValue({
+        id: 'fresh-thread',
+        title: 'new',
+      } as never);
+      vi.mocked(threadApi.getThreads).mockResolvedValue({
+        threads: [{ id: 'fresh-thread', title: 'new' }] as never,
+        count: 1,
+      });
+
+      // Only a rehydrated selection is present — the thread list hasn't loaded,
+      // so its message metadata is unknown. We must NOT assume it is fresh
+      // (it could already hold a server-side conversation). See #3713.
+      store.dispatch(setSelectedThread('rehydrated-thread'));
+      const listeners = renderProvider();
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:morning_briefing',
+          request_id: 'req-unknown',
+          full_response: 'briefing',
+        });
+      });
+
+      await waitFor(() => expect(threadApi.createNewThread).toHaveBeenCalledTimes(1));
+      expect(threadApi.appendMessage).toHaveBeenCalledWith(
+        'fresh-thread',
+        expect.objectContaining({ content: 'briefing' })
+      );
+      expect(threadApi.appendMessage).not.toHaveBeenCalledWith(
+        'rehydrated-thread',
+        expect.anything()
+      );
+    });
+
     it('creates a new thread when no visible thread exists for proactive handoff', async () => {
       vi.mocked(threadApi.createNewThread).mockResolvedValue({
         id: 'created-thread',

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -421,10 +421,10 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
   });
 
   describe('proactive thread resolution', () => {
-    it('reuses the selected thread when resolving a proactive: sender', async () => {
+    it('reuses the selected thread when it is fresh (no messages)', async () => {
       store.dispatch(
         loadThreads.fulfilled(
-          { threads: [{ id: 'visible-thread', title: 'x' }] as never, count: 1 },
+          { threads: [{ id: 'visible-thread', title: 'x', messageCount: 0 }] as never, count: 1 },
           'req-id',
           undefined
         )
@@ -440,7 +440,7 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
         });
       });
 
-      // createNewThread must NOT be invoked when a visible thread already exists.
+      // createNewThread must NOT be invoked when a fresh visible thread exists.
       expect(threadApi.createNewThread).not.toHaveBeenCalled();
       await waitFor(() =>
         expect(threadApi.appendMessage).toHaveBeenCalledWith(
@@ -448,6 +448,47 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
           expect.objectContaining({ content: 'ping', sender: 'agent' })
         )
       );
+    });
+
+    it('opens a new thread instead of interrupting a selected thread that has messages (#3713)', async () => {
+      vi.mocked(threadApi.createNewThread).mockResolvedValue({
+        id: 'fresh-thread',
+        title: 'new',
+      } as never);
+      vi.mocked(threadApi.getThreads).mockResolvedValue({
+        threads: [{ id: 'fresh-thread', title: 'new' }] as never,
+        count: 1,
+      });
+
+      // The user is mid-conversation: the selected thread already holds
+      // messages, so a proactive morning brief / subconscious update must
+      // NOT be injected into it.
+      store.dispatch(
+        loadThreads.fulfilled(
+          { threads: [{ id: 'busy-thread', title: 'chat', messageCount: 4 }] as never, count: 1 },
+          'req-id',
+          undefined
+        )
+      );
+      store.dispatch(setSelectedThread('busy-thread'));
+      const listeners = renderProvider();
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:morning_briefing',
+          request_id: 'req-mb',
+          full_response: "good morning! here's your briefing",
+        });
+      });
+
+      // The active conversation must be left untouched; delivery goes to a
+      // dedicated new thread.
+      await waitFor(() => expect(threadApi.createNewThread).toHaveBeenCalledTimes(1));
+      expect(threadApi.appendMessage).toHaveBeenCalledWith(
+        'fresh-thread',
+        expect.objectContaining({ content: "good morning! here's your briefing" })
+      );
+      expect(threadApi.appendMessage).not.toHaveBeenCalledWith('busy-thread', expect.anything());
     });
 
     it('creates a new thread when no visible thread exists for proactive handoff', async () => {


### PR DESCRIPTION
## Summary

- Morning brief (`proactive:morning_briefing`) and subconscious/heartbeat updates (`proactive:heartbeat-*`) were being injected into the user's currently-selected — and even actively-streaming — chat thread, interrupting the active conversation (#3713).
- `resolveVisibleThreadForProactive()` now reuses an existing thread **only when it is provably fresh (no messages)**, and otherwise opens a dedicated new thread, leaving in-progress chats untouched.
- Dropped the `firstActiveThreadId` fallback — a thread with an in-flight inference turn always has ≥1 message and must never be a proactive target.
- Unknown thread metadata (e.g. a rehydrated `selectedThreadId` before `loadThreads` resolves) is treated as **occupied** (fail-closed), so a proactive event can't append into an unloaded conversation.
- Frontend-only change; the core already isolates proactive output onto a dedicated `proactive:<job>` thread id — the renderer was collapsing it back into the visible thread.

## Problem

Both proactive features deliver via a `proactive_message` Socket.IO event tagged with an isolated `proactive:<job>` thread id. The renderer's `resolveVisibleThreadForProactive()` re-routed any `proactive:` message into `selectedThreadId ?? firstActiveThreadId ?? threads[0]` with no "is this thread in use?" guard. During an active conversation the selected thread *is* the live chat, so the briefing/subconscious content appeared mid-thread ("good morning! here's your briefing…", "Here's the PR activity from the last 24 hours…").

## Solution

- Added a `threadHasMessages()` helper that checks the in-memory message cache (`messagesByThreadId` / `state.messages`), the persisted `thread.messageCount`, and treats **unknown** thread metadata as occupied so we never append into a conversation we haven't loaded yet.
- Reuse logic is now: `candidate = selectedThreadId ?? threads[0]`; deliver in place only if `!threadHasMessages(candidate)`, otherwise create a new thread (existing creation path).
- A genuinely fresh/empty thread (e.g. the onboarding welcome thread) still receives proactive messages in place — welcome UX preserved.

### Behavior note
"Fresh" = provably no messages (not an is-streaming check). A proactive message arriving in the idle gap *between* turns of an ongoing chat will also open a new thread, matching the issue's "open a new thread rather than interrupt" acceptance criterion.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — clarified the "reuses the selected thread when it is fresh" test and added "opens a new thread instead of interrupting a selected thread that has messages (#3713)" and "treats a selected thread with unknown metadata as occupied".
- [x] **Diff coverage ≥ 80%** — frontend Vitest covers all new branches (fresh → reuse, occupied → new thread, unknown → new thread). 45/45 pass in `ChatRuntimeProvider.test.tsx`; Coverage Gate green.
- [x] N/A: behaviour-only change — no feature row added/removed/renamed in the coverage matrix.
- [x] N/A: no matrix feature IDs affected by this change.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch a release-cut surface, so the manual smoke checklist is unchanged.
- [x] Linked issue closed via `Closes #3713` in `## Related`.

## Impact

- Desktop/web renderer only. No Rust/core change, no migration, no perf or security implications.
- Restores expected behaviour: proactive content never interrupts an active chat.

## Related

- Closes: #3713
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: rca-3713
- Commit SHA: 0437e1a40

### Validation Run
- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/providers/__tests__/ChatRuntimeProvider.test.tsx` → 45 passed
- [x] N/A: Rust fmt/check — no Rust changed
- [x] N/A: Tauri fmt/check — no Rust changed

### Validation Blocked
- `command:` pre-push hook `pnpm rust:check` (Tauri `cargo check`)
- `error:` `failed to read app/src-tauri/vendor/tauri-cef/crates/tauri/Cargo.toml: No such file or directory` — vendored CEF submodule not checked out in this worktree
- `impact:` unrelated pre-existing/environment breakage; change is frontend-only and `tsc --noEmit` passed. Pushed with `--no-verify` per project workflow. CI runs a clean checkout and exercises the full suite.

### Behavior Changes
- Intended behavior change: proactive messages no longer reuse a thread that already has (or may have) messages.
- User-visible effect: morning brief / subconscious updates open a new thread instead of interrupting the active conversation.

### Parity Contract
- Legacy behavior preserved: fresh/empty selected thread (welcome flow) still receives proactive messages in place.
- Guard/fallback/dispatch parity checks: dedupe, new-thread-when-none-exists, and concurrent-creation paths unchanged; only the reuse condition tightened.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of proactive message delivery to prevent injection into active conversations. Messages are now directed to fresh threads instead of being appended to threads with existing messages, ensuring cleaner conversation organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->