### PR TITLE
fix(rpc): handle legacy namespaced method calls

### DIFF
--- a/app/src/services/__tests__/rpcMethods.test.ts
+++ b/app/src/services/__tests__/rpcMethods.test.ts
@@ -113,6 +113,17 @@ describe('rpcMethods catalog', () => {
     });
   });
 
+  describe('channels legacy alias resolution (Sentry OPENHUMAN-CORE-1Y / OPENHUMAN-CORE-1Z)', () => {
+    test('dotted channel list aliases resolve to channels_list', () => {
+      expect(normalizeRpcMethod('channels.list')).toBe(CORE_RPC_METHODS.channelsList);
+      expect(normalizeRpcMethod('openhuman.channels.list')).toBe(CORE_RPC_METHODS.channelsList);
+    });
+
+    test('canonical channels_list passes through unchanged', () => {
+      expect(normalizeRpcMethod('openhuman.channels_list')).toBe('openhuman.channels_list');
+    });
+  });
+
   test('catalog canonical methods exist in core schema registry (drift guard)', () => {
     const schemaSources = [
       fs.readFileSync(
@@ -147,6 +158,10 @@ describe('rpcMethods catalog', () => {
         path.resolve(__dirname, '../../../../src/openhuman/health/schemas.rs'),
         'utf8'
       ),
+      fs.readFileSync(
+        path.resolve(__dirname, '../../../../src/openhuman/channels/controllers/schemas.rs'),
+        'utf8'
+      ),
     ].join('\n');
 
     for (const method of Object.values(CORE_RPC_METHODS)) {
@@ -165,7 +180,9 @@ describe('rpcMethods catalog', () => {
                 ? 'mcp_clients'
                 : methodRoot.startsWith('health_')
                   ? 'health'
-                  : 'config';
+                  : methodRoot.startsWith('channels_')
+                    ? 'channels'
+                    : 'config';
       const fnName = methodRoot.slice(`${namespace}_`.length);
       expect(schemaSources).toContain(`namespace: "${namespace}"`);
       expect(schemaSources).toContain(`function: "${fnName}"`);

--- a/app/src/services/rpcMethods.ts
+++ b/app/src/services/rpcMethods.ts
@@ -57,6 +57,7 @@ export const CORE_RPC_METHODS = {
   embeddingsClearApiKey: 'openhuman.embeddings_clear_api_key',
   embeddingsEmbed: 'openhuman.embeddings_embed',
   embeddingsTestConnection: 'openhuman.embeddings_test_connection',
+  channelsList: 'openhuman.channels_list',
   mcpClientsInstalledList: 'openhuman.mcp_clients_installed_list',
   mcpClientsToolCall: 'openhuman.mcp_clients_tool_call',
   healthSnapshot: 'openhuman.health_snapshot',
@@ -66,9 +67,12 @@ export const CORE_RPC_METHODS = {
 export type CoreRpcMethod = (typeof CORE_RPC_METHODS)[keyof typeof CORE_RPC_METHODS];
 
 export const LEGACY_METHOD_ALIASES: Record<string, CoreRpcMethod> = {
+  // #3565: old desktop clients used dotted namespace/function channel calls.
+  'channels.list': CORE_RPC_METHODS.channelsList,
   // MCP clients — old method names that appeared in Sentry (CORE-RUST-DR/DS/DT/DV/DW).
   // See src/core/legacy_aliases.rs for the Rust-side mirror of this table.
   'mcp_clients.list': CORE_RPC_METHODS.mcpClientsInstalledList,
+  'openhuman.channels.list': CORE_RPC_METHODS.channelsList,
   'openhuman.mcp_clients_list': CORE_RPC_METHODS.mcpClientsInstalledList,
   'openhuman.mcp_list': CORE_RPC_METHODS.mcpClientsInstalledList,
   'openhuman.mcp_servers_list': CORE_RPC_METHODS.mcpClientsInstalledList,

--- a/src/core/dispatch.rs
+++ b/src/core/dispatch.rs
@@ -85,14 +85,15 @@ pub async fn dispatch(
     // Tier 4: unrecognised method. The JSON-RPC response is unchanged — the
     // caller still receives a method-not-found error. Only the *severity* of
     // how the transport layer records it differs by class (see
-    // `jsonrpc::rpc_handler`): known external probes (`is_known_probe_method`)
-    // are debug-only and never reach Sentry (#3567), while any other unknown
-    // method is downgraded to a warn-level capture (recorded for triage, no
-    // page) instead of an error event. Log here at debug with the method name
-    // so the path stays diagnosable without re-creating the Sentry noise.
+    // `jsonrpc::rpc_handler`): known non-actionable misses
+    // (`is_known_probe_method`) are debug-only and never reach Sentry
+    // (#3567, #3565), while any other unknown method is downgraded to a
+    // warn-level capture (recorded for triage, no page) instead of an error
+    // event. Log here at debug with the method name so the path stays
+    // diagnosable without re-creating the Sentry noise.
     if is_known_probe_method(method) {
         log::debug!(
-            "[rpc] unknown_method method={} class=known_probe (debug-only; not reported to Sentry)",
+            "[rpc] unknown_method method={} class=debug_only_known_miss (not reported to Sentry)",
             method
         );
     } else {
@@ -109,23 +110,28 @@ pub async fn dispatch(
 /// classifier ([`unknown_method_name`]) cannot drift apart.
 pub const UNKNOWN_METHOD_PREFIX: &str = "unknown method: ";
 
-/// Generic external probe / legacy method names that are never real RPC
-/// methods and never will be (issue #3567). Infra health-checks and JSON-RPC
-/// introspection clients poll these — `rpc.discover` (JSON-RPC service
-/// discovery), `list_methods`, liveness `status`, `auth.status`, `config/get`
-/// — and each miss previously produced a recurring Sentry ERROR event with
-/// zero user impact. The transport layer keeps these debug-only (never
-/// captured). The matching health-method *aliases* land separately in
-/// `legacy_aliases` (#3566), which depends on this severity change.
+/// Known non-actionable unknown method names that are debug-only.
+///
+/// Most entries are generic external probes that are never real RPC methods
+/// and never will be (issue #3567): `rpc.discover` (JSON-RPC service
+/// discovery), `list_methods`, liveness `status`, `auth.status`, `config/get`.
+/// This also covers retired feature calls from older clients when no safe
+/// canonical handler exists (#3565: `openhuman.memory_tree_create_namespace`).
+///
+/// Each miss previously produced recurring Sentry ERROR events with zero user
+/// impact. The transport layer keeps these debug-only (never captured). The
+/// matching health-method *aliases* land separately in `legacy_aliases`
+/// (#3566), which depends on this severity change.
 const KNOWN_PROBE_METHODS: &[&str] = &[
     "rpc.discover",
     "list_methods",
     "status",
     "auth.status",
     "config/get",
+    "openhuman.memory_tree_create_namespace",
 ];
 
-/// Returns `true` when `method` is a known external probe / legacy health name
+/// Returns `true` when `method` is a known non-actionable unknown method name
 /// from [`KNOWN_PROBE_METHODS`]. Matched against the *resolved* method name
 /// (after legacy-alias rewrite), i.e. the name embedded in the
 /// [`UNKNOWN_METHOD_PREFIX`] error string.
@@ -378,8 +384,12 @@ mod tests {
             "status",
             "auth.status",
             "config/get",
+            "openhuman.memory_tree_create_namespace",
         ] {
-            assert!(is_known_probe_method(m), "{m} should be a known probe");
+            assert!(
+                is_known_probe_method(m),
+                "{m} should be a debug-only known miss"
+            );
         }
         // Genuinely-unknown methods and near-misses are NOT allow-listed, so
         // they stay on the warn-for-triage path rather than being silenced.
@@ -387,7 +397,21 @@ mod tests {
         assert!(!is_known_probe_method("core.not_a_real_method"));
         assert!(!is_known_probe_method("Status")); // case-sensitive
         assert!(!is_known_probe_method("rpc.discover.extra")); // exact match only
+        assert!(!is_known_probe_method("memory_tree_create_namespace"));
         assert!(!is_known_probe_method(""));
+    }
+
+    #[tokio::test]
+    async fn dispatch_dotted_channel_list_aliases_route_to_registry() {
+        for method in ["channels.list", "openhuman.channels.list"] {
+            let out = dispatch(test_state(), method, json!({}))
+                .await
+                .unwrap_or_else(|err| panic!("{method} should route via channels_list: {err}"));
+            assert!(
+                out.is_array() || out.get("result").is_some(),
+                "expected {method} to return the channels_list payload, got {out}"
+            );
+        }
     }
 
     #[test]

--- a/src/core/legacy_aliases.rs
+++ b/src/core/legacy_aliases.rs
@@ -21,6 +21,10 @@
 /// Order doesn't matter for correctness, but is kept alphabetical by legacy
 /// key for easier diffing against the frontend table.
 const LEGACY_ALIASES: &[(&str, &str)] = &[
+    // #3565: old desktop clients called the channels controller with a dotted
+    // namespace/function spelling before the canonical
+    // `openhuman.<namespace>_<function>` form was established.
+    ("channels.list", "openhuman.channels_list"),
     // MCP clients — old method names that appeared in Sentry (CORE-RUST-DR/DS/DT/DV/DW).
     // Callers used dotted namespace, bare `mcp_list`, `mcp_servers_list`, and
     // `mcp_clients_list` before the canonical `mcp_clients_installed_list` was
@@ -28,6 +32,7 @@ const LEGACY_ALIASES: &[(&str, &str)] = &[
     // `mcp_clients_tool_call` that shipped in at least one older bundle.
     // `mcp_clients.list` sorts before all `openhuman.*` entries (m < o).
     ("mcp_clients.list", "openhuman.mcp_clients_installed_list"),
+    ("openhuman.channels.list", "openhuman.channels_list"),
     (
         "openhuman.get_analytics_settings",
         "openhuman.config_get_analytics_settings",
@@ -561,6 +566,15 @@ mod tests {
         // the table when it matches, not a copy of the input.
         let out = resolve_legacy("openhuman.ping");
         assert_eq!(out, "core.ping");
+    }
+
+    #[test]
+    fn resolve_legacy_rewrites_dotted_channel_list_aliases() {
+        assert_eq!(resolve_legacy("channels.list"), "openhuman.channels_list");
+        assert_eq!(
+            resolve_legacy("openhuman.channels.list"),
+            "openhuman.channels_list"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds Rust/core legacy aliases for `channels.list` and `openhuman.channels.list` so older desktop clients route to `openhuman.channels_list`.
- Mirrors the channel-list alias in the frontend RPC method catalog to keep the Rust and app alias tables in parity.
- Classifies retired `openhuman.memory_tree_create_namespace` calls as debug-only known misses so dead old-client traffic no longer creates Sentry error noise.
- Adds focused regression coverage for alias resolution, frontend catalog drift, dispatch routing, and exact debug-only unknown matching.

## Problem

- Older `openhuman@0.53.43` clients still call dotted / feature-level RPC names that no longer match the canonical `openhuman.<namespace>_<function>` registry shape.
- `channels.list` and `openhuman.channels.list` are valid legacy spellings but were falling through to `unknown method`.
- `openhuman.memory_tree_create_namespace` no longer has a safe current handler, so reporting it as an actionable Sentry error creates recurring low-value noise.

## Solution

- Map the two legacy channel-list names to `openhuman.channels_list` in `src/core/legacy_aliases.rs`.
- Add the same alias entries to `app/src/services/rpcMethods.ts`, preserving frontend/server alias parity.
- Extend the frontend RPC catalog drift guard so `channels` canonical methods are checked against the channels controller schema source.
- Extend the known debug-only unknown method allow-list for the retired memory-tree method, leaving the JSON-RPC response unchanged while changing observability severity.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — focused tests cover the changed Rust dispatch/alias paths and frontend catalog guard; CI diff-cover remains the merge gate for full merged coverage.
- [x] N/A: Coverage matrix updated — no feature row added/removed/renamed; this is compatibility/observability behavior for existing RPC surfaces.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix feature ID applies to this alias/dispatch fix.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces — no release smoke surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust JSON-RPC dispatch and app RPC catalog only.
- Compatibility: older clients using dotted channel-list methods now reach the canonical handler.
- Observability: retired memory-tree namespace calls still return method-not-found, but are treated as debug-only known misses instead of actionable Sentry errors.
- Security/performance/migration: no new external calls, no persistence migration, no secret handling changes.

## Related

- Closes #3565
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-3565-legacy-rpc-aliases`
- Commit SHA: `952cc34a3`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Focused tests:
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib core::dispatch::tests`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib core::legacy_aliases::tests`
  - `pnpm --dir app exec vitest run --config test/vitest.config.ts src/services/__tests__/rpcMethods.test.ts`
  - `pnpm --dir app exec eslint src/services/rpcMethods.ts`
  - `pnpm --dir app exec eslint src/services/__tests__/rpcMethods.test.ts`
  - `pnpm --dir app exec prettier --check src/services/rpcMethods.ts src/services/__tests__/rpcMethods.test.ts`
  - `git diff --check`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --all --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] N/A: Tauri fmt/check (if changed) — no Tauri crate files changed.

### Validation Blocked

- `command:` initial `cargo test --manifest-path Cargo.toml` / frontend checks before dependency install
- `error:` `whisper-rs-sys` requires `GGML_NATIVE=OFF` on Apple Silicon; full integration-target cargo test later hit local disk pressure; frontend worktree initially lacked `node_modules`.
- `impact:` switched to documented `GGML_NATIVE=OFF` and focused `--lib` Rust tests; installed worktree dependencies with `pnpm install --frozen-lockfile --ignore-scripts` and reran frontend checks successfully.

### Behavior Changes

- Intended behavior change: legacy dotted channel-list method names route to the canonical `openhuman.channels_list` handler.
- User-visible effect: older desktop clients avoid false `unknown method` failures for channel listing; removed memory-tree namespace calls stop surfacing as actionable Sentry errors.

### Parity Contract

- Legacy behavior preserved: unknown method JSON-RPC responses remain method-not-found for unhandled/retired methods.
- Guard/fallback/dispatch parity checks: Rust alias table and frontend alias table remain checked by existing parity tests; frontend catalog drift guard now includes `channels`; new dispatch tests cover both dotted channel-list spellings.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the channels list RPC method, including backward-compatible routing for legacy names like `channels.list` and `openhuman.channels.list`.

* **Bug Fixes**
  * Improved RPC method normalization and routing so dotted legacy method variants correctly resolve to the canonical channels list endpoint.
  * Expanded handling for specific “probe/known miss” unknown-method cases to improve debug classification without changing the outward error.

* **Tests**
  * Added/extended unit and async coverage for legacy alias resolution and channels namespace derivation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->