### PR TITLE
refactor(memory_sync): internalize the cap math into the orchestrator (single source of truth)

### DIFF
--- a/src/openhuman/memory_sync/composio/providers/gmail/provider.rs
+++ b/src/openhuman/memory_sync/composio/providers/gmail/provider.rs
@@ -184,6 +184,7 @@ impl ComposioProvider for GmailProvider {
     }
 }
 
-// Cap/date-floor math lives in the shared `super::super::helpers` module
-// (`ItemCap`, `pages_for_max_items`, `epoch_floor_from_depth`) so every provider
-// shares one implementation — see that module for the unit tests.
+// The `max_items` cap math (`ItemCap`) lives in the orchestrator now that it is
+// the sole consumer; the `sync_depth_days` date floor (`epoch_floor_from_depth`)
+// stays in `super::super::helpers` because `gmail::source` builds an
+// `after:<epoch>` filter from it.

--- a/src/openhuman/memory_sync/composio/providers/helpers.rs
+++ b/src/openhuman/memory_sync/composio/providers/helpers.rs
@@ -46,21 +46,13 @@ pub(crate) fn merge_extra(args: &mut serde_json::Value, extra: &serde_json::Valu
     }
 }
 
-// ── Cap enforcement helpers ──────────────────────────────────────────────
-
-/// Compute the number of API pages needed to cover `max_items` at `page_size`
-/// items per page, rounding up.
-///
-/// Returns `u32::MAX` when `page_size == 0` to avoid division by zero;
-/// callers should treat this as "no page cap beyond the provider's own upper
-/// bound".
-pub(crate) fn pages_for_max_items(max_items: u32, page_size: u32) -> u32 {
-    if page_size == 0 {
-        return u32::MAX;
-    }
-    // Widen to u64 before the addition to prevent overflow for large cap values.
-    (((max_items as u64) + (page_size as u64) - 1) / (page_size as u64)).min(u32::MAX as u64) as u32
-}
+// ── Window helper ────────────────────────────────────────────────────────
+//
+// The per-sync `max_items` cap math (`ItemCap` + `pages_for_max_items`) lives
+// in the orchestrator now that it is the sole consumer — see
+// [`super::orchestrator`]. `epoch_floor_from_depth` stays here because it is a
+// provider-facing window helper (gmail/source.rs builds an `after:<epoch>`
+// filter from it), not orchestrator-internal cap math.
 
 /// Compute the Unix epoch timestamp (seconds) for `sync_depth_days` days ago.
 /// Used to build after-date filters (e.g. Gmail `after:<epoch>`) on first sync.
@@ -70,85 +62,9 @@ pub(crate) fn epoch_floor_from_depth(sync_depth_days: u32) -> i64 {
     floor.timestamp()
 }
 
