### PR TITLE
fix(chat): don't fold a pipe-bearing prose line into a preceding table

### DIFF
--- a/app/src/utils/__tests__/agentMessageBubbles.test.ts
+++ b/app/src/utils/__tests__/agentMessageBubbles.test.ts
@@ -64,6 +64,16 @@ describe('splitAgentMessageIntoBubbles', () => {
     ]);
   });
 
+  it('keeps a table whose first data row carries a code-span pipe as one readable block', () => {
+    // splitMarkdownTableCells splits naively on "|", so a genuine first data row
+    // with a pipe inside a code span over-counts its cells (3 vs the header's 2).
+    // Dropping it would leave a header+separator-only block that renders as an
+    // empty-row table and detaches the real row; keeping the first data row makes
+    // parseMarkdownTable return null so the block falls back to readable markdown.
+    const content = '| Command | Use |\n| --- | --- |\n| `ps aux | grep node` | Find it |';
+    expect(splitAgentMessageIntoBubbles(content)).toEqual([content]);
+  });
+
   it('keeps double-newline paragraphs in the same bubble', () => {
     const content = 'First line\nSecond line\n\nThird paragraph\nFourth line';
     expect(splitAgentMessageIntoBubbles(content)).toEqual([

--- a/app/src/utils/__tests__/agentMessageBubbles.test.ts
+++ b/app/src/utils/__tests__/agentMessageBubbles.test.ts
@@ -51,6 +51,19 @@ describe('splitAgentMessageIntoBubbles', () => {
     ]);
   });
 
+  it('does not absorb a following prose line whose pipes give a different column count', () => {
+    // The prose line satisfies looksLikeMarkdownTableRow (it contains pipes) but
+    // has 3 "cells" vs the table's 2; absorbing it makes parseMarkdownTable
+    // reject the block (null), suppressing the table renderer and merging the
+    // prose into the table bubble.
+    const content =
+      '| Plan | Cost |\n| --- | --- |\n| Basic | $10 |\nEither pick Basic | Pro, then run `ps aux | grep node`.';
+    expect(splitAgentMessageIntoBubbles(content)).toEqual([
+      '| Plan | Cost |\n| --- | --- |\n| Basic | $10 |',
+      'Either pick Basic | Pro, then run `ps aux | grep node`.',
+    ]);
+  });
+
   it('keeps double-newline paragraphs in the same bubble', () => {
     const content = 'First line\nSecond line\n\nThird paragraph\nFourth line';
     expect(splitAgentMessageIntoBubbles(content)).toEqual([

--- a/app/src/utils/agentMessageBubbles.ts
+++ b/app/src/utils/agentMessageBubbles.ts
@@ -53,15 +53,23 @@ export function splitAgentMessageIntoBubbles(content: string): string[] {
       // absorbed into the table — otherwise parseMarkdownTable rejects the
       // mismatched block (returns null), suppressing the table UI and merging
       // the prose line into the table bubble.
+      //
+      // Always keep at least the first data row, though: splitMarkdownTableCells
+      // splits naively on "|" and does not honor escaped "\|" or pipes inside
+      // code spans, so a genuine first row carrying such a pipe over-counts its
+      // cells. Dropping it here would leave a header+separator-only block that
+      // parseMarkdownTable renders as an empty-row table (and detaches the real
+      // row). Keeping it preserves the count mismatch so parseMarkdownTable
+      // returns null and the block falls back to readable raw markdown.
       const headerCellCount = splitMarkdownTableCells(line).length;
       const tableLines = [line, lines[index + 1]];
       index += 2;
-      while (
-        index < lines.length &&
-        looksLikeMarkdownTableRow(lines[index]) &&
-        splitMarkdownTableCells(lines[index]).length === headerCellCount
-      ) {
+      let dataRowsAbsorbed = 0;
+      while (index < lines.length && looksLikeMarkdownTableRow(lines[index])) {
+        const matches = splitMarkdownTableCells(lines[index]).length === headerCellCount;
+        if (!matches && dataRowsAbsorbed > 0) break;
         tableLines.push(lines[index]);
+        dataRowsAbsorbed += 1;
         index += 1;
       }
       index -= 1;

--- a/app/src/utils/agentMessageBubbles.ts
+++ b/app/src/utils/agentMessageBubbles.ts
@@ -47,9 +47,20 @@ export function splitAgentMessageIntoBubbles(content: string): string[] {
       if (currentLines.length > 0) {
         flushCurrent();
       }
+      // A prose line that merely contains a pipe (e.g. "pick A | B, then run
+      // `ps aux | grep x`") satisfies looksLikeMarkdownTableRow but is not a
+      // table row. Require the same column count as the header so it isn't
+      // absorbed into the table — otherwise parseMarkdownTable rejects the
+      // mismatched block (returns null), suppressing the table UI and merging
+      // the prose line into the table bubble.
+      const headerCellCount = splitMarkdownTableCells(line).length;
       const tableLines = [line, lines[index + 1]];
       index += 2;
-      while (index < lines.length && looksLikeMarkdownTableRow(lines[index])) {
+      while (
+        index < lines.length &&
+        looksLikeMarkdownTableRow(lines[index]) &&
+        splitMarkdownTableCells(lines[index]).length === headerCellCount
+      ) {
         tableLines.push(lines[index]);
         index += 1;
       }


### PR DESCRIPTION
## Summary

- `splitAgentMessageIntoBubbles` extended a markdown-table block with every following line that `looksLikeMarkdownTableRow` (merely contains a pipe and ≥2 cells), regardless of column count.
- A normal prose line containing pipes — e.g. a shell snippet `run `'`ps aux | grep node`'` — was absorbed into the table; since its column count differs, `parseMarkdownTable` then rejects the block (returns `null`), so the table renderer never fires and the prose is merged into the table bubble.
- Only absorb continuation rows whose column count matches the header (matching `parseMarkdownTable`).

## Problem

The table-grouping loop used `looksLikeMarkdownTableRow` alone, which is true for any line with a pipe and 2+ cells. A common assistant reply — a table immediately followed by prose that contains a pipe (shell commands, "A | B" choices, etc.) — folded that prose line into the table segment. `parseMarkdownTable` requires every row to match the header column count, so the mismatched block becomes `null`: the dedicated table UI is suppressed and the prose line is rendered inside the table bubble.

## Solution

- Capture the header column count and require each continuation row to match it before absorbing it into the table block. A pipe-bearing prose line with a different cell count now starts its own bubble, and the table renders correctly.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case) — added a regression test; the existing table tests cover the happy path
- [x] **Diff coverage ≥ 80%** — the changed function is exercised by the `splitAgentMessageIntoBubbles` suite (`vitest`, 23 tests pass)
- [N/A] Coverage matrix updated — behaviour-only fix to already-covered code
- [N/A] Affected feature IDs under `## Related` — no matrix rows change
- [x] No new external network dependencies introduced — pure function, no I/O
- [N/A] Manual smoke checklist — does not touch release-cut surfaces
- [N/A] Linked issue — found via code review; no existing issue

## Proof

The new test feeds a 2-column table followed by `Either pick Basic | Pro, then run `'`ps aux | grep node`'.` (3 "cells"). On `main` the prose is folded into the table segment; with this change it becomes its own bubble and the table segment stays clean. Fails before, passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed message bubble parsing so prose lines containing pipe characters no longer get merged into preceding markdown tables when the table’s column structure doesn’t match.  
  * Improved markdown table bubble grouping so pipes inside inline code within the first data row don’t break the table into multiple bubbles.

* **Tests**
  * Added coverage for table/prose separation and for inline-code pipes within tables to ensure consistent message bubble rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->