### PR TITLE
fix(tinyplace): classify wallet-not-configured as expected user-state (#3964)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -103,6 +103,16 @@ pub async fn rpc_handler(State(state): State<AppState>, Json(req): Json<RpcReque
                     "[rpc] expected-user-state error — skipping Sentry: {}",
                     display_message
                 );
+            } else if is_wallet_not_configured_error(&display_message) {
+                // A `tinyplace_*` RPC needs a wallet-derived signer but the user
+                // has not set one up. Expected user-state (the UI shows a
+                // "set up wallet" prompt), not an internal failure — skip Sentry
+                // here so the message is left untouched for direct (agent-tool)
+                // callers. See `is_wallet_not_configured_error`.
+                tracing::info!(
+                    method = %method,
+                    "[rpc] wallet-not-configured (expected user-state) — skipping Sentry"
+                );
             } else if is_param_validation_error(&display_message) {
                 tracing::info!(
                     method = %method,
@@ -345,6 +355,27 @@ fn is_param_validation_error(msg: &str) -> bool {
     msg.starts_with("unknown param '")
         || msg.starts_with("missing required param '")
         || msg.starts_with("invalid params: ")
+}
+
+/// Returns `true` when the error is the wallet's "not configured yet" message.
+///
+/// Several `tinyplace_*` RPCs derive a signer seed from the wallet before they
+/// can run (the feed, signal/messaging, etc. — backend `GraphQLAuth::Agent`
+/// requires a signer). For a user who has not set up a wallet, the wallet layer
+/// returns [`crate::openhuman::wallet::WALLET_NOT_CONFIGURED_MESSAGE`]. That is
+/// an expected user-state, not an internal failure: the UI already renders a
+/// "set up wallet" prompt, and there is no local lever to make the call succeed
+/// until the user creates a wallet. Classifying it here — at the single Sentry
+/// boundary — keeps it out of Sentry for *every* path that surfaces it (the
+/// shared client builder and the direct `signal_store` seed call alike) without
+/// the controllers returning a structured envelope, which would leak the raw
+/// sentinel string to agent tools that call those handlers directly.
+///
+/// Matched against the shared wallet constant (exact equality) so a wording
+/// change in the wallet layer fails the coupling test in `jsonrpc_tests.rs`
+/// rather than silently letting the noise back into Sentry.
+fn is_wallet_not_configured_error(msg: &str) -> bool {
+    msg == crate::openhuman::wallet::WALLET_NOT_CONFIGURED_MESSAGE
 }
 
 /// Internal method invocation logic.

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -7,8 +7,8 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     build_http_schema_dump, default_state, escape_html, invoke_method, is_param_validation_error,
-    is_session_expired_error, is_unconfirmed_unauthorized_error, params_to_object,
-    parse_json_params, rpc_handler, type_name,
+    is_session_expired_error, is_unconfirmed_unauthorized_error, is_wallet_not_configured_error,
+    params_to_object, parse_json_params, rpc_handler, type_name,
 };
 
 struct EnvVarGuard {
@@ -1406,4 +1406,41 @@ async fn desktop_auth_rejects_embedded_fetch_metadata() {
         .expect("response body");
     let body = String::from_utf8(body.to_vec()).expect("html body should be utf8");
     assert!(body.contains("must be opened as a browser page"));
+}
+
+#[test]
+fn is_wallet_not_configured_error_matches_wallet_constant() {
+    // The classifier keys off the wallet layer's exact "not configured"
+    // message so a wallet-less user's tinyplace RPC stays out of Sentry.
+    assert!(is_wallet_not_configured_error(
+        crate::openhuman::wallet::WALLET_NOT_CONFIGURED_MESSAGE
+    ));
+}
+
+#[test]
+fn is_wallet_not_configured_error_is_coupled_to_the_wallet_constant() {
+    // Drift guard: if the wallet wording changes without updating the shared
+    // constant the classifier matches, this fails — preventing the noise from
+    // silently returning to Sentry. Mirrors the param-validation prefix locks.
+    assert_eq!(
+        crate::openhuman::wallet::WALLET_NOT_CONFIGURED_MESSAGE,
+        "wallet is not configured; run wallet setup first"
+    );
+}
+
+#[test]
+fn is_wallet_not_configured_error_does_not_match_other_errors() {
+    // Other wallet/seed-derivation failures (decrypt, key derivation, locked
+    // keychain) are real defects and must keep reaching Sentry.
+    assert!(!is_wallet_not_configured_error(
+        "tinyplace signer init: bad seed"
+    ));
+    assert!(!is_wallet_not_configured_error(
+        "decrypt secret: kms timeout"
+    ));
+    assert!(!is_wallet_not_configured_error(""));
+    // Substring-only must not qualify — exact equality is required.
+    assert!(!is_wallet_not_configured_error(
+        "rpc failed: wallet is not configured; run wallet setup first"
+    ));
 }

--- a/src/openhuman/wallet/mod.rs
+++ b/src/openhuman/wallet/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use execution::{sign_and_broadcast_evm, sign_and_broadcast_solana};
 pub(crate) use ops::secret_material;
 pub use ops::{
     reveal_recovery_phrase, setup, status, RevealRecoveryPhraseResult, WalletAccount, WalletChain,
-    WalletSetupParams, WalletSetupSource, WalletStatus,
+    WalletSetupParams, WalletSetupSource, WalletStatus, WALLET_NOT_CONFIGURED_MESSAGE,
 };
 pub use schemas::{
     all_controller_schemas, all_registered_controllers, all_wallet_controller_schemas,

--- a/src/openhuman/wallet/ops.rs
+++ b/src/openhuman/wallet/ops.rs
@@ -17,6 +17,14 @@ use crate::rpc::RpcOutcome;
 
 const LOG_PREFIX: &str = "[wallet]";
 const WALLET_STATE_FILENAME: &str = "wallet-state.json";
+/// Error message returned when the wallet has not been set up yet.
+///
+/// This is an expected user-state (the user simply has not created a wallet),
+/// not an internal failure. Downstream boundaries that surface this condition
+/// — e.g. the `tinyplace` client builder — match against this constant to
+/// classify it as `expected_user_state` so it stays out of Sentry. Keep it a
+/// shared constant so the producer here and any classifier cannot drift apart.
+pub const WALLET_NOT_CONFIGURED_MESSAGE: &str = "wallet is not configured; run wallet setup first";
 const VALID_MNEMONIC_WORD_COUNTS: [u8; 5] = [12, 15, 18, 21, 24];
 /// Keychain key for the encrypted mnemonic blob (user_id is added by the keyring module).
 const KEYCHAIN_MNEMONIC_KEY: &str = "wallet.mnemonic";
@@ -738,7 +746,7 @@ pub(crate) async fn secret_material(chain: WalletChain) -> Result<WalletSecretMa
                 "{LOG_PREFIX} secret_material missing wallet state chain={}",
                 chain.as_str()
             );
-            return Err("wallet is not configured; run wallet setup first".to_string());
+            return Err(WALLET_NOT_CONFIGURED_MESSAGE.to_string());
         }
     };
     let encrypted_mnemonic = state