-/// Single source of truth for the per-sync `max_items` cap.
-///
-/// Every Composio provider used to open-code three near-identical blocks — a
-/// page-count cap, a mid-page clamp, and a post-page hard stop — which is how
-/// the same off-by-a-page bug ended up in five providers and was missed in a
-/// sixth. Funnelling all of them through this one type keeps the rule in one
-/// place: construct it from `ctx.max_items`, derive the page cap, clamp each
-/// batch (or check per item), and stop once the cap is reached.
-///
-/// `None` cap means "no item limit beyond the provider's own internal page
-/// ceiling" (e.g. after the user clicks "All In").
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ItemCap {
-    cap: Option<usize>,
-    persisted: usize,
-}
-
-impl ItemCap {
-    /// Build from a source's `max_items` value (`None` = uncapped).
-    pub(crate) fn new(max_items: Option<u32>) -> Self {
-        Self {
-            cap: max_items.map(|n| n as usize),
-            persisted: 0,
-        }
-    }
-
-    /// The page ceiling to actually fetch: the smaller of the provider's own
-    /// `fallback` (e.g. `MAX_PAGES_PER_SYNC`) and the pages needed to cover the
-    /// cap. Uncapped → `fallback` unchanged.
-    pub(crate) fn max_pages(&self, page_size: u32, fallback: u32) -> u32 {
-        match self.cap {
-            Some(cap) => pages_for_max_items(cap as u32, page_size).min(fallback),
-            None => fallback,
-        }
-    }
-
-    /// How many more items may still be persisted. `None` = unlimited.
-    pub(crate) fn remaining(&self) -> Option<usize> {
-        self.cap.map(|cap| cap.saturating_sub(self.persisted))
-    }
-
-    /// True once the cap is set and reached — callers `break` their pagination.
-    pub(crate) fn is_reached(&self) -> bool {
-        matches!(self.remaining(), Some(0))
-    }
-
-    /// Record `n` newly-persisted items against the budget.
-    pub(crate) fn record(&mut self, n: usize) {
-        self.persisted = self.persisted.saturating_add(n);
-    }
-
-    /// Truncate a to-ingest batch down to the remaining budget, so a single
-    /// page larger than the cap never over-persists. No-op when uncapped.
-    pub(crate) fn clamp_batch<T>(&self, batch: &mut Vec<T>) {
-        if let Some(remaining) = self.remaining() {
-            if batch.len() > remaining {
-                batch.truncate(remaining);
-            }
-        }
-    }
-}
-
 #[cfg(test)]
