### PR TITLE
fix(agent-world): hide Jobs tab from sidebar nav

### DIFF
--- a/app/src/agentworld/pages/AgentWorld.tsx
+++ b/app/src/agentworld/pages/AgentWorld.tsx
@@ -44,8 +44,9 @@ const navIcon = (d: string) => (
 // Format: { slug: '<path-segment>', labelKey: 'agentWorld.<name>', iconPath: '<svg d>' }
 // Fan-out agents: add a row here AND a <Route> below AND an i18n key.
 // Sidebar order: Feed first, then Messages, then the rest; Profiles sits at the
-// end. Marketplace is intentionally OMITTED from the sidebar (its route still
-// exists below so buy/bid/offer flows remain reachable) — hidden, not removed.
+// end. Marketplace and Jobs are intentionally OMITTED from the sidebar (their
+// routes still exist below so buy/bid/offer and job-apply flows remain
+// reachable) — hidden, not removed.
 const SECTIONS: AgentWorldSection[] = [
   {
     slug: 'feed',
@@ -64,12 +65,6 @@ const SECTIONS: AgentWorldSection[] = [
     labelKey: 'agentWorld.ledger',
     iconPath:
       'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01',
-  },
-  {
-    slug: 'jobs',
-    labelKey: 'agentWorld.jobs',
-    iconPath:
-      'M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2M3.20898 7H20.791C21.4593 7 22 7.54066 22 8.20898V10.291C22 10.9593 21.4593 11.5 20.791 11.5H3.20898C2.54066 11.5 2 10.9593 2 10.291V8.20898C2 7.54066 2.54066 7 3.20898 7ZM5 11.5V19C5 20.1046 5.89543 21 7 21H17C18.1046 21 19 20.1046 19 19V11.5',
   },
   {
     slug: 'bounties',


### PR DESCRIPTION
## Summary

- Hide the **Jobs** tab from the tiny.place / Agent World sidebar navigation by removing its entry from the `SECTIONS` array in `app/src/agentworld/pages/AgentWorld.tsx`.
- The Jobs `<Route>`, the `JobsSection` component, and the `agentWorld.jobs` i18n keys are all **retained** — the page stays reachable by URL and from job-apply/bounty flows. Hidden, not removed.
- Mirrors the existing **Marketplace** precedent (already omitted from the sidebar while keeping its route), and updates the section comment block to document both.

## Problem

The Jobs tab should no longer surface in the Agent World sidebar, but the underlying Jobs page and the job-apply / bounty flows that deep-link into it must keep working.

## Solution

- Removed only the `{ slug: 'jobs', ... }` object from the `SECTIONS` array, which drives the sidebar nav via `TwoPaneNav`.
- Left `<Route path="jobs" element={<JobsSection />} />` and `import JobsSection` intact so the route remains reachable.
- Updated the comment above `SECTIONS` to note Jobs (like Marketplace) is intentionally omitted from the sidebar — hidden, not removed.

This is a single-file, hide-from-nav-only change. No route, component, logic, or translation was deleted.

## Submission Checklist

- [x] Tests added or updated — `N/A`: nav-only hide of an existing route entry; no logic changed and the `JobsSection` route/component are untouched. Mirrors the existing Marketplace hidden-not-removed precedent.
- [x] **Diff coverage ≥ 80%** — `N/A`: change only removes a static config-array literal and edits a comment; no executable changed lines to cover.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature added/removed; Jobs route still exists).
- [x] All affected feature IDs listed under `## Related` — `N/A`: no matrix feature rows affected.
- [x] No new external network dependencies introduced — confirmed (no dependency changes).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A`: sidebar nav visibility only.
- [x] Linked issue closed via `Closes #NNN` — `N/A`: no tracked issue for this change.

## Impact

- **Desktop UI only.** Jobs no longer appears in the Agent World sidebar. The `/agent-world/jobs` route and all internal links to it continue to function unchanged.
- No performance, security, migration, or compatibility implications.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `hide-agentworld-jobs-tab`
- Commit SHA: f202a2719

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on changed file
- [x] `pnpm typecheck` — `tsc --noEmit` passes
- [x] Focused tests: N/A (nav-only change)
- [x] Rust fmt/check (if changed): N/A — no Rust touched
- [x] Tauri fmt/check (if changed): N/A — no Tauri touched

### Validation Blocked

- `command:` `pnpm rust:check` and `pnpm --dir app run lint:commands-tokens` (pre-push hook)
- `error:` rust:check fails because the vendored `tauri-cef` submodule is not checked out in this worktree (`No such file or directory` for vendored tauri Cargo.toml); cmd-tokens fails because `ripgrep` is not installed in this environment.
- `impact:` None — both are pre-existing environment issues unrelated to this frontend-only change (it touches neither Rust nor `src/components/commands/`). Pushed with `--no-verify` per the project's pre-existing-breakage workflow rule.

### Behavior Changes

- Intended behavior change: Jobs tab is no longer rendered in the Agent World sidebar.
- User-visible effect: Sidebar shows Feed, Messages, Ledger, Bounties, Explore, Directory, Identities, Profiles — Jobs is hidden. Direct navigation to the Jobs page still works.

### Parity Contract

- Legacy behavior preserved: Jobs route + `JobsSection` component + `agentWorld.jobs` i18n keys all retained.
- Guard/fallback/dispatch parity checks: Route fallback (`<Route path="*" ...>`) and Jobs route unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed Marketplace and Jobs sections from the sidebar navigation while maintaining access through their existing routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->