### PR TITLE
fix(openrouter): use the loopback's bound port in the OAuth callback_url

### DIFF
--- a/app/src/utils/__tests__/openrouterOAuth.test.ts
+++ b/app/src/utils/__tests__/openrouterOAuth.test.ts
@@ -31,8 +31,10 @@ describe('connectOpenRouterViaOAuth', () => {
     expect(openExternalUrl).toHaveBeenCalledTimes(1);
     const authUrl = new URL(openExternalUrl.mock.calls[0][0]);
     expect(authUrl.origin + authUrl.pathname).toBe('https://openrouter.ai/auth');
+    // callback_url must use the port the listener actually bound to (carried in
+    // redirectUri), not the requested OPENROUTER_LOOPBACK_PORT constant.
     expect(authUrl.searchParams.get('callback_url')).toBe(
-      'http://localhost:3000/auth?state=expected-state'
+      'http://localhost:53824/auth?state=expected-state'
     );
     expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256');
     expect(authUrl.searchParams.get('code_challenge')).toBeTruthy();
@@ -41,6 +43,37 @@ describe('connectOpenRouterViaOAuth', () => {
       expect.objectContaining({ method: 'POST', headers: { 'Content-Type': 'application/json' } })
     );
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the listener bound port for callback_url when the requested port was busy', async () => {
+    // Port 3000 busy -> the Tauri listener falls back to an OS-assigned port and
+    // returns it in redirectUri. callback_url must point at that bound port, or
+    // OpenRouter redirects to a port nothing is listening on and OAuth fails.
+    const openExternalUrl = vi.fn().mockResolvedValue(undefined);
+    const startLoopbackListener = vi
+      .fn()
+      .mockResolvedValue({
+        redirectUri: 'http://127.0.0.1:54321/auth?state=expected-state',
+        state: 'expected-state',
+        awaitCallback: vi
+          .fn()
+          .mockResolvedValue('http://127.0.0.1:54321/auth?state=expected-state&code=abc123'),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ key: 'sk-or-via-oauth' }) });
+
+    await connectOpenRouterViaOAuth({
+      startLoopbackListener,
+      openExternalUrl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const authUrl = new URL(openExternalUrl.mock.calls[0][0]);
+    expect(authUrl.searchParams.get('callback_url')).toBe(
+      'http://localhost:54321/auth?state=expected-state'
+    );
   });
 
   it('rejects when the loopback listener is unavailable', async () => {

--- a/app/src/utils/openrouterOAuth.ts
+++ b/app/src/utils/openrouterOAuth.ts
@@ -105,8 +105,13 @@ function toOpenRouterCallbackUrl(redirectUri: string): string {
     throw new Error('OpenRouter OAuth listener returned an invalid redirect URL.');
   }
 
+  // Preserve the port the loopback listener actually bound to (carried in
+  // redirectUri): when the requested port is busy, the Tauri command falls back
+  // to an OS-assigned ephemeral port, so hardcoding OPENROUTER_LOOPBACK_PORT here
+  // sent OpenRouter a callback_url pointing at the wrong port. The PKCE
+  // callback_url is per-request, so the dynamic port is valid (this matches the
+  // sibling OAuthProviderButton flow, which trusts the bound port).
   parsed.hostname = 'localhost';
-  parsed.port = String(OPENROUTER_LOOPBACK_PORT);
   return parsed.toString();
 }
 


### PR DESCRIPTION
## Summary

- `toOpenRouterCallbackUrl` overwrote the redirect URL's port with the hardcoded `OPENROUTER_LOOPBACK_PORT` (3000), discarding the port the loopback listener actually bound to.
- When port 3000 is busy, `start_loopback_oauth_listener` falls back to an OS-assigned ephemeral port (returned in `redirectUri`), so `callback_url` pointed at the wrong port.
- Fixed by preserving the bound port (only normalizing the hostname to `localhost`).

## Problem

`connectOpenRouterViaOAuth` requests port 3000 but the Tauri command `start_loopback_oauth_listener` deliberately falls back to an ephemeral port when 3000 is in use (extremely common — Vite/Next/Node dev servers default to 3000), returning the real bound port inside `redirectUri`. `toOpenRouterCallbackUrl` then re-imposed `:3000`, so OpenRouter was told to redirect to `http://localhost:3000/...` while the listener was bound elsewhere. The auth code never reaches `awaitCallback()` (OAuth silently times out) — or the authorization `code` is delivered to whatever unrelated local server owns port 3000.

The sibling OAuth flow (`OAuthProviderButton.tsx`) already does this correctly: it trusts the bound port and matches `^https?://127\.0\.0\.1:\d+/auth` (any port).

## Solution

- In `toOpenRouterCallbackUrl`, drop `parsed.port = String(OPENROUTER_LOOPBACK_PORT)`; keep only the `localhost` hostname normalization so the bound port carried in `redirectUri` is preserved. The PKCE `callback_url` is per-request, so a dynamic port is valid.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case) — updated the existing assertion (which encoded the bug, asserting `:3000` for a mocked `:53824` listener) to assert the bound port, and added a case simulating the ephemeral-fallback (`:54321`) when 3000 is busy.
- [x] **Diff coverage ≥ 80%** — the changed function is exercised by the updated tests (`vitest`; `openrouterOAuth.ts` at ~84% lines). TS-only change.
- [N/A] Coverage matrix updated — behaviour-only fix to already-covered code; no feature rows added/removed/renamed.
- [N/A] Affected feature IDs listed under `## Related` — no matrix rows change.
- [x] No new external network dependencies introduced — tests use injected mocks (`startLoopbackListener`, `openExternalUrl`, `fetchImpl`).
- [N/A] Manual smoke checklist — does not touch release-cut surfaces beyond this single URL helper.
- [N/A] Linked issue — found via code review; no existing issue.

## Impact

Fixes OpenRouter "Connect"/OAuth for any user whose port 3000 is occupied, and prevents the authorization code from being sent to an unrelated local server on port 3000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenRouter OAuth reliability by ensuring the generated `callback_url` uses the loopback listener’s actual bound port (instead of a fixed default), preventing redirects to an unlistening port.
  * Added test coverage for scenarios where the requested port is unavailable and an OS-assigned fallback port is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->