-mod cap_helper_tests {
+mod window_helper_tests {
     use super::*;
-
-    #[test]
-    fn pages_for_max_items_rounds_up() {
-        assert_eq!(pages_for_max_items(100, 25), 4);
-        assert_eq!(pages_for_max_items(101, 25), 5);
-        assert_eq!(pages_for_max_items(1, 25), 1);
-        assert_eq!(pages_for_max_items(50, 50), 1);
-        assert_eq!(pages_for_max_items(51, 50), 2);
-    }
-
-    #[test]
-    fn pages_for_max_items_zero_page_size() {
-        assert_eq!(pages_for_max_items(100, 0), u32::MAX);
-    }
 
     #[test]
     fn epoch_floor_from_depth_is_in_the_past() {
@@ -160,61 +76,6 @@ mod cap_helper_tests {
             diff_days >= 29 && diff_days <= 31,
             "expected ~30 days in past, got {diff_days}"
         );
-    }
-
-    #[test]
-    fn item_cap_uncapped_is_never_reached() {
-        let mut cap = ItemCap::new(None);
-        assert_eq!(cap.remaining(), None);
-        assert!(!cap.is_reached());
-        cap.record(1_000_000);
-        assert!(!cap.is_reached());
-        assert_eq!(
-            cap.max_pages(25, 20),
-            20,
-            "uncapped keeps the provider fallback"
-        );
-    }
-
-    #[test]
-    fn item_cap_tracks_remaining_and_reached() {
-        let mut cap = ItemCap::new(Some(3));
-        assert_eq!(cap.remaining(), Some(3));
-        assert!(!cap.is_reached());
-        cap.record(2);
-        assert_eq!(cap.remaining(), Some(1));
-        assert!(!cap.is_reached());
-        cap.record(5); // saturates, never underflows
-        assert_eq!(cap.remaining(), Some(0));
-        assert!(cap.is_reached());
-    }
-
-    #[test]
-    fn item_cap_max_pages_is_min_of_fallback_and_needed() {
-        // cap=2, page_size=50 → 1 page needed, well under the fallback.
-        assert_eq!(ItemCap::new(Some(2)).max_pages(50, 20), 1);
-        // cap=1000, page_size=25 → 40 pages needed, clamped to fallback 20.
-        assert_eq!(ItemCap::new(Some(1000)).max_pages(25, 20), 20);
-    }
-
-    #[test]
-    fn item_cap_clamp_batch_truncates_to_remaining() {
-        let cap = ItemCap::new(Some(2));
-        let mut batch = vec![1, 2, 3, 4, 5];
-        cap.clamp_batch(&mut batch);
-        assert_eq!(batch, vec![1, 2]);
-
-        // Uncapped leaves the batch untouched.
-        let mut full = vec![1, 2, 3];
-        ItemCap::new(None).clamp_batch(&mut full);
-        assert_eq!(full, vec![1, 2, 3]);
-
-        // After recording progress, clamp uses the reduced budget.
-        let mut cap2 = ItemCap::new(Some(5));
-        cap2.record(3);
-        let mut batch2 = vec![1, 2, 3, 4];
-        cap2.clamp_batch(&mut batch2);
-        assert_eq!(batch2, vec![1, 2], "only 2 of the 5 budget remained");
     }
 }
 

--- a/src/openhuman/memory_sync/composio/providers/orchestrator.rs
+++ b/src/openhuman/memory_sync/composio/providers/orchestrator.rs
@@ -8,11 +8,13 @@
 //! [`SyncOutcome`]. The copy-paste is exactly how the page-granular cap bug
 //! (#3304) ended up in five providers and was missed in a sixth.
 //!
-//! [`ItemCap`] (PR #3304) centralised the cap *math*; this module centralises
-//! the *control flow*. A provider now implements only the slim
-//! [`IncrementalSource`] primitives and rides [`run_sync`], inheriting the
-//! `max_items` cap, the `sync_depth_days` window, dedup, cursor advance, and
-//! budget enforcement for free.
+//! [`ItemCap`] (PR #3304) centralised the cap *math*; this module owns it and
+//! the *control flow*. Now that every provider rides [`run_sync`], `ItemCap`
+//! lives here (orchestrator-private), not in the shared `helpers` module — the
+//! cap rule exists in exactly one place. A provider implements only the slim
+//! [`IncrementalSource`] primitives and inherits the `max_items` cap, the
+//! `sync_depth_days` window, dedup, cursor advance, and budget enforcement for
+//! free.
 //!
 //! ## Scopes: flat AND nested in one loop
 //!
@@ -39,9 +41,85 @@
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
-use super::helpers::ItemCap;
 use super::sync_state::SyncState;
 use super::{ProviderContext, SyncOutcome, SyncReason};
+
+/// Compute the number of API pages needed to cover `max_items` at `page_size`
+/// items per page, rounding up.
+///
+/// Returns `u32::MAX` when `page_size == 0` to avoid division by zero;
+/// callers should treat this as "no page cap beyond the provider's own upper
+/// bound".
+fn pages_for_max_items(max_items: u32, page_size: u32) -> u32 {
+    if page_size == 0 {
+        return u32::MAX;
+    }
+    // Widen to u64 before the addition to prevent overflow for large cap values.
+    (((max_items as u64) + (page_size as u64) - 1) / (page_size as u64)).min(u32::MAX as u64) as u32
+}
+
+/// Single source of truth for the per-sync `max_items` cap.
+///
+/// Every Composio provider used to open-code three near-identical blocks — a
+/// page-count cap, a mid-page clamp, and a post-page hard stop — which is how
+/// the same off-by-a-page bug (#3304) ended up in five providers and was missed
+/// in a sixth. Now that every provider rides [`run_sync`], this type and its
+/// page math are **orchestrator-private**: the cap rule lives in exactly one
+/// place — construct it from `ctx.max_items`, derive the page cap, clamp each
+/// batch before ingest, and stop once the cap is reached.
+///
+/// `None` cap means "no item limit beyond the provider's own internal page
+/// ceiling" (e.g. after the user clicks "All In").
+#[derive(Debug, Clone, Copy)]
+struct ItemCap {
+    cap: Option<usize>,
+    persisted: usize,
+}
+
+impl ItemCap {
+    /// Build from a source's `max_items` value (`None` = uncapped).
+    fn new(max_items: Option<u32>) -> Self {
+        Self {
+            cap: max_items.map(|n| n as usize),
+            persisted: 0,
+        }
+    }
+
+    /// The page ceiling to actually fetch: the smaller of the provider's own
+    /// `fallback` (e.g. `MAX_PAGES_PER_SYNC`) and the pages needed to cover the
+    /// cap. Uncapped → `fallback` unchanged.
+    fn max_pages(&self, page_size: u32, fallback: u32) -> u32 {
+        match self.cap {
+            Some(cap) => pages_for_max_items(cap as u32, page_size).min(fallback),
+            None => fallback,
+        }
+    }
+
+    /// How many more items may still be persisted. `None` = unlimited.
+    fn remaining(&self) -> Option<usize> {
+        self.cap.map(|cap| cap.saturating_sub(self.persisted))
+    }
+
+    /// True once the cap is set and reached — callers `break` their pagination.
+    fn is_reached(&self) -> bool {
+        matches!(self.remaining(), Some(0))
+    }
+
+    /// Record `n` newly-persisted items against the budget.
+    fn record(&mut self, n: usize) {
+        self.persisted = self.persisted.saturating_add(n);
+    }
+
+    /// Truncate a to-ingest batch down to the remaining budget, so a single
+    /// page larger than the cap never over-persists. No-op when uncapped.
+    fn clamp_batch<T>(&self, batch: &mut Vec<T>) {
+        if let Some(remaining) = self.remaining() {
+            if batch.len() > remaining {
+                batch.truncate(remaining);
+            }
+        }
+    }
+}
 
 /// A unit of work to iterate within one sync pass.
 ///
@@ -1390,5 +1468,76 @@ mod tests {
             .await
             .expect_err("without tolerance a scope fetch error propagates");
         assert!(err.contains("scope fetch failure"), "got: {err}");
+    }
+
+    // ── ItemCap / pages_for_max_items (relocated from helpers.rs, #3902) ──
+
+    #[test]
+    fn pages_for_max_items_rounds_up() {
+        assert_eq!(pages_for_max_items(100, 25), 4);
+        assert_eq!(pages_for_max_items(101, 25), 5);
+        assert_eq!(pages_for_max_items(1, 25), 1);
+        assert_eq!(pages_for_max_items(50, 50), 1);
+        assert_eq!(pages_for_max_items(51, 50), 2);
+    }
+
+    #[test]
+    fn pages_for_max_items_zero_page_size() {
+        assert_eq!(pages_for_max_items(100, 0), u32::MAX);
+    }
+
+    #[test]
+    fn item_cap_uncapped_is_never_reached() {
+        let mut cap = ItemCap::new(None);
+        assert_eq!(cap.remaining(), None);
+        assert!(!cap.is_reached());
+        cap.record(1_000_000);
+        assert!(!cap.is_reached());
+        assert_eq!(
+            cap.max_pages(25, 20),
+            20,
+            "uncapped keeps the provider fallback"
+        );
+    }
+
+    #[test]
+    fn item_cap_tracks_remaining_and_reached() {
+        let mut cap = ItemCap::new(Some(3));
+        assert_eq!(cap.remaining(), Some(3));
+        assert!(!cap.is_reached());
+        cap.record(2);
+        assert_eq!(cap.remaining(), Some(1));
+        assert!(!cap.is_reached());
+        cap.record(5); // saturates, never underflows
+        assert_eq!(cap.remaining(), Some(0));
+        assert!(cap.is_reached());
+    }
+
+    #[test]
+    fn item_cap_max_pages_is_min_of_fallback_and_needed() {
+        // cap=2, page_size=50 → 1 page needed, well under the fallback.
+        assert_eq!(ItemCap::new(Some(2)).max_pages(50, 20), 1);
+        // cap=1000, page_size=25 → 40 pages needed, clamped to fallback 20.
+        assert_eq!(ItemCap::new(Some(1000)).max_pages(25, 20), 20);
+    }
+
+    #[test]
+    fn item_cap_clamp_batch_truncates_to_remaining() {
+        let cap = ItemCap::new(Some(2));
+        let mut batch = vec![1, 2, 3, 4, 5];
+        cap.clamp_batch(&mut batch);
+        assert_eq!(batch, vec![1, 2]);
+
+        // Uncapped leaves the batch untouched.
+        let mut full = vec![1, 2, 3];
+        ItemCap::new(None).clamp_batch(&mut full);
+        assert_eq!(full, vec![1, 2, 3]);
+
+        // After recording progress, clamp uses the reduced budget.
+        let mut cap2 = ItemCap::new(Some(5));
+        cap2.record(3);
+        let mut batch2 = vec![1, 2, 3, 4];
+        cap2.clamp_batch(&mut batch2);
+        assert_eq!(batch2, vec![1, 2], "only 2 of the 5 budget remained");
     }
 }


