### PR TITLE
fix(inference): gate /responses fallback on provider capability (#3997)

### DIFF
--- a/src/openhuman/config/schema/cloud_providers.rs
+++ b/src/openhuman/config/schema/cloud_providers.rs
@@ -199,6 +199,36 @@ fn builtin_cloud_provider(type_str: &str) -> Option<&'static BuiltinCloudProvide
         .find(|provider| provider.slug == type_str)
 }
 
+/// Whether `slug` matches a built-in cloud provider preset.
+///
+/// The chat factory uses this to decide capability defaults (e.g. whether the
+/// provider exposes the OpenAI Responses API) only for providers we ship and
+/// therefore know the API surface of. Custom / user-defined slugs are treated
+/// as unknown and keep the permissive defaults.
+pub fn is_builtin_cloud_slug(slug: &str) -> bool {
+    builtin_cloud_provider(slug).is_some()
+}
+
+/// Whether a built-in cloud provider exposes the OpenAI **Responses API**
+/// (`/v1/responses`).
+///
+/// Only OpenAI's first-party endpoint serves `/responses`; every other built-in
+/// preset (DeepSeek, Groq, Mistral, Fireworks, …) is chat-completions-only.
+/// Enabling the chat-completions-404 → `/responses` fallback for those
+/// guarantees a second 404 against an endpoint that does not exist, which floods
+/// Sentry with an empty-body `"<provider> Responses API error:"` event
+/// (TAURI-RUST-5EN — same class as the local-provider TAURI-RUST-59Y fix). The
+/// factory consults this to build chat-completions-only built-ins with
+/// `new_no_responses_fallback`.
+///
+/// Custom / unknown slugs are intentionally NOT covered here (see
+/// [`is_builtin_cloud_slug`]): a user-defined OpenAI-compatible endpoint may be
+/// a genuine OpenAI proxy that does support `/responses`, so the factory keeps
+/// the fallback for those.
+pub fn builtin_cloud_supports_responses_api(slug: &str) -> bool {
+    matches!(slug, "openai")
+}
+
 /// Authentication header style for a cloud provider.
 ///
 /// Wire format is lowercase (e.g. `"bearer"`). Determines which HTTP headers
@@ -474,8 +504,8 @@ impl CloudProviderType {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_slug_reserved, migrate_legacy_fields, AuthStyle, CloudProviderCreds,
-        BUILTIN_CLOUD_PROVIDERS,
+        builtin_cloud_supports_responses_api, is_builtin_cloud_slug, is_slug_reserved,
+        migrate_legacy_fields, AuthStyle, CloudProviderCreds, BUILTIN_CLOUD_PROVIDERS,
     };
 
     #[test]
