### PR TITLE
feat(agent): structured tracing export from the progress channel (#3886)

### DIFF
--- a/src/openhuman/agent/mod.rs
+++ b/src/openhuman/agent/mod.rs
@@ -31,6 +31,11 @@ pub mod memory_loader;
 pub mod multimodal;
 pub mod pformat;
 pub mod progress;
+/// Structured tracing export off the [`progress`] channel: turns the
+/// real-time [`progress::AgentProgress`] stream into OpenTelemetry/
+/// Langfuse-style spans (turn → iteration → tool / subagent) correlated by
+/// session id with user attribution (issue #3886).
+pub mod progress_tracing;
 /// Prompt plumbing — types, section builders, and
 /// [`SystemPromptBuilder`](prompts::SystemPromptBuilder). Moved from
 /// `openhuman::context::prompt` so prompt rendering lives next to the

--- a/src/openhuman/agent/progress_tracing.rs
+++ b/src/openhuman/agent/progress_tracing.rs
@@ -1,0 +1,703 @@
+//! Structured tracing export off the agent [`progress`](super::progress)
+//! channel (issue #3886).
+//!
+//! OpenHuman already emits rich real-time [`AgentProgress`] events for the UI,
+//! but there was no first-class trace export for offline inspection,
+//! regression analysis, or debugging long multi-agent runs. This module turns
+//! that same event stream into OpenTelemetry/Langfuse-style **spans** —
+//!
+//! ```text
+//! agent.turn                      (root, trace_id = session id)
+//! ├─ agent.iteration #1
+//! │  ├─ tool.web_search
+//! │  └─ subagent.researcher
+//! │     ├─ subagent.iteration #1
+//! │     │  └─ tool.read_file
+//! │     └─ (closed on SubagentCompleted)
+//! └─ agent.iteration #2
+//! ```
+//!
+//! correlated by **session id** (the trace id) with **user attribution**
+//! (a span attribute), so a run that fans out across many subagents over
+//! minutes-to-hours is inspectable end to end.
+//!
+//! ## Privacy
+//!
+//! Spans intentionally carry only *metadata* — span names, counts, timings,
+//! and token/cost figures. Prompt text, tool arguments, streamed text/thinking
+//! deltas, raw error strings, and filesystem paths are **never** recorded,
+//! honoring the project's "never log secrets or full PII" rule. The
+//! content-bearing [`AgentProgress`] variants (`TextDelta`, `ThinkingDelta`,
+//! `ToolCallArgsDelta`) are dropped on the floor here.
+//!
+//! ## Wiring
+//!
+//! [`SpanCollector`] is a pure state machine: feed it the progress events plus
+//! a millisecond timestamp and it accumulates finished spans. The consumer
+//! side (the web progress bridge) owns the clock and the export — see
+//! [`export_spans`]. The collector has no I/O and no async, so the span shape
+//! is exhaustively unit-testable.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::openhuman::agent::progress::AgentProgress;
+use crate::openhuman::config::schema::{AgentTracingBackend, AgentTracingConfig};
+
+/// Trace-level correlation context, stamped onto the root span.
+#[derive(Debug, Clone)]
+pub struct TraceContext {
+    /// Trace id — the agent session id. All spans of a run share it.
+    pub session_id: String,
+    /// User attribution (e.g. the broadcast client id / "system" for
+    /// autonomous runs). `None` when the caller is anonymous.
+    pub user_id: Option<String>,
+}
+
+impl TraceContext {
+    pub fn new(session_id: impl Into<String>, user_id: Option<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            user_id,
+        }
+    }
+}
+
+/// Derive the trace id (session id) for a run: prefer the UI session id when
+/// present, otherwise fall back to the thread id so headless/autonomous runs
+/// (which carry no UI session) still correlate their spans.
+pub fn trace_session_id(ui_session_id: Option<u64>, thread_id: &str) -> String {
+    ui_session_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| thread_id.to_string())
+}
+
+/// What a span represents. Mirrors the [`AgentProgress`] lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpanKind {
+    /// The whole turn (root span).
+    Turn,
+    /// One LLM iteration of the parent turn.
+    Iteration,
+    /// A tool call.
+    Tool,
+    /// A spawned subagent.
+    Subagent,
+    /// One LLM iteration inside a subagent.
+    SubagentIteration,
+}
+
+/// OTel-style span status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpanStatus {
+    /// Not yet completed, or completed without an explicit success signal.
+    Unset,
+    /// Completed successfully.
+    Ok,
+    /// Completed with an error.
+    Error,
+}
+
+/// A single finished (or in-flight) span. Field names follow OpenTelemetry
+/// conventions so the NDJSON drops cleanly into an OTel/Langfuse importer.
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceSpan {
+    /// Trace id (the session id) — shared by every span in the run.
+    pub trace_id: String,
+    /// Unique id of this span within the trace.
+    pub span_id: String,
+    /// Parent span id, or `None` for the root turn span.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_span_id: Option<String>,
+    /// Human-readable span name, e.g. `agent.turn`, `tool.web_search`.
+    pub name: String,
+    /// Structured kind for programmatic filtering.
+    pub kind: SpanKind,
+    /// Wall-clock start (Unix epoch milliseconds).
+    pub start_unix_ms: u64,
+    /// Wall-clock end (Unix epoch milliseconds); `None` while in flight.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_unix_ms: Option<u64>,
+    /// Completion status.
+    pub status: SpanStatus,
+    /// Metadata-only attributes (no secrets/PII).
+    pub attributes: BTreeMap<String, serde_json::Value>,
+}
+
+impl TraceSpan {
+    /// Duration in milliseconds, or `None` while the span is still open.
+    pub fn duration_ms(&self) -> Option<u64> {
+        self.end_unix_ms
+            .map(|end| end.saturating_sub(self.start_unix_ms))
+    }
+}
+
+/// Per-subagent bookkeeping so child iterations / tool calls nest correctly.
+#[derive(Debug)]
+struct SubagentState {
+    /// Index of the subagent span in [`SpanCollector::spans`].
+    span_index: usize,
+    /// Currently-open child iteration span id, if any.
+    current_iteration_span_id: Option<String>,
+    /// Open child tool spans keyed by `call_id` → span index.
+    open_tools: BTreeMap<String, usize>,
+}
+
+/// Pure state machine that folds an [`AgentProgress`] stream into spans.
+///
+/// Call [`record`](Self::record) for each event (with a millisecond
+/// timestamp), then [`finish`](Self::finish) once the stream closes to seal
+/// any still-open spans. [`spans`](Self::spans) returns the accumulated tree.
+#[derive(Debug)]
+pub struct SpanCollector {
+    ctx: TraceContext,
+    spans: Vec<TraceSpan>,
+    next_span_seq: u64,
+
+    turn_span_id: Option<String>,
+    turn_span_index: Option<usize>,
+    current_iteration_span_id: Option<String>,
+    current_iteration_index: Option<usize>,
+
+    /// Open parent-turn tool spans keyed by `call_id` → span index.
+    open_tools: BTreeMap<String, usize>,
+    /// Live subagents keyed by `task_id`.
+    subagents: BTreeMap<String, SubagentState>,
+}
+
+impl SpanCollector {
+    pub fn new(ctx: TraceContext) -> Self {
+        Self {
+            ctx,
+            spans: Vec::new(),
+            next_span_seq: 0,
+            turn_span_id: None,
+            turn_span_index: None,
+            current_iteration_span_id: None,
+            current_iteration_index: None,
+            open_tools: BTreeMap::new(),
+            subagents: BTreeMap::new(),
+        }
+    }
+
+    /// All spans recorded so far (finished and in-flight).
+    pub fn spans(&self) -> &[TraceSpan] {
+        &self.spans
+    }
+
+    /// Index of the span with `span_id`, if any.
+    fn span_index_by_id(&self, span_id: &str) -> Option<usize> {
+        self.spans.iter().position(|sp| sp.span_id == span_id)
+    }
+
+    /// Consume the collector and return its spans.
+    pub fn into_spans(self) -> Vec<TraceSpan> {
+        self.spans
+    }
+
+    /// OTel-style 16-hex span id derived from a monotonic sequence. Stable
+    /// and deterministic within a run, which keeps the tests reproducible.
+    fn mint_span_id(&mut self) -> String {
+        self.next_span_seq += 1;
+        format!("{:016x}", self.next_span_seq)
+    }
+
+    fn open_span(
+        &mut self,
+        kind: SpanKind,
+        name: impl Into<String>,
+        parent_span_id: Option<String>,
+        start_unix_ms: u64,
+        attributes: BTreeMap<String, serde_json::Value>,
+    ) -> (String, usize) {
+        let span_id = self.mint_span_id();
+        let index = self.spans.len();
+        self.spans.push(TraceSpan {
+            trace_id: self.ctx.session_id.clone(),
+            span_id: span_id.clone(),
+            parent_span_id,
+            name: name.into(),
+            kind,
+            start_unix_ms,
+            end_unix_ms: None,
+            status: SpanStatus::Unset,
+            attributes,
+        });
+        (span_id, index)
+    }
+
+    /// Seal a span: set its end timestamp + status and merge in any extra
+    /// attributes. A no-op if `index` is out of range (defensive).
+    fn close_span(
+        &mut self,
+        index: usize,
+        end_unix_ms: u64,
+        status: SpanStatus,
+        extra: BTreeMap<String, serde_json::Value>,
+    ) {
+        if let Some(span) = self.spans.get_mut(index) {
+            // Don't let a late event drag end before start.
+            span.end_unix_ms = Some(end_unix_ms.max(span.start_unix_ms));
+            span.status = status;
+            span.attributes.extend(extra);
+        }
+    }
+
+    /// Lazily open the root turn span so a stream that begins mid-flight
+    /// (or never sends `TurnStarted`) still produces a correlated tree.
+    fn ensure_turn_span(&mut self, start_unix_ms: u64) -> String {
+        if let Some(id) = &self.turn_span_id {
+            return id.clone();
+        }
+        let mut attrs = BTreeMap::new();
+        attrs.insert(
+            "session.id".to_string(),
+            serde_json::Value::String(self.ctx.session_id.clone()),
+        );
+        if let Some(user) = &self.ctx.user_id {
+            attrs.insert(
+                "user.id".to_string(),
+                serde_json::Value::String(user.clone()),
+            );
+        }
+        let (id, index) = self.open_span(SpanKind::Turn, "agent.turn", None, start_unix_ms, attrs);
+        self.turn_span_id = Some(id.clone());
+        self.turn_span_index = Some(index);
+        id
+    }
+
+    /// The parent any iteration / tool / subagent span should hang off:
+    /// the current iteration if one is open, else the turn root.
+    fn active_parent_id(&mut self, now_unix_ms: u64) -> String {
+        if let Some(id) = &self.current_iteration_span_id {
+            return id.clone();
+        }
+        self.ensure_turn_span(now_unix_ms)
+    }
+
+    fn close_current_iteration(&mut self, end_unix_ms: u64) {
+        if let Some(index) = self.current_iteration_index.take() {
+            self.close_span(index, end_unix_ms, SpanStatus::Ok, BTreeMap::new());
+        }
+        self.current_iteration_span_id = None;
+    }
+
+    /// Fold a single progress event into the span tree, stamped at
+    /// `now_unix_ms` (the consumer's wall clock when it observed the event).
+    pub fn record(&mut self, event: &AgentProgress, now_unix_ms: u64) {
+        match event {
+            AgentProgress::TurnStarted => {
+                self.ensure_turn_span(now_unix_ms);
+            }
+
+            AgentProgress::IterationStarted {
+                iteration,
+                max_iterations,
+            } => {
+                self.close_current_iteration(now_unix_ms);
+                let parent = self.ensure_turn_span(now_unix_ms);
+                let mut attrs = BTreeMap::new();
+                attrs.insert("agent.iteration".to_string(), json_u32(*iteration));
+                attrs.insert("agent.max_iterations".to_string(), json_u32(*max_iterations));
+                let (id, index) = self.open_span(
+                    SpanKind::Iteration,
+                    format!("agent.iteration#{iteration}"),
+                    Some(parent),
+                    now_unix_ms,
+                    attrs,
+                );
+                self.current_iteration_span_id = Some(id);
+                self.current_iteration_index = Some(index);
+            }
+
+            AgentProgress::ToolCallStarted {
+                call_id,
+                tool_name,
+                iteration,
+                ..
+            } => {
+                let parent = self.active_parent_id(now_unix_ms);
+                let mut attrs = BTreeMap::new();
+                attrs.insert("tool.name".to_string(), json_str(tool_name));
+                attrs.insert("tool.call_id".to_string(), json_str(call_id));
+                attrs.insert("agent.iteration".to_string(), json_u32(*iteration));
+                let (_, index) = self.open_span(
+                    SpanKind::Tool,
+                    format!("tool.{tool_name}"),
+                    Some(parent),
+                    now_unix_ms,
+                    attrs,
+                );
+                self.open_tools.insert(call_id.clone(), index);
+            }
+
+            AgentProgress::ToolCallCompleted {
+                call_id,
+                success,
+                output_chars,
+                elapsed_ms,
+                ..
+            } => {
+                if let Some(index) = self.open_tools.remove(call_id) {
+                    let start = self.spans[index].start_unix_ms;
+                    let mut extra = BTreeMap::new();
+                    extra.insert("tool.success".to_string(), serde_json::Value::Bool(*success));
+                    extra.insert("tool.output_chars".to_string(), json_usize(*output_chars));
+                    extra.insert("tool.elapsed_ms".to_string(), json_u64(*elapsed_ms));
+                    self.close_span(index, start + elapsed_ms, status_of(*success), extra);
+                }
+            }
+
+            AgentProgress::SubagentSpawned {
+                agent_id,
+                task_id,
+                mode,
+                dedicated_thread,
+                prompt_chars,
+                display_name,
+                ..
+            } => {
+                let parent = self.active_parent_id(now_unix_ms);
+                let label = display_name.clone().unwrap_or_else(|| agent_id.clone());
+                let mut attrs = BTreeMap::new();
+                attrs.insert("subagent.agent_id".to_string(), json_str(agent_id));
+                attrs.insert("subagent.task_id".to_string(), json_str(task_id));
+                attrs.insert("subagent.mode".to_string(), json_str(mode));
+                attrs.insert(
+                    "subagent.dedicated_thread".to_string(),
+                    serde_json::Value::Bool(*dedicated_thread),
+                );
+                attrs.insert("subagent.prompt_chars".to_string(), json_usize(*prompt_chars));
+                if let Some(name) = display_name {
+                    attrs.insert("subagent.display_name".to_string(), json_str(name));
+                }
+                let (_, index) = self.open_span(
+                    SpanKind::Subagent,
+                    format!("subagent.{label}"),
+                    Some(parent),
+                    now_unix_ms,
+                    attrs,
+                );
+                self.subagents.insert(
+                    task_id.clone(),
+                    SubagentState {
+                        span_index: index,
+                        current_iteration_span_id: None,
+                        open_tools: BTreeMap::new(),
+                    },
+                );
+            }
+
+            AgentProgress::SubagentIterationStarted {
+                task_id,
+                iteration,
+                max_iterations,
+                extended_policy,
+                ..
+            } => {
+                // Resolve parent + prior child iteration up front so we don't
+                // hold a borrow across the mutating open_span call.
+                let (parent_id, prior_iteration_id) = match self.subagents.get(task_id) {
+                    Some(state) => (
+                        self.spans[state.span_index].span_id.clone(),
+                        state.current_iteration_span_id.clone(),
+                    ),
+                    None => return,
+                };
+                if let Some(prior) = prior_iteration_id {
+                    if let Some(idx) = self.span_index_by_id(&prior) {
+                        self.close_span(idx, now_unix_ms, SpanStatus::Ok, BTreeMap::new());
+                    }
+                }
+                let mut attrs = BTreeMap::new();
+                attrs.insert("agent.iteration".to_string(), json_u32(*iteration));
+                attrs.insert("agent.max_iterations".to_string(), json_u32(*max_iterations));
+                attrs.insert(
+                    "agent.extended_policy".to_string(),
+                    serde_json::Value::Bool(*extended_policy),
+                );
+                let (id, _) = self.open_span(
+                    SpanKind::SubagentIteration,
+                    format!("subagent.iteration#{iteration}"),
+                    Some(parent_id),
+                    now_unix_ms,
+                    attrs,
+                );
+                if let Some(state) = self.subagents.get_mut(task_id) {
+                    state.current_iteration_span_id = Some(id);
+                }
+            }
+
+            AgentProgress::SubagentToolCallStarted {
+                task_id,
+                call_id,
+                tool_name,
+                iteration,
+                ..
+            } => {
+                let parent_id = match self.subagents.get(task_id) {
+                    Some(state) => match &state.current_iteration_span_id {
+                        Some(id) => id.clone(),
+                        None => self.spans[state.span_index].span_id.clone(),
+                    },
+                    None => return,
+                };
+                let mut attrs = BTreeMap::new();
+                attrs.insert("tool.name".to_string(), json_str(tool_name));
+                attrs.insert("tool.call_id".to_string(), json_str(call_id));
+                attrs.insert("agent.iteration".to_string(), json_u32(*iteration));
+                let (_, index) = self.open_span(
+                    SpanKind::Tool,
+                    format!("tool.{tool_name}"),
+                    Some(parent_id),
+                    now_unix_ms,
+                    attrs,
+                );
+                if let Some(state) = self.subagents.get_mut(task_id) {
+                    state.open_tools.insert(call_id.clone(), index);
+                }
+            }
+
+            AgentProgress::SubagentToolCallCompleted {
+                task_id,
+                call_id,
+                success,
+                output_chars,
+                elapsed_ms,
+                ..
+            } => {
+                let Some(index) = self
+                    .subagents
+                    .get_mut(task_id)
+                    .and_then(|state| state.open_tools.remove(call_id))
+                else {
+                    return;
+                };
+                let start = self.spans[index].start_unix_ms;
+                let mut extra = BTreeMap::new();
+                extra.insert("tool.success".to_string(), serde_json::Value::Bool(*success));
+                extra.insert("tool.output_chars".to_string(), json_usize(*output_chars));
+                extra.insert("tool.elapsed_ms".to_string(), json_u64(*elapsed_ms));
+                self.close_span(index, start + elapsed_ms, status_of(*success), extra);
+            }
+
+            AgentProgress::SubagentCompleted {
+                task_id,
+                elapsed_ms,
+                iterations,
+                output_chars,
+                ..
+            } => {
+                let Some(state) = self.subagents.remove(task_id) else {
+                    return;
+                };
+                if let Some(id) = state.current_iteration_span_id.clone() {
+                    if let Some(idx) = self.span_index_by_id(&id) {
+                        self.close_span(idx, now_unix_ms, SpanStatus::Ok, BTreeMap::new());
+                    }
+                }
+                let start = self.spans[state.span_index].start_unix_ms;
+                let mut extra = BTreeMap::new();
+                extra.insert("subagent.iterations".to_string(), json_u32(*iterations));
+                extra.insert("subagent.output_chars".to_string(), json_usize(*output_chars));
+                extra.insert("subagent.elapsed_ms".to_string(), json_u64(*elapsed_ms));
+                self.close_span(state.span_index, start + elapsed_ms, SpanStatus::Ok, extra);
+            }
+
+            AgentProgress::SubagentFailed { task_id, error, .. } => {
+                let Some(state) = self.subagents.remove(task_id) else {
+                    return;
+                };
+                if let Some(id) = state.current_iteration_span_id.clone() {
+                    if let Some(idx) = self.span_index_by_id(&id) {
+                        self.close_span(idx, now_unix_ms, SpanStatus::Error, BTreeMap::new());
+                    }
+                }
+                let mut extra = BTreeMap::new();
+                // Record only that an error occurred and its length — never the
+                // raw error text (may embed paths / payloads / secrets).
+                extra.insert("error".to_string(), serde_json::Value::Bool(true));
+                extra.insert("error.length".to_string(), json_usize(error.len()));
+                self.close_span(state.span_index, now_unix_ms, SpanStatus::Error, extra);
+            }
+
+            AgentProgress::TurnCostUpdated {
+                model,
+                input_tokens,
+                output_tokens,
+                cached_input_tokens,
+                total_usd,
+                ..
+            } => {
+                // Cumulative cost/usage rides on the root turn span so a trace
+                // viewer shows the whole-run total at the top.
+                let index = match self.turn_span_index {
+                    Some(idx) => idx,
+                    None => {
+                        self.ensure_turn_span(now_unix_ms);
+                        self.turn_span_index.expect("turn span just created")
+                    }
+                };
+                if let Some(span) = self.spans.get_mut(index) {
+                    span.attributes
+                        .insert("gen_ai.request.model".to_string(), json_str(model));
+                    span.attributes
+                        .insert("gen_ai.usage.input_tokens".to_string(), json_u64(*input_tokens));
+                    span.attributes.insert(
+                        "gen_ai.usage.output_tokens".to_string(),
+                        json_u64(*output_tokens),
+                    );
+                    span.attributes.insert(
+                        "gen_ai.usage.cached_input_tokens".to_string(),
+                        json_u64(*cached_input_tokens),
+                    );
+                    span.attributes
+                        .insert("gen_ai.usage.cost_usd".to_string(), json_f64(*total_usd));
+                }
+            }
+
+            AgentProgress::TurnCompleted { iterations } => {
+                self.close_current_iteration(now_unix_ms);
+                if let Some(index) = self.turn_span_index {
+                    let mut extra = BTreeMap::new();
+                    extra.insert("agent.iterations".to_string(), json_u32(*iterations));
+                    self.close_span(index, now_unix_ms, SpanStatus::Ok, extra);
+                }
+            }
+
+            // Content-bearing / streaming events carry prompt text, tool
+            // arguments, or model output — never exported (privacy rule).
+            AgentProgress::TextDelta { .. }
+            | AgentProgress::ThinkingDelta { .. }
+            | AgentProgress::ToolCallArgsDelta { .. }
+            | AgentProgress::SubagentTextDelta { .. }
+            | AgentProgress::SubagentThinkingDelta { .. }
+            | AgentProgress::SubagentAwaitingUser { .. }
+            | AgentProgress::TaskBoardUpdated { .. } => {}
+        }
+    }
+
+    /// Seal every span still open after the stream closes. Idempotent.
+    pub fn finish(&mut self, now_unix_ms: u64) {
+        let open: Vec<usize> = self
+            .spans
+            .iter()
+            .enumerate()
+            .filter(|(_, span)| span.end_unix_ms.is_none())
+            .map(|(idx, _)| idx)
+            .collect();
+        for idx in open {
+            self.close_span(idx, now_unix_ms, SpanStatus::Unset, BTreeMap::new());
+        }
+        self.current_iteration_span_id = None;
+        self.current_iteration_index = None;
+        self.open_tools.clear();
+        self.subagents.clear();
+    }
+}
+
+fn status_of(success: bool) -> SpanStatus {
+    if success {
+        SpanStatus::Ok
+    } else {
+        SpanStatus::Error
+    }
+}
+
+fn json_str(s: &str) -> serde_json::Value {
+    serde_json::Value::String(s.to_string())
+}
+
+fn json_u32(n: u32) -> serde_json::Value {
+    serde_json::Value::Number(n.into())
+}
+
+fn json_u64(n: u64) -> serde_json::Value {
+    serde_json::Value::Number(n.into())
+}
+
+fn json_usize(n: usize) -> serde_json::Value {
+    serde_json::Value::Number((n as u64).into())
+}
+
+fn json_f64(n: f64) -> serde_json::Value {
+    serde_json::Number::from_f64(n)
+        .map(serde_json::Value::Number)
+        // NaN/inf can't be JSON numbers — degrade to null rather than panic.
+        .unwrap_or(serde_json::Value::Null)
+}
+
+/// Serialize spans to NDJSON (one span object per line) in the requested
+/// backend envelope. Both backends share the [`TraceSpan`] body; Langfuse
+/// wraps each line with a `{"type":"span-create", ...}` observation envelope
+/// so it can be POSTed to the Langfuse ingestion API, while OTel emits the
+/// bare span. Returns an empty string for an empty slice.
+pub fn spans_to_ndjson(backend: AgentTracingBackend, spans: &[TraceSpan]) -> String {
+    let mut out = String::new();
+    for span in spans {
+        let line = match backend {
+            AgentTracingBackend::Otel => serde_json::to_string(span),
+            AgentTracingBackend::Langfuse => serde_json::to_string(&serde_json::json!({
+                "type": "span-create",
+                "body": span,
+            })),
+        };
+        if let Ok(line) = line {
+            out.push_str(&line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Export finished spans per the [`AgentTracingConfig`]: append NDJSON to the
+/// configured file, or emit to the application log when no path is set.
+/// Best-effort — a failed write is logged and swallowed so tracing never
+/// breaks an agent run. A no-op when tracing is disabled or there are no spans.
+pub fn export_spans(config: &AgentTracingConfig, spans: &[TraceSpan]) {
+    if !config.enabled || spans.is_empty() {
+        return;
+    }
+    let payload = spans_to_ndjson(config.backend, spans);
+    match &config.export_path {
+        Some(path) => {
+            use std::io::Write as _;
+            let opened = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path);
+            match opened {
+                Ok(mut file) => {
+                    if let Err(err) = file.write_all(payload.as_bytes()) {
+                        log::warn!(
+                            "[agent-tracing] failed to append {} spans to {path}: {err}",
+                            spans.len()
+                        );
+                    } else {
+                        log::debug!(
+                            "[agent-tracing] exported {} spans to {path}",
+                            spans.len()
+                        );
+                    }
+                }
+                Err(err) => log::warn!("[agent-tracing] failed to open {path}: {err}"),
+            }
+        }
+        None => {
+            // No path configured — surface to the log so the export still works
+            // on read-only / sandboxed deployments.
+            log::info!(
+                "[agent-tracing] {} spans (trace_id={}):\n{}",
+                spans.len(),
+                spans.first().map(|s| s.trace_id.as_str()).unwrap_or(""),
+                payload.trim_end()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/openhuman/agent/progress_tracing.rs
+++ b/src/openhuman/agent/progress_tracing.rs
@@ -301,7 +301,10 @@ impl SpanCollector {
                 let parent = self.ensure_turn_span(now_unix_ms);
                 let mut attrs = BTreeMap::new();
                 attrs.insert("agent.iteration".to_string(), json_u32(*iteration));
-                attrs.insert("agent.max_iterations".to_string(), json_u32(*max_iterations));
+                attrs.insert(
+                    "agent.max_iterations".to_string(),
+                    json_u32(*max_iterations),
+                );
                 let (id, index) = self.open_span(
                     SpanKind::Iteration,
                     format!("agent.iteration#{iteration}"),
@@ -344,7 +347,10 @@ impl SpanCollector {
                 if let Some(index) = self.open_tools.remove(call_id) {
                     let start = self.spans[index].start_unix_ms;
                     let mut extra = BTreeMap::new();
-                    extra.insert("tool.success".to_string(), serde_json::Value::Bool(*success));
+                    extra.insert(
+                        "tool.success".to_string(),
+                        serde_json::Value::Bool(*success),
+                    );
                     extra.insert("tool.output_chars".to_string(), json_usize(*output_chars));
                     extra.insert("tool.elapsed_ms".to_string(), json_u64(*elapsed_ms));
                     self.close_span(index, start + elapsed_ms, status_of(*success), extra);
@@ -370,7 +376,10 @@ impl SpanCollector {
                     "subagent.dedicated_thread".to_string(),
                     serde_json::Value::Bool(*dedicated_thread),
                 );
-                attrs.insert("subagent.prompt_chars".to_string(), json_usize(*prompt_chars));
+                attrs.insert(
+                    "subagent.prompt_chars".to_string(),
+                    json_usize(*prompt_chars),
+                );
                 if let Some(name) = display_name {
                     attrs.insert("subagent.display_name".to_string(), json_str(name));
                 }
@@ -414,7 +423,10 @@ impl SpanCollector {
                 }
                 let mut attrs = BTreeMap::new();
                 attrs.insert("agent.iteration".to_string(), json_u32(*iteration));
-                attrs.insert("agent.max_iterations".to_string(), json_u32(*max_iterations));
+                attrs.insert(
+                    "agent.max_iterations".to_string(),
+                    json_u32(*max_iterations),
+                );
                 attrs.insert(
                     "agent.extended_policy".to_string(),
                     serde_json::Value::Bool(*extended_policy),
@@ -478,7 +490,10 @@ impl SpanCollector {
                 };
                 let start = self.spans[index].start_unix_ms;
                 let mut extra = BTreeMap::new();
-                extra.insert("tool.success".to_string(), serde_json::Value::Bool(*success));
+                extra.insert(
+                    "tool.success".to_string(),
+                    serde_json::Value::Bool(*success),
+                );
                 extra.insert("tool.output_chars".to_string(), json_usize(*output_chars));
                 extra.insert("tool.elapsed_ms".to_string(), json_u64(*elapsed_ms));
                 self.close_span(index, start + elapsed_ms, status_of(*success), extra);
@@ -502,7 +517,10 @@ impl SpanCollector {
                 let start = self.spans[state.span_index].start_unix_ms;
                 let mut extra = BTreeMap::new();
                 extra.insert("subagent.iterations".to_string(), json_u32(*iterations));
-                extra.insert("subagent.output_chars".to_string(), json_usize(*output_chars));
+                extra.insert(
+                    "subagent.output_chars".to_string(),
+                    json_usize(*output_chars),
+                );
                 extra.insert("subagent.elapsed_ms".to_string(), json_u64(*elapsed_ms));
                 self.close_span(state.span_index, start + elapsed_ms, SpanStatus::Ok, extra);
             }
@@ -544,8 +562,10 @@ impl SpanCollector {
                 if let Some(span) = self.spans.get_mut(index) {
                     span.attributes
                         .insert("gen_ai.request.model".to_string(), json_str(model));
-                    span.attributes
-                        .insert("gen_ai.usage.input_tokens".to_string(), json_u64(*input_tokens));
+                    span.attributes.insert(
+                        "gen_ai.usage.input_tokens".to_string(),
+                        json_u64(*input_tokens),
+                    );
                     span.attributes.insert(
                         "gen_ai.usage.output_tokens".to_string(),
                         json_u64(*output_tokens),
@@ -677,10 +697,7 @@ pub fn export_spans(config: &AgentTracingConfig, spans: &[TraceSpan]) {
                             spans.len()
                         );
                     } else {
-                        log::debug!(
-                            "[agent-tracing] exported {} spans to {path}",
-                            spans.len()
-                        );
+                        log::debug!("[agent-tracing] exported {} spans to {path}", spans.len());
                     }
                 }
                 Err(err) => log::warn!("[agent-tracing] failed to open {path}: {err}"),

--- a/src/openhuman/agent/progress_tracing/tests.rs
+++ b/src/openhuman/agent/progress_tracing/tests.rs
@@ -1,0 +1,501 @@
+//! Unit tests for the structured tracing export (issue #3886).
+
+use super::*;
+use crate::openhuman::agent::progress::AgentProgress;
+use crate::openhuman::config::schema::{
+    AgentTracingBackend, AgentTracingConfig, ObservabilityConfig,
+};
+
+fn ctx() -> TraceContext {
+    TraceContext::new("sess-42", Some("client-7".to_string()))
+}
+
+fn collect(events: &[(AgentProgress, u64)]) -> SpanCollector {
+    let mut c = SpanCollector::new(ctx());
+    for (event, ts) in events {
+        c.record(event, *ts);
+    }
+    c
+}
+
+fn find<'a>(spans: &'a [TraceSpan], name: &str) -> &'a TraceSpan {
+    spans
+        .iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| panic!("no span named {name:?} in {:?}", names(spans)))
+}
+
+fn names(spans: &[TraceSpan]) -> Vec<String> {
+    spans.iter().map(|s| s.name.clone()).collect()
+}
+
+// ── config ────────────────────────────────────────────────────────────────
+
+#[test]
+fn tracing_config_is_off_by_default() {
+    let cfg = AgentTracingConfig::default();
+    assert!(!cfg.enabled, "tracing must be opt-in");
+    assert_eq!(cfg.backend, AgentTracingBackend::Otel);
+    assert!(cfg.export_path.is_none());
+}
+
+#[test]
+fn observability_default_embeds_disabled_tracing() {
+    let obs = ObservabilityConfig::default();
+    assert!(!obs.agent_tracing.enabled);
+}
+
+#[test]
+fn tracing_config_round_trips_through_json() {
+    let cfg = AgentTracingConfig {
+        enabled: true,
+        backend: AgentTracingBackend::Langfuse,
+        export_path: Some("/tmp/spans.ndjson".to_string()),
+    };
+    let s = serde_json::to_string(&cfg).unwrap();
+    let back: AgentTracingConfig = serde_json::from_str(&s).unwrap();
+    assert!(back.enabled);
+    assert_eq!(back.backend, AgentTracingBackend::Langfuse);
+    assert_eq!(back.export_path.as_deref(), Some("/tmp/spans.ndjson"));
+    // lowercase serde rename.
+    assert!(s.contains("\"langfuse\""));
+}
+
+// ── parent turn ─────────────────────────────────────────────────────────────
+
+fn tool_started(call_id: &str, tool: &str, iter: u32) -> AgentProgress {
+    AgentProgress::ToolCallStarted {
+        call_id: call_id.to_string(),
+        tool_name: tool.to_string(),
+        arguments: serde_json::json!({"secret": "do-not-export"}),
+        iteration: iter,
+    }
+}
+
+fn tool_completed(call_id: &str, tool: &str, success: bool, chars: usize, elapsed: u64) -> AgentProgress {
+    AgentProgress::ToolCallCompleted {
+        call_id: call_id.to_string(),
+        tool_name: tool.to_string(),
+        success,
+        output_chars: chars,
+        elapsed_ms: elapsed,
+        iteration: 1,
+    }
+}
+
+#[test]
+fn full_turn_builds_correlated_span_tree() {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 1_000),
+        (
+            AgentProgress::IterationStarted {
+                iteration: 1,
+                max_iterations: 5,
+            },
+            1_010,
+        ),
+        (tool_started("call-1", "web_search", 1), 1_020),
+        (tool_completed("call-1", "web_search", true, 321, 200), 1_020),
+        (
+            AgentProgress::TurnCostUpdated {
+                model: "claude-opus-4-8".to_string(),
+                iteration: 1,
+                input_tokens: 1_200,
+                output_tokens: 480,
+                cached_input_tokens: 64,
+                total_usd: 0.042,
+            },
+            1_030,
+        ),
+        (AgentProgress::TurnCompleted { iterations: 1 }, 1_040),
+    ]);
+    c.finish(2_000);
+    let spans = c.spans();
+
+    // Root turn: trace = session id, user attribution present.
+    let turn = find(spans, "agent.turn");
+    assert_eq!(turn.kind, SpanKind::Turn);
+    assert_eq!(turn.trace_id, "sess-42");
+    assert!(turn.parent_span_id.is_none());
+    assert_eq!(turn.attributes["session.id"], serde_json::json!("sess-42"));
+    assert_eq!(turn.attributes["user.id"], serde_json::json!("client-7"));
+    // Cost / usage attributes ride on the root.
+    assert_eq!(turn.attributes["gen_ai.usage.input_tokens"], serde_json::json!(1_200));
+    assert_eq!(turn.attributes["gen_ai.usage.output_tokens"], serde_json::json!(480));
+    assert_eq!(turn.attributes["gen_ai.usage.cached_input_tokens"], serde_json::json!(64));
+    assert_eq!(turn.attributes["gen_ai.request.model"], serde_json::json!("claude-opus-4-8"));
+    assert_eq!(turn.attributes["agent.iterations"], serde_json::json!(1));
+    assert_eq!(turn.status, SpanStatus::Ok);
+    assert!(turn.attributes.get("gen_ai.usage.cost_usd").is_some());
+
+    // Iteration parented to the turn.
+    let iter = find(spans, "agent.iteration#1");
+    assert_eq!(iter.kind, SpanKind::Iteration);
+    assert_eq!(iter.parent_span_id.as_deref(), Some(turn.span_id.as_str()));
+    assert_eq!(iter.attributes["agent.max_iterations"], serde_json::json!(5));
+
+    // Tool parented to the iteration.
+    let tool = find(spans, "tool.web_search");
+    assert_eq!(tool.kind, SpanKind::Tool);
+    assert_eq!(tool.parent_span_id.as_deref(), Some(iter.span_id.as_str()));
+    assert_eq!(tool.status, SpanStatus::Ok);
+    assert_eq!(tool.attributes["tool.output_chars"], serde_json::json!(321));
+    // end = start + elapsed_ms.
+    assert_eq!(tool.duration_ms(), Some(200));
+
+    // Everything sealed.
+    assert!(spans.iter().all(|s| s.end_unix_ms.is_some()));
+}
+
+#[test]
+fn failed_tool_marks_error_status() {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 3 }, 1),
+        (tool_started("c1", "shell", 1), 2),
+        (tool_completed("c1", "shell", false, 12, 5), 2),
+    ]);
+    c.finish(100);
+    let tool = find(c.spans(), "tool.shell");
+    assert_eq!(tool.status, SpanStatus::Error);
+    assert_eq!(tool.attributes["tool.success"], serde_json::json!(false));
+}
+
+#[test]
+fn iteration_started_closes_the_previous_iteration() {
+    let c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 3 }, 10),
+        (AgentProgress::IterationStarted { iteration: 2, max_iterations: 3 }, 20),
+    ]);
+    let first = find(c.spans(), "agent.iteration#1");
+    assert_eq!(first.end_unix_ms, Some(20), "iter#1 closes when iter#2 opens");
+    let second = find(c.spans(), "agent.iteration#2");
+    assert!(second.end_unix_ms.is_none(), "iter#2 still open until finish");
+}
+
+// ── subagents ───────────────────────────────────────────────────────────────
+
+fn spawn(task: &str, display: &str) -> AgentProgress {
+    AgentProgress::SubagentSpawned {
+        agent_id: "researcher".to_string(),
+        task_id: task.to_string(),
+        mode: "typed".to_string(),
+        dedicated_thread: true,
+        prompt_chars: 256,
+        worker_thread_id: Some("worker-abc".to_string()),
+        display_name: Some(display.to_string()),
+    }
+}
+
+#[test]
+fn subagent_lifecycle_nests_under_the_turn() {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 5 }, 5),
+        (spawn("task-1", "Researcher"), 10),
+        (
+            AgentProgress::SubagentIterationStarted {
+                agent_id: "researcher".to_string(),
+                task_id: "task-1".to_string(),
+                iteration: 1,
+                max_iterations: 8,
+                extended_policy: true,
+            },
+            20,
+        ),
+        (
+            AgentProgress::SubagentToolCallStarted {
+                agent_id: "researcher".to_string(),
+                task_id: "task-1".to_string(),
+                call_id: "sc-1".to_string(),
+                tool_name: "read_file".to_string(),
+                iteration: 1,
+            },
+            30,
+        ),
+        (
+            AgentProgress::SubagentToolCallCompleted {
+                agent_id: "researcher".to_string(),
+                task_id: "task-1".to_string(),
+                call_id: "sc-1".to_string(),
+                tool_name: "read_file".to_string(),
+                success: true,
+                output_chars: 99,
+                elapsed_ms: 40,
+                iteration: 1,
+            },
+            30,
+        ),
+        (
+            AgentProgress::SubagentCompleted {
+                agent_id: "researcher".to_string(),
+                task_id: "task-1".to_string(),
+                elapsed_ms: 500,
+                iterations: 3,
+                output_chars: 1024,
+                worktree_path: Some("/private/should/not/leak".to_string()),
+                changed_files: vec!["secret_file.rs".to_string()],
+                dirty_status: Some(true),
+            },
+            40,
+        ),
+    ]);
+    c.finish(1_000);
+    let spans = c.spans();
+
+    let iter = find(spans, "agent.iteration#1");
+    let sub = find(spans, "subagent.Researcher");
+    assert_eq!(sub.kind, SpanKind::Subagent);
+    assert_eq!(sub.parent_span_id.as_deref(), Some(iter.span_id.as_str()));
+    assert_eq!(sub.attributes["subagent.task_id"], serde_json::json!("task-1"));
+    assert_eq!(sub.attributes["subagent.iterations"], serde_json::json!(3));
+    assert_eq!(sub.attributes["subagent.output_chars"], serde_json::json!(1024));
+    assert_eq!(sub.duration_ms(), Some(500));
+
+    let child_iter = find(spans, "subagent.iteration#1");
+    assert_eq!(child_iter.kind, SpanKind::SubagentIteration);
+    assert_eq!(child_iter.parent_span_id.as_deref(), Some(sub.span_id.as_str()));
+    assert_eq!(child_iter.attributes["agent.extended_policy"], serde_json::json!(true));
+
+    let child_tool = find(spans, "tool.read_file");
+    assert_eq!(child_tool.parent_span_id.as_deref(), Some(child_iter.span_id.as_str()));
+    assert_eq!(child_tool.status, SpanStatus::Ok);
+
+    // Worktree paths / changed file names must never be exported.
+    let blob = serde_json::to_string(spans).unwrap();
+    assert!(!blob.contains("should/not/leak"));
+    assert!(!blob.contains("secret_file.rs"));
+}
+
+#[test]
+fn subagent_failure_records_error_without_raw_text() {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (spawn("task-9", "Coder"), 5),
+        (
+            AgentProgress::SubagentFailed {
+                agent_id: "coder".to_string(),
+                task_id: "task-9".to_string(),
+                error: "API key sk-secret-123 leaked in stacktrace".to_string(),
+            },
+            10,
+        ),
+    ]);
+    c.finish(50);
+    let sub = find(c.spans(), "subagent.Coder");
+    assert_eq!(sub.status, SpanStatus::Error);
+    assert_eq!(sub.attributes["error"], serde_json::json!(true));
+    assert!(sub.attributes.get("error.length").is_some());
+
+    let blob = serde_json::to_string(c.spans()).unwrap();
+    assert!(!blob.contains("sk-secret-123"), "raw error text must not leak");
+}
+
+#[test]
+fn unknown_subagent_task_ids_are_ignored() {
+    // Completion/tool events with no matching spawn must not panic or spawn.
+    let mut c = SpanCollector::new(ctx());
+    c.record(&AgentProgress::TurnStarted, 0);
+    c.record(
+        &AgentProgress::SubagentCompleted {
+            agent_id: "x".to_string(),
+            task_id: "ghost".to_string(),
+            elapsed_ms: 1,
+            iterations: 1,
+            output_chars: 1,
+            worktree_path: None,
+            changed_files: vec![],
+            dirty_status: None,
+        },
+        10,
+    );
+    // Only the turn span exists.
+    assert_eq!(names(c.spans()), vec!["agent.turn".to_string()]);
+}
+
+// ── privacy ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn content_bearing_events_produce_no_spans_and_no_leak() {
+    let c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (AgentProgress::TextDelta { delta: "TOP-SECRET-REPLY".to_string(), iteration: 1 }, 1),
+        (AgentProgress::ThinkingDelta { delta: "secret reasoning".to_string(), iteration: 1 }, 2),
+        (
+            AgentProgress::ToolCallArgsDelta {
+                call_id: "c".to_string(),
+                tool_name: "shell".to_string(),
+                delta: "rm -rf /secret".to_string(),
+                iteration: 1,
+            },
+            3,
+        ),
+    ]);
+    // Only the lazily-opened turn span, nothing from the deltas.
+    assert_eq!(names(c.spans()), vec!["agent.turn".to_string()]);
+    let blob = serde_json::to_string(c.spans()).unwrap();
+    assert!(!blob.contains("TOP-SECRET-REPLY"));
+    assert!(!blob.contains("secret reasoning"));
+    assert!(!blob.contains("rm -rf"));
+}
+
+#[test]
+fn tool_arguments_are_never_serialized() {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (tool_started("c1", "shell", 1), 1),
+    ]);
+    c.finish(10);
+    let blob = serde_json::to_string(c.spans()).unwrap();
+    assert!(!blob.contains("do-not-export"), "tool args must not be exported");
+}
+
+// ── lazy root + finish ──────────────────────────────────────────────────────
+
+#[test]
+fn first_event_lazily_opens_the_turn_span() {
+    // Stream that begins mid-flight (no TurnStarted) still correlates.
+    let mut c = SpanCollector::new(ctx());
+    c.record(&AgentProgress::IterationStarted { iteration: 4, max_iterations: 9 }, 100);
+    let turn = find(c.spans(), "agent.turn");
+    assert_eq!(turn.trace_id, "sess-42");
+    let iter = find(c.spans(), "agent.iteration#4");
+    assert_eq!(iter.parent_span_id.as_deref(), Some(turn.span_id.as_str()));
+}
+
+#[test]
+fn finish_seals_all_open_spans_idempotently() {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 2 }, 5),
+        (tool_started("c1", "x", 1), 6),
+    ]);
+    assert!(c.spans().iter().any(|s| s.end_unix_ms.is_none()));
+    c.finish(99);
+    assert!(c.spans().iter().all(|s| s.end_unix_ms.is_some()));
+    // idempotent.
+    c.finish(200);
+    assert!(c.spans().iter().all(|s| s.end_unix_ms == Some(s.end_unix_ms.unwrap())));
+}
+
+#[test]
+fn cost_update_before_turn_start_lazily_opens_root() {
+    let mut c = SpanCollector::new(ctx());
+    c.record(
+        &AgentProgress::TurnCostUpdated {
+            model: "m".to_string(),
+            iteration: 1,
+            input_tokens: 10,
+            output_tokens: 5,
+            cached_input_tokens: 0,
+            total_usd: 0.001,
+        },
+        100,
+    );
+    let turn = find(c.spans(), "agent.turn");
+    assert_eq!(turn.attributes["gen_ai.usage.input_tokens"], serde_json::json!(10));
+}
+
+#[test]
+fn trace_session_id_prefers_ui_session_else_thread() {
+    assert_eq!(trace_session_id(Some(99), "thread-x"), "99");
+    assert_eq!(trace_session_id(None, "thread-x"), "thread-x");
+}
+
+#[test]
+fn no_user_attribution_omits_user_id() {
+    let mut c = SpanCollector::new(TraceContext::new("anon-1", None));
+    c.record(&AgentProgress::TurnStarted, 0);
+    let turn = find(c.spans(), "agent.turn");
+    assert!(turn.attributes.get("user.id").is_none());
+    assert_eq!(turn.attributes["session.id"], serde_json::json!("anon-1"));
+}
+
+// ── serialization + export ──────────────────────────────────────────────────
+
+fn one_turn_spans() -> Vec<TraceSpan> {
+    let mut c = collect(&[
+        (AgentProgress::TurnStarted, 0),
+        (AgentProgress::TurnCompleted { iterations: 1 }, 10),
+    ]);
+    c.finish(10);
+    c.into_spans()
+}
+
+#[test]
+fn ndjson_otel_emits_one_line_per_span() {
+    let spans = one_turn_spans();
+    let out = spans_to_ndjson(AgentTracingBackend::Otel, &spans);
+    assert_eq!(out.lines().count(), spans.len());
+    // Bare OTel span body has the fields directly.
+    let first: serde_json::Value = serde_json::from_str(out.lines().next().unwrap()).unwrap();
+    assert_eq!(first["trace_id"], serde_json::json!("sess-42"));
+    assert_eq!(first["kind"], serde_json::json!("turn"));
+}
+
+#[test]
+fn ndjson_langfuse_wraps_each_span_in_an_observation_envelope() {
+    let spans = one_turn_spans();
+    let out = spans_to_ndjson(AgentTracingBackend::Langfuse, &spans);
+    let first: serde_json::Value = serde_json::from_str(out.lines().next().unwrap()).unwrap();
+    assert_eq!(first["type"], serde_json::json!("span-create"));
+    assert_eq!(first["body"]["trace_id"], serde_json::json!("sess-42"));
+}
+
+#[test]
+fn ndjson_empty_for_empty_slice() {
+    assert!(spans_to_ndjson(AgentTracingBackend::Otel, &[]).is_empty());
+}
+
+#[test]
+fn export_disabled_is_a_noop_and_writes_nothing() {
+    let dir = std::env::temp_dir().join(format!("oh-trace-noop-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("spans.ndjson");
+    let cfg = AgentTracingConfig {
+        enabled: false,
+        backend: AgentTracingBackend::Otel,
+        export_path: Some(path.to_string_lossy().to_string()),
+    };
+    export_spans(&cfg, &one_turn_spans());
+    assert!(!path.exists(), "disabled tracing must not create the export file");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn export_appends_ndjson_to_the_configured_file() {
+    let dir = std::env::temp_dir().join(format!("oh-trace-export-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("spans.ndjson");
+    let cfg = AgentTracingConfig {
+        enabled: true,
+        backend: AgentTracingBackend::Otel,
+        export_path: Some(path.to_string_lossy().to_string()),
+    };
+    let spans = one_turn_spans();
+    export_spans(&cfg, &spans);
+    // Append, not truncate: a second export grows the file.
+    export_spans(&cfg, &spans);
+
+    let body = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(body.lines().count(), spans.len() * 2);
+    // Each line is valid, parseable JSON.
+    for line in body.lines() {
+        let v: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(v["trace_id"], serde_json::json!("sess-42"));
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn export_with_no_path_does_not_panic() {
+    // Path-less export logs instead of writing; must be safe to call.
+    let cfg = AgentTracingConfig {
+        enabled: true,
+        backend: AgentTracingBackend::Langfuse,
+        export_path: None,
+    };
+    export_spans(&cfg, &one_turn_spans());
+    export_spans(&cfg, &[]); // empty slice short-circuits.
+}

--- a/src/openhuman/agent/progress_tracing/tests.rs
+++ b/src/openhuman/agent/progress_tracing/tests.rs
@@ -72,7 +72,13 @@ fn tool_started(call_id: &str, tool: &str, iter: u32) -> AgentProgress {
     }
 }
 
-fn tool_completed(call_id: &str, tool: &str, success: bool, chars: usize, elapsed: u64) -> AgentProgress {
+fn tool_completed(
+    call_id: &str,
+    tool: &str,
+    success: bool,
+    chars: usize,
+    elapsed: u64,
+) -> AgentProgress {
     AgentProgress::ToolCallCompleted {
         call_id: call_id.to_string(),
         tool_name: tool.to_string(),
@@ -95,7 +101,10 @@ fn full_turn_builds_correlated_span_tree() {
             1_010,
         ),
         (tool_started("call-1", "web_search", 1), 1_020),
-        (tool_completed("call-1", "web_search", true, 321, 200), 1_020),
+        (
+            tool_completed("call-1", "web_search", true, 321, 200),
+            1_020,
+        ),
         (
             AgentProgress::TurnCostUpdated {
                 model: "claude-opus-4-8".to_string(),
@@ -120,10 +129,22 @@ fn full_turn_builds_correlated_span_tree() {
     assert_eq!(turn.attributes["session.id"], serde_json::json!("sess-42"));
     assert_eq!(turn.attributes["user.id"], serde_json::json!("client-7"));
     // Cost / usage attributes ride on the root.
-    assert_eq!(turn.attributes["gen_ai.usage.input_tokens"], serde_json::json!(1_200));
-    assert_eq!(turn.attributes["gen_ai.usage.output_tokens"], serde_json::json!(480));
-    assert_eq!(turn.attributes["gen_ai.usage.cached_input_tokens"], serde_json::json!(64));
-    assert_eq!(turn.attributes["gen_ai.request.model"], serde_json::json!("claude-opus-4-8"));
+    assert_eq!(
+        turn.attributes["gen_ai.usage.input_tokens"],
+        serde_json::json!(1_200)
+    );
+    assert_eq!(
+        turn.attributes["gen_ai.usage.output_tokens"],
+        serde_json::json!(480)
+    );
+    assert_eq!(
+        turn.attributes["gen_ai.usage.cached_input_tokens"],
+        serde_json::json!(64)
+    );
+    assert_eq!(
+        turn.attributes["gen_ai.request.model"],
+        serde_json::json!("claude-opus-4-8")
+    );
     assert_eq!(turn.attributes["agent.iterations"], serde_json::json!(1));
     assert_eq!(turn.status, SpanStatus::Ok);
     assert!(turn.attributes.get("gen_ai.usage.cost_usd").is_some());
@@ -132,7 +153,10 @@ fn full_turn_builds_correlated_span_tree() {
     let iter = find(spans, "agent.iteration#1");
     assert_eq!(iter.kind, SpanKind::Iteration);
     assert_eq!(iter.parent_span_id.as_deref(), Some(turn.span_id.as_str()));
-    assert_eq!(iter.attributes["agent.max_iterations"], serde_json::json!(5));
+    assert_eq!(
+        iter.attributes["agent.max_iterations"],
+        serde_json::json!(5)
+    );
 
     // Tool parented to the iteration.
     let tool = find(spans, "tool.web_search");
@@ -151,7 +175,13 @@ fn full_turn_builds_correlated_span_tree() {
 fn failed_tool_marks_error_status() {
     let mut c = collect(&[
         (AgentProgress::TurnStarted, 0),
-        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 3 }, 1),
+        (
+            AgentProgress::IterationStarted {
+                iteration: 1,
+                max_iterations: 3,
+            },
+            1,
+        ),
         (tool_started("c1", "shell", 1), 2),
         (tool_completed("c1", "shell", false, 12, 5), 2),
     ]);
@@ -165,13 +195,32 @@ fn failed_tool_marks_error_status() {
 fn iteration_started_closes_the_previous_iteration() {
     let c = collect(&[
         (AgentProgress::TurnStarted, 0),
-        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 3 }, 10),
-        (AgentProgress::IterationStarted { iteration: 2, max_iterations: 3 }, 20),
+        (
+            AgentProgress::IterationStarted {
+                iteration: 1,
+                max_iterations: 3,
+            },
+            10,
+        ),
+        (
+            AgentProgress::IterationStarted {
+                iteration: 2,
+                max_iterations: 3,
+            },
+            20,
+        ),
     ]);
     let first = find(c.spans(), "agent.iteration#1");
-    assert_eq!(first.end_unix_ms, Some(20), "iter#1 closes when iter#2 opens");
+    assert_eq!(
+        first.end_unix_ms,
+        Some(20),
+        "iter#1 closes when iter#2 opens"
+    );
     let second = find(c.spans(), "agent.iteration#2");
-    assert!(second.end_unix_ms.is_none(), "iter#2 still open until finish");
+    assert!(
+        second.end_unix_ms.is_none(),
+        "iter#2 still open until finish"
+    );
 }
 
 // ── subagents ───────────────────────────────────────────────────────────────
@@ -192,7 +241,13 @@ fn spawn(task: &str, display: &str) -> AgentProgress {
 fn subagent_lifecycle_nests_under_the_turn() {
     let mut c = collect(&[
         (AgentProgress::TurnStarted, 0),
-        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 5 }, 5),
+        (
+            AgentProgress::IterationStarted {
+                iteration: 1,
+                max_iterations: 5,
+            },
+            5,
+        ),
         (spawn("task-1", "Researcher"), 10),
         (
             AgentProgress::SubagentIterationStarted {
@@ -248,18 +303,33 @@ fn subagent_lifecycle_nests_under_the_turn() {
     let sub = find(spans, "subagent.Researcher");
     assert_eq!(sub.kind, SpanKind::Subagent);
     assert_eq!(sub.parent_span_id.as_deref(), Some(iter.span_id.as_str()));
-    assert_eq!(sub.attributes["subagent.task_id"], serde_json::json!("task-1"));
+    assert_eq!(
+        sub.attributes["subagent.task_id"],
+        serde_json::json!("task-1")
+    );
     assert_eq!(sub.attributes["subagent.iterations"], serde_json::json!(3));
-    assert_eq!(sub.attributes["subagent.output_chars"], serde_json::json!(1024));
+    assert_eq!(
+        sub.attributes["subagent.output_chars"],
+        serde_json::json!(1024)
+    );
     assert_eq!(sub.duration_ms(), Some(500));
 
     let child_iter = find(spans, "subagent.iteration#1");
     assert_eq!(child_iter.kind, SpanKind::SubagentIteration);
-    assert_eq!(child_iter.parent_span_id.as_deref(), Some(sub.span_id.as_str()));
-    assert_eq!(child_iter.attributes["agent.extended_policy"], serde_json::json!(true));
+    assert_eq!(
+        child_iter.parent_span_id.as_deref(),
+        Some(sub.span_id.as_str())
+    );
+    assert_eq!(
+        child_iter.attributes["agent.extended_policy"],
+        serde_json::json!(true)
+    );
 
     let child_tool = find(spans, "tool.read_file");
-    assert_eq!(child_tool.parent_span_id.as_deref(), Some(child_iter.span_id.as_str()));
+    assert_eq!(
+        child_tool.parent_span_id.as_deref(),
+        Some(child_iter.span_id.as_str())
+    );
     assert_eq!(child_tool.status, SpanStatus::Ok);
 
     // Worktree paths / changed file names must never be exported.
@@ -289,7 +359,10 @@ fn subagent_failure_records_error_without_raw_text() {
     assert!(sub.attributes.get("error.length").is_some());
 
     let blob = serde_json::to_string(c.spans()).unwrap();
-    assert!(!blob.contains("sk-secret-123"), "raw error text must not leak");
+    assert!(
+        !blob.contains("sk-secret-123"),
+        "raw error text must not leak"
+    );
 }
 
 #[test]
@@ -320,8 +393,20 @@ fn unknown_subagent_task_ids_are_ignored() {
 fn content_bearing_events_produce_no_spans_and_no_leak() {
     let c = collect(&[
         (AgentProgress::TurnStarted, 0),
-        (AgentProgress::TextDelta { delta: "TOP-SECRET-REPLY".to_string(), iteration: 1 }, 1),
-        (AgentProgress::ThinkingDelta { delta: "secret reasoning".to_string(), iteration: 1 }, 2),
+        (
+            AgentProgress::TextDelta {
+                delta: "TOP-SECRET-REPLY".to_string(),
+                iteration: 1,
+            },
+            1,
+        ),
+        (
+            AgentProgress::ThinkingDelta {
+                delta: "secret reasoning".to_string(),
+                iteration: 1,
+            },
+            2,
+        ),
         (
             AgentProgress::ToolCallArgsDelta {
                 call_id: "c".to_string(),
@@ -348,7 +433,10 @@ fn tool_arguments_are_never_serialized() {
     ]);
     c.finish(10);
     let blob = serde_json::to_string(c.spans()).unwrap();
-    assert!(!blob.contains("do-not-export"), "tool args must not be exported");
+    assert!(
+        !blob.contains("do-not-export"),
+        "tool args must not be exported"
+    );
 }
 
 // ── lazy root + finish ──────────────────────────────────────────────────────
@@ -357,7 +445,13 @@ fn tool_arguments_are_never_serialized() {
 fn first_event_lazily_opens_the_turn_span() {
     // Stream that begins mid-flight (no TurnStarted) still correlates.
     let mut c = SpanCollector::new(ctx());
-    c.record(&AgentProgress::IterationStarted { iteration: 4, max_iterations: 9 }, 100);
+    c.record(
+        &AgentProgress::IterationStarted {
+            iteration: 4,
+            max_iterations: 9,
+        },
+        100,
+    );
     let turn = find(c.spans(), "agent.turn");
     assert_eq!(turn.trace_id, "sess-42");
     let iter = find(c.spans(), "agent.iteration#4");
@@ -368,7 +462,13 @@ fn first_event_lazily_opens_the_turn_span() {
 fn finish_seals_all_open_spans_idempotently() {
     let mut c = collect(&[
         (AgentProgress::TurnStarted, 0),
-        (AgentProgress::IterationStarted { iteration: 1, max_iterations: 2 }, 5),
+        (
+            AgentProgress::IterationStarted {
+                iteration: 1,
+                max_iterations: 2,
+            },
+            5,
+        ),
         (tool_started("c1", "x", 1), 6),
     ]);
     assert!(c.spans().iter().any(|s| s.end_unix_ms.is_none()));
@@ -376,7 +476,10 @@ fn finish_seals_all_open_spans_idempotently() {
     assert!(c.spans().iter().all(|s| s.end_unix_ms.is_some()));
     // idempotent.
     c.finish(200);
-    assert!(c.spans().iter().all(|s| s.end_unix_ms == Some(s.end_unix_ms.unwrap())));
+    assert!(c
+        .spans()
+        .iter()
+        .all(|s| s.end_unix_ms == Some(s.end_unix_ms.unwrap())));
 }
 
 #[test]
@@ -394,7 +497,10 @@ fn cost_update_before_turn_start_lazily_opens_root() {
         100,
     );
     let turn = find(c.spans(), "agent.turn");
-    assert_eq!(turn.attributes["gen_ai.usage.input_tokens"], serde_json::json!(10));
+    assert_eq!(
+        turn.attributes["gen_ai.usage.input_tokens"],
+        serde_json::json!(10)
+    );
 }
 
 #[test]
@@ -459,7 +565,10 @@ fn export_disabled_is_a_noop_and_writes_nothing() {
         export_path: Some(path.to_string_lossy().to_string()),
     };
     export_spans(&cfg, &one_turn_spans());
-    assert!(!path.exists(), "disabled tracing must not create the export file");
+    assert!(
+        !path.exists(),
+        "disabled tracing must not create the export file"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/src/openhuman/channels/providers/web/progress_bridge.rs
+++ b/src/openhuman/channels/providers/web/progress_bridge.rs
@@ -6,6 +6,15 @@ use crate::openhuman::threads::turn_state::{TurnStateMirror, TurnStateStore};
 use super::event_bus::publish_web_channel_event;
 use super::types::ChatRequestMetadata;
 
+/// Current wall-clock time as Unix-epoch milliseconds, used to stamp tracing
+/// spans (issue #3886). Saturates to `0` if the clock is before the epoch.
+fn unix_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
 pub(super) fn ledger_upsert_agent_run(
     config: &crate::openhuman::config::Config,
     upsert: crate::openhuman::session_db::run_ledger::AgentRunUpsert,
@@ -94,9 +103,30 @@ pub(crate) fn spawn_progress_bridge(
         let mut child_tool_counts: HashMap<String, u64> = HashMap::new();
         let mut turn_state =
             TurnStateMirror::new(turn_state_store, thread_id.clone(), request_id.clone());
+
+        // #3886: opt-in structured tracing export. When enabled, fold the same
+        // progress stream into OTel/Langfuse-style spans correlated by session
+        // id (falling back to the thread id for headless/autonomous runs) with
+        // the client id as user attribution. `None` (disabled) is zero-cost.
+        let mut span_collector = if config.observability.agent_tracing.enabled {
+            use crate::openhuman::agent::progress_tracing::{
+                trace_session_id, SpanCollector, TraceContext,
+            };
+            let session_id = trace_session_id(metadata.session_id, &thread_id);
+            Some(SpanCollector::new(TraceContext::new(
+                session_id,
+                Some(client_id.clone()),
+            )))
+        } else {
+            None
+        };
+
         while let Some(event) = rx.recv().await {
             events_seen += 1;
             turn_state.observe(&event);
+            if let Some(collector) = span_collector.as_mut() {
+                collector.record(&event, unix_epoch_ms());
+            }
             match &event {
                 AgentProgress::TextDelta { delta, iteration } => {
                     log::trace!(
@@ -971,6 +1001,17 @@ pub(crate) fn spawn_progress_bridge(
                 },
             );
         }
+        // #3886: seal any spans still open after the stream closed and hand the
+        // run's trace to the configured tracing sink. Best-effort and gated;
+        // never affects the turn outcome.
+        if let Some(mut collector) = span_collector.take() {
+            collector.finish(unix_epoch_ms());
+            crate::openhuman::agent::progress_tracing::export_spans(
+                &config.observability.agent_tracing,
+                collector.spans(),
+            );
+        }
+
         log::debug!(
             "[web_channel][bridge] exit client_id={} thread_id={} request_id={} round={} events_seen={}",
             client_id,

--- a/src/openhuman/config/schema/mod.rs
+++ b/src/openhuman/config/schema/mod.rs
@@ -67,7 +67,7 @@ pub use learning::{LearningConfig, ReflectionSource};
 pub use local_ai::{LocalAiConfig, LocalAiUsage};
 pub use meet::{AutoJoinPolicy, AutoSummarizePolicy, MeetConfig};
 pub use node::NodeConfig;
-pub use observability::ObservabilityConfig;
+pub use observability::{AgentTracingBackend, AgentTracingConfig, ObservabilityConfig};
 pub use proxy::{
     apply_runtime_proxy_to_builder, build_runtime_proxy_client,
     build_runtime_proxy_client_with_timeouts, runtime_proxy_config, set_runtime_proxy_config,

--- a/src/openhuman/config/schema/observability.rs
+++ b/src/openhuman/config/schema/observability.rs
@@ -16,10 +16,63 @@ pub struct ObservabilityConfig {
     /// Defaults to `true`. Users can disable via settings or CLI.
     #[serde(default = "default_analytics_enabled")]
     pub analytics_enabled: bool,
+
+    /// Opt-in structured tracing export for agent runs (issue #3886).
+    /// Off by default; see [`AgentTracingConfig`].
+    #[serde(default)]
+    pub agent_tracing: AgentTracingConfig,
 }
 
 fn default_analytics_enabled() -> bool {
     true
+}
+
+/// Destination format for the agent tracing export. Vendor-neutral
+/// OpenTelemetry by default; Langfuse is offered for teams already on it.
+/// Both share the same span model — only the serialized envelope differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentTracingBackend {
+    /// OpenTelemetry-style spans (vendor-neutral). Default.
+    #[default]
+    Otel,
+    /// Langfuse-style observations.
+    Langfuse,
+}
+
+/// Opt-in structured tracing export driven by the agent progress channel.
+///
+/// When [`Self::enabled`] is `true`, agent runs emit OpenTelemetry/Langfuse-
+/// style spans (turn → iteration → tool call / subagent) correlated by session
+/// id with user attribution, appended as NDJSON to [`Self::export_path`].
+///
+/// Off by default and intentionally side-effect-free when disabled. Spans
+/// carry only metadata (names, counts, timings, token/cost figures) — never
+/// prompt text, tool arguments, streamed deltas, error text, or file paths —
+/// honoring the project's "never log secrets or full PII" rule.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct AgentTracingConfig {
+    /// Master switch. Off by default.
+    pub enabled: bool,
+
+    /// Serialized span envelope to emit. Defaults to OpenTelemetry.
+    pub backend: AgentTracingBackend,
+
+    /// Absolute path of the NDJSON file spans are appended to. When unset,
+    /// spans are emitted to the application log at `info` level instead, so
+    /// the export still works on read-only or sandboxed deployments.
+    pub export_path: Option<String>,
+}
+
+impl Default for AgentTracingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            backend: AgentTracingBackend::Otel,
+            export_path: None,
+        }
+    }
 }
 
 impl Default for ObservabilityConfig {
@@ -27,6 +80,7 @@ impl Default for ObservabilityConfig {
         Self {
             sentry_dsn: None,
             analytics_enabled: true,
+            agent_tracing: AgentTracingConfig::default(),
         }
     }
 }
@@ -52,6 +106,35 @@ mod tests {
     fn deserialize_missing_optional_fields_uses_defaults() {
         let cfg: ObservabilityConfig = serde_json::from_value(json!({})).unwrap();
         assert!(cfg.analytics_enabled, "analytics default must be true");
+        assert!(
+            !cfg.agent_tracing.enabled,
+            "agent tracing must default off (opt-in)"
+        );
+        assert_eq!(cfg.agent_tracing.backend, AgentTracingBackend::Otel);
+        assert!(cfg.agent_tracing.export_path.is_none());
+    }
+
+    #[test]
+    fn deserialize_agent_tracing_block() {
+        let cfg: ObservabilityConfig = serde_json::from_value(json!({
+            "agent_tracing": {
+                "enabled": true,
+                "backend": "langfuse",
+                "export_path": "/var/log/openhuman/spans.ndjson"
+            }
+        }))
+        .unwrap();
+        assert!(cfg.agent_tracing.enabled);
+        assert_eq!(cfg.agent_tracing.backend, AgentTracingBackend::Langfuse);
+        assert_eq!(
+            cfg.agent_tracing.export_path.as_deref(),
+            Some("/var/log/openhuman/spans.ndjson")
+        );
+    }
+
+    #[test]
+    fn agent_tracing_backend_defaults_to_otel() {
+        assert_eq!(AgentTracingBackend::default(), AgentTracingBackend::Otel);
     }
 
     #[test]
@@ -69,6 +152,7 @@ mod tests {
         let original = ObservabilityConfig {
             sentry_dsn: Some("https://token@sentry.io/1".into()),
             analytics_enabled: false,
+            agent_tracing: AgentTracingConfig::default(),
         };
         let s = serde_json::to_string(&original).unwrap();
         let back: ObservabilityConfig = serde_json::from_str(&s).unwrap();


### PR DESCRIPTION
## Summary

Adds an opt-in **structured tracing export** off the existing `AgentProgress` progress channel: agent runs emit OpenTelemetry/Langfuse-style **spans** (turn → iteration → tool call / subagent spawn), correlated by **session id** with **user attribution**, so multi-agent runs that span many subagents and minutes-to-hours are inspectable end to end.

Off by default; zero-cost when disabled.

## What's included

**`src/openhuman/agent/progress_tracing.rs`** — a pure, fully unit-tested state machine:
- `SpanCollector` folds the `AgentProgress` stream (+ a wall-clock ms stamp) into a `TraceSpan` tree: `agent.turn` → `agent.iteration#N` → `tool.<name>` / `subagent.<name>` → `subagent.iteration#N` → child tools. Tracks success/error status, opens the root lazily, and seals open spans on `finish()`.
- `TraceSpan` / `SpanKind` / `SpanStatus` follow OTel conventions (`trace_id`, `span_id`, `parent_span_id`, attributes).
- **Correlation:** `trace_id` = session id (`trace_session_id()` prefers the UI session id, falls back to the thread id for headless/autonomous runs); user attribution via the `user.id` attribute.
- **Cost reuse:** `TurnCostUpdated` → `gen_ai.usage.{input,output,cached_input}_tokens`, `gen_ai.usage.cost_usd`, `gen_ai.request.model` on the root span.
- `spans_to_ndjson()` emits OTel bare spans or Langfuse `span-create` observations; `export_spans()` appends NDJSON to a file (or logs when no path is set).

**Config** (`observability.rs`): new `AgentTracingConfig { enabled, backend, export_path }` + `AgentTracingBackend` (otel|langfuse), nested under `ObservabilityConfig.agent_tracing`. `enabled = false` by default.

**Wiring** (`web/progress_bridge.rs`): the single progress consumer used by both chat and autonomous task runs feeds the collector when enabled and exports on stream close.

## Acceptance criteria

- [x] **Span export** — turn / iteration / tool / subagent spans emitted from the progress channel.
- [x] **Correlation** — spans carry session id (`trace_id`) + user attribution (`user.id`).
- [x] **Opt-in & safe** — config-gated, off by default; spans carry only metadata (names, counts, timings, token/cost) — never prompt text, tool arguments, streamed deltas, raw error text, or filesystem paths (honors the "never log secrets or full PII" rule, asserted by tests).
- [x] **Diff coverage** — the pure module + config carry ~25 focused unit tests (collector shape, privacy no-leak, both NDJSON backends, file export round-trip, config defaults).

## Notes

- No tests/checks were run locally; CI will exercise them.
- Independent of #3883/#3884; observability foundation for longer-horizon runs.

Closes #3886