### PR TITLE
fix(intelligence): make workflow-run approval modal opaque

### DIFF
--- a/app/src/components/intelligence/WorkflowRunApprovalCard.test.tsx
+++ b/app/src/components/intelligence/WorkflowRunApprovalCard.test.tsx
@@ -78,6 +78,23 @@ describe('WorkflowRunApprovalCard', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
+  it('uses an opaque warning surface so thread text does not show through (#3783)', () => {
+    render(
+      <WorkflowRunApprovalCard
+        definition={def()}
+        reasons={['high_children']}
+        onApprove={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const card = screen.getByTestId('workflow-approval-card');
+    expect(card).toHaveClass('bg-amber-50');
+    expect(card).toHaveClass('dark:bg-amber-950');
+    // No fractional-opacity background that would let thread text bleed through.
+    expect(card.className).not.toMatch(/\bbg-[^\s/]+\/\d+/);
+    expect(card.className).not.toMatch(/\bdark:bg-[^\s/]+\/\d+/);
+  });
+
   it('disables both buttons and shows the starting label while a start is in flight', () => {
     render(
       <WorkflowRunApprovalCard

--- a/app/src/components/intelligence/WorkflowRunApprovalCard.tsx
+++ b/app/src/components/intelligence/WorkflowRunApprovalCard.tsx
@@ -62,7 +62,7 @@ export const WorkflowRunApprovalCard: React.FC<Props> = ({
       role="alertdialog"
       aria-label={t('orchestration.approval.title')}
       data-testid="workflow-approval-card"
-      className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm dark:border-amber-500/40 dark:bg-amber-500/10">
+      className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm shadow-sm dark:border-amber-700 dark:bg-amber-950">
       <div className="flex items-start gap-2">
         <span aria-hidden className="text-base leading-none">
           ⚠️


### PR DESCRIPTION
## Summary

The workflow-run approval modal (`WorkflowRunApprovalCard`, a `role="alertdialog"`) used a fractional-opacity dark background — `dark:bg-amber-500/10` (10% opacity). In dark mode this let the underlying thread/processing text bleed straight through the modal, making both the dialog and the thread content hard to read — the exact symptom reported in #3783.

The sibling chat `ApprovalRequestCard` had the same class of bug and was already fixed in #3790 by switching to an opaque `dark:bg-amber-950` surface. This PR applies the matching fix to the workflow-run approval modal so the two approval surfaces stay visually consistent and legible.

## Changes

- `WorkflowRunApprovalCard.tsx`: root container `dark:border-amber-500/40 dark:bg-amber-500/10` → opaque `shadow-sm dark:border-amber-700 dark:bg-amber-950`. Light mode (`bg-amber-50`) was already opaque and is unchanged.
- `WorkflowRunApprovalCard.test.tsx`: added a regression test asserting the card uses `bg-amber-50` + `dark:bg-amber-950` and carries **no** fractional-opacity background class (`bg-…/NN` / `dark:bg-…/NN`).

## Acceptance criteria

- [x] **Repro gone** — modal now has an opaque background; thread text no longer bleeds through in dark mode.
- [x] **Regression safety** — Vitest unit test added asserting the opaque surface and rejecting any fractional-opacity background.
- [x] **Diff coverage ≥ 80%** — the only changed source line (the className) is exercised by the new test.

Closes #3783<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Workflow Run approval card styling in dark mode by updating its background and border colors to reduce text bleed-through.

* **Tests**
  * Added a unit test to verify the approval card uses the dedicated opaque warning surface styles and does not include fractional-opacity background utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->