### PR TITLE
fix(observability): demote Ollama 501 'server does not support embeddings' (TAURI-RUST-8WA)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -833,7 +833,7 @@ fn is_loopback_unavailable(lower: &str) -> bool {
 /// the local Ollama daemon — pure user-state errors the UI already surfaces
 /// (toast / settings page warning) where Sentry has no remediation path.
 ///
-/// Three canonical wire shapes are covered, all emitted by
+/// Several canonical wire shapes are covered, all emitted by
 /// `openhuman::embeddings::ollama::OllamaEmbedding::embed` and the embed
 /// service fallback path:
 ///
@@ -848,21 +848,31 @@ fn is_loopback_unavailable(lower: &str) -> bool {
 ///   `ollama embed failed with status 404 Not Found: {"error":"model \"<id>\" not found, try pulling it first"}`.
 ///   (Self-hosted Sentry events still flow from older client releases that
 ///   predate this matcher; they drop off naturally as users upgrade.)
+/// - **TAURI-RUST-3X / -8WA** (~982 events on 0.57.52): 501 "embeddings not
+///   supported". Two bodies — the model is chat/vision-only
+///   (`{"error":"this model does not support embeddings"}`) or the Ollama
+///   daemon was started without embed support
+///   (`{"error":"This server does not support embeddings. Start it with `--embeddings`"}`).
+/// - **TAURI-RUST-3E** (~249 events): 401 auth-required Ollama endpoint with
+///   no credentials configured. Wire shape:
+///   `ollama embed failed with status 401 Unauthorized: {"error": "unauthorized"}`.
 /// - **OPENHUMAN-TAURI-GX**: user opted into Ollama embeddings but the
 ///   daemon isn't running on `localhost:11434`, so the embed service falls
 ///   back to cloud embeddings for the session. Wire shape:
 ///   `ollama embeddings opted-in but daemon unreachable at http://localhost:11434; falling back to cloud embeddings for this session`.
 ///
-/// All three are user-config: the user picked the wrong model id, forgot to
-/// pull it, or forgot to start the daemon. The remediation is "fix the
-/// model id in Settings" / "run `ollama pull <id>`" / "start ollama" —
-/// none of which Sentry can do for them.
+/// All are user-config: the user picked the wrong model id, forgot to pull
+/// it, ran a daemon without embed support, omitted credentials, or forgot to
+/// start the daemon. The remediation is "fix the model id in Settings" /
+/// "run `ollama pull <id>`" / "start ollama with `--embeddings`" / "add a
+/// key" / "start ollama" — none of which Sentry can do for them.
 ///
-/// The classifier is anchored on the `"ollama embed"` prefix
-/// (`"ollama embed failed"` for the 400/404 shapes, `"ollama embeddings opted-in"`
-/// for the daemon-unreachable fallback) so unrelated 400/404 errors elsewhere
-/// in the codebase that happen to contain `"invalid model name"` or
-/// `"not found"` substrings are not silenced.
+/// Each arm is anchored on the `"ollama embed"` prefix
+/// (`"ollama embed failed"` for the failed-request shapes,
+/// `"ollama embeddings opted-in"` for the daemon-unreachable fallback) so
+/// unrelated errors elsewhere in the codebase that happen to contain
+/// `"invalid model name"`, `"not found"`, or `"does not support embeddings"`
+/// substrings are not silenced.
 ///
 /// Routes to [`ExpectedErrorKind::ProviderUserState`] — the same bucket that
 /// holds the composio / gmail / OAuth user-state errors. We deliberately do
@@ -890,9 +900,17 @@ fn is_ollama_user_config_rejection(lower: &str) -> bool {
         return true;
     }
 
-    if lower.contains("ollama embed failed")
-        && lower.contains("this model does not support embeddings")
-    {
+    // 3X / 8WA — 501-status "embeddings not supported". Ollama emits two
+    // bodies for this: the model is chat/vision-only
+    // (`{"error":"this model does not support embeddings"}`) or the daemon
+    // itself was started without embedding support
+    // (`{"error":"This server does not support embeddings. Start it with `--embeddings`"}`,
+    // TAURI-RUST-8WA, ~982 events on 0.57.52). Both are user-side Ollama
+    // config the app can't fix — it can neither swap the user's model nor
+    // restart their daemon with `--embeddings`. Anchor on the shared
+    // `does not support embeddings` phrase (still gated by the
+    // `ollama embed failed` prefix) so a future qualifier wording still demotes.
+    if lower.contains("ollama embed failed") && lower.contains("does not support embeddings") {
         return true;
     }
 
@@ -2751,6 +2769,9 @@ mod tests {
             "ollama embeddings opted-in but daemon unreachable at http://localhost:11434; falling back to cloud embeddings for this session",
             // TAURI-RUST-3X — 501-status model-does-not-support-embeddings.
             r#"ollama embed failed with status 501 Not Implemented: {"error":"this model does not support embeddings"}"#,
+            // TAURI-RUST-8WA — 501-status daemon started without embed support.
+            // Exact wire body so a narrow-back to "this model …" fails CI.
+            r#"ollama embed failed with status 501 Not Implemented: {"error":"This server does not support embeddings. Start it with `--embeddings`"}"#,
             // TAURI-RUST-3E — 401 unauthorized embed (auth required at ollama endpoint).
             r#"ollama embed failed with status 401 Unauthorized: {"error": "unauthorized"}"#,
         ] {


### PR DESCRIPTION
## Summary

- Demote the Ollama `501 Not Implemented` embed rejection whose body is `This server does not support embeddings. Start it with \`--embeddings\`` — previously it slipped the classifier and paged Sentry on every embed attempt (~982 events / 2 users on 0.57.52).
- The existing 501 arm matched only the `this model does not support embeddings` body; broaden it to the shared `does not support embeddings` phrase (still gated by the `ollama embed failed` prefix).
- Pin the exact 8WA wire body in the classifier test so a narrow-back fails CI; refresh the stale rustdoc to enumerate the 501 + 401 shapes.

## Problem

`is_ollama_user_config_rejection` (`src/core/observability.rs`) demotes Ollama embed user-config rejections to `ExpectedErrorKind::ProviderUserState` (info log, no Sentry). Ollama returns **two** distinct 501 bodies for "can't embed":

- `{"error":"this model does not support embeddings"}` — the model is chat/vision-only (covered).
- `{"error":"This server does not support embeddings. Start it with \`--embeddings\`"}` — the daemon was started without embed support (**not** covered).

The arm anchored on `this model does not support embeddings`, so the server-shape body was captured to Sentry. `OllamaEmbedding::embed` (`src/openhuman/embeddings/ollama.rs:413`) reports it via `report_error_or_expected` on every embed attempt, flooding self-hosted Sentry **TAURI-RUST-8WA** with ~982 events from 2 users on the latest release (0.57.52).

This is genuinely user-side config the app has no lever over — it cannot restart the user's local Ollama daemon with `--embeddings`. Remediation lives in Ollama's own returned message. Same bucket as the rest of the Ollama embed user-config family (XS/K/8K/3E/GX).

## Solution

- Replace the 501 arm sub-anchor `this model does not support embeddings` with the shared `does not support embeddings`, keeping the `ollama embed failed` prefix gate so unrelated errors are not silenced.
- Add the exact 8WA wire body to `classifies_ollama_user_config_rejections`; the 500 and out-of-RAM negatives still assert `None` (a server-side bug must still page).
- Update the rustdoc to document the 501 (model + server) and 401 shapes and correct the stale "three canonical shapes" count.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — the changed executable line (the broadened 501 arm) is exercised by the added 8WA test case; `cargo test --lib core::observability` → 179 passed.
- [x] N/A: classifier-only change, no feature row — Coverage matrix ([`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)) unaffected.
- [x] N/A: no feature-matrix IDs affected — All affected feature IDs listed under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: observability classifier, not a release-cut surface — Manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)).
- [x] N/A: Sentry-only (TAURI-RUST-8WA), no GitHub issue — Linked issue closed via `Closes #NNN`.

## Impact

- Desktop only. Removes a Sentry alert flood (~982 events / 2 users on 0.57.52); no runtime behavior change for end users — the embed still fails and the user still sees the same surfaced message, it is just no longer captured as a Sentry error.
- No performance, security, migration, or compatibility implications. Demotion drops the event to an `info` log (still locally visible).

## Related

- Closes:
- Follow-up PR(s)/TODOs: none
- Sentry-Issue: TAURI-RUST-8WA

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/8WA-ollama-embed-501-server-shape
- Commit SHA: `327c969f459db4b857ff715f4a8ff1fcffbabbff`

### Validation Run

- [x] N/A: Rust-only change, no `app/` files — `pnpm --filter openhuman-app format:check`
- [x] N/A: Rust-only change — `pnpm typecheck`
- [x] Focused tests: `cargo test --lib core::observability` → 179 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean + `cargo clippy --lib` exit 0
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` change (pre-push `rust:check` ran green)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a 501 "server does not support embeddings" Ollama embed error is demoted to an info log instead of being captured to Sentry.
- User-visible effect: none (the embed outcome and surfaced message are unchanged; only Sentry capture stops).

### Parity Contract

- Legacy behavior preserved: all previously-matched Ollama embed shapes (XS/K/8K/3E/GX + the 501 model-shape) still demote; 500 and out-of-RAM still reach Sentry.
- Guard/fallback/dispatch parity checks: arm remains gated by the `ollama embed failed` prefix; negative tests assert unrelated errors stay `None`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and classification for Ollama embedding configuration issues.

* **Tests**
  * Added test coverage for Ollama embedding support validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->