### PR TITLE
fix(observability): drop cron agent-job session-expired events in before_send (TAURI-RUST-M)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -2892,16 +2892,29 @@ pub fn is_max_iterations_event(event: &sentry::protocol::Event<'_>) -> bool {
 /// keeps OPENHUMAN-TAURI-25 / -1Q / -27 / -1G permanently off Sentry
 /// (~185 events/day combined).
 ///
-/// Scope: only the three domains that surface session-expired today
-/// (`llm_provider`, `backend_api`, `rpc`). Composio's OAuth-state 401
-/// is excluded — that's actionable and must reach Sentry.
+/// Scope: only the four domains that surface session-expired today
+/// (`llm_provider`, `backend_api`, `rpc`, `cron`). Composio's OAuth-state
+/// 401 is excluded — that's actionable and must reach Sentry.
+///
+/// The `cron` arm targets TAURI-RUST-M (Sentry #80, 42k+ events): a
+/// cron-fired agent job (`morning_briefing`) that exhausts its retries
+/// against a global backend 401 and calls `report_error` with
+/// `domain=cron`, `operation=agent_job`, `failure=retries_exhausted`.
+/// That path carries no `status` tag, so — like the rpc pre-flight guard —
+/// it is accepted on the session-expired body alone. Primary suppression
+/// is the `is_session_expired_failure` halt-on-first guard in
+/// `cron::scheduler::execute_job_with_retry` (#3350); this arm is the
+/// defense-in-depth for any future cron call site that re-emits the same
+/// shape without routing through that guard. Genuine cron failures (a
+/// non-session error body) don't match `is_session_expired_message`, so
+/// they still page.
 #[cfg(feature = "crash-reporting")]
 pub fn is_session_expired_event(event: &sentry::protocol::Event<'_>) -> bool {
     let tags = &event.tags;
     let Some(domain) = tags.get("domain").map(String::as_str) else {
         return false;
     };
-    if !matches!(domain, "llm_provider" | "backend_api" | "rpc") {
+    if !matches!(domain, "llm_provider" | "backend_api" | "rpc" | "cron") {
         return false;
     }
 
@@ -2921,10 +2934,11 @@ pub fn is_session_expired_event(event: &sentry::protocol::Event<'_>) -> bool {
         return true;
     }
 
-    // Pre-flight rpc guard has no status tag — accept on body alone,
-    // scoped to the rpc dispatcher (other domains don't emit the
-    // "no session token stored" sentinel).
-    if domain == "rpc" && body_matches {
+    // The rpc pre-flight guard and the cron agent-job report both emit
+    // without a `status` tag — accept on the session-expired body alone,
+    // scoped to those two domains (others must carry the 401 to be
+    // suppressed, so a real defect still pages).
+    if matches!(domain, "rpc" | "cron") && body_matches {
         return true;
     }
 
@@ -7824,6 +7838,52 @@ mod tests {
     }
 
     #[cfg(feature = "crash-reporting")]
+    #[test]
+    fn session_expired_before_send_matches_cron_agent_job() {
+        // TAURI-RUST-M (Sentry #80, 42k+ events): a cron-fired `morning_briefing`
+        // agent job exhausts its retries against a global backend 401 and calls
+        // `report_error` with `domain=cron`, `operation=agent_job`,
+        // `failure=retries_exhausted` and the raw `SESSION_EXPIRED:` sentinel as
+        // the message. The cron path carries no `status` tag, so the filter must
+        // accept on the session-expired body alone (mirroring the rpc branch).
+        // Primary suppression is the `is_session_expired_failure` halt-on-first
+        // guard in `cron::scheduler::execute_job_with_retry` (#3350); this
+        // `before_send` arm is the defense-in-depth for any future cron call
+        // site that re-emits the same shape without routing through that guard.
+        let msg = "SESSION_EXPIRED: backend session not active — sign in to resume LLM work";
+        let event = event_with_tags_and_message(
+            &[
+                ("domain", "cron"),
+                ("operation", "agent_job"),
+                ("failure", "retries_exhausted"),
+            ],
+            msg,
+        );
+        assert!(
+            is_session_expired_event(&event),
+            "cron agent_job session-expired retries-exhausted events should be filtered"
+        );
+    }
+
+    #[test]
+    fn session_expired_before_send_keeps_genuine_cron_failures() {
+        // A genuine cron agent_job failure whose body is NOT a session-expired
+        // sentinel must still page — the `cron` domain is only suppressed when
+        // the body matches, so real defects keep reaching Sentry.
+        let event = event_with_tags_and_message(
+            &[
+                ("domain", "cron"),
+                ("operation", "agent_job"),
+                ("failure", "retries_exhausted"),
+            ],
+            "tool execution failed: connection reset by peer while calling search_web",
+        );
+        assert!(
+            !is_session_expired_event(&event),
+            "non-session cron failures must keep reaching Sentry"
+        );
+    }
+
     #[test]
     fn max_iterations_filter_matches_message_path() {
         // `report_error_message` calls `sentry::capture_message`, which

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -7865,6 +7865,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "crash-reporting")]
     #[test]
     fn session_expired_before_send_keeps_genuine_cron_failures() {
         // A genuine cron agent_job failure whose body is NOT a session-expired
@@ -7884,6 +7885,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "crash-reporting")]
     #[test]
     fn max_iterations_filter_matches_message_path() {
         // `report_error_message` calls `sentry::capture_message`, which

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1958,15 +1958,28 @@ pub fn is_max_iterations_event(event: &sentry::protocol::Event<'_>) -> bool {
 /// keeps OPENHUMAN-TAURI-25 / -1Q / -27 / -1G permanently off Sentry
 /// (~185 events/day combined).
 ///
-/// Scope: only the three domains that surface session-expired today
-/// (`llm_provider`, `backend_api`, `rpc`). Composio's OAuth-state 401
-/// is excluded — that's actionable and must reach Sentry.
+/// Scope: only the four domains that surface session-expired today
+/// (`llm_provider`, `backend_api`, `rpc`, `cron`). Composio's OAuth-state
+/// 401 is excluded — that's actionable and must reach Sentry.
+///
+/// The `cron` arm targets TAURI-RUST-M (Sentry #80, 42k+ events): a
+/// cron-fired agent job (`morning_briefing`) that exhausts its retries
+/// against a global backend 401 and calls `report_error` with
+/// `domain=cron`, `operation=agent_job`, `failure=retries_exhausted`.
+/// That path carries no `status` tag, so — like the rpc pre-flight guard —
+/// it is accepted on the session-expired body alone. Primary suppression
+/// is the `is_session_expired_failure` halt-on-first guard in
+/// `cron::scheduler::execute_job_with_retry` (#3350); this arm is the
+/// defense-in-depth for any future cron call site that re-emits the same
+/// shape without routing through that guard. Genuine cron failures (a
+/// non-session error body) don't match `is_session_expired_message`, so
+/// they still page.
 pub fn is_session_expired_event(event: &sentry::protocol::Event<'_>) -> bool {
     let tags = &event.tags;
     let Some(domain) = tags.get("domain").map(String::as_str) else {
         return false;
     };
-    if !matches!(domain, "llm_provider" | "backend_api" | "rpc") {
+    if !matches!(domain, "llm_provider" | "backend_api" | "rpc" | "cron") {
         return false;
     }
 
@@ -1986,10 +1999,11 @@ pub fn is_session_expired_event(event: &sentry::protocol::Event<'_>) -> bool {
         return true;
     }
 
-    // Pre-flight rpc guard has no status tag — accept on body alone,
-    // scoped to the rpc dispatcher (other domains don't emit the
-    // "no session token stored" sentinel).
-    if domain == "rpc" && body_matches {
+    // The rpc pre-flight guard and the cron agent-job report both emit
+    // without a `status` tag — accept on the session-expired body alone,
+    // scoped to those two domains (others must carry the 401 to be
+    // suppressed, so a real defect still pages).
+    if matches!(domain, "rpc" | "cron") && body_matches {
         return true;
     }
 
@@ -5331,6 +5345,52 @@ mod tests {
         assert!(
             !is_session_expired_event(&event),
             "non-core domains must not be filtered as backend session expiry"
+        );
+    }
+
+    #[test]
+    fn session_expired_before_send_matches_cron_agent_job() {
+        // TAURI-RUST-M (Sentry #80, 42k+ events): a cron-fired `morning_briefing`
+        // agent job exhausts its retries against a global backend 401 and calls
+        // `report_error` with `domain=cron`, `operation=agent_job`,
+        // `failure=retries_exhausted` and the raw `SESSION_EXPIRED:` sentinel as
+        // the message. The cron path carries no `status` tag, so the filter must
+        // accept on the session-expired body alone (mirroring the rpc branch).
+        // Primary suppression is the `is_session_expired_failure` halt-on-first
+        // guard in `cron::scheduler::execute_job_with_retry` (#3350); this
+        // `before_send` arm is the defense-in-depth for any future cron call
+        // site that re-emits the same shape without routing through that guard.
+        let msg = "SESSION_EXPIRED: backend session not active — sign in to resume LLM work";
+        let event = event_with_tags_and_message(
+            &[
+                ("domain", "cron"),
+                ("operation", "agent_job"),
+                ("failure", "retries_exhausted"),
+            ],
+            msg,
+        );
+        assert!(
+            is_session_expired_event(&event),
+            "cron agent_job session-expired retries-exhausted events should be filtered"
+        );
+    }
+
+    #[test]
+    fn session_expired_before_send_keeps_genuine_cron_failures() {
+        // A genuine cron agent_job failure whose body is NOT a session-expired
+        // sentinel must still page — the `cron` domain is only suppressed when
+        // the body matches, so real defects keep reaching Sentry.
+        let event = event_with_tags_and_message(
+            &[
+                ("domain", "cron"),
+                ("operation", "agent_job"),
+                ("failure", "retries_exhausted"),
+            ],
+            "tool execution failed: connection reset by peer while calling search_web",
+        );
+        assert!(
+            !is_session_expired_event(&event),
+            "non-session cron failures must keep reaching Sentry"
         );
     }
 


### PR DESCRIPTION
## Summary

- Closes a defense-in-depth gap in the Sentry `before_send` filter `is_session_expired_event`: the `cron` domain was excluded, so cron-fired agent-job session-expired noise (Sentry **TAURI-RUST-M / #80**, 42k+ events) had only the call-site guard protecting it.
- Adds `cron` to the filter's domain allowlist and accepts on the session-expired body alone (the cron `report_error` path carries no `status` tag, mirroring the existing `rpc` pre-flight branch).
- Genuine non-session cron failures still page — suppression requires the body to match `is_session_expired_message`.

## Problem

A scheduled `morning_briefing` cron agent fires while the user's backend JWT has lapsed. Every retry hits the same global 401, the loop exhausts, and `cron::scheduler::execute_job_with_retry` calls `report_error` with `domain=cron`, `operation=agent_job`, `failure=retries_exhausted`, carrying the raw `SESSION_EXPIRED: backend session not active — sign in to resume LLM work` sentinel. This is expected user state (only fixable by signing in from the UI), not a defect.

The **primary** fix already shipped — PR #3350 (`is_session_expired_failure`, in `v0.57.18+`) halts the retry loop on first occurrence and skips `report_error` entirely. But the `before_send` defense-in-depth filter `is_session_expired_event` was scoped to `llm_provider`/`backend_api`/`rpc` and **excluded `cron`**, leaving the call-site guard as the sole protection. Any future cron call site that re-emits the shape without routing through that guard would flood Sentry again.

Note: this hardening helps future builds only — it cannot retroactively silence the live #80 events, which originate from clients on pre-fix builds (98.8% from a single client stuck on 0.56.0). Those go silent once clients update to a build containing #3350; the Sentry issue should be marked resolved in v0.57.18.

## Solution

- `is_session_expired_event` (`src/core/observability.rs`): add `cron` to the domain `matches!` allowlist, and extend the body-only acceptance branch from `domain == "rpc"` to `matches!(domain, "rpc" | "cron")`.
- The body-match requirement (`is_session_expired_message`) keeps it narrowly scoped: a genuine cron failure with a non-session error body is not suppressed and still reaches Sentry.
- Doc comment updated to document the `cron` arm and its relationship to the #3350 primary guard.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — added `session_expired_before_send_matches_cron_agent_job` (positive) and `session_expired_before_send_keeps_genuine_cron_failures` (negative/edge).
- [x] **Diff coverage ≥ 80%** — both changed logic lines are exercised by the two new tests; whole change is in `src/core/observability.rs` (cargo-llvm-cov path). Existing 39 session-expired tests still pass.
- [x] Coverage matrix updated — `N/A: behaviour-only defense-in-depth change, no new feature row`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature ID affected`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — pure in-process classifier, no network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal Sentry-noise filter, no user-facing surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: tracked in self-hosted Sentry (TAURI-RUST-M / #80), no GitHub issue`.

## Impact

- Desktop/CLI core only; no UI, no migration, no protocol change.
- Reduces Sentry noise for the cron session-expired path on future builds; no behaviour change to cron execution itself (the retry-halt remains the #3350 call-site guard).
- Security/perf: none — pure tag+body classification in `before_send`.

## Related

- Closes: N/A — tracked in self-hosted Sentry as TAURI-RUST-M (issue #80); no GitHub issue. Mark resolved in v0.57.18 once pre-fix clients update.
- Follow-up PR(s)/TODOs: builds on the primary call-site fix in #3350.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/sentry-80-cron-session-expired-before-send`
- Commit SHA: `ba21f4bbd7845a19f0b37dfc4d8fd6346ee4fefb`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: Rust-only change`
- [x] `pnpm typecheck` — `N/A: Rust-only change`
- [x] Focused tests: `cargo test --lib session_expired` — 39 passed, 0 failed (incl. 2 new cron tests)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean
- [x] Tauri fmt/check (if changed): `N/A: Tauri shell untouched`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: cron-domain session-expired events are dropped in `before_send` (defense-in-depth) on future builds.
- User-visible effect: none — internal Sentry-noise reduction only.

### Parity Contract

- Legacy behavior preserved: `llm_provider`/`backend_api`/`rpc` matching unchanged; only adds the `cron` arm.
- Guard/fallback/dispatch parity checks: cron suppression gated on body-match (`is_session_expired_message`), so genuine cron failures still page — verified by `session_expired_before_send_keeps_genuine_cron_failures`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A