@@ -558,6 +588,48 @@ mod tests {
             assert!(
                 slugs.insert(provider.slug),
                 "duplicate built-in cloud provider slug {}",
+                provider.slug
+            );
+        }
+    }
+
+    #[test]
+    fn is_builtin_cloud_slug_matches_presets_only() {
+        for slug in ["openai", "deepseek", "groq", "mistral"] {
+            assert!(is_builtin_cloud_slug(slug), "{slug} is a built-in preset");
+        }
+        for slug in ["my-proxy", "custom-openai", "totally-unknown", ""] {
+            assert!(
+                !is_builtin_cloud_slug(slug),
+                "{slug:?} is not a built-in preset"
+            );
+        }
+    }
+
+    #[test]
+    fn only_openai_builtin_exposes_responses_api() {
+        assert!(builtin_cloud_supports_responses_api("openai"));
+        for slug in ["deepseek", "groq", "mistral", "fireworks", "together"] {
+            assert!(
+                !builtin_cloud_supports_responses_api(slug),
+                "{slug} is chat-completions-only and must not advertise the Responses API"
+            );
+        }
+    }
+
+    /// Drift guard (TAURI-RUST-5EN): couple the capability helper to the
+    /// preset list so adding a new built-in that wrongly claims the Responses
+    /// API — or renaming `openai` — fails CI rather than silently re-enabling
+    /// the guaranteed-404 `/responses` fallback. OpenAI's first-party endpoint
+    /// is the only built-in that serves `/v1/responses`.
+    #[test]
+    fn responses_api_capability_is_coupled_to_the_preset_list() {
+        for provider in BUILTIN_CLOUD_PROVIDERS {
+            let expected = provider.slug == "openai";
+            assert_eq!(
+                builtin_cloud_supports_responses_api(provider.slug),
+                expected,
+                "built-in {} Responses-API capability drifted from the openai-only invariant",
                 provider.slug
             );
         }

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -24,7 +24,9 @@
 //!
 //! Unknown slugs and missing-creds configurations produce actionable errors.
 
-use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+use crate::openhuman::config::schema::cloud_providers::{
+    builtin_cloud_supports_responses_api, is_builtin_cloud_slug, AuthStyle,
+};
 use crate::openhuman::config::Config;
 use crate::openhuman::credentials::AuthService;
 use crate::openhuman::inference::provider::claude_agent_sdk::subprocess::ClaudeAgentSdkProvider;
@@ -1509,14 +1511,36 @@ fn make_cloud_provider_by_slug(
                 redact_endpoint(&openai_codex_routing.endpoint),
                 openai_codex_routing.account_id.is_some()
             );
-            let mut provider = OpenAiCompatibleProvider::new(
-                slug,
-                &openai_codex_routing.endpoint,
-                (!key.trim().is_empty()).then_some(key.as_str()),
-                CompatAuthStyle::Bearer,
-            )
-            .with_temperature_unsupported_models(unsupported.to_vec())
-            .with_temperature_override(temperature_override);
+            // Enable the chat-completions-404 → `/v1/responses` fallback only
+            // for providers that actually expose the Responses API. Built-in
+            // chat-completions-only providers (DeepSeek, Groq, Mistral, …) do
+            // not — hitting their non-existent `/responses` guarantees a second
+            // 404 and floods Sentry with an empty-body "<provider> Responses
+            // API error:" event (TAURI-RUST-5EN, same class as the
+            // local-provider TAURI-RUST-59Y fix). OpenAI keeps the fallback
+            // (genuine `/responses`), and so do custom / unknown slugs, whose
+            // endpoint may be a real OpenAI proxy.
+            let responses_fallback =
+                !is_builtin_cloud_slug(slug) || builtin_cloud_supports_responses_api(slug);
+            let credential = (!key.trim().is_empty()).then_some(key.as_str());
+            let base_provider = if responses_fallback {
+                OpenAiCompatibleProvider::new(
+                    slug,
+                    &openai_codex_routing.endpoint,
+                    credential,
+                    CompatAuthStyle::Bearer,
+                )
+            } else {
+                OpenAiCompatibleProvider::new_no_responses_fallback(
+                    slug,
+                    &openai_codex_routing.endpoint,
+                    credential,
+                    CompatAuthStyle::Bearer,
+                )
+            };
+            let mut provider = base_provider
+                .with_temperature_unsupported_models(unsupported.to_vec())
+                .with_temperature_override(temperature_override);
             if let Some(account_id) = openai_codex_routing.account_id.as_deref() {
                 provider = provider.with_extra_header(OPENAI_CODEX_ACCOUNT_HEADER, account_id);
             }

--- a/src/openhuman/inference/provider/factory_tests.rs
+++ b/src/openhuman/inference/provider/factory_tests.rs
@@ -1536,6 +1536,130 @@ async fn cloud_provider_falls_back_to_responses_on_404() {
     drop(result);
 }
 
+/// TAURI-RUST-5EN: a built-in chat-completions-only cloud provider (DeepSeek)
+/// must NOT fall back to `/v1/responses` on a chat-completions 404. DeepSeek
+/// exposes no Responses API, so the fallback is a guaranteed second 404 that
+/// floods Sentry with an empty-body "deepseek Responses API error:" event.
+/// Bearer-path counterpart to `ollama_provider_does_not_fall_back_to_responses_on_404`.
+#[tokio::test]
+async fn deepseek_builtin_does_not_fall_back_to_responses_on_404() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_string(r#"{"error":{"message":"model not found","code":404}}"#),
+        )
+        .expect(1) // exactly one attempt — no retry, no fallback
+        .mount(&mock_server)
+        .await;
+
+    // DeepSeek has no /v1/responses — the fallback must never reach it.
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(404).set_body_string(""))
+        .expect(0) // must not be called
+        .mount(&mock_server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let entry = CloudProviderCreds {
+        id: "p_deepseek".to_string(),
+        slug: "deepseek".to_string(),
+        label: "DeepSeek".to_string(),
+        endpoint: format!("{}/v1", mock_server.uri()),
+        auth_style: AuthStyle::Bearer,
+        default_model: Some("deepseek-v4-flash".to_string()),
+        ..Default::default()
+    };
+    let config = config_with_providers_in_tempdir(&tmp, vec![entry]);
+    // Bearer providers fail at call time with "API key not set" before any HTTP
+    // request, so stash a key to let the chat-completions call reach the mock.
+    AuthService::from_config(&config)
+        .store_provider_token(
+            "provider:deepseek",
+            "default",
+            "sk-test",
+            Default::default(),
+            true,
+        )
+        .expect("store provider token");
+
+    let (provider, model) =
+        create_chat_provider_from_string("chat", "deepseek:deepseek-v4-flash", &config)
+            .expect("deepseek provider must build");
+
+    let result = provider.chat_with_system(None, "hello", &model, 0.0).await;
+    assert!(
+        result.is_err(),
+        "chat-completions 404 should surface as an error, not a success"
+    );
+
+    // wiremock verifies expect(0) on /v1/responses when the server is dropped.
+}
+
+/// Counterpart guard: a custom (non-built-in) Bearer slug KEEPS the responses
+/// fallback — its endpoint may be a genuine OpenAI proxy that serves
+/// `/v1/responses`. Ensures the 5EN slug-gate only disables the fallback for
+/// known chat-completions-only built-ins, not for unknown providers.
+#[tokio::test]
+async fn custom_bearer_provider_keeps_responses_fallback_on_404() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_string(r#"{"error":{"message":"model not found","code":404}}"#),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Unknown slug → fallback retained → /v1/responses MUST be called.
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(
+                r#"{"output":[{"content":[{"type":"output_text","text":"ok"}]}]}"#,
+            ),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let entry = CloudProviderCreds {
+        id: "p_custom".to_string(),
+        slug: "my-openai-proxy".to_string(),
+        label: "My Proxy".to_string(),
+        endpoint: format!("{}/v1", mock_server.uri()),
+        auth_style: AuthStyle::Bearer,
+        default_model: Some("proxy-model".to_string()),
+        ..Default::default()
+    };
+    let config = config_with_providers_in_tempdir(&tmp, vec![entry]);
+    AuthService::from_config(&config)
+        .store_provider_token(
+            "provider:my-openai-proxy",
+            "default",
+            "sk-test",
+            Default::default(),
+            true,
+        )
+        .expect("store provider token");
+
+    let (provider, model) =
+        create_chat_provider_from_string("chat", "my-openai-proxy:proxy-model", &config)
+            .expect("custom bearer provider must build");
+
+    let result = provider.chat_with_system(None, "hello", &model, 0.0).await;
+    drop(result);
+
+    // wiremock verifies expect(1) on /v1/responses when the server is dropped.
+}
+
 #[tokio::test]
 #[ignore = "requires live LM Studio on localhost:1234"]
 async fn live_lmstudio_provider_streams_thinking_and_text() {


### PR DESCRIPTION
## Summary

- Built-in chat-completions-only cloud providers (DeepSeek, Groq, Mistral, Fireworks, …) no longer fall back to `/v1/responses` on a chat-completions 404. They have no Responses API, so the fallback was a guaranteed second 404 that flooded Sentry with empty-body `"<provider> Responses API error:"` events (TAURI-RUST-5EN: 846 events / 17 users, still firing on 0.57.18).
- Gate the responses fallback on provider capability: only `openai` (genuine first-party `/responses`) and custom / unknown slugs (which may be a real OpenAI proxy) keep it; known chat-completions-only built-ins build with `new_no_responses_fallback`.
- Same class as the local-provider fix TAURI-RUST-59Y (Ollama / LM Studio). No happy-path change — the fallback only ever fires on a chat-completions failure.

## Problem

For a Bearer cloud provider, the chat factory built every provider via `OpenAiCompatibleProvider::new(...)` (`src/openhuman/inference/provider/factory.rs`), which sets `supports_responses_fallback = true`. When DeepSeek's `/v1/chat/completions` call fails with a 404 (or transport error), the provider retries against `/v1/responses` — an endpoint DeepSeek does not expose — producing a bare 404 with an empty body. No HTTP-error classifier matches the empty body, so it is reported to Sentry via `report_error` under `operation=responses_api`.

Breadcrumb from the Sentry event confirms the sequence:
`[provider:deepseek] outbound chat/completions -> https://api.deepseek.com/v1/chat/completions` → fallback → `…/v1/responses` → 404.

Among the built-in cloud presets, only OpenAI's first-party endpoint serves `/responses`; every other built-in is chat-completions-only and shares this latent defect (groq, mistral, fireworks, moonshot, together, cerebras, xai, …).

## Solution

- Add two single-source-of-truth helpers in `config/schema/cloud_providers.rs`:
  - `is_builtin_cloud_slug(slug)` — whether the slug is a shipped preset (so capability defaults apply only where we know the API surface).
  - `builtin_cloud_supports_responses_api(slug)` — `matches!(slug, "openai")`; the only built-in that exposes `/v1/responses`.
- In the factory's Bearer arm, enable the responses fallback only when `!is_builtin_cloud_slug(slug) || builtin_cloud_supports_responses_api(slug)` — i.e. keep it for OpenAI and for custom/unknown slugs, disable it for known chat-completions-only built-ins (built with `new_no_responses_fallback`). The codex-OAuth `responses_api_primary` path is untouched.
- **Not suppression of a real defect**: the fallback was a guaranteed-useless second request. Removing it eliminates the noise *and* lets the genuine chat-completions failure surface once, properly classified (config-rejection stays demoted; a real 404 is reported once under `chat_completions`). A drift-guard test couples the capability helper to the preset list so a future built-in that wrongly claims the Responses API fails CI instead of silently re-enabling the guaranteed-404 fallback.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — 5 unit tests: capability/membership helpers + drift guard, plus two wiremock integration tests (DeepSeek built-in skips `/responses`; custom Bearer slug keeps it).
- [x] **Diff coverage ≥ 80%** — changed factory lines exercised by both wiremock branches; helper lines by the unit tests. CI coverage gate is authoritative.
- [x] N/A: behaviour-only change, no feature row added/removed/renamed — Coverage matrix updated
- [x] N/A: no matrix change — All affected feature IDs from the matrix are listed in `## Related`
- [x] No new external network dependencies introduced — wiremock mock server only, no live network.
- [x] N/A: no release-cut surface change — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop only; Rust-core change. Removes a recurring error-level Sentry event class (TAURI-RUST-5EN) for DeepSeek and every other chat-completions-only built-in cloud provider.
- No user-visible behaviour change; no API, schema, or migration impact. Security-neutral (no credential handling touched).

## Related

- Closes: #3997
- Sentry-Issue: TAURI-RUST-5EN
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3997-responses-fallback-capability-gate`
- Commit SHA: `37108cb95`

### Validation Run

- [x] N/A: no frontend/TS change — `pnpm --filter openhuman-app format:check`
- [x] N/A: no frontend/TS change — `pnpm typecheck`
- [x] Focused tests: `cargo test --lib` for the 5 new tests (cloud_providers helpers + factory wiremock) — pass
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean · `cargo clippy` 0 warnings on changed files
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml` — exit 0

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a chat-completions 404 on a built-in chat-completions-only cloud provider no longer triggers a `/v1/responses` fallback request (and the Sentry event it produced).
- User-visible effect: none — the genuine chat-completions failure is still surfaced to the caller.

### Parity Contract

- Legacy behavior preserved: OpenAI and custom/unknown Bearer slugs keep the responses fallback unchanged; the codex-OAuth `responses_api_primary` path is untouched.
- Guard/fallback/dispatch parity checks: fallback disabled only for known chat-completions-only built-ins, gated by a single-source capability helper with a drift-guard test.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 30d-merged for `deepseek` / `responses`). PR #3976 is the DeepSeek **402** insufficient-credits family — different status, different path.
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cloud provider fallback behavior: built-in providers (e.g., DeepSeek) no longer incorrectly attempt the Responses API fallback when the primary endpoint fails. Custom cloud providers retain fallback functionality.

* **Tests**
  * Added regression tests for cloud provider error handling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->