### PR TITLE
fix(rpc): alias legacy tool_registry.diagnostics to canonical method (#3294)

### DIFF
--- a/app/src/services/__tests__/rpcMethods.test.ts
+++ b/app/src/services/__tests__/rpcMethods.test.ts
@@ -82,6 +82,13 @@ describe('rpcMethods catalog', () => {
       );
     });
 
+    test('dotted tool_registry.diagnostics resolves to the canonical method (#3294)', () => {
+      expect(normalizeRpcMethod('tool_registry.diagnostics')).toBe(
+        CORE_RPC_METHODS.toolRegistryDiagnostics
+      );
+      expect(CORE_RPC_METHODS.toolRegistryDiagnostics).toBe('openhuman.tool_registry_diagnostics');
+    });
+
     test('canonical mcp_clients_installed_list passes through unchanged', () => {
       expect(normalizeRpcMethod('openhuman.mcp_clients_installed_list')).toBe(
         'openhuman.mcp_clients_installed_list'
@@ -155,6 +162,10 @@ describe('rpcMethods catalog', () => {
         'utf8'
       ),
       fs.readFileSync(
+        path.resolve(__dirname, '../../../../src/openhuman/tool_registry/schemas.rs'),
+        'utf8'
+      ),
+      fs.readFileSync(
         path.resolve(__dirname, '../../../../src/openhuman/health/schemas.rs'),
         'utf8'
       ),
@@ -182,7 +193,9 @@ describe('rpcMethods catalog', () => {
                   ? 'health'
                   : methodRoot.startsWith('channels_')
                     ? 'channels'
-                    : 'config';
+                    : methodRoot.startsWith('tool_registry_')
+                      ? 'tool_registry'
+                      : 'config';
       const fnName = methodRoot.slice(`${namespace}_`.length);
       expect(schemaSources).toContain(`namespace: "${namespace}"`);
       expect(schemaSources).toContain(`function: "${fnName}"`);

--- a/app/src/services/rpcMethods.ts
+++ b/app/src/services/rpcMethods.ts
@@ -60,6 +60,7 @@ export const CORE_RPC_METHODS = {
   channelsList: 'openhuman.channels_list',
   mcpClientsInstalledList: 'openhuman.mcp_clients_installed_list',
   mcpClientsToolCall: 'openhuman.mcp_clients_tool_call',
+  toolRegistryDiagnostics: 'openhuman.tool_registry_diagnostics',
   healthSnapshot: 'openhuman.health_snapshot',
   healthSystemInfo: 'openhuman.health_system_info',
 } as const;
@@ -77,6 +78,12 @@ export const LEGACY_METHOD_ALIASES: Record<string, CoreRpcMethod> = {
   'openhuman.mcp_list': CORE_RPC_METHODS.mcpClientsInstalledList,
   'openhuman.mcp_servers_list': CORE_RPC_METHODS.mcpClientsInstalledList,
   'openhuman.tool_registry_call': CORE_RPC_METHODS.mcpClientsToolCall,
+  // #3294: old desktop bundles called the tool-registry diagnostics
+  // controller with the dotted `tool_registry.diagnostics` spelling before the
+  // canonical `openhuman.tool_registry_diagnostics` form, so the Tool Policy
+  // diagnostics panel failed with "unknown method". Keep in sync with the
+  // Rust-side mirror in src/core/legacy_aliases.rs.
+  'tool_registry.diagnostics': CORE_RPC_METHODS.toolRegistryDiagnostics,
   'openhuman.get_analytics_settings': CORE_RPC_METHODS.configGetAnalyticsSettings,
   'openhuman.get_composio_trigger_settings': CORE_RPC_METHODS.configGetComposioTriggerSettings,
   'openhuman.get_dashboard_settings': CORE_RPC_METHODS.configGetDashboardSettings,

--- a/src/core/legacy_aliases.rs
+++ b/src/core/legacy_aliases.rs
@@ -68,6 +68,16 @@ const LEGACY_ALIASES: &[(&str, &str)] = &[
         "openhuman.tool_registry_call",
         "openhuman.mcp_clients_tool_call",
     ),
+    // #3294: old desktop bundles called the tool-registry diagnostics
+    // controller with the dotted `tool_registry.diagnostics` spelling, before
+    // the canonical `openhuman.<namespace>_<function>` form
+    // (`openhuman.tool_registry_diagnostics`) was established. Without this
+    // alias the Tool Policy diagnostics panel's RPC failed with "unknown
+    // method" on those clients.
+    (
+        "tool_registry.diagnostics",
+        "openhuman.tool_registry_diagnostics",
+    ),
     (
         "openhuman.update_analytics_settings",
         "openhuman.config_update_analytics_settings",
@@ -574,6 +584,18 @@ mod tests {
         assert_eq!(
             resolve_legacy("openhuman.channels.list"),
             "openhuman.channels_list"
+        );
+    }
+
+    #[test]
+    fn resolve_legacy_rewrites_tool_registry_diagnostics() {
+        // #3294: the dotted `tool_registry.diagnostics` spelling sent by older
+        // desktop bundles must resolve to the canonical controller name so the
+        // Tool Policy diagnostics panel works instead of failing with
+        // "unknown method".
+        assert_eq!(
+            resolve_legacy("tool_registry.diagnostics"),
+            "openhuman.tool_registry_diagnostics"
         );
     }
 


### PR DESCRIPTION
## Summary

The Tool Policy diagnostics panel fails with an **"unknown method"** error for users on older shipped bundles.

- **Frontend (older bundles)** call the dotted `tool_registry.diagnostics`.
- **Backend** registers the canonical `openhuman.<namespace>_<function>` form → `openhuman.tool_registry_diagnostics`.
- The server-side **legacy-alias table was missing this pair**, so the rewrite that normally protects older clients didn't fire (126 events / 124 users).

(On current `main` the panel already sends the canonical name, so up-to-date clients work — this restores compatibility for the shipped clients still in the wild.)

## Fix

Add the missing alias to **both** mirrored tables (kept identical and enforced by the `frontend_legacy_aliases_match_server_alias_table` parity test):

- `src/core/legacy_aliases.rs` — `("tool_registry.diagnostics", "openhuman.tool_registry_diagnostics")` so the server rewrites the legacy incoming name.
- `app/src/services/rpcMethods.ts` — added the `toolRegistryDiagnostics` constant to `CORE_RPC_METHODS` and the `'tool_registry.diagnostics'` entry to `LEGACY_METHOD_ALIASES`.

## Tests

- Added a focused Rust regression test (`resolve_legacy_rewrites_tool_registry_diagnostics`).
- Existing `resolve_legacy_rewrites_every_table_entry` (Rust) and `resolves all legacy aliases…` (TS) iterate every table entry, so the new alias is covered on both sides.
- Verified the target `openhuman.tool_registry_diagnostics` is a declared HTTP method, so the schema-registry parity tests (`frontend_core_rpc_methods_exist_in_core_schema_registry`, `legacy_alias_targets_exist_in_core_schema_registry`) stay green.

No tests/checks were run locally; CI will exercise them.

Closes #3294<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool registry diagnostics RPC method, enabling new diagnostic operations on tool registry components.

* **Improvements**
  * Implemented backward compatibility layer supporting legacy method naming conventions, ensuring existing integrations and clients continue to function without modification.

* **Tests**
  * Added regression test coverage to verify proper translation and handling of legacy method naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->