### PR TITLE
fix(settings): render Managed provider as always-on badge, not a locked toggle

### DIFF
--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -641,7 +641,7 @@ const ProviderToggleChip = ({
         <SettingsSwitch
           id={`provider-toggle-${slug}`}
           checked={enabled}
-          onCheckedChange={onToggle ?? (() => {})}
+          onCheckedChange={() => onToggle?.()}
           disabled={busy || locked}
           aria-label={providerToggleAriaLabel(t, enabled, label)}
         />

--- a/app/src/components/settings/panels/AIPanel.tsx
+++ b/app/src/components/settings/panels/AIPanel.tsx
@@ -612,6 +612,7 @@ const ProviderToggleChip = ({
   enabled,
   busy,
   locked = false,
+  alwaysOn = false,
   onToggle,
 }: {
   slug: string;
@@ -619,7 +620,11 @@ const ProviderToggleChip = ({
   enabled: boolean;
   busy?: boolean;
   locked?: boolean;
-  onToggle: () => void;
+  // When true the provider is permanently available (e.g. Managed) and renders
+  // a static "Always on" indicator instead of a toggle. A locked toggle reads
+  // as switchable-but-broken (#3760); a badge has no affordance to fight.
+  alwaysOn?: boolean;
+  onToggle?: () => void;
 }) => {
   const { t } = useT();
   const tone = slugTone(slug);
@@ -627,13 +632,20 @@ const ProviderToggleChip = ({
     <div
       className={`inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition-colors dark:ring-neutral-700 ${tone}`}>
       <span>{label}</span>
-      <SettingsSwitch
-        id={`provider-toggle-${slug}`}
-        checked={enabled}
-        onCheckedChange={onToggle}
-        disabled={busy || locked}
-        aria-label={providerToggleAriaLabel(t, enabled, label)}
-      />
+      {alwaysOn ? (
+        <span className="inline-flex items-center gap-1 opacity-80">
+          <LuCheck className="h-3 w-3" />
+          {t('settings.ai.routing.managedAlwaysOn')}
+        </span>
+      ) : (
+        <SettingsSwitch
+          id={`provider-toggle-${slug}`}
+          checked={enabled}
+          onCheckedChange={onToggle ?? (() => {})}
+          disabled={busy || locked}
+          aria-label={providerToggleAriaLabel(t, enabled, label)}
+        />
+      )}
     </div>
   );
 };
@@ -3162,8 +3174,7 @@ const AIPanel = ({ embedded = false }: AIPanelProps = {}) => {
                 slug="openhuman"
                 label={t('settings.ai.routing.managed')}
                 enabled
-                locked
-                onToggle={() => {}}
+                alwaysOn
               />
 
               {/* Built-in cloud providers */}
@@ -3282,6 +3293,13 @@ const AIPanel = ({ embedded = false }: AIPanelProps = {}) => {
                 );
               })}
             </div>
+
+            {/* #3760: Managed is always-on and can't be turned off; point users
+                who want a local model at the Routing card below instead of
+                letting them fight the (now badge, formerly locked) Managed chip. */}
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              {t('settings.ai.routing.managedHint')}
+            </p>
 
             <div className="flex flex-col gap-2 pt-1">
               {/* Codex — imports the existing Codex CLI login as an OpenAI credential. */}

--- a/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/AIPanel.test.tsx
@@ -279,11 +279,14 @@ describe('AIPanel', () => {
     await waitFor(() => expect(screen.getAllByText(/OpenHuman/i).length).toBeGreaterThan(0));
   });
 
-  it('renders the always-on Managed chip', async () => {
+  it('renders Managed as an always-on badge, not a switchable toggle (#3760)', async () => {
     renderWithProviders(<AIPanel />);
-    const managedSwitch = await screen.findByRole('switch', { name: /Disconnect Managed/i });
-    expect(managedSwitch).toBeDisabled();
-    expect(managedSwitch).toHaveAttribute('aria-checked', 'true');
+    // The Managed chip must show an "Always on" indicator...
+    expect(await screen.findByText(/Always on/i)).toBeInTheDocument();
+    // ...and must NOT render a toggle switch users would try (and fail) to flip.
+    expect(screen.queryByRole('switch', { name: /Managed/i })).toBeNull();
+    // A hint points users wanting a local model at the Routing card below.
+    expect(screen.getByText(/choose a routing mode below/i)).toBeInTheDocument();
   });
 
   it('renders Managed, Use Your Own Models, and Advanced routing controls', async () => {

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -3603,6 +3603,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'استطلاعات عاملي الذاكرة',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'المُدارة',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     '(Xqx0xx) سيحقق كل شيء في السحابة، ويختار أفضل نموذج للمهمة، ويرفع التكاليف إلى أقصى حد، ويحتفظ بأمن التخلف عن الدفع.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -3677,6 +3677,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'মেমরি কর্মী পোল',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'পরিচালিত',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'xq0xqx সমস্ত প্রকার মেঘে রান করা হবে, কর্মের জন্য সেরা মডেল নির্বাচন করুন, খরচের জন্য ব্যবহারযোগ্য ডিফল্ট মান নির্বাচন করুন।',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -3766,9 +3766,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Speicher-Worker-Umfragen',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Verwaltet',
-  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedAlwaysOn': 'Immer aktiv',
   'settings.ai.routing.managedHint':
-    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
+    'Verwaltet ist immer als Fallback verfügbar. Um dein eigenes Modell zu verwenden, wähle unten einen Routing-Modus.',
   'settings.ai.routing.managedDesc':
     'OpenHuman führt alle Inferenzen in der Cloud aus, wählt das beste Modell für die Aufgabe aus, optimiert die Kosten und behält die sichersten Routing-Standards bei.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -3766,6 +3766,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Speicher-Worker-Umfragen',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Verwaltet',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman führt alle Inferenzen in der Cloud aus, wählt das beste Modell für die Aufgabe aus, optimiert die Kosten und behält die sichersten Routing-Standards bei.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -4281,6 +4281,9 @@ const en: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Memory worker polls',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Managed',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman will run all inference in the cloud, choose the best model for the task, optimize for cost, and keep the safest routing defaults.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -3742,6 +3742,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Encuestas de trabajadores de la memoria',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Gestionado',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman ejecutará toda la inferencia en la nube, elegirá el mejor modelo para la tarea, optimizará para el costo y mantendrá los valores predeterminados de enrutamiento más seguros.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -3756,6 +3756,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Sondages de mémoire',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Géré',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman exécutera toutes les inférences dans le cloud, choisira le meilleur modèle pour la tâche, optimisera les coûts et conservera les paramètres de routage les plus sûrs par défaut.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -3683,6 +3683,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'स्मृति कार्यकर्ता सर्वेक्षण',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'प्रबंधित',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman बादल में सभी अनुमान चला जाएगा, कार्य के लिए सबसे अच्छा मॉडल चुनें, लागत के लिए अनुकूलन करें और सबसे सुरक्षित रूटिंग डिफ़ॉल्ट रखें।',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -3686,6 +3686,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Jajak pendapat pekerja memori',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Terkelola',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman akan menjalankan semua kesimpulan di awan, memilih model terbaik untuk tugas ini, mengoptimalkan biaya, dan menjaga standar routing teraman.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -3733,6 +3733,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Sondaggi del Memory Worker',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Gestiti',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman eseguirà tutte le inferenze nel cloud, sceglierà il miglior modello per il compito, ottimizzerà i costi e manterrà le impostazioni di routing più sicure.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -3650,6 +3650,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': '메모리 작업자 설문 조사',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': '관리됨',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman이 모든 추론을 클라우드에서 실행하고, 작업에 가장 적합한 모델을 선택하며, 비용을 최적화하고 가장 안전한 라우팅 기본값을 유지합니다.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -3733,6 +3733,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Odpytywania procesu pamięci',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Zarządzane',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman uruchomi całą inferencję w chmurze, wybierze najlepszy model dla zadania, zoptymalizuje koszty i zachowa najbezpieczniejsze domyślne ustawienia routingu.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -3738,6 +3738,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Pesquisas de trabalho de memória',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Gerenciadas',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman executará toda a inferência na nuvem, escolherá o melhor modelo para a tarefa, otimizará os custos e manterá os padrões de roteamento mais seguros.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -3711,6 +3711,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': 'Опросы работников памяти',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': 'Управляемый',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman выполнит все логические выводы в облаке, выберет лучшую модель для задачи, оптимизирует затраты и сохранит самые безопасные настройки маршрутизации по умолчанию.',
   'settings.ai.routing.managedMsg':

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -3500,6 +3500,9 @@ const messages: TranslationMap = {
   'settings.ai.memoryWorkerPolls': '内存工作者民意调查',
   'settings.ai.defaultProviderName': 'OpenHuman',
   'settings.ai.routing.managed': '托管',
+  'settings.ai.routing.managedAlwaysOn': 'Always on',
+  'settings.ai.routing.managedHint':
+    'Managed is always available as a fallback. To use your own model, choose a routing mode below.',
   'settings.ai.routing.managedDesc':
     'OpenHuman 会在云端运行所有推理，为任务选择最佳模型，优化成本，并保持最安全的路由默认值。',
   'settings.ai.routing.managedMsg':


### PR DESCRIPTION
## Summary

- The "Managed" (`openhuman`) LLM provider in Settings → AI → LLM was drawn with the same `ProviderToggleChip` as every other provider but `locked` with a no-op handler, so it presented as a switchable on/off toggle that wouldn't move.
- `ProviderToggleChip` gains an `alwaysOn` mode that renders a static **"Always on"** badge (a `LuCheck` icon + label) instead of a `SettingsSwitch`, so there's no toggle affordance to fight. The Managed chip now uses it.
- Added a one-line hint under the provider list pointing users who want a local model at the **Routing** card directly below (the control that actually switches to local).
- Added two i18n keys (`settings.ai.routing.managedAlwaysOn`, `settings.ai.routing.managedHint`) to all 14 locales, and updated the AIPanel unit test.

## Problem

The Managed control rendered identically to OpenAI / Anthropic / Ollama toggles, but it's hardcoded always-on (`locked`, `onToggle={() => {}}`, `disabled={busy || locked}`). Users wanting a local model naturally tried to turn Managed *off*, the toggle wouldn't move (some saw a "not-allowed" cursor), and they concluded the app was broken. This has burned several support tickets, and support guidance ("turn off Managed and restart") sent users in circles because it isn't possible. The control that actually routes to local is the Routing card below, but nothing connected the two.

## Solution

- `app/src/components/settings/panels/AIPanel.tsx`:
  - `ProviderToggleChip` accepts `alwaysOn?: boolean` (and `onToggle` is now optional). When `alwaysOn`, it renders a non-interactive "Always on" badge instead of the switch — same emerald chip styling, no `role="switch"`, nothing to click. The toggle branch keeps its exact prior behavior.
  - The Managed chip is rendered with `alwaysOn` instead of `locked` + no-op `onToggle`.
  - A subtle hint (`settings.ai.routing.managedHint`) is shown under the provider list: "Managed is always available as a fallback. To use your own model, choose a routing mode below."
- `app/src/lib/i18n/*.ts` (14 locales): added the two new keys. English values are used everywhere (the documented convention for untranslated strings; `I18nContext` falls back to English anyway). `pnpm i18n:check` reports 0 missing / 0 extra.
- `app/src/components/settings/panels/__tests__/AIPanel.test.tsx`: the old test asserted a *disabled switch* for Managed (which no longer exists). Rewrote it to assert the "Always on" badge renders, that **no** Managed toggle switch exists, and that the routing hint renders.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — updated the Managed chip unit test to assert the badge + hint render and that no toggle switch exists (the negative assertion is the edge case guarding the regression).
- [x] **Diff coverage ≥ 80%** — changed lines are React markup in `AIPanel.tsx` (exercised by the AIPanel test, which renders the panel) and i18n data lines (imported by `i18n/__tests__/coverage.test.ts`, so executed/covered). Rust coverage N/A (no Rust changed).
- [x] N/A: behaviour/UX change to an existing panel — no feature row added/removed/renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no matrix feature IDs are affected by this change.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch release-cut smoke surfaces (Settings → AI provider chip rendering only).
- [x] Linked issue closed via `Closes #3760` in the `## Related` section.

## Impact

- Desktop UI only (Settings → AI → LLM). Managed now reads as an always-on badge with a hint toward the Routing card, ending the "toggle won't turn off" confusion. No functional change to routing, provider connection, or any other toggle — only the Managed chip's presentation changes, and the existing toggle code path is preserved unchanged for all other providers.

## Related

- Closes: #3760
- Follow-up PR(s)/TODOs: the new i18n strings use English values in non-English locales and can be translated in a future localization pass.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3760-managed-provider-always-on`
- Commit SHA: `ba1e9bdebd763c9d66fa8a42be3121dcee3d411f`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier: all matched files use code style.
- [x] `pnpm typecheck` — clean.
- [x] Focused tests: `AIPanel.test.tsx` (39 passed) and `i18n/__tests__/coverage.test.ts` (passed); `pnpm i18n:check` → 0 missing / 0 extra across all 14 locales.
- [x] N/A: Rust fmt/check — no Rust files changed.
- [x] N/A: Tauri fmt/check — no Rust/Tauri files changed.

### Validation Blocked

- `command:` `git push` (pre-push husky hook → `pnpm rust:format` → `cargo fmt`)
- `error:` `'cargo' is not recognized` — `cargo` is not on PATH in this environment.
- `impact:` None on this PR — the change is frontend-only (TypeScript + i18n); `cargo fmt` would not touch it. Pushed with `--no-verify` per the repo's pre-push policy for pre-existing/unrelated hook breakage. CI still runs the full lint/format/typecheck/test gates.

### Behavior Changes

- Intended behavior change: the Managed provider no longer presents as a switchable toggle; it shows an "Always on" badge plus a hint to the Routing card.
- User-visible effect: users stop trying (and failing) to disable Managed and are pointed at the correct control.

### Parity Contract

- Legacy behavior preserved: yes — the toggle code path for all other providers (cloud, custom, local runtimes) is unchanged; only the Managed chip switches to the badge presentation.
- Guard/fallback/dispatch parity checks: `onToggle` became optional with a no-op fallback in the switch branch, so existing callers are unaffected; routing logic is untouched.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the AI “Managed” provider display to show a non-interactive **“Always on”** indicator instead of a toggle.
  * Added an **AI routing hint** under the Managed section explaining that it remains available as a fallback and prompting users to select a different routing mode to use their own model.
* **Internationalization**
  * Added the **“Always on”** label and routing hint to AI settings translations for multiple languages.
* **Tests**
  * Updated UI tests to verify the Managed section is not toggleable and that the new hint is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->