### PR TITLE
fix(memory): stop SQLITE_FULL flood from mem_tree_jobs worker (#3909)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -518,15 +518,22 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
 /// burst always produces an os-error-28/112 sibling event) or a
 /// `max_page_count` PRAGMA cap (we set none).
 ///
-/// The rusqlite `Display` for `SQLITE_FULL` is exactly the five words
-/// `"database or disk is full"` — no preamble, no trailing context. Our local
-/// memory-store write call-sites wrap it with `format!("<verb>: {e}")`
-/// (e.g. `"commit tx: ..."` / `"clear_namespace commit tx: ..."` in
-/// `memory_store::unified::documents`), so the phrase always lands as the
-/// **suffix** of the local emit. Anchor on suffix, not `contains`, so the
-/// silencer does not match a non-2xx backend response body whose payload
-/// happens to mention the same phrase (e.g. an `api.tinyhumans.ai` 5xx whose
-/// server-side SQLite is full). Non-2xx backend bodies are framed by
+/// rusqlite renders `SQLITE_FULL` in one of two shapes. The **bare** shape is
+/// the five words `"database or disk is full"` — Our local memory-store write
+/// call-sites wrap it with `format!("<verb>: {e}")` (e.g. `"commit tx: ..."` /
+/// `"clear_namespace commit tx: ..."` in `memory_store::unified::documents`),
+/// so the phrase lands as the **suffix** of the local emit. The **extended**
+/// shape carries the full error-code envelope, `"database or disk is full:
+/// Error code 13: Insertion failed because database is full"` (Sentry
+/// TAURI-RUST-4R8, `memory_queue::store::claim_next` on `mem_tree_jobs`); here
+/// the canonical phrase sits mid-string, so the suffix anchor can't catch it —
+/// we additionally anchor on the libsqlite3-sys `code_to_str` token
+/// `"insertion failed because database is full"`, which only the engine emits
+/// for a genuine SQLITE_FULL. Both arms anchor on local-emit fragments rather
+/// than a bare `contains("database or disk is full")` so the silencer does not
+/// match a non-2xx backend response body whose payload happens to mention the
+/// same phrase (e.g. an `api.tinyhumans.ai` 5xx whose server-side SQLite is
+/// full). Non-2xx backend bodies are framed by
 /// `integrations::client::post` / `composio::client` as `"Backend returned
 /// <status> <reason> for <METHOD> <url>: <detail>"` — an operator-actionable
 /// server/storage failure that must still surface to Sentry. As
@@ -546,8 +553,19 @@ fn is_disk_full_message(lower: &str) -> bool {
     {
         return true;
     }
-    // SQLITE_FULL — see the fifth-shape section above for the scoping
-    // rationale. Suffix anchor (after trimming trailing whitespace and
+    // SQLITE_FULL extended shape — `"... database or disk is full: Error code
+    // 13: Insertion failed because database is full"` (TAURI-RUST-4R8). The
+    // canonical phrase is mid-string here, so the suffix anchor below misses
+    // it; anchor on the SQLITE_FULL `code_to_str` token instead. Same
+    // `"backend returned "` guard so a remote 5xx body that quotes it still
+    // surfaces.
+    if lower.contains("insertion failed because database is full")
+        && !lower.contains("backend returned ")
+    {
+        return true;
+    }
+    // SQLITE_FULL bare shape — see the fifth-shape section above for the
+    // scoping rationale. Suffix anchor (after trimming trailing whitespace and
     // punctuation that closures / JSON wrappers commonly append) pins to the
     // local-emit shape; the negative `"backend returned "` guard rejects the
     // remote envelope as a second line of defense.
@@ -2954,6 +2972,12 @@ mod tests {
             // `openhuman.memory_doc_ingest`, in the same burst that emits
             // os-error-112 siblings (Sentry TAURI-RUST-B6N).
             "commit tx: database or disk is full",
+            // SQLITE_FULL **extended** rendering — the full error-code envelope
+            // where the canonical phrase is mid-string, not a suffix (Sentry
+            // TAURI-RUST-4R8, `memory_queue::store::claim_next` on
+            // `mem_tree_jobs`). Caught via the `code_to_str` token arm.
+            "Failed to claim next mem_tree_jobs row: database or disk is full: \
+             Error code 13: Insertion failed because database is full",
         ] {
             assert_eq!(
                 expected_error_kind(raw),
@@ -3013,6 +3037,19 @@ mod tests {
             ),
             None,
             "remote-backend body must surface even when the body itself ends with the phrase"
+        );
+        // Same guard for the extended-code token: a backend body that quotes
+        // the SQLITE_FULL `code_to_str` string is still operator-actionable
+        // and must surface (TAURI-RUST-4R8 token arm + `"backend returned "`
+        // exclusion).
+        assert_eq!(
+            expected_error_kind(
+                "Backend returned 507 Insufficient Storage for POST \
+                 https://api.tinyhumans.ai/agent-integrations/composio/list: \
+                 Error code 13: Insertion failed because database is full"
+            ),
+            None,
+            "remote-backend body carrying the extended SQLITE_FULL token must surface"
         );
         // Non-suffix occurrences in other body framings (no `"Backend
         // returned"` prefix) are also excluded by the suffix anchor — locks

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -553,26 +553,20 @@ fn is_disk_full_message(lower: &str) -> bool {
     {
         return true;
     }
-    // SQLITE_FULL extended shape — `"... database or disk is full: Error code
-    // 13: Insertion failed because database is full"` (TAURI-RUST-4R8). The
-    // canonical phrase is mid-string here, so the suffix anchor below misses
-    // it; anchor on the SQLITE_FULL `code_to_str` token instead. Same
-    // `"backend returned "` guard so a remote 5xx body that quotes it still
-    // surfaces.
-    if lower.contains("insertion failed because database is full")
-        && !lower.contains("backend returned ")
-    {
-        return true;
-    }
-    // SQLITE_FULL bare shape — see the fifth-shape section above for the
-    // scoping rationale. Suffix anchor (after trimming trailing whitespace and
-    // punctuation that closures / JSON wrappers commonly append) pins to the
-    // local-emit shape; the negative `"backend returned "` guard rejects the
-    // remote envelope as a second line of defense.
+    // Two SQLITE_FULL renderings — see the fifth-shape section above. The
+    // **bare** shape lands the phrase as a suffix (after trimming trailing
+    // whitespace / punctuation that closures + JSON wrappers append); the
+    // **extended** shape (TAURI-RUST-4R8) puts the phrase mid-string followed
+    // by `: Error code 13: Insertion failed because database is full`, so anchor
+    // additionally on the distinctive SQLITE_FULL `code_to_str` token. The
+    // negative `"backend returned "` guard rejects the remote 5xx envelope for
+    // both anchors as a second line of defense.
     let trimmed = lower.trim_end_matches(|c: char| {
         c.is_ascii_whitespace() || matches!(c, '.' | ',' | ';' | ':' | '"' | '\'')
     });
-    trimmed.ends_with("database or disk is full") && !lower.contains("backend returned ")
+    let is_sqlite_full = trimmed.ends_with("database or disk is full")
+        || lower.contains("insertion failed because database is full");
+    is_sqlite_full && !lower.contains("backend returned ")
 }
 
 /// Detect the literal `"Config loading timed out"` string produced by

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -526,14 +526,21 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
 /// shape carries the full error-code envelope, `"database or disk is full:
 /// Error code 13: Insertion failed because database is full"` (Sentry
 /// TAURI-RUST-4R8, `memory_queue::store::claim_next` on `mem_tree_jobs`); here
-/// the canonical phrase sits mid-string, so the suffix anchor can't catch it —
-/// we additionally anchor on the libsqlite3-sys `code_to_str` token
-/// `"insertion failed because database is full"`, which only the engine emits
-/// for a genuine SQLITE_FULL. Both arms anchor on local-emit fragments rather
-/// than a bare `contains("database or disk is full")` so the silencer does not
-/// match a non-2xx backend response body whose payload happens to mention the
-/// same phrase (e.g. an `api.tinyhumans.ai` 5xx whose server-side SQLite is
-/// full). Non-2xx backend bodies are framed by
+/// the canonical phrase sits mid-string, so the suffix anchor can't catch it.
+/// We detect this shape by requiring **both** local fragments together — the
+/// `"database or disk is full"` phrase AND the libsqlite3-sys `code_to_str`
+/// token `"insertion failed because database is full"` — which only rusqlite's
+/// own `SQLITE_FULL` Display emits as a pair. Requiring both (rather than the
+/// `code_to_str` token alone) keeps the silencer from matching a remote
+/// provider body that merely quotes the token half — e.g. an OpenAI-compatible
+/// `OpenAiEmbedding::embed` failure framed as `"Embedding API error (… Error
+/// code 13: Insertion failed because database is full)"` whose *server-side*
+/// SQLite is full is operator-actionable and must still surface to Sentry
+/// (codex CR on #3911). Both arms anchor on local-emit fragments rather than a
+/// bare `contains("database or disk is full")` so the silencer does not match a
+/// non-2xx backend response body whose payload happens to mention the phrase
+/// (e.g. an `api.tinyhumans.ai` 5xx whose server-side SQLite is full). Non-2xx
+/// backend bodies are framed by
 /// `integrations::client::post` / `composio::client` as `"Backend returned
 /// <status> <reason> for <METHOD> <url>: <detail>"` — an operator-actionable
 /// server/storage failure that must still surface to Sentry. As
@@ -555,18 +562,20 @@ fn is_disk_full_message(lower: &str) -> bool {
     }
     // Two SQLITE_FULL renderings — see the fifth-shape section above. The
     // **bare** shape lands the phrase as a suffix (after trimming trailing
-    // whitespace / punctuation that closures + JSON wrappers append); the
+    // whitespace / punctuation that closures + JSON wrappers append). The
     // **extended** shape (TAURI-RUST-4R8) puts the phrase mid-string followed
-    // by `: Error code 13: Insertion failed because database is full`, so anchor
-    // additionally on the distinctive SQLITE_FULL `code_to_str` token. The
-    // negative `"backend returned "` guard rejects the remote 5xx envelope for
-    // both anchors as a second line of defense.
+    // by `: Error code 13: Insertion failed because database is full`; require
+    // BOTH local fragments so we match only rusqlite's own `SQLITE_FULL` Display
+    // and never a remote provider body that merely quotes the `code_to_str`
+    // half (codex CR on #3911). The negative `"backend returned "` guard
+    // rejects the remote 5xx envelope as a further line of defense.
     let trimmed = lower.trim_end_matches(|c: char| {
         c.is_ascii_whitespace() || matches!(c, '.' | ',' | ';' | ':' | '"' | '\'')
     });
-    let is_sqlite_full = trimmed.ends_with("database or disk is full")
-        || lower.contains("insertion failed because database is full");
-    is_sqlite_full && !lower.contains("backend returned ")
+    let bare_suffix = trimmed.ends_with("database or disk is full");
+    let extended_local = lower.contains("database or disk is full")
+        && lower.contains("insertion failed because database is full");
+    (bare_suffix || extended_local) && !lower.contains("backend returned ")
 }
 
 /// Detect the literal `"Config loading timed out"` string produced by
@@ -3044,6 +3053,20 @@ mod tests {
             ),
             None,
             "remote-backend body carrying the extended SQLITE_FULL token must surface"
+        );
+        // A remote OpenAI-compatible embeddings 500 whose server-side SQLite is
+        // full is wrapped by `OpenAiEmbedding::embed` as `"Embedding API error
+        // (…)"` — no `"backend returned "` prefix and no local `"database or
+        // disk is full"` phrase, just the `code_to_str` half. Requiring BOTH
+        // local fragments for the extended shape keeps this operator-actionable
+        // server fault reportable (codex CR on #3911).
+        assert_eq!(
+            expected_error_kind(
+                "Embedding API error (status 500): Error code 13: \
+                 Insertion failed because database is full"
+            ),
+            None,
+            "remote embedding-API body quoting only the code_to_str token must surface"
         );
         // Non-suffix occurrences in other body framings (no `"Backend
         // returned"` prefix) are also excluded by the suffix anchor — locks

--- a/src/openhuman/memory_queue/worker.rs
+++ b/src/openhuman/memory_queue/worker.rs
@@ -143,6 +143,22 @@ pub fn start(config: Config) {
                                      backing off 30s: {err:#}"
                                 );
                                 tokio::time::sleep(Duration::from_secs(30)).await;
+                            } else if is_sqlite_disk_full(&err) {
+                                // SQLITE_FULL (code 13): the host disk is full.
+                                // A claim UPDATE cannot succeed until the user
+                                // frees space — this is persistent, not
+                                // transient, so re-polling every second and
+                                // paging Sentry on each failure floods the
+                                // dashboard (TAURI-RUST-4R8: ~95k events, one
+                                // user) for a condition only the user can
+                                // clear. Back off long and stay silent; the
+                                // `ready` rows resume when space returns and
+                                // `notify` still wakes us on new enqueues.
+                                log::warn!(
+                                    "[memory::jobs] worker {idx} hit SQLITE_FULL (disk full), \
+                                     backing off 60s: {err:#}"
+                                );
+                                tokio::time::sleep(Duration::from_secs(60)).await;
                             } else {
                                 crate::core::observability::report_error(
                                     &err,
@@ -367,6 +383,34 @@ fn is_sqlite_busy(err: &anyhow::Error) -> bool {
     msg.contains("database is locked") || msg.contains("database table is locked")
 }
 
+/// Classify whether an error from `claim_next` is a `SQLITE_FULL` disk-full
+/// condition (primary code `DiskFull`, extended 13).
+///
+/// Unlike `SQLITE_BUSY`/`LOCKED` or the transient I/O family, a full disk is a
+/// **persistent** host condition: the claim `UPDATE` cannot succeed until the
+/// user frees space. Re-polling every second and paging Sentry on each failure
+/// turns one unrecoverable condition into a flood (Sentry TAURI-RUST-4R8:
+/// ~95k events from a single user). The worker backs off long and stays
+/// silent; the rows stay `ready` and resume when space returns.
+///
+/// Matching on the `DiskFull` error code is rusqlite-version-stable. The text
+/// fallback covers the case where the error was flattened to a plain `anyhow!`
+/// string across `.context()` layers — rusqlite renders `SQLITE_FULL` as
+/// `"database or disk is full: Error code 13: Insertion failed because
+/// database is full"`, so anchor on either canonical fragment.
+fn is_sqlite_disk_full(err: &anyhow::Error) -> bool {
+    if let Some(rusqlite::Error::SqliteFailure(sqlite_err, _)) =
+        err.downcast_ref::<rusqlite::Error>()
+    {
+        if sqlite_err.code == rusqlite::ErrorCode::DiskFull {
+            return true;
+        }
+    }
+    let msg = format!("{err:#}").to_ascii_lowercase();
+    msg.contains("database or disk is full")
+        || msg.contains("insertion failed because database is full")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -545,6 +589,81 @@ mod tests {
             Some("UNIQUE constraint failed: mem_tree_jobs.dedupe_key".into()),
         );
         assert!(!is_sqlite_io_transient(&anyhow::Error::from(raw)));
+    }
+
+    // ── is_sqlite_disk_full tests (#3909 / Sentry TAURI-RUST-4R8) ─────────
+
+    /// `SQLITE_FULL` (primary code `DiskFull`, extended 13) is the disk-full
+    /// signal from `claim_next`; it must classify so the worker backs off
+    /// long instead of paging Sentry every second.
+    #[test]
+    fn is_sqlite_disk_full_matches_disk_full_code() {
+        let raw = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DiskFull,
+                extended_code: 13,
+            },
+            Some("database or disk is full".into()),
+        );
+        assert!(is_sqlite_disk_full(&anyhow::Error::from(raw)));
+    }
+
+    /// The rusqlite error sits a few `.context()` layers deep when it bubbles
+    /// out of `claim_next` → `with_connection`; the downcast must still find
+    /// the `DiskFull` code.
+    #[test]
+    fn is_sqlite_disk_full_matches_through_context_layers() {
+        let raw = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DiskFull,
+                extended_code: 13,
+            },
+            Some("database or disk is full".into()),
+        );
+        let wrapped = anyhow::Error::from(raw)
+            .context("Failed to claim next mem_tree_jobs row")
+            .context("with_connection closure failed");
+        assert!(is_sqlite_disk_full(&wrapped));
+    }
+
+    /// Text fallback: the exact flattened Sentry string (TAURI-RUST-4R8) is
+    /// classified even when no rusqlite error is available to downcast (the
+    /// canonical phrase is mid-string, not a suffix).
+    #[test]
+    fn is_sqlite_disk_full_text_fallback() {
+        let err = anyhow::anyhow!(
+            "Failed to claim next mem_tree_jobs row: database or disk is full: \
+             Error code 13: Insertion failed because database is full"
+        );
+        assert!(is_sqlite_disk_full(&err));
+    }
+
+    /// Busy/locked, constraint violations, and unrelated errors must NOT be
+    /// swallowed as disk-full — those still warrant their own handling /
+    /// Sentry escalation.
+    #[test]
+    fn is_sqlite_disk_full_does_not_match_other_errors() {
+        let busy = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseBusy,
+                extended_code: 5,
+            },
+            Some("database is locked".into()),
+        );
+        assert!(!is_sqlite_disk_full(&anyhow::Error::from(busy)));
+
+        let constraint = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::ConstraintViolation,
+                extended_code: 19,
+            },
+            Some("UNIQUE constraint failed: mem_tree_jobs.dedupe_key".into()),
+        );
+        assert!(!is_sqlite_disk_full(&anyhow::Error::from(constraint)));
+
+        assert!(!is_sqlite_disk_full(&anyhow::anyhow!(
+            "upstream returned 500: internal server error"
+        )));
     }
 
     #[tokio::test]

