### PR TITLE
fix(onboarding): update walkthrough targets

### DIFF
--- a/app/src/components/walkthrough/AppWalkthrough.tsx
+++ b/app/src/components/walkthrough/AppWalkthrough.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { type EventData, EVENTS, Joyride, STATUS } from 'react-joyride';
 import { useNavigate } from 'react-router-dom';
 
+import { useT } from '../../lib/i18n/I18nContext';
 import { createWalkthroughSteps } from './walkthroughSteps';
 import WalkthroughTooltip from './WalkthroughTooltip';
 
@@ -98,13 +99,14 @@ export function resetWalkthrough(): void {
  */
 const AppWalkthrough = ({ onboarded = false }: { onboarded?: boolean }) => {
   const navigate = useNavigate();
+  const { t } = useT();
 
   // Only start running if the walkthrough is pending on first render.
   // Using a lazy initializer keeps this stable across re-renders.
   const [run, setRun] = useState<boolean>(() => isWalkthroughPending(onboarded));
 
   // Memoize steps so they are only recreated when `navigate` identity changes.
-  const steps = useMemo(() => createWalkthroughSteps(navigate), [navigate]);
+  const steps = useMemo(() => createWalkthroughSteps(navigate, t), [navigate, t]);
 
   // Listen for the `walkthrough:restart` custom event (dispatched by
   // `resetWalkthrough()`) and restart the tour immediately.

--- a/app/src/components/walkthrough/AppWalkthrough.tsx
+++ b/app/src/components/walkthrough/AppWalkthrough.tsx
@@ -32,7 +32,7 @@ export function isWalkthroughPending(userIsOnboarded = false): boolean {
 
 /**
  * Flags the walkthrough as pending. Called by OnboardingLayout when the user
- * completes the wizard and is about to navigate to /home.
+ * completes the wizard and is about to navigate to /chat.
  *
  * Best-effort: if localStorage is unavailable (SecurityError / quota) the
  * error is logged and the call is silently swallowed so navigation always
@@ -65,7 +65,7 @@ export function markWalkthroughComplete(): void {
 }
 
 /**
- * Resets the walkthrough so it will play again on next visit to /home.
+ * Resets the walkthrough so it will play again on the current app shell.
  *
  * - Removes the completed flag from localStorage.
  * - Sets the pending flag so `isWalkthroughPending()` returns true.

--- a/app/src/components/walkthrough/WalkthroughTooltip.tsx
+++ b/app/src/components/walkthrough/WalkthroughTooltip.tsx
@@ -2,10 +2,8 @@ import type { TooltipRenderProps } from 'react-joyride';
 
 import { useT } from '../../lib/i18n/I18nContext';
 
-/** Emoji accents per step — adds visual personality to each tooltip.
- *  10 entries map to: home-card, home-cta, chat, integrations, channels,
- *  intelligence, settings, quick-access tabs, notifications, final. */
-const STEP_ICONS = ['🏠', '💬', '🗨️', '🧩', '📱', '🧠', '⚙️', '⚡', '🔔', '🎉'];
+/** Emoji accents per walkthrough step. */
+const STEP_ICONS = ['💬', '👋', '🗨️', '🧩', '📱', '⚙️', '💬', '👤', '🧠', '🌐', '🔌', '✉️', '🎉'];
 
 /**
  * Premium tooltip for the post-onboarding Joyride walkthrough.

--- a/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
+++ b/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
@@ -519,10 +519,10 @@ describe('WalkthroughTooltip', () => {
 // ── createWalkthroughSteps tests ──────────────────────────────────────────
 
 describe('createWalkthroughSteps', () => {
-  it('returns 10 steps', () => {
+  it('returns 13 steps', () => {
     const navigate = vi.fn();
     const steps = createWalkthroughSteps(navigate);
-    expect(steps).toHaveLength(10);
+    expect(steps).toHaveLength(13);
   });
 
   it('first step targets home-card', () => {
@@ -551,19 +551,18 @@ describe('createWalkthroughSteps', () => {
     const navigate = vi.fn();
     const steps = createWalkthroughSteps(navigate);
 
-    // Steps: 2=chat, 3=integrations, 4=channels, 5=activity, 6=settings, 7=home-return, 9=chat-welcome
-    const crossPageIndices = [2, 3, 4, 5, 6, 7, 9];
+    // Steps: 2=chat, 3=integrations, 4=channels, 5=settings, 6=chat-tab, 12=chat-welcome
+    const crossPageIndices = [2, 3, 4, 5, 6, 12];
     for (const idx of crossPageIndices) {
       expect(typeof steps[idx].before, `step[${idx}] should have a before fn`).toBe('function');
     }
   });
 
-  it('home-only steps do not have before functions', () => {
+  it('same-shell steps do not have before functions', () => {
     const navigate = vi.fn();
     const steps = createWalkthroughSteps(navigate);
 
-    // Steps: 0=home-card, 1=home-cta, 8=tab-notifications (step 9 now has a before hook)
-    const homeOnlyIndices = [0, 1, 8];
+    const homeOnlyIndices = [0, 1, 7, 8, 9, 10, 11];
     for (const idx of homeOnlyIndices) {
       expect(steps[idx].before, `step[${idx}] should not have a before fn`).toBeUndefined();
     }
@@ -573,10 +572,9 @@ describe('createWalkthroughSteps', () => {
     { idx: 2, route: '/chat', target: 'chat-agent-panel' },
     { idx: 3, route: '/connections', target: 'skills-grid' },
     { idx: 4, route: null, target: 'skills-channels' },
-    { idx: 5, route: '/activity', target: 'intelligence-header' },
-    { idx: 6, route: '/settings', target: 'settings-menu' },
-    { idx: 7, route: '/home', target: 'tab-chat' },
-    { idx: 9, route: '/chat', target: 'chat-agent-panel' },
+    { idx: 5, route: '/settings', target: 'settings-menu' },
+    { idx: 6, route: null, target: 'tab-chat' },
+    { idx: 12, route: '/chat', target: 'chat-agent-panel' },
   ])('before hook for step $idx calls navigate("$route")', async ({ idx, route, target }) => {
     const navigate = vi.fn();
 
@@ -593,6 +591,30 @@ describe('createWalkthroughSteps', () => {
     } finally {
       document.body.removeChild(el);
     }
+  });
+
+  it('targets only current walkthrough anchors', () => {
+    const navigate = vi.fn();
+    const steps = createWalkthroughSteps(navigate);
+    const targets = steps.map(step => step.target);
+
+    expect(targets).toEqual([
+      '[data-walkthrough="home-card"]',
+      '[data-walkthrough="home-cta"]',
+      '[data-walkthrough="chat-agent-panel"]',
+      '[data-walkthrough="skills-grid"]',
+      '[data-walkthrough="skills-channels"]',
+      '[data-walkthrough="settings-menu"]',
+      '[data-walkthrough="tab-chat"]',
+      '[data-walkthrough="tab-human"]',
+      '[data-walkthrough="tab-brain"]',
+      '[data-walkthrough="tab-agent-world"]',
+      '[data-walkthrough="tab-connections"]',
+      '[data-walkthrough="tab-feedback"]',
+      '[data-walkthrough="chat-agent-panel"]',
+    ]);
+    expect(targets).not.toContain('[data-walkthrough="tab-activity"]');
+    expect(targets).not.toContain('[data-walkthrough="intelligence-header"]');
   });
 
   it('final step before hook creates thread and seeds welcome message', async () => {

--- a/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
+++ b/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
@@ -573,7 +573,7 @@ describe('createWalkthroughSteps', () => {
     { idx: 3, route: '/connections', target: 'skills-grid' },
     { idx: 4, route: null, target: 'skills-channels' },
     { idx: 5, route: '/settings', target: 'settings-menu' },
-    { idx: 6, route: null, target: 'tab-chat' },
+    { idx: 6, route: '/chat', target: 'tab-chat' },
     { idx: 12, route: '/chat', target: 'chat-agent-panel' },
   ])('before hook for step $idx calls navigate("$route")', async ({ idx, route, target }) => {
     const navigate = vi.fn();

--- a/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
+++ b/app/src/components/walkthrough/__tests__/AppWalkthrough.test.tsx
@@ -9,7 +9,7 @@
  *  - AppWalkthrough does not render when already completed
  *  - AppWalkthrough restarts when walkthrough:restart event fires
  *  - Completing/skipping the tour calls markWalkthroughComplete (localStorage set)
- *  - createWalkthroughSteps: 9 steps, cross-page steps have before functions
+ *  - createWalkthroughSteps: current targets, cross-page steps have before functions
  *  - waitForTarget: resolves when element added, rejects on timeout
  *  - WalkthroughTooltip renders step title, content, and navigation buttons
  */

--- a/app/src/components/walkthrough/walkthroughSteps.ts
+++ b/app/src/components/walkthrough/walkthroughSteps.ts
@@ -6,6 +6,8 @@ import { store } from '../../store';
 import { addMessageLocal, createNewThread, setSelectedThread } from '../../store/threadSlice';
 import type { ThreadMessage } from '../../types/thread';
 
+type Translator = (key: string, fallback?: string) => string;
+
 /**
  * Polls via setTimeout until `[data-walkthrough="<selector>"]` appears in the
  * DOM, then resolves. Rejects after `timeout` ms (default 3000).
@@ -52,14 +54,16 @@ export function waitForTarget(selector: string, timeout = 3000): Promise<void> {
  * All targets follow the `[data-walkthrough="<name>"]` convention — add the
  * attribute to the corresponding DOM element in the page/component.
  */
-export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
+export function createWalkthroughSteps(
+  navigate: NavigateFunction,
+  t: Translator = (_key, fallback) => fallback ?? _key
+): Step[] {
   return [
     // ── Step 1 — /chat empty state ────────────────────────────────────────
     {
       target: '[data-walkthrough="home-card"]',
-      title: 'Start in chat',
-      content:
-        'Chat is your starting point. New windows open with the same greeting and quick actions you saw after setup.',
+      title: t('walkthrough.steps.startChat.title'),
+      content: t('walkthrough.steps.startChat.content'),
       placement: 'bottom',
       skipBeacon: true,
     },
@@ -67,8 +71,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 2 — /chat empty state ────────────────────────────────────────
     {
       target: '[data-walkthrough="home-cta"]',
-      title: 'Say hello',
-      content: 'Tap here to start a conversation with your AI assistant anytime.',
+      title: t('walkthrough.steps.sayHello.title'),
+      content: t('walkthrough.steps.sayHello.content'),
       placement: 'bottom',
       skipBeacon: true,
     },
@@ -76,9 +80,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 3 — /chat ────────────────────────────────────────────────────
     {
       target: '[data-walkthrough="chat-agent-panel"]',
-      title: 'Meet your AI',
-      content:
-        'This is where conversations happen. Ask questions, get summaries, or brainstorm. Everything stays searchable.',
+      title: t('walkthrough.steps.meetAi.title'),
+      content: t('walkthrough.steps.meetAi.content'),
       placement: 'bottom',
       skipBeacon: true,
       before: async () => {
@@ -90,9 +93,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 4 — /connections (Apps tab) ──────────────────────────────────
     {
       target: '[data-walkthrough="skills-grid"]',
-      title: 'Connect your world',
-      content:
-        'Gmail, Slack, WhatsApp, and more — each connection gives your assistant superpowers.',
+      title: t('walkthrough.steps.connectWorld.title'),
+      content: t('walkthrough.steps.connectWorld.content'),
       placement: 'top',
       skipBeacon: true,
       before: async () => {
@@ -104,9 +106,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 5 — /connections (Messaging tab) ────────────────────────────
     {
       target: '[data-walkthrough="skills-channels"]',
-      title: 'Chat where you already are',
-      content:
-        'WhatsApp, Telegram, Slack, Discord — connect your messaging apps so your assistant can reach you anywhere.',
+      title: t('walkthrough.steps.messagingApps.title'),
+      content: t('walkthrough.steps.messagingApps.content'),
       placement: 'bottom',
       skipBeacon: true,
       before: async () => {
@@ -117,9 +118,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 6 — /settings ────────────────────────────────────────────────
     {
       target: '[data-walkthrough="settings-menu"]',
-      title: 'Make it yours',
-      content:
-        'Preferences, privacy, notifications — everything is here. You can restart this tour anytime from this page.',
+      title: t('walkthrough.steps.settings.title'),
+      content: t('walkthrough.steps.settings.content'),
       placement: 'top',
       skipBeacon: true,
       before: async () => {
@@ -131,8 +131,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 7 — primary nav: Chat ────────────────────────────────────────
     {
       target: '[data-walkthrough="tab-chat"]',
-      title: 'Jump back to chat',
-      content: 'Use the Chat tab whenever you want to return to conversations.',
+      title: t('walkthrough.steps.chatTab.title'),
+      content: t('walkthrough.steps.chatTab.content'),
       placement: 'top',
       skipBeacon: true,
       before: async () => {
@@ -143,9 +143,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 8 — primary nav: Human ───────────────────────────────────────
     {
       target: '[data-walkthrough="tab-human"]',
-      title: 'Meet your human profile',
-      content:
-        'Human is where your personal context, identity, and assistant-facing profile come together.',
+      title: t('walkthrough.steps.humanTab.title'),
+      content: t('walkthrough.steps.humanTab.content'),
       placement: 'top',
       skipBeacon: true,
     },
@@ -153,9 +152,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 9 — primary nav: Brain ───────────────────────────────────────
     {
       target: '[data-walkthrough="tab-brain"]',
-      title: 'Open your Brain',
-      content:
-        'Brain is the memory graph: the place to inspect what OpenHuman knows and how ideas connect.',
+      title: t('walkthrough.steps.brainTab.title'),
+      content: t('walkthrough.steps.brainTab.content'),
       placement: 'top',
       skipBeacon: true,
     },
@@ -163,8 +161,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 10 — primary nav: Agent World ────────────────────────────────
     {
       target: '[data-walkthrough="tab-agent-world"]',
-      title: 'Explore Agent World',
-      content: 'Agent World is where reusable agents and shared automations live.',
+      title: t('walkthrough.steps.agentWorldTab.title'),
+      content: t('walkthrough.steps.agentWorldTab.content'),
       placement: 'top',
       skipBeacon: true,
     },
@@ -172,9 +170,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 11 — primary nav: Connections ────────────────────────────────
     {
       target: '[data-walkthrough="tab-connections"]',
-      title: 'Manage connections',
-      content:
-        'Connections is always available from the main nav when you want to add or adjust services.',
+      title: t('walkthrough.steps.connectionsTab.title'),
+      content: t('walkthrough.steps.connectionsTab.content'),
       placement: 'top',
       skipBeacon: true,
     },
@@ -182,8 +179,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 12 — primary nav: Feedback ───────────────────────────────────
     {
       target: '[data-walkthrough="tab-feedback"]',
-      title: 'Send feedback',
-      content: 'Feedback gives you a direct place to report rough edges or ask for improvements.',
+      title: t('walkthrough.steps.feedbackTab.title'),
+      content: t('walkthrough.steps.feedbackTab.content'),
       placement: 'top',
       skipBeacon: true,
     },
@@ -191,9 +188,8 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
     // ── Step 13 — /chat (pre-seeded welcome message) ──────────────────────
     {
       target: '[data-walkthrough="chat-agent-panel"]',
-      title: "You're all set!",
-      content:
-        'Your assistant left you a welcome note — this is your space to chat, ask questions, or brainstorm. Have fun!',
+      title: t('walkthrough.steps.allSet.title'),
+      content: t('walkthrough.steps.allSet.content'),
       placement: 'bottom',
       skipBeacon: true,
       before: async () => {

--- a/app/src/components/walkthrough/walkthroughSteps.ts
+++ b/app/src/components/walkthrough/walkthroughSteps.ts
@@ -136,6 +136,7 @@ export function createWalkthroughSteps(
       placement: 'top',
       skipBeacon: true,
       before: async () => {
+        navigate('/chat');
         await waitForTarget('tab-chat');
       },
     },

--- a/app/src/components/walkthrough/walkthroughSteps.ts
+++ b/app/src/components/walkthrough/walkthroughSteps.ts
@@ -43,7 +43,7 @@ export function waitForTarget(selector: string, timeout = 3000): Promise<void> {
 }
 
 /**
- * Factory that produces the 10-step walkthrough sequence.
+ * Factory that produces the post-onboarding walkthrough sequence.
  *
  * Steps that navigate to a different page receive a `before` async hook that
  * calls `navigate(path)` and then waits for the target element to appear in
@@ -54,17 +54,17 @@ export function waitForTarget(selector: string, timeout = 3000): Promise<void> {
  */
 export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
   return [
-    // ── Step 1 — /home ────────────────────────────────────────────────────
+    // ── Step 1 — /chat empty state ────────────────────────────────────────
     {
       target: '[data-walkthrough="home-card"]',
-      title: 'Your command center',
+      title: 'Start in chat',
       content:
-        "This is your home base — a quick snapshot of what's happening and what needs your attention.",
+        'Chat is your starting point. New windows open with the same greeting and quick actions you saw after setup.',
       placement: 'bottom',
       skipBeacon: true,
     },
 
-    // ── Step 2 — /home ────────────────────────────────────────────────────
+    // ── Step 2 — /chat empty state ────────────────────────────────────────
     {
       target: '[data-walkthrough="home-cta"]',
       title: 'Say hello',
@@ -87,7 +87,7 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
       },
     },
 
-    // ── Step 4 — /connections (Apps tab) ─────────────────────────────────
+    // ── Step 4 — /connections (Apps tab) ──────────────────────────────────
     {
       target: '[data-walkthrough="skills-grid"]',
       title: 'Connect your world',
@@ -114,20 +114,6 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
       },
     },
 
-    // ── Step 6 — /activity (Activity) ────────────────────────────────────
-    {
-      target: '[data-walkthrough="intelligence-header"]',
-      title: 'Your activity hub',
-      content:
-        'This is where your assistant learns and remembers. It gets smarter the more you use it.',
-      placement: 'bottom',
-      skipBeacon: true,
-      before: async () => {
-        navigate('/activity');
-        await waitForTarget('intelligence-header');
-      },
-    },
-
     // ── Step 6 — /settings ────────────────────────────────────────────────
     {
       target: '[data-walkthrough="settings-menu"]',
@@ -142,29 +128,67 @@ export function createWalkthroughSteps(navigate: NavigateFunction): Step[] {
       },
     },
 
-    // ── Step 7 — /home ────────────────────────────────────────────────────
+    // ── Step 7 — primary nav: Chat ────────────────────────────────────────
     {
       target: '[data-walkthrough="tab-chat"]',
-      title: 'Quick access',
-      content: 'These tabs are your shortcuts — always one tap away.',
+      title: 'Jump back to chat',
+      content: 'Use the Chat tab whenever you want to return to conversations.',
       placement: 'top',
       skipBeacon: true,
       before: async () => {
-        navigate('/home');
         await waitForTarget('tab-chat');
       },
     },
 
-    // ── Step 8 — /home (already there) ───────────────────────────────────
+    // ── Step 8 — primary nav: Human ───────────────────────────────────────
     {
-      target: '[data-walkthrough="tab-activity"]',
-      title: 'Stay in the loop',
-      content: 'Alerts and automations live here — briefings, notifications, background activity.',
+      target: '[data-walkthrough="tab-human"]',
+      title: 'Meet your human profile',
+      content:
+        'Human is where your personal context, identity, and assistant-facing profile come together.',
       placement: 'top',
       skipBeacon: true,
     },
 
-    // ── Step 9 — /chat (pre-seeded welcome message) ───────────────────────
+    // ── Step 9 — primary nav: Brain ───────────────────────────────────────
+    {
+      target: '[data-walkthrough="tab-brain"]',
+      title: 'Open your Brain',
+      content:
+        'Brain is the memory graph: the place to inspect what OpenHuman knows and how ideas connect.',
+      placement: 'top',
+      skipBeacon: true,
+    },
+
+    // ── Step 10 — primary nav: Agent World ────────────────────────────────
+    {
+      target: '[data-walkthrough="tab-agent-world"]',
+      title: 'Explore Agent World',
+      content: 'Agent World is where reusable agents and shared automations live.',
+      placement: 'top',
+      skipBeacon: true,
+    },
+
+    // ── Step 11 — primary nav: Connections ────────────────────────────────
+    {
+      target: '[data-walkthrough="tab-connections"]',
+      title: 'Manage connections',
+      content:
+        'Connections is always available from the main nav when you want to add or adjust services.',
+      placement: 'top',
+      skipBeacon: true,
+    },
+
+    // ── Step 12 — primary nav: Feedback ───────────────────────────────────
+    {
+      target: '[data-walkthrough="tab-feedback"]',
+      title: 'Send feedback',
+      content: 'Feedback gives you a direct place to report rough edges or ask for improvements.',
+      placement: 'top',
+      skipBeacon: true,
+    },
+
+    // ── Step 13 — /chat (pre-seeded welcome message) ──────────────────────
     {
       target: '[data-walkthrough="chat-agent-panel"]',
       title: "You're all set!",

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -4917,45 +4917,42 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'يُعاد التعيين {time}.',
   'upsell.usageLimit.upgradePlan': 'ترقية الخطة',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'ابدأ من الدردشة',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
-  'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'الدردشة هي نقطة البداية. تفتح النوافذ الجديدة بالترحيب نفسه والإجراءات السريعة التي رأيتها بعد الإعداد.',
+  'walkthrough.steps.sayHello.title': 'قل مرحباً',
+  'walkthrough.steps.sayHello.content': 'اضغط هنا لبدء محادثة مع مساعد الذكاء الاصطناعي في أي وقت.',
+  'walkthrough.steps.meetAi.title': 'تعرّف إلى الذكاء الاصطناعي',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'هنا تجري المحادثات. اطرح الأسئلة، واحصل على الملخصات، أو طوّر الأفكار. يبقى كل شيء قابلاً للبحث.',
+  'walkthrough.steps.connectWorld.title': 'صِل عالمك',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail وSlack وWhatsApp والمزيد: كل اتصال يمنح مساعدك قدرات جديدة.',
+  'walkthrough.steps.messagingApps.title': 'تحدث حيث أنت بالفعل',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'اربط WhatsApp وTelegram وSlack وDiscord حتى يتمكن مساعدك من الوصول إليك في أي مكان.',
+  'walkthrough.steps.settings.title': 'اجعله مناسباً لك',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
-  'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'التفضيلات والخصوصية والإشعارات كلها هنا. يمكنك إعادة تشغيل هذه الجولة من هذه الصفحة في أي وقت.',
+  'walkthrough.steps.chatTab.title': 'ارجع إلى الدردشة',
+  'walkthrough.steps.chatTab.content': 'استخدم تبويب Chat عندما تريد الرجوع إلى محادثاتك.',
+  'walkthrough.steps.humanTab.title': 'تعرّف إلى ملف Human',
+  'walkthrough.steps.humanTab.content': 'يجمع Human سياقك الشخصي وهويتك والملف الذي يراه المساعد.',
+  'walkthrough.steps.brainTab.title': 'افتح Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain هو مخطط الذاكرة: المكان الذي تفحص فيه ما يعرفه OpenHuman وكيف ترتبط الأفكار.',
+  'walkthrough.steps.agentWorldTab.title': 'استكشف Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World هو مكان الوكلاء القابلين لإعادة الاستخدام والأتمتة المشتركة.',
+  'walkthrough.steps.connectionsTab.title': 'إدارة الاتصالات',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections متاح دائماً في التنقل الرئيسي عندما تريد إضافة الخدمات أو تعديلها.',
+  'walkthrough.steps.feedbackTab.title': 'إرسال ملاحظات',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'يوفر Feedback مكاناً مباشراً للإبلاغ عن المشاكل أو طلب التحسينات.',
+  'walkthrough.steps.allSet.title': 'كل شيء جاهز!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'ترك لك المساعد رسالة ترحيب: هذه مساحتك للدردشة وطرح الأسئلة وتطوير الأفكار. استمتع!',
   'walkthrough.tooltip.letsGo': 'هيا بنا!',
   'walkthrough.tooltip.next': 'التالي →',
   'walkthrough.tooltip.skip': 'تخطّي الجولة',

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -4917,6 +4917,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'يُعاد التعيين {time}.',
   'upsell.usageLimit.upgradePlan': 'ترقية الخطة',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'هيا بنا!',
   'walkthrough.tooltip.next': 'التالي →',
   'walkthrough.tooltip.skip': 'تخطّي الجولة',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -5014,6 +5014,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'এটি {time} রিসেট হবে।',
   'upsell.usageLimit.upgradePlan': 'প্ল্যান আপগ্রেড করুন',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'চলুন শুরু করি!',
   'walkthrough.tooltip.next': 'পরবর্তী →',
   'walkthrough.tooltip.skip': 'ট্যুর এড়িয়ে যান',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -5014,45 +5014,44 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'এটি {time} রিসেট হবে।',
   'upsell.usageLimit.upgradePlan': 'প্ল্যান আপগ্রেড করুন',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'চ্যাট থেকে শুরু করুন',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'চ্যাটই আপনার শুরু করার জায়গা। নতুন উইন্ডো সেটআপের পর দেখা একই শুভেচ্ছা ও দ্রুত কাজ নিয়ে খুলবে।',
+  'walkthrough.steps.sayHello.title': 'শুভেচ্ছা জানান',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'যেকোনো সময় আপনার AI সহকারীর সঙ্গে কথা শুরু করতে এখানে চাপুন।',
+  'walkthrough.steps.meetAi.title': 'আপনার AI-কে জানুন',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'কথোপকথন এখানেই হয়। প্রশ্ন করুন, সারাংশ নিন বা ভাবনা গুছান। সবকিছু খুঁজে পাওয়া যায়।',
+  'walkthrough.steps.connectWorld.title': 'আপনার জগৎ যুক্ত করুন',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp এবং আরও অনেক কিছু: প্রতিটি সংযোগ আপনার সহকারীকে নতুন ক্ষমতা দেয়।',
+  'walkthrough.steps.messagingApps.title': 'যেখানে আছেন সেখানেই চ্যাট করুন',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord যুক্ত করুন, যাতে সহকারী আপনাকে যেকোনো জায়গায় পৌঁছাতে পারে।',
+  'walkthrough.steps.settings.title': 'নিজের মতো সাজান',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'পছন্দ, গোপনীয়তা ও নোটিফিকেশন এখানে আছে। এই পেজ থেকে যেকোনো সময় ট্যুরটি আবার শুরু করতে পারেন।',
+  'walkthrough.steps.chatTab.title': 'চ্যাটে ফিরে যান',
+  'walkthrough.steps.chatTab.content': 'কথোপকথনে ফিরতে চাইলে Chat ট্যাব ব্যবহার করুন।',
+  'walkthrough.steps.humanTab.title': 'আপনার Human প্রোফাইল দেখুন',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human আপনার ব্যক্তিগত প্রসঙ্গ, পরিচয় এবং সহকারীর দেখা প্রোফাইল একত্র করে।',
+  'walkthrough.steps.brainTab.title': 'আপনার Brain খুলুন',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain হলো মেমোরি গ্রাফ: OpenHuman কী জানে এবং ধারণাগুলো কীভাবে যুক্ত তা দেখার জায়গা।',
+  'walkthrough.steps.agentWorldTab.title': 'Agent World ঘুরে দেখুন',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World-এ পুনরায় ব্যবহারযোগ্য এজেন্ট ও শেয়ার করা অটোমেশন থাকে।',
+  'walkthrough.steps.connectionsTab.title': 'সংযোগ পরিচালনা করুন',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'সেবা যোগ বা বদলাতে চাইলে Connections সবসময় প্রধান নেভিগেশনে থাকে।',
+  'walkthrough.steps.feedbackTab.title': 'মতামত পাঠান',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback সমস্যা জানানো বা উন্নতির অনুরোধ করার সরাসরি জায়গা।',
+  'walkthrough.steps.allSet.title': 'সব প্রস্তুত!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'আপনার সহকারী একটি স্বাগত নোট রেখে গেছে: এখানে আপনি চ্যাট করতে, প্রশ্ন করতে বা ধারণা গুছাতে পারেন। উপভোগ করুন!',
   'walkthrough.tooltip.letsGo': 'চলুন শুরু করি!',
   'walkthrough.tooltip.next': 'পরবর্তী →',
   'walkthrough.tooltip.skip': 'ট্যুর এড়িয়ে যান',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -5145,45 +5145,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Es setzt {time} zurück.',
   'upsell.usageLimit.upgradePlan': 'Upgrade-Plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Im Chat starten',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'Der Chat ist dein Startpunkt. Neue Fenster öffnen mit derselben Begrüßung und den Schnellaktionen aus der Einrichtung.',
+  'walkthrough.steps.sayHello.title': 'Sag Hallo',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Tippe hier, um jederzeit ein Gespräch mit deinem KI-Assistenten zu starten.',
+  'walkthrough.steps.meetAi.title': 'Lerne deine KI kennen',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'Hier finden Unterhaltungen statt. Stelle Fragen, lass dir Zusammenfassungen geben oder sammle Ideen. Alles bleibt durchsuchbar.',
+  'walkthrough.steps.connectWorld.title': 'Verbinde deine Welt',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp und mehr: Jede Verbindung gibt deinem Assistenten neue Fähigkeiten.',
+  'walkthrough.steps.messagingApps.title': 'Chatte dort, wo du schon bist',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord: Verbinde deine Messenger, damit dein Assistent dich überall erreichen kann.',
+  'walkthrough.steps.settings.title': 'Passe alles an',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+    'Einstellungen, Datenschutz und Benachrichtigungen sind hier. Du kannst diese Tour jederzeit von dieser Seite neu starten.',
+  'walkthrough.steps.chatTab.title': 'Zurück zum Chat',
   'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Nutze den Chat-Tab, wenn du zu deinen Unterhaltungen zurückkehren möchtest.',
+  'walkthrough.steps.humanTab.title': 'Dein Human-Profil',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human bündelt deinen persönlichen Kontext, deine Identität und dein Assistentenprofil.',
+  'walkthrough.steps.brainTab.title': 'Öffne dein Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain ist der Wissensgraph: Hier prüfst du, was OpenHuman weiß und wie Ideen verbunden sind.',
+  'walkthrough.steps.agentWorldTab.title': 'Agent World erkunden',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'In Agent World findest du wiederverwendbare Agenten und gemeinsame Automatisierungen.',
+  'walkthrough.steps.connectionsTab.title': 'Verbindungen verwalten',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections ist immer in der Hauptnavigation verfügbar, wenn du Dienste hinzufügen oder anpassen möchtest.',
+  'walkthrough.steps.feedbackTab.title': 'Feedback senden',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback ist der direkte Ort, um Probleme zu melden oder Verbesserungen vorzuschlagen.',
+  'walkthrough.steps.allSet.title': 'Alles bereit!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Dein Assistent hat dir eine Willkommensnotiz hinterlassen: Hier kannst du chatten, fragen oder Ideen sammeln. Viel Spaß!',
   'walkthrough.tooltip.letsGo': 'Lass uns gehen!',
   'walkthrough.tooltip.next': 'Weiter →',
   'walkthrough.tooltip.skip': 'Tour überspringen',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -5145,6 +5145,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Es setzt {time} zurück.',
   'upsell.usageLimit.upgradePlan': 'Upgrade-Plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'Lass uns gehen!',
   'walkthrough.tooltip.next': 'Weiter →',
   'walkthrough.tooltip.skip': 'Tour überspringen',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -5627,6 +5627,45 @@ const en: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Resets in {time}',
   'upsell.usageLimit.upgradePlan': 'Upgrade plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Start in chat',
+  'walkthrough.steps.startChat.content':
+    'Chat is your starting point. New windows open with the same greeting and quick actions you saw after setup.',
+  'walkthrough.steps.sayHello.title': 'Say hello',
+  'walkthrough.steps.sayHello.content':
+    'Tap here to start a conversation with your AI assistant anytime.',
+  'walkthrough.steps.meetAi.title': 'Meet your AI',
+  'walkthrough.steps.meetAi.content':
+    'This is where conversations happen. Ask questions, get summaries, or brainstorm. Everything stays searchable.',
+  'walkthrough.steps.connectWorld.title': 'Connect your world',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp, and more - each connection gives your assistant superpowers.',
+  'walkthrough.steps.messagingApps.title': 'Chat where you already are',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord - connect your messaging apps so your assistant can reach you anywhere.',
+  'walkthrough.steps.settings.title': 'Make it yours',
+  'walkthrough.steps.settings.content':
+    'Preferences, privacy, notifications - everything is here. You can restart this tour anytime from this page.',
+  'walkthrough.steps.chatTab.title': 'Jump back to chat',
+  'walkthrough.steps.chatTab.content':
+    'Use the Chat tab whenever you want to return to conversations.',
+  'walkthrough.steps.humanTab.title': 'Meet your human profile',
+  'walkthrough.steps.humanTab.content':
+    'Human is where your personal context, identity, and assistant-facing profile come together.',
+  'walkthrough.steps.brainTab.title': 'Open your Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain is the memory graph: the place to inspect what OpenHuman knows and how ideas connect.',
+  'walkthrough.steps.agentWorldTab.title': 'Explore Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World is where reusable agents and shared automations live.',
+  'walkthrough.steps.connectionsTab.title': 'Manage connections',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections is always available from the main nav when you want to add or adjust services.',
+  'walkthrough.steps.feedbackTab.title': 'Send feedback',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback gives you a direct place to report rough edges or ask for improvements.',
+  'walkthrough.steps.allSet.title': "You're all set!",
+  'walkthrough.steps.allSet.content':
+    'Your assistant left you a welcome note - this is your space to chat, ask questions, or brainstorm. Have fun!',
   'walkthrough.tooltip.letsGo': "Let's go!",
   'walkthrough.tooltip.next': 'Next →',
   'walkthrough.tooltip.skip': 'Skip tour',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -5107,6 +5107,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Se restablece {time}.',
   'upsell.usageLimit.upgradePlan': 'Mejorar plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': '¡Vamos!',
   'walkthrough.tooltip.next': 'Siguiente →',
   'walkthrough.tooltip.skip': 'Omitir tour',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -5109,43 +5109,43 @@ const messages: TranslationMap = {
   'upsell.usageLimit.weeklyInference': '{amount}',
   'walkthrough.steps.startChat.title': 'Empieza en el chat',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rápidas que viste después de la configuración.',
   'walkthrough.steps.sayHello.title': 'Saluda',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+    'Toca aquí para iniciar una conversación con tu asistente de IA cuando quieras.',
   'walkthrough.steps.meetAi.title': 'Conoce tu IA',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+    'Aquí ocurren las conversaciones. Haz preguntas, pide resúmenes o explora ideas. Todo queda disponible para buscar.',
   'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp y más: cada conexión le da más capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estás',
   'walkthrough.steps.messagingApps.content':
     'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
   'walkthrough.steps.settings.title': 'Hazlo tuyo',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+    'Preferencias, privacidad y notificaciones están aquí. Puedes reiniciar este recorrido desde esta página cuando quieras.',
   'walkthrough.steps.chatTab.title': 'Vuelve al chat',
   'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+    'Usa la pestaña Chat cuando quieras volver a tus conversaciones.',
   'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+    'Human reúne tu contexto personal, identidad y perfil visible para el asistente.',
   'walkthrough.steps.brainTab.title': 'Abre tu Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+    'Brain es el grafo de memoria: el lugar para revisar qué sabe OpenHuman y cómo se conectan las ideas.',
   'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
   'walkthrough.steps.agentWorldTab.content':
     'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
   'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+    'Connections siempre está disponible en la navegación principal para agregar o ajustar servicios.',
   'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
   'walkthrough.steps.feedbackTab.content':
     'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.title': '¡Todo listo!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Tu asistente te dejó una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. ¡Diviértete!',
   'walkthrough.tooltip.letsGo': '¡Vamos!',
   'walkthrough.tooltip.next': 'Siguiente →',
   'walkthrough.tooltip.skip': 'Omitir tour',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -5127,6 +5127,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Réinitialisation {time}.',
   'upsell.usageLimit.upgradePlan': 'Mettre à niveau le plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': "C'est parti !",
   'walkthrough.tooltip.next': 'Suivant →',
   'walkthrough.tooltip.skip': 'Passer la visite',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -5127,45 +5127,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Réinitialisation {time}.',
   'upsell.usageLimit.upgradePlan': 'Mettre à niveau le plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Commencez dans le chat',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'Le chat est votre point de départ. Les nouvelles fenêtres s’ouvrent avec le même accueil et les actions rapides vues pendant la configuration.',
+  'walkthrough.steps.sayHello.title': 'Dites bonjour',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Appuyez ici pour lancer une conversation avec votre assistant IA à tout moment.',
+  'walkthrough.steps.meetAi.title': 'Rencontrez votre IA',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'C’est ici que les conversations ont lieu. Posez des questions, demandez des résumés ou explorez des idées. Tout reste consultable.',
+  'walkthrough.steps.connectWorld.title': 'Connectez votre monde',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp et plus encore : chaque connexion donne de nouveaux pouvoirs à votre assistant.',
+  'walkthrough.steps.messagingApps.title': 'Discutez là où vous êtes déjà',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord : connectez vos messageries pour que votre assistant puisse vous joindre partout.',
+  'walkthrough.steps.settings.title': 'Personnalisez-le',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+    'Préférences, confidentialité et notifications sont ici. Vous pouvez relancer cette visite depuis cette page à tout moment.',
+  'walkthrough.steps.chatTab.title': 'Retour au chat',
   'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Utilisez l’onglet Chat dès que vous voulez revenir à vos conversations.',
+  'walkthrough.steps.humanTab.title': 'Votre profil humain',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human réunit votre contexte personnel, votre identité et le profil visible par l’assistant.',
+  'walkthrough.steps.brainTab.title': 'Ouvrez votre Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain est le graphe de mémoire : l’endroit où vérifier ce qu’OpenHuman sait et comment les idées se relient.',
+  'walkthrough.steps.agentWorldTab.title': 'Explorez Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World regroupe les agents réutilisables et les automatisations partagées.',
+  'walkthrough.steps.connectionsTab.title': 'Gérer les connexions',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections reste disponible dans la navigation principale pour ajouter ou ajuster des services.',
+  'walkthrough.steps.feedbackTab.title': 'Envoyer un retour',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback vous donne un lieu direct pour signaler les problèmes ou demander des améliorations.',
+  'walkthrough.steps.allSet.title': 'Tout est prêt !',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Votre assistant vous a laissé une note de bienvenue : cet espace sert à discuter, poser des questions ou explorer des idées. Amusez-vous bien !',
   'walkthrough.tooltip.letsGo': "C'est parti !",
   'walkthrough.tooltip.next': 'Suivant →',
   'walkthrough.tooltip.skip': 'Passer la visite',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -5017,6 +5017,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'यह {time} रीसेट होती है।',
   'upsell.usageLimit.upgradePlan': 'प्लान अपग्रेड करें',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'चलिए शुरू करें!',
   'walkthrough.tooltip.next': 'अगला →',
   'walkthrough.tooltip.skip': 'टूर छोड़ें',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -5017,45 +5017,44 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'यह {time} रीसेट होती है।',
   'upsell.usageLimit.upgradePlan': 'प्लान अपग्रेड करें',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'चैट से शुरू करें',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'चैट आपका शुरुआती स्थान है। नई विंडो उसी स्वागत संदेश और तेज़ कार्रवाइयों के साथ खुलती हैं जो आपने सेटअप के बाद देखीं।',
+  'walkthrough.steps.sayHello.title': 'नमस्ते कहें',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'कभी भी अपने AI सहायक से बातचीत शुरू करने के लिए यहां टैप करें।',
+  'walkthrough.steps.meetAi.title': 'अपने AI से मिलें',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'बातचीत यहीं होती है। सवाल पूछें, सारांश लें या विचार करें। सब कुछ खोजने योग्य रहता है।',
+  'walkthrough.steps.connectWorld.title': 'अपनी दुनिया जोड़ें',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp और बहुत कुछ: हर कनेक्शन आपके सहायक को नई क्षमताएं देता है।',
+  'walkthrough.steps.messagingApps.title': 'जहां आप पहले से हैं वहीं चैट करें',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord जोड़ें ताकि आपका सहायक आपको कहीं भी पहुंच सके।',
+  'walkthrough.steps.settings.title': 'इसे अपना बनाएं',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'पसंद, गोपनीयता और सूचनाएं यहां हैं। आप इस पेज से यह टूर कभी भी फिर शुरू कर सकते हैं।',
+  'walkthrough.steps.chatTab.title': 'चैट पर वापस जाएं',
+  'walkthrough.steps.chatTab.content': 'जब भी बातचीत पर लौटना हो, Chat टैब का उपयोग करें।',
+  'walkthrough.steps.humanTab.title': 'अपनी Human प्रोफ़ाइल देखें',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human आपका निजी संदर्भ, पहचान और सहायक को दिखने वाली प्रोफ़ाइल एक साथ रखता है।',
+  'walkthrough.steps.brainTab.title': 'अपना Brain खोलें',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain मेमोरी ग्राफ है: यहां देखें कि OpenHuman क्या जानता है और विचार कैसे जुड़े हैं।',
+  'walkthrough.steps.agentWorldTab.title': 'Agent World देखें',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World में पुन: उपयोग योग्य एजेंट और साझा ऑटोमेशन रहते हैं।',
+  'walkthrough.steps.connectionsTab.title': 'कनेक्शन प्रबंधित करें',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'सेवाएं जोड़ने या बदलने के लिए Connections हमेशा मुख्य नेविगेशन में उपलब्ध है।',
+  'walkthrough.steps.feedbackTab.title': 'फ़ीडबैक भेजें',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback समस्याएं बताने या सुधार मांगने की सीधी जगह है।',
+  'walkthrough.steps.allSet.title': 'सब तैयार है!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'आपके सहायक ने स्वागत नोट छोड़ा है: यहां आप चैट कर सकते हैं, सवाल पूछ सकते हैं या विचार कर सकते हैं। आनंद लें!',
   'walkthrough.tooltip.letsGo': 'चलिए शुरू करें!',
   'walkthrough.tooltip.next': 'अगला →',
   'walkthrough.tooltip.skip': 'टूर छोड़ें',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -5029,45 +5029,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Akan direset {time}.',
   'upsell.usageLimit.upgradePlan': 'Upgrade paket',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Mulai di chat',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'Chat adalah titik awal Anda. Jendela baru terbuka dengan sapaan dan tindakan cepat yang sama seperti setelah penyiapan.',
+  'walkthrough.steps.sayHello.title': 'Sapa dulu',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Ketuk di sini untuk memulai percakapan dengan asisten AI kapan saja.',
+  'walkthrough.steps.meetAi.title': 'Kenali AI Anda',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'Di sinilah percakapan berlangsung. Ajukan pertanyaan, minta ringkasan, atau susun ide. Semuanya tetap bisa dicari.',
+  'walkthrough.steps.connectWorld.title': 'Hubungkan dunia Anda',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp, dan lainnya: setiap koneksi memberi asisten Anda kemampuan baru.',
+  'walkthrough.steps.messagingApps.title': 'Chat di tempat Anda biasa berada',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord: hubungkan aplikasi pesan agar asisten dapat menjangkau Anda di mana saja.',
+  'walkthrough.steps.settings.title': 'Sesuaikan sendiri',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+    'Preferensi, privasi, dan notifikasi ada di sini. Anda dapat memulai ulang tur ini dari halaman ini kapan saja.',
+  'walkthrough.steps.chatTab.title': 'Kembali ke chat',
   'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Gunakan tab Chat kapan pun Anda ingin kembali ke percakapan.',
+  'walkthrough.steps.humanTab.title': 'Kenali profil Human Anda',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human menyatukan konteks pribadi, identitas, dan profil yang dilihat asisten.',
+  'walkthrough.steps.brainTab.title': 'Buka Brain Anda',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain adalah grafik memori: tempat melihat apa yang diketahui OpenHuman dan bagaimana ide saling terhubung.',
+  'walkthrough.steps.agentWorldTab.title': 'Jelajahi Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World adalah tempat agen yang dapat digunakan ulang dan automasi bersama.',
+  'walkthrough.steps.connectionsTab.title': 'Kelola koneksi',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections selalu tersedia di navigasi utama saat Anda ingin menambah atau menyesuaikan layanan.',
+  'walkthrough.steps.feedbackTab.title': 'Kirim masukan',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback memberi tempat langsung untuk melaporkan masalah atau meminta peningkatan.',
+  'walkthrough.steps.allSet.title': 'Semua siap!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Asisten meninggalkan catatan sambutan: ini ruang Anda untuk chat, bertanya, atau menyusun ide. Selamat mencoba!',
   'walkthrough.tooltip.letsGo': 'Ayo mulai!',
   'walkthrough.tooltip.next': 'Berikutnya →',
   'walkthrough.tooltip.skip': 'Lewati tur',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -5029,6 +5029,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Akan direset {time}.',
   'upsell.usageLimit.upgradePlan': 'Upgrade paket',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'Ayo mulai!',
   'walkthrough.tooltip.next': 'Berikutnya →',
   'walkthrough.tooltip.skip': 'Lewati tur',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -5096,45 +5096,44 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Si resetta {time}.',
   'upsell.usageLimit.upgradePlan': 'Aggiorna piano',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Inizia dalla chat',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'La chat è il tuo punto di partenza. Le nuove finestre si aprono con lo stesso saluto e le azioni rapide viste durante la configurazione.',
+  'walkthrough.steps.sayHello.title': 'Saluta',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Tocca qui per avviare una conversazione con il tuo assistente IA in qualsiasi momento.',
+  'walkthrough.steps.meetAi.title': 'Conosci la tua IA',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'Qui avvengono le conversazioni. Fai domande, ottieni riassunti o sviluppa idee. Tutto resta ricercabile.',
+  'walkthrough.steps.connectWorld.title': 'Connetti il tuo mondo',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp e altro: ogni connessione dà nuovi poteri al tuo assistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatta dove sei già',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord: collega le app di messaggistica così il tuo assistente può raggiungerti ovunque.',
+  'walkthrough.steps.settings.title': 'Rendilo tuo',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Preferenze, privacy e notifiche sono qui. Puoi riavviare questo tour da questa pagina in qualsiasi momento.',
+  'walkthrough.steps.chatTab.title': 'Torna alla chat',
+  'walkthrough.steps.chatTab.content': 'Usa la scheda Chat quando vuoi tornare alle conversazioni.',
+  'walkthrough.steps.humanTab.title': 'Scopri il tuo profilo umano',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human riunisce contesto personale, identità e profilo visibile all’assistente.',
+  'walkthrough.steps.brainTab.title': 'Apri il tuo Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain è il grafo della memoria: il posto dove vedere cosa sa OpenHuman e come si collegano le idee.',
+  'walkthrough.steps.agentWorldTab.title': 'Esplora Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World ospita agenti riutilizzabili e automazioni condivise.',
+  'walkthrough.steps.connectionsTab.title': 'Gestisci connessioni',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections è sempre nella navigazione principale quando vuoi aggiungere o modificare servizi.',
+  'walkthrough.steps.feedbackTab.title': 'Invia feedback',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback è il luogo diretto per segnalare problemi o chiedere miglioramenti.',
+  'walkthrough.steps.allSet.title': 'Tutto pronto!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Il tuo assistente ti ha lasciato una nota di benvenuto: qui puoi chattare, fare domande o sviluppare idee. Buon divertimento!',
   'walkthrough.tooltip.letsGo': 'Andiamo!',
   'walkthrough.tooltip.next': 'Avanti →',
   'walkthrough.tooltip.skip': 'Salta tour',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -5096,6 +5096,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Si resetta {time}.',
   'upsell.usageLimit.upgradePlan': 'Aggiorna piano',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'Andiamo!',
   'walkthrough.tooltip.next': 'Avanti →',
   'walkthrough.tooltip.skip': 'Salta tour',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -4971,45 +4971,43 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': '{time}에 초기화됩니다.',
   'upsell.usageLimit.upgradePlan': '플랜 업그레이드',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': '채팅에서 시작하기',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
-  'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    '채팅이 시작점입니다. 새 창은 설정 후 보았던 같은 인사와 빠른 작업으로 열립니다.',
+  'walkthrough.steps.sayHello.title': '인사하기',
+  'walkthrough.steps.sayHello.content': '언제든 여기를 눌러 AI 어시스턴트와 대화를 시작하세요.',
+  'walkthrough.steps.meetAi.title': 'AI 만나기',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    '대화가 이루어지는 곳입니다. 질문하고, 요약을 받고, 아이디어를 정리하세요. 모든 내용은 검색할 수 있습니다.',
+  'walkthrough.steps.connectWorld.title': '내 세계 연결하기',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp 등 각 연결은 어시스턴트에 더 많은 기능을 더합니다.',
+  'walkthrough.steps.messagingApps.title': '이미 쓰는 곳에서 채팅하기',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord를 연결하면 어시스턴트가 어디서든 연락할 수 있습니다.',
+  'walkthrough.steps.settings.title': '내 방식으로 설정하기',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    '환경설정, 개인정보, 알림이 모두 여기에 있습니다. 이 페이지에서 언제든 투어를 다시 시작할 수 있습니다.',
+  'walkthrough.steps.chatTab.title': '채팅으로 돌아가기',
+  'walkthrough.steps.chatTab.content': '대화로 돌아가고 싶을 때 Chat 탭을 사용하세요.',
+  'walkthrough.steps.humanTab.title': 'Human 프로필 보기',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human은 개인 맥락, 정체성, 어시스턴트가 보는 프로필을 한곳에 모읍니다.',
+  'walkthrough.steps.brainTab.title': 'Brain 열기',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain은 메모리 그래프입니다. OpenHuman이 무엇을 알고 아이디어가 어떻게 연결되는지 확인하는 곳입니다.',
+  'walkthrough.steps.agentWorldTab.title': 'Agent World 탐색',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World에는 재사용 가능한 에이전트와 공유 자동화가 있습니다.',
+  'walkthrough.steps.connectionsTab.title': '연결 관리',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    '서비스를 추가하거나 조정하고 싶을 때 Connections는 항상 기본 내비게이션에 있습니다.',
+  'walkthrough.steps.feedbackTab.title': '피드백 보내기',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback은 문제를 보고하거나 개선을 요청하는 직접적인 공간입니다.',
+  'walkthrough.steps.allSet.title': '준비 완료!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    '어시스턴트가 환영 메모를 남겼습니다. 이곳에서 채팅하고, 질문하고, 아이디어를 정리해 보세요. 즐겁게 사용하세요!',
   'walkthrough.tooltip.letsGo': '시작해 봅시다!',
   'walkthrough.tooltip.next': '다음 →',
   'walkthrough.tooltip.skip': '투어 건너뛰기',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -4971,6 +4971,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': '{time}에 초기화됩니다.',
   'upsell.usageLimit.upgradePlan': '플랜 업그레이드',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': '시작해 봅시다!',
   'walkthrough.tooltip.next': '다음 →',
   'walkthrough.tooltip.skip': '투어 건너뛰기',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -5091,45 +5091,44 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Resetuje się {time}.',
   'upsell.usageLimit.upgradePlan': 'Podnieś plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Zacznij na czacie',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'Czat jest punktem startowym. Nowe okna otwierają się z tym samym powitaniem i szybkimi akcjami z konfiguracji.',
+  'walkthrough.steps.sayHello.title': 'Przywitaj się',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Kliknij tutaj, aby w dowolnym momencie rozpocząć rozmowę z asystentem AI.',
+  'walkthrough.steps.meetAi.title': 'Poznaj swoją AI',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'Tutaj odbywają się rozmowy. Zadawaj pytania, proś o podsumowania lub rozwijaj pomysły. Wszystko pozostaje wyszukiwalne.',
+  'walkthrough.steps.connectWorld.title': 'Połącz swój świat',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp i więcej: każde połączenie daje asystentowi nowe możliwości.',
+  'walkthrough.steps.messagingApps.title': 'Czatuj tam, gdzie już jesteś',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord: połącz komunikatory, aby asystent mógł dotrzeć do Ciebie wszędzie.',
+  'walkthrough.steps.settings.title': 'Dostosuj pod siebie',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Preferencje, prywatność i powiadomienia są tutaj. Możesz uruchomić tę prezentację ponownie z tej strony.',
+  'walkthrough.steps.chatTab.title': 'Wróć do czatu',
+  'walkthrough.steps.chatTab.content': 'Użyj karty Chat, gdy chcesz wrócić do rozmów.',
+  'walkthrough.steps.humanTab.title': 'Poznaj profil Human',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human łączy Twój kontekst osobisty, tożsamość i profil widoczny dla asystenta.',
+  'walkthrough.steps.brainTab.title': 'Otwórz Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain to graf pamięci: miejsce, w którym sprawdzisz, co wie OpenHuman i jak łączą się idee.',
+  'walkthrough.steps.agentWorldTab.title': 'Odkryj Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World to miejsce na agentów wielokrotnego użytku i wspólne automatyzacje.',
+  'walkthrough.steps.connectionsTab.title': 'Zarządzaj połączeniami',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections jest zawsze dostępne w głównej nawigacji, gdy chcesz dodać lub zmienić usługi.',
+  'walkthrough.steps.feedbackTab.title': 'Wyślij opinię',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback daje bezpośrednie miejsce do zgłaszania problemów lub próśb o ulepszenia.',
+  'walkthrough.steps.allSet.title': 'Gotowe!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Asystent zostawił Ci wiadomość powitalną: tu możesz czatować, pytać i rozwijać pomysły. Miłej zabawy!',
   'walkthrough.tooltip.letsGo': 'Zaczynamy!',
   'walkthrough.tooltip.next': 'Dalej →',
   'walkthrough.tooltip.skip': 'Pomiń przewodnik',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -5091,6 +5091,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Resetuje się {time}.',
   'upsell.usageLimit.upgradePlan': 'Podnieś plan',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'Zaczynamy!',
   'walkthrough.tooltip.next': 'Dalej →',
   'walkthrough.tooltip.skip': 'Pomiń przewodnik',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -5098,6 +5098,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Será redefinido {time}.',
   'upsell.usageLimit.upgradePlan': 'Fazer upgrade do plano',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'Vamos lá!',
   'walkthrough.tooltip.next': 'Próximo →',
   'walkthrough.tooltip.skip': 'Pular tour',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -5098,45 +5098,44 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Será redefinido {time}.',
   'upsell.usageLimit.upgradePlan': 'Fazer upgrade do plano',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Comece no chat',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'O chat é seu ponto de partida. Novas janelas abrem com a mesma saudação e ações rápidas vistas na configuração.',
+  'walkthrough.steps.sayHello.title': 'Diga olá',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Toque aqui para iniciar uma conversa com seu assistente de IA quando quiser.',
+  'walkthrough.steps.meetAi.title': 'Conheça sua IA',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'É aqui que as conversas acontecem. Faça perguntas, peça resumos ou desenvolva ideias. Tudo continua pesquisável.',
+  'walkthrough.steps.connectWorld.title': 'Conecte seu mundo',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp e mais: cada conexão dá novos poderes ao seu assistente.',
+  'walkthrough.steps.messagingApps.title': 'Converse onde você já está',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord: conecte seus apps de mensagens para que seu assistente alcance você em qualquer lugar.',
+  'walkthrough.steps.settings.title': 'Deixe do seu jeito',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Preferências, privacidade e notificações ficam aqui. Você pode reiniciar este tour por esta página a qualquer momento.',
+  'walkthrough.steps.chatTab.title': 'Volte ao chat',
+  'walkthrough.steps.chatTab.content': 'Use a aba Chat sempre que quiser retornar às conversas.',
+  'walkthrough.steps.humanTab.title': 'Conheça seu perfil humano',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human reúne seu contexto pessoal, identidade e perfil visível ao assistente.',
+  'walkthrough.steps.brainTab.title': 'Abra seu Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain é o grafo de memória: o lugar para ver o que o OpenHuman sabe e como as ideias se conectam.',
+  'walkthrough.steps.agentWorldTab.title': 'Explore o Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World é onde ficam agentes reutilizáveis e automações compartilhadas.',
+  'walkthrough.steps.connectionsTab.title': 'Gerencie conexões',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections está sempre na navegação principal quando você quiser adicionar ou ajustar serviços.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar feedback',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback oferece um lugar direto para relatar problemas ou pedir melhorias.',
+  'walkthrough.steps.allSet.title': 'Tudo pronto!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Seu assistente deixou uma nota de boas-vindas: este é seu espaço para conversar, perguntar ou explorar ideias. Divirta-se!',
   'walkthrough.tooltip.letsGo': 'Vamos lá!',
   'walkthrough.tooltip.next': 'Próximo →',
   'walkthrough.tooltip.skip': 'Pular tour',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -5060,45 +5060,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Сбросится {time}.',
   'upsell.usageLimit.upgradePlan': 'Улучшить план',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': 'Начните в чате',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
+    'Чат — ваша отправная точка. Новые окна открываются с тем же приветствием и быстрыми действиями, которые вы видели после настройки.',
+  'walkthrough.steps.sayHello.title': 'Поздоровайтесь',
   'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    'Нажмите здесь, чтобы в любой момент начать разговор с ИИ-ассистентом.',
+  'walkthrough.steps.meetAi.title': 'Познакомьтесь с ИИ',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+    'Здесь проходят разговоры. Задавайте вопросы, получайте сводки или обдумывайте идеи. Все остается доступным для поиска.',
+  'walkthrough.steps.connectWorld.title': 'Подключите свой мир',
   'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    'Gmail, Slack, WhatsApp и другое: каждое подключение дает ассистенту новые возможности.',
+  'walkthrough.steps.messagingApps.title': 'Общайтесь там, где уже работаете',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    'WhatsApp, Telegram, Slack, Discord: подключите мессенджеры, чтобы ассистент мог связаться с вами где угодно.',
+  'walkthrough.steps.settings.title': 'Настройте под себя',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+    'Предпочтения, приватность и уведомления находятся здесь. Этот тур можно перезапустить с этой страницы в любое время.',
+  'walkthrough.steps.chatTab.title': 'Вернуться в чат',
   'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+    'Используйте вкладку Chat, когда хотите вернуться к разговорам.',
+  'walkthrough.steps.humanTab.title': 'Ваш профиль Human',
   'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    'Human объединяет личный контекст, идентичность и профиль, видимый ассистенту.',
+  'walkthrough.steps.brainTab.title': 'Откройте Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+    'Brain — это граф памяти: здесь можно увидеть, что знает OpenHuman и как связаны идеи.',
+  'walkthrough.steps.agentWorldTab.title': 'Исследуйте Agent World',
   'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Agent World — место для переиспользуемых агентов и общих автоматизаций.',
+  'walkthrough.steps.connectionsTab.title': 'Управляйте подключениями',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+    'Connections всегда доступен в основной навигации, когда нужно добавить или настроить сервисы.',
+  'walkthrough.steps.feedbackTab.title': 'Отправить отзыв',
   'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    'Feedback дает прямое место для сообщений о проблемах и просьб об улучшениях.',
+  'walkthrough.steps.allSet.title': 'Все готово!',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    'Ассистент оставил приветственную заметку: здесь можно общаться, задавать вопросы и развивать идеи. Удачи!',
   'walkthrough.tooltip.letsGo': 'Поехали!',
   'walkthrough.tooltip.next': 'Далее →',
   'walkthrough.tooltip.skip': 'Пропустить тур',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -5060,6 +5060,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': 'Сбросится {time}.',
   'upsell.usageLimit.upgradePlan': 'Улучшить план',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': 'Поехали!',
   'walkthrough.tooltip.next': 'Далее →',
   'walkthrough.tooltip.skip': 'Пропустить тур',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -4774,6 +4774,45 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': '重置时间',
   'upsell.usageLimit.upgradePlan': '升级方案',
   'upsell.usageLimit.weeklyInference': '{amount}',
+  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.content':
+    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
+  'walkthrough.steps.sayHello.title': 'Saluda',
+  'walkthrough.steps.sayHello.content':
+    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
+  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+  'walkthrough.steps.meetAi.content':
+    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
+  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
+  'walkthrough.steps.connectWorld.content':
+    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
+  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+  'walkthrough.steps.messagingApps.content':
+    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
+  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+  'walkthrough.steps.settings.content':
+    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
+  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
+  'walkthrough.steps.chatTab.content':
+    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
+  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
+  'walkthrough.steps.humanTab.content':
+    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
+  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+  'walkthrough.steps.brainTab.content':
+    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
+  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
+  'walkthrough.steps.agentWorldTab.content':
+    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
+  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+  'walkthrough.steps.connectionsTab.content':
+    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
+  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
+  'walkthrough.steps.feedbackTab.content':
+    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
+  'walkthrough.steps.allSet.title': 'Todo listo!',
+  'walkthrough.steps.allSet.content':
+    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
   'walkthrough.tooltip.letsGo': '出发吧！',
   'walkthrough.tooltip.next': '下一步 →',
   'walkthrough.tooltip.skip': '跳过引导',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -4774,45 +4774,39 @@ const messages: TranslationMap = {
   'upsell.usageLimit.resetsIn': '重置时间',
   'upsell.usageLimit.upgradePlan': '升级方案',
   'upsell.usageLimit.weeklyInference': '{amount}',
-  'walkthrough.steps.startChat.title': 'Empieza en el chat',
+  'walkthrough.steps.startChat.title': '从聊天开始',
   'walkthrough.steps.startChat.content':
-    'El chat es tu punto de partida. Las ventanas nuevas se abren con el mismo saludo y las acciones rapidas que viste despues de la configuracion.',
-  'walkthrough.steps.sayHello.title': 'Saluda',
-  'walkthrough.steps.sayHello.content':
-    'Toca aqui para iniciar una conversacion con tu asistente de IA cuando quieras.',
-  'walkthrough.steps.meetAi.title': 'Conoce tu IA',
+    '聊天是你的起点。新窗口会显示设置后看到的同一欢迎语和快捷操作。',
+  'walkthrough.steps.sayHello.title': '打个招呼',
+  'walkthrough.steps.sayHello.content': '随时点击这里，开始和你的 AI 助手对话。',
+  'walkthrough.steps.meetAi.title': '认识你的 AI',
   'walkthrough.steps.meetAi.content':
-    'Aqui ocurren las conversaciones. Haz preguntas, pide resumenes o explora ideas. Todo queda disponible para buscar.',
-  'walkthrough.steps.connectWorld.title': 'Conecta tu mundo',
-  'walkthrough.steps.connectWorld.content':
-    'Gmail, Slack, WhatsApp y mas: cada conexion le da mas capacidades a tu asistente.',
-  'walkthrough.steps.messagingApps.title': 'Chatea donde ya estas',
+    '对话都在这里进行。你可以提问、获取摘要或整理想法，所有内容都可以搜索。',
+  'walkthrough.steps.connectWorld.title': '连接你的世界',
+  'walkthrough.steps.connectWorld.content': 'Gmail、Slack、WhatsApp 等连接会为助手带来更多能力。',
+  'walkthrough.steps.messagingApps.title': '在常用地方聊天',
   'walkthrough.steps.messagingApps.content':
-    'WhatsApp, Telegram, Slack, Discord: conecta tus apps de mensajes para que tu asistente pueda encontrarte en cualquier lugar.',
-  'walkthrough.steps.settings.title': 'Hazlo tuyo',
+    '连接 WhatsApp、Telegram、Slack、Discord，让助手能在任何地方联系你。',
+  'walkthrough.steps.settings.title': '按你的方式设置',
   'walkthrough.steps.settings.content':
-    'Preferencias, privacidad y notificaciones estan aqui. Puedes reiniciar este recorrido desde esta pagina cuando quieras.',
-  'walkthrough.steps.chatTab.title': 'Vuelve al chat',
-  'walkthrough.steps.chatTab.content':
-    'Usa la pestana Chat cuando quieras volver a tus conversaciones.',
-  'walkthrough.steps.humanTab.title': 'Conoce tu perfil humano',
-  'walkthrough.steps.humanTab.content':
-    'Human reune tu contexto personal, identidad y perfil visible para el asistente.',
-  'walkthrough.steps.brainTab.title': 'Abre tu Brain',
+    '偏好、隐私和通知都在这里。你可以随时从此页面重新开始本引导。',
+  'walkthrough.steps.chatTab.title': '返回聊天',
+  'walkthrough.steps.chatTab.content': '想回到对话时，使用 Chat 标签。',
+  'walkthrough.steps.humanTab.title': '了解你的 Human 资料',
+  'walkthrough.steps.humanTab.content': 'Human 汇集你的个人上下文、身份以及助手可见的资料。',
+  'walkthrough.steps.brainTab.title': '打开 Brain',
   'walkthrough.steps.brainTab.content':
-    'Brain es el grafo de memoria: el lugar para revisar que sabe OpenHuman y como se conectan las ideas.',
-  'walkthrough.steps.agentWorldTab.title': 'Explora Agent World',
-  'walkthrough.steps.agentWorldTab.content':
-    'Agent World es donde viven agentes reutilizables y automatizaciones compartidas.',
-  'walkthrough.steps.connectionsTab.title': 'Gestiona conexiones',
+    'Brain 是记忆图谱，用来查看 OpenHuman 知道什么，以及想法如何相互连接。',
+  'walkthrough.steps.agentWorldTab.title': '探索 Agent World',
+  'walkthrough.steps.agentWorldTab.content': 'Agent World 是可复用代理和共享自动化所在的位置。',
+  'walkthrough.steps.connectionsTab.title': '管理连接',
   'walkthrough.steps.connectionsTab.content':
-    'Connections siempre esta disponible en la navegacion principal para agregar o ajustar servicios.',
-  'walkthrough.steps.feedbackTab.title': 'Enviar comentarios',
-  'walkthrough.steps.feedbackTab.content':
-    'Feedback te da un lugar directo para reportar problemas o pedir mejoras.',
-  'walkthrough.steps.allSet.title': 'Todo listo!',
+    '想添加或调整服务时，Connections 始终可从主导航进入。',
+  'walkthrough.steps.feedbackTab.title': '发送反馈',
+  'walkthrough.steps.feedbackTab.content': 'Feedback 提供直接入口，用来报告问题或请求改进。',
+  'walkthrough.steps.allSet.title': '全部就绪！',
   'walkthrough.steps.allSet.content':
-    'Tu asistente te dejo una nota de bienvenida: este es tu espacio para chatear, preguntar o explorar ideas. Diviertete!',
+    '你的助手留下了一条欢迎消息：这里就是你聊天、提问和整理想法的空间。祝你使用愉快！',
   'walkthrough.tooltip.letsGo': '出发吧！',
   'walkthrough.tooltip.next': '下一步 →',
   'walkthrough.tooltip.skip': '跳过引导',

--- a/app/src/pages/onboarding/Onboarding.tsx
+++ b/app/src/pages/onboarding/Onboarding.tsx
@@ -15,8 +15,8 @@ import WelcomePage from './pages/WelcomePage';
  * Routed onboarding flow.
  *
  *   welcome → runtime-choice
- *     ├── cloud  → /home
- *     └── custom → /custom/inference → voice → oauth → search → embeddings → vault → /home
+ *     ├── cloud  → /chat
+ *     └── custom → /custom/inference → voice → oauth → search → embeddings → vault → /chat
  *
  * Each custom step asks Default (let OpenHuman manage it) vs Configure
  * (let me pick). Default is a one-click pick; Configure renders inline

--- a/app/src/pages/onboarding/OnboardingContext.tsx
+++ b/app/src/pages/onboarding/OnboardingContext.tsx
@@ -26,7 +26,7 @@ export interface OnboardingContextValue {
   setDraft: (updater: (prev: OnboardingDraft) => OnboardingDraft) => void;
   /**
    * Persist `onboarding_completed=true`, notify the backend (best-effort), and
-   * navigate to `/home`. Called by the final step.
+   * navigate to `/chat`. Called by the final step.
    */
   completeAndExit: () => Promise<void>;
 }

--- a/app/src/pages/onboarding/OnboardingLayout.tsx
+++ b/app/src/pages/onboarding/OnboardingLayout.tsx
@@ -11,7 +11,7 @@ import { OnboardingContext, type OnboardingDraft } from './OnboardingContext';
 /**
  * Full-page chrome for the onboarding flow. Hosts the shared draft + the
  * completion side-effects (persist `onboarding_completed`, notify backend,
- * navigate to /home). Individual steps render through `<Outlet />`.
+ * navigate to /chat). Individual steps render through `<Outlet />`.
  */
 const OnboardingLayout = () => {
   const navigate = useNavigate();
@@ -66,16 +66,16 @@ const OnboardingLayout = () => {
     // Fire onboarding_complete analytics event before navigation.
     trackEvent('onboarding_complete');
 
-    // Flag the Joyride walkthrough as pending so it auto-starts on /home.
+    // Flag the Joyride walkthrough as pending so it auto-starts on the chat landing surface.
     // Best-effort: localStorage failures must not block navigation.
     try {
       setWalkthroughPending();
-      console.debug('[onboarding:layout] walkthrough pending flag set — navigating to /home');
+      console.debug('[onboarding:layout] walkthrough pending flag set — navigating to /chat');
     } catch (e) {
       console.warn('[onboarding:layout] could not set walkthrough pending flag; continuing', e);
     }
 
-    navigate('/home', { replace: true });
+    navigate('/chat', { replace: true });
   }, [draft.connectedSources, navigate, setOnboardingCompletedFlag, setOnboardingTasks, snapshot]);
 
   const value = useMemo(

--- a/app/src/pages/onboarding/__tests__/OnboardingLayout.test.tsx
+++ b/app/src/pages/onboarding/__tests__/OnboardingLayout.test.tsx
@@ -143,7 +143,7 @@ async function setupLayout(onboardingTasks: unknown = null) {
           <Route path="/onboarding" element={<OnboardingLayout />}>
             <Route index element={<TriggerComplete />} />
           </Route>
-          <Route path="/home" element={<div data-testid="home-page" />} />
+          <Route path="/chat" element={<div data-testid="chat-page" />} />
         </Routes>
       </MemoryRouter>
     </Provider>
@@ -221,9 +221,9 @@ describe('OnboardingLayout — Joyride walkthrough integration (#1123)', () => {
     expect(chatSend).not.toHaveBeenCalled();
   });
 
-  // Covers the catch branch in completeAndExit (OnboardingLayout.tsx:138):
-  // when setWalkthroughPending throws, navigation still proceeds to /home.
-  it('still navigates to /home when setWalkthroughPending throws', async () => {
+  // Covers the catch branch in completeAndExit:
+  // when setWalkthroughPending throws, navigation still proceeds to /chat.
+  it('still navigates to /chat when setWalkthroughPending throws', async () => {
     // Override default impl to throw for this one test invocation
     mockSetWalkthroughPending.mockImplementationOnce(() => {
       throw new Error('storage unavailable');
@@ -235,7 +235,7 @@ describe('OnboardingLayout — Joyride walkthrough integration (#1123)', () => {
     });
 
     // Navigation should still proceed even when the flag cannot be written.
-    expect(screen.getByTestId('home-page')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-page')).toBeInTheDocument();
   });
 
   it('still completes onboarding when persisting onboarding tasks fails', async () => {
@@ -250,7 +250,7 @@ describe('OnboardingLayout — Joyride walkthrough integration (#1123)', () => {
     });
 
     expect(mockSetOnboardingCompletedFlag).toHaveBeenCalledWith(true);
-    expect(screen.getByTestId('home-page')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-page')).toBeInTheDocument();
 
     warnSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- Updates the post-onboarding Joyride walkthrough to land on the current `/chat` surface instead of the legacy `/home` redirect.
- Removes stale tutorial references to `/activity`, `tab-activity`, and `intelligence-header`.
- Adds current primary nav targets for Chat, Human, Brain, Agent World, Connections, and Feedback.
- Updates walkthrough/onboarding tests so stale anchors cannot be reintroduced silently.

## Problem

- The onboarding tutorial was pointing users at UI elements and routes that no longer exist in the current desktop shell.
- The stale steps created a bad first-run experience by navigating through compatibility redirects and targeting removed nav items.

## Solution

- Reworked the walkthrough step list around the current chat landing page and primary nav configuration.
- Changed onboarding completion to navigate directly to `/chat`, where the walkthrough actually starts.
- Updated comments, tooltip step icons, and focused tests to match the current route/target contract.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: focused walkthrough/unit coverage was run; full merged coverage is left to CI for this narrow frontend-only tutorial fix.
- [x] N/A: coverage matrix feature rows were not added, removed, or renamed.
- [x] N/A: no affected coverage-matrix feature IDs for this walkthrough copy/target fix.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: manual smoke checklist is unchanged; this does not alter release-cut smoke surfaces.
- [x] N/A: no linked issue provided.

## Impact

- Desktop first-run/onboarding UX is corrected to the current shell layout.
- No backend, persistence, security, or migration impact.
- Existing `/home` compatibility route remains unchanged; onboarding now skips that redirect and lands on `/chat` directly.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/current-onboarding-walkthrough
- Commit SHA: 24b2700d3

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/components/walkthrough/__tests__/AppWalkthrough.test.tsx src/pages/onboarding/__tests__/OnboardingLayout.test.tsx`; `pnpm i18n:check`; targeted ESLint on walkthrough and locale files
- [x] Rust fmt/check (if changed): pre-push hook ran `cargo fmt --manifest-path ../Cargo.toml --all --check`, `cargo fmt --manifest-path src-tauri/Cargo.toml --all --check`, and `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] Tauri fmt/check (if changed): pre-push hook completed cleanly; no Tauri code changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: post-onboarding users land on `/chat` and see tour steps for the current shell/navigation.
- User-visible effect: the tutorial no longer points at removed activity/home nav elements.

### Parity Contract

- Legacy behavior preserved: final walkthrough step still seeds the welcome chat message; `/home` route remains a compatibility redirect.
- Guard/fallback/dispatch parity checks: tests assert current walkthrough anchors and completion still proceeds if setting the pending flag fails.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned post-onboarding walkthrough with expanded step coverage, including new guidance for chat navigation, feature discovery, connections, and account settings configuration
  * Updated onboarding flow to direct users to the chat interface upon completion instead of the home page
  * Enhanced walkthrough step visual indicators with updated emoji styling for improved visual feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->