### PR DESCRIPTION
## Summary

- The payoff of #3333: now that **all six** Composio providers ride `run_sync` (slack #3924, gmail #3874, both merged), the per-sync `max_items` cap math lives in **exactly one place** — the orchestrator.
- Relocates `ItemCap` + `pages_for_max_items` (and their unit tests) out of the shared `providers::helpers` module into `orchestrator.rs` as **private** items.
- Mechanical, behaviour-preserving: 3 files, net relocation; all `memory_sync` provider/unit/e2e tests stay green.

## Problem

Each conversion PR slimmed its own provider into `IncrementalSource` primitives, but the cap helpers stayed in the shared `helpers` module where any future provider could reach back in and re-open-code a cap loop — the exact pattern that produced the page-granular cap bug (#3304) across five providers. With the sixth conversion (gmail) now merged, nothing outside the orchestrator uses them.

## Solution

- Move `ItemCap` + `pages_for_max_items` into `orchestrator.rs` as private (`struct ItemCap`, `fn pages_for_max_items` — no longer `pub(crate)`), with their tests. Verified: zero code references to either symbol outside the orchestrator.
- Keep `epoch_floor_from_depth` in `helpers` — it is a **provider-facing window helper** (`gmail::source` builds an `after:<epoch>` filter from it), not orchestrator-internal cap math.
- Refresh the stale doc/comment in `orchestrator.rs` and `gmail/provider.rs`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `ItemCap`/`pages_for_max_items` unit tests moved into the orchestrator's test module (incl. clamp / cap-reached / zero-page-size edge cases); `epoch_floor_from_depth` test stays in `helpers`. All provider e2e (gmail cap, slack cap/bus/sync-status) re-run green on the relocated code.
- [x] **Diff coverage ≥ 80%** — net code is a relocation; the moved cap unit tests + the gmail/slack cap e2e exercise every moved line.
- [x] Coverage matrix updated — N/A: behaviour-preserving refactor, no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: refactor touches no matrix feature IDs.
- [x] No new external network dependencies introduced — loopback mock backend used by all touched e2e.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: internal sync-helper relocation, no release-cut surface change.
- [x] Linked issue closed via `Closes #NNN` — see `## Related`.

## Impact

- Desktop/CLI core only. No behaviour change — same caps, windows, cursors, and outcomes. Pure relocation + visibility tightening (the cap types are now orchestrator-private).

## Related

- Closes #3902
- Parent: #3333 · All six conversions merged: #3852 (orchestrator + notion) · #3860 (github/linear) · #3873 (clickup) · #3874 (gmail) · #3924 (slack)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: refactor/3902-internalize-cap
- Commit SHA: 12d29eae9de77bc88cf5f2b8f3a9d15b7ef39908

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no app/ changes
- [x] `pnpm typecheck` — N/A: no TypeScript changes
- [x] Focused tests: `cargo test --lib memory_sync::composio::providers` (477 pass, incl. relocated cap tests), `--test memory_sync_providers_raw_coverage_e2e` (gmail+slack cap), `--test memory_sync_slack_bus_raw_coverage_e2e`, `--test memory_sources_e2e`, `--test json_rpc_e2e` — all green
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean, `cargo clippy --lib` clean on touched files
- [x] Tauri fmt/check (if changed): N/A: no Tauri changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none (behaviour-preserving relocation)
- User-visible effect: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated pagination and item capacity management into the sync orchestrator for improved maintainability and consistency across data providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->