### PR TITLE
fix(scheduler-agent): scope boundary so calendar/meet-link reads don't mis-route to the scheduler (#3717)

### DIFF
--- a/src/openhuman/agent_registry/agents/scheduler_agent/agent.toml
+++ b/src/openhuman/agent_registry/agents/scheduler_agent/agent.toml
@@ -1,7 +1,7 @@
 id = "scheduler_agent"
 display_name = "Scheduler Agent"
 delegate_name = "schedule_task"
-when_to_use = "Scheduling specialist — owns reminders, recurring jobs, cron listing/removal, relative-time grounding, and confirmation-before-create flows. Use for any request to remind, schedule, repeat, pause, remove, or inspect scheduled jobs."
+when_to_use = "Scheduling specialist — owns reminders, recurring jobs, cron listing/removal, relative-time grounding, and confirmation-before-create flows. Use ONLY for requests to remind, schedule, repeat, pause, remove, or inspect scheduled jobs/cron. Do NOT use to read or summarise existing calendar events, meetings, or availability, or to fetch a meeting/meet/video-call link — this agent has no calendar, email, or meeting access (its only tools are time + cron). Route any read of live calendar/meeting/meet-link data to the calendar/email integration instead."
 temperature = 0.2
 max_iterations = 8
 agent_tier = "worker"

--- a/src/openhuman/agent_registry/agents/scheduler_agent/prompt.md
+++ b/src/openhuman/agent_registry/agents/scheduler_agent/prompt.md
@@ -1,6 +1,12 @@
 # Scheduler Agent
 
-You are the scheduling specialist. Own reminders, one-shot jobs, recurring jobs, job listing, job removal, and relative-time grounding.
+You are the scheduling specialist. You own OpenHuman's **in-app scheduler** (its internal cron/routines engine): you **create and manage scheduled jobs** that run later — one-shot reminders, recurring jobs, and agent jobs — plus job listing, job removal, and relative-time grounding. You make things happen *later or repeatedly*; you do not look anything up that exists *now*.
+
+## Scope boundary — fail fast, never thrash
+
+Your ONLY tools are `current_time`, `resolve_time`, `cron_add`, `cron_list`, `cron_remove`, and `ask_user_clarification`. They write to and read OpenHuman's own scheduled-job store — **not** any external service. You have **no** access to the user's live calendar, email, meetings, or video-call links, and you cannot read what is already on their schedule outside the cron jobs you manage.
+
+So the line is: **create/manage a future job → you. Read existing live data → not you.** If you are handed a task you cannot satisfy with your tools — e.g. reading or summarising an existing calendar event/meeting, checking availability, or fetching a meet/Zoom/Meet link — do **not** loop, guess, or try tools that cannot answer it. In a **single step**, return that this request needs the live calendar/email integration (not the scheduler), naming what you would have needed. Burning iterations on tools that can't satisfy the request is a failure, not effort.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- Add a hard **negative boundary** to the scheduler agent's `when_to_use` (the text the orchestrator routes on): use it ONLY for scheduled jobs/cron; do NOT use it to read existing calendar events, meetings, availability, or to fetch a meet/video-call link.
- Add a **positive identity + fail-fast scope boundary** to the scheduler's system prompt so a mis-routed live-read returns in a single step instead of grinding to its iteration cap.
- Metadata/prompt only — no behavioural code change.

## Problem

Part of #3717 (Bug 1 — agent over-executes simple queries). A "give me the meet link / summarise my meeting" request is a **live calendar read**, but it was being routed to `schedule_task` (the scheduler agent), whose only tools are time + cron (`current_time`, `resolve_time`, `cron_add/list/remove`) and which has **no calendar/email/meeting access**.

Routing is a competition over each delegate's `when_to_use`: the scheduler's description claimed all scheduling-flavoured requests with **no negative boundary**, and the word "meeting" lured the request in. Because the scheduler has no tool that can satisfy a calendar read, it **thrashed to its 8-iteration cap** and gave up — the exact "Scheduler Agent x8" symptom reported in the issue (the count equals `max_iterations = 8`).

## Solution

- `agent.toml` `when_to_use`: explicit "Use ONLY for … Do NOT use to read/summarise existing calendar events, meetings, availability, or fetch a meet/video-call link — route those to the calendar/email integration." Removes the wrong attractor at the routing layer.
- `prompt.md`: assert the agent's real identity — OpenHuman's **in-app scheduler** that *creates* future jobs (reminders, recurring, agent jobs), not a reader of live data — plus a "Scope boundary — fail fast, never thrash" section so that if it is still handed a live read, it bails in one step pointing at the integration, rather than burning iterations.

Design note: the complementary "positive bias" (advertising calendar on `integrations_agent`) was intentionally **skipped** — the orchestrator prompt already maps "calendar → live integration" and connected toolkits get their own synthesised delegate, so the negative boundary on the scheduler is the root-cause fix. See follow-ups.

## Submission Checklist

- [x] Tests added or updated — N/A (metadata/prompt-only). Existing prompt-contract test `scheduler_agent::prompt::tests::build_returns_scheduler_contract` invariants (`Scheduler Agent`, `explicit user confirmation`, `Evidence used`) are preserved.
- [x] **Diff coverage ≥ 80%** — N/A: changed lines are TOML/Markdown data, not executable code; the prompt builder is exercised by the existing test above.
- [x] Coverage matrix updated — N/A: behaviour-only change (prompt/metadata, no new feature row).
- [x] All affected feature IDs listed under Related — N/A: no matrix feature changed.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if needed — N/A: no release-cut surface touched.
- [x] Linked issue — referenced below; intentionally not auto-closed (this is one slice of #3717).

## Impact

- Routing/quality change for the desktop/CLI/channel agent: simple "meet link / meeting summary" lookups should no longer mis-route to the scheduler and thrash to its cap. No runtime/API/migration impact; no code paths changed.

## Related

- Part of #3717 (not closing — Bug 2 "insights panel splits response" and the broader complexity-gate work are separate PRs).
- Follow-up PR(s)/TODOs:
  - Bug 2 panel-anchoring fix (separate branch `panel-anchor-fix`).
  - Optional: single-shot / lower iteration cap for read-only delegates so even a correct lookup can't grind to its cap.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/scheduler-calendar-boundary
- Commit SHA: 23b7af4f3b239e9a93f19d7ed1e7964507e56e94

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no app/ change
- [x] `pnpm typecheck` — N/A: no TS change
- [x] Focused tests — N/A: `scheduler_agent` prompt-contract test invariants preserved (no test code changed)
- [x] Rust fmt/check (if changed) — pre-push `pnpm rust:check` passed on push
- [x] Tauri fmt/check (if changed) — N/A: no Tauri change

### Validation Blocked

- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes

- Intended behavior change: stop routing live calendar/meeting reads to the scheduler agent.
- User-visible effect: simple "meet link / meeting summary" requests resolve via the calendar integration instead of spinning the scheduler to its iteration cap.

### Parity Contract

- Legacy behavior preserved: scheduler's real surface (reminders, recurring jobs, agent jobs, job list/remove, time grounding) unchanged.
- Guard/fallback/dispatch parity checks: prompt-contract test invariants intact; TOML validated.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A