### PR TITLE
fix(composio): pin toolkit_versions=latest in direct-mode tool listings (#3932)

### DIFF
--- a/src/openhuman/composio/tools/direct.rs
+++ b/src/openhuman/composio/tools/direct.rs
@@ -213,7 +213,10 @@ impl ComposioTool {
         let url = format!("{}/tools", self.base_v3);
         let mut req = self.client().get(&url).header("x-api-key", &self.api_key);
 
-        req = req.query(&[("limit", "200")]);
+        // #3932: pin toolkit_versions=latest. Composio v3 otherwise defaults to
+        // the 00000000_00 snapshot, which lists zero tools for any toolkit
+        // published after it (Outlook and every other post-launch toolkit).
+        req = req.query(&[("limit", "200"), ("toolkit_versions", "latest")]);
         if let Some(app) = app_name.map(str::trim).filter(|app| !app.is_empty()) {
             req = req.query(&[("toolkits", app), ("toolkit_slug", app)]);
         }
@@ -274,7 +277,13 @@ impl ComposioTool {
         toolkits: &[&str],
         tags: Option<&[&str]>,
     ) -> Vec<(&'static str, String)> {
-        let mut params: Vec<(&'static str, String)> = vec![("limit", "200".to_string())];
+        // #3932: pin toolkit_versions=latest. Without it Composio v3 defaults to
+        // the 00000000_00 snapshot, which lists zero tools for any toolkit
+        // published after it (Outlook and every other post-launch toolkit).
+        let mut params: Vec<(&'static str, String)> = vec![
+            ("limit", "200".to_string()),
+            ("toolkit_versions", "latest".to_string()),
+        ];
 
         let trimmed: Vec<&str> = toolkits
             .iter()

--- a/src/openhuman/composio/tools/direct_tests.rs
+++ b/src/openhuman/composio/tools/direct_tests.rs
@@ -346,7 +346,13 @@ fn build_execute_action_v3_request_drops_blank_optional_fields() {
 #[test]
 fn build_list_tool_schemas_v3_query_always_includes_limit() {
     let params = ComposioTool::build_list_tool_schemas_v3_query(&[], None);
-    assert_eq!(params, vec![("limit", "200".to_string())]);
+    assert_eq!(
+        params,
+        vec![
+            ("limit", "200".to_string()),
+            ("toolkit_versions", "latest".to_string()),
+        ]
+    );
 }
 
 #[test]
@@ -356,6 +362,7 @@ fn build_list_tool_schemas_v3_query_joins_toolkits_as_csv() {
         params,
         vec![
             ("limit", "200".to_string()),
+            ("toolkit_versions", "latest".to_string()),
             ("toolkits", "github,gmail".to_string()),
         ]
     );
@@ -373,6 +380,7 @@ fn build_list_tool_schemas_v3_query_emits_repeated_tags_params() {
         params,
         vec![
             ("limit", "200".to_string()),
+            ("toolkit_versions", "latest".to_string()),
             ("toolkits", "github".to_string()),
             ("tags", "stars".to_string()),
             ("tags", "repos".to_string()),
@@ -387,6 +395,7 @@ fn build_list_tool_schemas_v3_query_tags_without_toolkit_filter() {
         params,
         vec![
             ("limit", "200".to_string()),
+            ("toolkit_versions", "latest".to_string()),
             ("tags", "readOnlyHint".to_string()),
         ]
     );
@@ -402,6 +411,7 @@ fn build_list_tool_schemas_v3_query_trims_and_drops_blank_entries() {
         params,
         vec![
             ("limit", "200".to_string()),
+            ("toolkit_versions", "latest".to_string()),
             ("toolkits", "github".to_string()),
             ("tags", "stars".to_string()),
         ]
@@ -415,10 +425,24 @@ fn build_list_tool_schemas_v3_query_empty_tags_slice_is_no_filter() {
     let blank = ComposioTool::build_list_tool_schemas_v3_query(&["gmail"], Some(&["  "]));
     let expected = vec![
         ("limit", "200".to_string()),
+        ("toolkit_versions", "latest".to_string()),
         ("toolkits", "gmail".to_string()),
     ];
     assert_eq!(empty, expected);
     assert_eq!(blank, expected);
+}
+
+#[test]
+fn build_list_tool_schemas_v3_query_pins_toolkit_versions_latest() {
+    // #3932: without toolkit_versions, Composio v3 defaults to the pinned
+    // 00000000_00 snapshot, so any toolkit published after it (Outlook and
+    // every other post-launch toolkit) lists zero tools. `latest` keeps them
+    // visible.
+    let params = ComposioTool::build_list_tool_schemas_v3_query(&["outlook"], None);
+    assert!(
+        params.contains(&("toolkit_versions", "latest".to_string())),
+        "query must pin toolkit_versions=latest; got {params:?}"
+    );
 }
 
 // ── list_tool_schemas_v3 over HTTP (direct-mode tags reach the wire) ───────
@@ -474,11 +498,66 @@ async fn list_tool_schemas_v3_sends_repeated_tags_to_v3_tools_endpoint() {
     );
     assert!(query.contains("toolkits=github"), "query was: {query}");
     assert!(query.contains("limit=200"), "query was: {query}");
+    // #3932: post-launch toolkits are invisible without toolkit_versions=latest.
+    assert!(
+        query.contains("toolkit_versions=latest"),
+        "query was: {query}"
+    );
 
     // And the v3 envelope reshapes back into schema items.
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].slug, "GITHUB_STAR_A_REPOSITORY");
     assert_eq!(items[0].toolkit_slug.as_deref(), Some("github"));
+}
+
+#[tokio::test]
+async fn list_actions_v3_sends_toolkit_versions_latest_to_v3_tools_endpoint() {
+    use axum::{extract::RawQuery, routing::get, Json, Router};
+    use std::sync::Mutex;
+
+    // The legacy direct-mode discovery path (`list_actions` → `list_actions_v3`)
+    // builds its own query inline, separate from `build_list_tool_schemas_v3_query`,
+    // so it needs its own wire-level guard that toolkit_versions=latest reaches /tools.
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let sink = captured.clone();
+    let app = Router::new().route(
+        "/tools",
+        get(move |RawQuery(q): RawQuery| {
+            let sink = sink.clone();
+            async move {
+                *sink.lock().unwrap() = q;
+                Json(json!({
+                    "items": [{
+                        "slug": "OUTLOOK_SEND_EMAIL",
+                        "name": "Outlook Send Email",
+                        "toolkit": { "slug": "outlook" }
+                    }]
+                }))
+            }
+        }),
+    );
+    let base = start_mock_backend(app).await;
+
+    let tool = ComposioTool::new_with_v3_base("ck_test_direct", None, test_security(), base);
+    let actions = tool
+        .list_actions(Some("outlook"))
+        .await
+        .expect("direct v3 action listing should succeed against the mock");
+
+    let query = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("mock server should have observed a query string");
+
+    assert!(
+        query.contains("toolkit_versions=latest"),
+        "post-launch toolkits (e.g. Outlook) need toolkit_versions=latest; query was: {query}"
+    );
+    assert!(query.contains("toolkits=outlook"), "query was: {query}");
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].name, "OUTLOOK_SEND_EMAIL");
 }
 
 // ── execute_action over HTTP (correct v3 path/slug/body reach the wire) ────


### PR DESCRIPTION
## Summary

- Direct-mode (BYO Composio API key) tool/action listings now pin `toolkit_versions=latest` on the Composio v3 `GET /tools` requests.
- Fixes toolkits published after Composio's initial `00000000_00` snapshot (Outlook, and roughly half of all toolkits) returning **zero tools** in direct mode.
- Applied at both direct-mode call sites: `list_tool_schemas_v3` (via the `build_list_tool_schemas_v3_query` builder) and `list_actions_v3`.

## Problem

In direct Composio mode the client called `GET /api/v3/tools` without a `toolkit_versions` parameter. The Composio v3 API defaults that parameter to the pinned `00000000_00` snapshot, so any toolkit whose entire definition was published after that snapshot does not exist at the default version and the catalogue returns `{"tools":[]}` with HTTP 200.

This was reported for Outlook (#3932), whose toolkit version is `20260615_00` — so the agent saw a connected account with valid OAuth/scopes but zero available tools. The same class of bug silently hides every post-snapshot toolkit (~half of the catalogue) from direct-mode users.

## Solution

- Pin `toolkit_versions=latest` on both direct-mode v3 `/tools` requests so post-launch toolkits resolve.
- The backend-proxy path (`client.rs`, `/agent-integrations/composio/tools`) is intentionally out of scope — it does not take a user key and resolves versions server-side.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case) — new builder unit test `build_list_tool_schemas_v3_query_pins_toolkit_versions_latest`, new wire test `list_actions_v3_sends_toolkit_versions_latest_to_v3_tools_endpoint`, and the existing `list_tool_schemas_v3` wire test extended to assert the param reaches the wire. The bug's failure mode (missing param ⇒ pinned snapshot) is what the tests guard against.
- [x] **Diff coverage ≥ 80%** — both changed production lines are directly exercised by the added/updated tests. Verified locally (`cargo test -p openhuman --lib composio` → 876 passed, 0 failed) and by CI (Coverage Gate / Rust Core Coverage passed).
- [x] N/A: Coverage matrix — behaviour-only bug fix, no feature rows added/removed/renamed.
- [x] N/A: Affected feature IDs — no matrix rows touched.
- [x] No new external network dependencies — direct-mode tests use the existing in-process axum mock.
- [x] N/A: Manual smoke checklist — does not touch release-cut surfaces.
- [x] Linked issue closed via `Closes #3932` (see Related).

## Impact

- Runtime/platform: Rust core only; affects direct (BYO-key) Composio tool discovery on all platforms.
- Restores visibility of post-snapshot Composio toolkits (Outlook, etc.). One additional constant query parameter; no migration, security, or compatibility implications.

## Related

- Closes: #3932
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata

> AI-assisted PR (authored with Claude Code). Human contributor reviewed the diff before submission.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3932-composio-toolkit-versions-latest`
- Commit SHA: `4195c9fe`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no `app/` TypeScript changes
- [x] N/A: `pnpm typecheck` — no TypeScript changes
- [x] Focused tests: `cargo test -p openhuman --lib composio` → 876 passed, 0 failed
- [x] Rust fmt/check: `cargo fmt --manifest-path Cargo.toml -- --check` → clean
- [x] N/A: Tauri fmt/check — no `app/src-tauri` changes

### Validation Blocked

- `command:` `pnpm test:coverage` / full `diff-cover` coverage pipeline
- `error:` coverage tooling (`cargo-llvm-cov` + merged lcov) not set up locally; the core crate's first build required installing LLVM/libclang on this Windows host
- `impact:` none in practice — CI's Coverage Gate (diff-cover ≥ 80%) and Rust Core Coverage passed; both changed production lines are exercised by the added/updated tests

### Behavior Changes

- Intended behavior change: direct-mode Composio tool/action listings request `toolkit_versions=latest`
- User-visible effect: post-snapshot toolkits (e.g. Outlook) return their tools in direct mode instead of an empty list

### Parity Contract

- Legacy behavior preserved: backend-proxy mode unchanged; direct-mode query gains only the one parameter
- Guard/fallback/dispatch parity: `list_actions` still falls back v3 → v2; the v2 path is unchanged

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found (searched open/merged PRs and the codebase; `toolkit_versions` was absent)
- Canonical PR: this PR
- Resolution: N/A
