### PR TITLE
fix(local_ai): reject ollama.com website as Ollama base URL (#3991, TAURI-RUST-A3T)

### DIFF
--- a/src/openhuman/inference/local/ollama.rs
+++ b/src/openhuman/inference/local/ollama.rs
@@ -4,6 +4,44 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434";
 
+/// Hosts that serve the public Ollama website / model registry — never a local
+/// or self-hosted Ollama API server. Pointing the base URL at one makes every
+/// `/api/tags` poll hit ollama.com (HTTP 429 from its rate limiter), floods
+/// Sentry with `list_models: non-success response`, and sends pointless traffic
+/// to Ollama Inc. (TAURI-RUST-A3T).
+///
+/// Matched **exactly** (no suffix match) so a user's own self-hosted server at
+/// e.g. `ollama.mycompany.com` is unaffected.
+fn is_ollama_registry_host(host: &str) -> bool {
+    matches!(
+        host.trim()
+            .trim_end_matches('.')
+            .to_ascii_lowercase()
+            .as_str(),
+        "ollama.com" | "www.ollama.com" | "ollama.ai" | "www.ollama.ai" | "registry.ollama.ai"
+    )
+}
+
+/// Returns `url` unless its host is a public Ollama registry host
+/// ([`is_ollama_registry_host`]), in which case it logs a warning and falls back
+/// to [`DEFAULT_OLLAMA_BASE_URL`]. This heals stale config/env values that
+/// already target ollama.com (set before validation rejected it), so the
+/// diagnostics poller stops hitting the website on the next launch.
+fn reject_registry_host_or_default(url: String) -> String {
+    let is_registry = reqwest::Url::parse(&url)
+        .ok()
+        .and_then(|u| u.host_str().map(is_ollama_registry_host))
+        .unwrap_or(false);
+    if is_registry {
+        log::warn!(
+            "[local_ai] ignoring Ollama base URL {} (public website/registry, not a local server) — falling back to {DEFAULT_OLLAMA_BASE_URL}",
+            redact_ollama_base_url(&url)
+        );
+        return DEFAULT_OLLAMA_BASE_URL.to_string();
+    }
+    url
+}
+
 /// Rewrite unspecified bind addresses (`0.0.0.0`, `[::]`) to their loopback
 /// equivalents (`127.0.0.1`, `[::1]`).  Ollama's default `OLLAMA_HOST` is
 /// `0.0.0.0:11434` — a valid *server-side* bind address but an invalid
@@ -46,7 +84,9 @@ pub(crate) fn ollama_base_url() -> String {
     if let Ok(url) = std::env::var("OPENHUMAN_OLLAMA_BASE_URL") {
         let trimmed = url.trim();
         if !trimmed.is_empty() {
-            return normalize_unspecified_host(trimmed.trim_end_matches('/'));
+            return reject_registry_host_or_default(normalize_unspecified_host(
+                trimmed.trim_end_matches('/'),
+            ));
         }
     }
 
@@ -59,7 +99,7 @@ pub(crate) fn ollama_base_url() -> String {
                 format!("http://{trimmed}")
             };
             log::debug!("[local_ai] ollama_base_url: using OLLAMA_HOST -> {url}");
-            return normalize_unspecified_host(&url);
+            return reject_registry_host_or_default(normalize_unspecified_host(&url));
         }
     }
 
