### PR TITLE
fix(tools): App UI Control toggle grants click/type mutations (#3762)

### DIFF
--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -350,41 +350,67 @@ impl Agent {
         let profile_mcp_allowlist: Option<Vec<String>> =
             profile.and_then(|p| p.allowed_mcp_servers.clone());
 
-        let mut tools = tools::all_tools_with_runtime(
-            Arc::new(config.clone()),
-            &security,
-            runtime,
-            audit,
-            memory.clone(),
-            &config.browser,
-            &config.http_request,
-            &config.action_dir,
-            &config.agents,
-            config,
-            profile_skill_allowlist.as_ref(),
-            profile_mcp_allowlist.as_deref(),
-        );
-
-        // Filter tools by user preference stored in app state.
-        {
+        // Load the user's persisted tool preferences once. They drive two
+        // things below: granting the App UI Control / App Automation mutation
+        // opt-in (#3762) and filtering the tool set to the enabled snapshot.
+        let enabled_tools: Vec<String> = {
             use crate::openhuman::app_state::load_stored_app_state;
             match load_stored_app_state(config) {
-                Ok(stored) => {
-                    if let Some(ref tasks) = stored.onboarding_tasks {
-                        if !tasks.enabled_tools.is_empty() {
-                            crate::openhuman::tools::filter_tools_by_user_preference(
-                                &mut tools,
-                                &tasks.enabled_tools,
-                            );
-                        }
-                    }
-                }
+                Ok(stored) => stored
+                    .onboarding_tasks
+                    .map(|tasks| tasks.enabled_tools)
+                    .unwrap_or_default(),
                 Err(e) => {
                     log::warn!(
                         "[session-builder] failed to load app state for tool filtering: {e}"
                     );
+                    Vec::new()
                 }
             }
+        };
+
+        // Enabling the "App UI Control" (`ax_interact`) or "App Automation"
+        // (`automate`) tool in Settings → Features grants the mutating
+        // click/type actions its description promises — not just the read-only
+        // `list`. Previously those actions required the UI-less
+        // `computer_control.ax_interact_mutations` flag or Full autonomy, so the
+        // toggle silently did nothing on the default (Supervised) autonomy
+        // (#3762). The actions stay approval-gated and bound by the
+        // sensitive-app denylist; Full autonomy continues to grant this
+        // independently via `app_control_enabled`.
+        let adjusted_config: Config;
+        let tool_config: &Config = if !config.computer_control.ax_interact_mutations
+            && tools::enables_app_ui_control_mutations(&enabled_tools)
+        {
+            let mut c = config.clone();
+            c.computer_control.ax_interact_mutations = true;
+            log::debug!(
+                "[session-builder] action=grant_app_ui_control_mutations source=features_toggle"
+            );
+            adjusted_config = c;
+            &adjusted_config
+        } else {
+            config
+        };
+
+        let mut tools = tools::all_tools_with_runtime(
+            Arc::new(tool_config.clone()),
+            &security,
+            runtime,
+            audit,
+            memory.clone(),
+            &tool_config.browser,
+            &tool_config.http_request,
+            &tool_config.action_dir,
+            &tool_config.agents,
+            tool_config,
+            profile_skill_allowlist.as_ref(),
+            profile_mcp_allowlist.as_deref(),
+        );
+
+        // Filter tools by the user preference loaded above.
+        if !enabled_tools.is_empty() {
+            crate::openhuman::tools::filter_tools_by_user_preference(&mut tools, &enabled_tools);
         }
 
         if read_only_tools_only {

--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -353,12 +353,6 @@ impl Agent {
         // Load the user's persisted tool preferences once. They drive two
         // things below: granting the App UI Control / App Automation mutation
         // opt-in (#3762) and filtering the tool set to the enabled snapshot.
-        // Set when app-state load fails outright (a genuine IO/decrypt error —
-        // missing files and quarantined-invalid JSON already resolve to an Ok
-        // default upstream). On such a failure we cannot know the user's tool
-        // opt-ins, so we fail closed to read-only tools below rather than expose
-        // the full mutating set the user never opted into (#3762 review).
-        let mut app_state_load_failed = false;
         let enabled_tools: Vec<String> = {
             use crate::openhuman::app_state::load_stored_app_state;
             match load_stored_app_state(config) {
@@ -367,11 +361,9 @@ impl Agent {
                     .map(|tasks| tasks.enabled_tools)
                     .unwrap_or_default(),
                 Err(e) => {
-                    log::error!(
-                        "[session-builder] failed to load app state for tool filtering; \
-                         failing closed to read-only tools: {e}"
+                    log::warn!(
+                        "[session-builder] failed to load app state for tool filtering: {e}"
                     );
-                    app_state_load_failed = true;
                     Vec::new()
                 }
             }
@@ -421,19 +413,16 @@ impl Agent {
             crate::openhuman::tools::filter_tools_by_user_preference(&mut tools, &enabled_tools);
         }
 
-        if read_only_tools_only || app_state_load_failed {
+        if read_only_tools_only {
             let before = tools.len();
             tools.retain(|tool| {
                 tool.permission_level() <= tools::PermissionLevel::ReadOnly
                     && !matches!(tool.scope(), tools::ToolScope::CliRpcOnly)
             });
             log::info!(
-                "[agent::builder] read-only tool filter applied: before={} after={} \
-                 (read_only_request={} app_state_load_failed={})",
+                "[agent::builder] read-only tool filter applied: before={} after={}",
                 before,
-                tools.len(),
-                read_only_tools_only,
-                app_state_load_failed
+                tools.len()
             );
         }
 

--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -353,6 +353,12 @@ impl Agent {
         // Load the user's persisted tool preferences once. They drive two
         // things below: granting the App UI Control / App Automation mutation
         // opt-in (#3762) and filtering the tool set to the enabled snapshot.
+        // Set when app-state load fails outright (a genuine IO/decrypt error —
+        // missing files and quarantined-invalid JSON already resolve to an Ok
+        // default upstream). On such a failure we cannot know the user's tool
+        // opt-ins, so we fail closed to read-only tools below rather than expose
+        // the full mutating set the user never opted into (#3762 review).
+        let mut app_state_load_failed = false;
         let enabled_tools: Vec<String> = {
             use crate::openhuman::app_state::load_stored_app_state;
             match load_stored_app_state(config) {
@@ -361,9 +367,11 @@ impl Agent {
                     .map(|tasks| tasks.enabled_tools)
                     .unwrap_or_default(),
                 Err(e) => {
-                    log::warn!(
-                        "[session-builder] failed to load app state for tool filtering: {e}"
+                    log::error!(
+                        "[session-builder] failed to load app state for tool filtering; \
+                         failing closed to read-only tools: {e}"
                     );
+                    app_state_load_failed = true;
                     Vec::new()
                 }
             }
@@ -413,16 +421,19 @@ impl Agent {
             crate::openhuman::tools::filter_tools_by_user_preference(&mut tools, &enabled_tools);
         }
 
-        if read_only_tools_only {
+        if read_only_tools_only || app_state_load_failed {
             let before = tools.len();
             tools.retain(|tool| {
                 tool.permission_level() <= tools::PermissionLevel::ReadOnly
                     && !matches!(tool.scope(), tools::ToolScope::CliRpcOnly)
             });
             log::info!(
-                "[agent::builder] read-only tool filter applied: before={} after={}",
+                "[agent::builder] read-only tool filter applied: before={} after={} \
+                 (read_only_request={} app_state_load_failed={})",
                 before,
-                tools.len()
+                tools.len(),
+                read_only_tools_only,
+                app_state_load_failed
             );
         }
 

--- a/src/openhuman/tools/mod.rs
+++ b/src/openhuman/tools/mod.rs
@@ -63,4 +63,4 @@ pub use traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolContent, ToolResult, ToolScope,
     ToolSpec,
 };
-pub(crate) use user_filter::filter_tools_by_user_preference;
+pub(crate) use user_filter::{enables_app_ui_control_mutations, filter_tools_by_user_preference};

--- a/src/openhuman/tools/user_filter.rs
+++ b/src/openhuman/tools/user_filter.rs
@@ -354,6 +354,30 @@ fn expand_enabled_tool_names(enabled_tool_names: &[String]) -> HashSet<String> {
     expanded
 }
 
+/// True when the persisted tool-preference snapshot opts into the mutating
+/// app-control actions — i.e. the user enabled "App UI Control" (`ax_interact`)
+/// or "App Automation" (`automate`) in Settings → Features → Tools.
+///
+/// Those tools' descriptions promise clicking buttons and typing into fields,
+/// but enabling the toggle alone only made the read-only `list` action
+/// available — the mutating `press` / `set_value` actions required a separate,
+/// UI-less `computer_control.ax_interact_mutations` flag or Full autonomy
+/// (#3762). The session builder uses this to treat enabling the tool as the
+/// user-facing opt-in for those mutations, equivalent to setting that flag. The
+/// actions stay approval-gated and bound by the sensitive-app denylist.
+///
+/// Reuses [`expand_enabled_tool_names`] so it is robust to both persisted
+/// formats (UI toggle ids or Rust tool names). An empty snapshot ("not yet
+/// configured" / all-enabled) is treated as no explicit opt-in, preserving the
+/// safe default.
+pub(crate) fn enables_app_ui_control_mutations(enabled_tool_names: &[String]) -> bool {
+    if enabled_tool_names.is_empty() {
+        return false;
+    }
+    let expanded = expand_enabled_tool_names(enabled_tool_names);
+    expanded.contains("ax_interact") || expanded.contains("automate")
+}
+
 /// Given the list of enabled tools from app state, retain only tools that are
 /// either infrastructure (not filterable), explicitly enabled, or a default-ON
 /// capability the snapshot never explicitly opted out of.
@@ -601,5 +625,33 @@ mod tests {
         let mut t = tools(&["cron_add", "service_start"]);
         filter_tools_by_user_preference(&mut t, &["totally_unknown".to_string()]);
         assert_eq!(names(&t).len(), 2);
+    }
+
+    // #3762: enabling the App UI Control / App Automation tool is the opt-in
+    // for the mutating click/type actions.
+    #[test]
+    fn app_ui_control_opt_in_detects_ax_interact_and_automate() {
+        assert!(enables_app_ui_control_mutations(&[
+            "ax_interact".to_string()
+        ]));
+        assert!(enables_app_ui_control_mutations(&["automate".to_string()]));
+        // Present alongside other enabled tools.
+        assert!(enables_app_ui_control_mutations(&[
+            "cron_add".to_string(),
+            "automate".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn app_ui_control_opt_in_false_when_absent_or_empty() {
+        assert!(!enables_app_ui_control_mutations(&[]));
+        assert!(!enables_app_ui_control_mutations(&[
+            "cron_add".to_string(),
+            "service_start".to_string(),
+        ]));
+        // Unknown entries never opt in.
+        assert!(!enables_app_ui_control_mutations(&[
+            "totally_unknown".to_string()
+        ]));
     }
 }

--- a/src/openhuman/tools/user_filter.rs
+++ b/src/openhuman/tools/user_filter.rs
@@ -466,7 +466,10 @@ pub(crate) fn filter_tools_by_user_preference(
 
 #[cfg(test)]
 mod tests {
-    use super::{expand_enabled_tool_names, filter_tools_by_user_preference};
+    use super::{
+        enables_app_ui_control_mutations, expand_enabled_tool_names,
+        filter_tools_by_user_preference,
+    };
     use crate::openhuman::tools::traits::{Tool, ToolResult};
     use async_trait::async_trait;
 


### PR DESCRIPTION
## Summary

The "App UI Control" (`ax_interact`) / "App Automation" (`automate`) toggle in Settings → Features → Tools is described as letting the agent "click buttons, type in fields," but enabling it only made the read-only `list` action available. The mutating `press` / `set_value` actions are gated by `app_control_enabled()`, which required either `computer_control.ax_interact_mutations` (a config flag with **no UI**) or Full autonomy — so on the default Supervised autonomy the toggle silently did nothing its description promised.

## Fix

Backend-only, no new RPC. The agent session builder (`factory.rs`) already loads the user's enabled-tools snapshot to filter the tool set, so it has both `config` and the enabled list in one place. Enabling the tool is now treated as the user-facing opt-in for its mutations:

- `src/openhuman/tools/user_filter.rs` — `enables_app_ui_control_mutations(enabled_tools)`: true when the persisted snapshot contains `ax_interact` or `automate`. Reuses `expand_enabled_tool_names` so it handles both persisted formats (UI ids / Rust tool names); empty snapshot → false (safe default). + unit tests.
- `src/openhuman/tools/mod.rs` — re-export the helper.
- `src/openhuman/agent/harness/session/builder/factory.rs` — load the enabled-tools snapshot once; if the toggle opts in and the flag isn't already set, build the tools with a config clone where `computer_control.ax_interact_mutations = true`.

The mutating actions **remain approval-gated** (they return `external_effect_with_args == true` → ApprovalGate) and bound by the sensitive-app denylist. Full autonomy continues to grant this independently via `app_control_enabled`.

## Acceptance criteria

- [x] Enabling "App UI Control" / "App Automation" lets the agent click/type, subject to the normal approval gate.
- [x] No remaining mismatch between the toggle's "click buttons, type in fields" description and what enabling it does — so no description/UI change was needed.

## Tests

Unit tests added for the opt-in helper (present / absent / empty / unknown). The decision logic lives in that tested helper; `factory.rs` is thin wiring. Not run locally (per workflow); CI executes them.

Closes #3762<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application of persisted tool preferences during session initialization, ensuring enabled tools take effect more consistently.
  * Added “fail-closed” behavior on load failure by restricting tools to read-only when appropriate.

* **Tests**
  * Extended unit test coverage for tool preference filtering, including new logic for detecting opt-in UI mutation permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->