### PR TITLE
feat(notifications): filter alerts by category

### DIFF
--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -705,6 +705,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'لا توجد تنبيهات بعد',
   'alerts.markAllRead': 'تحديد الكل كمقروء',
   'alerts.unread': 'غير مقروء',
+  'alerts.filterAll': 'الكل',
   'rewards.title': 'المكافآت',
   'rewards.referrals': 'الإحالات',
   'rewards.coupons': 'استرداد',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -720,6 +720,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'এখনো কোনো সতর্কতা নেই',
   'alerts.markAllRead': 'সব পঠিত চিহ্নিত করুন',
   'alerts.unread': 'অপঠিত',
+  'alerts.filterAll': 'সব',
   'rewards.title': 'পুরস্কার',
   'rewards.referrals': 'রেফারেল',
   'rewards.coupons': 'রিডিম',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -737,6 +737,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Noch keine Benachrichtigungen',
   'alerts.markAllRead': 'Alle als gelesen markieren',
   'alerts.unread': 'ungelesen',
+  'alerts.filterAll': 'Alle',
   'rewards.title': 'Belohnungen',
   'rewards.referrals': 'Empfehlungen',
   'rewards.coupons': 'Einlösen',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -976,6 +976,7 @@ const en: TranslationMap = {
   'alerts.empty': 'No alerts yet',
   'alerts.markAllRead': 'Mark all as read',
   'alerts.unread': 'unread',
+  'alerts.filterAll': 'All',
 
   // Rewards
   'rewards.title': 'Rewards',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -734,6 +734,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Sin alertas aún',
   'alerts.markAllRead': 'Marcar todo como leído',
   'alerts.unread': 'sin leer',
+  'alerts.filterAll': 'Todas',
   'rewards.title': 'Recompensas',
   'rewards.referrals': 'Referidos',
   'rewards.coupons': 'Canjear',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -737,6 +737,7 @@ const messages: TranslationMap = {
   'alerts.empty': "Aucune alerte pour l'instant",
   'alerts.markAllRead': 'Tout marquer comme lu',
   'alerts.unread': 'non lu',
+  'alerts.filterAll': 'Toutes',
   'rewards.title': 'Récompenses',
   'rewards.referrals': 'Parrainages',
   'rewards.coupons': 'Échanger',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -717,6 +717,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'अभी कोई अलर्ट नहीं',
   'alerts.markAllRead': 'सभी पढ़ा हुआ मार्क करें',
   'alerts.unread': 'अनरीड',
+  'alerts.filterAll': 'सभी',
   'rewards.title': 'रिवॉर्ड',
   'rewards.referrals': 'रेफरल',
   'rewards.coupons': 'रिडीम करें',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -722,6 +722,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Belum ada peringatan',
   'alerts.markAllRead': 'Tandai semua sudah dibaca',
   'alerts.unread': 'belum dibaca',
+  'alerts.filterAll': 'Semua',
   'rewards.title': 'Hadiah',
   'rewards.referrals': 'Referral',
   'rewards.coupons': 'Tukarkan',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -734,6 +734,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Nessun avviso',
   'alerts.markAllRead': 'Segna tutti come letti',
   'alerts.unread': 'non letti',
+  'alerts.filterAll': 'Tutte',
   'rewards.title': 'Premi',
   'rewards.referrals': 'Referral',
   'rewards.coupons': 'Riscatta',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -716,6 +716,7 @@ const messages: TranslationMap = {
   'alerts.empty': '아직 알림이 없습니다',
   'alerts.markAllRead': '모두 읽음으로 표시',
   'alerts.unread': '읽지 않음',
+  'alerts.filterAll': '전체',
   'rewards.title': '보상',
   'rewards.referrals': '추천',
   'rewards.coupons': '교환',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -724,6 +724,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Brak alertów',
   'alerts.markAllRead': 'Oznacz wszystkie jako przeczytane',
   'alerts.unread': 'nieprzeczytane',
+  'alerts.filterAll': 'Wszystkie',
   'rewards.title': 'Nagrody',
   'rewards.referrals': 'Polecenia',
   'rewards.coupons': 'Wykorzystaj',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -735,6 +735,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Nenhum alerta ainda',
   'alerts.markAllRead': 'Marcar tudo como lido',
   'alerts.unread': 'não lido',
+  'alerts.filterAll': 'Todas',
   'rewards.title': 'Recompensas',
   'rewards.referrals': 'Indicações',
   'rewards.coupons': 'Resgatar',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -725,6 +725,7 @@ const messages: TranslationMap = {
   'alerts.empty': 'Оповещений пока нет',
   'alerts.markAllRead': 'Отметить всё прочитанным',
   'alerts.unread': 'непрочитано',
+  'alerts.filterAll': 'Все',
   'rewards.title': 'Награды',
   'rewards.referrals': 'Рефералы',
   'rewards.coupons': 'Активировать',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -694,6 +694,7 @@ const messages: TranslationMap = {
   'alerts.empty': '暂无通知',
   'alerts.markAllRead': '全部标记为已读',
   'alerts.unread': '未读',
+  'alerts.filterAll': '全部',
   'rewards.title': '奖励',
   'rewards.referrals': '邀请',
   'rewards.coupons': '优惠券',

--- a/app/src/pages/Notifications.tsx
+++ b/app/src/pages/Notifications.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import NotificationBody from '../components/notifications/NotificationBody';
 import NotificationCenter from '../components/notifications/NotificationCenter';
+import PillTabBar from '../components/PillTabBar';
 import { useT } from '../lib/i18n/I18nContext';
 import { resolveSystemRoute } from '../lib/notificationRouter';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -14,6 +15,22 @@ import {
   type NotificationItem,
   selectUnreadCount,
 } from '../store/notificationSlice';
+
+// Canonical display order for category chips; only categories present in the
+// feed get a chip, but when several are present they always appear in this
+// order so the row is stable regardless of arrival order.
+const CATEGORY_ORDER: NotificationCategory[] = [
+  'messages',
+  'agents',
+  'skills',
+  'system',
+  'meetings',
+  'reminders',
+  'important',
+];
+
+// Sentinel value for the "All" chip (clears the category filter).
+type CategoryFilter = NotificationCategory | 'all';
 
 function formatTime(ts: number, t: (key: string) => string): string {
   const delta = Date.now() - ts;
@@ -32,6 +49,23 @@ const Notifications = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const unread = useMemo(() => selectUnreadCount(items), [items]);
+  const [selectedCategory, setSelectedCategory] = useState<CategoryFilter>('all');
+
+  // Categories actually present in the feed, in canonical order — drives the
+  // chip row so there are never any dead chips.
+  const availableCategories = useMemo(() => {
+    const present = new Set(items.map(item => item.category));
+    return CATEGORY_ORDER.filter(category => present.has(category));
+  }, [items]);
+
+  // Items shown in the list, narrowed to the selected category ('all' = no filter).
+  const visibleItems = useMemo(
+    () =>
+      selectedCategory === 'all'
+        ? items
+        : items.filter(item => item.category === selectedCategory),
+    [items, selectedCategory],
+  );
 
   const categoryLabel = (category: NotificationCategory): string => {
     switch (category) {
@@ -97,13 +131,34 @@ const Notifications = () => {
           </div>
         </div>
 
-        {items.length === 0 ? (
+        {/* Category-chip filter row — hidden entirely when the feed is empty. */}
+        {items.length > 0 && (
+          <div
+            data-testid="notification-category-filter"
+            className="border-b border-stone-100 dark:border-neutral-800 px-4 py-2">
+            <PillTabBar<CategoryFilter>
+              items={[
+                { label: t('alerts.filterAll'), value: 'all' },
+                ...availableCategories.map(category => ({
+                  label: categoryLabel(category),
+                  value: category,
+                })),
+              ]}
+              selected={selectedCategory}
+              onChange={setSelectedCategory}
+            />
+          </div>
+        )}
+
+        {/* Empty when the feed is empty OR the active category filter excludes
+            every item. */}
+        {visibleItems.length === 0 ? (
           <div className="px-6 py-16 text-center text-sm text-stone-500 dark:text-neutral-400">
             {t('alerts.empty')}
           </div>
         ) : (
           <ul className="divide-y divide-stone-100 dark:divide-neutral-800">
-            {items.map(item => (
+            {visibleItems.map(item => (
               <li key={item.id} data-testid="notification-item">
                 {/* `role="button"` instead of a real `<button>` — the row body
                     contains `NotificationLinkPill` (also a `<button>`), and

--- a/app/src/pages/__tests__/Notifications.test.tsx
+++ b/app/src/pages/__tests__/Notifications.test.tsx
@@ -139,3 +139,53 @@ describe('Notifications page row wrapper', () => {
     expect(store.getState().notifications.items[0].read).toBe(false);
   });
 });
+
+// #3715: category-chip filter row above the system-events list.
+describe('Notifications page category filter', () => {
+  it('hides the chip row entirely when there are no notifications', () => {
+    renderPage([]);
+    expect(screen.queryByTestId('notification-category-filter')).not.toBeInTheDocument();
+  });
+
+  it('renders an "All" chip plus one chip per category present (no dead chips)', () => {
+    renderPage([
+      makeItem('n-1', 'a', { category: 'messages' }),
+      makeItem('n-2', 'b', { category: 'agents' }),
+      makeItem('n-3', 'c', { category: 'messages' }),
+    ]);
+
+    const filter = screen.getByTestId('notification-category-filter');
+    const chips = within(filter).getAllByRole('tab');
+    // All + messages + agents — and NOT the absent categories.
+    expect(chips.map(c => c.textContent)).toEqual([
+      'alerts.filterAll',
+      'notifications.category.messages',
+      'notifications.category.agents',
+    ]);
+    expect(
+      within(filter).queryByText('notifications.category.system')
+    ).not.toBeInTheDocument();
+  });
+
+  it('filters the list to the selected category and back to all', () => {
+    renderPage([
+      makeItem('n-1', 'a', { category: 'messages' }),
+      makeItem('n-2', 'b', { category: 'agents' }),
+    ]);
+
+    // Default: All — both rows visible.
+    expect(screen.getAllByTestId('notification-item')).toHaveLength(2);
+
+    const filter = screen.getByTestId('notification-category-filter');
+    fireEvent.click(within(filter).getByText('notifications.category.messages'));
+
+    // Narrowed to the single messages row.
+    const rows = screen.getAllByTestId('notification-item');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain('notifications.category.messages');
+
+    // Clicking "All" restores the full feed.
+    fireEvent.click(within(filter).getByText('alerts.filterAll'));
+    expect(screen.getAllByTestId('notification-item')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

The Notifications page (system-events list) tags every alert with a category but offered no way to **filter** by it. This adds a horizontal category-chip filter row above the system-events list, mirroring the Skills page `selectedCategory` pattern.

- **All** chip (default) plus one chip per category **actually present** in the feed — no dead chips.
- Clicking a chip filters the list live; **All** clears the filter.
- The filter row hides entirely when there are no notifications.
- Reuses the existing `PillTabBar` component and `notifications.category.*` i18n keys; adds one new `alerts.filterAll` key across all 14 locales.

## Changes

- `app/src/pages/Notifications.tsx` — `selectedCategory` state, `availableCategories`/`visibleItems` memos, `PillTabBar` chip row above the list, collapsed the two identical empty-state branches.
- `app/src/lib/i18n/*.ts` — new `alerts.filterAll` key in `en.ts` + real translations for all other locales (parity for `pnpm i18n:check`).
- `app/src/pages/__tests__/Notifications.test.tsx` — tests: row hidden when empty, chip-per-present-category (no dead chips), filter + All-restore behaviour.

## Acceptance criteria

- [x] Chip row renders above the system-events notifications list
- [x] Selecting a category filters the list; All shows everything
- [x] Only categories present in the feed get a chip
- [x] Labels localized; parity maintained for `pnpm i18n:check`
- [x] Unit test covers chip render + filter behaviour

Closes #3715

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category filtering to the Notifications page, allowing users to filter notifications by category or view all items.
  * Expanded translation support across 14 languages (Arabic, Bengali, German, English, Spanish, French, Hindi, Indonesian, Italian, Korean, Polish, Portuguese, Russian, and Chinese Simplified) to accommodate the new filter option.

* **Tests**
  * Added comprehensive test coverage for the new notification category filter UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->