### PR TITLE
fix(inference): skip /responses fallback for OpenRouter (#4000)

### DIFF
--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -1509,14 +1509,33 @@ fn make_cloud_provider_by_slug(
                 redact_endpoint(&openai_codex_routing.endpoint),
                 openai_codex_routing.account_id.is_some()
             );
-            let mut provider = OpenAiCompatibleProvider::new(
-                slug,
-                &openai_codex_routing.endpoint,
-                (!key.trim().is_empty()).then_some(key.as_str()),
-                CompatAuthStyle::Bearer,
-            )
-            .with_temperature_unsupported_models(unsupported.to_vec())
-            .with_temperature_override(temperature_override);
+            // OpenRouter does not implement the OpenAI Responses API: its
+            // `/v1/responses` rejects our `ResponsesRequest` body with
+            // `invalid_union` (TAURI-RUST-863). Skip the `/v1/responses`
+            // fallback for it so a `chat/completions` 404 surfaces
+            // OpenRouter's real, actionable error (e.g. "No endpoints found
+            // that support tool use") instead of issuing a doomed second
+            // request. Same class as the Ollama / LM Studio guard
+            // (TAURI-RUST-59Y).
+            let base_provider =
+                if crate::openhuman::inference::provider::ops::is_openrouter_provider(entry) {
+                    OpenAiCompatibleProvider::new_no_responses_fallback(
+                        slug,
+                        &openai_codex_routing.endpoint,
+                        (!key.trim().is_empty()).then_some(key.as_str()),
+                        CompatAuthStyle::Bearer,
+                    )
+                } else {
+                    OpenAiCompatibleProvider::new(
+                        slug,
+                        &openai_codex_routing.endpoint,
+                        (!key.trim().is_empty()).then_some(key.as_str()),
+                        CompatAuthStyle::Bearer,
+                    )
+                };
+            let mut provider = base_provider
+                .with_temperature_unsupported_models(unsupported.to_vec())
+                .with_temperature_override(temperature_override);
             if let Some(account_id) = openai_codex_routing.account_id.as_deref() {
                 provider = provider.with_extra_header(OPENAI_CODEX_ACCOUNT_HEADER, account_id);
             }

--- a/src/openhuman/inference/provider/factory_tests.rs
+++ b/src/openhuman/inference/provider/factory_tests.rs
@@ -1479,6 +1479,81 @@ async fn lmstudio_provider_does_not_fall_back_to_responses_on_404() {
     );
 }
 
+/// Regression guard for TAURI-RUST-863: OpenRouter is a builtin cloud
+/// provider (`AuthStyle::Bearer`) but does NOT implement the OpenAI Responses
+/// API — its `/v1/responses` rejects our request body with `invalid_union`.
+/// So a `chat/completions` 404 (e.g. "No endpoints found that support tool
+/// use" for a model whose providers can't do tool calling) must NOT trigger
+/// the `/v1/responses` fallback: that second request is guaranteed to fail and
+/// produced ~3.1k Sentry events while masking OpenRouter's real, actionable
+/// error. Same class as the Ollama / LM Studio guards (TAURI-RUST-59Y), but
+/// keyed via `is_openrouter_provider` in the Bearer arm.
+#[tokio::test]
+async fn openrouter_provider_does_not_fall_back_to_responses_on_404() {
+    let mock_server = MockServer::start().await;
+
+    // chat/completions returns OpenRouter's tool-routing 404.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(404).set_body_string(
+            r#"{"error":{"message":"No endpoints found that support tool use. Try disabling \"spawn_async_subagent\".","code":404}}"#,
+        ))
+        .expect(1) // exactly one attempt — no retry
+        .mount(&mock_server)
+        .await;
+
+    // /v1/responses must NOT be called for OpenRouter.
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{"output_text":"should not reach here"}"#),
+        )
+        .expect(0) // must not be called
+        .mount(&mock_server)
+        .await;
+
+    // Point the builtin `openrouter` slug at the mock server. The slug match in
+    // `is_openrouter_provider` drives the no-fallback construction regardless of
+    // the (mock) host. A tempdir-backed config + seeded key let the request
+    // actually fire (OpenRouter is `AuthStyle::Bearer`, so it requires a key).
+    let tmp = TempDir::new().expect("tempdir");
+    let config = config_with_providers_in_tempdir(
+        &tmp,
+        vec![CloudProviderCreds {
+            id: "p_openrouter".to_string(),
+            slug: "openrouter".to_string(),
+            label: "OpenRouter".to_string(),
+            endpoint: format!("{}/v1", mock_server.uri()),
+            auth_style: AuthStyle::Bearer,
+            default_model: Some("nvidia/nemotron-3.5-content-safety:free".to_string()),
+            ..Default::default()
+        }],
+    );
+    store_byo_key(&config, "openrouter", "sk-or-test");
+
+    let (provider, model) = create_chat_provider_from_string(
+        "chat",
+        "openrouter:nvidia/nemotron-3.5-content-safety:free",
+        &config,
+    )
+    .expect("openrouter provider must build");
+
+    // The call fails with the genuine 404 — and must NOT reach `/v1/responses`.
+    let result = provider.chat_with_system(None, "hello", &model, 0.0).await;
+    assert!(
+        result.is_err(),
+        "provider should fail with 404, got success"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("404") || err_msg.contains("No endpoints found"),
+        "error should reference the genuine 404, got: {err_msg}"
+    );
+
+    // wiremock verifies expect(0) on the responses mock when the server is dropped.
+}
+
 /// Counterpart to the no-fallback tests: a cloud provider (responses_fallback=true)
 /// MUST retry against `/v1/responses` when chat/completions returns 404.
 /// This guards against an accidental inversion of the supports_responses_fallback flag.