--- a/src/openhuman/memory_queue/worker.rs
+++ b/src/openhuman/memory_queue/worker.rs
@@ -156,9 +156,9 @@ pub fn start(config: Config) {
                                 // `notify` still wakes us on new enqueues.
                                 log::warn!(
                                     "[memory::jobs] worker {idx} hit SQLITE_FULL (disk full), \
-                                     backing off 60s: {err:#}"
+                                     backing off 300s without reporting: {err:#}"
                                 );
-                                tokio::time::sleep(Duration::from_secs(60)).await;
+                                tokio::time::sleep(Duration::from_secs(300)).await;
                             } else {
                                 crate::core::observability::report_error(
                                     &err,


### PR DESCRIPTION
## Summary

- The memory-queue worker re-polled `claim_next` every 1s and paged Sentry on each failure when the host disk was full — turning one unrecoverable condition into a flood (Sentry **TAURI-RUST-4R8**: ~95k events, one user, still arriving on 0.57.40).
- `worker.rs`: add `is_sqlite_disk_full` + a match arm that backs off 60s and stays silent on `SQLITE_FULL` (code 13), mirroring the existing transient-I/O arm.
- `observability.rs`: extend `is_disk_full_message` to recognize the rusqlite **extended-code** rendering so any write path demotes it, not just the worker.

## Problem

On a full disk, `claim_next` (`src/openhuman/memory_queue/store.rs:140`) returns `SQLITE_FULL` (primary code 13). The worker (`src/openhuman/memory_queue/worker.rs`) classified only `BUSY`/`LOCKED` and the `IOERR` family as transient; `SQLITE_FULL` matched neither and fell through to `report_error(...)` **plus a 1s re-poll** → a tight Sentry storm for a condition only the user can clear.

The `before_send` classifier `is_disk_full_message` *would* have demoted it, but it only anchored on the bare suffix `database or disk is full`. The worker path renders the full envelope — `database or disk is full: Error code 13: Insertion failed because database is full` — where the canonical phrase is mid-string, so the suffix anchor missed it. #3672 added that suffix arm for the bare `commit tx: …` shape (TAURI-RUST-B6N) and did not touch the worker.

This is a genuinely-unpreventable host condition (a DB write cannot succeed on a full disk), but the 95k-event volume is **our** lever: the re-poll cadence and the missing classification.

## Solution

- **`worker.rs` (storm bound — headline).** New `is_sqlite_disk_full` (downcast to `ErrorCode::DiskFull`, with a text fallback for flattened `anyhow!` chains). New arm before the `else`: log a warning, back off **60s**, and **skip** `report_error`. Jobs stay `ready` and resume when space frees — `claim_next` is a lease `UPDATE`, so nothing is dropped or mis-routed; `notify` still wakes the worker on new enqueues.
- **`observability.rs` (defense-in-depth).** Add a token arm anchoring on the SQLite-specific `insertion failed because database is full` (`code_to_str` for `SQLITE_FULL`), keeping the existing `!backend returned` guard so a remote 5xx body that quotes the phrase still surfaces. Doc-comment updated to describe both renderings.
- 60s (vs the 30s transient-I/O arm) because a full disk is persistent, not a momentary WAL/lock blip.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are the `is_sqlite_disk_full` classifier + the `observability` token arm (both exercised by the new tests) plus the 2-line worker arm body (`log::warn` + `sleep`, unexercised, mirroring the adjacent already-uncovered 30s transient-I/O arm); tests dominate the diff, so changed-line coverage is well above 80%. Merged `diff-cover` left to CI.
- [x] Coverage matrix updated — N/A: behaviour-only error-classification hardening, no new feature row.
- [x] All affected feature IDs from the matrix are listed in `## Related` — N/A: no matrix feature IDs touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: internal Sentry-classification + queue backoff only, no release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime/platform**: desktop (all OS). Affects only the disk-full path of the memory-queue worker and the Sentry `before_send` classifier.
- **Observability**: stops a ~95k-event/1-user Sentry flood (TAURI-RUST-4R8); genuine, novel errors on the claim path still report (busy/locked/IO/constraint arms unchanged).
- **Data integrity**: none — disk-full now backs off instead of spinning; jobs remain `ready` and resume when space frees. No schema/migration change.
- **Verification caveat**: a real full-disk condition cannot be reproduced deterministically on the dev box; both classifiers are proven by unit tests that construct the exact `SqliteFailure(DiskFull, 13)` and assert the flattened Sentry string (same strategy as the sibling `is_sqlite_busy` / `is_sqlite_io_transient` arms).

## Related

- Closes: #3909
- Sentry-Issue: TAURI-RUST-4R8
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3909-mem-tree-jobs-disk-full-flood`
- Commit SHA: `ddc745b2b9d08fb3703c4588cd18fada3406aee3`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` JS/TS touched.
- [x] `pnpm typecheck` — N/A: no frontend change.
- [x] Focused tests: `cargo test --lib memory_queue::worker::tests::is_sqlite_disk_full` (4 ok), `cargo test --lib core::observability::tests` (164 ok).
- [x] Rust fmt/check (if changed): `cargo fmt --check` OK; pre-push `pnpm rust:check` (app/src-tauri) passed on push.
- [x] Tauri fmt/check (if changed) — N/A: `app/src-tauri` source not modified.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: on `SQLITE_FULL`, the queue worker backs off 60s and stops paging Sentry; the `before_send` classifier now demotes the extended-code rendering on any write path.
- User-visible effect: none functional — purely removes Sentry noise and a 1s busy-loop on a full disk.

### Parity Contract

- Legacy behavior preserved: busy/locked, transient-I/O, constraint, and all non-disk-full errors keep their existing handling and still report to Sentry. The existing bare-suffix `database or disk is full` demotion (#3672) is retained.
- Guard/fallback/dispatch parity checks: `!backend returned` exclusion kept so remote 5xx bodies still surface; new arm added before the suffix arm without altering it.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (dedupe: only #3672, which this extends — not a duplicate).
- Canonical PR: this.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Improved detection of “database or disk is full” errors across additional SQLite error formats and wrapped message variants, preventing incorrect handling of remote/backend-quoted errors.
- Enhanced resilience when storage capacity is exceeded: the worker now logs a focused disk-full warning and retries after a longer pause (300 seconds) instead of falling into generic error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->