### PR TITLE
fix(sentry): re-register inboundFiltersIntegration so ignoreErrors runs (#3963)

### DIFF
--- a/app/src/services/__tests__/analytics.test.ts
+++ b/app/src/services/__tests__/analytics.test.ts
@@ -16,7 +16,7 @@ const hoisted = vi.hoisted(() => ({
   browserApiErrorsIntegration: vi.fn(() => ({ name: 'BrowserApiErrors' })),
   globalHandlersIntegration: vi.fn(() => ({ name: 'GlobalHandlers' })),
   httpContextIntegration: vi.fn(() => ({ name: 'HttpContext' })),
-  inboundFiltersIntegration: vi.fn(() => ({ name: 'InboundFilters' })),
+  eventFiltersIntegration: vi.fn(() => ({ name: 'EventFilters' })),
   // Config state
   analyticsEnabled: false,
   appEnvironment: 'staging' as 'staging' | 'production' | 'development',
@@ -36,7 +36,7 @@ vi.mock('@sentry/react', () => ({
   browserApiErrorsIntegration: hoisted.browserApiErrorsIntegration,
   globalHandlersIntegration: hoisted.globalHandlersIntegration,
   httpContextIntegration: hoisted.httpContextIntegration,
-  inboundFiltersIntegration: hoisted.inboundFiltersIntegration,
+  eventFiltersIntegration: hoisted.eventFiltersIntegration,
 }));
 
 // `initSentry()` reads `getCoreStateSnapshot().snapshot.analyticsEnabled` to
@@ -310,9 +310,10 @@ describe('initSentry beforeSend manual-staging bypass', () => {
     expect(names).toContain('HttpContext');
   });
 
-  test('registers inboundFiltersIntegration so ignoreErrors takes effect (#3963)', async () => {
+  test('registers eventFiltersIntegration so ignoreErrors takes effect (#3963)', async () => {
     // Regression for #3963: `defaultIntegrations: false` dropped
-    // `inboundFiltersIntegration`, the only integration that consumes the
+    // `eventFiltersIntegration` (the v9 rename of `inboundFiltersIntegration`),
+    // the only integration that consumes the
     // top-level `ignoreErrors` option. That made the curated `ignoreErrors`
     // list dead config (since PR #52) and let "ResizeObserver loop completed
     // with undelivered notifications" + the other intended noise filters leak.
@@ -328,9 +329,9 @@ describe('initSentry beforeSend manual-staging bypass', () => {
       ignoreErrors: string[];
     };
     const names = opts.integrations.map(i => i.name).filter(Boolean);
-    expect(names).toContain('InboundFilters');
+    expect(names).toContain('EventFilters');
     // The integration factory must actually have been invoked.
-    expect(hoisted.inboundFiltersIntegration).toHaveBeenCalled();
+    expect(hoisted.eventFiltersIntegration).toHaveBeenCalled();
     // The intended noise filters must still be configured for it to consume.
     expect(opts.ignoreErrors).toEqual(
       expect.arrayContaining([

--- a/app/src/services/__tests__/analytics.test.ts
+++ b/app/src/services/__tests__/analytics.test.ts
@@ -16,6 +16,7 @@ const hoisted = vi.hoisted(() => ({
   browserApiErrorsIntegration: vi.fn(() => ({ name: 'BrowserApiErrors' })),
   globalHandlersIntegration: vi.fn(() => ({ name: 'GlobalHandlers' })),
   httpContextIntegration: vi.fn(() => ({ name: 'HttpContext' })),
+  inboundFiltersIntegration: vi.fn(() => ({ name: 'InboundFilters' })),
   // Config state
   analyticsEnabled: false,
   appEnvironment: 'staging' as 'staging' | 'production' | 'development',
@@ -35,6 +36,7 @@ vi.mock('@sentry/react', () => ({
   browserApiErrorsIntegration: hoisted.browserApiErrorsIntegration,
   globalHandlersIntegration: hoisted.globalHandlersIntegration,
   httpContextIntegration: hoisted.httpContextIntegration,
+  inboundFiltersIntegration: hoisted.inboundFiltersIntegration,
 }));
 
 // `initSentry()` reads `getCoreStateSnapshot().snapshot.analyticsEnabled` to
@@ -306,6 +308,38 @@ describe('initSentry beforeSend manual-staging bypass', () => {
     expect(opts.replaysOnErrorSampleRate).toBe(0);
     const names = opts.integrations.map(i => i.name).filter(Boolean);
     expect(names).toContain('HttpContext');
+  });
+
+  test('registers inboundFiltersIntegration so ignoreErrors takes effect (#3963)', async () => {
+    // Regression for #3963: `defaultIntegrations: false` dropped
+    // `inboundFiltersIntegration`, the only integration that consumes the
+    // top-level `ignoreErrors` option. That made the curated `ignoreErrors`
+    // list dead config (since PR #52) and let "ResizeObserver loop completed
+    // with undelivered notifications" + the other intended noise filters leak.
+    // Assert BOTH halves of the fix so a future curated-list edit can't
+    // silently re-break it: the integration is registered AND the
+    // ignoreErrors patterns are present.
+    hoisted.init.mockReset();
+    const { initSentry } = await import('../analytics');
+    initSentry();
+
+    const opts = hoisted.init.mock.calls[0][0] as {
+      integrations: Array<{ name?: string }>;
+      ignoreErrors: string[];
+    };
+    const names = opts.integrations.map(i => i.name).filter(Boolean);
+    expect(names).toContain('InboundFilters');
+    // The integration factory must actually have been invoked.
+    expect(hoisted.inboundFiltersIntegration).toHaveBeenCalled();
+    // The intended noise filters must still be configured for it to consume.
+    expect(opts.ignoreErrors).toEqual(
+      expect.arrayContaining([
+        'ResizeObserver loop',
+        'Network request failed',
+        'Load failed',
+        'AbortError',
+      ])
+    );
   });
 
   test('keeps os/browser/device contexts and forwards them through beforeSend (#1403)', async () => {

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -148,14 +148,15 @@ export function initSentry(): void {
     defaultIntegrations: false,
     integrations: [
       // #3963: `defaultIntegrations: false` (above) drops every default
-      // integration — including `inboundFiltersIntegration`, the ONLY one that
-      // consumes the top-level `ignoreErrors` option below. Without it the
-      // curated `ignoreErrors` list is dead config and benign browser noise
+      // integration — including `eventFiltersIntegration` (the v9 rename of the
+      // old `inboundFiltersIntegration`), the ONLY one that consumes the
+      // top-level `ignoreErrors` option below. Without it the curated
+      // `ignoreErrors` list is dead config and benign browser noise
       // ("ResizeObserver loop completed with undelivered notifications", etc.)
       // floods the dashboard. Re-register it explicitly so the filters run
       // (as an event processor, ahead of `beforeSend`). Keep this first so a
       // future curated-list edit is less likely to drop it silently.
-      Sentry.inboundFiltersIntegration(),
+      Sentry.eventFiltersIntegration(),
       Sentry.functionToStringIntegration(),
       Sentry.linkedErrorsIntegration(),
       Sentry.dedupeIntegration(),

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -147,6 +147,15 @@ export function initSentry(): void {
     tracesSampleRate: 0,
     defaultIntegrations: false,
     integrations: [
+      // #3963: `defaultIntegrations: false` (above) drops every default
+      // integration — including `inboundFiltersIntegration`, the ONLY one that
+      // consumes the top-level `ignoreErrors` option below. Without it the
+      // curated `ignoreErrors` list is dead config and benign browser noise
+      // ("ResizeObserver loop completed with undelivered notifications", etc.)
+      // floods the dashboard. Re-register it explicitly so the filters run
+      // (as an event processor, ahead of `beforeSend`). Keep this first so a
+      // future curated-list edit is less likely to drop it silently.
+      Sentry.inboundFiltersIntegration(),
       Sentry.functionToStringIntegration(),
       Sentry.linkedErrorsIntegration(),
       Sentry.dedupeIntegration(),


### PR DESCRIPTION
## Summary

`initSentry()` in `app/src/services/analytics.ts` sets `defaultIntegrations: false` and re-adds a curated integration list that **omitted `inboundFiltersIntegration`** — the only integration that consumes the top-level `ignoreErrors` option. As a result the curated list

```
ignoreErrors: ['ResizeObserver loop', 'Network request failed', 'Load failed', 'AbortError']
```

has been **dead config since it was added (PR #52)**, and `ResizeObserver loop completed with undelivered notifications` (Sentry **TAURI-REACT-1R**, 126 events / 124 users) plus the three other intended noise filters all leaked to the dashboard.

## Fix

Re-register `Sentry.inboundFiltersIntegration()` (first in the `integrations` array) so the existing `ignoreErrors` patterns take effect — it runs as an event processor ahead of `beforeSend`. The `ignoreErrors` list itself is unchanged; this only restores the intended (and legitimate) suppression of self-recovering browser noise.

## Test

Added a regression test (`registers inboundFiltersIntegration so ignoreErrors takes effect (#3963)`) asserting **both** halves so a future curated-list edit can't silently re-break it:
- the integration is registered (`InboundFilters` present in `integrations` + the factory was invoked), and
- the four `ignoreErrors` patterns are still configured for it to consume.

## Notes

- `@sentry/react@^10.38.0` re-exports `inboundFiltersIntegration` (from `@sentry/core`), which reads the top-level `ignoreErrors`/`denyUrls`/`allowUrls` and registers under name `InboundFilters`. Stable across v10.x.
- Existing integration test (`#1403`) is unaffected — it uses `toContain`, which tolerates the added entry.
- No tests/checks were run locally; CI will exercise them.

Closes #3963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for error filtering configuration.

* **Chores**
  * Improved error tracking by enhancing filter configuration to reduce noise in error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->