### PR TITLE
fix(analytics): register inboundFiltersIntegration so ignoreErrors runs (#3963)

### DIFF
--- a/app/src/services/__tests__/analytics.test.ts
+++ b/app/src/services/__tests__/analytics.test.ts
@@ -10,6 +10,7 @@ const hoisted = vi.hoisted(() => ({
   init: vi.fn(),
   // Integration stubs — these aren't introspected, just need to exist so
   // `Sentry.init()` accepts the integrations array without throwing.
+  inboundFiltersIntegration: vi.fn(() => ({ name: 'InboundFilters' })),
   functionToStringIntegration: vi.fn(() => ({})),
   linkedErrorsIntegration: vi.fn(() => ({})),
   dedupeIntegration: vi.fn(() => ({})),
@@ -29,6 +30,7 @@ vi.mock('@sentry/react', () => ({
   captureMessage: hoisted.captureMessage,
   flush: hoisted.flush,
   init: hoisted.init,
+  inboundFiltersIntegration: hoisted.inboundFiltersIntegration,
   functionToStringIntegration: hoisted.functionToStringIntegration,
   linkedErrorsIntegration: hoisted.linkedErrorsIntegration,
   dedupeIntegration: hoisted.dedupeIntegration,
@@ -306,6 +308,27 @@ describe('initSentry beforeSend manual-staging bypass', () => {
     expect(opts.replaysOnErrorSampleRate).toBe(0);
     const names = opts.integrations.map(i => i.name).filter(Boolean);
     expect(names).toContain('HttpContext');
+  });
+
+  test('registers inboundFiltersIntegration so ignoreErrors is live (TAURI-REACT-1R)', async () => {
+    // Regression for TAURI-REACT-1R: `defaultIntegrations: false` drops
+    // InboundFilters, the only integration that consumes `ignoreErrors`. When
+    // a past edit re-added a curated integration list but omitted it, the whole
+    // `ignoreErrors` list went inert and "ResizeObserver loop completed with
+    // undelivered notifications" (plus the other non-actionable errors) leaked
+    // to the dashboard for months. Assert both halves stay coupled: the
+    // integration is present AND the filter list still carries the patterns.
+    hoisted.init.mockReset();
+    const { initSentry } = await import('../analytics');
+    initSentry();
+
+    const opts = hoisted.init.mock.calls[0][0] as {
+      integrations: Array<{ name?: string }>;
+      ignoreErrors: string[];
+    };
+    const names = opts.integrations.map(i => i.name).filter(Boolean);
+    expect(names).toContain('InboundFilters');
+    expect(opts.ignoreErrors).toContain('ResizeObserver loop');
   });
 
   test('keeps os/browser/device contexts and forwards them through beforeSend (#1403)', async () => {

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -147,6 +147,15 @@ export function initSentry(): void {
     tracesSampleRate: 0,
     defaultIntegrations: false,
     integrations: [
+      // `defaultIntegrations: false` (above) drops InboundFilters, which is
+      // the only integration that consumes the `ignoreErrors` option below.
+      // Without it that whole list is dead config and the listed
+      // non-actionable errors — e.g. "ResizeObserver loop completed with
+      // undelivered notifications" (TAURI-REACT-1R) — all leak to the
+      // dashboard. Re-include it explicitly (same pattern as httpContext for
+      // #1403). It runs as an event processor before `beforeSend`, so filtered
+      // errors are dropped before the consent gate even sees them.
+      Sentry.inboundFiltersIntegration(),
       Sentry.functionToStringIntegration(),
       Sentry.linkedErrorsIntegration(),
       Sentry.dedupeIntegration(),


### PR DESCRIPTION
## Summary

- Re-register `Sentry.inboundFiltersIntegration()` in the frontend `Sentry.init` integrations array so the existing `ignoreErrors` list is actually applied.
- Fixes a long-standing config defect where `defaultIntegrations: false` silently disabled the only integration that consumes `ignoreErrors`, so the whole noise filter was inert.
- Stops the `ResizeObserver loop completed with undelivered notifications` flood (TAURI-REACT-1R) plus the other listed non-actionable errors from leaking to Sentry.
- Adds a regression test coupling the integration's presence to the filter list so a future curated-list edit can't silently break it again.

## Problem

`app/src/services/analytics.ts::initSentry()` sets `defaultIntegrations: false` (privacy hardening) and re-adds a curated integration list. That list **omits `inboundFiltersIntegration`** — the integration that reads the top-level `ignoreErrors` / `denyUrls` / `ignoreTransactions` options. As a result the deliberate filter list

```
ignoreErrors: ['ResizeObserver loop', 'Network request failed', 'Load failed', 'AbortError']
```

has been **dead config since it was introduced (PR #52, 2026-03-29)**. The `ResizeObserver loop` benign-noise error surfaced as TAURI-REACT-1R: 126 events / 124 users over 2026-06-18 → 06-22 on releases 0.57.44 and 0.57.52, all via `auto.browser.global_handlers.onerror` with no actionable stack (~1:1 event:user — a one-shot, self-recovering browser condition, not a runaway loop). The defect is present on current `main` (0.57.53).

## Solution

Add `Sentry.inboundFiltersIntegration()` as the first entry in the integrations array (mirroring how `httpContextIntegration` was re-added for #1403). In `@sentry/react` v10 the integration reads the client's existing top-level `ignoreErrors`, so no further wiring is needed — the line-238 list becomes live as-is. It runs as an event processor **before** `beforeSend`, so filtered errors are dropped before the analytics-consent gate even sees them.

This is an RCA-first fix, **not** a new suppression: the suppression was always intended and merely inert. Re-enabling it also restores the intended filtering of `Network request failed` / `Load failed` / `AbortError` — all deliberately-listed generic browser noise.

Regression test extends the existing `initSentry` integration test to assert (a) `InboundFilters` is registered and (b) `ignoreErrors` still carries `ResizeObserver loop`, keeping the integration and the filter list coupled.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — the single changed production line (`inboundFiltersIntegration()`) executes in every `initSentry()` test; verified via the analytics Vitest suite (33 passing).
- [x] N/A: behaviour/config-only change — no feature rows added/removed/renamed in the coverage matrix.
- [x] N/A: no coverage-matrix feature IDs affected by this change.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut manual-smoke surfaces (Sentry client filter config only).
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform**: desktop frontend (React surface) only. No Rust, RPC, or schema changes.
- **Observability**: meaningfully reduces Sentry noise — TAURI-REACT-1R and the three other listed error classes will now be filtered as originally intended. Reviewers should be aware `Network request failed` / `Load failed` / `AbortError` start being dropped (this is the intended, previously-broken behavior).
- **Security/migration**: none.

## Related

- Closes: #3963
- Sentry-Issue: TAURI-REACT-1R
- Follow-up PR(s)/TODOs: consider unifying the React (`analytics.ts`) and Tauri-shell (`lib.rs`) Sentry init so curated integration lists can't drift independently.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A (GitHub issue #3963)
- URL: https://github.com/tinyhumansai/openhuman/issues/3963

### Commit & Branch

- Branch: `fix/3963-sentry-inbound-filters`
- Commit SHA: e6167bd14

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `vitest run src/services/__tests__/analytics.test.ts` (33 passed)
- [x] N/A: no Rust core files changed.
- [x] N/A: no Tauri shell files changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: the deliberate `ignoreErrors` list is now actually applied.
- User-visible effect: none in-app; fewer non-actionable errors reach the Sentry dashboard.