### PR DESCRIPTION
## Summary

- The tiny.place / Agent World **Feed** errored into Sentry for every user without a wallet — `openhuman.tinyplace_graphql_home_feed` returned `wallet is not configured` as a plain string and the transport boundary escalated it to an **error-level** Sentry event (TAURI-RUST-FFB: 2253 events / 146 users).
- **Bucket = preventable user-state.** Two changes:
  1. **Prevention at source (the headline fix)** — `FeedSection` no longer fires the wallet-requiring `homeFeed()` RPC unconditionally on mount. It now gates the call on wallet status and renders the configure-wallet state when no wallet exists, so wallet-less users **never invoke** the RPC that produced the error.
  2. **Boundary classifier (defense-in-depth)** — wallet-not-configured is also classified as an expected user-state at the JSON-RPC transport boundary, so any *other* path that still surfaces the condition (agent tools, messaging/signal) stays out of Sentry. This is the safety net behind the prevention, not the primary fix.
- No behaviour change for users: the feed already renders a "set up wallet" prompt; the gate now shows it without a failed round-trip, and the classifier removes residual noise.

## Problem

`FeedSection` fetched `homeFeed()` on mount **unconditionally** — even for a user with no wallet configured. The component already fetches wallet status (`fetchWalletStatus()`) and already owns a wallet-locked predicate, but only used it to prettify the error *after* the call failed. So the wallet-requiring RPC was invoked → errored → got reported, instead of never being called.

On the Rust side, for a wallet-less user, `tinyplace/state.rs::client()` → `wallet::tinyplace_signer_seed()` → `wallet/ops.rs` `secret_material` returns the plain `String` `"wallet is not configured; run wallet setup first"`. Because it is unstructured, `core::jsonrpc` saw `expected_user_state = false` and called `report_error_or_expected` → an error-level Sentry capture.

The failing condition is **preventable**: the client knows, before calling, whether a wallet is configured. `home_feed` legitimately requires a signer, so the right move is to **not call it** when there's no wallet — not merely to demote the resulting error.

## Solution

**Prevention at source (headline) — `app/src/agentworld/pages/FeedSection.tsx`:**

