### PR TITLE
fix(settings): call canonical RPC name in Tool Policy diagnostics panel

### DIFF
--- a/app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.tsx
+++ b/app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.tsx
@@ -59,7 +59,7 @@ const ToolPolicyDiagnosticsPanel = () => {
     (async () => {
       try {
         const diagnostics = await callCoreRpc<ToolPolicyDiagnostics>({
-          method: 'tool_registry.diagnostics',
+          method: 'openhuman.tool_registry_diagnostics',
           params: {},
           timeoutMs: 10_000,
         });

--- a/app/src/components/settings/panels/__tests__/ToolPolicyDiagnosticsPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ToolPolicyDiagnosticsPanel.test.tsx
@@ -44,7 +44,9 @@ describe('ToolPolicyDiagnosticsPanel', () => {
     expect(screen.getByText(/Total tools/i)).toBeInTheDocument();
     expect(screen.getAllByText('10').length).toBeGreaterThan(0);
     expect(screen.getByText(/Recent \(24h\): 5/i)).toBeInTheDocument();
-    expect(hoisted.callCoreRpc).toHaveBeenCalled();
+    expect(hoisted.callCoreRpc).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'openhuman.tool_registry_diagnostics' })
+    );
   });
 
   test('renders unavailable card when the RPC throws', async () => {


### PR DESCRIPTION
## Summary

- Fix the Tool Policy diagnostics panel (Settings → Agents & Autonomy → Diagnostics), which always rendered the "Diagnostics unavailable" card and never loaded.
- The panel called the bare `tool_registry.diagnostics`; the dispatchable method is `openhuman.tool_registry_diagnostics`. Corrected the caller and updated the panel's unit test to assert the canonical name.
- Frontend-only — no schema/dispatch/Rust change.

## Problem

The core builds every RPC method name as `openhuman.<namespace>_<function>` (`src/core/all.rs`). The tool-registry diagnostics controller is registered with `namespace = "tool_registry"` / function `diagnostics` (`src/openhuman/tool_registry/schemas.rs`), i.e. `openhuman.tool_registry_diagnostics`. The panel (`app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.tsx`) instead passed the bare `tool_registry.diagnostics`, which `normalizeRpcMethod` does not rewrite — so dispatch missed and the panel showed its unavailable/error state.

## Solution

Change the caller to the canonical `openhuman.tool_registry_diagnostics` and update the panel unit test to assert it (regression guard). **Verified live:** the panel now loads — Policy posture, Inventory, MCP allowlists, MCP write audit, recent blocked calls, and redacted surfaces all populate, with no `unknown method` error.

### Local validation
- `pnpm --filter openhuman-app run test src/components/settings/panels/__tests__/ToolPolicyDiagnosticsPanel.test.tsx` → 4/4 ✅
- `pnpm typecheck` ✅ · Prettier ✅ · ESLint ✅
- Manual: Diagnostics panel loads in a local desktop build ✅

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — the panel's existing unit test now asserts the canonical method name; the suite also covers the unavailable/error and populated-allowlist/audit branches.
- [x] **Diff coverage ≥ 80%** — the only changed source line (the method string) is exercised by the panel unit test that asserts it; no Rust changed.
- [x] Coverage matrix updated — `N/A`: one-line method-name fix; no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A`: no matrix rows affected.
- [x] No new external network dependencies introduced — none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A`: settings-panel bug fix; no release-cut flow change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Platform:** desktop UI only. No backend/schema/migration impact.
- **Behavior:** the Tool Policy diagnostics panel works (loads posture + inventory + MCP allowlists/audit) instead of always erroring.
- **Risk:** minimal — single method-name string, guarded by the panel unit test.

## Related

- Closes: #3917
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

`N/A` — human-authored PR.

### Linear Issue
- Key: `N/A`
- URL: `N/A`

### Commit & Branch
- Branch: `N/A`
- Commit SHA: `N/A`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — Prettier on changed files ✅
- [x] `pnpm typecheck` ✅
- [x] Focused tests: `ToolPolicyDiagnosticsPanel.test.tsx` (4/4) ✅
- [x] Rust fmt/check (if changed): N/A — no Rust changed.
- [x] Tauri fmt/check (if changed): N/A — no Tauri/`app/src-tauri` changed.

### Validation Blocked
- `command:` `N/A`
- `error:` `N/A`
- `impact:` `N/A`

### Behavior Changes
- Intended behavior change: `N/A`
- User-visible effect: `N/A`

### Parity Contract
- Legacy behavior preserved: `N/A`
- Guard/fallback/dispatch parity checks: `N/A`

### Duplicate / Superseded PR Handling
- Duplicate PR(s): `N/A`
- Canonical PR: `N/A`
- Resolution (closed/superseded/updated): `N/A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tool policy diagnostics backend integration to use a new backend method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->