### PR TITLE
fix(tinyplace): classify wallet-not-configured as expected user state

### DIFF
--- a/src/openhuman/tinyplace/error.rs
+++ b/src/openhuman/tinyplace/error.rs
@@ -1,0 +1,96 @@
+//! Error classification for the tiny.place client-build chokepoint.
+//!
+//! Every `tinyplace_*` controller obtains its client via
+//! [`TinyPlaceState::client`](super::state::TinyPlaceState::client), which
+//! derives a signer seed from the user's wallet. When the user has not set up
+//! a wallet yet, that derivation fails with the plain string
+//! [`wallet::WALLET_NOT_CONFIGURED_MESSAGE`]. home_feed (backend
+//! `GraphQLAuth::Agent`) legitimately needs a configured signer, so there is no
+//! local lever to make the call succeed — this is an **expected user state**,
+//! not an internal failure.
+//!
+//! Left as an unstructured string, the JSON-RPC boundary (`src/core/jsonrpc.rs`)
+//! treats it as `expected_user_state = false` and escalates it to an
+//! error-level Sentry capture — flooding Sentry with noise from wallet-less
+//! users opening the Agent World Feed (issue #3964).
+//!
+//! [`classify_client_build_error`] reclassifies **only that exact message**
+//! into a [`StructuredRpcError`] with `expected_user_state: true`, mirroring the
+//! `threads::NotFound → ThreadNotFound` pattern. Every other failure
+//! (decrypt, key derivation, config load) passes through unchanged and keeps
+//! paging.
+
+use serde_json::json;
+
+use crate::openhuman::wallet::WALLET_NOT_CONFIGURED_MESSAGE;
+use crate::rpc::StructuredRpcError;
+
+/// Stable JSON-RPC discriminator the frontend can branch on to render the
+/// "set up wallet" prompt without string-matching the message.
+pub const WALLET_NOT_CONFIGURED_KIND: &str = "WalletNotConfigured";
+
+/// Classify an error returned while building the tiny.place client.
+///
+/// The wallet-not-configured condition is reclassified into a structured,
+/// expected-user-state envelope so the JSON-RPC boundary skips Sentry. Any
+/// other error string is returned verbatim so genuine failures still page.
+pub(crate) fn classify_client_build_error(err: String) -> String {
+    if err == WALLET_NOT_CONFIGURED_MESSAGE {
+        StructuredRpcError {
+            message: err,
+            data: Some(json!({ "kind": WALLET_NOT_CONFIGURED_KIND })),
+            expected_user_state: true,
+        }
+        .encode()
+    } else {
+        err
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wallet_not_configured_becomes_expected_user_state_envelope() {
+        let raw = classify_client_build_error(WALLET_NOT_CONFIGURED_MESSAGE.to_string());
+        let structured = StructuredRpcError::decode(&raw)
+            .expect("wallet-not-configured must emit a structured envelope");
+        assert_eq!(structured.message, WALLET_NOT_CONFIGURED_MESSAGE);
+        assert!(
+            structured.expected_user_state,
+            "wallet-not-configured is an expected user state, not a Sentry error"
+        );
+        let data = structured.data.expect("structured error must carry data");
+        assert_eq!(data["kind"], WALLET_NOT_CONFIGURED_KIND);
+    }
+
+    #[test]
+    fn unrelated_errors_pass_through_and_still_page() {
+        for err in [
+            "decrypt failed: bad key",
+            "tinyplace signer init: invalid seed length",
+            "config load timed out",
+        ] {
+            let raw = classify_client_build_error(err.to_string());
+            assert_eq!(raw, err, "non-wallet errors must be returned verbatim");
+            assert!(
+                StructuredRpcError::decode(&raw).is_none(),
+                "non-wallet errors must NOT carry the expected-user-state sentinel"
+            );
+        }
+    }
+
+    /// Coupling guard: the classifier keys off the *exact* string the wallet
+    /// layer emits. This fails loudly if either side drifts, preventing a
+    /// silent regression back to error-level Sentry noise (#3964).
+    #[test]
+    fn classifier_is_coupled_to_the_wallet_message_constant() {
+        assert_eq!(
+            WALLET_NOT_CONFIGURED_MESSAGE,
+            "wallet is not configured; run wallet setup first",
+            "the tiny.place classifier and the wallet origin must agree on this \
+             exact string; update both sites together if it changes"
+        );
+    }
+}

--- a/src/openhuman/tinyplace/error.rs
+++ b/src/openhuman/tinyplace/error.rs
@@ -87,8 +87,7 @@ mod tests {
     #[test]
     fn classifier_is_coupled_to_the_wallet_message_constant() {
         assert_eq!(
-            WALLET_NOT_CONFIGURED_MESSAGE,
-            "wallet is not configured; run wallet setup first",
+            WALLET_NOT_CONFIGURED_MESSAGE, "wallet is not configured; run wallet setup first",
             "the tiny.place classifier and the wallet origin must agree on this \
              exact string; update both sites together if it changes"
         );

--- a/src/openhuman/tinyplace/error.rs
+++ b/src/openhuman/tinyplace/error.rs
@@ -36,6 +36,9 @@ pub const WALLET_NOT_CONFIGURED_KIND: &str = "WalletNotConfigured";
 /// other error string is returned verbatim so genuine failures still page.
 pub(crate) fn classify_client_build_error(err: String) -> String {
     if err == WALLET_NOT_CONFIGURED_MESSAGE {
+        log::debug!(
+            "[tinyplace] client-build error reclassified as expected user state kind={WALLET_NOT_CONFIGURED_KIND} (Sentry-suppressed, #3964)"
+        );
         StructuredRpcError {
             message: err,
             data: Some(json!({ "kind": WALLET_NOT_CONFIGURED_KIND })),
@@ -43,6 +46,7 @@ pub(crate) fn classify_client_build_error(err: String) -> String {
         }
         .encode()
     } else {
+        log::debug!("[tinyplace] client-build error passed through unchanged (still pages)");
         err
     }
 }

--- a/src/openhuman/tinyplace/mod.rs
+++ b/src/openhuman/tinyplace/mod.rs
@@ -27,6 +27,7 @@
 
 pub(crate) mod agent;
 mod agent_tools;
+mod error;
 mod manifest;
 mod ops;
 mod payment;

--- a/src/openhuman/tinyplace/state.rs
+++ b/src/openhuman/tinyplace/state.rs
@@ -50,6 +50,11 @@ impl TinyPlaceState {
     ///
     /// Returns `Err` if the wallet is locked/unconfigured or the seed derivation
     /// fails — the renderer should surface an "unlock wallet" prompt.
+    ///
+    /// The wallet-not-configured case is reclassified into an expected
+    /// user-state envelope ([`error::classify_client_build_error`]) so the
+    /// JSON-RPC boundary keeps it out of Sentry (#3964). Decrypt / key-derivation
+    /// / config failures pass through unchanged and still page.
     pub(crate) async fn client(&self) -> Result<&TinyPlaceClient, String> {
         self.client
             .get_or_try_init(|| async {
@@ -69,5 +74,6 @@ impl TinyPlaceState {
                 }))
             })
             .await
+            .map_err(super::error::classify_client_build_error)
     }
 }

--- a/src/openhuman/wallet/mod.rs
+++ b/src/openhuman/wallet/mod.rs
@@ -35,11 +35,11 @@ pub use execution::{
 /// Crate-internal signing primitives the `web3` layer builds on. Not part of
 /// the agent / RPC surface.
 pub(crate) use execution::{sign_and_broadcast_evm, sign_and_broadcast_solana};
-pub(crate) use ops::{secret_material, WALLET_NOT_CONFIGURED_MESSAGE};
 pub use ops::{
     reveal_recovery_phrase, setup, status, RevealRecoveryPhraseResult, WalletAccount, WalletChain,
     WalletSetupParams, WalletSetupSource, WalletStatus,
 };
+pub(crate) use ops::{secret_material, WALLET_NOT_CONFIGURED_MESSAGE};
 pub use schemas::{
     all_controller_schemas, all_registered_controllers, all_wallet_controller_schemas,
     all_wallet_registered_controllers, schemas, wallet_schemas,

--- a/src/openhuman/wallet/mod.rs
+++ b/src/openhuman/wallet/mod.rs
@@ -35,7 +35,7 @@ pub use execution::{
 /// Crate-internal signing primitives the `web3` layer builds on. Not part of
 /// the agent / RPC surface.
 pub(crate) use execution::{sign_and_broadcast_evm, sign_and_broadcast_solana};
-pub(crate) use ops::secret_material;
+pub(crate) use ops::{secret_material, WALLET_NOT_CONFIGURED_MESSAGE};
 pub use ops::{
     reveal_recovery_phrase, setup, status, RevealRecoveryPhraseResult, WalletAccount, WalletChain,
     WalletSetupParams, WalletSetupSource, WalletStatus,

--- a/src/openhuman/wallet/ops.rs
+++ b/src/openhuman/wallet/ops.rs
@@ -17,6 +17,12 @@ use crate::rpc::RpcOutcome;
 
 const LOG_PREFIX: &str = "[wallet]";
 const WALLET_STATE_FILENAME: &str = "wallet-state.json";
+/// Canonical error string for "no wallet configured yet". Hoisted to a shared
+/// constant so downstream chokepoints (e.g. the tiny.place client builder) can
+/// classify this exact expected-user-state condition without re-typing the
+/// literal — a coupling test in `tinyplace::error` guards against drift.
+pub(crate) const WALLET_NOT_CONFIGURED_MESSAGE: &str =
+    "wallet is not configured; run wallet setup first";
 const VALID_MNEMONIC_WORD_COUNTS: [u8; 5] = [12, 15, 18, 21, 24];
 /// Keychain key for the encrypted mnemonic blob (user_id is added by the keyring module).
 const KEYCHAIN_MNEMONIC_KEY: &str = "wallet.mnemonic";
@@ -738,7 +744,7 @@ pub(crate) async fn secret_material(chain: WalletChain) -> Result<WalletSecretMa
                 "{LOG_PREFIX} secret_material missing wallet state chain={}",
                 chain.as_str()
             );
-            return Err("wallet is not configured; run wallet setup first".to_string());
+            return Err(WALLET_NOT_CONFIGURED_MESSAGE.to_string());
         }
     };
     let encrypted_mnemonic = state


### PR DESCRIPTION
## Summary

`tinyplace` `home_feed` (and every other `tinyplace_*` RPC) builds its client via `TinyPlaceState::client()`, which derives a signer seed from the user's wallet. For a user who has **not** set up a wallet, that derivation returns the plain string `wallet is not configured; run wallet setup first` (from `wallet/ops.rs::secret_material`).

Because the error is an unstructured string, the JSON-RPC boundary (`src/core/jsonrpc.rs`) sees `expected_user_state = false` and escalates it to an **error-level Sentry capture**. Result: ~2253 error events from 146 users simply opening the Agent World **Feed** (`TAURI-RUST-FFB`, active on `openhuman@0.57.53`). The user-facing UX is already correct (the feed renders a "set up wallet" prompt) — this is purely Sentry noise.

`home_feed` legitimately requires a configured signer (backend `GraphQLAuth::Agent`), so there's no local lever to make the call succeed without a wallet — it's an **expected user state**, not an internal failure.

## Fix

Classify the wallet-not-configured condition with the existing first-class `StructuredRpcError { expected_user_state: true }` mechanism (same pattern as `threads::NotFound → ThreadNotFound`), at the `tinyplace` **client-build chokepoint** so the whole `tinyplace_*` family benefits:

- `wallet/ops.rs` — hoist the message to a shared `pub(crate) const WALLET_NOT_CONFIGURED_MESSAGE` and use it at the `secret_material` origin.
- `wallet/mod.rs` — re-export the constant crate-internally.
- `tinyplace/error.rs` (new) — `classify_client_build_error()` reclassifies **only that exact message** into `StructuredRpcError { kind: "WalletNotConfigured", expected_user_state: true }`. Every other failure (decrypt, key derivation, config load) passes through verbatim and keeps paging.
- `tinyplace/state.rs` — `client()` ends with `.map_err(super::error::classify_client_build_error)`.

This is a **typed expected-user-state classification, not suppression of a real defect**: only the exact expected message is reclassified; decrypt / key-derivation / config errors continue to page. Drift is guarded by hoisting the message to a shared constant plus a coupling test.

## Tests

- `tinyplace::error` unit tests: the wallet message becomes an `expected_user_state` envelope with the stable `WalletNotConfigured` kind; unrelated errors pass through unchanged with no sentinel; and a **coupling test** pins the shared constant to its literal so either side drifting fails loudly.

Per the working agreement, the full local test/coverage matrix was not run — CI will exercise it.

Closes #3964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced error classification system to distinguish wallet configuration issues from unexpected system failures.
  * Enhanced error handling in wallet client initialization to properly categorize configuration-related errors.
  * Updated error messages and handling to ensure wallet configuration scenarios are consistently processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->