### PR TITLE
fix(chat): decouple provider webviews from thread routes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import { PersistGate } from 'redux-persist/integration/react';
 
 import AppRoutes from './AppRoutes';
+import WebviewHost from './components/accounts/WebviewHost';
 import AppBackground from './components/AppBackground';
 import AppUpdatePrompt from './components/AppUpdatePrompt';
 import BootCheckGate from './components/BootCheckGate/BootCheckGate';
@@ -57,7 +58,8 @@ import {
   stopWebviewAccountService,
 } from './services/webviewAccountService';
 import { persistor, store } from './store';
-import { useAppSelector } from './store/hooks';
+import { setActiveAccount } from './store/accountsSlice';
+import { useAppDispatch, useAppSelector } from './store/hooks';
 import { AGENT_ACCOUNT_ID } from './utils/accountsFullscreen';
 import { DEV_FORCE_ONBOARDING } from './utils/config';
 
@@ -164,6 +166,7 @@ function AppShell() {
 function AppShellDesktop() {
   const location = useLocation();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const { snapshot, isBootstrapping } = useCoreState();
   const onOnboardingRoute = location.pathname.startsWith('/onboarding');
   const onboardingPending =
@@ -200,15 +203,23 @@ function AppShellDesktop() {
   }, [location.pathname]);
 
   // Hide the active connected-app webview when we navigate away from the chat
-  // surface. The native CEF webview composites above the HTML, so without this
-  // it lingers on top of the newly-routed page until the user returns.
+  // surface. Provider CEF selection is intentionally route-independent; any
+  // real route change clears that high-level selection so the native view
+  // cannot linger over the newly-routed page.
   const activeAccountId = useAppSelector(state => state.accounts.activeAccountId);
+  const accountsById = useAppSelector(state => state.accounts.accounts);
+  const previousPathRef = useRef(location.pathname);
   useEffect(() => {
-    const onChat = location.pathname === '/chat' || location.pathname.startsWith('/chat/');
-    if (!onChat && activeAccountId && activeAccountId !== AGENT_ACCOUNT_ID) {
+    if (
+      location.pathname !== previousPathRef.current &&
+      activeAccountId &&
+      activeAccountId !== AGENT_ACCOUNT_ID
+    ) {
       void hideWebviewAccount(activeAccountId);
+      dispatch(setActiveAccount(AGENT_ACCOUNT_ID));
     }
-  }, [location.pathname, activeAccountId]);
+    previousPathRef.current = location.pathname;
+  }, [dispatch, location.pathname, activeAccountId]);
 
   // Sync the notch indicator to the persisted always-on listening state once
   // the core is ready (once per boot). Extracted to a hook so it's testable.
@@ -232,10 +243,23 @@ function AppShellDesktop() {
   );
   const chromeless = !token || onOnboardingRoute || onHiddenChromePath;
 
+  const activeProviderAccount =
+    activeAccountId && activeAccountId !== AGENT_ACCOUNT_ID
+      ? (accountsById[activeAccountId] ?? null)
+      : null;
+
   const content = (
     <div ref={scrollRef} className="relative h-full overflow-y-auto">
       <GlobalUpsellBanner />
       <AppRoutes />
+      {activeProviderAccount && (
+        <div className="absolute inset-0 z-30">
+          <WebviewHost
+            accountId={activeProviderAccount.id}
+            provider={activeProviderAccount.provider}
+          />
+        </div>
+      )}
     </div>
   );
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -163,7 +163,7 @@ function AppShell() {
 }
 
 /** Desktop inner shell — lives inside the Router so it can use useLocation. */
