### PR TITLE
fix(agentbox): call core via openhuman.agentbox_status (#3914)

### DIFF
--- a/app/src/components/settings/panels/AgentBoxPanel.tsx
+++ b/app/src/components/settings/panels/AgentBoxPanel.tsx
@@ -44,7 +44,7 @@ const AgentBoxPanel = () => {
     setState({ kind: 'loading' });
     try {
       const status = await callCoreRpc<AgentBoxStatus>({
-        method: 'agentbox.status',
+        method: 'openhuman.agentbox_status',
         params: {},
         timeoutMs: 10_000,
       });

--- a/app/src/components/settings/panels/__tests__/AgentBoxPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AgentBoxPanel.test.tsx
@@ -36,7 +36,7 @@ describe('AgentBoxPanel', () => {
     expect(screen.getByText('https://api.gmi-serving.com')).toBeInTheDocument();
     expect(screen.getByText('deepseek-ai/DeepSeek-V4-Pro')).toBeInTheDocument();
     expect(hoisted.callCoreRpc).toHaveBeenCalledWith(
-      expect.objectContaining({ method: 'agentbox.status' })
+      expect.objectContaining({ method: 'openhuman.agentbox_status' })
     );
   });
 


### PR DESCRIPTION
## Summary

- Fix the AgentBox settings panel to call the core with the canonical JSON-RPC method `openhuman.agentbox_status` instead of the bare `agentbox.status`.
- Convert the panel unit test that asserted the wrong method name into a regression guard for the correct name.
- Frontend-only; no schema, dispatch, or Rust change.

## Problem

The core builds every RPC method name as `openhuman.<namespace>_<function>` (`src/core/all.rs`). The AgentBox controller registers `namespace = "agentbox"`, `function = "status"` (`src/openhuman/agentbox/schemas.rs`), so it is dispatchable only as `openhuman.agentbox_status` — exactly what the module doc states. The panel (`app/src/components/settings/panels/AgentBoxPanel.tsx`) instead invoked the bare `agentbox.status`; `normalizeRpcMethod` does not rewrite it, so dispatch missed. Result: the panel always errored and showed the unavailable card, and the core reported `unknown method: agentbox.status` to Sentry at warn (TAURI-RUST-ETZ — 810 events / 82 users since the feature shipped in #3651). Every other frontend caller already uses the fully-qualified `openhuman.*` form; AgentBox was the lone outlier.

## Solution

- Use the canonical method name `openhuman.agentbox_status` at the call site. The panel now reaches the real handler and renders the AgentBox status (mode flag + non-secret GMI provider wiring).
- Update the unit test to assert the canonical name, so a future regression to a bare/wrong method string fails CI.
- This is a root-cause fix: the feature works and the events stop at source. The `unknown method` Sentry warn in `dispatch.rs` is left untouched — it is the correct alarm, not something to suppress.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — both changed lines are exercised by `AgentBoxPanel.test.tsx` (4 tests, all green).
- [x] N/A: behaviour-only fix, no feature-matrix row changes — Coverage matrix
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: no release-cut surface touched — Manual smoke checklist
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop only. Settings → Developer → AgentBox panel now loads instead of always erroring.
- No performance, migration, or security implications. No API surface change (the method name was always the registered one; only the caller was wrong).
- Sentry: `unknown method: agentbox.status` stops at source once the fixed build ships. Pre-fix builds keep emitting until users update (expected tail); the Sentry issue is being resolved as `resolvedInNextRelease`.

## Related

- Closes: #3914
- Sentry: TAURI-RUST-ETZ
- Introduced by: #3651
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3914-agentbox-rpc-method
- Commit SHA: b76bdc3641d1927a1d22e0bfebb4c44c87dcddac

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/components/settings/panels/__tests__/AgentBoxPanel.test.tsx` — 4 passed
- [x] N/A: no Rust changed — Rust fmt/check
- [x] N/A: no Rust changed — Tauri fmt/check

### Validation Blocked

- `command:` pre-push `pnpm rust:check` (`cargo check --manifest-path app/src-tauri/Cargo.toml`)
- `error:` Command failed with signal "SIGTERM" — the CEF-heavy `src-tauri` check is killed under resource pressure before completing (no compile errors emitted; the core crate checks clean with 0 errors). Pushed with `--no-verify` per the project's documented allowance for unrelated transient hook breakage.
- `impact:` none — this PR changes only two frontend string literals and touches zero Rust.

### Behavior Changes

- Intended behavior change: AgentBox panel calls the correct core method.
- User-visible effect: the panel loads and shows AgentBox status instead of the unavailable/error card.

### Parity Contract

- Legacy behavior preserved: yes — the method name used is the one the core has always registered (`openhuman.agentbox_status`); no handler/schema/dispatch behavior changes.
- Guard/fallback/dispatch parity checks: the `unknown method` dispatch warn is intentionally left intact.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected agent box status checking by updating the API endpoint in the settings panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
