### PR TITLE
fix(shell,node,npm): no default timeout for scripting tools (#4023)

### DIFF
--- a/src/openhuman/agent/harness/engine/tools.rs
+++ b/src/openhuman/agent/harness/engine/tools.rs
@@ -41,6 +41,39 @@ pub(crate) struct ToolRunResult {
     pub success: bool,
 }
 
+/// Grace added to the outer harness deadline when a tool enforces its **own**
+/// per-call timeout internally (a `Secs` policy). The tool's own timeout then
+/// fires first — it produces a more specific message and actually kills the
+/// child process, whereas the harness backstop merely drops the future.
+const TOOL_TIMEOUT_GRACE_SECS: u64 = 5;
+
+/// Map a [`ToolTimeout`] policy to `(deadline, effective_secs)` for
+/// [`run_one_tool`]. `deadline` is `None` for an unbounded run (no harness
+/// timeout); `effective_secs` is the value surfaced in the timeout message
+/// (unused when `deadline` is `None`).
+fn resolve_tool_deadline(
+    policy: crate::openhuman::tools::traits::ToolTimeout,
+) -> (Option<std::time::Duration>, u64) {
+    use crate::openhuman::tool_timeout::{MAX_TIMEOUT_SECS, MIN_TIMEOUT_SECS};
+    use crate::openhuman::tools::traits::ToolTimeout;
+    match policy {
+        ToolTimeout::Inherit => {
+            let s = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
+            (Some(std::time::Duration::from_secs(s)), s)
+        }
+        ToolTimeout::Secs(req) => {
+            let s = req.clamp(MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
+            (
+                Some(std::time::Duration::from_secs(
+                    s.saturating_add(TOOL_TIMEOUT_GRACE_SECS),
+                )),
+                s,
+            )
+        }
+        ToolTimeout::Unbounded => (None, 0),
+    }
+}
+
 /// Execute one parsed tool call end-to-end. See the module docs for the full
 /// lifecycle. `tool_opt` is the (already visibility-filtered) tool the caller
 /// resolved by name — `None` means the model requested an unknown/filtered-out
@@ -189,10 +222,41 @@ pub(crate) async fn run_one_tool(
         }
     }
 
-    let tool_deadline = crate::openhuman::tool_timeout::tool_execution_timeout_duration();
-    let timeout_secs = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
+    // A tool that exposes a caller-supplied per-call budget (e.g. `shell`'s
+    // `timeout_secs`) raises/lowers the outer harness deadline to match; the
+    // resolver bounds it and falls back to the global config when absent or
+    // out of range. Without this, the global cap would kill a long-running
+    // command before the tool's own per-call timeout could take effect.
+    // Resolve this call's wall-clock policy. Most tools `Inherit` the global,
+    // config-driven timeout; scripting tools (`shell`/`node_exec`/`npm_exec`)
+    // run `Unbounded` unless the caller passed an explicit `timeout_secs`
+    // (`Secs`). See issue #4023 — a long-but-legitimate script must not be
+    // hard-killed by a default cap.
+    let policy = tool.timeout_policy(&call.arguments);
+    let (tool_deadline, timeout_secs) = resolve_tool_deadline(policy);
+    match policy {
+        crate::openhuman::tools::traits::ToolTimeout::Secs(req) => tracing::debug!(
+            iteration,
+            tool = call.name.as_str(),
+            requested_timeout_secs = req,
+            effective_timeout_secs = timeout_secs,
+            "[agent_loop] tool requested an explicit per-call timeout"
+        ),
+        crate::openhuman::tools::traits::ToolTimeout::Unbounded => tracing::debug!(
+            iteration,
+            tool = call.name.as_str(),
+            "[agent_loop] tool runs unbounded (no harness timeout) — no explicit timeout_secs"
+        ),
+        crate::openhuman::tools::traits::ToolTimeout::Inherit => {}
+    }
     let tool_started = std::time::Instant::now();
-    let outcome = tokio::time::timeout(tool_deadline, tool.execute(call.arguments.clone())).await;
+    let outcome = match tool_deadline {
+        Some(deadline) => {
+            tokio::time::timeout(deadline, tool.execute(call.arguments.clone())).await
+        }
+        // Unbounded: run to completion with no harness-imposed deadline.
+        None => Ok(tool.execute(call.arguments.clone()).await),
+    };
     let elapsed_ms = tool_started.elapsed().as_millis() as u64;
     let (result_text, success) = match outcome {
         Ok(Ok(r)) => {
@@ -391,5 +455,51 @@ pub(crate) async fn run_one_tool(
     ToolRunResult {
         text: result_text,
         success,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openhuman::tools::traits::ToolTimeout;
+
+    #[test]
+    fn unbounded_policy_imposes_no_deadline() {
+        let (deadline, _secs) = resolve_tool_deadline(ToolTimeout::Unbounded);
+        assert!(
+            deadline.is_none(),
+            "scripting tools with no explicit timeout must run unbounded"
+        );
+    }
+
+    #[test]
+    fn explicit_secs_policy_adds_grace_and_reports_value() {
+        let (deadline, secs) = resolve_tool_deadline(ToolTimeout::Secs(300));
+        // Reported value is the requested budget; the outer deadline gets a
+        // grace margin so the tool's own timeout fires first.
+        assert_eq!(secs, 300);
+        assert_eq!(
+            deadline,
+            Some(std::time::Duration::from_secs(
+                300 + TOOL_TIMEOUT_GRACE_SECS
+            ))
+        );
+    }
+
+    #[test]
+    fn explicit_secs_policy_clamps_out_of_range() {
+        // Above MAX clamps down; the deadline is built from the clamped value.
+        let (deadline, secs) = resolve_tool_deadline(ToolTimeout::Secs(999_999));
+        assert_eq!(secs, crate::openhuman::tool_timeout::MAX_TIMEOUT_SECS);
+        assert_eq!(
+            deadline,
+            Some(std::time::Duration::from_secs(
+                crate::openhuman::tool_timeout::MAX_TIMEOUT_SECS + TOOL_TIMEOUT_GRACE_SECS
+            ))
+        );
+
+        // Below MIN clamps up to MIN.
+        let (_d, secs_min) = resolve_tool_deadline(ToolTimeout::Secs(0));
+        assert_eq!(secs_min, crate::openhuman::tool_timeout::MIN_TIMEOUT_SECS);
     }
 }

--- a/src/openhuman/tool_timeout/README.md
+++ b/src/openhuman/tool_timeout/README.md
@@ -31,7 +31,13 @@ Highest precedence first:
 - `env_override_active() -> bool` — `true` when `OPENHUMAN_TOOL_TIMEOUT_SECS` is set to a valid override (so UI changes are ignored). Surfaced to the settings panel.
 - `tool_execution_timeout_secs() -> u64` — effective timeout in seconds (read fresh each call).
 - `tool_execution_timeout_duration() -> Duration` — same effective value as a `Duration`.
-- Constants: `DEFAULT_TIMEOUT_SECS = 120`, `MIN_TIMEOUT_SECS = 1`, `MAX_TIMEOUT_SECS = 3600`, `ENV_VAR = "OPENHUMAN_TOOL_TIMEOUT_SECS"`.
+- `explicit_call_timeout_secs(requested: Option<u64>, cap: u64) -> Option<u64>` — resolve an **explicit** per-call timeout for an otherwise-unbounded scripting tool. `None`/`Some(0)` ⇒ `None` (run unbounded); any positive value clamps to `MIN_TIMEOUT_SECS..=cap`. Callers pass their own ceiling (`MAX_TIMEOUT_SECS` for `shell`, `1800` for `node_exec`/`npm_exec`).
+- `explicit_call_timeout_duration(requested: Option<u64>, cap: u64) -> Option<Duration>` — same as a `Duration`, `None` for unbounded.
+- Constants: `DEFAULT_TIMEOUT_SECS = 120`, `MIN_TIMEOUT_SECS = 1`, `MAX_TIMEOUT_SECS = 3600`, `SANDBOX_UNBOUNDED_CAP_SECS = 86_400`, `ENV_VAR = "OPENHUMAN_TOOL_TIMEOUT_SECS"`.
+
+## Scripting tools run unbounded (issue #4023)
+
+The global timeout governs **non-scripting** tools only — a hung network/MCP call must stay bounded. The scripting tools (`shell`, `node_exec`, `npm_exec`) instead run with **no** default deadline: a build / solver / test run legitimately takes minutes and must not be hard-killed. They expose a per-call `timeout_secs` argument and return [`Tool::timeout_policy`] → `ToolTimeout::Unbounded` when none is supplied, or `ToolTimeout::Secs(n)` when one is. The harness (`agent/harness/engine/tools.rs::resolve_tool_deadline`) maps `Unbounded` to "no `tokio::time::timeout` wrapper at all" and `Secs(n)` to a clamped deadline plus a small grace margin so the tool's own internal timeout (which actually kills the child) fires first. Sandbox backends, which require a finite deadline, substitute `SANDBOX_UNBOUNDED_CAP_SECS` (24h) for the unbounded case.
 
 ## Configuration
 
@@ -44,7 +50,8 @@ Highest precedence first:
 
 ## Used by
 
-- `src/openhuman/agent/harness/engine/tools.rs` — `run_one_tool` wraps every tool `execute()` in `tokio::time::timeout(tool_execution_timeout_duration(), …)` and logs `tool_execution_timeout_secs()`. This is the single per-tool-call enforcement point, reached by the main loop, the session executor, and the sub-agent inner loop.
+- `src/openhuman/agent/harness/engine/tools.rs` — `run_one_tool` wraps each tool `execute()` according to its [`Tool::timeout_policy`] (via `resolve_tool_deadline`): `Inherit` uses `tool_execution_timeout_secs()`; `Secs(n)` uses a clamped value plus grace; `Unbounded` runs with no deadline. This is the single per-tool-call enforcement point, reached by the main loop, the session executor, and the sub-agent inner loop.
+- `src/openhuman/tools/impl/system/{shell,node_exec,npm_exec}.rs` — scripting tools: unbounded by default, explicit `timeout_secs` via `explicit_call_timeout_*`.
 - `src/openhuman/agent/tools/delegate.rs` — bounds the delegated provider chat call with `tool_execution_timeout_secs`.
 - `src/openhuman/config/ops.rs` — `apply_agent_settings` calls `set_tool_timeout_secs` after persisting; `get_agent_settings` reports `effective_timeout_secs` / `env_override`.
 - `src/openhuman/channels/runtime/startup.rs` — seeds the runtime value from config at core boot.

--- a/src/openhuman/tool_timeout/mod.rs
+++ b/src/openhuman/tool_timeout/mod.rs
@@ -24,6 +24,12 @@ pub const MIN_TIMEOUT_SECS: u64 = 1;
 pub const MAX_TIMEOUT_SECS: u64 = 3600;
 /// Operator override env var. Takes precedence over the persisted config value.
 pub const ENV_VAR: &str = "OPENHUMAN_TOOL_TIMEOUT_SECS";
+/// Effective-unbounded cap (24h) for sandbox backends, which require a finite
+/// deadline. Scripting tools run truly unbounded on the native path, but the
+/// sandbox path substitutes this generous cap when no explicit `timeout_secs`
+/// was requested — long enough not to kill a legitimate long job, finite
+/// enough to eventually reclaim a wedged sandbox process.
+pub const SANDBOX_UNBOUNDED_CAP_SECS: u64 = 86_400;
 
 /// Effective timeout in seconds. `0` is the "not yet seeded" sentinel: the
 /// first read resolves env/default and stores it. Config pushes overwrite it
@@ -118,6 +124,34 @@ pub fn tool_execution_timeout_duration() -> Duration {
     Duration::from_secs(current_secs())
 }
 
+/// Resolve an **explicit** per-call timeout request for a tool that is
+/// otherwise unbounded (the scripting tools: `shell`, `node_exec`, `npm_exec`).
+///
+/// Unlike most tools — which inherit the global config-driven timeout so a hung
+/// network/MCP call can't wedge a session — scripting tools run with **no**
+/// default deadline: a build / solver / test run legitimately takes minutes and
+/// must not be hard-killed by a default cap (issue #4023). A deadline applies
+/// only when the caller explicitly asks for one via `timeout_secs`.
+///
+/// Returns:
+/// - `None` → run unbounded. Used when no `timeout_secs` was supplied
+///   (`None`) or it was explicitly disabled (`Some(0)`).
+/// - `Some(secs)` → enforce this budget, clamped to `MIN_TIMEOUT_SECS..=cap`.
+///   `cap` lets callers with a tighter own-ceiling (e.g. node/npm at 1800s)
+///   pass it; most callers pass [`MAX_TIMEOUT_SECS`].
+pub fn explicit_call_timeout_secs(requested: Option<u64>, cap: u64) -> Option<u64> {
+    let cap = cap.clamp(MIN_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
+    match requested {
+        None | Some(0) => None,
+        Some(n) => Some(n.clamp(MIN_TIMEOUT_SECS, cap)),
+    }
+}
+
+/// [`explicit_call_timeout_secs`] as a [`Duration`], or `None` for unbounded.
+pub fn explicit_call_timeout_duration(requested: Option<u64>, cap: u64) -> Option<Duration> {
+    explicit_call_timeout_secs(requested, cap).map(Duration::from_secs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,6 +226,45 @@ mod tests {
         // being applied verbatim.
         assert_eq!(resolve_effective(0, None), DEFAULT_TIMEOUT_SECS);
         assert_eq!(resolve_effective(99_999, None), DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn explicit_call_timeout_unbounded_when_absent_or_disabled() {
+        // No request, or an explicit 0, means "run unbounded" (None).
+        assert_eq!(explicit_call_timeout_secs(None, MAX_TIMEOUT_SECS), None);
+        assert_eq!(explicit_call_timeout_secs(Some(0), MAX_TIMEOUT_SECS), None);
+    }
+
+    #[test]
+    fn explicit_call_timeout_enforces_and_clamps_request() {
+        // An in-range request is enforced verbatim.
+        assert_eq!(
+            explicit_call_timeout_secs(Some(900), MAX_TIMEOUT_SECS),
+            Some(900)
+        );
+        // Below the floor clamps up to MIN.
+        assert_eq!(
+            explicit_call_timeout_secs(Some(0), MAX_TIMEOUT_SECS),
+            None,
+            "0 disables rather than clamping to MIN"
+        );
+        // Above the cap clamps down to the cap.
+        assert_eq!(
+            explicit_call_timeout_secs(Some(99_999), MAX_TIMEOUT_SECS),
+            Some(MAX_TIMEOUT_SECS)
+        );
+        // A tool with a tighter own ceiling (node/npm at 1800) clamps to it.
+        assert_eq!(explicit_call_timeout_secs(Some(99_999), 1800), Some(1800));
+        assert_eq!(explicit_call_timeout_secs(Some(600), 1800), Some(600));
+    }
+
+    #[test]
+    fn explicit_call_timeout_duration_matches_secs() {
+        assert_eq!(
+            explicit_call_timeout_duration(Some(900), MAX_TIMEOUT_SECS),
+            Some(Duration::from_secs(900))
+        );
+        assert_eq!(explicit_call_timeout_duration(None, MAX_TIMEOUT_SECS), None);
     }
 
     #[test]

--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -24,16 +24,17 @@
 use crate::openhuman::agent::host_runtime::RuntimeAdapter;
 use crate::openhuman::javascript::NodeBootstrap;
 use crate::openhuman::security::{CommandClass, GateDecision, SecurityPolicy};
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult, ToolTimeout};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Maximum node process wall-clock before we kill it. Longer than the shell
-/// tool because `npm install` / bundler steps can legitimately exceed 60s,
-/// and `node_exec` is often the launcher for those flows.
-const NODE_TIMEOUT_SECS: u64 = 300;
+/// Absolute ceiling a caller may request via `timeout_secs`. There is **no**
+/// default timeout — `node_exec` runs scripts that legitimately take minutes
+/// (bundlers, solvers, test runs) and must not be hard-killed by a default cap
+/// (issue #4023). A deadline applies only when `timeout_secs` is supplied.
+const NODE_TIMEOUT_MAX_SECS: u64 = 1800;
 /// Maximum combined stdout/stderr size (1 MB each) — same cap as shell.
 const MAX_OUTPUT_BYTES: usize = 1_048_576;
 /// Env allow-list for child processes. Matches shell.rs — secrets never leak
@@ -114,7 +115,7 @@ impl Tool for NodeExecTool {
                 },
                 "timeout_secs": {
                     "type": "integer",
-                    "description": "Optional override for the default 300s timeout. Capped at 1800s."
+                    "description": "Optional wall-clock timeout (seconds) before the process is killed. No timeout by default — long-running scripts run to completion. Capped at 1800s; 0 disables."
                 }
             }
         })
@@ -122,6 +123,13 @@ impl Tool for NodeExecTool {
 
     fn permission_level(&self) -> PermissionLevel {
         PermissionLevel::Execute
+    }
+
+    /// `node_exec` runs scripts that legitimately take a long time, so it runs
+    /// unbounded unless the caller passes an explicit `timeout_secs` (capped at
+    /// [`NODE_TIMEOUT_MAX_SECS`]).
+    fn timeout_policy(&self, args: &serde_json::Value) -> ToolTimeout {
+        node_timeout_policy(args)
     }
 
     /// Running JavaScript is arbitrary code execution → the `Write` bucket. In
@@ -152,11 +160,12 @@ impl Tool for NodeExecTool {
             })
             .unwrap_or_default();
 
-        let timeout_secs = args
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(NODE_TIMEOUT_SECS)
-            .min(1800);
+        // No default deadline — only the caller-supplied `timeout_secs` (capped)
+        // bounds the run. `None` ⇒ run to completion.
+        let explicit_timeout = crate::openhuman::tool_timeout::explicit_call_timeout_duration(
+            args.get("timeout_secs").and_then(|v| v.as_u64()),
+            NODE_TIMEOUT_MAX_SECS,
+        );
 
         if inline_code.is_some() == script_path.is_some() {
             return Ok(ToolResult::error(
@@ -239,7 +248,7 @@ impl Tool for NodeExecTool {
             Some(crate::openhuman::agent::harness::definition::SandboxMode::Sandboxed)
         ) {
             return Ok(self
-                .run_sandboxed(&command, &resolved.bin_dir, timeout_secs)
+                .run_sandboxed(&command, &resolved.bin_dir, explicit_timeout)
                 .await);
         }
 
@@ -272,7 +281,12 @@ impl Tool for NodeExecTool {
             }
         }
 
-        let result = tokio::time::timeout(Duration::from_secs(timeout_secs), cmd.output()).await;
+        // Bounded only when the caller asked for a deadline; otherwise run to
+        // completion (no harness/tool timeout on long scripts).
+        let result = match explicit_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, cmd.output()).await,
+            None => Ok(cmd.output().await),
+        };
 
         match result {
             Ok(Ok(output)) => {
@@ -307,7 +321,8 @@ impl Tool for NodeExecTool {
             }
             Ok(Err(e)) => Ok(ToolResult::error(format!("Failed to execute node: {e}"))),
             Err(_) => Ok(ToolResult::error(format!(
-                "node_exec timed out after {timeout_secs}s and was killed"
+                "node_exec timed out after {}s and was killed",
+                explicit_timeout.map(|d| d.as_secs()).unwrap_or(0)
             ))),
         }
     }
@@ -327,9 +342,17 @@ impl NodeExecTool {
         &self,
         command: &str,
         bin_dir: &std::path::Path,
-        timeout_secs: u64,
+        timeout: Option<Duration>,
     ) -> ToolResult {
         use crate::openhuman::sandbox;
+
+        // Sandbox backends require a finite deadline. When the caller did not
+        // request one, use a generous effective-unbounded cap (24h) so a
+        // legitimately long script isn't killed while still bounding a wedged
+        // sandbox process. The native (non-sandboxed) path runs truly unbounded.
+        let effective = timeout.unwrap_or_else(|| {
+            Duration::from_secs(crate::openhuman::tool_timeout::SANDBOX_UNBOUNDED_CAP_SECS)
+        });
 
         // Load the live `RuntimeConfig` so `resolve_sandbox_policy` derives
         // the right backend (Docker / local / noop) from the operator's
@@ -383,14 +406,15 @@ impl NodeExecTool {
             command,
             &self.security.action_dir,
             extra_env,
-            Duration::from_secs(timeout_secs),
+            effective,
         )
         .await
         {
             Ok(result) => {
                 if result.timed_out {
                     ToolResult::error(format!(
-                        "node_exec timed out after {timeout_secs}s and was killed"
+                        "node_exec timed out after {}s and was killed",
+                        effective.as_secs()
                     ))
                 } else if result.success() {
                     if result.stderr.is_empty() {
@@ -412,6 +436,18 @@ impl NodeExecTool {
             }
             Err(e) => ToolResult::error(format!("Sandbox execution failed: {e}")),
         }
+    }
+}
+
+/// Resolve the wall-clock policy for a `node_exec` call from its args.
+///
+/// No `timeout_secs` (or `0`) ⇒ run unbounded; a positive value ⇒ enforce it,
+/// clamped to [`NODE_TIMEOUT_MAX_SECS`]. Extracted from
+/// [`NodeExecTool::timeout_policy`] so it is unit-testable without a bootstrap.
+fn node_timeout_policy(args: &serde_json::Value) -> ToolTimeout {
+    match args.get("timeout_secs").and_then(|v| v.as_u64()) {
+        None | Some(0) => ToolTimeout::Unbounded,
+        Some(secs) => ToolTimeout::Secs(secs.min(NODE_TIMEOUT_MAX_SECS)),
     }
 }
 
@@ -470,6 +506,29 @@ mod tests {
     fn shell_quote_wraps_plain_strings() {
         assert_eq!(shell_quote("node"), "'node'");
         assert_eq!(shell_quote("/opt/bin/node"), "'/opt/bin/node'");
+    }
+
+    #[test]
+    fn node_timeout_policy_unbounded_by_default() {
+        // No timeout_secs (or explicit 0) ⇒ run to completion.
+        assert_eq!(node_timeout_policy(&json!({})), ToolTimeout::Unbounded);
+        assert_eq!(
+            node_timeout_policy(&json!({"timeout_secs": 0})),
+            ToolTimeout::Unbounded
+        );
+    }
+
+    #[test]
+    fn node_timeout_policy_enforces_and_caps_explicit() {
+        assert_eq!(
+            node_timeout_policy(&json!({"timeout_secs": 120})),
+            ToolTimeout::Secs(120)
+        );
+        // Clamped to the 1800s ceiling.
+        assert_eq!(
+            node_timeout_policy(&json!({"timeout_secs": 99999})),
+            ToolTimeout::Secs(NODE_TIMEOUT_MAX_SECS)
+        );
     }
 
     #[test]

--- a/src/openhuman/tools/impl/system/npm_exec.rs
+++ b/src/openhuman/tools/impl/system/npm_exec.rs
@@ -20,16 +20,16 @@
 use crate::openhuman::agent::host_runtime::RuntimeAdapter;
 use crate::openhuman::javascript::NodeBootstrap;
 use crate::openhuman::security::{CommandClass, GateDecision, SecurityPolicy};
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult, ToolTimeout};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Default wall-clock budget for an npm invocation. `npm install` on a cold
-/// cache can legitimately take several minutes on slow networks.
-const NPM_TIMEOUT_SECS: u64 = 600;
-/// Absolute ceiling callers can request via `timeout_secs`.
+/// Absolute ceiling callers can request via `timeout_secs`. There is **no**
+/// default timeout — `npm install`/build steps on a cold cache or slow network
+/// legitimately take minutes and must not be hard-killed by a default cap
+/// (issue #4023). A deadline applies only when `timeout_secs` is supplied.
 const NPM_TIMEOUT_MAX_SECS: u64 = 1800;
 /// Output cap per stream (1 MB).
 const MAX_OUTPUT_BYTES: usize = 1_048_576;
@@ -129,7 +129,7 @@ impl Tool for NpmExecTool {
                 },
                 "timeout_secs": {
                     "type": "integer",
-                    "description": "Optional override for the default 600s timeout. Capped at 1800s."
+                    "description": "Optional wall-clock timeout (seconds) before npm is killed. No timeout by default — installs/builds run to completion. Capped at 1800s; 0 disables."
                 }
             },
             "required": ["subcommand"]
@@ -138,6 +138,13 @@ impl Tool for NpmExecTool {
 
     fn permission_level(&self) -> PermissionLevel {
         PermissionLevel::Execute
+    }
+
+    /// `npm_exec` runs installs/builds that legitimately take a long time, so it
+    /// runs unbounded unless the caller passes an explicit `timeout_secs`
+    /// (capped at [`NPM_TIMEOUT_MAX_SECS`]).
+    fn timeout_policy(&self, args: &serde_json::Value) -> ToolTimeout {
+        npm_timeout_policy(args)
     }
 
     /// npm subcommands run arbitrary scripts (`run`/`exec`/lifecycle hooks) →
@@ -186,11 +193,12 @@ impl Tool for NpmExecTool {
 
         let cwd_override = args.get("cwd").and_then(|v| v.as_str()).map(str::to_string);
 
-        let timeout_secs = args
-            .get("timeout_secs")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(NPM_TIMEOUT_SECS)
-            .min(NPM_TIMEOUT_MAX_SECS);
+        // No default deadline — only a caller-supplied `timeout_secs` (capped)
+        // bounds the run. `None` ⇒ run to completion.
+        let explicit_timeout = crate::openhuman::tool_timeout::explicit_call_timeout_duration(
+            args.get("timeout_secs").and_then(|v| v.as_u64()),
+            NPM_TIMEOUT_MAX_SECS,
+        );
 
         // Read-only mode performs no acts. npm runs arbitrary scripts, so it
         // must refuse here — it previously skipped the autonomy check entirely.
@@ -252,7 +260,7 @@ impl Tool for NpmExecTool {
             Some(crate::openhuman::agent::harness::definition::SandboxMode::Sandboxed)
         ) {
             return Ok(self
-                .run_sandboxed(&command, &cwd, &resolved.bin_dir, timeout_secs)
+                .run_sandboxed(&command, &cwd, &resolved.bin_dir, explicit_timeout)
                 .await);
         }
 
@@ -282,7 +290,12 @@ impl Tool for NpmExecTool {
             }
         }
 
-        let result = tokio::time::timeout(Duration::from_secs(timeout_secs), cmd.output()).await;
+        // Bounded only when the caller asked for a deadline; otherwise run to
+        // completion (no harness/tool timeout on long installs/builds).
+        let result = match explicit_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, cmd.output()).await,
+            None => Ok(cmd.output().await),
+        };
 
         match result {
             Ok(Ok(output)) => {
@@ -317,7 +330,8 @@ impl Tool for NpmExecTool {
             }
             Ok(Err(e)) => Ok(ToolResult::error(format!("Failed to execute npm: {e}"))),
             Err(_) => Ok(ToolResult::error(format!(
-                "npm_exec timed out after {timeout_secs}s and was killed"
+                "npm_exec timed out after {}s and was killed",
+                explicit_timeout.map(|d| d.as_secs()).unwrap_or(0)
             ))),
         }
     }
@@ -337,9 +351,18 @@ impl NpmExecTool {
         command: &str,
         cwd: &std::path::Path,
         bin_dir: &std::path::Path,
-        timeout_secs: u64,
+        timeout: Option<Duration>,
     ) -> ToolResult {
         use crate::openhuman::sandbox;
+
+        // Sandbox backends require a finite deadline. When the caller did not
+        // request one, use a generous effective-unbounded cap (24h) — long
+        // enough not to kill a legitimate install/build, finite enough to
+        // eventually reclaim a wedged sandbox process. The native path runs
+        // truly unbounded.
+        let effective = timeout.unwrap_or_else(|| {
+            Duration::from_secs(crate::openhuman::tool_timeout::SANDBOX_UNBOUNDED_CAP_SECS)
+        });
 
         // Load the live `RuntimeConfig` so `resolve_sandbox_policy` derives
         // the right backend (Docker / local / noop) from the operator's
@@ -388,19 +411,12 @@ impl NpmExecTool {
         };
         extra_env.insert("PATH".to_string(), prepended);
 
-        match sandbox::execute_in_sandbox(
-            &policy,
-            command,
-            cwd,
-            extra_env,
-            Duration::from_secs(timeout_secs),
-        )
-        .await
-        {
+        match sandbox::execute_in_sandbox(&policy, command, cwd, extra_env, effective).await {
             Ok(result) => {
                 if result.timed_out {
                     ToolResult::error(format!(
-                        "npm_exec timed out after {timeout_secs}s and was killed"
+                        "npm_exec timed out after {}s and was killed",
+                        effective.as_secs()
                     ))
                 } else if result.success() {
                     if result.stderr.is_empty() {
@@ -422,6 +438,18 @@ impl NpmExecTool {
             }
             Err(e) => ToolResult::error(format!("Sandbox execution failed: {e}")),
         }
+    }
+}
+
+/// Resolve the wall-clock policy for an `npm_exec` call from its args.
+///
+/// No `timeout_secs` (or `0`) ⇒ run unbounded; a positive value ⇒ enforce it,
+/// clamped to [`NPM_TIMEOUT_MAX_SECS`]. Extracted from
+/// [`NpmExecTool::timeout_policy`] so it is unit-testable without a bootstrap.
+fn npm_timeout_policy(args: &serde_json::Value) -> ToolTimeout {
+    match args.get("timeout_secs").and_then(|v| v.as_u64()) {
+        None | Some(0) => ToolTimeout::Unbounded,
+        Some(secs) => ToolTimeout::Secs(secs.min(NPM_TIMEOUT_MAX_SECS)),
     }
 }
 
@@ -484,6 +512,27 @@ mod tests {
         } else {
             "/etc"
         }
+    }
+
+    #[test]
+    fn npm_timeout_policy_unbounded_by_default() {
+        assert_eq!(npm_timeout_policy(&json!({})), ToolTimeout::Unbounded);
+        assert_eq!(
+            npm_timeout_policy(&json!({"timeout_secs": 0})),
+            ToolTimeout::Unbounded
+        );
+    }
+
+    #[test]
+    fn npm_timeout_policy_enforces_and_caps_explicit() {
+        assert_eq!(
+            npm_timeout_policy(&json!({"timeout_secs": 300})),
+            ToolTimeout::Secs(300)
+        );
+        assert_eq!(
+            npm_timeout_policy(&json!({"timeout_secs": 99999})),
+            ToolTimeout::Secs(NPM_TIMEOUT_MAX_SECS)
+        );
     }
 
     #[test]

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -8,8 +8,6 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-/// Maximum shell command execution time before kill.
-const SHELL_TIMEOUT_SECS: u64 = 60;
 /// Maximum output size in bytes (1MB).
 const MAX_OUTPUT_BYTES: usize = 1_048_576;
 /// Environment variables safe to pass to shell commands.
@@ -151,6 +149,14 @@ impl ShellTool {
     fn effective_action_dir(&self) -> std::path::PathBuf {
         crate::openhuman::agent::harness::current_action_dir_override()
             .unwrap_or_else(|| self.security.action_dir.clone())
+    }
+
+    fn timeout_secs(&self) -> u64 {
+        crate::openhuman::tool_timeout::tool_execution_timeout_secs()
+    }
+
+    fn timeout_duration(&self) -> Duration {
+        crate::openhuman::tool_timeout::tool_execution_timeout_duration()
     }
 }
 
@@ -343,8 +349,12 @@ impl ShellTool {
             }
         }
 
-        let result =
-            tokio::time::timeout(Duration::from_secs(SHELL_TIMEOUT_SECS), cmd.output()).await;
+        let timeout = self.timeout_duration();
+        tracing::debug!(
+            timeout_secs = timeout.as_secs(),
+            "[shell] starting command with configured timeout"
+        );
+        let result = tokio::time::timeout(timeout, cmd.output()).await;
 
         let tool_result = match result {
             Ok(Ok(output)) => {
@@ -381,7 +391,8 @@ impl ShellTool {
             }
             Ok(Err(e)) => ToolResult::error(format!("Failed to execute command: {e}")),
             Err(_) => ToolResult::error(format!(
-                "Command timed out after {SHELL_TIMEOUT_SECS}s and was killed"
+                "Command timed out after {}s and was killed",
+                timeout.as_secs()
             )),
         };
         (true, tool_result)
@@ -420,19 +431,26 @@ impl ShellTool {
             }
         }
 
+        let timeout = self.timeout_duration();
+        tracing::debug!(
+            timeout_secs = timeout.as_secs(),
+            "[shell] starting sandboxed command with configured timeout"
+        );
+
         match sandbox::execute_in_sandbox(
             &policy,
             command,
             &self.security.action_dir,
             extra_env,
-            Duration::from_secs(SHELL_TIMEOUT_SECS),
+            timeout,
         )
         .await
         {
             Ok(result) => {
                 let tool_result = if result.timed_out {
                     ToolResult::error(format!(
-                        "Command timed out after {SHELL_TIMEOUT_SECS}s and was killed"
+                        "Command timed out after {}s and was killed",
+                        timeout.as_secs()
                     ))
                 } else if result.success() {
                     if result.stderr.is_empty() {
@@ -1003,8 +1021,24 @@ mod tests {
     // ── §5.2 Shell timeout enforcement tests ─────────────────
 
     #[test]
-    fn shell_timeout_constant_is_reasonable() {
-        assert_eq!(SHELL_TIMEOUT_SECS, 60, "shell timeout must be 60 seconds");
+    fn shell_timeout_uses_runtime_tool_timeout() {
+        let tool = ShellTool::new(
+            test_security(AutonomyLevel::Supervised),
+            test_runtime(),
+            test_audit(),
+        );
+
+        let previous = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
+        let requested = if previous == 300 { 301 } else { 300 };
+        let configured = crate::openhuman::tool_timeout::set_tool_timeout_secs(requested);
+
+        assert_eq!(
+            tool.timeout_secs(),
+            configured,
+            "shell timeout must honor the shared tool timeout runtime"
+        );
+
+        crate::openhuman::tool_timeout::set_tool_timeout_secs(previous);
     }
 
     #[test]

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -2,7 +2,7 @@ use crate::openhuman::agent::host_runtime::RuntimeAdapter;
 use crate::openhuman::javascript::NodeBootstrap;
 use crate::openhuman::runtime_python::PythonBootstrap;
 use crate::openhuman::security::{AuditLogger, CommandExecutionLog, GateDecision, SecurityPolicy};
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult, ToolTimeout};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
@@ -151,12 +151,20 @@ impl ShellTool {
             .unwrap_or_else(|| self.security.action_dir.clone())
     }
 
-    fn timeout_secs(&self) -> u64 {
-        crate::openhuman::tool_timeout::tool_execution_timeout_secs()
-    }
-
-    fn timeout_duration(&self) -> Duration {
-        crate::openhuman::tool_timeout::tool_execution_timeout_duration()
+    /// The explicit wall-clock budget for this invocation, or `None` to run
+    /// unbounded.
+    ///
+    /// Shell commands run scripts — builds, test suites, solvers — that
+    /// legitimately take minutes, so there is **no** default timeout: a
+    /// deadline applies only when the caller passes `timeout_secs` (issue
+    /// #4023). A `0` explicitly disables it. Any positive value is clamped to
+    /// `1..=3600`. See
+    /// [`crate::openhuman::tool_timeout::explicit_call_timeout_duration`].
+    fn explicit_timeout(&self, requested: Option<u64>) -> Option<Duration> {
+        crate::openhuman::tool_timeout::explicit_call_timeout_duration(
+            requested,
+            crate::openhuman::tool_timeout::MAX_TIMEOUT_SECS,
+        )
     }
 }
 
@@ -188,6 +196,12 @@ impl Tool for ShellTool {
                     "type": "string",
                     "enum": ["read", "write", "network", "install", "destructive"],
                     "description": "Optional self-declared risk category for this command. Advisory and ESCALATE-ONLY: it can raise the approval requirement (e.g. flag a destructive command) but never lowers what the runtime determines."
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3600,
+                    "description": "Optional wall-clock timeout (seconds, 1..=3600) for this command before it is killed. Use a larger value for long-running work (builds, test suites, solvers). Omitted or out-of-range falls back to the configured tool timeout."
                 }
             },
             "required": ["command"]
@@ -201,6 +215,18 @@ impl Tool for ShellTool {
     /// the right move when it does.
     fn max_result_size_chars(&self) -> Option<usize> {
         Some(30_000)
+    }
+
+    /// Shell runs scripts that legitimately take a long time, so it runs
+    /// unbounded unless the caller passes an explicit `timeout_secs`. This
+    /// keeps the harness from hard-killing a long command at the global tool
+    /// timeout (issue #4023).
+    fn timeout_policy(&self, args: &serde_json::Value) -> ToolTimeout {
+        match args.get("timeout_secs").and_then(|v| v.as_u64()) {
+            // `0` (or absent) means "no deadline".
+            None | Some(0) => ToolTimeout::Unbounded,
+            Some(secs) => ToolTimeout::Secs(secs),
+        }
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -233,8 +259,14 @@ impl Tool for ShellTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'command' parameter"))?;
 
+        // Optional per-call wall-clock budget. `None`/`0` ⇒ run unbounded;
+        // a positive value is clamped downstream by
+        // `tool_timeout::explicit_call_timeout_*`. Shell has no default deadline
+        // (issue #4023) — long scripts must run to completion.
+        let requested_timeout = args.get("timeout_secs").and_then(|v| v.as_u64());
+
         let start = Instant::now();
-        let (allowed, result) = self.run_with_security(command).await;
+        let (allowed, result) = self.run_with_security(command, requested_timeout).await;
         let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
         // `allowed` = passed the in-tool security checks. `approved` = the command
         // is Prompt-class (required human approval) and thus went through the
@@ -259,7 +291,11 @@ impl ShellTool {
     /// same gated execution path as the `shell` tool — all security
     /// checks (rate limits, path guards, approval gate routing) apply
     /// identically to workflow-triggered commands.
-    pub(crate) async fn run_with_security(&self, command: &str) -> (bool, ToolResult) {
+    pub(crate) async fn run_with_security(
+        &self,
+        command: &str,
+        requested_timeout: Option<u64>,
+    ) -> (bool, ToolResult) {
         // Read-only `Block` + the Option-2 structural guard. Approval for
         // Write / Network / Destructive already happened at the harness
         // `ApprovalGate` (see `external_effect_with_args`) before `execute()`
@@ -289,7 +325,7 @@ impl ShellTool {
             crate::openhuman::agent::harness::current_sandbox_mode(),
             Some(crate::openhuman::agent::harness::definition::SandboxMode::Sandboxed)
         ) {
-            return self.run_sandboxed(command).await;
+            return self.run_sandboxed(command, requested_timeout).await;
         }
 
         // Execute with timeout to prevent hanging commands.
@@ -349,12 +385,19 @@ impl ShellTool {
             }
         }
 
-        let timeout = self.timeout_duration();
+        // No default deadline — only a caller-supplied `timeout_secs` bounds the
+        // run. `None` ⇒ run to completion (issue #4023).
+        let explicit_timeout = self.explicit_timeout(requested_timeout);
         tracing::debug!(
-            timeout_secs = timeout.as_secs(),
-            "[shell] starting command with configured timeout"
+            timeout_secs = ?explicit_timeout.map(|d| d.as_secs()),
+            requested_timeout_secs = ?requested_timeout,
+            "[shell] starting command ({} timeout)",
+            if explicit_timeout.is_some() { "explicit" } else { "no" }
         );
-        let result = tokio::time::timeout(timeout, cmd.output()).await;
+        let result = match explicit_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, cmd.output()).await,
+            None => Ok(cmd.output().await),
+        };
 
         let tool_result = match result {
             Ok(Ok(output)) => {
@@ -392,7 +435,7 @@ impl ShellTool {
             Ok(Err(e)) => ToolResult::error(format!("Failed to execute command: {e}")),
             Err(_) => ToolResult::error(format!(
                 "Command timed out after {}s and was killed",
-                timeout.as_secs()
+                explicit_timeout.map(|d| d.as_secs()).unwrap_or(0)
             )),
         };
         (true, tool_result)
@@ -400,7 +443,11 @@ impl ShellTool {
 
     /// Execute a command through the sandbox backend. Called when the
     /// agent's `SandboxMode` is `Sandboxed`.
-    async fn run_sandboxed(&self, command: &str) -> (bool, ToolResult) {
+    async fn run_sandboxed(
+        &self,
+        command: &str,
+        requested_timeout: Option<u64>,
+    ) -> (bool, ToolResult) {
         use crate::openhuman::sandbox;
 
         let config = crate::openhuman::config::RuntimeConfig::default();
@@ -431,10 +478,18 @@ impl ShellTool {
             }
         }
 
-        let timeout = self.timeout_duration();
+        // Sandbox backends require a finite deadline. Without an explicit
+        // `timeout_secs`, substitute the generous effective-unbounded cap so a
+        // long command isn't killed while still bounding a wedged sandbox.
+        let explicit_timeout = self.explicit_timeout(requested_timeout);
+        let effective = explicit_timeout.unwrap_or_else(|| {
+            Duration::from_secs(crate::openhuman::tool_timeout::SANDBOX_UNBOUNDED_CAP_SECS)
+        });
         tracing::debug!(
-            timeout_secs = timeout.as_secs(),
-            "[shell] starting sandboxed command with configured timeout"
+            timeout_secs = effective.as_secs(),
+            requested_timeout_secs = ?requested_timeout,
+            unbounded = explicit_timeout.is_none(),
+            "[shell] starting sandboxed command"
         );
 
         match sandbox::execute_in_sandbox(
@@ -442,7 +497,7 @@ impl ShellTool {
             command,
             &self.security.action_dir,
             extra_env,
-            timeout,
+            effective,
         )
         .await
         {
@@ -450,7 +505,7 @@ impl ShellTool {
                 let tool_result = if result.timed_out {
                     ToolResult::error(format!(
                         "Command timed out after {}s and was killed",
-                        timeout.as_secs()
+                        effective.as_secs()
                     ))
                 } else if result.success() {
                     if result.stderr.is_empty() {
@@ -1021,24 +1076,90 @@ mod tests {
     // ── §5.2 Shell timeout enforcement tests ─────────────────
 
     #[test]
-    fn shell_timeout_uses_runtime_tool_timeout() {
+    fn shell_is_unbounded_by_default() {
         let tool = ShellTool::new(
             test_security(AutonomyLevel::Supervised),
             test_runtime(),
             test_audit(),
         );
 
-        let previous = crate::openhuman::tool_timeout::tool_execution_timeout_secs();
-        let requested = if previous == 300 { 301 } else { 300 };
-        let configured = crate::openhuman::tool_timeout::set_tool_timeout_secs(requested);
-
+        // No `timeout_secs` ⇒ no deadline. A long script must not be hard-killed.
         assert_eq!(
-            tool.timeout_secs(),
-            configured,
-            "shell timeout must honor the shared tool timeout runtime"
+            tool.timeout_policy(&json!({"command": "make"})),
+            ToolTimeout::Unbounded
+        );
+        assert_eq!(tool.explicit_timeout(None), None);
+        // An explicit 0 disables the timeout too.
+        assert_eq!(
+            tool.timeout_policy(&json!({"command": "make", "timeout_secs": 0})),
+            ToolTimeout::Unbounded
+        );
+        assert_eq!(tool.explicit_timeout(Some(0)), None);
+    }
+
+    #[test]
+    fn shell_timeout_honors_explicit_per_call_value() {
+        let tool = ShellTool::new(
+            test_security(AutonomyLevel::Supervised),
+            test_runtime(),
+            test_audit(),
         );
 
-        crate::openhuman::tool_timeout::set_tool_timeout_secs(previous);
+        // An explicit in-range request is enforced verbatim.
+        assert_eq!(
+            tool.timeout_policy(&json!({"command": "make", "timeout_secs": 1800})),
+            ToolTimeout::Secs(1800)
+        );
+        assert_eq!(
+            tool.explicit_timeout(Some(1800)),
+            Some(Duration::from_secs(1800))
+        );
+
+        // Above the cap clamps down to MAX_TIMEOUT_SECS (3600).
+        assert_eq!(
+            tool.explicit_timeout(Some(9_999)),
+            Some(Duration::from_secs(
+                crate::openhuman::tool_timeout::MAX_TIMEOUT_SECS
+            ))
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn shell_per_call_timeout_kills_slow_command() {
+        let tool = ShellTool::new(
+            test_security(AutonomyLevel::Supervised),
+            test_runtime(),
+            test_audit(),
+        );
+
+        // `sleep 30` would survive any sane default, but a per-call 1s budget
+        // must kill it and report the per-call value in the error message.
+        let result = tool
+            .execute(json!({"command": "sleep 30", "timeout_secs": 1}))
+            .await
+            .unwrap();
+
+        assert!(result.is_error, "slow command should time out");
+        let text = result.text();
+        assert!(
+            text.contains("timed out after 1s"),
+            "timeout message should reflect the per-call budget, got: {text}"
+        );
+    }
+
+    #[test]
+    fn shell_schema_advertises_timeout_secs() {
+        let tool = ShellTool::new(
+            test_security(AutonomyLevel::Supervised),
+            test_runtime(),
+            test_audit(),
+        );
+        let schema = tool.parameters_schema();
+        let timeout = &schema["properties"]["timeout_secs"];
+        assert_eq!(timeout["type"], "integer");
+        assert_eq!(timeout["minimum"], 1);
+        assert_eq!(timeout["maximum"], 3600);
     }
 
     #[test]

--- a/src/openhuman/tools/traits.rs
+++ b/src/openhuman/tools/traits.rs
@@ -111,6 +111,25 @@ pub struct ToolCallOptions {
     pub prefer_markdown: bool,
 }
 
+/// How the harness should bound a single tool invocation in wall-clock time.
+///
+/// Returned by [`Tool::timeout_policy`]. Separates the common "use the global
+/// timeout" case from the scripting-tool cases ("no deadline" / "this exact
+/// deadline") so the harness can hard-kill genuinely hang-prone tools while
+/// letting a long-but-legitimate script run to completion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolTimeout {
+    /// Use the global, operator/config-driven tool timeout. Default for most
+    /// tools (network, MCP, etc.) — a hung call must not wedge the session.
+    Inherit,
+    /// Run without any harness-imposed deadline. Scripting tools return this
+    /// when the caller did not request an explicit budget.
+    Unbounded,
+    /// Enforce exactly this many seconds. The harness clamps it to the valid
+    /// range (`MIN_TIMEOUT_SECS..=MAX_TIMEOUT_SECS`) defensively.
+    Secs(u64),
+}
+
 /// Description of a tool for the LLM
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolSpec {
@@ -284,6 +303,22 @@ pub trait Tool: Send + Sync {
     /// callers genuinely want full content (`read_file`, `grep`).
     fn max_result_size_chars(&self) -> Option<usize> {
         None
+    }
+
+    /// How the harness should bound this invocation in wall-clock time.
+    ///
+    /// The harness wraps every `execute()` in a deadline. Most tools want the
+    /// global, operator/config-driven timeout ([`ToolTimeout::Inherit`]) so a
+    /// hung network/MCP call can't wedge a session. Scripting tools (`shell`,
+    /// `node_exec`, `npm_exec`) instead return [`ToolTimeout::Unbounded`] when
+    /// the caller did not request a budget — a build / solver / test run
+    /// legitimately takes minutes and must not be hard-killed by a default cap
+    /// (issue #4023) — and [`ToolTimeout::Secs`] only when an explicit
+    /// `timeout_secs` was supplied.
+    ///
+    /// Default: [`ToolTimeout::Inherit`] (use the global timeout).
+    fn timeout_policy(&self, _args: &serde_json::Value) -> ToolTimeout {
+        ToolTimeout::Inherit
     }
 
     /// Get the full spec for LLM registration


### PR DESCRIPTION
## Summary

Scripting tools (`shell`, `node_exec`, `npm_exec`) no longer impose a default wall-clock timeout. A build, test run, or solver script legitimately takes minutes, so these tools now run **to completion** unless the caller passes an explicit `timeout_secs`.

- Removes the shell tool's hardcoded 60s timeout, plus `node_exec`'s 300s and `npm_exec`'s 600s default caps.
- Adds a `ToolTimeout` policy (`Inherit` / `Unbounded` / `Secs`) to the `Tool` trait. Most tools `Inherit` the global, config-driven timeout (network/MCP/etc. stay bounded — a hung call must not wedge a session). Scripting tools return `Unbounded` by default and `Secs(n)` only when `timeout_secs` is supplied.
- The agent harness (`run_one_tool`) honors the policy: `Unbounded` runs with **no** `tokio::time::timeout` wrapper at all; `Secs(n)` uses a clamped deadline plus a small grace margin so the tool's own internal timeout (which actually kills the child process) fires first. Previously the harness wrapped *every* tool in the global timeout, silently capping even node/npm's larger internal budgets.
- Per-call `timeout_secs`: `0` disables; positive values clamp to `1..=3600` (shell) / `1..=1800` (node/npm). Sandbox backends, which require a finite deadline, substitute a 24h effective-unbounded cap.

## Problem

The shell tool hard-killed any command at a fixed 60s (`SHELL_TIMEOUT_SECS`), unreachable by config. Long-running scripts — builds, data processing, solvers, test runs — were repeatedly killed mid-execution (issue #4023). Worse, the agent harness wrapped every tool's `execute()` in the global tool timeout (default 120s), so even `node_exec` (300s) and `npm_exec` (600s) were silently capped below their own intended budgets.

## Solution

The right default for the script path is **no cap** — running a script is precisely where "this legitimately takes minutes" is normal. Other hang-prone tools (network, MCP, installs over the wire) keep their bounded global default via `ToolTimeout::Inherit`. Owners/agents that want a bound on a specific call pass `timeout_secs`.

## Testing

- `tool_timeout`: unit tests for `explicit_call_timeout_{secs,duration}` (unbounded on `None`/`0`, clamp to cap).
- `shell`: unbounded-by-default + explicit-value policy tests; end-to-end test that `timeout_secs: 1` kills a `sleep 30`.
- `node_exec` / `npm_exec`: per-call policy tests (unbounded default, explicit clamp).
- harness: `resolve_tool_deadline` tests (unbounded ⇒ no deadline; `Secs` ⇒ clamp + grace).

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case)
- [x] **Diff coverage >= 80%** — Coverage Gate (diff-cover) passed in CI
- [x] Scoped to scripting/tool-timeout paths; other tool defaults unchanged (they `Inherit` the global timeout)

