### PR TITLE
fix(settings): call registered openhuman.tool_registry_diagnostics RPC (#3917)

### DIFF
--- a/app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.test.tsx
+++ b/app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ToolPolicyDiagnosticsPanel from './ToolPolicyDiagnosticsPanel';
+
+const navigateBack = vi.fn();
+
+vi.mock('../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack,
+    breadcrumbs: [{ label: 'Settings' }, { label: 'Tool Policy' }],
+  }),
+}));
+
+vi.mock('../components/SettingsBackButton', () => ({
+  default: ({ onBack }: { onBack?: () => void }) => (
+    <button type="button" data-testid="settings-header-back" onClick={onBack}>
+      back
+    </button>
+  ),
+}));
+
+const callCoreRpc = vi.fn();
+vi.mock('../../../services/coreRpcClient', () => ({
+  callCoreRpc: (arg: { method: string; params: unknown }) => callCoreRpc(arg),
+}));
+
+function diagnosticsResult(autonomyLevel = 'supervised') {
+  return {
+    total_tools: 12,
+    enabled_tools: 9,
+    mcp_stdio_tools: 3,
+    json_rpc_tools: 9,
+    possible_write_surfaces: ['memory.put'],
+    policy_surfaces: ['tool_registry.diagnostics'],
+    posture: {
+      autonomy_level: autonomyLevel,
+      workspace_only: true,
+      max_actions_per_hour: 30,
+      require_approval_for_medium_risk: true,
+      block_high_risk_commands: true,
+    },
+    mcp_allowlists: { enabled: false, server_count: 0, enabled_server_count: 0, servers: [] },
+    mcp_write_audit: { enabled: false, recent_rows: null, last_error: null },
+    recent_denials: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  callCoreRpc.mockResolvedValue(diagnosticsResult());
+});
+
+describe('<ToolPolicyDiagnosticsPanel />', () => {
+  // Regression for TAURI-RUST-83E: the panel previously called the bare,
+  // unregistered `tool_registry.diagnostics`, which the core dispatcher rejects
+  // with "unknown method" (the registered name is the namespaced
+  // `openhuman.tool_registry_diagnostics`). The mismatch broke the panel for
+  // every user and flooded Sentry. Pin the exact registered method name.
+  it('invokes the registered openhuman.tool_registry_diagnostics RPC method', async () => {
+    render(<ToolPolicyDiagnosticsPanel />);
+
+    await waitFor(() => {
+      expect(callCoreRpc).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'openhuman.tool_registry_diagnostics' })
+      );
+    });
+  });
+
+  it('renders the diagnostics posture once the RPC resolves', async () => {
+    render(<ToolPolicyDiagnosticsPanel />);
+
+    // The autonomy level only renders in the ready state, so finding it also
+    // proves the panel left loading and did not fall into the error branch.
+    expect(await screen.findByText('supervised')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.tsx
+++ b/app/src/components/settings/panels/ToolPolicyDiagnosticsPanel.tsx
@@ -59,7 +59,7 @@ const ToolPolicyDiagnosticsPanel = () => {
     (async () => {
       try {
         const diagnostics = await callCoreRpc<ToolPolicyDiagnostics>({
-          method: 'tool_registry.diagnostics',
+          method: 'openhuman.tool_registry_diagnostics',
           params: {},
           timeoutMs: 10_000,
         });


### PR DESCRIPTION
## Summary

- Fix the **Settings → Developer & Diagnostics → Tool Policy** panel, which errored for every user who opened it.
- The panel called the unregistered JSON-RPC method `tool_registry.diagnostics`; corrected to the registered `openhuman.tool_registry_diagnostics`.
- Add a regression test pinning the exact registered method name.

## Problem

`ToolPolicyDiagnosticsPanel.tsx` invoked `callCoreRpc({ method: 'tool_registry.diagnostics' })`. Core controllers are registered as `openhuman.<namespace>_<function>` — `rpc_method_name()` builds `format!("openhuman.{}_{}", namespace, function)` (`src/core/all.rs:474`), so the real name is `openhuman.tool_registry_diagnostics`. The frontend string was missing the `openhuman.` prefix and used a `.` separator instead of `_`, so the method never resolved.

Result: the dispatcher returned `unknown method: tool_registry.diagnostics`, the panel fell into its error state for everyone, and the miss flooded the warn-level Sentry channel — TAURI-RUST-83E: **1242 events / 75 users**, first seen on `0.57.5`, still active. Exposure widened by #3639 dropping the dev-mode gate (panel now always visible). Wrong since the panel was introduced (972e3273).

## Solution

- Correct the method name to the registered `openhuman.tool_registry_diagnostics` (one-line change).
- Add `ToolPolicyDiagnosticsPanel.test.tsx`: asserts the panel invokes the registered method (regression guard) and renders the ready/posture state on success.
- Deliberately **not** added to `KNOWN_PROBE_METHODS` — that allow-list suppresses Sentry for genuine non-actionable probes. This is a real defect (broken panel), so the fix is to make the call resolve, not to silence the symptom.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — regression test pins the registered method + asserts the ready state (the prior bug surfaced as the error state).
- [x] **Diff coverage ≥ 80%** — changed lines are the method string + its test; both exercised by the new test.
- [x] N/A: bug fix, no feature row added/removed/renamed — Coverage matrix updated
- [x] N/A: no matrix change — All affected feature IDs from the matrix are listed
- [x] No new external network dependencies introduced — test mocks `callCoreRpc`.
- [x] N/A: no release-cut surface change — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop only; frontend-only one-line change plus a unit test. No Rust, API, or schema change.
- Restores the Tool Policy Diagnostics panel and removes the recurring warn-level Sentry noise (TAURI-RUST-83E) as a consequence of the real fix.

## Related

- Closes: #3917
- Sentry-Issue: TAURI-RUST-83E
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3917-tool-registry-diagnostics-rpc-method`
- Commit SHA: `2db8869e932e010537ceaf96a95a683e9301add1`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — touched files clean (prettier)
- [x] `pnpm typecheck` — clean
- [x] Focused tests: `pnpm debug unit src/components/settings/panels/ToolPolicyDiagnosticsPanel.test.tsx` — 2/2 pass
- [x] N/A: no Rust change — Rust fmt/check (if changed)
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml` — exit 0 (ran via pre-push hook)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Tool Policy Diagnostics panel loads instead of erroring.
- User-visible effect: panel renders posture/inventory diagnostics; no more silent error state.

### Parity Contract

- Legacy behavior preserved: same panel UI/data contract; only the RPC method string corrected to the name the core already exposes.
- Guard/fallback/dispatch parity checks: registered method confirmed via `rpc_method_name` (`src/core/all.rs`) and existing Rust e2e (`tests/*` call `openhuman.tool_registry_diagnostics`).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 30d-merged for `tool_registry`/`diagnostics`)
- Canonical PR: this
- Resolution: N/A
