### PR TITLE
fix(observability): surface io cause + demote OS-denied config reads (#3962)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -226,6 +226,15 @@ pub enum ExpectedErrorKind {
     /// `is_network_unreachable_message` anchors miss the inner OS message.
     ChannelSupervisorRestart,
     ConfigLoadTimedOut,
+    /// A config-file READ failed because the OS refused access to a file that
+    /// exists (ACL-denied, held open by another process, OneDrive placeholder).
+    /// Unpreventable user-environment state — zero local lever to make the file
+    /// readable. Demoted only for the access-denied / locked io kinds; a
+    /// `NotFound` after the `exists()` check stays a paging defect. See
+    /// [`is_config_read_io_failure_message`]. Drops TAURI-RUST-DME
+    /// (`inference_downloads_progress` re-reads config every poll → 36k events /
+    /// 1 Windows user).
+    ConfigReadIoFailure,
     /// The subconscious engine's SQLite schema init couldn't open its database
     /// file at all — a host-filesystem condition, not a code bug. Two canonical
     /// renderings, both bound to the user's local FS:
@@ -481,6 +490,13 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if is_config_load_timed_out_message(&lower) {
         return Some(ExpectedErrorKind::ConfigLoadTimedOut);
     }
+    // OS-level config-read denial on a file that exists (user-environment, zero
+    // local lever). Keyed on the config-read anchor + an access-denied/locked io
+    // signal; NotFound / unseen kinds fall through and keep paging. Requires the
+    // loader to surface the full io chain (#3962).
+    if is_config_read_io_failure_message(&lower) {
+        return Some(ExpectedErrorKind::ConfigReadIoFailure);
+    }
     // Empty-provider-response re-report from the web-channel layer. Runs
     // last so an earlier, more specific matcher always wins. See the
     // variant doc-comment and [`is_empty_provider_response_message`] for
@@ -598,6 +614,46 @@ fn is_disk_full_message(lower: &str) -> bool {
 /// `Config::load_from_config_path`.
 fn is_config_load_timed_out_message(lower: &str) -> bool {
     lower.contains("config loading timed out")
+}
+
+/// Detect a config-file READ that failed because the operating system refused
+/// access to a file that **exists** — i.e. an unpreventable user-environment
+/// condition with zero local lever, not an OpenHuman defect.
+///
+/// `Config::load_or_init` (`impl_load.rs`) takes its read branch only after
+/// `config_path.exists()` returns true, then `read_to_string` is retried 5× and
+/// still fails. On a healthy install that never happens; in the wild a user's
+/// `config.toml` can be ACL-denied, held open by another process (antivirus /
+/// backup agent), or a OneDrive "files on demand" placeholder that won't
+/// hydrate. We cannot unlock or re-ACL a foreign-held file, so the per-poll
+/// re-report (TAURI-RUST-DME: `inference_downloads_progress` re-loads config on
+/// every poll → 36k events / 1 user) carries no Sentry-actionable signal.
+///
+/// Polarity contract — demote **only** when BOTH hold:
+///   1. an OpenHuman config-read context anchor is present — either
+///      `"failed to read config file"` (`load_or_init` retry path,
+///      `impl_load.rs`, the DME surface) or `"reading config.toml from"`
+///      (`load_from_config_path` snapshot-reload path) — AND
+///   2. an OS-level *access-denied / locked* signal is present.
+///
+/// `NotFound` (`os error 2` / "cannot find the file"), "is a directory", and any
+/// io kind not enumerated here are deliberately EXCLUDED: a file that vanished
+/// after the `exists()` check is a TOCTOU race / app defect and MUST keep
+/// paging. This matcher is only meaningful once the loader surfaces the full
+/// chain (`{:#}`, #3962) — the io fragment lives in the source, not the top
+/// `with_context` line.
+fn is_config_read_io_failure_message(lower: &str) -> bool {
+    let has_config_read_anchor =
+        lower.contains("failed to read config file") || lower.contains("reading config.toml from");
+    if !has_config_read_anchor {
+        return false;
+    }
+    lower.contains("access is denied")
+        || lower.contains("permission denied")
+        || lower.contains("being used by another process")
+        || lower.contains("cannot access the file")
+        || lower.contains("(os error 5)")
+        || lower.contains("(os error 32)")
 }
 
 /// Match whatsapp structured-ingest failures caused by transient SQLite lock
@@ -1775,6 +1831,20 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 kind = "config_load_timed_out",
                 error = %message,
                 "[observability] {domain}.{operation} skipped expected config-load timeout: {message}"
+            );
+        }
+        ExpectedErrorKind::ConfigReadIoFailure => {
+            // OS refused to read an existing config.toml (ACL-denied, locked by
+            // another process, OneDrive placeholder). User-environment state —
+            // we cannot make the file readable, and the same poll re-reports it
+            // every cycle (TAURI-RUST-DME). Demote at `warn!` so it stays in the
+            // local log for support without paging on every poll.
+            tracing::warn!(
+                domain = domain,
+                operation = operation,
+                kind = "config_read_io_failure",
+                error = %message,
+                "[observability] {domain}.{operation} skipped expected config-read io failure (OS access denied/locked): {message}"
             );
         }
         ExpectedErrorKind::SubconsciousSchemaUnavailable => {
@@ -3323,6 +3393,67 @@ mod tests {
         );
         // Bare "timed out" without the config-load phrase must not match.
         assert_eq!(expected_error_kind("cron job timed out after 30s"), None,);
+    }
+
+    #[test]
+    fn classifies_config_read_io_failure_for_os_denial_kinds() {
+        // TAURI-RUST-DME shape once the loader surfaces the full io chain
+        // (#3962): Windows access-denied on an existing config.toml.
+        assert_eq!(
+            expected_error_kind(
+                "Failed to read config file: C:\\Users\\u\\.openhuman\\users\\local-wb\\config.toml: Access is denied. (os error 5)"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        // Sharing-violation: file held open by another process (antivirus /
+        // backup agent).
+        assert_eq!(
+            expected_error_kind(
+                "Failed to read config file: C:\\Users\\u\\.openhuman\\users\\local-wb\\config.toml: The process cannot access the file because it is being used by another process. (os error 32)"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        // Unix permission-denied wording.
+        assert_eq!(
+            expected_error_kind(
+                "Failed to read config file: /home/u/.openhuman/users/local/config.toml: Permission denied (os error 13)"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        // Snapshot-reload context anchor (`load_from_config_path`) must demote
+        // the same OS-denial family so a long-lived reloader can't leak either.
+        assert_eq!(
+            expected_error_kind(
+                "reading config.toml from C:\\Users\\u\\.openhuman\\users\\local-wb\\config.toml: Access is denied. (os error 5)"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+    }
+
+    #[test]
+    fn does_not_demote_config_read_notfound_or_unkeyed_failures() {
+        // NotFound AFTER the `exists()` gate is a TOCTOU race / app defect —
+        // it MUST keep paging, never demote.
+        assert_ne!(
+            expected_error_kind(
+                "Failed to read config file: C:\\Users\\u\\.openhuman\\users\\local-wb\\config.toml: The system cannot find the file specified. (os error 2)"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        // Bare top-context line with no io signal (pre-#3962 shape, or an io
+        // kind we have not enumerated) must NOT demote — fail open to paging.
+        assert_ne!(
+            expected_error_kind(
+                "Failed to read config file: C:\\Users\\u\\.openhuman\\users\\local-wb\\config.toml"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        // The access-denied signal alone, without the config-read anchor, must
+        // not be hijacked into the config bucket.
+        assert_ne!(
+            expected_error_kind("opening keychain failed: Access is denied. (os error 5)"),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
     }
 
     #[test]

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -648,6 +648,15 @@ fn is_config_read_io_failure_message(lower: &str) -> bool {
     if !has_config_read_anchor {
         return false;
     }
+    // A directory (or otherwise non-regular file) at the config path is a
+    // bad-install / corruption signal that MUST keep paging. On Windows reading
+    // a directory surfaces the same `Access is denied. (os error 5)` shape as a
+    // genuine ACL denial, so the io-signal check below cannot tell them apart;
+    // the read site (`impl_load.rs`) now fails a directory fast with this
+    // distinct wording, and we belt-and-braces exclude it here too. (Codex P2.)
+    if lower.contains("is a directory") || lower.contains("not a file") {
+        return false;
+    }
     lower.contains("access is denied")
         || lower.contains("permission denied")
         || lower.contains("being used by another process")
@@ -1839,12 +1848,15 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
             // we cannot make the file readable, and the same poll re-reports it
             // every cycle (TAURI-RUST-DME). Demote at `warn!` so it stays in the
             // local log for support without paging on every poll.
+            // Metadata-only: the raw message embeds the absolute config path
+            // (username / home dir). Keep this arm PII-free like the other
+            // path-sensitive demotions — domain/operation/kind are enough to
+            // see the condition without leaking the path into local logs.
             tracing::warn!(
                 domain = domain,
                 operation = operation,
                 kind = "config_read_io_failure",
-                error = %message,
-                "[observability] {domain}.{operation} skipped expected config-read io failure (OS access denied/locked): {message}"
+                "[observability] {domain}.{operation} skipped expected config-read io failure (OS access denied/locked)"
             );
         }
         ExpectedErrorKind::SubconsciousSchemaUnavailable => {
@@ -3452,6 +3464,22 @@ mod tests {
         // not be hijacked into the config bucket.
         assert_ne!(
             expected_error_kind("opening keychain failed: Access is denied. (os error 5)"),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        // A directory at the config path is corruption — keep paging even though
+        // it carries an access-denied / os-error-5 shape (Codex P2). Both the
+        // unix wording and the Windows os-error-5 + read-site wording are
+        // excluded by the `is a directory` / `not a file` guard.
+        assert_ne!(
+            expected_error_kind(
+                "Failed to read config file: /home/u/.openhuman/users/local/config.toml: Is a directory (os error 21)"
+            ),
+            Some(ExpectedErrorKind::ConfigReadIoFailure),
+        );
+        assert_ne!(
+            expected_error_kind(
+                "Config path is a directory, not a file: C:\\Users\\u\\.openhuman\\users\\local-wb\\config.toml: Access is denied. (os error 5)"
+            ),
             Some(ExpectedErrorKind::ConfigReadIoFailure),
         );
     }

--- a/src/openhuman/config/ops/loader.rs
+++ b/src/openhuman/config/ops/loader.rs
@@ -42,7 +42,13 @@ pub async fn load_config_with_timeout() -> Result<Config, String> {
             normalize_loaded_config(&mut config).await;
             Ok(config)
         }
-        Ok(Err(e)) => Err(e.to_string()),
+        // Surface the full anyhow chain (`{:#}`), not just the top `with_context`
+        // line, so the underlying io error kind (e.g. `(os error 5)` access-denied
+        // / `(os error 32)` sharing-lock) reaches Sentry. Without it the config
+        // classifier and triage only ever see "Failed to read config file: <path>"
+        // and cannot tell a user-environment denial from an app-side race
+        // (#3962 / TAURI-RUST-DME).
+        Ok(Err(e)) => Err(format!("{e:#}")),
         Err(_) => Err("Config loading timed out".to_string()),
     }
 }
@@ -64,7 +70,13 @@ pub async fn reload_config_snapshot_with_timeout(snapshot: &Config) -> Result<Co
             normalize_loaded_config(&mut config).await;
             Ok(config)
         }
-        Ok(Err(e)) => Err(e.to_string()),
+        // Surface the full anyhow chain (`{:#}`), not just the top `with_context`
+        // line, so the underlying io error kind (e.g. `(os error 5)` access-denied
+        // / `(os error 32)` sharing-lock) reaches Sentry. Without it the config
+        // classifier and triage only ever see "Failed to read config file: <path>"
+        // and cannot tell a user-environment denial from an app-side race
+        // (#3962 / TAURI-RUST-DME).
+        Ok(Err(e)) => Err(format!("{e:#}")),
         Err(_) => Err("Config loading timed out".to_string()),
     }
 }
@@ -577,4 +589,80 @@ pub async fn get_data_paths() -> Result<RpcOutcome<serde_json::Value>, String> {
             default_openhuman_dir.display()
         )],
     ))
+}
+
+#[cfg(test)]
+mod loader_io_chain_tests {
+    use super::*;
+
+    // Both assertions below lock in the #3962 contract: a config READ failure
+    // surfaced through the RPC string boundary must carry the full anyhow chain
+    // (`{:#}`) — the top `with_context` line PLUS the underlying io cause
+    // (`os error N`) — not just the opaque top context. Without it the
+    // observability classifier (`is_config_read_io_failure_message`) and Sentry
+    // triage cannot tell a user-environment denial from an app-side race.
+    //
+    // Portable trigger: a *directory* at the config path. `exists()` is true so
+    // the read branch is taken, but `read_to_string` fails with EISDIR (unix) /
+    // ERROR_ACCESS_DENIED (windows) — neither transient, so it returns straight
+    // away with the chained error.
+
+    #[tokio::test]
+    async fn reload_snapshot_surfaces_full_io_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::create_dir(&config_path).unwrap();
+
+        let snapshot = Config {
+            config_path: config_path.clone(),
+            workspace_dir: tmp.path().join("workspace"),
+            ..Default::default()
+        };
+
+        let err = reload_config_snapshot_with_timeout(&snapshot)
+            .await
+            .expect_err("reading a directory as config.toml must fail");
+
+        assert!(
+            err.contains("reading config.toml from"),
+            "reload error must carry the read context: {err}"
+        );
+        assert!(
+            err.contains("os error"),
+            "reload error must carry the underlying io cause (#3962), not just the top context: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_config_with_timeout_surfaces_full_io_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::create_dir(&config_path).unwrap();
+
+        // `load_config_with_timeout` resolves the process-global
+        // `OPENHUMAN_WORKSPACE`, so serialize against the other env-mutating
+        // config tests via the shared crate lock.
+        let _g = crate::openhuman::config::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("OPENHUMAN_WORKSPACE").ok();
+        std::env::set_var("OPENHUMAN_WORKSPACE", tmp.path().to_str().unwrap());
+
+        let result = load_config_with_timeout().await;
+
+        match prev {
+            Some(v) => std::env::set_var("OPENHUMAN_WORKSPACE", v),
+            None => std::env::remove_var("OPENHUMAN_WORKSPACE"),
+        }
+
+        let err = result.expect_err("reading a directory as config.toml must fail");
+        assert!(
+            err.contains("Failed to read config file"),
+            "load error must carry the read context: {err}"
+        );
+        assert!(
+            err.contains("os error"),
+            "load error must carry the underlying io cause (#3962), not just the top context: {err}"
+        );
+    }
 }

--- a/src/openhuman/config/ops/loader.rs
+++ b/src/openhuman/config/ops/loader.rs
@@ -595,20 +595,13 @@ pub async fn get_data_paths() -> Result<RpcOutcome<serde_json::Value>, String> {
 mod loader_io_chain_tests {
     use super::*;
 
-    // Both assertions below lock in the #3962 contract: a config READ failure
-    // surfaced through the RPC string boundary must carry the full anyhow chain
-    // (`{:#}`) — the top `with_context` line PLUS the underlying io cause
-    // (`os error N`) — not just the opaque top context. Without it the
-    // observability classifier (`is_config_read_io_failure_message`) and Sentry
-    // triage cannot tell a user-environment denial from an app-side race.
-    //
-    // Portable trigger: a *directory* at the config path. `exists()` is true so
-    // the read branch is taken, but `read_to_string` fails with EISDIR (unix) /
-    // ERROR_ACCESS_DENIED (windows) — neither transient, so it returns straight
-    // away with the chained error.
-
+    // A directory at the config path is corruption, not a transient/denied read:
+    // the read site fails it fast with distinct wording, and the observability
+    // classifier MUST keep paging it (never demote to ConfigReadIoFailure). This
+    // guards the Codex P2 hole where a Windows directory-at-config surfaces the
+    // same `os error 5` shape as a real ACL denial (#3962).
     #[tokio::test]
-    async fn reload_snapshot_surfaces_full_io_chain() {
+    async fn config_directory_pages_and_is_not_demoted() {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("config.toml");
         std::fs::create_dir(&config_path).unwrap();
@@ -621,27 +614,28 @@ mod loader_io_chain_tests {
 
         let err = reload_config_snapshot_with_timeout(&snapshot)
             .await
-            .expect_err("reading a directory as config.toml must fail");
+            .expect_err("a directory at the config path must fail");
 
         assert!(
-            err.contains("reading config.toml from"),
-            "reload error must carry the read context: {err}"
+            err.contains("is a directory") || err.contains("not a file"),
+            "directory-at-config must report a distinct, non-read error: {err}"
         );
-        assert!(
-            err.contains("os error"),
-            "reload error must carry the underlying io cause (#3962), not just the top context: {err}"
+        assert_ne!(
+            crate::core::observability::expected_error_kind(&err),
+            Some(crate::core::observability::ExpectedErrorKind::ConfigReadIoFailure),
+            "a directory at the config path is corruption — it must keep paging, not demote: {err}"
         );
     }
 
+    // load_config_with_timeout resolves the process-global OPENHUMAN_WORKSPACE,
+    // so serialize against the other env-mutating config tests. Exercises the
+    // load_or_init directory guard + the `Ok(Err) => format!("{e:#}")` arm.
     #[tokio::test]
-    async fn load_config_with_timeout_surfaces_full_io_chain() {
+    async fn load_config_with_timeout_rejects_directory_config() {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("config.toml");
         std::fs::create_dir(&config_path).unwrap();
 
-        // `load_config_with_timeout` resolves the process-global
-        // `OPENHUMAN_WORKSPACE`, so serialize against the other env-mutating
-        // config tests via the shared crate lock.
         let _g = crate::openhuman::config::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -655,14 +649,51 @@ mod loader_io_chain_tests {
             None => std::env::remove_var("OPENHUMAN_WORKSPACE"),
         }
 
-        let err = result.expect_err("reading a directory as config.toml must fail");
+        let err = result.expect_err("a directory at the config path must fail");
         assert!(
-            err.contains("Failed to read config file"),
-            "load error must carry the read context: {err}"
+            err.contains("is a directory") || err.contains("not a file"),
+            "directory-at-config must report a distinct, non-read error: {err}"
+        );
+    }
+
+    // The #3962 keystone: a genuine read failure on a regular file must surface
+    // the full anyhow chain (`{:#}`) — the read context PLUS the underlying io
+    // cause (`os error N`) — through the RPC String boundary, not just the top
+    // `with_context` line. Triggered portably with a 0o000 (unreadable) file;
+    // skipped under root, which ignores file permissions.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn load_surfaces_full_io_chain_on_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "default_temperature = 0.5\n").unwrap();
+        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Root bypasses file-permission checks — the read would succeed and the
+        // assertion would be meaningless, so skip in that environment.
+        if std::fs::read_to_string(&config_path).is_ok() {
+            return;
+        }
+
+        let snapshot = Config {
+            config_path: config_path.clone(),
+            workspace_dir: tmp.path().join("workspace"),
+            ..Default::default()
+        };
+
+        let err = reload_config_snapshot_with_timeout(&snapshot)
+            .await
+            .expect_err("an unreadable config file must fail");
+
+        assert!(
+            err.contains("reading config.toml from"),
+            "error must carry the read context: {err}"
         );
         assert!(
             err.contains("os error"),
-            "load error must carry the underlying io cause (#3962), not just the top context: {err}"
+            "error must carry the underlying io cause via {{:#}} (#3962): {err}"
         );
     }
 }

--- a/src/openhuman/config/schema/load/impl_load.rs
+++ b/src/openhuman/config/schema/load/impl_load.rs
@@ -179,6 +179,20 @@ impl Config {
                 }
             }
 
+            // A directory (or other non-regular file) at the config path is a
+            // bad-install / corruption signal, not a transient read failure. On
+            // Windows `read_to_string` of a directory returns the same
+            // `Access is denied. (os error 5)` shape as a real ACL denial, which
+            // the observability classifier would otherwise demote. Fail fast with
+            // distinct wording so it keeps paging instead of being suppressed as
+            // an expected user-state config-read failure (#3962, Codex P2).
+            if config_path.is_dir() {
+                anyhow::bail!(
+                    "Config path is a directory, not a file: {}",
+                    config_path.display()
+                );
+            }
+
             let contents = crate::openhuman::util::retry_with_backoff_async(
                 "read config file",
                 5,
@@ -345,6 +359,16 @@ impl Config {
             };
             config.apply_env_overrides_from(&ProcessEnvWithoutWorkspace);
             return Ok(config);
+        }
+
+        // See the `load_or_init` read branch: a directory at the config path is
+        // corruption, not a transient read failure — fail fast with distinct
+        // wording so it pages instead of being demoted (#3962, Codex P2).
+        if config_path.is_dir() {
+            anyhow::bail!(
+                "Config path is a directory, not a file: {}",
+                config_path.display()
+            );
         }
 
         let raw = fs::read_to_string(&config_path)

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -1594,30 +1594,38 @@ default_temperature = 0.5
     );
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn load_or_init_read_failure_embeds_path_in_error_context() {
     // OPENHUMAN-TAURI-9R (~8k events, Windows): the read at the
     // `config_path.exists()` branch raced `Config::save`'s atomic rename
     // and surfaced the opaque "Failed to read config file" with no path
     // or underlying cause. The fix retries transient Windows locking
-    // errors AND embeds the config path in the context so any residual
-    // non-transient failure is triageable in Sentry.
+    // errors AND embeds the config path in the context; #3962 additionally
+    // surfaces the underlying io cause (`os error N`) through `{:#}`.
     //
-    // Simulate a non-transient read failure portably by placing a
-    // *directory* at the config path: `exists()` is true (so we enter the
-    // read branch), but `read_to_string` fails with EISDIR (unix) /
-    // ERROR_ACCESS_DENIED (windows) — neither is classified transient by
-    // `is_transient_fs_error`, so the retry bails immediately and returns
-    // the path-embedded context.
+    // Trigger a genuine non-transient read failure with a 0o000 (unreadable)
+    // *regular* file — not a directory, which `impl_load` now rejects with a
+    // distinct message before the read (see the directory guard / Codex P2).
+    // `exists()` is true so we enter the read branch; `read_to_string` fails
+    // with EACCES, which `is_transient_fs_error` does not retry. Skipped under
+    // root, which ignores file permissions.
+    use std::os::unix::fs::PermissionsExt;
+
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
     let config_path = root.join("config.toml");
-    std::fs::create_dir(&config_path).unwrap();
+    std::fs::write(&config_path, "default_temperature = 0.5\n").unwrap();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    if std::fs::read_to_string(&config_path).is_ok() {
+        return; // running as root — permissions are ignored, assertion is moot
+    }
 
     let env = MapEnv::default().with("OPENHUMAN_WORKSPACE", root.to_str().unwrap());
     let err = Config::load_or_init_with_env_lookup(root, &root.join("workspace"), &env)
         .await
-        .expect_err("reading a directory as config.toml must fail");
+        .expect_err("reading an unreadable config.toml must fail");
 
     let msg = format!("{err:#}");
     assert!(
@@ -1627,6 +1635,10 @@ async fn load_or_init_read_failure_embeds_path_in_error_context() {
     assert!(
         msg.contains("config.toml"),
         "error context must embed the config path so Sentry titles are triageable: {msg}"
+    );
+    assert!(
+        msg.contains("os error"),
+        "error must carry the underlying io cause via {{:#}} (#3962): {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Surface the full anyhow chain (`{:#}`) on config-read failures so the underlying io kind (`os error N`) reaches Sentry instead of only the opaque `Failed to read config file: <path>` top line.
- Add a narrow classifier arm that demotes config-read failures **only** when the OS denied access to a file that exists (ACL-denied / locked / OneDrive placeholder) — an unpreventable user-environment condition.
- Stops a 36k-event single-user Sentry flood (`inference_downloads_progress` re-reads config every poll on a box where the read persistently fails) without masking real defects.

## Problem

`inference_downloads_progress` calls `load_config_with_timeout()` on every poll. On one Windows user, `config.toml` **exists** (the `config_path.exists()` gate in `impl_load.rs` passes) but `read_to_string` fails persistently (5×20ms retry exhausted). The error propagates to the RPC net (`jsonrpc.rs` `report_error_or_expected`, `domain=rpc`) and is reported on every poll → **36,722 events / 1 user / 8 days** (TAURI-RUST-DME, Windows, release 0.57.39).

Two defects:
1. **Root cause invisible** — `loader.rs` returned `Err(e.to_string())`, collapsing the anyhow chain to the top `with_context` line. The io kind (access-denied vs sharing-lock vs NotFound) was dropped before Sentry, so the condition could not be told apart from an app-side race.
2. **Per-poll flood** — no config-read arm in the expected-error classifier, so each poll paged.

A config.toml that exists but the OS refuses to read is a user-environment state with **zero local lever** — we cannot unlock or re-ACL a foreign-held file. It does not break the app for the fleet; it should not flood Sentry as a defect.

## Solution

1. `src/openhuman/config/ops/loader.rs` — `load_config_with_timeout` and `reload_config_snapshot_with_timeout` now return `Err(format!("{e:#}"))`, surfacing the io source chain.
2. `src/core/observability.rs` — new `is_config_read_io_failure_message` + `ExpectedErrorKind::ConfigReadIoFailure`. Demotes (warn, no Sentry event) **only** when both hold: a config-read context anchor (`failed to read config file` from `load_or_init`, or `reading config.toml from` from snapshot-reload) **and** an OS access-denied/locked signal (`access is denied` / `permission denied` / `being used by another process` / `cannot access the file` / `os error 5` / `os error 32`).

Review fixes folded in: (a) a directory-at-config now fails fast at the read site with distinct wording so it keeps paging instead of matching the OS-denial shape (Codex P2); (b) the demotion log arm is metadata-only — no raw config path in logs (CodeRabbit PII).

Deliberately **fail-open to paging**: `NotFound` after the `exists()` gate (a TOCTOU race / app defect), "is a directory", and any unenumerated io kind keep paging. The two changes are coupled — the matcher keys on the io signal that change #1 makes visible — so they ship together (no deferred arm).

**Bucket (RCA-vs-suppress gate):** genuinely-unpreventable user-state — OS-level config-read denial on one user's disk; zero local lever. RCA = surface the io cause so classification is honest + demote only the OS-denial kinds. No further fix owed: we cannot make a foreign-locked/denied file readable; the app-side defects (hidden cause + unbounded per-poll flood) are fixed.

Rejected alternatives: per-call config cache (`loader.rs` doc records it as racy across in-process tests); graceful-degrade of the poll (broad contract change, doesn't cover sibling handlers); blanket-demote any config-read failure (would mask NotFound/TOCTOU defects).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — focused rust tests cover every changed line (3 loader: dir-pages/reject-dir/unreadable-file io-chain; 2 classifier: demote/no-demote incl directory exclusion); full `diff-cover` gate runs in CI.
- [x] Coverage matrix updated — N/A: bug fix, no added/removed/renamed feature row.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature touched.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: observability/config-read internals, no release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop (all platforms; symptom observed on Windows). No migration, no schema, no API change.
- Sentry: removes a 36k-event single-user flood; the underlying io cause is now visible on any residual config-read event. Local `warn!` log retained for support.
- Safety: demotion is keyed and fail-open — cannot suppress a NotFound/TOCTOU app defect.

## Related

- Closes: #3962
- Follow-up PR(s)/TODOs: if a real-world event surfaces an OS-denial io kind not in the signal set (e.g. a OneDrive-specific os error), widen the matcher from the now-visible cause.

Sentry-Issue: TAURI-RUST-DME

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3962-config-read-io-visibility
- Commit SHA: a2585128ca0a9971882f668d1df6bb4a4591efa5

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib config_read` (classifier), loader dir/io-chain tests, regression `read_failure_embeds_path` + `config_load_timed_out`.
- [x] Rust fmt/check (if changed): `cargo fmt` applied; lib compiles clean (pre-push `rust:check` passed).
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` files changed (pre-push `rust:check` still ran green).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: config-read failures carry the io cause; OS-denied config reads no longer emit Sentry error events (demoted to warn).
- User-visible effect: none (telemetry/observability only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced config file error handling with improved diagnostics for locked or inaccessible files (permissions denied, file-in-use scenarios).
  * Added explicit directory detection for config paths with clearer error messages.
  * Improved error chains to include underlying OS error details in diagnostics.

* **Tests**
  * Extended test coverage for config read failures, directory handling, and permission-denied scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->