### PR TITLE
fix(inference): demote chat-factory empty-model bail to expected config-rejection (#4001)

### DIFF
--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -304,6 +304,41 @@ fn classify_inference_error_surfaces_provider_config_rejection_actionably() {
     }
 }
 
+#[test]
+fn classify_inference_error_chat_factory_empty_model_is_actionable_config() {
+    // TAURI-RUST-GKV — the factory's #2784 empty-model bail is a LOCAL
+    // string (no provider JSON body). Before the shared classifier learned
+    // its anchor it fell through to the generic `inference` catch-all:
+    // vague "something went wrong" copy AND retryable=true (a useless Retry
+    // button that re-fires the per-message Sentry flood). It must now route
+    // through the config-rejection arm to the actionable Settings → LLM
+    // copy, classified non-retryable so the FE hides Retry.
+    let raw = "[chat-factory] no model configured: role 'chat' resolved to an empty model id \
+               for slug 'nvidia'. Include a model in the provider string (e.g. \
+               'nvidia:<model-id>') or set default_model on the cloud_providers entry for \
+               slug 'nvidia'.";
+    let ClassifiedError {
+        error_type: category,
+        message,
+        source,
+        retryable,
+        ..
+    } = classify_inference_error(raw);
+    assert_eq!(
+        category, "model_unavailable",
+        "empty-model config rejection must classify as model_unavailable, not generic: {category}"
+    );
+    assert_eq!(source, "config", "must be sourced as user config: {source}");
+    assert!(
+        !retryable,
+        "empty-model config rejection must be non-retryable (hide Retry)"
+    );
+    assert!(
+        message.contains("Settings → LLM"),
+        "must give the actionable remediation copy: {message}"
+    );
+}
+
 // ── #2364: rate-limit classification + retry-after surfacing ────
 
 #[test]

