### PR TITLE
fix(provider): demote BYO insufficient-credits 402 to info across all emit paths

### DIFF
--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -194,6 +194,17 @@ impl Provider for OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::super::is_provider_insufficient_credits_402(status, &error) {
+                // Residual 402 after the request already caps max_tokens: the
+                // user's own BYO provider balance is exhausted — no local lever,
+                // so demote to info instead of paging on every retry
+                // (TAURI-RUST-4QF / #3961).
+                super::super::log_provider_insufficient_credits_402(
+                    "chat_completions",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                );
             } else if super::super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),
@@ -996,6 +1007,20 @@ impl Provider for OpenAiCompatibleProvider {
                         Some(model_owned.as_str()),
                         status,
                     );
+                } else if crate::openhuman::inference::provider::is_provider_insufficient_credits_402(
+                    status,
+                    &raw_error,
+                ) {
+                    // Residual 402 after max_tokens is already capped: the user's
+                    // BYO provider balance is exhausted (no local lever), so demote
+                    // to info instead of paging on every retry (TAURI-RUST-4QF /
+                    // #3961).
+                    crate::openhuman::inference::provider::log_provider_insufficient_credits_402(
+                        "stream_chat",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                    );
                 } else if crate::openhuman::inference::provider::should_report_provider_http_failure(
                     status,
                 ) {
@@ -1208,6 +1233,20 @@ impl Provider for OpenAiCompatibleProvider {
                     &raw_error,
                 ) {
                     crate::openhuman::inference::provider::log_byo_provider_auth_failure(
+                        "stream_chat_history",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                    );
+                } else if crate::openhuman::inference::provider::is_provider_insufficient_credits_402(
+                    status,
+                    &raw_error,
+                ) {
+                    // Residual 402 after max_tokens is already capped: the user's
+                    // BYO provider balance is exhausted (no local lever), so demote
+                    // to info instead of paging on every retry (TAURI-RUST-4QF /
+                    // #3961).
+                    crate::openhuman::inference::provider::log_provider_insufficient_credits_402(
                         "stream_chat_history",
                         provider_name.as_str(),
                         Some(model_owned.as_str()),

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1132,6 +1132,156 @@ async fn streaming_chat_byo_auth_failure_propagates_error_without_sentry_report(
 }
 
 // ----------------------------------------------------------
+// BYO insufficient-credits 402 demotion (#3961 / TAURI-RUST-4QF)
+// ----------------------------------------------------------
+//
+// A user's own BYO provider (e.g. DeepSeek) running out of balance returns
+// `402 Insufficient Balance` on every agent retry. That is expected user-state
+// once `max_tokens` is already capped — no local lever — so it must be demoted
+// to an info log, not paged to Sentry. The demote arm existed only in the
+// `native_chat` cascade (#3617); these guard the four other emit paths it now
+// also covers: non-streaming `chat_completions`, `stream_chat`,
+// `stream_chat_history`, and the shared `api_error` helper.
+
+/// Verbatim TAURI-RUST-4QF DeepSeek body. Coupling the test to the exact wire
+/// string makes a provider wording drift fail CI rather than silently leak
+/// events back to Sentry.
+const DEEPSEEK_402_BODY: &str = r#"{"error":{"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}}"#;
+
+/// Install a capturing Sentry hub for the duration of the returned guard. The
+/// `TestTransport` records any event `report_error` would emit, so an empty
+/// event list proves the failure was demoted (info log) rather than reported.
+fn install_capturing_sentry() -> (TestTransport, sentry::HubSwitchGuard) {
+    let transport = TestTransport::new();
+    let sentry_options = sentry::ClientOptions {
+        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
+        transport: Some(Arc::new(transport.clone())),
+        ..Default::default()
+    };
+    let hub = Arc::new(sentry::Hub::new(
+        Some(Arc::new(sentry_options.into())),
+        Arc::new(Default::default()),
+    ));
+    let guard = sentry::HubSwitchGuard::new(hub);
+    (transport, guard)
+}
+
+#[tokio::test]
+async fn chat_completions_insufficient_credits_402_not_reported_to_sentry() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(402).set_body_string(DEEPSEEK_402_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_capturing_sentry();
+    let provider =
+        OpenAiCompatibleProvider::new("deepseek", &mock_server.uri(), None, AuthStyle::None);
+
+    let err = provider
+        .chat_with_system(None, "hello", "deepseek-chat", 0.7)
+        .await
+        .expect_err("402 insufficient balance must still propagate as Err");
+    assert!(err.to_string().contains("402"), "err: {err}");
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "BYO 402 insufficient balance (chat_completions) must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn stream_chat_insufficient_credits_402_not_reported_to_sentry() {
+    use futures_util::StreamExt;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(402).set_body_string(DEEPSEEK_402_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_capturing_sentry();
+    let provider =
+        OpenAiCompatibleProvider::new("deepseek", &mock_server.uri(), None, AuthStyle::None);
+
+    let mut stream = provider.stream_chat_with_system(
+        None,
+        "hello",
+        "deepseek-chat",
+        0.7,
+        super::traits::StreamOptions::new(true),
+    );
+    let mut saw_error = false;
+    while let Some(item) = stream.next().await {
+        saw_error |= item.is_err();
+    }
+    assert!(saw_error, "402 must surface as a stream error");
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "BYO 402 insufficient balance (stream_chat) must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn stream_chat_history_insufficient_credits_402_not_reported_to_sentry() {
+    use futures_util::StreamExt;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(402).set_body_string(DEEPSEEK_402_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_capturing_sentry();
+    let provider =
+        OpenAiCompatibleProvider::new("deepseek", &mock_server.uri(), None, AuthStyle::None);
+
+    let mut stream = provider.stream_chat_with_history(
+        &[ChatMessage::user("hello")],
+        "deepseek-chat",
+        0.7,
+        super::traits::StreamOptions::new(true),
+    );
+    let mut saw_error = false;
+    while let Some(item) = stream.next().await {
+        saw_error |= item.is_err();
+    }
+    assert!(saw_error, "402 must surface as a stream error");
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "BYO 402 insufficient balance (stream_chat_history) must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn api_error_helper_insufficient_credits_402_not_reported_to_sentry() {
+    // Direct coverage of the shared `api_error` helper, which backs
+    // `chat_with_history` / `chat_with_tools` and any other path that delegates
+    // its HTTP-error construction.
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(402).set_body_string(DEEPSEEK_402_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_capturing_sentry();
+    let response = reqwest::Client::new()
+        .post(mock_server.uri())
+        .send()
+        .await
+        .expect("mock request should succeed");
+
+    let err = crate::openhuman::inference::provider::api_error("deepseek", response).await;
+    assert!(err.to_string().contains("402"), "err: {err}");
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "BYO 402 insufficient balance (api_error) must not be reported to Sentry"
+    );
+}
+
+// ----------------------------------------------------------
 // Custom endpoint path tests (Issue #114)
 // ----------------------------------------------------------
 

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -719,6 +719,10 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     // from Sentry (TAURI-RUST-8FQ flood).
     let is_openai_oauth_session_expired =
         is_openai_oauth_session_expired_http(provider, status, &body);
+    // BYO provider balance exhausted (402 + credit/payment phrase). Residual
+    // user-state once max_tokens is already capped — no local lever, so demote
+    // from Sentry instead of paging on every retry (TAURI-RUST-4QF / #3961).
+    let is_insufficient_credits = is_provider_insufficient_credits_402(status, &body);
 
     if is_auth_failure && is_backend {
         // Single source of truth for backend session-expiry handling (warn +
@@ -741,6 +745,8 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
         log_byo_provider_auth_failure("api_error", provider, None, status);
     } else if is_openai_oauth_session_expired {
         log_openai_oauth_session_expired("api_error", provider, None, status);
+    } else if is_insufficient_credits {
+        log_provider_insufficient_credits_402("api_error", provider, None, status);
     } else if should_report_provider_http_failure(status) {
         crate::core::observability::report_error(
             message.as_str(),


### PR DESCRIPTION
## Summary

A user's own BYO DeepSeek account running out of balance returns `402 Payment Required: Insufficient Balance` on every agent retry, flooding Sentry at `error` level (~23,970 events, 17 users — TAURI-RUST-4QF).

Closes #3961

## Root cause

The OpenAI-compatible provider has multiple non-2xx error cascades, each ending in a hard `report_error`. The insufficient-credits-402 demote arm added in #3617 (`is_provider_insufficient_credits_402` → `log_provider_insufficient_credits_402`, an info log) was wired into **only** the `native_chat` cascade (`compatible_provider_impl.rs`). The remaining emit paths still hard-reported a 402:

- non-streaming `chat_completions` — **this is the 4QF path** (`operation=chat_completions`)
- `stream_chat`
- `stream_chat_history`
- the shared `api_error` helper (`ops/http_error.rs`)

The desktop-shell `before_send` net (#3913, v0.57.53) now drops these from Sentry, but that's defense-in-depth — the source still emits the event on every retry.

## Fix

Propagate the existing demote arm to the four paths that lacked it. Placement mirrors the proven `native_chat` arm: inserted between the BYO-auth arm and the terminal `should_report_provider_http_failure` report.

- `src/openhuman/inference/provider/compatible_provider_impl.rs` — `chat_completions`, `stream_chat`, `stream_chat_history` cascades.
- `src/openhuman/inference/provider/ops/http_error.rs` — `api_error` helper.

The user's BYO balance is exhausted with no local lever once `max_tokens` is already capped, so an info log is the correct classification. The demote stays gated on `402` **and** a credit/payment phrase (`is_provider_insufficient_credits_402`, already phrase-tested), so genuine non-2xx errors are unaffected. I verified the earlier `api_error` arms are all status/provider-gated away from a 402, so the new arm is reached for this user-state.

## Tests

Method-level regression tests (wiremock + `sentry::test::TestTransport` capturing hub), each mocking the **verbatim** DeepSeek `402 Insufficient Balance` body and asserting the call still propagates an `Err` **and** emits **zero** Sentry events:

- `chat_completions_insufficient_credits_402_not_reported_to_sentry`
- `stream_chat_insufficient_credits_402_not_reported_to_sentry`
- `stream_chat_history_insufficient_credits_402_not_reported_to_sentry`
- `api_error_helper_insufficient_credits_402_not_reported_to_sentry`

## Testing

Per worker policy, tests/checks were not run locally (CI runs on GitHub). The added tests cover all four newly-demoted emit paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced provider error handling to properly detect and log insufficient credits conditions without escalating to error tracking systems.

* **Tests**
  * Added comprehensive test coverage for provider insufficient credits error scenarios across multiple request and streaming paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->