### PR TITLE
fix(settings): call openhuman.agentbox_status from the AgentBox panel (#3914)

### DIFF
--- a/app/src/components/settings/panels/AgentBoxPanel.tsx
+++ b/app/src/components/settings/panels/AgentBoxPanel.tsx
@@ -44,7 +44,7 @@ const AgentBoxPanel = () => {
     setState({ kind: 'loading' });
     try {
       const status = await callCoreRpc<AgentBoxStatus>({
-        method: 'agentbox.status',
+        method: 'openhuman.agentbox_status',
         params: {},
         timeoutMs: 10_000,
       });

--- a/app/src/components/settings/panels/__tests__/AgentBoxPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AgentBoxPanel.test.tsx
@@ -36,7 +36,7 @@ describe('AgentBoxPanel', () => {
     expect(screen.getByText('https://api.gmi-serving.com')).toBeInTheDocument();
     expect(screen.getByText('deepseek-ai/DeepSeek-V4-Pro')).toBeInTheDocument();
     expect(hoisted.callCoreRpc).toHaveBeenCalledWith(
-      expect.objectContaining({ method: 'agentbox.status' })
+      expect.objectContaining({ method: 'openhuman.agentbox_status' })
     );
   });
 


### PR DESCRIPTION
## Summary

- Fix the AgentBox settings panel (Settings → Developer → AgentBox), which always rendered the "unavailable" card and never loaded its status.
- The panel called the bare `agentbox.status`; the dispatchable method is `openhuman.agentbox_status`. Corrected the caller and updated the panel's unit test to assert the canonical name.
- Frontend-only — no schema/dispatch/Rust change.

## Problem

The core builds every RPC method name as `openhuman.<namespace>_<function>` (`src/core/all.rs`). The AgentBox controller is registered with `namespace = "agentbox"` / function `status` (`src/openhuman/agentbox/schemas.rs`; the module doc states `openhuman.agentbox_status`). The panel (`app/src/components/settings/panels/AgentBoxPanel.tsx`) instead passed the bare `agentbox.status`, which `normalizeRpcMethod` does not rewrite — so dispatch missed, the panel showed the unavailable/error state, and the core emitted `unknown method: agentbox.status` (Sentry TAURI-RUST-ETZ, ~810 events / 82 users). Introduced by #3651.

## Solution

Change the caller to the canonical `openhuman.agentbox_status` and update the panel unit test to assert it (regression guard). **Verified live:** the panel now loads its status — "Marketplace mode: Disabled" + "GMI MaaS provider: Not configured" — with no `unknown method` error.

### Local validation
- `pnpm --filter openhuman-app run test src/components/settings/panels/__tests__/AgentBoxPanel.test.tsx` → 4/4 ✅
- `pnpm typecheck` ✅ · Prettier ✅ · ESLint ✅
- Manual: AgentBox panel loads status in a local desktop build ✅

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — the panel's existing unit test now asserts the canonical method name; the suite also covers the not-configured/error branches.
- [x] **Diff coverage ≥ 80%** — the only changed source line (the method string) is exercised by the panel unit test that asserts it; no Rust changed.
- [x] Coverage matrix updated — `N/A`: one-line method-name fix; no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A`: no matrix rows affected.
- [x] No new external network dependencies introduced — none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A`: settings-panel bug fix; no release-cut flow change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Platform:** desktop UI only. No backend/schema/migration impact.
- **Behavior:** the AgentBox status panel works (loads mode + GMI provider wiring) instead of always erroring; removes the recurring `unknown method: agentbox.status` Sentry warn-noise as a root-cause consequence (not a suppression).
- **Risk:** minimal — single method-name string, guarded by the panel unit test.

## Related

- Closes: #3914
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

`N/A` — human-authored PR.

### Linear Issue
- Key: `N/A`
- URL: `N/A`

### Commit & Branch
- Branch: `N/A`
- Commit SHA: `N/A`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — Prettier on changed files ✅
- [x] `pnpm typecheck` ✅
- [x] Focused tests: `AgentBoxPanel.test.tsx` (4/4) ✅
- [x] Rust fmt/check (if changed): N/A — no Rust changed.
- [x] Tauri fmt/check (if changed): N/A — no Tauri/`app/src-tauri` changed.

### Validation Blocked
- `command:` `N/A`
- `error:` `N/A`
- `impact:` `N/A`

### Behavior Changes
- Intended behavior change: `N/A`
- User-visible effect: `N/A`

### Parity Contract
- Legacy behavior preserved: `N/A`
- Guard/fallback/dispatch parity checks: `N/A`

### Duplicate / Superseded PR Handling
- Duplicate PR(s): `N/A`
- Canonical PR: `N/A`
- Resolution (closed/superseded/updated): `N/A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated agent box status retrieval to use the correct API method for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->