### PR TITLE
fix(chat): classify resume-on-reopen errors + de-poison thread (#3714)

### DIFF
--- a/app/src/services/chatService.ts
+++ b/app/src/services/chatService.ts
@@ -99,10 +99,12 @@ export interface ChatErrorEvent {
     | 'cancelled'
     | 'rate_limited'
     | 'auth_error'
+    | 'session_expired'
     | 'provider_error'
     | 'context_overflow'
     | 'model_unavailable'
     | 'payload_too_large'
+    | 'provider_request_rejected'
     | 'budget_exhausted';
   round: number | null;
 }

--- a/src/openhuman/channels/providers/web/run_task.rs
+++ b/src/openhuman/channels/providers/web/run_task.rs
@@ -345,16 +345,22 @@ pub(crate) async fn run_chat_task(
 /// cached back, because its in-memory history would replay a provider request
 /// rejection on every subsequent turn.
 ///
-/// True only for a classified `provider_request_rejected` (a 4xx / malformed
-/// payload — for the managed backend an in-stream SSE `event: error` frame
-/// stamped `errorCode:"BAD_REQUEST"`, surfaced as
-/// `"OpenHuman streaming API error: {…}"`, not an HTTP 400). Successes and
-/// transient failures (rate-limit, timeout, 5xx) return false so the warm
-/// session — and the user's mid-thread context — is preserved for a retry.
+/// True only for a *retryable* `provider_request_rejected` — i.e. the
+/// poisoned-history case. The copy-split in `web_errors.rs` marks a tool-ordering
+/// rejection (orphaned / mismatched `tool_call_id` — for the managed backend an
+/// in-stream SSE `event: error` frame stamped `errorCode:"BAD_REQUEST"`)
+/// `retryable: true` because the de-poison makes "send it again" true, while a
+/// genuine model/parameter 400 stays `retryable: false`. Gating on `&& retryable`
+/// therefore evicts ONLY the poisoned session: a non-retryable param 400 keeps
+/// its warm session (no needless reseed), exactly like successes and transient
+/// failures (rate-limit, timeout, 5xx, session-expiry).
 fn turn_result_poisoned_session(result: &Result<WebChatTaskResult, String>) -> bool {
     matches!(
         result,
-        Err(err) if classify_inference_error(err).error_type == "provider_request_rejected"
+        Err(err) if {
+            let classified = classify_inference_error(err);
+            classified.error_type == "provider_request_rejected" && classified.retryable
+        }
     )
 }
 
@@ -390,14 +396,32 @@ mod tests {
     }
 
     #[test]
-    fn poisoned_on_byo_provider_4xx_envelope() {
-        // BYO/direct provider path: a real `… API error (400 …)` envelope.
+    fn poisoned_on_byo_provider_tool_ordering_400() {
+        // BYO/direct provider tool-ordering rejection — classifies as a
+        // *retryable* provider_request_rejected (poisoned history), so it evicts.
         let err: Result<WebChatTaskResult, String> = Err(
-            "custom_openai API error (400 Bad Request): {\"error\":{\"message\":\
-             \"Invalid 'tool_calls': orphaned tool call id\"}}"
+            "OpenAI API error (400 Bad Request): {\"error\":{\"message\":\"Invalid parameter: \
+             messages with role 'tool' must be a response to a preceding message with \
+             'tool_calls'.\"}}"
                 .to_string(),
         );
         assert!(turn_result_poisoned_session(&err));
+    }
+
+    #[test]
+    fn genuine_param_400_keeps_warm_session() {
+        // A non-poisoning model/parameter 400 is a *non-retryable*
+        // provider_request_rejected — narrowing on `&& retryable` must keep its
+        // warm session (resending the same params won't help; no reseed needed).
+        let err: Result<WebChatTaskResult, String> = Err(
+            "custom_openai API error (400 Bad Request): {\"error\":{\"message\":\
+             \"Unsupported value: 'temperature' must be 1 for this model\"}}"
+                .to_string(),
+        );
+        assert!(
+            !turn_result_poisoned_session(&err),
+            "non-retryable param 400 is not poisoned history — keep warm session"
+        );
     }
 
     #[test]

--- a/src/openhuman/channels/providers/web/run_task.rs
+++ b/src/openhuman/channels/providers/web/run_task.rs
@@ -13,7 +13,8 @@ use super::session::{
 use super::types::SessionEntry;
 use super::types::{ChatRequestMetadata, WebChatTaskResult};
 use super::web_errors::{
-    inference_budget_exceeded_user_message, is_inference_budget_exceeded_error,
+    classify_inference_error, inference_budget_exceeded_user_message,
+    is_inference_budget_exceeded_error,
 };
 
 #[cfg(any(test, debug_assertions))]
@@ -301,15 +302,126 @@ pub(crate) async fn run_chat_task(
     // Only the primary (non-fork) turn writes its agent back to the shared
     // cache; a fork is fully isolated and lets its agent drop here.
     if !fork {
-        let mut sessions = THREAD_SESSIONS.lock().await;
-        sessions.insert(
-            map_key,
-            SessionEntry {
-                agent,
-                fingerprint: current_fp,
-            },
-        );
+        // De-poison guard. A `provider_request_rejected` outcome means the
+        // provider could not parse THIS turn's request — an orphaned
+        // `tool_calls` round-trip, an empty `tool_call_id`, or a reasoning
+        // echo it rejects. For the managed backend that rejection arrives as an
+        // in-stream `event: error` SSE frame carrying `errorCode:"BAD_REQUEST"`
+        // (the response already flushed HTTP 200), NOT an HTTP 400 — so we key
+        // off the classified type, not a status code. Re-caching this agent
+        // would replay the identical malformed history on every later turn,
+        // dead-ending the thread. Drop it instead (the entry was already
+        // removed from the map at the top of this fn): the next turn cold-boots
+        // and reseeds from the plain-text conversation log, which is
+        // structurally incapable of carrying tool malformation
+        // (`seed_resume_from_messages` rebuilds only system/user/assistant
+        // text). Transient failures (rate-limit / timeout / 5xx) keep the warm
+        // session so the user can retry this turn with context intact.
+        if turn_result_poisoned_session(&result) {
+            log::warn!(
+                "[web-channel] dropping session agent after provider_request_rejected — \
+                 next turn cold-boots from the conversation log (de-poison) \
+                 client={} thread={} request_id={}",
+                client_id,
+                thread_id,
+                request_id
+            );
+        } else {
+            let mut sessions = THREAD_SESSIONS.lock().await;
+            sessions.insert(
+                map_key,
+                SessionEntry {
+                    agent,
+                    fingerprint: current_fp,
+                },
+            );
+        }
     }
 
     result
+}
+
+/// Whether a completed turn's session agent must be **dropped** rather than
+/// cached back, because its in-memory history would replay a provider request
+/// rejection on every subsequent turn.
+///
+/// True only for a classified `provider_request_rejected` (a 4xx / malformed
+/// payload — for the managed backend an in-stream SSE `event: error` frame
+/// stamped `errorCode:"BAD_REQUEST"`, surfaced as
+/// `"OpenHuman streaming API error: {…}"`, not an HTTP 400). Successes and
+/// transient failures (rate-limit, timeout, 5xx) return false so the warm
+/// session — and the user's mid-thread context — is preserved for a retry.
+fn turn_result_poisoned_session(result: &Result<WebChatTaskResult, String>) -> bool {
+    matches!(
+        result,
+        Err(err) if classify_inference_error(err).error_type == "provider_request_rejected"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok() -> Result<WebChatTaskResult, String> {
+        Ok(WebChatTaskResult {
+            full_response: "hello".to_string(),
+            citations: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn poisoned_on_managed_sse_bad_request_frame() {
+        // Managed backend 400: flushed HTTP 200, then an in-stream SSE error
+        // frame stamped errorCode:"BAD_REQUEST" — the exact shape the de-poison
+        // guard must catch (no HTTP 400 status anywhere in the string). Payload
+        // mirrors the real backend frame verified against tinyhumansai/backend
+        // upstream/develop `routes/inference.ts::writeInferenceSSE`
+        // ({error:{message,type:"stream_error",errorCode}}), wrapped by the
+        // client's `sse_error_frame_bail_message` as
+        // "OpenHuman streaming API error: <payload>". `validateToolMessageOrdering`
+        // throws BadRequestError (errorCode=BAD_REQUEST) for an orphaned tool_call_id.
+        let err: Result<WebChatTaskResult, String> = Err(
+            "OpenHuman streaming API error: {\"error\":{\"message\":\"Message has tool role, \
+             but there was no previous assistant message with a tool call!\",\
+             \"type\":\"stream_error\",\"errorCode\":\"BAD_REQUEST\"}}"
+                .to_string(),
+        );
+        assert!(turn_result_poisoned_session(&err));
+    }
+
+    #[test]
+    fn poisoned_on_byo_provider_4xx_envelope() {
+        // BYO/direct provider path: a real `… API error (400 …)` envelope.
+        let err: Result<WebChatTaskResult, String> = Err(
+            "custom_openai API error (400 Bad Request): {\"error\":{\"message\":\
+             \"Invalid 'tool_calls': orphaned tool call id\"}}"
+                .to_string(),
+        );
+        assert!(turn_result_poisoned_session(&err));
+    }
+
+    #[test]
+    fn transient_failures_keep_warm_session() {
+        for raw in [
+            // rate limit / 429 — history is fine, user should retry warm
+            "OpenAI API error (429 Too Many Requests): slow down",
+            // timeout
+            "request timed out while reading response",
+            // upstream 5xx
+            "OpenAI API error (503 Service Unavailable): no healthy upstream",
+            // session expiry — not a payload problem
+            "SESSION_EXPIRED: backend session not active — sign in to resume LLM work",
+        ] {
+            let err: Result<WebChatTaskResult, String> = Err(raw.to_string());
+            assert!(
+                !turn_result_poisoned_session(&err),
+                "transient/non-payload error must keep warm session: {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn success_keeps_warm_session() {
+        assert!(!turn_result_poisoned_session(&ok()));
+    }
 }

--- a/src/openhuman/channels/providers/web_errors.rs
+++ b/src/openhuman/channels/providers/web_errors.rs
@@ -406,13 +406,30 @@ fn classify_by_backend_error_code(
             fallback_available: None,
         },
         BackendErrorCode::BadRequest => {
-            // Same code, two shapes (B8/F8): a backend-flagged *malformed*
+            // Same code, three shapes. FIRST: a tool-ordering rejection
+            // (`validateToolMessageOrdering` — an orphaned `role:'tool'` message
+            // with no matching assistant `tool_call`) is *poisoned history*, not
+            // a model/param problem. The de-poison guard in `run_task.rs` has
+            // already evicted the offending warm session by the time this copy
+            // is built, so the next turn cold-boots clean — tell the user
+            // exactly that (and mark retryable, because resending now works).
+            if is_malformed_tool_history_text(&err.to_lowercase()) {
+                ClassifiedError {
+                    error_type: "provider_request_rejected",
+                    message: malformed_history_user_message().to_string(),
+                    source: "provider",
+                    retryable: true,
+                    retry_after_ms: None,
+                    provider,
+                    fallback_available: None,
+                }
+            // Else two shapes (B8/F8): a backend-flagged *malformed*
             // payload is a client bug (the request was built wrong — it pages
             // Sentry at the FE layer, gated elsewhere), while a plain
             // user-parameter rejection is a model/param mismatch the user can
             // fix. The copy differs: don't tell the user to abandon the thread
             // for a one-off malformation (only this turn failed).
-            if body_flags_malformed(err) {
+            } else if body_flags_malformed(err) {
                 ClassifiedError {
                     error_type: "provider_request_rejected",
                     message: "Something went wrong with this message. Try rephrasing it — \
@@ -488,7 +505,32 @@ pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
     // before the generic provider-429 branch — otherwise users see
     // a confusing "your AI provider is rate-limiting you" message
     // for limits OpenHuman itself enforced (issue #2364).
-    let classified = if is_action_budget_exhausted(&lower) {
+    let classified = if crate::core::observability::is_session_expired_message(err) {
+        // The OpenHuman app-session JWT expired (or the scheduler gate flagged
+        // signed-out / `SESSION_EXPIRED` sentinel). There is NO client-side
+        // refresh — recovery is an interactive re-auth only — so this is
+        // non-retryable and must route the user to sign-in. Checked FIRST so the
+        // `auth_error` arm below can't claim the backend's `401 "Invalid token"`
+        // envelope (it contains "401") and mislead managed-backend users with
+        // "check your API key". `is_session_expired_message` is conjunctively
+        // scoped to the OpenHuman/Embedding "Invalid token" envelopes + the
+        // `SESSION_EXPIRED` / "no backend session" / "session jwt required"
+        // sentinels, so a BYO provider's own 401 still falls through to
+        // `auth_error`.
+        ClassifiedError {
+            error_type: "session_expired",
+            message: "Your OpenHuman session expired while the app was idle. \
+                 Please sign in again to resume."
+                .to_string(),
+            source: "auth",
+            retryable: false,
+            retry_after_ms: None,
+            // OpenHuman's own session — provider name (if any leaked into the
+            // surrounding chain) is irrelevant to a sign-in prompt.
+            provider: None,
+            fallback_available: None,
+        }
+    } else if is_action_budget_exhausted(&lower) {
         ClassifiedError {
             error_type: "action_budget_exceeded",
             message: with_provider_detail(
@@ -725,6 +767,21 @@ pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
             provider: None,
             fallback_available: None,
         }
+    } else if is_provider_request_rejected_text(&lower) && is_malformed_tool_history_text(&lower) {
+        // Same poisoned-history rejection as the managed `BAD_REQUEST` branch,
+        // but on a BYO/direct provider (e.g. OpenAI "messages with role 'tool'
+        // must be a response to a preceding message with 'tool_calls'"). The
+        // de-poison guard already evicted the warm session, so resending works.
+        // Checked BEFORE the generic 4xx arm so the actionable copy wins.
+        ClassifiedError {
+            error_type: "provider_request_rejected",
+            message: malformed_history_user_message().to_string(),
+            source: "provider",
+            retryable: true,
+            retry_after_ms: None,
+            provider,
+            fallback_available,
+        }
     } else if is_provider_request_rejected_text(&lower) {
         // A provider rejected the request with a 4xx that none of the
         // specific arms above claimed (generic 400 Bad Request, 404, 422).
@@ -745,6 +802,32 @@ pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
             ),
             source: "provider",
             retryable: false,
+            retry_after_ms: None,
+            provider,
+            fallback_available,
+        }
+    } else if is_connection_dropped_text(&lower) {
+        // A transport-level drop with no provider status and no managed
+        // `errorCode`: a stale keep-alive socket reused after sleep/wake, a
+        // network change, or a RAW mid-stream SSE drop — the managed backend
+        // intentionally omits `errorCode` for raw upstream/network drops
+        // (backend `routes/inference.ts`), so those reach here as
+        // `"OpenHuman streaming API error: <body>"` with nothing to branch on.
+        // These previously fell to the generic catch-all ("Something went
+        // wrong"). The turn's history is NOT poisoned — the agent loop bails
+        // before committing the failed iteration (`engine/core.rs`) — so this is
+        // cleanly retryable and the warm session is kept. Placed LAST so every
+        // specific provider-status / 4xx arm claims its shape first; only an
+        // otherwise-unclassified transport error lands here.
+        ClassifiedError {
+            error_type: "network",
+            message: with_provider_detail(
+                "The connection to the AI service dropped mid-response — usually a \
+                 sleep/wake or network change. Please try again.",
+                err,
+            ),
+            source: "transport",
+            retryable: true,
             retry_after_ms: None,
             provider,
             fallback_available,
@@ -804,6 +887,59 @@ pub(crate) fn is_empty_provider_response_text(lower: &str) -> bool {
 /// reach this predicate.
 ///
 /// Caller passes the already-lowercased error string.
+/// User-facing copy for a poisoned-history 400 (orphaned tool message). The
+/// de-poison guard (`run_task.rs`) has already evicted the offending warm
+/// session by the time this is shown, so "send it again" is literally true.
+pub(crate) fn malformed_history_user_message() -> &'static str {
+    "We hit a temporary glitch in this conversation — we've cleared it. \
+     Please send your message again."
+}
+
+/// Detect a malformed tool-history rejection (orphaned / mismatched
+/// `role:'tool'` message). This is the *poisoned history* shape the de-poison
+/// guard recovers from — NOT a model/parameter mismatch — so it earns the
+/// "we cleared it, resend" copy instead of "try a different model".
+///
+/// Anchored on the managed backend's `validateToolMessageOrdering` strings
+/// (verified against tinyhumansai/backend `chatCompletions.ts` — "role 'tool' …
+/// matching tool_call", "does not match any tool_call from the preceding
+/// assistant message"), the raw upstream jinja variant ("tool role … no
+/// previous assistant message with a tool call"), and the equivalent BYO
+/// provider phrasings. Caller passes the already-lowercased error string.
+pub(crate) fn is_malformed_tool_history_text(lower: &str) -> bool {
+    let tool_role = lower.contains("role 'tool'") || lower.contains("tool role");
+    let about_tool_call = lower.contains("tool call") || lower.contains("tool_call");
+    (tool_role && about_tool_call)
+        || lower.contains("does not match any tool_call from the preceding assistant message")
+}
+
+/// Detect a transport-level connection drop with no provider status / managed
+/// `errorCode` — the residue that otherwise falls to the generic `inference`
+/// catch-all (issue #3714 bucket #1).
+///
+/// Anchored on the canonical reqwest/hyper shapes for a severed or never-opened
+/// connection (stale keep-alive reused after sleep/wake, network change, raw
+/// mid-stream SSE drop). Intentionally does NOT match `"timed out"` (the
+/// dedicated `timeout` arm owns that) nor any `4xx/5xx` status (those arms claim
+/// their shapes earlier). Caller passes the already-lowercased error string.
+pub(crate) fn is_connection_dropped_text(lower: &str) -> bool {
+    const DROP_MARKERS: &[&str] = &[
+        "connection closed before message completed", // hyper IncompleteMessage
+        "error reading a body from connection",
+        "connection reset",
+        "connection refused",
+        "connection aborted",
+        "broken pipe",
+        "unexpected end of file",
+        "unexpected eof",
+        "error sending request",
+        "tcp connect error",
+        "dns error",
+        "failed to lookup address",
+    ];
+    DROP_MARKERS.iter().any(|marker| lower.contains(marker))
+}
+
 pub(crate) fn is_provider_request_rejected_text(lower: &str) -> bool {
     // Match only when the 4xx status appears inside a provider error envelope
     // (`<provider> API error (4xx …)`, emitted by

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -135,7 +135,6 @@ async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
     .await
     .expect("start_chat should accept valid request");
 
-    let expected = generic_inference_error_user_message().to_string();
     let recv = timeout(Duration::from_secs(20), async move {
         loop {
             let event = rx.recv().await.expect("event stream should stay open");
@@ -151,11 +150,16 @@ async fn start_chat_emits_sanitized_chat_error_on_inference_failure() {
     .await
     .expect("expected chat_error event for started chat request");
 
+    // #3714: "error sending request for url …" is a transport drop, now classified
+    // by the dedicated `network` arm (was the generic catch-all). The key property
+    // this test guards — raw transport details must never leak into the
+    // user-facing copy — still holds for the new arm.
+    assert_eq!(recv.error_type.as_deref(), Some("network"));
     let message = recv.message.unwrap_or_default();
-    assert_eq!(message, expected);
     assert!(
-        !message.contains("error sending request for url"),
-        "chat error payload must not expose raw transport details"
+        !message.contains("error sending request for url")
+            && !message.contains("internal-api.example.invalid"),
+        "chat error payload must not expose raw transport details: {message}"
     );
 
     // Reset the test-only forced error slot while still holding

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -1925,3 +1925,126 @@ async fn parallel_turn_runs_concurrently_with_primary_on_same_thread() {
 
     set_test_run_chat_task_block(None).await;
 }
+
+// ── #3714: session-expired arm (must precede `auth_error`) ──────────────
+#[test]
+fn classify_session_expired_sentinel_routes_to_signin_not_generic() {
+    for raw in [
+        "SESSION_EXPIRED: backend session not active — sign in to resume LLM work",
+        "SESSION_EXPIRED: backend session token expired locally — re-authentication required",
+        "no backend session token; run auth_store_session first",
+    ] {
+        let c = classify_inference_error(raw);
+        assert_eq!(c.error_type, "session_expired", "raw={raw:?}");
+        assert!(!c.retryable, "session-expiry is not retryable: {raw:?}");
+        assert_ne!(
+            c.message,
+            generic_inference_error_user_message(),
+            "must not be the generic catch-all: {raw:?}"
+        );
+    }
+}
+
+#[test]
+fn classify_session_expired_claims_managed_backend_401_invalid_token_before_auth_error() {
+    // The OpenHuman backend 401 "Invalid token" envelope contains "401", which
+    // the `auth_error` arm would otherwise claim ("check your API key") — wrong
+    // for managed-backend users. The session arm must win.
+    let c = classify_inference_error(
+        "OpenHuman API error (401 Unauthorized): {\"error\":\"Invalid token\"}",
+    );
+    assert_eq!(c.error_type, "session_expired");
+}
+
+#[test]
+fn classify_byo_provider_401_stays_auth_error_not_session_expired() {
+    // A BYO provider's own 401 (user's API key) must NOT be swallowed by the
+    // session arm — it stays actionable as `auth_error`.
+    let c = classify_inference_error(
+        "OpenAI API error (401 Unauthorized): {\"error\":{\"message\":\"invalid_api_key\"}}",
+    );
+    assert_eq!(c.error_type, "auth_error");
+}
+
+// ── #3714: transport-drop arm (bucket #1, was the generic catch-all) ─────
+#[test]
+fn classify_connection_drop_routes_to_network_retryable() {
+    for raw in [
+        "error sending request for url (https://api.tinyhumans.ai/openai/v1/chat/completions): \
+         connection closed before message completed",
+        "request or response body error: unexpected end of file",
+        // Raw mid-stream SSE drop: managed backend leaves OFF the errorCode, so
+        // it reaches the ladder as a streaming error with a transport body.
+        "OpenHuman streaming API error: error reading a body from connection: \
+         end of file before message length reached",
+    ] {
+        let c = classify_inference_error(raw);
+        assert_eq!(c.error_type, "network", "raw={raw:?}");
+        assert!(c.retryable, "transport drop is retryable: {raw:?}");
+        assert_ne!(
+            c.message,
+            generic_inference_error_user_message(),
+            "raw={raw:?}"
+        );
+    }
+}
+
+#[test]
+fn classify_managed_sse_badrequest_not_misread_as_network() {
+    // A managed 400 frame carries errorCode → must stay provider_request_rejected
+    // (claimed by the errorCode short-circuit before the transport arm).
+    let c = classify_inference_error(
+        "OpenHuman streaming API error: {\"error\":{\"message\":\"Message has tool role, \
+         but there was no previous assistant message with a tool call!\",\
+         \"type\":\"stream_error\",\"errorCode\":\"BAD_REQUEST\"}}",
+    );
+    assert_eq!(c.error_type, "provider_request_rejected");
+}
+
+#[test]
+fn classify_timeout_not_shadowed_by_network_arm() {
+    let c = classify_inference_error("request timed out while reading response");
+    assert_eq!(c.error_type, "timeout");
+}
+
+// ── #3714: poisoned-history 400 gets the "we cleared it, resend" copy ────
+#[test]
+fn classify_managed_tool_ordering_400_gets_cleared_resend_copy() {
+    // Managed backend `validateToolMessageOrdering` rejection (orphaned tool
+    // message) arrives as a BAD_REQUEST SSE frame — must read "we cleared it,
+    // send again" (not "try a different model") and be retryable, since the
+    // de-poison guard already evicted the bad warm session.
+    let c = classify_inference_error(
+        "OpenHuman streaming API error: {\"error\":{\"message\":\"Message at index 3 has role \
+         'tool' but is not preceded by an assistant message with a matching tool_call\",\
+         \"type\":\"stream_error\",\"errorCode\":\"BAD_REQUEST\"}}",
+    );
+    assert_eq!(c.error_type, "provider_request_rejected");
+    assert!(c.retryable, "post-eviction resend works → retryable");
+    assert!(c.message.contains("cleared it"), "got: {}", c.message);
+    assert!(!c.message.contains("different model"), "got: {}", c.message);
+}
+
+#[test]
+fn classify_byo_tool_ordering_400_gets_cleared_resend_copy() {
+    let c = classify_inference_error(
+        "OpenAI API error (400 Bad Request): {\"error\":{\"message\":\"Invalid parameter: \
+         messages with role 'tool' must be a response to a preceding message with 'tool_calls'.\"}}",
+    );
+    assert_eq!(c.error_type, "provider_request_rejected");
+    assert!(c.retryable);
+    assert!(c.message.contains("cleared it"), "got: {}", c.message);
+}
+
+#[test]
+fn classify_genuine_param_400_keeps_model_mismatch_copy_not_glitch() {
+    // A real model/param 400 (no tool-ordering signature) must NOT get the
+    // "we cleared it" copy — resending the same params fails again.
+    let c = classify_inference_error(
+        "custom_openai API error (400 Bad Request): {\"error\":{\"message\":\
+         \"Unsupported value: 'temperature' must be 1 for this model\"}}",
+    );
+    assert_eq!(c.error_type, "provider_request_rejected");
+    assert!(!c.retryable, "param mismatch is not retryable");
+    assert!(!c.message.contains("cleared it"), "got: {}", c.message);
+}

--- a/tests/channels_provider_leftovers_raw_coverage_e2e.rs
+++ b/tests/channels_provider_leftovers_raw_coverage_e2e.rs
@@ -328,10 +328,12 @@ async fn web_round19_covers_classifier_variants_and_cancel_cleanup() {
     assert_eq!(budget.error_type, "budget_exhausted");
     assert_eq!(budget.source, "openhuman_billing");
 
+    // #3714: a DNS / transport drop now classifies as the dedicated `network`
+    // arm (was the generic `inference` catch-all), still retryable.
     let network = web_test_support::classify_error_for_test(
         "request error: dns error while trying to connect",
     );
-    assert_eq!(network.error_type, "inference");
+    assert_eq!(network.error_type, "network");
     assert!(network.retryable);
 
     web_test_support::set_forced_run_chat_task_error_for_test(Some(


### PR DESCRIPTION
## Summary

- Resume-on-reopen failures no longer collapse into the generic *"Something went wrong. Please try again."* — `classify_inference_error` now has dedicated arms for **session expiry**, **transport/connection drops**, and **poisoned tool history**.
- **De-poison**: a `provider_request_rejected` (400 / malformed-history) turn now evicts its warm session so the thread auto-recovers on the next turn instead of 400-ing forever.
- `session_expired` → *"sign in again"* (non-retryable); `network` → *"connection dropped, try again"* (retryable); poisoned-history 400 → *"We hit a temporary glitch — we've cleared it, send it again"* (retryable).
- FE `ChatErrorEvent.error_type` union extended with `session_expired` + `provider_request_rejected` (additive).
- 13 new unit tests; 53 web classifier + run_task tests green.

## Problem

Issue #3714: reopening the app after a long idle shows a generic, non-actionable *"Something went wrong"* with no way to know what failed. Root cause: `classify_inference_error`'s catch-all swallowed three distinct buckets —

1. **Expired app-session JWT** (the `SESSION_EXPIRED` / "no backend session" sentinels; there is **no** client-side refresh, so the only recovery is re-auth). The managed-backend `401 "Invalid token"` envelope was also being mislabeled by the `auth_error` arm as "check your API key" — wrong for managed users.
2. **Transport / connection drops on wake** (stale keep-alive socket, raw mid-stream SSE drop — the backend intentionally omits an `errorCode` for raw network drops, so it had nothing to branch on).
3. **A poisoned warm session**: a completed tool iteration that committed a malformed `tool_call_id` stays cached and 400s on **every** subsequent turn (the backend's `validateToolMessageOrdering` rejects it).

## Solution

- **De-poison** (`web/run_task.rs`): at the cache write-back, if the turn classified as `provider_request_rejected`, skip re-inserting the agent into `THREAD_SESSIONS` (it was already removed at the top of the fn) so the poisoned session is dropped. The next turn cold-boots and reseeds from the plain-text conversation log via `seed_resume_from_messages`, which rebuilds only system/user/assistant text and is structurally incapable of carrying tool malformation. Scoped to 400 only — rate-limit/timeout/5xx/session-expiry keep the warm session, since the agent loop bails before committing a failed iteration so their history stays clean.
- **`session_expired` arm** (`web_errors.rs`, first — before `auth_error`): reuses `observability::is_session_expired_message`. Non-retryable, routes to sign-in. Conjunctively scoped to OpenHuman/Embedding envelopes + sentinels, so a BYO 401 still falls through to `auth_error`.
- **`network` arm** (last — before the catch-all): new `is_connection_dropped_text` (connection-closed/EOF/reset/refused/broken-pipe/dns/send-request). Retryable. Runs after the `errorCode` short-circuit so a managed 400/429 SSE frame is never misread as a drop.
- **Poisoned-history copy split**: new `is_malformed_tool_history_text` (anchored on the verified `tinyhumansai/backend` `validateToolMessageOrdering` strings) swaps in the *"we've cleared it, send again"* copy (retryable, since the de-poison already evicted the session) for both the managed `BAD_REQUEST` path and the BYO 4xx path. A genuine param 400 keeps the *"try a different model"* copy and stays non-retryable.

Detection keys off the classified `errorCode`/`error_type`, never the HTTP status — verified against the backend, the managed chat path delivers 4xx/429 as in-band SSE error frames on a flushed 200.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — 13 new unit tests (de-poison eviction scoping; session/network/poisoned-history arms; ordering guards).
- [x] **Diff coverage ≥ 80%** — changed Rust logic lines are exercised by the 13 new unit tests; the FE change is a type-only union addition. `diff-cover` gate runs in CI.
- [x] N/A: behaviour-only change (error-classification copy + recovery) — no new feature row in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: behaviour-only change — no matrix feature IDs to list.
- [x] No new external network dependencies introduced.
- [x] N/A: error-copy/classification refinement — no new `docs/RELEASE-MANUAL-SMOKE.md` step.
- [x] Linked issue closed via `Closes #3714` below.

## Impact

- **Desktop chat (managed + BYO providers).** No new deps, no migration. Pure classification + warm-session-eviction logic; all existing `classify_inference_error` arms unchanged (50 existing tests pass). The de-poison costs one extra cold-boot reseed on a 400 turn (cheap, lossless — same path used on app restart).

## Related

- Closes: #3714
- Follow-up PR(s)/TODOs: FE affordances (Sign-in button for `session_expired`, Retry for `network`); `classify_subagent_failure` rate-limit/session-expiry messaging parity.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3714-resume-error
- Commit SHA: b2049419f5e467c81639def6c70bc085a7b420d5

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — validated by CI "Frontend Quality" job (passed); not run locally (node_modules absent in worktree)
- [x] `pnpm typecheck` — validated by CI "Frontend Quality" job (passed); not run locally (node_modules absent in worktree)
- [x] Focused tests: `cargo test --lib web::tests::classify web::run_task::tests` → 53 passed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` changes

### Validation Blocked

- `command:` pnpm typecheck / pnpm --filter openhuman-app format:check
- `error:` node_modules not installed in this worktree (`tsc: command not found`)
- `impact:` FE change is a 2-line additive union member (`session_expired`, `provider_request_rejected`) with no exhaustive consumers — verified type-safe by inspection; CI typecheck/format will validate.

### Behavior Changes

- Intended behavior change: resume-on-reopen errors are classified (session_expired / network / poisoned-history) instead of the generic catch-all; a 400-poisoned warm session is evicted so the thread recovers.
- User-visible effect: actionable error copy per failure type + automatic recovery of a poisoned thread on the next turn.

### Parity Contract

- Legacy behavior preserved: all existing classify arms unchanged (50 existing tests pass); new arms are additive and ordered to not shadow existing verdicts (session before auth_error; network last before catch-all; malformed-history before generic 4xx).
- Guard/fallback/dispatch parity checks: de-poison scoped to `provider_request_rejected` only; transient errors (rate-limit/timeout/5xx/session) keep the warm session.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added specific error classification for session expiration and provider request rejections.
  * Introduced clearer user-facing messages for conversation glitches and network interruptions.

* **Bug Fixes**
  * Improved detection of malformed conversation history to prevent replay of corrupted context.
  * Enhanced session management to properly handle retryable errors.
  * Added detection for mid-response connection drops with appropriate messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