- Replace `useMyAgentId` with `useWalletResolution`, which resolves wallet status once on mount and returns a tri-state `configured`: `'resolving'` (in flight), `'no'` (wallet_status resolved with no usable Solana account → no wallet), `'yes'` (usable account exists), `'unknown'` (wallet_status fetch failed). The predicate mirrors the established `WalletAddressChip` convention (a usable wallet = wallet_status resolves with a Solana account).
- Gate the `homeFeed()` mount fetch on that state:
  - `'resolving'` → stay on loading, fire nothing (no call during the unknown window).
  - `'no'` → render the configure-wallet state, **skip the RPC entirely**.
  - `'yes'` → fire the feed fetch.
  - `'unknown'` (transport/RPC error — we can't *prove* the wallet is absent) → fall through and fire the fetch, letting the boundary classifier handle any wallet-locked error.
- Loading / error / payment-required / empty UX preserved; a new `wallet_unconfigured` render branch surfaces the existing "set up your wallet" prompt without a failed round-trip.

**Boundary classifier (defense-in-depth) — Rust core, unchanged from the prior commits:**

- Hoist the wallet-not-configured message into a shared `pub const WALLET_NOT_CONFIGURED_MESSAGE` (single source of truth + drift guard).
- Classify that exact message as an expected user-state at the JSON-RPC transport boundary (`core::jsonrpc`), alongside the existing `is_session_expired_error` / `is_param_validation_error` skips. This covers paths the FE gate can't — agent tools (`tinyplace_feed`, `tinyplace_call`) and the direct `signal_store::global_signal_store()` seed call used by `tinyplace_signal_*`.
- **Not suppression of a real defect**: only the exact expected message is reclassified (exact equality, keyed on the shared constant + a coupling test). Every other seed error — decrypt failure, key derivation, locked keychain, config-load timeout — passes through unchanged and is still reported to Sentry, so a genuine wallet defect is never masked.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — FE: 3 new Vitest cases (no RPC when unconfigured, RPC fires when configured, fall-through on unknown status) + 35 existing FeedSection tests green. Rust: 3 unit tests (expected-state classification, non-expected passthrough, constant-coupling drift guard).
- [x] **Diff coverage ≥ 80%** — the FE gate and the Rust classifier are exercised by the added tests; CI coverage gate is authoritative.
- [x] N/A: behaviour-only change, no feature row added/removed/renamed — Coverage matrix updated
- [x] N/A: no matrix change — All affected feature IDs from the matrix are listed in `## Related`
- [x] No new external network dependencies introduced — pure in-process gate + classification, no network.
- [x] N/A: no release-cut surface change — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop only; React (`FeedSection`) + Rust-core change. Removes a recurring error-level Sentry event class (TAURI-RUST-FFB) for wallet-less users: the FE gate stops the call at the source for the home-feed path, and the boundary classifier covers the residual `tinyplace_*` surface.
- No user-visible behaviour change; no API, schema, or migration impact. Security-neutral (no secret handling touched).

## Related

- Closes: #3964
- Sentry-Issue: TAURI-RUST-FFB
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3964-tinyplace-wallet-not-configured-expected`
- Commit SHA: `bf523f598`

### Validation Run

- [x] Focused FE tests: `cd app && npx vitest run --config test/vitest.config.ts src/agentworld/pages/FeedSection.test.tsx` — 38/38 pass
- [x] `pnpm typecheck` — clean
- [x] ESLint on changed files — 0 errors (2 pre-existing `set-state-in-effect` warnings, no net new); `prettier --check` clean on changed files
- [x] Focused Rust tests: `cargo test --lib core::jsonrpc::tests::is_wallet_not_configured` — 3/3 pass (prior commits)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean · `cargo check` exit 0 · `cargo clippy --lib` 0 warnings on changed files (prior commits)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: wallet-less users no longer fire the home-feed RPC on mount (prevention at source); wallet-not-configured on the residual `tinyplace_*` RPC surface is no longer reported to Sentry as an internal error (defense-in-depth).
- User-visible effect: none — the feed still renders the existing "set up wallet" prompt, now without a failed round-trip.

### Parity Contract

- Legacy behavior preserved: when a wallet IS configured, the feed fetches and renders exactly as before; the JSON-RPC error message and the frontend's existing `isWalletLocked` string-match are unchanged for any path that still reaches the boundary.
- Guard/fallback/dispatch parity checks: the gate only skips the RPC on a positive "no wallet" signal; an inconclusive wallet_status fetch falls through to the call so behaviour is unchanged on transport errors. The classifier is exact-equality on the shared constant; all other seed-derivation errors keep error-level Sentry reporting.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 30d-merged for `wallet` / `tinyplace` / `home_feed`)
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for wallet not configured scenarios. The application now properly recognizes this as an expected user state rather than an exception, reducing unnecessary error logging and providing clearer feedback.

* **Tests**
  * Added test coverage for wallet configuration error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
