### PR TITLE
fix(cron): seed morning briefing disabled by default

### DIFF
--- a/src/openhuman/cron/seed.rs
+++ b/src/openhuman/cron/seed.rs
@@ -1,7 +1,8 @@
 //! Seed default proactive agent cron jobs.
 //!
 //! Called once after onboarding completes to create:
-//! - A recurring daily morning briefing job (7 AM, user's local time or UTC)
+//! - A recurring daily morning briefing job (7 AM, user's local time or UTC),
+//!   seeded disabled until the user opts in
 //!
 //! The morning briefing uses `mode: "proactive"` delivery so the
 //! channels module's
@@ -73,7 +74,7 @@ pub fn seed_proactive_agents(config: &Config) -> Result<()> {
     prune_legacy_welcome(config, &existing);
 
     if !has(MORNING_BRIEFING_JOB_NAME) {
-        tracing::info!("[cron::seed] creating morning_briefing daily cron job");
+        tracing::info!("[cron::seed] creating morning_briefing daily cron job (disabled — opt-in)");
         seed_morning_briefing(config)?;
     } else {
         tracing::debug!("[cron::seed] morning_briefing job already exists — skipping");
@@ -164,7 +165,12 @@ fn prune_legacy_welcome(config: &Config, existing: &[crate::openhuman::cron::Cro
 /// (unless a timezone is later set explicitly).
 /// The cron expression `0 7 * * *` fires once per day. Users can later
 /// adjust the schedule or time zone via `cron.update_job`.
+///
+/// Created disabled in a single insert. The briefing is a full proactive agent
+/// turn, so it must not start billing inference until the user explicitly
+/// enables it from Settings/Routines (`cron.update_job → enabled=true`).
 fn seed_morning_briefing(config: &Config) -> Result<()> {
+    tracing::debug!("[cron::seed] seed_morning_briefing start");
     let schedule = Schedule::Cron {
         expr: "0 7 * * *".to_string(),
         tz: None,
@@ -178,7 +184,7 @@ fn seed_morning_briefing(config: &Config) -> Result<()> {
         "efficient briefing they can scan in 30 seconds over coffee."
     );
 
-    add_agent_job_with_definition(
+    let job = add_agent_job_with_definition(
         config,
         Some(MORNING_BRIEFING_JOB_NAME.to_string()),
         schedule,
@@ -188,9 +194,14 @@ fn seed_morning_briefing(config: &Config) -> Result<()> {
         Some(proactive_delivery()),
         false, // recurring — do not delete after run
         Some(MORNING_BRIEFING_JOB_NAME.to_string()),
-        true, // enabled
+        false, // enabled=false — opt-in, created disabled atomically
     )?;
 
+    tracing::debug!(
+        job_id = %job.id,
+        enabled = job.enabled,
+        "[cron::seed] seed_morning_briefing done — created disabled (opt-in)"
+    );
     Ok(())
 }
 
@@ -325,6 +336,54 @@ mod tests {
                 .count(),
             1,
             "second seed must not duplicate the tinyplace_autopilot job"
+        );
+    }
+
+    #[test]
+    fn seeds_morning_briefing_disabled_and_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        seed_proactive_agents(&config).expect("first seed");
+        let jobs = list_jobs(&config).unwrap();
+        assert!(
+            jobs.iter()
+                .filter(|j| matches!(j.job_type, crate::openhuman::cron::JobType::Agent))
+                .all(|j| !j.enabled),
+            "fresh onboarding seed must not create enabled billable agent cron jobs: {jobs:?}"
+        );
+        let briefings: Vec<_> = jobs
+            .iter()
+            .filter(|j| j.name.as_deref() == Some(MORNING_BRIEFING_JOB_NAME))
+            .collect();
+        assert_eq!(
+            briefings.len(),
+            1,
+            "exactly one morning_briefing job, got {briefings:?}"
+        );
+        let briefing = briefings[0];
+        assert!(
+            !briefing.enabled,
+            "morning_briefing must be seeded disabled until explicit opt-in"
+        );
+        assert_eq!(
+            briefing.agent_id.as_deref(),
+            Some(MORNING_BRIEFING_JOB_NAME)
+        );
+        assert!(matches!(
+            briefing.schedule,
+            Schedule::Cron { ref expr, .. } if expr == "0 7 * * *"
+        ));
+
+        seed_proactive_agents(&config).expect("second seed");
+        let after = list_jobs(&config).unwrap();
+        assert_eq!(
+            after
+                .iter()
+                .filter(|j| j.name.as_deref() == Some(MORNING_BRIEFING_JOB_NAME))
+                .count(),
+            1,
+            "second seed must not duplicate the morning_briefing job"
         );
     }
 


### PR DESCRIPTION
## Summary

- Seed the default `morning_briefing` proactive cron job disabled instead of enabled.
- Keep the existing schedule, prompt, agent id, delivery, and user opt-in path through `cron.update` unchanged.
- Add explicit seed regression coverage for disabled-by-default, idempotency, and no enabled billable agent cron jobs after fresh onboarding seed.
- Add grep-friendly seed diagnostics that identify morning briefing as disabled/opt-in.

## Problem

- Fresh onboarding currently creates `morning_briefing` as an enabled daily proactive agent job.
- That job can run a full billable agent turn daily without explicit user opt-in.
- The existing `tinyplace_autopilot` seed path already treats autonomous spend as opt-in and creates the job disabled atomically; morning briefing should follow that same default-off posture.

## Solution

- Pass `enabled=false` when creating the seeded `morning_briefing` job via `add_agent_job_with_definition`.
- Preserve explicit opt-in through the existing Settings/Routines toggle, which already calls `cron.update` with `enabled=true`.
- Cover the seed path with a unit test that verifies the briefing is created disabled, has the expected agent id/schedule, remains idempotent, and no freshly seeded agent cron job is enabled.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. Targeted Rust regression covers the changed seed path; CI remains authoritative for merged diff coverage.
- [x] N/A: Coverage matrix updated — behaviour-only cron seed default; no added/removed/renamed feature row in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related`; no matrix row changed
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)); core seed default only
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: desktop/core cron seed behavior only.
- New users still receive a `morning_briefing` routine entry, but it starts disabled and will not be picked up by `due_jobs` until explicitly enabled.
- Existing users/jobs are not migrated or mutated.
- No RPC, schema, frontend, or storage format changes.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes: Closes #4022
- Follow-up PR(s)/TODOs: None

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `issue/4022-morning-briefing-cron-is-seeded-enabled`
- Commit SHA: `286223b18c57c3381534116f8ccd71de0901838d`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (via pre-push hook)
- [x] `pnpm typecheck` / `pnpm --filter openhuman-app compile` (via pre-push hook)
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib openhuman::cron::seed::tests -- --nocapture`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --check`; `cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check` (via pre-push hook); `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Fresh onboarding seeds `morning_briefing` disabled until explicit opt-in.
- User-visible effect: A new idle user will not have an enabled daily billable briefing cron by default.

### Parity Contract

- Legacy behavior preserved: Schedule, prompt, delivery mode, agent id, boot backfill scope, and `cron.update` enable path are unchanged.
- Guard/fallback/dispatch parity checks: Existing `due_jobs` only selects `enabled = 1`; seeded briefing now starts outside that runnable set.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found for this branch
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A
