### PR TITLE
fix(sentry): re-register inboundFiltersIntegration so ignoreErrors runs

### DIFF
--- a/app/src/services/__tests__/analytics.test.ts
+++ b/app/src/services/__tests__/analytics.test.ts
@@ -10,6 +10,7 @@ const hoisted = vi.hoisted(() => ({
   init: vi.fn(),
   // Integration stubs — these aren't introspected, just need to exist so
   // `Sentry.init()` accepts the integrations array without throwing.
+  inboundFiltersIntegration: vi.fn(() => ({ name: 'InboundFilters' })),
   functionToStringIntegration: vi.fn(() => ({})),
   linkedErrorsIntegration: vi.fn(() => ({})),
   dedupeIntegration: vi.fn(() => ({})),
@@ -29,6 +30,7 @@ vi.mock('@sentry/react', () => ({
   captureMessage: hoisted.captureMessage,
   flush: hoisted.flush,
   init: hoisted.init,
+  inboundFiltersIntegration: hoisted.inboundFiltersIntegration,
   functionToStringIntegration: hoisted.functionToStringIntegration,
   linkedErrorsIntegration: hoisted.linkedErrorsIntegration,
   dedupeIntegration: hoisted.dedupeIntegration,
@@ -306,6 +308,33 @@ describe('initSentry beforeSend manual-staging bypass', () => {
     expect(opts.replaysOnErrorSampleRate).toBe(0);
     const names = opts.integrations.map(i => i.name).filter(Boolean);
     expect(names).toContain('HttpContext');
+  });
+
+  test('registers inboundFiltersIntegration so ignoreErrors is not inert (#3963)', async () => {
+    // Regression for #3963: `defaultIntegrations: false` drops the integration
+    // that consumes the top-level `ignoreErrors` option. The curated list must
+    // re-include `inboundFiltersIntegration`, otherwise the intended
+    // `ResizeObserver loop` / network-noise filters silently leak to Sentry.
+    // Asserting both the integration AND the non-empty filter list guards the
+    // coupling — dropping either re-opens the flood.
+    hoisted.init.mockReset();
+    hoisted.inboundFiltersIntegration.mockClear();
+    const { initSentry } = await import('../analytics');
+    initSentry();
+
+    const opts = hoisted.init.mock.calls[0][0] as {
+      integrations: Array<{ name?: string }>;
+      ignoreErrors: string[];
+    };
+    expect(hoisted.inboundFiltersIntegration).toHaveBeenCalledTimes(1);
+    const names = opts.integrations.map(i => i.name).filter(Boolean);
+    expect(names).toContain('InboundFilters');
+    expect(opts.ignoreErrors).toEqual([
+      'ResizeObserver loop',
+      'Network request failed',
+      'Load failed',
+      'AbortError',
+    ]);
   });
 
   test('keeps os/browser/device contexts and forwards them through beforeSend (#1403)', async () => {

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -147,6 +147,14 @@ export function initSentry(): void {
     tracesSampleRate: 0,
     defaultIntegrations: false,
     integrations: [
+      // #3963: `defaultIntegrations: false` (above) drops the integration that
+      // consumes the top-level `ignoreErrors` option (below), so the intended
+      // noise filter has been dead config since it was added. Re-include it
+      // explicitly so `ignoreErrors` runs again. It executes as an event
+      // processor *before* `beforeSend`, so the consent/privacy logic there is
+      // unaffected — this only restores the pre-`beforeSend` drop of the four
+      // benign `ResizeObserver loop` / network-noise patterns.
+      Sentry.inboundFiltersIntegration(),
       Sentry.functionToStringIntegration(),
       Sentry.linkedErrorsIntegration(),
       Sentry.dedupeIntegration(),


### PR DESCRIPTION
## Summary

- `initSentry()` (`app/src/services/analytics.ts`) sets `defaultIntegrations: false` then re-adds a curated integration list that **omitted `inboundFiltersIntegration`** — the only integration that consumes the top-level `ignoreErrors` option.
- As a result the intended noise filter `ignoreErrors: ['ResizeObserver loop', 'Network request failed', 'Load failed', 'AbortError']` has been **dead config since it was added (PR #52)**, letting benign `ResizeObserver loop completed with undelivered notifications.` events flood Sentry (TAURI-REACT-1R: 126 events / 124 users on 0.57.44 & 0.57.52).
- Re-register `Sentry.inboundFiltersIntegration()` so the existing `ignoreErrors` list runs again.
- Add a regression test asserting both that the integration is registered **and** that the `ignoreErrors` list is present, so a future curated-list edit can't silently drop it again.

## Problem

With `defaultIntegrations: false`, Sentry does not auto-include `inboundFiltersIntegration`. That integration is what reads the top-level `ignoreErrors` option and drops matching events (it runs as an event processor, *before* `beforeSend`). Because the curated `integrations` array never re-added it, `ignoreErrors` silently did nothing — purely a config defect, not a new suppression. ResizeObserver loop notifications are genuinely-benign, self-recovering browser noise, so filtering them is legitimate and was always the intent.

## Solution

- `app/src/services/analytics.ts`: add `Sentry.inboundFiltersIntegration()` to the curated `integrations` array, with a comment explaining why it's required under `defaultIntegrations: false` and noting it executes before `beforeSend` (so the consent/privacy logic there is unaffected — this only restores the pre-`beforeSend` drop of the four intended patterns).
- `app/src/services/__tests__/analytics.test.ts`: mock `inboundFiltersIntegration` and add a regression test asserting the integration is registered (`InboundFilters` present in `integrations`) and `ignoreErrors` deep-equals the intended four-pattern list. Verified the test **fails** when the integration line is removed (it guards the coupling) and passes with the fix.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — added a regression test; confirmed it fails without the fix (guards the bug) and passes with it.
- [x] **Diff coverage ≥ 80%** — changed lines are one source line (`Sentry.inboundFiltersIntegration()`) plus test code; the new Vitest test exercises that line via the captured `Sentry.init` options. Rust coverage N/A (no Rust changed).
- [x] N/A: behaviour/config-correctness change — no feature row added/removed/renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no matrix feature IDs are affected by this change.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch release-cut surfaces (internal Sentry init wiring only).
- [x] Linked issue closed via `Closes #3963` in the `## Related` section.

## Impact

- Desktop (React renderer) Sentry only. Restores the intended `ignoreErrors` suppression so benign `ResizeObserver loop` / `Network request failed` / `Load failed` / `AbortError` events stop flooding the dashboard. No behavior change to real error reporting — only the four already-intended noise patterns are dropped, by the same `ignoreErrors` list that has been present (but inert) since PR #52.

## Related

- Closes: #3963
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3963-sentry-inbound-filters`
- Commit SHA: `8b510d122ab8ef86718c5876f84765f6c9f4ade4`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier: all matched files use code style.
- [x] `pnpm typecheck` — clean.
- [x] Focused tests: `app/src/services/__tests__/analytics.test.ts` — 33 passed (incl. new regression test); verified it fails without the fix.
- [x] N/A: Rust fmt/check — no Rust files changed.
- [x] N/A: Tauri fmt/check — no Rust/Tauri files changed.

### Validation Blocked

- `command:` `git push` (pre-push husky hook → `pnpm rust:format` → `cargo fmt`)
- `error:` `'cargo' is not recognized` — `cargo` is not on PATH in this environment.
- `impact:` None on this PR — the change is frontend-only TypeScript; `cargo fmt` would not touch it. Pushed with `--no-verify` per the repo's pre-push policy for pre-existing/unrelated hook breakage. CI still runs the full lint/format/typecheck/test gates.

### Behavior Changes

- Intended behavior change: the existing `ignoreErrors` list is actually applied to outgoing Sentry events.
- User-visible effect: none in-app; reduces Sentry dashboard noise.

### Parity Contract

- Legacy behavior preserved: yes — real error reporting, consent gating, and the `beforeSend` privacy filter are all unchanged. Only the four already-declared `ignoreErrors` patterns are now dropped (as originally intended).
- Guard/fallback/dispatch parity checks: `inboundFiltersIntegration` runs before `beforeSend`, so all downstream consent/PII-stripping logic is unaffected.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensured error filtering correctly applies configured error exclusions during event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->