--- a/src/openhuman/inference/provider/config_rejection.rs
+++ b/src/openhuman/inference/provider/config_rejection.rs
@@ -166,6 +166,21 @@ pub fn is_provider_config_rejection_message(body: &str) -> bool {
         // `{"error":{"message":"model field is required","code":"missing_required_field"}}`
         // when the request body contains an empty `"model":""` field.
         "model field is required",
+        // TAURI-RUST-GKV (~2.3k events / 1 user) — the LOCAL form of the
+        // 4NM empty-model state, caught one layer earlier. The #2784 guard
+        // in `factory::make_cloud_provider_by_slug` bails BEFORE any
+        // provider HTTP call when a `<slug>` provider string carries no
+        // model and the `cloud_providers` entry has no `default_model`:
+        //   "[chat-factory] no model configured: role '<r>' resolved to an
+        //    empty model id for slug '<s>'. Include a model in the provider
+        //    string (e.g. '<s>:<model-id>') or set default_model …".
+        // User-state — the remediation is "add/pick a model in Settings →
+        // LLM", which the user-facing copy surfaces; Sentry has no
+        // remediation. Anchored on the role/slug-interpolation-free
+        // substring, which is also `factory::NO_MODEL_CONFIGURED_ANCHOR`; a
+        // round-trip test in `factory_tests.rs` couples the two so a
+        // wording drift fails CI instead of silently re-flooding Sentry.
+        "resolved to an empty model id",
         // TAURI-RUST-2G (~2684 events) / TAURI-RUST-2F (~950 events) —
         // thinking-mode model (DeepSeek-R1 / Moonshot K2-thinking on
         // `provider=cloud` custom_openai) rejects a follow-up turn that
@@ -602,6 +617,36 @@ mod tests {
         assert!(is_provider_config_rejection_message(
             "model field is required"
         ));
+    }
+
+    #[test]
+    fn detects_chat_factory_empty_model_local_bail() {
+        // TAURI-RUST-GKV — the #2784 factory guard
+        // (`make_cloud_provider_by_slug`) catches the empty-model state
+        // BEFORE the provider HTTP call (the local form of 4NM) and bails
+        // with this body (role/slug interpolated). Verbatim from Sentry
+        // issue 18482 (role='chat', slug='nvidia').
+        let body = "[chat-factory] no model configured: role 'chat' resolved to an empty model id \
+                    for slug 'nvidia'. Include a model in the provider string (e.g. \
+                    'nvidia:<model-id>') or set default_model on the cloud_providers entry for \
+                    slug 'nvidia'.";
+        assert!(
+            is_provider_config_rejection_message(body),
+            "TAURI-RUST-GKV empty-model bail must classify as provider config-rejection: {body:?}"
+        );
+        // Bare anchor on its own (the literal shared with
+        // `factory::NO_MODEL_CONFIGURED_ANCHOR`).
+        assert!(is_provider_config_rejection_message(
+            "resolved to an empty model id"
+        ));
+        // Negative: a near-miss model-resolution error that does NOT carry
+        // the anchor (or any other phrase) must stay Sentry-actionable.
+        assert!(
+            !is_provider_config_rejection_message(
+                "could not resolve the model registry for slug 'nvidia'"
+            ),
+            "unrelated model-resolution error must not classify on the GKV anchor"
+        );
     }
 
     #[test]

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -62,6 +62,16 @@ pub const CLAUDE_AGENT_SDK_PROVIDER: &str = "claude_agent_sdk";
 /// instead of silently routing through the managed OpenHuman backend.
 pub const BYOK_INCOMPLETE_SENTINEL: &str = "__byok_incomplete__";
 
+/// Interpolation-free substring of the empty-model bail emitted by
+/// [`make_cloud_provider_by_slug`] when a `<slug>` provider string carries
+/// no model and the `cloud_providers` entry has no `default_model` (the
+/// #2784 guard). The Sentry-demotion + user-copy classifier
+/// [`super::is_provider_config_rejection_message`] keys on this exact literal,
+/// and a round-trip test in `factory_tests.rs` asserts the bail body still
+/// contains it — so a wording drift fails CI instead of silently re-flooding
+/// Sentry (TAURI-RUST-GKV).
+pub(crate) const NO_MODEL_CONFIGURED_ANCHOR: &str = "resolved to an empty model id";
+
 fn is_abstract_tier_model(model: &str) -> bool {
     use crate::openhuman::config::{
         MODEL_AGENTIC_V1, MODEL_CHAT_V1, MODEL_CODING_V1, MODEL_REASONING_QUICK_V1,

--- a/src/openhuman/inference/provider/factory_tests.rs
+++ b/src/openhuman/inference/provider/factory_tests.rs
@@ -453,6 +453,23 @@ fn cloud_provider_with_no_model_and_no_default_rejected() {
         msg.contains("nvidia-nim"),
         "error must name the slug; got: {msg}"
     );
+
+    // TAURI-RUST-GKV coupling — the SAME bail body that floods Sentry must:
+    //   (a) still contain the classifier anchor const, and
+    //   (b) be recognised by the shared config-rejection classifier
+    //       (which both demotes the Sentry event AND drives the actionable
+    //       user-facing copy in `classify_inference_error`).
+    // If the bail wording drifts off the anchor, (a) fails; if the
+    // classifier phrase drifts, (b) fails — CI catches either direction, so
+    // the demotion can never silently regress into an error flood.
+    assert!(
+        msg.contains(super::NO_MODEL_CONFIGURED_ANCHOR),
+        "bail body must contain NO_MODEL_CONFIGURED_ANCHOR; got: {msg}"
+    );
+    assert!(
+        crate::openhuman::inference::provider::is_provider_config_rejection_message(&msg),
+        "empty-model bail must classify as provider config-rejection: {msg}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Demote the chat-factory **empty-model** bail (`[chat-factory] no model configured … resolved to an empty model id`) from a Sentry `error` event to a breadcrumb — it floods at one event per chat message (TAURI-RUST-GKV: 2333 events / 1 user).
- Single-line classifier add: the interpolation-free anchor `"resolved to an empty model id"` joins `is_provider_config_rejection_message`.
- Because the **same predicate** drives `classify_inference_error`, the user now gets the actionable *"Check your model and routing in Settings → LLM"* copy (non-retryable) instead of the generic retryable catch-all that shows a useless Retry button.
- CI-coupled to the source: a round-trip test asserts the real bail body still contains `NO_MODEL_CONFIGURED_ANCHOR` **and** classifies — a wording drift on either side fails CI rather than silently re-flooding Sentry.

## Problem

A user configured `chat_provider = "nvidia"` (slug only, no `:model`) with no `default_model` on the `nvidia` `cloud_providers` entry. The #2784 guard in `make_cloud_provider_by_slug` (`factory.rs`) correctly bails **before** the provider HTTP call with an actionable message — but the error-classifier never learned that local message. The web channel rebuilds the session per turn (the failed build is never cached), so every chat message re-runs `create_chat_provider("chat")` → `report_error_or_expected` → `tracing::error!` → a fresh Sentry event. Its provider-side twin `"model field is required"` (TAURI-RUST-4NM) and the adjacent abstract-tier bail are already demoted; the local guard that supersedes 4NM was the gap.

## Solution

- Add `"resolved to an empty model id"` to the `is_provider_config_rejection_message` allowlist (`config_rejection.rs`), classifying it `ProviderConfigRejection` → `expected_error_kind` demotes it to an info breadcrumb.
- Add `pub(crate) const NO_MODEL_CONFIGURED_ANCHOR` in `factory.rs` (the same literal the bail emits) for the drift-coupling test.
- The shared predicate also lives on the `classify_inference_error` config-rejection arm, so user-facing copy upgrades to `model_unavailable` / `source=config` / **non-retryable** / "Settings → LLM" — no behavior change to inference, only telemetry severity + error copy.
- Design note (bucket = **preventable user-state**): the actionable error itself already shipped in #2784; this is the consistency arm matching the already-demoted twins. The deeper prevent-at-source (a frontend model-picker gate that won't let a chat provider be saved without a model) is a separate follow-up in the React app — called out below, not silently dropped.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only classifier change, no feature row added/removed — Coverage matrix updated in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)
- [x] N/A: no matrix feature IDs touched — All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: no release-cut surface touched (Sentry severity + chat error copy only) — Manual smoke checklist updated ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop only** (Rust core). No migration, no schema change, no new deps.
- Telemetry: removes a per-message `error` Sentry flood (a real defect could no longer hide behind it — the anchor is our own unique local string, single emit site, so it cannot mask a backend bug).
- UX: the affected user now sees an actionable, non-retryable error pointing to Settings → LLM instead of a generic "try again" loop.
- Security: none.

## Related

- Closes #4001
- Sentry-Issue: TAURI-RUST-GKV
- Follow-up PR(s)/TODOs: frontend model-picker gate so a chat provider cannot be saved without a model (prevent-at-source; React app, out of this core-scope change).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A (GitHub issue #4001 / Sentry TAURI-RUST-GKV)
- URL: https://github.com/tinyhumansai/openhuman/issues/4001

### Commit & Branch

- Branch: `fix/4001-chat-factory-empty-model`
- Commit SHA: `f91b943304e0247e85c7b2628d989a7e6b9a88c0`

### Validation Run

- [x] N/A: no frontend (`app/src`) files changed — `pnpm --filter openhuman-app format:check`
- [x] N/A: no TypeScript changed — `pnpm typecheck`
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib -- config_rejection cloud_provider_with_no_model_and_no_default_rejected classify_inference_error_chat_factory_empty_model_is_actionable_config classify_inference_error_surfaces_provider_config_rejection_actionably` → 32 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean · `GGML_NATIVE=OFF cargo check` exit 0
- [x] Tauri fmt/check (if changed): `pnpm rust:check` via pre-push hook — passed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: empty-model config bail is demoted from a Sentry `error` event to a breadcrumb; its user-facing copy becomes the actionable non-retryable "Settings → LLM" message.
- User-visible effect: affected users see an actionable error (and no Retry button) instead of a generic retryable failure; no change for correctly-configured providers.
