### PR TITLE
fix(settings): prompt for managed embeddings sign-in

### DIFF
--- a/app/src/components/settings/panels/EmbeddingsPanel.tsx
+++ b/app/src/components/settings/panels/EmbeddingsPanel.tsx
@@ -5,9 +5,12 @@
  * to enter the key, test connection, and save. Dimension changes show a
  * destructive confirm dialog since they invalidate stored vectors.
  */
+import debugFactory from 'debug';
 import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useT } from '../../../lib/i18n/I18nContext';
+import { useCoreState } from '../../../providers/CoreStateProvider';
 import {
   clearEmbeddingsApiKey,
   type EmbeddingProviderEntry,
@@ -18,6 +21,7 @@ import {
   testEmbeddingsConnection,
   updateEmbeddingsSettings,
 } from '../../../services/api/embeddingsApi';
+import { isLocalSessionToken } from '../../../utils/localSession';
 import PanelPage from '../../layout/PanelPage';
 import Button from '../../ui/Button';
 import SettingsBackButton from '../components/SettingsBackButton';
@@ -42,9 +46,15 @@ interface EmbeddingsPanelProps {
   embedded?: boolean;
 }
 
+const log = debugFactory('app:settings:embeddings');
+const MANAGED_BACKEND_SESSION_ERROR = /No backend session for cloud embeddings/i;
+
 const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
   const { t } = useT();
+  const navigate = useNavigate();
+  const { clearSession, snapshot } = useCoreState();
   const { navigateBack } = useSettingsNavigation();
+  const isLocalSession = isLocalSessionToken(snapshot.sessionToken);
 
   const [settings, setSettings] = useState<EmbeddingsSettings | null>(null);
   const [status, setStatus] = useState<Status>({ kind: 'loading' });
@@ -57,6 +67,7 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
   const [setupTestResult, setSetupTestResult] = useState<EmbeddingsTestResult | null>(null);
   const [setupSaving, setSetupSaving] = useState(false);
   const [setupError, setSetupError] = useState('');
+  const [managedSignInPromptVisible, setManagedSignInPromptVisible] = useState(false);
 
   // Confirm wipe dialog
   const [pendingWipe, setPendingWipe] = useState<{
@@ -110,9 +121,21 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
   const currentModels = currentEntry?.models ?? [];
   const currentModel = currentModels.find(m => m.id === settings.model) ?? currentModels[0];
   const allowedDims = currentModel?.allowed_dimensions ?? [];
+  const managedBlocked = isLocalSession && selectedProvider === 'managed';
+  const showManagedSignInPrompt = managedBlocked || managedSignInPromptVisible;
+  const managedSignInMessage = t('settings.embeddings.managedSignInMessage');
 
   function handleProviderClick(entry: EmbeddingProviderEntry) {
     if (entry.slug === selectedProvider) return;
+
+    if (entry.slug === 'managed' && isLocalSession) {
+      log('[ui-flow] blocked managed provider switch for local session');
+      setManagedSignInPromptVisible(true);
+      setStatus({ kind: 'error', message: managedSignInMessage });
+      return;
+    }
+
+    setManagedSignInPromptVisible(false);
 
     if (entry.slug === 'custom') {
       // For custom, open setup popup to enter endpoint
@@ -338,12 +361,45 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
     try {
       const result = await testEmbeddingsConnection();
       if (result.success) {
+        setManagedSignInPromptVisible(false);
         setStatus({ kind: 'saved' });
+      } else if (
+        selectedProvider === 'managed' &&
+        result.error &&
+        MANAGED_BACKEND_SESSION_ERROR.test(result.error)
+      ) {
+        log('[ui-flow] mapped managed embeddings backend-session test failure to sign-in guidance');
+        setManagedSignInPromptVisible(true);
+        setStatus({ kind: 'error', message: managedSignInMessage });
       } else {
-        setStatus({ kind: 'error', message: result.error ?? 'Test failed' });
+        setStatus({
+          kind: 'error',
+          message: result.error ?? t('settings.embeddings.testFailedFallback'),
+        });
       }
     } catch (err) {
-      setStatus({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      if (selectedProvider === 'managed' && MANAGED_BACKEND_SESSION_ERROR.test(message)) {
+        log(
+          '[ui-flow] mapped managed embeddings thrown backend-session failure to sign-in guidance'
+        );
+        setManagedSignInPromptVisible(true);
+        setStatus({ kind: 'error', message: managedSignInMessage });
+      } else {
+        setStatus({ kind: 'error', message });
+      }
+    }
+  }
+
+  async function handleManagedSignIn() {
+    log('[ui-flow] managed embeddings sign-in recovery clicked');
+    try {
+      await clearSession();
+      navigate('/', { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log('[ui-flow] managed embeddings sign-in recovery failed: %s', message);
+      setStatus({ kind: 'error', message });
     }
   }
 
@@ -389,6 +445,11 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
                             : t('settings.embeddings.statusNeedsKey')}
                         </SettingsBadge>
                       )}
+                      {entry.slug === 'managed' && isLocalSession && (
+                        <SettingsBadge variant="warning">
+                          {t('settings.embeddings.statusNeedsSignIn')}
+                        </SettingsBadge>
+                      )}
                     </span>
                     <span className="block mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">
                       {entry.description}
@@ -421,6 +482,21 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
             <p className="text-xs text-amber-800 dark:text-amber-200 leading-relaxed">
               {t('settings.embeddings.vectorSearchDisabled')}
             </p>
+          </div>
+        )}
+
+        {showManagedSignInPrompt && (
+          <div className="rounded-xl border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-900/10 p-3 space-y-3">
+            <p className="text-xs text-amber-800 dark:text-amber-200 leading-relaxed">
+              {managedSignInMessage}
+            </p>
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              onClick={() => void handleManagedSignIn()}>
+              {t('settings.embeddings.signInAgain')}
+            </Button>
           </div>
         )}
 
@@ -487,7 +563,8 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
                   variant="secondary"
                   size="xs"
                   onClick={() => void handleTestConnection()}
-                  disabled={selectedProvider === 'none'}>
+                  disabled={selectedProvider === 'none' || managedBlocked}
+                  title={managedBlocked ? managedSignInMessage : undefined}>
                   {t('settings.embeddings.testConnection')}
                 </Button>
               </div>

--- a/app/src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx
@@ -10,6 +10,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { patchCoreStateSnapshot } from '../../../../lib/coreState/store';
 import {
   clearEmbeddingsApiKey,
   type EmbeddingProviderEntry,
@@ -20,6 +21,7 @@ import {
   updateEmbeddingsSettings,
 } from '../../../../services/api/embeddingsApi';
 import { renderWithProviders } from '../../../../test/test-utils';
+import { createLocalSessionToken } from '../../../../utils/localSession';
 import EmbeddingsPanel from '../EmbeddingsPanel';
 
 vi.mock('../../../../services/api/embeddingsApi', () => ({
@@ -76,6 +78,7 @@ const makeSettings = (overrides: Partial<EmbeddingsSettings> = {}): EmbeddingsSe
 describe('EmbeddingsPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    patchCoreStateSnapshot({ snapshot: { sessionToken: null } });
     vi.mocked(loadEmbeddingsSettings).mockResolvedValue(makeSettings());
     vi.mocked(updateEmbeddingsSettings).mockResolvedValue({
       provider: 'managed',
@@ -158,6 +161,41 @@ describe('EmbeddingsPanel', () => {
     // No RPC — already selected
     await new Promise(r => setTimeout(r, 50));
     expect(vi.mocked(updateEmbeddingsSettings)).not.toHaveBeenCalled();
+  });
+
+  it('labels selected Managed embeddings as requiring sign-in during local sessions', async () => {
+    patchCoreStateSnapshot({ snapshot: { sessionToken: createLocalSessionToken() } });
+
+    renderWithProviders(<EmbeddingsPanel />);
+
+    expect(await screen.findByText('Requires sign-in')).toBeInTheDocument();
+    expect(screen.getByText(/Managed embeddings require OpenHuman sign-in/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /test connection/i })).toBeDisabled();
+  });
+
+  it('blocks switching to Managed embeddings during local sessions', async () => {
+    patchCoreStateSnapshot({ snapshot: { sessionToken: createLocalSessionToken() } });
+    const settings = makeSettings({
+      provider: 'openai',
+      model: 'openai-model-v1',
+      providers: [
+        makeProvider('managed', { requires_api_key: false }),
+        makeProvider('openai', { requires_api_key: true, has_api_key: true }),
+      ],
+    });
+    vi.mocked(loadEmbeddingsSettings).mockResolvedValue(settings);
+
+    renderWithProviders(<EmbeddingsPanel />);
+    await screen.findByText('Managed');
+
+    fireEvent.click(screen.getByRole('radio', { name: /managed/i }));
+
+    expect(vi.mocked(updateEmbeddingsSettings)).not.toHaveBeenCalled();
+    expect(
+      (await screen.findAllByText(/Managed embeddings require OpenHuman sign-in/i)).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /sign in again/i })).toBeInTheDocument();
   });
 
   // ─── Setup popup — API key entry ──────────────────────────────────────────
@@ -632,6 +670,44 @@ describe('EmbeddingsPanel', () => {
     fireEvent.click(testBtn);
 
     await waitFor(() => expect(screen.getByText(/connection refused/i)).toBeInTheDocument());
+  });
+
+  it('maps Managed backend-session test failures to sign-in guidance', async () => {
+    const settings = makeSettings({
+      provider: 'managed',
+      providers: [
+        makeProvider('managed', {
+          requires_api_key: false,
+          models: [
+            {
+              id: 'managed-model-v1',
+              label: 'Managed Model v1',
+              default_dimensions: 1536,
+              allowed_dimensions: [1536],
+            },
+          ],
+        }),
+      ],
+    });
+    vi.mocked(loadEmbeddingsSettings).mockResolvedValue(settings);
+    vi.mocked(testEmbeddingsConnection).mockResolvedValueOnce({
+      success: false,
+      provider: 'managed',
+      model: 'managed-model-v1',
+      error:
+        'No backend session for cloud embeddings: log in to OpenHuman, or set memory.embedding_provider to "ollama"',
+    });
+
+    renderWithProviders(<EmbeddingsPanel />);
+    await screen.findByText('Managed');
+
+    fireEvent.click(await screen.findByRole('button', { name: /test connection/i }));
+
+    expect(
+      (await screen.findAllByText(/Managed embeddings require OpenHuman sign-in/i)).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /sign in again/i })).toBeInTheDocument();
+    expect(screen.queryByText(/No backend session for cloud embeddings/i)).not.toBeInTheDocument();
   });
 
   // ─── Model select (multiple catalog models) ───────────────────────────────

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -1144,6 +1144,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'مزود التضمينات',
   'settings.embeddings.statusConfigured': 'تم التهيئة',
   'settings.embeddings.statusNeedsKey': 'يحتاج مفتاح API',
+  'settings.embeddings.statusNeedsSignIn': 'يتطلب تسجيل الدخول',
   'settings.embeddings.apiKeyLabel': 'مفتاح API لـ {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (مخزن)',
   'settings.embeddings.placeholderKey': 'الصق مفتاح API الخاص بك…',
@@ -1162,6 +1163,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'جارٍ الاختبار…',
   'settings.embeddings.testSuccess': 'متصل — {dims} بُعد',
   'settings.embeddings.testFailed': 'فشل: {error}',
+  'settings.embeddings.testFailedFallback': 'فشل الاختبار',
   'settings.embeddings.saving': 'جارٍ الحفظ…',
   'settings.embeddings.saved': 'تم الحفظ.',
   'settings.embeddings.errorPrefix': 'فشل',
@@ -1176,6 +1178,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'تم تعطيل البحث والتذكير بالذاكرة سيستخدم مضاهاة الكلمات الرئيسية والراحة فقط - لا ترتيب ساكن.',
   'settings.embeddings.clearKey': 'مسح مفتاح API',
+  'settings.embeddings.managedSignInMessage':
+    'تتطلب التضمينات المُدارة تسجيل الدخول إلى OpenHuman. سجّل الدخول مرة أخرى لاستخدام واجهة OpenHuman الخلفية، أو اختر مزود تضمينات محليًا أو بمفتاحك الخاص.',
+  'settings.embeddings.signInAgain': 'سجّل الدخول مرة أخرى',
   'pages.settings.ai.embeddings': 'التضمينات',
   'pages.settings.ai.embeddingsDesc': 'نموذج ترميز المتجهات لاسترجاع الذاكرة',
   'mcp.alphaBadge': 'ألفا',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -1163,6 +1163,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'এমবেডিং প্রদানকারী',
   'settings.embeddings.statusConfigured': 'কনফিগার করা হয়েছে',
   'settings.embeddings.statusNeedsKey': 'API কী প্রয়োজন',
+  'settings.embeddings.statusNeedsSignIn': 'সাইন-ইন প্রয়োজন',
   'settings.embeddings.apiKeyLabel': '{provider} API কী',
   'settings.embeddings.placeholderStored': '•••••••• (সঞ্চিত)',
   'settings.embeddings.placeholderKey': 'আপনার API কী পেস্ট করুন…',
@@ -1181,6 +1182,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'পরীক্ষা হচ্ছে…',
   'settings.embeddings.testSuccess': 'সংযুক্ত — {dims} মাত্রা',
   'settings.embeddings.testFailed': 'ব্যর্থ: {error}',
+  'settings.embeddings.testFailedFallback': 'পরীক্ষা ব্যর্থ হয়েছে',
   'settings.embeddings.saving': 'সংরক্ষণ হচ্ছে…',
   'settings.embeddings.saved': 'সংরক্ষিত।',
   'settings.embeddings.errorPrefix': 'ব্যর্থ',
@@ -1195,6 +1197,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'ভেক্টর অনুসন্ধান নিষ্ক্রিয় করা হয়েছে । মনে রাখবেন যে, শুধু শব্দ ও ছাদের সঙ্গে মিল রেখে শব্দ ব্যবহার করা হবে ।',
   'settings.embeddings.clearKey': 'API কী মুছুন',
+  'settings.embeddings.managedSignInMessage':
+    'ম্যানেজড এমবেডিং ব্যবহার করতে OpenHuman-এ সাইন ইন করতে হবে। OpenHuman ব্যাকএন্ড ব্যবহার করতে আবার সাইন ইন করুন, অথবা স্থানীয় বা নিজের API কী-ভিত্তিক এমবেডিং প্রদানকারী বেছে নিন।',
+  'settings.embeddings.signInAgain': 'আবার সাইন ইন করুন',
   'pages.settings.ai.embeddings': 'এমবেডিংস',
   'pages.settings.ai.embeddingsDesc': 'মেমরি পুনরুদ্ধারের জন্য ভেক্টর এনকোডিং মডেল',
   'mcp.alphaBadge': 'আলফা',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -1195,6 +1195,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Embedding-Anbieter',
   'settings.embeddings.statusConfigured': 'Konfiguriert',
   'settings.embeddings.statusNeedsKey': 'API-Schlüssel benötigt',
+  'settings.embeddings.statusNeedsSignIn': 'Anmeldung erforderlich',
   'settings.embeddings.apiKeyLabel': '{provider} API-Schlüssel',
   'settings.embeddings.placeholderStored': '•••••••• (gespeichert)',
   'settings.embeddings.placeholderKey': 'API-Schlüssel einfügen…',
@@ -1214,6 +1215,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Wird getestet…',
   'settings.embeddings.testSuccess': 'Verbunden — {dims} Dimensionen',
   'settings.embeddings.testFailed': 'Fehlgeschlagen: {error}',
+  'settings.embeddings.testFailedFallback': 'Test fehlgeschlagen',
   'settings.embeddings.saving': 'Wird gespeichert…',
   'settings.embeddings.saved': 'Gespeichert.',
   'settings.embeddings.errorPrefix': 'Fehlgeschlagen',
@@ -1228,6 +1230,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'Die Vektorsuche ist deaktiviert. Der Speicherabruf verwendet nur Keyword-Matching und Aktualität — kein semantisches Ranking.',
   'settings.embeddings.clearKey': 'API-Schlüssel löschen',
+  'settings.embeddings.managedSignInMessage':
+    'Verwaltete Embeddings erfordern eine OpenHuman-Anmeldung. Melde dich erneut an, um das OpenHuman-Backend zu verwenden, oder wähle einen lokalen Anbieter bzw. einen Anbieter mit eigenem API-Schlüssel.',
+  'settings.embeddings.signInAgain': 'Erneut anmelden',
   'pages.settings.ai.embeddings': 'Einbettungen',
   'pages.settings.ai.embeddingsDesc': 'Vektorkodierungsmodell für den Speicherabruf',
   'mcp.alphaBadge': 'Alpha',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -1511,6 +1511,7 @@ const en: TranslationMap = {
   'settings.embeddings.providerAria': 'Embedding provider',
   'settings.embeddings.statusConfigured': 'Configured',
   'settings.embeddings.statusNeedsKey': 'Needs API key',
+  'settings.embeddings.statusNeedsSignIn': 'Requires sign-in',
   'settings.embeddings.apiKeyLabel': '{provider} API key',
   'settings.embeddings.placeholderStored': '•••••••• (stored)',
   'settings.embeddings.placeholderKey': 'Paste your API key…',
@@ -1529,6 +1530,7 @@ const en: TranslationMap = {
   'settings.embeddings.testing': 'Testing…',
   'settings.embeddings.testSuccess': 'Connected — {dims} dimensions',
   'settings.embeddings.testFailed': 'Failed: {error}',
+  'settings.embeddings.testFailedFallback': 'Test failed',
   'settings.embeddings.saving': 'Saving…',
   'settings.embeddings.saved': 'Saved.',
   'settings.embeddings.errorPrefix': 'Failed',
@@ -1543,6 +1545,9 @@ const en: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'Vector search is disabled. Memory recall will use keyword matching and recency only — no semantic ranking.',
   'settings.embeddings.clearKey': 'Clear API key',
+  'settings.embeddings.managedSignInMessage':
+    'Managed embeddings require OpenHuman sign-in. Sign in again to use the OpenHuman backend, or choose a local or bring-your-own-key embeddings provider.',
+  'settings.embeddings.signInAgain': 'Sign in again',
   'pages.settings.ai.embeddings': 'Embeddings',
   'pages.settings.ai.embeddingsDesc': 'Vector encoding model for memory retrieval',
 

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -1190,6 +1190,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Proveedor de embeddings',
   'settings.embeddings.statusConfigured': 'Configurado',
   'settings.embeddings.statusNeedsKey': 'Necesita clave API',
+  'settings.embeddings.statusNeedsSignIn': 'Requiere inicio de sesión',
   'settings.embeddings.apiKeyLabel': 'Clave API de {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (almacenado)',
   'settings.embeddings.placeholderKey': 'Pega tu clave API…',
@@ -1208,6 +1209,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Probando…',
   'settings.embeddings.testSuccess': 'Conectado — {dims} dimensiones',
   'settings.embeddings.testFailed': 'Fallido: {error}',
+  'settings.embeddings.testFailedFallback': 'La prueba falló',
   'settings.embeddings.saving': 'Guardando…',
   'settings.embeddings.saved': 'Guardado.',
   'settings.embeddings.errorPrefix': 'Fallido',
@@ -1222,6 +1224,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'La búsqueda vectorial está desactivada. La recuperación de memoria utilizará únicamente la coincidencia de palabras clave y la actualidad — sin clasificación semántica.',
   'settings.embeddings.clearKey': 'Borrar clave API',
+  'settings.embeddings.managedSignInMessage':
+    'Las incrustaciones administradas requieren iniciar sesión en OpenHuman. Vuelve a iniciar sesión para usar el backend de OpenHuman, o elige un proveedor local o con tu propia clave API.',
+  'settings.embeddings.signInAgain': 'Iniciar sesión de nuevo',
   'pages.settings.ai.embeddings': 'Incrustaciones',
   'pages.settings.ai.embeddingsDesc':
     'Modelo de codificación vectorial para recuperación de memoria',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -1195,6 +1195,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': "Fournisseur d'embeddings",
   'settings.embeddings.statusConfigured': 'Configuré',
   'settings.embeddings.statusNeedsKey': 'Clé API requise',
+  'settings.embeddings.statusNeedsSignIn': 'Connexion requise',
   'settings.embeddings.apiKeyLabel': 'Clé API {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (stocké)',
   'settings.embeddings.placeholderKey': 'Collez votre clé API…',
@@ -1214,6 +1215,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Test en cours…',
   'settings.embeddings.testSuccess': 'Connecté — {dims} dimensions',
   'settings.embeddings.testFailed': 'Échec : {error}',
+  'settings.embeddings.testFailedFallback': 'Test échoué',
   'settings.embeddings.saving': 'Enregistrement…',
   'settings.embeddings.saved': 'Enregistré.',
   'settings.embeddings.errorPrefix': 'Échec',
@@ -1228,6 +1230,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'La recherche vectorielle est désactivée. Le rappel de la mémoire utilisera uniquement la correspondance de mots-clés et la récence — pas de classement sémantique.',
   'settings.embeddings.clearKey': 'Effacer la clé API',
+  'settings.embeddings.managedSignInMessage':
+    'Les embeddings gérés nécessitent une connexion OpenHuman. Connectez-vous de nouveau pour utiliser le backend OpenHuman, ou choisissez un fournisseur local ou avec votre propre clé API.',
+  'settings.embeddings.signInAgain': 'Se reconnecter',
   'pages.settings.ai.embeddings': 'Intégrations',
   'pages.settings.ai.embeddingsDesc':
     "Modèle d'encodage vectoriel pour la récupération de la mémoire",

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -1160,6 +1160,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'एम्बेडिंग प्रदाता',
   'settings.embeddings.statusConfigured': 'कॉन्फ़िगर किया गया',
   'settings.embeddings.statusNeedsKey': 'API कुंजी चाहिए',
+  'settings.embeddings.statusNeedsSignIn': 'साइन इन आवश्यक',
   'settings.embeddings.apiKeyLabel': '{provider} API कुंजी',
   'settings.embeddings.placeholderStored': '•••••••• (संग्रहीत)',
   'settings.embeddings.placeholderKey': 'अपनी API कुंजी पेस्ट करें…',
@@ -1179,6 +1180,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'परीक्षण हो रहा है…',
   'settings.embeddings.testSuccess': 'कनेक्ट — {dims} आयाम',
   'settings.embeddings.testFailed': 'विफल: {error}',
+  'settings.embeddings.testFailedFallback': 'परीक्षण विफल',
   'settings.embeddings.saving': 'सहेजा जा रहा है…',
   'settings.embeddings.saved': 'सहेजा गया।',
   'settings.embeddings.errorPrefix': 'विफल',
@@ -1193,6 +1195,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'वेक्टर खोज अक्षम है। मेमोरी रिकॉल केवल कीवर्ड मेलिंग और रीसेंसी का उपयोग करेगा - कोई सेमैनेटिक रैंकिंग नहीं।',
   'settings.embeddings.clearKey': 'API कुंजी साफ़ करें',
+  'settings.embeddings.managedSignInMessage':
+    'मैनेज्ड एम्बेडिंग्स के लिए OpenHuman में साइन इन करना आवश्यक है। OpenHuman बैकएंड उपयोग करने के लिए फिर से साइन इन करें, या स्थानीय/अपनी API कुंजी वाले एम्बेडिंग प्रदाता को चुनें।',
+  'settings.embeddings.signInAgain': 'फिर से साइन इन करें',
   'pages.settings.ai.embeddings': 'एम्बेडिंग्स',
   'pages.settings.ai.embeddingsDesc': 'मेमोरी पुनर्प्राप्ति के लिए वेक्टर एन्कोडिंग मॉडल',
   'mcp.alphaBadge': 'अल्फ़ा',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -1168,6 +1168,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Penyedia embedding',
   'settings.embeddings.statusConfigured': 'Dikonfigurasi',
   'settings.embeddings.statusNeedsKey': 'Perlu kunci API',
+  'settings.embeddings.statusNeedsSignIn': 'Perlu masuk',
   'settings.embeddings.apiKeyLabel': 'Kunci API {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (disimpan)',
   'settings.embeddings.placeholderKey': 'Tempel kunci API Anda…',
@@ -1186,6 +1187,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Menguji…',
   'settings.embeddings.testSuccess': 'Terhubung — {dims} dimensi',
   'settings.embeddings.testFailed': 'Gagal: {error}',
+  'settings.embeddings.testFailedFallback': 'Pengujian gagal',
   'settings.embeddings.saving': 'Menyimpan…',
   'settings.embeddings.saved': 'Tersimpan.',
   'settings.embeddings.errorPrefix': 'Gagal',
@@ -1200,6 +1202,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'Pencarian Vektor dinonaktifkan. Recall memori akan menggunakan kata kunci pencocokan dan retensi saja - tidak ada peringkat semantik.',
   'settings.embeddings.clearKey': 'Hapus kunci API',
+  'settings.embeddings.managedSignInMessage':
+    'Embedding terkelola memerlukan masuk ke OpenHuman. Masuk lagi untuk menggunakan backend OpenHuman, atau pilih penyedia embedding lokal atau dengan kunci API sendiri.',
+  'settings.embeddings.signInAgain': 'Masuk lagi',
   'pages.settings.ai.embeddings': 'Penyematan',
   'pages.settings.ai.embeddingsDesc': 'Model encoding vektor untuk pengambilan memori',
   'mcp.alphaBadge': 'Alfa',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -1186,6 +1186,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Fornitore di embeddings',
   'settings.embeddings.statusConfigured': 'Configurato',
   'settings.embeddings.statusNeedsKey': 'Chiave API necessaria',
+  'settings.embeddings.statusNeedsSignIn': 'Accesso richiesto',
   'settings.embeddings.apiKeyLabel': 'Chiave API {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (memorizzato)',
   'settings.embeddings.placeholderKey': 'Incolla la tua chiave API…',
@@ -1205,6 +1206,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Test in corso…',
   'settings.embeddings.testSuccess': 'Connesso — {dims} dimensioni',
   'settings.embeddings.testFailed': 'Fallito: {error}',
+  'settings.embeddings.testFailedFallback': 'Test non riuscito',
   'settings.embeddings.saving': 'Salvataggio…',
   'settings.embeddings.saved': 'Salvato.',
   'settings.embeddings.errorPrefix': 'Fallito',
@@ -1219,6 +1221,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'La ricerca vettoriale è disabilitata. Il richiamo della memoria utilizzerà solo il confronto delle parole chiave e la recenza — nessuna classificazione semantica.',
   'settings.embeddings.clearKey': 'Cancella chiave API',
+  'settings.embeddings.managedSignInMessage':
+    'Gli embedding gestiti richiedono l’accesso a OpenHuman. Accedi di nuovo per usare il backend OpenHuman oppure scegli un provider locale o con la tua chiave API.',
+  'settings.embeddings.signInAgain': 'Accedi di nuovo',
   'pages.settings.ai.embeddings': 'Incorporamenti',
   'pages.settings.ai.embeddingsDesc':
     'Modello di codifica vettoriale per il recupero della memoria',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -1161,6 +1161,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': '임베딩 제공자',
   'settings.embeddings.statusConfigured': '구성됨',
   'settings.embeddings.statusNeedsKey': 'API 키 필요',
+  'settings.embeddings.statusNeedsSignIn': '로그인 필요',
   'settings.embeddings.apiKeyLabel': '{provider} API 키',
   'settings.embeddings.placeholderStored': '•••••••(저장됨)',
   'settings.embeddings.placeholderKey': 'API 키를 붙여넣으세요…',
@@ -1179,6 +1180,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': '테스트 중…',
   'settings.embeddings.testSuccess': '연결됨 — {dims} 차원',
   'settings.embeddings.testFailed': '실패: {error}',
+  'settings.embeddings.testFailedFallback': '테스트 실패',
   'settings.embeddings.saving': '저장 중…',
   'settings.embeddings.saved': '저장됨.',
   'settings.embeddings.errorPrefix': '실패',
@@ -1193,6 +1195,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     '벡터 검색이 비활성화되어 있습니다. 메모리 회상은 의미 순위 없이 키워드 매칭과 최신성만 사용합니다.',
   'settings.embeddings.clearKey': 'API 키 삭제',
+  'settings.embeddings.managedSignInMessage':
+    '관리형 임베딩을 사용하려면 OpenHuman 로그인이 필요합니다. OpenHuman 백엔드를 사용하려면 다시 로그인하거나, 로컬 또는 자체 API 키 임베딩 제공자를 선택하세요.',
+  'settings.embeddings.signInAgain': '다시 로그인',
   'pages.settings.ai.embeddings': '임베딩',
   'pages.settings.ai.embeddingsDesc': '메모리 검색을 위한 벡터 인코딩 모델',
   'mcp.alphaBadge': '알파',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -1180,6 +1180,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Dostawca embeddings',
   'settings.embeddings.statusConfigured': 'Skonfigurowano',
   'settings.embeddings.statusNeedsKey': 'Wymaga klucza API',
+  'settings.embeddings.statusNeedsSignIn': 'Wymaga logowania',
   'settings.embeddings.apiKeyLabel': 'Klucz API {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (zapisane)',
   'settings.embeddings.placeholderKey': 'Wklej swój klucz API…',
@@ -1198,6 +1199,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Testowanie…',
   'settings.embeddings.testSuccess': 'Połączono — wymiarów: {dims}',
   'settings.embeddings.testFailed': 'Niepowodzenie: {error}',
+  'settings.embeddings.testFailedFallback': 'Test nie powiódł się',
   'settings.embeddings.saving': 'Zapisywanie…',
   'settings.embeddings.saved': 'Zapisano.',
   'settings.embeddings.errorPrefix': 'Niepowodzenie',
@@ -1212,6 +1214,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'Wyszukiwanie wektorowe jest wyłączone. Pamięć będzie używać tylko dopasowania słów kluczowych i świeżości — bez rankingu semantycznego.',
   'settings.embeddings.clearKey': 'Wyczyść klucz API',
+  'settings.embeddings.managedSignInMessage':
+    'Zarządzane embeddings wymagają logowania do OpenHuman. Zaloguj się ponownie, aby użyć backendu OpenHuman, albo wybierz lokalnego dostawcę lub dostawcę z własnym kluczem API.',
+  'settings.embeddings.signInAgain': 'Zaloguj ponownie',
   'pages.settings.ai.embeddings': 'Embeddingi',
   'pages.settings.ai.embeddingsDesc': 'Model kodowania wektorowego do wyszukiwania w pamięci',
   'mcp.alphaBadge': 'Alfa',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -1193,6 +1193,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Provedor de embeddings',
   'settings.embeddings.statusConfigured': 'Configurado',
   'settings.embeddings.statusNeedsKey': 'Precisa de chave API',
+  'settings.embeddings.statusNeedsSignIn': 'Requer login',
   'settings.embeddings.apiKeyLabel': 'Chave API {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (armazenado)',
   'settings.embeddings.placeholderKey': 'Cole sua chave API…',
@@ -1212,6 +1213,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Testando…',
   'settings.embeddings.testSuccess': 'Conectado — {dims} dimensões',
   'settings.embeddings.testFailed': 'Falhou: {error}',
+  'settings.embeddings.testFailedFallback': 'Teste falhou',
   'settings.embeddings.saving': 'Salvando…',
   'settings.embeddings.saved': 'Salvo.',
   'settings.embeddings.errorPrefix': 'Falhou',
@@ -1226,6 +1228,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'A pesquisa vetorial está desativada. A recuperação de memória usará apenas correspondência de palavras-chave e recência — sem classificação semântica.',
   'settings.embeddings.clearKey': 'Limpar chave API',
+  'settings.embeddings.managedSignInMessage':
+    'Embeddings gerenciados exigem login no OpenHuman. Entre novamente para usar o backend do OpenHuman ou escolha um provedor local ou com sua própria chave API.',
+  'settings.embeddings.signInAgain': 'Entrar novamente',
   'pages.settings.ai.embeddings': 'Incorporações',
   'pages.settings.ai.embeddingsDesc': 'Modelo de codificação vetorial para recuperação de memória',
   'mcp.alphaBadge': 'Alfa',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -1177,6 +1177,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': 'Провайдер эмбеддингов',
   'settings.embeddings.statusConfigured': 'Настроено',
   'settings.embeddings.statusNeedsKey': 'Нужен API-ключ',
+  'settings.embeddings.statusNeedsSignIn': 'Требуется вход',
   'settings.embeddings.apiKeyLabel': 'API-ключ {provider}',
   'settings.embeddings.placeholderStored': '•••••••• (сохранено)',
   'settings.embeddings.placeholderKey': 'Вставьте API-ключ…',
@@ -1196,6 +1197,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': 'Проверка…',
   'settings.embeddings.testSuccess': 'Подключено — {dims} измерений',
   'settings.embeddings.testFailed': 'Ошибка: {error}',
+  'settings.embeddings.testFailedFallback': 'Тест не пройден',
   'settings.embeddings.saving': 'Сохранение…',
   'settings.embeddings.saved': 'Сохранено.',
   'settings.embeddings.errorPrefix': 'Ошибка',
@@ -1210,6 +1212,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     'Векторный поиск отключен. При вызове из памяти будут использоваться только сопоставление ключевых слов и актуальность — без семантического ранжирования.',
   'settings.embeddings.clearKey': 'Удалить API-ключ',
+  'settings.embeddings.managedSignInMessage':
+    'Управляемые эмбеддинги требуют входа в OpenHuman. Войдите снова, чтобы использовать backend OpenHuman, или выберите локального провайдера либо провайдера со своим API-ключом.',
+  'settings.embeddings.signInAgain': 'Войти снова',
   'pages.settings.ai.embeddings': 'Эмбеддинги',
   'pages.settings.ai.embeddingsDesc': 'Модель векторного кодирования для извлечения из памяти',
   'mcp.alphaBadge': 'Альфа',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -1110,6 +1110,7 @@ const messages: TranslationMap = {
   'settings.embeddings.providerAria': '嵌入提供商',
   'settings.embeddings.statusConfigured': '已配置',
   'settings.embeddings.statusNeedsKey': '需要 API 密钥',
+  'settings.embeddings.statusNeedsSignIn': '需要登录',
   'settings.embeddings.apiKeyLabel': '{provider} API 密钥',
   'settings.embeddings.placeholderStored': '••••••••（已存储）',
   'settings.embeddings.placeholderKey': '粘贴您的 API 密钥…',
@@ -1128,6 +1129,7 @@ const messages: TranslationMap = {
   'settings.embeddings.testing': '测试中…',
   'settings.embeddings.testSuccess': '已连接 — {dims} 维度',
   'settings.embeddings.testFailed': '失败：{error}',
+  'settings.embeddings.testFailedFallback': '测试失败',
   'settings.embeddings.saving': '保存中…',
   'settings.embeddings.saved': '已保存。',
   'settings.embeddings.errorPrefix': '失败',
@@ -1142,6 +1144,9 @@ const messages: TranslationMap = {
   'settings.embeddings.vectorSearchDisabled':
     '向量搜索已禁用。记忆召回将只使用关键词匹配和时间新近度，不进行语义排序。',
   'settings.embeddings.clearKey': '清除 API 密钥',
+  'settings.embeddings.managedSignInMessage':
+    '托管嵌入需要登录 OpenHuman。请重新登录以使用 OpenHuman 后端，或选择本地/自带 API 密钥的嵌入提供商。',
+  'settings.embeddings.signInAgain': '重新登录',
   'pages.settings.ai.embeddings': '向量嵌入',
   'pages.settings.ai.embeddingsDesc': '用于记忆检索的向量编码模型',
   'mcp.alphaBadge': '阿尔法',


### PR DESCRIPTION
## Summary

- Adds local-session handling for Managed (OpenHuman) embeddings in the settings panel.
- Shows a localized sign-in requirement badge, inline recovery callout, and Sign in again action when Managed cannot use the backend.
- Blocks switching to Managed during local sessions while keeping the recovery path visible.
- Maps `No backend session for cloud embeddings` test failures to the same sign-in guidance instead of showing the raw core error.
- Adds regression coverage and translations for the new badge, guidance, button, and fallback copy.

## Problem

- Managed embeddings are presented as the default no-key provider, but they still require an active OpenHuman backend session.
- Local-session users could see Managed as the selected/default provider and attempt connection tests that only surfaced the raw core error.
- A blocked Managed switch from a non-Managed provider still needs an in-panel recovery action, not just a transient status-line error.

## Solution

- `EmbeddingsPanel` reads `CoreStateProvider` session state and uses `isLocalSessionToken` to detect local sessions.
- The Managed provider remains visible but is labeled as requiring sign-in during local sessions.
- Managed test actions are disabled when selected in local mode, and blocked Managed switches set a prompt flag so the sign-in callout is still reachable.
- Known backend-session test failures are remapped to localized sign-in guidance; ordinary non-Managed failures keep their existing error path.
- New user-facing strings are routed through i18n and mirrored across all supported app locales.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: behavior-only settings-panel bugfix; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: settings-panel UI bugfix only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: desktop/web settings UI only.
- Performance, security, migration, or compatibility implications: none expected.
- Compatibility: non-Managed providers, API-key setup, custom endpoint setup, ordinary connection failures, model selection, and dimension updates preserve their existing behavior.

## Related

- Supersedes #3858
- Closes #3787
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A — GitHub issue #3787
- URL: N/A — GitHub issue #3787

### Commit & Branch

- Branch: `issue/3858-fix-settings-prompt-for-managed-embeddin`
- Commit SHA: `132bad2ef`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] `pnpm i18n:check`
- [x] `git diff --check`
- [x] Focused tests: `pnpm --dir app exec vitest run src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx --config test/vitest.config.ts`
- [x] Focused coverage: `pnpm --filter openhuman-app exec vitest run --config test/vitest.config.ts --coverage src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx`
- [x] Focused lint: `pnpm --filter openhuman-app exec eslint src/components/settings/panels/EmbeddingsPanel.tsx src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx`
- [x] Full app lint: `pnpm --filter openhuman-app lint` (0 errors; existing warnings)
- [x] Pre-push hook: `format:check`, `lint`, `compile`, `rust:check`, and `lint:commands-tokens`
- [x] Rust fmt/check (if changed): N/A: no Rust files changed; pre-push hook ran Rust format checks and Tauri/core check.
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed; pre-push hook ran Tauri format/check.

### Validation Blocked

- `command:` `pnpm i18n:english:check`
- `error:` Fails on pre-existing unrelated English leftovers such as `conversations.backgroundTasks.*`, `settings.ai.claudeCode.*`, and `settings.ai.routing.workload.*`; none of the new embeddings keys are listed.
- `impact:` New locale keys have translations and `pnpm i18n:check` passes with 0 missing/extra keys.

### Behavior Changes

- Intended behavior change: Managed embeddings now clearly require OpenHuman sign-in when the current session cannot use the backend.
- User-visible effect: local-session users see a warning badge/callout and a disabled Managed test button; blocked Managed switching shows the recovery callout; backend-session test failures show sign-in guidance instead of the raw core error.

### Parity Contract

- Legacy behavior preserved: non-Managed provider selection, API-key setup, custom endpoint setup, ordinary connection failure display, model selection, and dimension updates are unchanged.
- Guard/fallback/dispatch parity checks: backend-session errors are remapped only for selected Managed embeddings; other test failures still show their original error or the localized fallback.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): #3858
- Canonical PR: this PR
- Resolution (closed/superseded/updated): This branch is a replacement implementation for the same issue, including the previously requested blocked-switch recovery path and i18n fixes.
