### PR TITLE
fix(inference): demote OpenRouter no-tool-use-endpoint 404 + surface it in Subconscious (#3996)

### DIFF
--- a/src/openhuman/inference/provider/config_rejection.rs
+++ b/src/openhuman/inference/provider/config_rejection.rs
@@ -236,6 +236,18 @@ pub fn is_provider_config_rejection_message(body: &str) -> bool {
         // harmless (`.any()` short-circuits) and kept so each Sentry
         // family stays self-documenting.
         "does not support tools",
+        // TAURI-RUST-ADC (~5.9k events / 10 users) — OpenRouter's
+        // *router-level* phrasing of the same tool-capability user-state.
+        // When the picked model has no provider endpoint that supports tool
+        // calling, OpenRouter returns a 404 with `{"error":{"message":"No
+        // endpoints found that support tool use. Try disabling \"<tool>\".
+        // ..."}}`. The wording differs from the direct-provider `does not
+        // support tools` body above ("tool use" vs "tools", prefixed with
+        // "No endpoints found"), so it needs its own anchor. Same user-state
+        // class: pick a tool-capable model. Surfaced most often by the
+        // autonomous Subconscious loop, which additionally halts on this via
+        // its own capability breaker (`subconscious/engine.rs`).
+        "no endpoints found that support tool use",
         // TAURI-RUST-4P6 (~36.6k events / 2 users) — user picked an
         // *embedding* model (Ollama `bge-m3:latest`, OpenHuman's default
         // memory-tree embed model) as their chat model. Ollama rejects every
@@ -351,6 +363,13 @@ mod tests {
             (
                 "J4",
                 r#"custom_openai streaming API error (404 Not Found): {"error":{"message":"model 'llama3.3' not found","type":"not_found_error","param":null,"code":null}}"#,
+            ),
+            // TAURI-RUST-ADC — OpenRouter router-level "no tool-use endpoint"
+            // 404, surfaced by the autonomous Subconscious loop on a
+            // content-safety model that supports no tools.
+            (
+                "ADC",
+                r#"openrouter API error (404 Not Found): {"error":{"message":"No endpoints found that support tool use. Try disabling \"spawn_async_subagent\". To learn more about provider routing, visit: https://openrouter.ai/docs/guides/routing/provider-selection"}}"#,
             ),
             // TAURI-RUST-4NM — nvidia-nim (and compatible providers) return
             // this body when the request body has an empty `"model":""`.

--- a/src/openhuman/subconscious/engine.rs
+++ b/src/openhuman/subconscious/engine.rs
@@ -34,6 +34,13 @@ const TICK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60
 /// Per-tool-call timeout injected into the agent config.
 const TOOL_CALL_TIMEOUT_SECS: u64 = 5 * 60;
 
+/// Actionable reason surfaced (via `SubconsciousStatus.provider_unavailable_reason`)
+/// when a subconscious tick fails because the configured chat model has no
+/// tool-use endpoint. The subconscious turn is inherently tool-bearing (it
+/// maintains its scratchpad through tools), so a tool-incapable model can never
+/// satisfy a tick — this tells the user how to recover. See TAURI-RUST-ADC.
+const TOOL_UNSUPPORTED_REASON: &str = "The selected chat model has no tool-use endpoint, so Subconscious can't run. Pick a tool-capable model in Settings > AI.";
+
 /// Pick the `TrustedAutomationSource` variant for a subconscious tick.
 ///
 /// Extracted from the engine's `run_agent` body so the
@@ -285,6 +292,21 @@ impl SubconsciousEngine {
         state.total_ticks += 1;
         if agent_failed {
             state.consecutive_failures += 1;
+            // Surface an actionable reason when the failure is a permanent
+            // tool-capability error: the subconscious turn is inherently
+            // tool-bearing, so the configured chat model can never satisfy it
+            // and the user must pick a tool-capable model. The hard Sentry
+            // flood from this error is suppressed at the provider classifier
+            // (is_provider_config_rejection_message, TAURI-RUST-ADC); here we
+            // only make the cause visible in Subconscious status.
+            if let Err(e) = &agent_result {
+                if is_tool_capability_error(e) {
+                    info!(
+                        "[subconscious] configured chat model has no tool-use endpoint — Subconscious can't run until the model changes (TAURI-RUST-ADC)"
+                    );
+                    state.provider_unavailable_reason = Some(TOOL_UNSUPPORTED_REASON.to_string());
+                }
+            }
         } else {
             state.consecutive_failures = 0;
             state.last_tick_at = tick_at;
@@ -462,6 +484,18 @@ fn resolve_subconscious_route(config: &Config) -> SubconsciousProviderRoute {
     } else {
         SubconsciousProviderRoute::Other(raw.to_string())
     }
+}
+
+/// True when an agent-run error means the configured chat model can't do tool
+/// calls at all — a permanent, user-actionable condition (pick a tool-capable
+/// model). Matches both the direct-provider body (`<model> does not support
+/// tools`) and OpenRouter's router-level phrasing (`No endpoints found that
+/// support tool use`, TAURI-RUST-ADC). Kept narrow to tool capability so an
+/// unrelated provider error (auth, billing, rate-limit) is not misread as one.
+fn is_tool_capability_error(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("no endpoints found that support tool use")
+        || lower.contains("does not support tools")
 }
 
 // ── Pre-LLM memory retrieval ────────────────────────────────────────────────

--- a/src/openhuman/subconscious/engine_tests.rs
+++ b/src/openhuman/subconscious/engine_tests.rs
@@ -18,3 +18,33 @@ fn tick_origin_with_external_sync_chunk_uses_tainted_source() {
         TrustedAutomationSource::SubconsciousTainted
     ));
 }
+
+// ── Tool-capability error detection (TAURI-RUST-ADC) ────────────────────
+
+#[test]
+fn tool_capability_error_matches_openrouter_and_direct_bodies() {
+    // OpenRouter router-level 404 (the reported ADC body).
+    assert!(is_tool_capability_error(
+        r#"agent run: openrouter API error (404 Not Found): {"error":{"message":"No endpoints found that support tool use. Try disabling \"spawn_async_subagent\"."}}"#
+    ));
+    // Direct-provider "does not support tools" phrasing (TAURI-RUST-35 family).
+    assert!(is_tool_capability_error(
+        r#"agent run: cloud API error: {"error":{"message":"qwen2:0.5b does not support tools"}}"#
+    ));
+    // Case-insensitive.
+    assert!(is_tool_capability_error(
+        "NO ENDPOINTS FOUND THAT SUPPORT TOOL USE"
+    ));
+}
+
+#[test]
+fn tool_capability_error_ignores_unrelated_failures() {
+    // A different 404, an auth wall, and a generic timeout must NOT match.
+    assert!(!is_tool_capability_error(
+        r#"agent run: openrouter API error (404 Not Found): {"error":{"message":"model 'llama3.3' not found"}}"#
+    ));
+    assert!(!is_tool_capability_error(
+        "agent run: Backend returned 401 Unauthorized: Invalid token"
+    ));
+    assert!(!is_tool_capability_error("agent run: request timed out"));
+}


### PR DESCRIPTION
## Summary

- Stop the Subconscious loop from flooding Sentry with permanent OpenRouter `404 No endpoints found that support tool use` errors when the chat model has no tool-use endpoint (TAURI-RUST-ADC: 5.9k events / 10 users).
- **Primary fix:** demote that OpenRouter 404 in the provider classifier — it is the same tool-incapable-model user-state already handled for the direct-provider `does not support tools` body, just OpenRouter's router-level wording.
- **Secondary:** when a subconscious tick fails for this reason, set an actionable `provider_unavailable_reason` so the cause is visible in Subconscious status and the user knows to pick a tool-capable model.

## Problem

The Subconscious tick runs a full tool-bearing agent (`subconscious/engine.rs::run_agent` → `Agent::from_config` → `run_single`, with scratchpad tools + `spawn_subagent`). The agent runs the **global chat model** (`from_config_for_agent("orchestrator")`). When that model has no tool-use endpoint — e.g. a user picked a content-safety model routed via OpenRouter — **every tick** sends a tool-bearing request and OpenRouter returns a permanent `404 "No endpoints found that support tool use. Try disabling \"spawn_async_subagent\"."`.

The agent error path (`agent/harness/engine/core.rs`) treats this permanent 404 as non-transient and hard-reports via `report_error_or_expected`. The provider classifier already pins the direct-provider phrasing `does not support tools`, but **not** OpenRouter's router-level `No endpoints found that support tool use`, so the 404 slipped through and the autonomous loop re-fired it every interval.

Bucket: **preventable user-state** — the user must pick a tool-capable model. There is no a-priori capability registry to filter the picker, so the levers are (a) demote the now-known error and (b) surface an actionable reason so the user can fix the root cause.

## Solution

**Primary — classifier (`inference/provider/config_rejection.rs`).**
- Add `no endpoints found that support tool use` to `is_provider_config_rejection_message`, routing the OpenRouter 404 to `ExpectedErrorKind::ProviderConfigRejection` (demoted, not a hard Sentry event). Same user-state class as the sibling `does not support tools` / embedding-model phrases already pinned there — this is the project's established handling for a tool-incapable model.

**Secondary — actionable surface (`subconscious/engine.rs`).**
- When a tick's agent run fails, `is_tool_capability_error(err)` (matching both OpenRouter's `no endpoints found that support tool use` and the direct-provider `does not support tools`, kept narrow so unrelated auth/billing/rate-limit errors don't match) sets `provider_unavailable_reason` to an actionable message surfaced via `SubconsciousStatus`.

**Why no sticky circuit-breaker:** an earlier revision added a route-keyed breaker to skip ticks, but review (CodeRabbit P1) correctly flagged that the subconscious agent runs the **global** chat model, not `subconscious_provider` — so a model-derived breaker key would have been keyed on the wrong field and never cleared. Removed it. Re-running the cheap, now-silenced failure once per ≥5-min interval is acceptable; the classifier demotion is what removes the flood, consistent with how chat handles the identical error.

This mirrors the project's established handling of tool-incapable / capability-mismatch models (the existing `does not support tools` arm, the embedding-endpoint fix #3625).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — new unit tests exercise `is_tool_capability_error` (positive + negative) and the classifier phrase (real ADC wire body added to `detects_wave4_sentry_bodies`); the remaining changed lines are a thin `provider_unavailable_reason` assignment in the tick failure path. Coverage gate enforced by CI.
- [x] N/A: behaviour/observability change — no feature rows added/removed/renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no coverage-matrix feature IDs affected by this change.
- [x] No new external network dependencies introduced (pure unit tests, no backend).
- [x] N/A: does not touch release-cut manual-smoke surfaces (subconscious provider-error handling only).
- [x] Linked issue closed via `Closes #3996` in the `## Related` section.

## Impact

- **Platform**: desktop Rust core only. No frontend, RPC, schema, or migration change — reuses the existing `provider_unavailable_reason` surface.
- **Observability**: removes the TAURI-RUST-ADC flood — the OpenRouter `no tool-use endpoint` 404 is demoted to provider-config-rejection like its `does not support tools` sibling.
- **Behavior**: a Subconscious instance on a tool-incapable model now reports an actionable "pick a tool-capable model" reason in its status instead of failing silently; no change to tick scheduling.
- **Security/migration**: none.

## Related

- Closes: #3996
- Sentry-Issue: TAURI-RUST-ADC
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A (GitHub issue #3996)
- URL: https://github.com/tinyhumansai/openhuman/issues/3996

### Commit & Branch

- Branch: `fix/3996-subconscious-tool-capability-breaker`
- Commit SHA: 055db85c8

### Validation Run

- [x] N/A: no frontend files changed (`format:check` not applicable).
- [x] N/A: no TypeScript changed (`typecheck` not applicable).
- [x] N/A: local `cargo test --lib` cfg(test) link of the full core crate could not complete under heavy concurrent-worktree build contention on this machine — the CI Rust test job runs `openhuman::subconscious::engine` + `openhuman::inference::provider::config_rejection` and gates the merge.
- [x] Rust fmt/check: `cargo fmt` applied; `GGML_NATIVE=OFF cargo check` clean (pre-push `rust:check` hook passed).
- [x] N/A: no Tauri shell files changed.

### Validation Blocked

- `command:` `cargo test --lib openhuman::subconscious::engine ...`
- `error:` local `cfg(test)` link of the full core crate stalled under heavy concurrent-worktree build contention on this machine (not a code fault — `cargo check` compiles clean).
- `impact:` focused tests not yet confirmed green locally; the CI Rust test matrix gates them on this PR.

### Behavior Changes

- Intended behavior change: the OpenRouter `no tool-use endpoint` 404 is now a demoted expected error instead of a hard Sentry event; a subconscious tick that hits it records an actionable status reason.
- User-visible effect: none in-app beyond the Subconscious settings status reason; fewer non-actionable Sentry events.

### Parity Contract

- Legacy behavior preserved: tool-capable models tick exactly as before; tick scheduling and failure accounting are unchanged. Only a `provider_unavailable_reason` string is set on the specific tool-capability failure.
- Guard/fallback/dispatch parity checks: classifier addition routes to the existing `ProviderConfigRejection` kind; no new variant, no change to other matchers.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found (searched open + 30d-merged for smart_walk/openrouter/tool-use).
- Canonical PR: this.
- Resolution: N/A.