### PR DESCRIPTION
## Summary

- OpenRouter no longer issues a guaranteed-fail `/v1/responses` fallback when `chat/completions` returns 404.
- Users now see OpenRouter's real, actionable error (e.g. *"No endpoints found that support tool use"*) instead of a misleading `Responses API … invalid_union` error.
- Kills the Sentry flood `TAURI-RUST-863` (~3.1k events / 19 users) and removes a wasted second network round-trip per occurrence.

## Problem

When a user selects an OpenRouter model whose providers can't satisfy the request (e.g. `nvidia/nemotron-3.5-content-safety:free`, which has no tool-capable endpoint while the agent sends tools), OpenRouter replies:

```
404 Not Found: {"error":{"message":"No endpoints found that support tool use. Try disabling \"spawn_async_subagent\". …","code":404}}
```

OpenRouter is a builtin cloud provider built with `supports_responses_fallback = true` (the `AuthStyle::Bearer` arm in `provider/factory.rs` constructs via `OpenAiCompatibleProvider::new`). So the 404 triggers the `/v1/responses` fallback — but OpenRouter does **not** implement the OpenAI Responses API and rejects our `ResponsesRequest` body:

```
400: {"error":{"code":"invalid_prompt","message":"Invalid Responses API request"},"metadata":{"raw":"[{\"code\":\"invalid_union\", …}]"}}
```

That doomed second request is reported at `operation=responses_api` as `TAURI-RUST-863`, masking the genuine cause from the user.

## Solution

OpenRouter's `/v1/responses` is body-incompatible (it rejects with `invalid_union`), so the fallback is *always* wrong for it. Build the OpenRouter provider with `new_no_responses_fallback`, keyed via the existing `is_openrouter_provider(entry)` check in the Bearer arm. Because every fallback site is gated by `supports_responses_fallback` (or `responses_api_primary`, which OpenRouter never sets), this single switch disables the fallback across all chat / streaming / history cascades. A `chat/completions` 404 now surfaces OpenRouter's own error with the `enrich_404_message` "check endpoint/model" hint.

Exact precedent: **TAURI-RUST-59Y** disabled the same guaranteed-404 `/responses` fallback for Ollama / LM Studio.

This is a **prevention** fix (remove a request that can only fail), not Sentry suppression.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — `openrouter_provider_does_not_fall_back_to_responses_on_404` (404 → no `/responses` call); `cloud_provider_falls_back_to_responses_on_404` still green.
- [x] **Diff coverage ≥ 80%** — two small, fully test-exercised edits (Bearer-arm branch + regression test).
- [x] N/A: behaviour-only change, no feature rows added/removed/renamed — Coverage matrix updated.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`.
- [x] No new external network dependencies introduced (wiremock mock server).
- [x] N/A: no release-cut surface touched — Manual smoke checklist updated.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Desktop** Rust core only. No schema, migration, or API-shape change.
- Behavioral: BYO OpenRouter requests that previously emitted a confusing `invalid_union` error now bubble OpenRouter's real `4xx`. No change to the happy path (`chat/completions` 200) or to any non-OpenRouter provider — `is_openrouter_provider` is the sole gate.
- Removes one wasted HTTP request per failing OpenRouter call.

## Related

- Closes #4000
- Sentry-Issue: `TAURI-RUST-863` (~3.1k ev / 19 users) — fixed by this PR.
- Follow-up PR(s)/TODOs: `TAURI-RUST-ADC` (~5.9k ev / 10 users) is the **same root cause** surfacing as the genuine `404 No endpoints found that support tool use`. That is **preventable user-state** (an agent that needs tools was routed to a non-tool-capable model) and deserves a real **prevention** fix (tool-capability gating / model validation), **not** a classifier demotion. Tracked in #4000 so it is not buried.
- Precedent: `TAURI-RUST-59Y` (Ollama / LM Studio — same guaranteed-404 `/responses` fallback class).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/4000-openrouter-no-responses-fallback`
- Commit SHA: `a15d685d0`

### Validation Run

- [x] N/A: no `app/` frontend change — `pnpm --filter openhuman-app format:check`.
- [x] N/A: no TypeScript change — `pnpm typecheck`.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::inference::provider::factory` → 124 passed, 0 failed.
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo check --lib` exit 0; pre-push `rust:check` passed.
- [x] N/A: no `app/src-tauri` change — Tauri fmt/check.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: OpenRouter `chat/completions` 404 no longer triggers a `/v1/responses` fallback.
- User-visible effect: users see OpenRouter's real error (e.g. "No endpoints found that support tool use") instead of a misleading `Responses API invalid_union` error.

### Parity Contract

- Legacy behavior preserved: generic cloud providers still fall back to `/responses` on 404 (`cloud_provider_falls_back_to_responses_on_404` green); Ollama/LM Studio guards unchanged.
- Guard/fallback/dispatch parity checks: gate is `is_openrouter_provider`; OpenRouter never sets `responses_api_primary`, so no codex-OAuth path is affected.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 30d-merged for openrouter/responses/invalid_prompt)
- Canonical PR: this
- Resolution: N/A