@@ -81,7 +121,7 @@ pub(crate) fn ollama_base_url_from_config(config: &crate::openhuman::config::Con
     if let Some(ref url) = config.local_ai.base_url {
         let trimmed = url.trim().trim_end_matches('/');
         if !trimmed.is_empty() {
-            let normalized = normalize_unspecified_host(trimmed);
+            let normalized = reject_registry_host_or_default(normalize_unspecified_host(trimmed));
             log::debug!(
                 "[local_ai] ollama_base_url_from_config: using config base_url -> {}",
                 redact_ollama_base_url(&normalized)
@@ -119,6 +159,18 @@ pub(crate) fn validate_ollama_url(raw: &str) -> Result<String, String> {
 
     if parsed.host_str().map(|h| h.is_empty()).unwrap_or(true) {
         return Err("URL must have a non-empty host".to_string());
+    }
+
+    if parsed
+        .host_str()
+        .map(is_ollama_registry_host)
+        .unwrap_or(false)
+    {
+        return Err(
+            "ollama.com is the Ollama website, not a local server. Enter your local Ollama \
+             address (e.g. http://localhost:11434) or your own server's URL."
+                .to_string(),
+        );
     }
 
     if !parsed.username().is_empty() || parsed.password().is_some() {
@@ -967,6 +1019,94 @@ mod tests {
             validate_ollama_url("http://[::]:11434"),
             Ok("http://[::1]:11434".to_string())
         );
+    }
+
+    // ── public Ollama registry-host rejection (TAURI-RUST-A3T) ─────────
+
+    #[test]
+    fn is_ollama_registry_host_matches_public_hosts_case_insensitively() {
+        for host in [
+            "ollama.com",
+            "OLLAMA.COM",
+            "www.ollama.com",
+            "ollama.ai",
+            "www.ollama.ai",
+            "registry.ollama.ai",
+            "ollama.com.", // trailing FQDN dot
+        ] {
+            assert!(is_ollama_registry_host(host), "expected reject: {host}");
+        }
+    }
+
+    #[test]
+    fn is_ollama_registry_host_allows_self_hosted_and_loopback() {
+        // No suffix match: a user's own subdomain must NOT be blocked.
+        for host in [
+            "localhost",
+            "127.0.0.1",
+            "ollama.mycompany.com",
+            "my-ollama.lan",
+            "remote-ollama.example.com",
+            "notollama.com",
+        ] {
+            assert!(!is_ollama_registry_host(host), "expected allow: {host}");
+        }
+    }
+
+    #[test]
+    fn validate_ollama_url_rejects_public_registry_hosts() {
+        // The bug: ollama.com is the website/registry, not a local server.
+        // `/api/tags` against it returns HTTP 429 and floods Sentry.
+        for url in [
+            "https://ollama.com",
+            "http://ollama.com",
+            "https://ollama.com/",
+            "https://www.ollama.com:443",
+            "https://ollama.ai",
+            "https://registry.ollama.ai",
+        ] {
+            let err = validate_ollama_url(url).unwrap_err();
+            assert!(
+                err.contains("ollama.com is the Ollama website"),
+                "expected website rejection for {url}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_ollama_url_still_accepts_self_hosted_subdomain() {
+        assert_eq!(
+            validate_ollama_url("https://ollama.mycompany.com:11434"),
+            Ok("https://ollama.mycompany.com:11434".to_string())
+        );
+    }
+
+    #[test]
+    fn ollama_base_url_from_config_heals_registry_host_to_default() {
+        // Existing users who saved ollama.com before validation rejected it
+        // must stop hitting the website on the next launch.
+        let _lock = test_lock();
+        let _g = OllamaEnvGuard::clear();
+        let config = make_config_with_base_url(Some("https://ollama.com"));
+        assert_eq!(
+            ollama_base_url_from_config(&config),
+            DEFAULT_OLLAMA_BASE_URL
+        );
+    }
+
+    #[test]
+    fn ollama_base_url_heals_registry_host_from_env_override() {
+        let _lock = test_lock();
+        let _g = OllamaEnvGuard::set("https://ollama.com");
+        assert_eq!(ollama_base_url(), DEFAULT_OLLAMA_BASE_URL);
+    }
+
+    #[test]
+    fn ollama_base_url_heals_registry_host_from_ollama_host() {
+        let _lock = test_lock();
+        let _g1 = OllamaEnvGuard::clear();
+        let _g2 = OllamaEnvGuard::set_var(OLLAMA_HOST_VAR, "ollama.com");
+        assert_eq!(ollama_base_url(), DEFAULT_OLLAMA_BASE_URL);
     }
 
     // ── redact_ollama_base_url ────────────────────────────────────────

--- a/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
+++ b/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
@@ -262,7 +262,16 @@ impl LocalAiService {
 
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            tracing::error!(
+            // Defense-in-depth (TAURI-RUST-A3T): the diagnostics caller already
+            // tolerates this failure (degrades to empty models + surfaces the
+            // error to the UI as `tags_error`). A non-2xx from the configured
+            // endpoint is an external/server condition, not an openhuman code
+            // defect, so log at `warn!` (breadcrumb) instead of `error!` to
+            // avoid flooding Sentry on every diagnostics poll. The root-cause
+            // fix for the common case lives in `validate_ollama_url` /
+            // `reject_registry_host_or_default` (rejecting the ollama.com
+            // public-website host, which returns 429).
+            tracing::warn!(
                 target: "local_ai::ollama_admin",
                 %url,
                 %status,


### PR DESCRIPTION
## Summary

- Reject the public Ollama website/registry hosts (`ollama.com`, `www.ollama.com`, `ollama.ai`, `www.ollama.ai`, `registry.ollama.ai`) as the Local Model base URL — they are never a local `/api/tags` server.
- Prevent at source: `validate_ollama_url` rejects them with an actionable message, blocking new saves.
- Heal existing configs: `ollama_base_url` / `ollama_base_url_from_config` fall back to the localhost default (with a warn) when a stale config/env value still targets a registry host, so already-affected users stop hitting the website on next launch.
- Defense-in-depth: demote the tolerated diagnostics `list_models` non-success log from `error!` to `warn!` so it no longer floods Sentry on every poll.

## Problem

Sentry `TAURI-RUST-A3T` — `[local_ai:ollama_admin] list_models: non-success response`, 422 events / 3 users (all Windows, 0.57.18 → 0.57.52). Every event is identical: `429 Too Many Requests` from `https://ollama.com/api/tags`.

A user set `config.local_ai.base_url = "https://ollama.com"` — the Ollama **website / model registry**, not a local inference server. `validate_ollama_url` accepted it (syntactically valid https host). `LocalAiService::diagnostics` then polls `/api/tags` (health check + `list_models_at`, back-to-back); ollama.com rate-limits the second request → 429 → `tracing::error!` → Sentry. The diagnostics path already **tolerates** the failure (degrades to empty models + surfaces `tags_error` to the UI), so the Sentry flood was the only consequence. openhuman never seeds this value (default `None`).

**Bucket (RCA-vs-suppress gate):** preventable user-state. RCA = reject the registry host so `/api/tags` never targets the website. The `error!`→`warn!` demotion is defense-in-depth, not the headline.

## Solution

- `is_ollama_registry_host(host)` — exact host match (no suffix match), case-insensitive, trailing-dot tolerant. A self-hosted `ollama.<company>.com` is unaffected.
- `validate_ollama_url`: reject registry hosts with *"ollama.com is the Ollama website, not a local server. Enter your local Ollama address (e.g. http://localhost:11434) or your own server's URL."* — gates the Ollama-provider save path (`config/ops/model.rs`).
- `reject_registry_host_or_default`: applied in both resolve fns so stale configs/env (`OLLAMA_HOST`, `OPENHUMAN_OLLAMA_BASE_URL`, `config.local_ai.base_url`) heal to `http://localhost:11434` with a warn.
- `ollama_admin/diagnostics.rs`: `error!` → `warn!` on the non-success branch (warn maps to a Sentry breadcrumb, not an event). `return Err(...)` unchanged.

Mirrors the classify/prevent-at-source pattern from #3769 (TAURI-RUST-8X3, sibling — custom-provider 404 path; no file overlap).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — registry-host accept/reject + validate reject + resolve-heal (config/env/OLLAMA_HOST) + self-hosted-subdomain still-accepted
- [x] **Diff coverage ≥ 80%** — new logic unit-tested; existing `list_models` non-success test covers the demoted line
- [x] N/A: behaviour-only change — Coverage matrix updated
- [x] N/A: no matrix feature touched — affected feature IDs listed in `## Related`
- [x] No new external network dependencies introduced
- [x] N/A: no release-cut surface touched — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop (all platforms). **User-visible:** entering `ollama.com` as the Local Model URL now yields an actionable "that's the website, use a local address" error instead of a silent broken setup; users who already saved it auto-recover to localhost on next launch.
- Stops the Sentry flood and pointless/abusive traffic to ollama.com. No performance/security/migration impact.

## Related

- Closes #3991
- Closes: `TAURI-RUST-A3T` (self-hosted Sentry — resolved on merge via curl per Phase 7)
- Sibling: #3769 (`TAURI-RUST-8X3`) — same classify/prevent-at-source pattern, custom-provider 404 path
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3991-ollama-registry-host`
- Commit SHA: `97ae2e5d4`

### Validation Run

- [x] N/A: Rust-only change — `pnpm --filter openhuman-app format:check`
- [x] N/A: Rust-only change — `pnpm typecheck`
- [x] Focused tests: `cargo test --lib openhuman::inference::local::ollama` (51/0), `cargo test --lib ...::ollama_admin` (34/0)
- [x] Rust fmt/check: `cargo fmt --check` clean, `GGML_NATIVE=OFF cargo check` pass
- [x] N/A: no `src-tauri` change — Tauri fmt/check

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Ollama base URL pointed at the public website is rejected (new) or healed to localhost (existing); tolerated diagnostics non-success demoted from Sentry error to breadcrumb.
- User-visible effect: actionable validation error + auto-recovery; no more opaque `list_models` failure spam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for Ollama server configuration to prevent accidental misconfiguration with public registry URLs.
  * Improved error logging in diagnostics to reduce unnecessary noise.

* **Tests**
  * Added tests for URL validation and registry domain detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->