-function AppShellDesktop() {
+export function AppShellDesktop() {
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -208,6 +208,7 @@ function AppShellDesktop() {
   // cannot linger over the newly-routed page.
   const activeAccountId = useAppSelector(state => state.accounts.activeAccountId);
   const accountsById = useAppSelector(state => state.accounts.accounts);
+  const accountsOverlayOpen = useAppSelector(state => state.accounts.overlayOpen);
   const previousPathRef = useRef(location.pathname);
   useEffect(() => {
     if (
@@ -252,7 +253,7 @@ function AppShellDesktop() {
     <div ref={scrollRef} className="relative h-full overflow-y-auto">
       <GlobalUpsellBanner />
       <AppRoutes />
-      {activeProviderAccount && (
+      {activeProviderAccount && !accountsOverlayOpen && (
         <div className="absolute inset-0 z-30">
           <WebviewHost
             accountId={activeProviderAccount.id}

--- a/app/src/AppRoutes.tsx
+++ b/app/src/AppRoutes.tsx
@@ -128,7 +128,7 @@ const AppRoutes = () => {
       {/* Unified chat = agent + connected web apps. Replaces the old
           /conversations and /accounts routes. */}
       <Route
-        path="/chat"
+        path="/chat/:threadId?"
         element={
           <ProtectedRoute requireAuth={true}>
             <Accounts />

--- a/app/src/AppRoutesIOS.tsx
+++ b/app/src/AppRoutesIOS.tsx
@@ -66,7 +66,7 @@ const AppRoutesIOS: FC = () => {
         }
       />
       <Route
-        path="/chat"
+        path="/chat/:threadId?"
         element={
           <RequirePairing>
             <Accounts />

--- a/app/src/__tests__/App.webviewOverlay.test.tsx
+++ b/app/src/__tests__/App.webviewOverlay.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppShellDesktop } from '../App';
+
+const { hideWebviewAccountMock, mockDispatch } = vi.hoisted(() => ({
+  hideWebviewAccountMock: vi.fn().mockResolvedValue(undefined),
+  mockDispatch: vi.fn(),
+}));
+
+const baseState = {
+  accounts: {
+    accounts: {
+      'acct-whatsapp': {
+        id: 'acct-whatsapp',
+        provider: 'whatsapp',
+        label: 'WhatsApp',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        status: 'open',
+      },
+    },
+    order: ['acct-whatsapp'],
+    activeAccountId: 'acct-whatsapp',
+    lastActiveAccountId: 'acct-whatsapp',
+    messages: {},
+    unread: {},
+    logs: {},
+    overlayOpen: false,
+  },
+};
+
+let mockState = baseState;
+
+vi.mock('../services/webviewAccountService', () => ({
+  hideWebviewAccount: hideWebviewAccountMock,
+  startWebviewAccountService: vi.fn(),
+  stopWebviewAccountService: vi.fn(),
+}));
+vi.mock('../lib/webviewNotifications', () => ({
+  startWebviewNotificationsService: vi.fn(),
+  stopWebviewNotificationsService: vi.fn(),
+}));
+vi.mock('../lib/nativeNotifications', () => ({
+  startNativeNotificationsService: vi.fn(),
+  stopNativeNotificationsService: vi.fn(),
+}));
+vi.mock('../services/internetStatusListener', () => ({
+  startInternetStatusListener: vi.fn(),
+  stopInternetStatusListener: vi.fn(),
+}));
+vi.mock('../services/coreHealthMonitor', () => ({
+  startCoreHealthMonitor: vi.fn(),
+  stopCoreHealthMonitor: vi.fn(),
+}));
+vi.mock('../services/analytics', () => ({ trackPageView: vi.fn() }));
+vi.mock('../hooks/useNotchBootSync', () => ({ useNotchBootSync: vi.fn() }));
+vi.mock('../providers/CoreStateProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useCoreState: () => ({
+    snapshot: { sessionToken: 'token', onboardingCompleted: true },
+    isBootstrapping: false,
+  }),
+}));
+vi.mock('../store/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: (state: typeof baseState) => unknown) => selector(mockState),
+}));
+vi.mock('../components/accounts/WebviewHost', () => ({
+  default: ({ accountId }: { accountId: string }) => (
+    <div data-testid="webview-host">{accountId}</div>
+  ),
+}));
+vi.mock('../AppRoutes', () => ({ default: () => <main data-testid="routes" /> }));
+vi.mock('../components/AppBackground', () => ({ default: () => null }));
+vi.mock('../components/layout/shell/AppSidebar', () => ({ default: () => <aside /> }));
+vi.mock('../components/layout/shell/RootShellLayout', () => ({
+  default: ({ sidebar, children }: { sidebar: React.ReactNode; children: React.ReactNode }) => (
+    <div>
+      {sidebar}
+      {children}
+    </div>
+  ),
+}));
+vi.mock('../components/layout/shell/SidebarSlot', () => ({
+  SidebarSlotProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../components/OpenhumanLinkModal', () => ({ default: () => null }));
+vi.mock('../components/upsell/GlobalUpsellBanner', () => ({ default: () => null }));
+vi.mock('../features/meet/MascotFrameProducer', () => ({ MascotFrameProducer: () => null }));
+vi.mock('../components/walkthrough/AppWalkthrough', () => ({ default: () => null }));
+
+describe('AppShellDesktop provider webview visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState = baseState;
+  });
+
+  it('mounts the active provider webview when rail overlays are closed', () => {
+    renderShell();
+
+    expect(screen.getByTestId('webview-host')).toHaveTextContent('acct-whatsapp');
+  });
+
+  it('does not mount the provider webview while a rail overlay is open', () => {
+    mockState = { ...baseState, accounts: { ...baseState.accounts, overlayOpen: true } };
+
+    renderShell();
+
+    expect(screen.queryByTestId('webview-host')).not.toBeInTheDocument();
+  });
+});
+
+function renderShell() {
+  return render(
+    <MemoryRouter initialEntries={['/chat/thread-1']}>
+      <AppShellDesktop />
+    </MemoryRouter>
+  );
+}

--- a/app/src/__tests__/App.webviewOverlay.test.tsx
+++ b/app/src/__tests__/App.webviewOverlay.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppShellDesktop } from '../App';
@@ -93,6 +94,7 @@ vi.mock('../components/walkthrough/AppWalkthrough', () => ({ default: () => null
 describe('AppShellDesktop provider webview visibility', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    HTMLElement.prototype.scrollTo = vi.fn();
     mockState = baseState;
   });
 
@@ -109,12 +111,43 @@ describe('AppShellDesktop provider webview visibility', () => {
 
     expect(screen.queryByTestId('webview-host')).not.toBeInTheDocument();
   });
+
+  it('does not mount a provider webview when the active account is missing', () => {
+    mockState = {
+      ...baseState,
+      accounts: { ...baseState.accounts, activeAccountId: 'missing-account' },
+    };
+
+    renderShell();
+
+    expect(screen.queryByTestId('webview-host')).not.toBeInTheDocument();
+  });
+
+  it('hides the active provider and restores the agent selection on route changes', async () => {
+    renderShell('/chat/thread-1', '/settings');
+
+    await waitFor(() => expect(hideWebviewAccountMock).toHaveBeenCalledWith('acct-whatsapp'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/setActiveAccount',
+      payload: '__agent__',
+    });
+  });
 });
 
-function renderShell() {
+function renderShell(initialPath = '/chat/thread-1', nextPath?: string) {
   return render(
-    <MemoryRouter initialEntries={['/chat/thread-1']}>
-      <AppShellDesktop />
+    <MemoryRouter initialEntries={[initialPath]}>
+      <RouteChangeHarness nextPath={nextPath} />
     </MemoryRouter>
   );
+}
+
+function RouteChangeHarness({ nextPath }: { nextPath?: string }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (nextPath) {
+      navigate(nextPath);
+    }
+  }, [navigate, nextPath]);
+  return <AppShellDesktop />;
 }

--- a/app/src/components/OpenhumanLinkModal.tsx
+++ b/app/src/components/OpenhumanLinkModal.tsx
@@ -11,7 +11,6 @@
  * Mounted once at AppShell root.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { useChannelDefinitions } from '../hooks/useChannelDefinitions';
 import { useT } from '../lib/i18n/I18nContext';
@@ -456,7 +455,6 @@ export function statusDisplay(status: AccountStatus): { labelKey: string; dotCla
 const AccountsSetupBody = ({ close }: { close: () => void }) => {
   const { t } = useT();
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
   const accountsById = useAppSelector(s => s.accounts.accounts);
   const order = useAppSelector(s => s.accounts.order);
 
@@ -508,12 +506,11 @@ const AccountsSetupBody = ({ close }: { close: () => void }) => {
 
   const handleDone = () => {
     close();
-    // Navigate to /chat and activate the first newly-added account so its
-    // WebviewHost mounts and the auth flow starts immediately.
+    // Activate the first newly-added account so the shell-level WebviewHost
+    // opens the auth flow immediately without mutating the current route.
     const firstNew = [...newlyAdded.keys()][0];
     if (firstNew) {
       dispatch(setActiveAccount(firstNew));
-      navigate('/chat');
     }
   };
 

--- a/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
+++ b/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
@@ -98,7 +98,7 @@ describe('OpenhumanLinkModal accounts setup', () => {
     expect(Object.values(store.getState().accounts.accounts)).toHaveLength(0);
   });
 
-  it('Done button navigates to /chat and sets first new account as active', () => {
+  it('Done button sets first new account as active without navigating', () => {
     const { store } = renderModal();
     openAccountsModal();
 
@@ -113,7 +113,7 @@ describe('OpenhumanLinkModal accounts setup', () => {
     fireEvent.click(screen.getByRole('button', { name: /Continue with Telegram Web sign-in/ }));
 
     expect(store.getState().accounts.activeAccountId).toBe(accountIds[0]);
-    expect(mockNavigate).toHaveBeenCalledWith('/chat');
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('Skip button closes modal without navigating', () => {

--- a/app/src/components/intelligence/IntelligenceAgentWorkTab.test.tsx
+++ b/app/src/components/intelligence/IntelligenceAgentWorkTab.test.tsx
@@ -8,6 +8,8 @@ import {
 } from '../../services/api/agentWorkApi';
 import IntelligenceAgentWorkTab from './IntelligenceAgentWorkTab';
 
+const hoisted = vi.hoisted(() => ({ dispatch: vi.fn(), navigate: vi.fn() }));
+
 vi.mock('../../services/api/agentWorkApi', () => ({
   agentWorkApi: { list: vi.fn(), control: vi.fn() },
 }));
@@ -16,8 +18,8 @@ vi.mock('../../services/api/agentWorkApi', () => ({
 vi.mock('../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
 
 // Navigation + store: the tab only dispatches + navigates on click; stub them.
-vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
-vi.mock('../../store/hooks', () => ({ useAppDispatch: () => vi.fn() }));
+vi.mock('react-router-dom', () => ({ useNavigate: () => hoisted.navigate }));
+vi.mock('../../store/hooks', () => ({ useAppDispatch: () => hoisted.dispatch }));
 vi.mock('../../store/threadSlice', () => ({
   loadThreadMessages: vi.fn(),
   loadThreads: vi.fn(),
@@ -104,6 +106,8 @@ describe('IntelligenceAgentWorkTab', () => {
     // call history, not queued *Once values / persistent implementations).
     mockList.mockReset();
     mockControl.mockReset();
+    hoisted.dispatch.mockReset();
+    hoisted.navigate.mockReset();
   });
 
   it('fetches agent work on mount', async () => {
@@ -146,6 +150,16 @@ describe('IntelligenceAgentWorkTab', () => {
     expect(screen.getByText('$0.05')).toBeInTheDocument();
     // worker-thread jump button present
     expect(screen.getByText('intelligence.agentWork.openWorker')).toBeInTheDocument();
+  });
+
+  it('opens worker threads on the routed chat URL', async () => {
+    mockList.mockResolvedValue(workingResponse());
+    render(<IntelligenceAgentWorkTab />);
+    await waitFor(() => expect(screen.getByText('Researcher')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('intelligence.agentWork.openWorker'));
+
+    expect(hoisted.navigate).toHaveBeenCalledWith('/chat/thread-w');
   });
 
   it('shows Stop (not Retry/Continue) for a live working run', async () => {

--- a/app/src/components/intelligence/IntelligenceAgentWorkTab.tsx
+++ b/app/src/components/intelligence/IntelligenceAgentWorkTab.tsx
@@ -11,7 +11,7 @@
  * {data, loading, error} state, mirroring {@link IntelligenceTasksTab}'s
  * mount pattern (mountedRef + a 0ms `setTimeout` so the first paint shows the
  * loading state before the RPC resolves). Each row offers jumps to the parent
- * / worker thread via the same navigate('/chat', { openThreadId }) path the
+ * / worker thread via the same /chat/:threadId path the
  * Tasks tab uses for "View session".
  */
 import debug from 'debug';
@@ -28,6 +28,7 @@ import {
 } from '../../services/api/agentWorkApi';
 import { useAppDispatch } from '../../store/hooks';
 import { loadThreadMessages, loadThreads, setSelectedThread } from '../../store/threadSlice';
+import { chatThreadPath } from '../../utils/chatRoutes';
 
 const log = debug('intelligence:agent-work');
 
@@ -158,7 +159,7 @@ export default function IntelligenceAgentWorkTab() {
       dispatch(setSelectedThread(threadId));
       void dispatch(loadThreads());
       void dispatch(loadThreadMessages(threadId));
-      navigate('/chat', { state: { openThreadId: threadId } });
+      navigate(chatThreadPath(threadId));
     },
     [dispatch, navigate]
   );

--- a/app/src/components/intelligence/IntelligenceAgentsTab.tsx
+++ b/app/src/components/intelligence/IntelligenceAgentsTab.tsx
@@ -16,6 +16,7 @@ import {
   setSelectedThread,
 } from '../../store/threadSlice';
 import type { ThreadMessage } from '../../types/thread';
+import { chatThreadPath } from '../../utils/chatRoutes';
 import AgentsLibraryPanel from './AgentsLibraryPanel';
 
 const log = debug('intelligence:agents-tab');
@@ -82,7 +83,7 @@ export default function IntelligenceAgentsTab() {
         dispatch(setActiveThread(thread.id));
         void dispatch(loadThreads());
         void dispatch(loadThreadMessages(thread.id));
-        navigate('/chat');
+        navigate(chatThreadPath(thread.id));
 
         await chatSend({
           threadId: thread.id,

--- a/app/src/components/intelligence/IntelligenceTasksTab.tsx
+++ b/app/src/components/intelligence/IntelligenceTasksTab.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../store/threadSlice';
 import type { ThreadMessage } from '../../types/thread';
 import type { TaskBoard, TaskBoardCard, TaskBoardCardStatus } from '../../types/turnState';
+import { chatThreadPath } from '../../utils/chatRoutes';
 import { UserTaskComposer } from './UserTaskComposer';
 
 const log = debug('intelligence:tasks');
@@ -391,7 +392,7 @@ export default function IntelligenceTasksTab() {
         dispatch(setActiveThread(thread.id));
         void dispatch(loadThreads());
         void dispatch(loadThreadMessages(thread.id));
-        navigate('/chat');
+        navigate(chatThreadPath(thread.id));
 
         await chatSend({
           threadId: thread.id,
@@ -588,10 +589,7 @@ export default function IntelligenceTasksTab() {
             dispatch(setSelectedThread(tid));
             void dispatch(loadThreads());
             void dispatch(loadThreadMessages(tid));
-            // Pass the thread as an explicit open-intent so Conversations'
-            // mount-resume honors it (its default resume only considers
-            // General-tab threads and would otherwise drop this task session).
-            navigate('/chat', { state: { openThreadId: tid } });
+            navigate(chatThreadPath(tid));
           }}
           workingCardId={workingCardId}
           mutatingCardId={mutatingCardId}

--- a/app/src/components/intelligence/__tests__/IntelligenceAgentsTab.test.tsx
+++ b/app/src/components/intelligence/__tests__/IntelligenceAgentsTab.test.tsx
@@ -174,6 +174,6 @@ describe('IntelligenceAgentsTab', () => {
         })
       )
     );
-    expect(hoisted.navigate).toHaveBeenCalledWith('/chat');
+    expect(hoisted.navigate).toHaveBeenCalledWith('/chat/thread-agent-task');
   });
 });

--- a/app/src/components/intelligence/__tests__/IntelligenceTasksTab.test.tsx
+++ b/app/src/components/intelligence/__tests__/IntelligenceTasksTab.test.tsx
@@ -432,9 +432,7 @@ describe('IntelligenceTasksTab', () => {
     await waitFor(() => expect(screen.getByText('Worked card')).toBeInTheDocument());
     fireEvent.click(screen.getByText('stub-view-session'));
 
-    expect(hoisted.navigate).toHaveBeenCalledWith('/chat', {
-      state: { openThreadId: 'task-session-99' },
-    });
+    expect(hoisted.navigate).toHaveBeenCalledWith('/chat/task-session-99');
   });
 
   test('renders persisted agent boards from the turn-state list', async () => {

--- a/app/src/components/layout/shell/SidebarAppRail.test.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SidebarAppRail from './SidebarAppRail';
+
+const mockNavigate = vi.fn();
+const mockDispatch = vi.fn();
+
+const mockState = {
+  accounts: {
+    accounts: {
+      'acct-whatsapp': {
+        id: 'acct-whatsapp',
+        provider: 'whatsapp',
+        label: 'WhatsApp',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        status: 'open',
+      },
+    },
+    order: ['acct-whatsapp'],
+    activeAccountId: null,
+    unread: {},
+  },
+};
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../services/analytics', () => ({ trackEvent: vi.fn() }));
+vi.mock('../../../services/webviewAccountService', () => ({ purgeWebviewAccount: vi.fn() }));
+vi.mock('../../../store/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (sel: (state: typeof mockState) => unknown) => sel(mockState),
+}));
+
+describe('SidebarAppRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects a provider webview without mutating the current route', () => {
+    renderRail('/chat/thread-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'WhatsApp' }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/setActiveAccount',
+      payload: 'acct-whatsapp',
+    });
+  });
+
+  it('does not navigate again when selecting the agent from a thread route', () => {
+    renderRail('/chat/thread-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'accounts.agent' }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/setActiveAccount',
+      payload: '__agent__',
+    });
+  });
+});
+
+function renderRail(route: string) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <SidebarAppRail />
+    </MemoryRouter>
+  );
+}

--- a/app/src/components/layout/shell/SidebarAppRail.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.tsx
@@ -1,6 +1,6 @@
 import debugFactory from 'debug';
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useT } from '../../../lib/i18n/I18nContext';
 import { trackEvent } from '../../../services/analytics';
@@ -92,6 +92,7 @@ export default function SidebarAppRail() {
   const { t } = useT();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const accountsById = useAppSelector(state => state.accounts.accounts);
   const order = useAppSelector(state => state.accounts.order);
   const activeAccountId = useAppSelector(state => state.accounts.activeAccountId);
@@ -120,11 +121,12 @@ export default function SidebarAppRail() {
     dispatch(setAccountsOverlayOpen(overlayOpen));
   }, [overlayOpen, dispatch]);
 
-  // Bring the chat surface forward whenever the user picks something on the
-  // rail from another route — that's where the agent chat / provider webview
-  // actually render.
+  // Bring the chat surface forward when the user explicitly picks the agent.
+  // Provider CEF selection is a high-level rail overlay and intentionally does
+  // not mutate the current route.
   const goToChat = () => {
-    if (!window.location.hash.replace(/^#/, '').startsWith('/chat')) {
+    const onChat = location.pathname === '/chat' || location.pathname.startsWith('/chat/');
+    if (!onChat) {
       navigate('/chat');
     }
   };
@@ -145,7 +147,6 @@ export default function SidebarAppRail() {
     // Issue #1233 — record this real-account selection in the persisted MRU
     // pointer so the next session can prewarm it.
     dispatch(setLastActiveAccount(id));
-    goToChat();
   };
 
   const selectAgent = () => {
@@ -170,7 +171,6 @@ export default function SidebarAppRail() {
     }
     dispatch(setActiveAccount(id));
     dispatch(setLastActiveAccount(id));
-    goToChat();
   };
 
   const openContextMenu = (accountId: string, e: React.MouseEvent) => {

--- a/app/src/components/layout/shell/SidebarNav.test.tsx
+++ b/app/src/components/layout/shell/SidebarNav.test.tsx
@@ -1,7 +1,8 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../../test/test-utils';
+import { AGENT_ACCOUNT_ID } from '../../../utils/accountsFullscreen';
 import SidebarNav from './SidebarNav';
 
 // Analytics is fire-and-forget; stub it so the nav renders without a transport.
@@ -32,5 +33,35 @@ describe('SidebarNav active matching', () => {
 
     expect(tabButton('Tiny.Place')).not.toHaveAttribute('aria-current');
     expect(tabButton('Chat')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('clears an active provider selection when clicking the already-active nav item', () => {
+    const { store } = renderWithProviders(<SidebarNav />, {
+      initialEntries: ['/connections'],
+      preloadedState: {
+        accounts: {
+          accounts: {
+            'acct-slack': {
+              id: 'acct-slack',
+              provider: 'slack',
+              label: 'Slack',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              status: 'open',
+            },
+          },
+          order: ['acct-slack'],
+          activeAccountId: 'acct-slack',
+          lastActiveAccountId: 'acct-slack',
+          messages: {},
+          unread: {},
+          logs: {},
+          overlayOpen: false,
+        },
+      },
+    });
+
+    fireEvent.click(tabButton('Connections'));
+
+    expect(store.getState().accounts.activeAccountId).toBe(AGENT_ACCOUNT_ID);
   });
 });

--- a/app/src/components/layout/shell/SidebarNav.tsx
+++ b/app/src/components/layout/shell/SidebarNav.tsx
@@ -4,9 +4,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { NAV_TABS, type NavTab } from '../../../config/navConfig';
 import { useT } from '../../../lib/i18n/I18nContext';
 import { trackEvent } from '../../../services/analytics';
+import { setActiveAccount } from '../../../store/accountsSlice';
 import { selectCompanionSessionActive } from '../../../store/companionSlice';
-import { useAppSelector } from '../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { selectUnreadCount } from '../../../store/notificationSlice';
+import { AGENT_ACCOUNT_ID } from '../../../utils/accountsFullscreen';
 import { NavIcon } from './navIcons';
 
 /**
@@ -35,6 +37,7 @@ function matchActive(path: string, pathname: string): boolean {
  */
 export default function SidebarNav() {
   const { t } = useT();
+  const dispatch = useAppDispatch();
   const location = useLocation();
   const navigate = useNavigate();
   const unreadCount = useAppSelector(state => selectUnreadCount(state.notifications.items));
@@ -44,6 +47,7 @@ export default function SidebarNav() {
   const activeTab = tabs.find(tab => matchActive(tab.path, location.pathname));
 
   const handleClick = (tab: NavTab, active: boolean) => {
+    dispatch(setActiveAccount(AGENT_ACCOUNT_ID));
     if (!active) {
       trackEvent('tab_bar_change', {
         from_tab: activeTab?.id ?? 'unknown',

--- a/app/src/components/layout/shell/useHomeNav.test.tsx
+++ b/app/src/components/layout/shell/useHomeNav.test.tsx
@@ -95,7 +95,7 @@ describe('useHomeNav', () => {
     const { result } = renderHook(() => useHomeNav(), { wrapper });
     result.current();
 
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/empty-1');
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'thread/setSelectedThread',
       payload: 'empty-1',
@@ -125,7 +125,7 @@ describe('useHomeNav', () => {
       type: 'thread/loadThreadMessages',
       payload: 'fresh-thread',
     });
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/fresh-thread');
   });
 
   it('swallows a failed thread creation without throwing', async () => {

--- a/app/src/components/layout/shell/useHomeNav.ts
+++ b/app/src/components/layout/shell/useHomeNav.ts
@@ -5,6 +5,7 @@ import { setActiveAccount } from '../../../store/accountsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { createNewThread, loadThreadMessages, setSelectedThread } from '../../../store/threadSlice';
 import { AGENT_ACCOUNT_ID } from '../../../utils/accountsFullscreen';
+import { chatThreadPath } from '../../../utils/chatRoutes';
 
 /**
  * The shell's "Home" action — shared by the sidebar header (expanded) and the
@@ -35,6 +36,7 @@ export function useHomeNav(): () => void {
     if (empty) {
       dispatch(setSelectedThread(empty.id));
       void dispatch(loadThreadMessages(empty.id));
+      navigate(chatThreadPath(empty.id));
       return;
     }
     void dispatch(createNewThread())
@@ -42,6 +44,7 @@ export function useHomeNav(): () => void {
       .then(thr => {
         dispatch(setSelectedThread(thr.id));
         void dispatch(loadThreadMessages(thr.id));
+        navigate(chatThreadPath(thr.id));
       })
       .catch(() => {});
   }, [navigate, location.pathname, dispatch, threads]);

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -1,6 +1,7 @@
+import debugFactory from 'debug';
 import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
-import WebviewHost from '../components/accounts/WebviewHost';
 import {
   CustomGifMascot,
   getMascotPalette,
@@ -10,12 +11,9 @@ import {
 import { useHumanMascot } from '../features/human/useHumanMascot';
 import { usePrewarmMostRecentAccount } from '../hooks/usePrewarmMostRecentAccount';
 import { useT } from '../lib/i18n/I18nContext';
-import {
-  hideWebviewAccount,
-  showWebviewAccount,
-  startWebviewAccountService,
-} from '../services/webviewAccountService';
-import { useAppSelector } from '../store/hooks';
+import { startWebviewAccountService } from '../services/webviewAccountService';
+import { setActiveAccount } from '../store/accountsSlice';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
   selectCustomMascotGifUrl,
   selectCustomPrimaryColor,
@@ -28,6 +26,7 @@ import Conversations, { AgentChatPanel } from './Conversations';
 
 // Persistence key for face-toggle state across sessions.
 const FACE_MODE_KEY = 'chat.faceMode';
+const debug = debugFactory('accounts');
 
 /**
  * Mascot + TTS panel rendered in face mode (right column of the Assistant
@@ -107,13 +106,11 @@ const FaceModePanel = () => {
 };
 
 const Accounts = () => {
-  const { t } = useT();
+  const dispatch = useAppDispatch();
+  const { threadId } = useParams<{ threadId?: string }>();
   const accountsById = useAppSelector(state => state.accounts.accounts);
   const order = useAppSelector(state => state.accounts.order);
   const activeAccountId = useAppSelector(state => state.accounts.activeAccountId);
-  // Overlay state is owned by the persistent app rail (now in the sidebar); we
-  // only read it here to hide/restore the active provider webview.
-  const overlayOpen = useAppSelector(state => state.accounts.overlayOpen);
 
   const [faceMode] = useState<boolean>(() => {
     try {
@@ -131,6 +128,12 @@ const Accounts = () => {
     startWebviewAccountService();
   }, []);
 
+  useEffect(() => {
+    if (!threadId) return;
+    debug('[chat][route] selecting agent for thread route thread=%s', threadId);
+    dispatch(setActiveAccount(AGENT_ID));
+  }, [dispatch, threadId]);
+
   // Issue #1233 — prewarm the MRU account once on mount so its CEF profile
   // and provider page are warm before the user actually clicks the rail.
   // Skipped for power users with many accounts to bound the spawn cost.
@@ -142,23 +145,7 @@ const Accounts = () => {
   usePrewarmMostRecentAccount({ accounts, accountsById, activeAccountId });
 
   const selectedId = activeAccountId ?? AGENT_ID;
-  const active = selectedId === AGENT_ID ? null : (accountsById[selectedId] ?? null);
   const isAgentSelected = selectedId === AGENT_ID;
-
-  // The child Tauri webview is a native view composited above the HTML
-  // canvas, so DOM z-index can't put React overlays on top of it. Hide
-  // the active webview while a rail overlay (add-account modal or the
-  // right-click context menu, both owned by the persistent sidebar rail) is
-  // open and restore it on close. No-op when the agent pane is selected.
-  const activeId = active?.id ?? null;
-  useEffect(() => {
-    if (!activeId) return;
-    if (overlayOpen) {
-      void hideWebviewAccount(activeId);
-    } else {
-      void showWebviewAccount(activeId);
-    }
-  }, [overlayOpen, activeId]);
 
   return (
     <div
@@ -184,28 +171,12 @@ const Accounts = () => {
         </main>
       ) : (
         <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-          {/* Agent chat — kept mounted even while a webview app is shown so its
-              thread sidebar projection persists. `min-h-0` lets the message list
-              own the scroll instead of pushing the composer off-screen. */}
-          <div
-            className={`min-h-0 flex-1 overflow-hidden ${isAgentSelected ? '' : 'invisible'}`}
-            aria-hidden={!isAgentSelected}>
+          {/* Agent chat owns the routed /chat surface. Connected-app CEF views
+              are mounted at the desktop shell level so their selection stays
+              independent from URL routing. */}
+          <div className="min-h-0 flex-1 overflow-hidden" aria-hidden={!isAgentSelected}>
             <AgentChatPanel />
           </div>
-
-          {/* Selected connected app — fills the main content fully (no padding
-              or margins) on top of the hidden agent chat. */}
-          {!isAgentSelected && active && (
-            <div className="absolute inset-0">
-              <WebviewHost accountId={active.id} provider={active.provider} />
-            </div>
-          )}
-
-          {!isAgentSelected && !active && (
-            <div className="absolute inset-0 flex items-center justify-center text-sm text-stone-400 dark:text-neutral-500">
-              {t('accounts.noAccounts')}
-            </div>
-          )}
         </main>
       )}
     </div>

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -156,10 +156,9 @@ const Accounts = () => {
       {/* "Talk to Tiny" face-mode toggle — hidden (kept for potential re-enable). */}
 
       {/* Main pane. In face mode (agent selected) it's a horizontal split with
-          the mascot panel. Otherwise the agent chat is ALWAYS mounted — so the
-          thread sidebar it projects stays consistent regardless of which app is
-          selected — and a selected app's webview fills the pane edge-to-edge on
-          top of it. */}
+          the mascot panel. Connected-app CEF views are hosted above this page
+          by the desktop shell, so the routed chat panel must only mount while
+          the agent is active; its thread effects own `/chat/:threadId`. */}
       {isAgentSelected && faceMode ? (
         <main className="flex min-w-0 flex-1 flex-row gap-3">
           <div className="flex min-h-0 w-[360px] flex-none flex-col">
@@ -171,12 +170,11 @@ const Accounts = () => {
         </main>
       ) : (
         <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-          {/* Agent chat owns the routed /chat surface. Connected-app CEF views
-              are mounted at the desktop shell level so their selection stays
-              independent from URL routing. */}
-          <div className="min-h-0 flex-1 overflow-hidden" aria-hidden={!isAgentSelected}>
-            <AgentChatPanel />
-          </div>
+          {isAgentSelected && (
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <AgentChatPanel />
+            </div>
+          )}
         </main>
       )}
     </div>

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1,7 +1,7 @@
 import { convertFileSrc } from '@tauri-apps/api/core';
 import debugFactory from 'debug';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { type ChatSendError, chatSendError } from '../chat/chatSendError';
 import { checkPromptInjection, promptGuardMessage } from '../chat/promptInjectionGuard';
@@ -67,6 +67,7 @@ import type { ConfirmationModal as ConfirmationModalType } from '../types/intell
 import type { ThreadMessage } from '../types/thread';
 import type { TaskBoardCard, TaskBoardCardStatus } from '../types/turnState';
 import { splitAgentMessageIntoBubbles } from '../utils/agentMessageBubbles';
+import { chatThreadPath } from '../utils/chatRoutes';
 import { CHAT_ATTACHMENTS_ENABLED } from '../utils/config';
 import { BILLING_DASHBOARD_URL } from '../utils/links';
 import { openUrl } from '../utils/openUrl';
@@ -208,6 +209,7 @@ const Conversations = ({
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
+  const { threadId: routeThreadId } = useParams<{ threadId?: string }>();
   const { threads, selectedThreadId, messages, isLoadingMessages, messagesError } = useAppSelector(
     state => state.thread
   );
@@ -425,6 +427,8 @@ const Conversations = ({
     const thread = await dispatch(createNewThread()).unwrap();
     dispatch(setSelectedThread(thread.id));
     void dispatch(loadThreadMessages(thread.id));
+    debug('[chat][route] created thread thread=%s navigate=true', thread.id);
+    navigate(chatThreadPath(thread.id));
   };
 
   const handleUseOpenRouterFree = async () => {
@@ -499,7 +503,8 @@ const Conversations = ({
         // Tasks board) wins over passive resume — and bypasses the General-tab
         // visibility filter so a task-labelled session thread can actually be
         // opened (the resume default below only considers General threads).
-        const openThreadId = (location.state as { openThreadId?: string } | null)?.openThreadId;
+        const openThreadId =
+          routeThreadId ?? (location.state as { openThreadId?: string } | null)?.openThreadId;
         const openThread = openThreadId ? data.threads.find(t => t.id === openThreadId) : undefined;
         if (openThread) {
           // An explicit open intent (e.g. View work from the Tasks board) opens
@@ -507,7 +512,12 @@ const Conversations = ({
           // filtered to General.
           dispatch(setSelectedThread(openThread.id));
           void dispatch(loadThreadMessages(openThread.id));
+          debug('[chat][route] opened requested thread thread=%s', openThread.id);
           return;
+        }
+        if (openThreadId) {
+          debug('[chat][route] requested thread not found thread=%s; falling back', openThreadId);
+          navigate('/chat', { replace: true });
         }
         // Default landing is a fresh "new window" (the merged Home surface) —
         // we no longer resume the last conversation on open. Reuse an existing
@@ -531,7 +541,7 @@ const Conversations = ({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
+  }, [dispatch, routeThreadId]);
 
   useEffect(() => {
     if (selectedThreadId) {
@@ -1581,6 +1591,7 @@ const Conversations = ({
               onClick={() => {
                 dispatch(setSelectedThread(thread.id));
                 void dispatch(loadThreadMessages(thread.id));
+                navigate(chatThreadPath(thread.id));
               }}
               onKeyDown={e => {
                 if (e.target !== e.currentTarget) return;
@@ -1588,6 +1599,7 @@ const Conversations = ({
                   e.preventDefault();
                   dispatch(setSelectedThread(thread.id));
                   void dispatch(loadThreadMessages(thread.id));
+                  navigate(chatThreadPath(thread.id));
                 }
               }}
               className={`w-full text-left px-3 py-1.5 border-b border-stone-100/60 dark:border-neutral-800/60 transition-colors group cursor-pointer ${
@@ -1797,6 +1809,7 @@ const Conversations = ({
                   // event, so forcing it active would wedge the composer.
                   dispatch(setSelectedThread(card.sessionThreadId));
                   void dispatch(loadThreadMessages(card.sessionThreadId));
+                  navigate(chatThreadPath(card.sessionThreadId));
                 }}
               />
             )}
@@ -2529,6 +2542,7 @@ const Conversations = ({
             onClick={() => {
               dispatch(setSelectedThread(selectedThreadParent.id));
               void dispatch(loadThreadMessages(selectedThreadParent.id));
+              navigate(chatThreadPath(selectedThreadParent.id));
             }}
             className="mt-2 flex items-center gap-1 rounded px-1 text-[11px] font-medium text-primary-600 hover:text-primary-700 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
             data-testid="worker-thread-back-to-parent">

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1696,6 +1696,9 @@ const Conversations = ({
                       cancelText: t('common.cancel'),
                       destructive: true,
                       onConfirm: () => {
+                        if (shouldSyncChatRoute && routeThreadId === thread.id) {
+                          navigate('/chat', { replace: true });
+                        }
                         void dispatch(deleteThread(thread.id));
                       },
                       onCancel: () => {},

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -1818,7 +1818,9 @@ const Conversations = ({
                   // event, so forcing it active would wedge the composer.
                   dispatch(setSelectedThread(card.sessionThreadId));
                   void dispatch(loadThreadMessages(card.sessionThreadId));
-                  navigate(chatThreadPath(card.sessionThreadId));
+                  if (shouldSyncChatRoute) {
+                    navigate(chatThreadPath(card.sessionThreadId));
+                  }
                 }}
               />
             )}

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -523,6 +523,7 @@ const Conversations = ({
         if (openThreadId) {
           debug('[chat][route] requested thread not found thread=%s; falling back', openThreadId);
           navigate('/chat', { replace: true });
+          return;
         }
         // Default landing is a fresh "new window" (the merged Home surface) —
         // we no longer resume the last conversation on open. Reuse an existing

--- a/app/src/pages/Conversations.tsx
+++ b/app/src/pages/Conversations.tsx
@@ -210,6 +210,7 @@ const Conversations = ({
   const navigate = useNavigate();
   const location = useLocation();
   const { threadId: routeThreadId } = useParams<{ threadId?: string }>();
+  const shouldSyncChatRoute = variant === 'page' && location.pathname.startsWith('/chat');
   const { threads, selectedThreadId, messages, isLoadingMessages, messagesError } = useAppSelector(
     state => state.thread
   );
@@ -427,8 +428,12 @@ const Conversations = ({
     const thread = await dispatch(createNewThread()).unwrap();
     dispatch(setSelectedThread(thread.id));
     void dispatch(loadThreadMessages(thread.id));
-    debug('[chat][route] created thread thread=%s navigate=true', thread.id);
-    navigate(chatThreadPath(thread.id));
+    if (shouldSyncChatRoute) {
+      debug('[chat][route] created thread thread=%s navigate=true', thread.id);
+      navigate(chatThreadPath(thread.id));
+    } else {
+      debug('[chat][route] created thread thread=%s navigate=false', thread.id);
+    }
   };
 
   const handleUseOpenRouterFree = async () => {
@@ -1591,7 +1596,9 @@ const Conversations = ({
               onClick={() => {
                 dispatch(setSelectedThread(thread.id));
                 void dispatch(loadThreadMessages(thread.id));
-                navigate(chatThreadPath(thread.id));
+                if (shouldSyncChatRoute) {
+                  navigate(chatThreadPath(thread.id));
+                }
               }}
               onKeyDown={e => {
                 if (e.target !== e.currentTarget) return;
@@ -1599,7 +1606,9 @@ const Conversations = ({
                   e.preventDefault();
                   dispatch(setSelectedThread(thread.id));
                   void dispatch(loadThreadMessages(thread.id));
-                  navigate(chatThreadPath(thread.id));
+                  if (shouldSyncChatRoute) {
+                    navigate(chatThreadPath(thread.id));
+                  }
                 }
               }}
               className={`w-full text-left px-3 py-1.5 border-b border-stone-100/60 dark:border-neutral-800/60 transition-colors group cursor-pointer ${

--- a/app/src/pages/__tests__/Accounts.webviewSelection.test.tsx
+++ b/app/src/pages/__tests__/Accounts.webviewSelection.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Accounts from '../Accounts';
+
+const mockDispatch = vi.fn();
+
+const agentState = {
+  accounts: {
+    accounts: {
+      'acct-whatsapp': {
+        id: 'acct-whatsapp',
+        provider: 'whatsapp',
+        label: 'WhatsApp',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        status: 'open',
+      },
+    },
+    order: ['acct-whatsapp'],
+    activeAccountId: '__agent__',
+  },
+};
+
+let mockState = agentState;
+
+vi.mock('../../hooks/usePrewarmMostRecentAccount', () => ({
+  usePrewarmMostRecentAccount: vi.fn(),
+}));
+vi.mock('../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+vi.mock('../../services/webviewAccountService', () => ({ startWebviewAccountService: vi.fn() }));
+vi.mock('../../store/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: (state: typeof agentState) => unknown) => selector(mockState),
+}));
+vi.mock('../../features/human/Mascot', () => ({
+  CustomGifMascot: () => null,
+  RiveMascot: () => null,
+  getMascotPalette: () => ({ bodyFill: '#000000', neckShadowColor: '#111111' }),
+  hexToArgbInt: () => 0,
+}));
+vi.mock('../../features/human/useHumanMascot', () => ({
+  useHumanMascot: () => ({ face: null, visemeCode: null }),
+}));
+vi.mock('../../store/mascotSlice', () => ({
+  selectCustomMascotGifUrl: () => null,
+  selectCustomPrimaryColor: () => '#000000',
+  selectCustomSecondaryColor: () => '#111111',
+  selectMascotColor: () => 'blue',
+}));
+vi.mock('../Conversations', () => ({
+  default: ({ variant }: { variant: string }) => <div data-testid="conversations">{variant}</div>,
+  AgentChatPanel: () => <div data-testid="agent-chat-panel" />,
+}));
+
+describe('Accounts provider selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState = agentState;
+  });
+
+  it('mounts the routed agent chat panel while the agent is selected', () => {
+    renderAccounts();
+
+    expect(screen.getByTestId('agent-chat-panel')).toBeInTheDocument();
+  });
+
+  it('does not mount the routed agent chat panel while a provider is selected', () => {
+    mockState = {
+      ...agentState,
+      accounts: { ...agentState.accounts, activeAccountId: 'acct-whatsapp' },
+    };
+
+    renderAccounts();
+
+    expect(screen.queryByTestId('agent-chat-panel')).not.toBeInTheDocument();
+  });
+});
+
+function renderAccounts() {
+  return render(
+    <MemoryRouter>
+      <Accounts />
+    </MemoryRouter>
+  );
+}

--- a/app/src/pages/__tests__/Accounts.webviewSelection.test.tsx
+++ b/app/src/pages/__tests__/Accounts.webviewSelection.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import Accounts from '../Accounts';
@@ -75,12 +75,23 @@ describe('Accounts provider selection', () => {
 
     expect(screen.queryByTestId('agent-chat-panel')).not.toBeInTheDocument();
   });
+
+  it('selects the agent account for thread routes', () => {
+    renderAccounts('/chat/thread-route-1');
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/setActiveAccount',
+      payload: '__agent__',
+    });
+  });
 });
 
-function renderAccounts() {
+function renderAccounts(route = '/chat') {
   return render(
-    <MemoryRouter>
-      <Accounts />
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/chat/:threadId?" element={<Accounts />} />
+      </Routes>
     </MemoryRouter>
   );
 }

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -10,7 +10,7 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SidebarSlotOutlet, SidebarSlotProvider } from '../../components/layout/shell/SidebarSlot';
@@ -1626,7 +1626,7 @@ describe('Conversations — open-session resume (View work)', () => {
     mockGetThreadMessages.mockResolvedValue({ messages: [], count: 0 });
   });
 
-  it('honours location.state.openThreadId to open a task session on mount', async () => {
+  it('honours /chat/:threadId to open a task session on mount', async () => {
     // A task-labelled session thread, reachable only via an explicit
     // open-intent because it's hidden behind the default General tab.
     const taskThread = makeThread({
@@ -1642,11 +1642,10 @@ describe('Conversations — open-session resume (View work)', () => {
     await act(async () => {
       render(
         <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[
-              { pathname: '/conversations', state: { openThreadId: 'task-open-1' } },
-            ]}>
-            <Conversations />
+          <MemoryRouter initialEntries={['/chat/task-open-1']}>
+            <Routes>
+              <Route path="/chat/:threadId" element={<Conversations />} />
+            </Routes>
           </MemoryRouter>
         </Provider>
       );

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -453,6 +453,7 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('route-path')).toHaveTextContent('/chat');
     });
+    expect(threadApi.createNewThread).not.toHaveBeenCalled();
   });
 
   it('updates the route when selecting sidebar threads by click or keyboard', async () => {

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -10,7 +10,7 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SidebarSlotOutlet, SidebarSlotProvider } from '../../components/layout/shell/SidebarSlot';
@@ -221,6 +221,39 @@ async function renderConversations(preload: Record<string, unknown> = {}) {
   return store;
 }
 
+async function renderConversationsRoute(route: string, preload: Record<string, unknown> = {}) {
+  const store = buildStore(preload);
+  const { default: Conversations } = await import('../Conversations');
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[route]}>
+        <SidebarSlotProvider>
+          <SidebarSlotOutlet />
+          <Routes>
+            <Route
+              path="/chat/:threadId?"
+              element={
+                <>
+                  <LocationProbe />
+                  <Conversations />
+                </>
+              }
+            />
+          </Routes>
+        </SidebarSlotProvider>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  return store;
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <span data-testid="route-path">{location.pathname}</span>;
+}
+
 /** The thread sidebar is always projected now (no toggle); just flush effects. */
 async function openSidebar() {
   await act(async () => {});
@@ -374,6 +407,50 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
       expect(screen.getAllByText('Thread Alpha').length).toBeGreaterThan(0);
     });
     expect(screen.getAllByText('Thread Beta').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to /chat when the routed thread id is missing', async () => {
+    mockGetThreads.mockResolvedValue({
+      threads: [makeThread({ id: 't-1', title: 'Thread Alpha' })],
+      count: 1,
+    });
+
+    await act(async () => {
+      await renderConversationsRoute('/chat/missing-thread', { thread: emptyThreadState });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('route-path')).toHaveTextContent('/chat');
+    });
+  });
+
+  it('updates the route when selecting sidebar threads by click or keyboard', async () => {
+    const threads = [
+      makeThread({ id: 't-1', title: 'Thread Alpha' }),
+      makeThread({ id: 't-2', title: 'Thread Beta' }),
+    ];
+    mockGetThreads.mockResolvedValue({ threads, count: 2 });
+
+    await act(async () => {
+      await renderConversationsRoute('/chat', { thread: emptyThreadState });
+    });
+    await openSidebar();
+
+    const alphaRow = await screen.findByRole('button', { name: /Thread Alpha/ });
+    await act(async () => {
+      fireEvent.click(alphaRow);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('route-path')).toHaveTextContent('/chat/t-1');
+    });
+
+    const betaRow = await screen.findByRole('button', { name: /Thread Beta/ });
+    await act(async () => {
+      fireEvent.keyDown(betaRow, { key: 'Enter' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('route-path')).toHaveTextContent('/chat/t-2');
+    });
   });
 
   // Covers line 1083: messagesError branch renders error state

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -774,6 +774,27 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
     expect(screen.getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
   });
 
+  it('replaces the route when deleting the currently-routed thread', async () => {
+    const thread = makeThread({ id: 't-del', title: 'Deletable Thread' });
+    mockGetThreads.mockResolvedValue({ threads: [thread], count: 1 });
+
+    await act(async () => {
+      await renderConversationsRoute('/chat/t-del', { thread: selectedThreadState(thread) });
+    });
+    await openSidebar();
+
+    const deleteBtn = await screen.findByTitle('Delete thread');
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    });
+
+    await waitFor(() => expect(threadApi.deleteThread).toHaveBeenCalledWith('t-del'));
+    expect(screen.getByTestId('route-path')).toHaveTextContent('/chat');
+  });
+
   // Covers lines 1399, 1409-1410: isNearLimit UpsellBanner render + onCtaClick
   it('renders near-limit UpsellBanner and clicking Upgrade calls openUrl', async () => {
     const { openUrl } = await import('../../utils/openUrl');

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -249,6 +249,37 @@ async function renderConversationsRoute(route: string, preload: Record<string, u
   return store;
 }
 
+async function renderEmbeddedConversationsRoute(
+  route: string,
+  preload: Record<string, unknown> = {}
+) {
+  const store = buildStore(preload);
+  const { default: Conversations } = await import('../Conversations');
+
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[route]}>
+        <SidebarSlotProvider>
+          <SidebarSlotOutlet />
+          <Routes>
+            <Route
+              path="/human"
+              element={
+                <>
+                  <LocationProbe />
+                  <Conversations variant="sidebar" composer="mic-cloud" projectThreadList />
+                </>
+              }
+            />
+          </Routes>
+        </SidebarSlotProvider>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  return store;
+}
+
 function LocationProbe() {
   const location = useLocation();
   return <span data-testid="route-path">{location.pathname}</span>;
@@ -451,6 +482,36 @@ describe('Conversations — smoke render (#1123 welcome-lock removal)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('route-path')).toHaveTextContent('/chat/t-2');
     });
+  });
+
+  it('does not push chat routes when embedded chat creates a thread', async () => {
+    mockGetThreads.mockResolvedValue({ threads: [], count: 0 });
+
+    await act(async () => {
+      await renderEmbeddedConversationsRoute('/human', { thread: emptyThreadState });
+    });
+
+    await waitFor(() => {
+      expect(threadApi.createNewThread).toHaveBeenCalled();
+    });
+    expect(screen.getByTestId('route-path')).toHaveTextContent('/human');
+  });
+
+  it('does not push chat routes when embedded chat selects a thread', async () => {
+    const threads = [makeThread({ id: 't-1', title: 'Thread Alpha' })];
+    mockGetThreads.mockResolvedValue({ threads, count: 1 });
+
+    await act(async () => {
+      await renderEmbeddedConversationsRoute('/human', { thread: emptyThreadState });
+    });
+    await openSidebar();
+
+    const alphaRow = await screen.findByRole('button', { name: /Thread Alpha/ });
+    await act(async () => {
+      fireEvent.click(alphaRow);
+    });
+
+    expect(screen.getByTestId('route-path')).toHaveTextContent('/human');
   });
 
   // Covers line 1083: messagesError branch renders error state

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -1846,4 +1846,44 @@ describe('Conversations — open-session resume (View work)', () => {
     // onViewSession navigates the chat view to the card's session thread.
     await waitFor(() => expect(store.getState().thread.selectedThreadId).toBe('sess-99'));
   });
+
+  it('does not push chat routes when embedded chat opens task session work', async () => {
+    const thread = makeThread({ id: 'board-thread', title: 'Board thread' });
+    mockGetThreads.mockResolvedValue({ threads: [thread], count: 1 });
+
+    const store = await renderEmbeddedConversationsRoute('/human', {
+      thread: selectedThreadState(thread),
+    });
+
+    const selectedId = store.getState().thread.selectedThreadId ?? 'board-thread';
+    await act(async () => {
+      store.dispatch(
+        setTaskBoardForThread({
+          threadId: selectedId,
+          board: {
+            threadId: selectedId,
+            updatedAt: '',
+            cards: [
+              {
+                id: 'tc1',
+                title: 'Worked card',
+                status: 'in_progress',
+                order: 0,
+                updatedAt: '',
+                sessionThreadId: 'sess-99',
+              },
+            ],
+          },
+        })
+      );
+    });
+
+    const viewBtn = await screen.findByTitle('View work');
+    await act(async () => {
+      fireEvent.click(viewBtn);
+    });
+
+    await waitFor(() => expect(store.getState().thread.selectedThreadId).toBe('sess-99'));
+    expect(screen.getByTestId('route-path')).toHaveTextContent('/human');
+  });
 });

--- a/app/src/services/__tests__/webviewAccountService.loadListener.test.ts
+++ b/app/src/services/__tests__/webviewAccountService.loadListener.test.ts
@@ -5,6 +5,7 @@ import { store } from '../../store';
 import { addAccount, resetAccountsState } from '../../store/accountsSlice';
 import {
   closeWebviewAccount,
+  hideWebviewAccount,
   openWebviewAccount,
   retryWebviewAccountLoad,
   setWebviewAccountBounds,
@@ -217,6 +218,22 @@ describe('webviewAccountService load listener', () => {
     await fireLoadEvent({ state: 'finished', url: 'x' });
 
     expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
+
+  it('skips reveal when a load finishes after the host hides during an overlay', async () => {
+    const bounds = { x: 5, y: 15, width: 1024, height: 768 };
+    await openWebviewAccount({ accountId: ACCOUNT_ID, provider: 'telegram', bounds });
+
+    vi.mocked(invoke).mockClear();
+    await hideWebviewAccount(ACCOUNT_ID);
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith('webview_account_hide', {
+      args: { account_id: ACCOUNT_ID },
+    });
+
+    vi.mocked(invoke).mockClear();
+    await fireLoadEvent({ state: 'finished', url: 'https://web.telegram.org/' });
+
+    expect(vi.mocked(invoke)).not.toHaveBeenCalledWith('webview_account_reveal', expect.anything());
   });
 
   it('retry re-opens with cached bounds and provider', async () => {

--- a/app/src/services/webviewAccountService.ts
+++ b/app/src/services/webviewAccountService.ts
@@ -1368,6 +1368,12 @@ export async function setWebviewAccountBounds(
 
 export async function hideWebviewAccount(accountId: string): Promise<void> {
   if (!isTauri()) return;
+  // Hide is used when the React host unmounts for route changes or shell
+  // overlays. Clear reveal-eligible state before the IPC so a late
+  // `webview-account:load` event cannot reveal the native CEF view over UI
+  // that no longer owns it.
+  lastBoundsByAccount.delete(accountId);
+  loadingAccounts.delete(accountId);
   try {
     await invoke('webview_account_hide', { args: { account_id: accountId } });
   } catch (err) {

--- a/app/src/store/accountsSlice.ts
+++ b/app/src/store/accountsSlice.ts
@@ -144,8 +144,9 @@ const accountsSlice = createSlice({
 
     /**
      * Signals that a rail overlay (add-account modal / context menu) opened or
-     * closed. Read by the chat page to hide/restore the active provider webview,
-     * which composites above HTML and would otherwise paint over the overlay.
+     * closed. Read by the desktop shell to hide/restore the active provider
+     * webview, which composites above HTML and would otherwise paint over the
+     * overlay.
      */
     setAccountsOverlayOpen(state, action: PayloadAction<boolean>) {
       state.overlayOpen = action.payload;

--- a/app/src/store/index.ts
+++ b/app/src/store/index.ts
@@ -116,7 +116,7 @@ const persistedChannelConnectionsReducer = persistReducer(
 // Issue #2044 — `activeAccountId` is deliberately NOT persisted. It is a
 // per-session UX selection: persisting it caused provider webviews to
 // auto-surface on dev hot reload / app restart without an explicit user
-// click, because `Accounts.tsx` immediately mounts `WebviewHost` for the
+// click, because the desktop shell immediately mounts `WebviewHost` for the
 // active account and `WebviewHost` calls `openWebviewAccount` on mount.
 // `lastActiveAccountId` is still persisted so the off-screen MRU prewarm
 // can warm the same account in the background — that webview stays

--- a/app/src/test/test-utils.tsx
+++ b/app/src/test/test-utils.tsx
@@ -12,6 +12,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { SidebarSlotOutlet, SidebarSlotProvider } from '../components/layout/shell/SidebarSlot';
 import { getCoreStateSnapshot } from '../lib/coreState/store';
 import { CoreStateContext } from '../providers/coreStateContext';
+import accountsReducer from '../store/accountsSlice';
 import backendMeetReducer from '../store/backendMeetSlice';
 import channelConnectionsReducer from '../store/channelConnectionsSlice';
 import companionReducer from '../store/companionSlice';
@@ -38,6 +39,7 @@ import themeReducer from '../store/themeSlice';
  * meeting status from this slice.
  */
 const testRootReducer = combineReducers({
+  accounts: accountsReducer,
   backendMeet: backendMeetReducer,
   channelConnections: channelConnectionsReducer,
   companion: companionReducer,

--- a/app/src/utils/chatRoutes.ts
+++ b/app/src/utils/chatRoutes.ts
@@ -1,0 +1,3 @@
+export function chatThreadPath(threadId: string): string {
+  return `/chat/${encodeURIComponent(threadId)}`;
+}


### PR DESCRIPTION
## Summary

- Adds stable `/chat/:threadId` routes for conversation threads and route-aware thread selection.
- Hosts provider CEF webviews at the desktop shell level so selecting a connected app does not mutate the URL.
- Hides the active provider webview on real route changes and while rail overlays are open, then resets route-change selection back to the agent account.
- Updates task/session/Home thread links and focused tests for route selection, provider rail behavior, rail overlay visibility, provider-hidden chat effects, link modal activation, and task navigation.

## Problem

- Conversation thread selection needs a URL-level contract so the shell/webview layer can react consistently when the user switches threads.
- Provider webview selection was coupled to `/chat`, which meant opening a connected app from a thread route could push the UI back to the chat route and fight route-driven thread selection.
- Native CEF views composite above HTML, so shell-level hosting must also respect rail overlays such as add-account and context menus.
- Hidden chat-route effects must not run underneath a selected provider webview.

## Solution

- Make thread IDs the route contract for agent conversation selection via `/chat/:threadId`.
- Treat provider CEF selection as high-level shell state hosted by `AppShellDesktop`, not as navigation.
- Clear/hide the active provider overlay when the pathname changes, so normal route navigation dismisses connected app webviews.
- Suppress shell-level `WebviewHost` mounting while `accounts.overlayOpen` is true; `WebviewHost` cleanup hides the native view while preserving the selected provider account.
- Mount `AgentChatPanel` only while the agent account is active so hidden chat thread effects cannot navigate and dismiss provider selection.
- Keep `/chat` as the existing agent chat entry point and fall back there if a route thread is missing.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). N/A: full local coverage was not run; focused Vitest coverage for changed frontend behavior plus CI coverage gate will enforce changed-line coverage.
- [x] Coverage matrix updated — N/A: behaviour-only routing/webview shell change; no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut checklist surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no linked issue provided.

## Impact

- Desktop: provider CEF selection no longer changes the current URL; route changes and rail overlays hide provider overlays; hidden chat effects do not run while providers are selected.
- Frontend routing: chat thread URLs now use `/chat/:threadId` while `/chat` remains supported.
- Mobile/iOS routes accept the same chat route shape, but CEF overlay behavior remains desktop-only.
- No backend migration, security model change, or new external dependency.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/chat-thread-routes-webview-overlay`
- Commit SHA: `da3cf3976d55974fcb8bf571c064a0a362f7b328`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/pages/__tests__/Accounts.webviewSelection.test.tsx src/__tests__/App.webviewOverlay.test.tsx src/components/layout/shell/SidebarAppRail.test.tsx src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx src/pages/__tests__/Conversations.render.test.tsx src/components/intelligence/__tests__/IntelligenceAgentsTab.test.tsx src/components/intelligence/__tests__/IntelligenceTasksTab.test.tsx src/components/layout/shell/useHomeNav.test.tsx`
- [x] Rust fmt/check (if changed): `pnpm --filter openhuman-app format:check` includes `cargo fmt --manifest-path ../Cargo.toml --all --check` and `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check`; no Rust source changed.
- [x] Tauri fmt/check (if changed): pre-push hook ran `pnpm rust:check` successfully; no Tauri source changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Provider CEF selection no longer changes the URL; route changes and rail overlays hide provider overlays; conversation threads have `/chat/:threadId` URLs; hidden chat effects are unmounted under provider selection.
- User-visible effect: Opening a connected app from a thread stays on the current route, while navigating elsewhere or opening rail controls hides the connected app.

### Parity Contract

- Legacy behavior preserved: `/chat` remains the agent chat entry and Home/agent paths still navigate there; provider sessions continue to open through `WebviewHost`.
- Guard/fallback/dispatch parity checks: Route-param thread opening falls back to `/chat` when the thread is missing; provider overlay cleanup hides the native view and route changes reset active selection.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added deep-link support for chat threads via `/chat/:threadId` (optional `threadId`), enabling direct opening of specific conversations.
* **Bug Fixes**
  * Improved provider webview overlay behavior, including correct hide/show during route changes and prevention of late re-reveals after the UI updates.
  * Updated route-driven cleanup so the chat surface and selected account state stay consistent when navigating.
* **Improvements**
  * Reduced unnecessary navigation when already on a chat route.
  * Updated account setup “Done/Continue” to activate the first new account without forcing navigation.
* **Tests**
  * Expanded coverage for webview selection, rail/sidebar navigation, and thread routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->