### PR TITLE
fix(tinyplace): gate feed fetch on wallet status so wallet-less users never hit the RPC (#3964)

### DIFF
--- a/app/src/agentworld/pages/FeedSection.test.tsx
+++ b/app/src/agentworld/pages/FeedSection.test.tsx
@@ -254,6 +254,42 @@ describe('Feed list', () => {
     });
   });
 
+  test('does NOT call homeFeed when no wallet is configured (prevention at source)', async () => {
+    // wallet_status resolves with no Solana account → no wallet configured.
+    vi.mocked(fetchWalletStatus).mockResolvedValue({ accounts: [] } as any);
+    vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({ items: [sampleFeedItem], count: 1 });
+    render(<FeedSection />);
+    await waitFor(() => {
+      expect(screen.getByText(/set up your wallet to view your feed/i)).toBeInTheDocument();
+    });
+    // The wallet-requiring RPC must never be invoked for a wallet-less user.
+    expect(vi.mocked(apiClient.graphql.homeFeed)).not.toHaveBeenCalled();
+  });
+
+  test('still calls homeFeed when wallet IS configured', async () => {
+    vi.mocked(fetchWalletStatus).mockResolvedValue({
+      accounts: [{ chain: 'solana', address: MY_AGENT_ID }],
+    } as any);
+    vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({ items: [sampleFeedItem], count: 1 });
+    render(<FeedSection />);
+    await waitFor(() => {
+      expect(screen.getByText('Hello from the network')).toBeInTheDocument();
+    });
+    expect(vi.mocked(apiClient.graphql.homeFeed)).toHaveBeenCalled();
+  });
+
+  test('falls through to homeFeed when wallet status fetch fails (unknown)', async () => {
+    // A transport/RPC failure is "unknown", not "unconfigured": proceed and let
+    // the backend boundary classifier handle any wallet-locked error.
+    vi.mocked(fetchWalletStatus).mockRejectedValue(new Error('core rpc unavailable'));
+    vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({ items: [sampleFeedItem], count: 1 });
+    render(<FeedSection />);
+    await waitFor(() => {
+      expect(screen.getByText('Hello from the network')).toBeInTheDocument();
+    });
+    expect(vi.mocked(apiClient.graphql.homeFeed)).toHaveBeenCalled();
+  });
+
   test('tolerates response missing items field and shows empty state', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({} as any);

--- a/app/src/agentworld/pages/FeedSection.tsx
+++ b/app/src/agentworld/pages/FeedSection.tsx
@@ -35,9 +35,29 @@ const log = debug('agentworld:feed');
 
 type FeedState =
   | { status: 'loading' }
+  | { status: 'wallet_unconfigured' }
   | { status: 'payment_required'; challenge: unknown }
   | { status: 'error'; message: string }
   | { status: 'ok'; items: GqlHomeFeedItem[] };
+
+/**
+ * Result of resolving the local wallet on mount.
+ *
+ * `configured`:
+ * - `'resolving'` → wallet_status still in flight; callers must NOT fire
+ *   wallet-requiring RPCs yet.
+ * - `'no'`        → wallet_status resolved with no usable (Solana) account,
+ *   i.e. no wallet is configured at all. This is the only state where we have
+ *   a positive lever to skip the wallet-gated RPC entirely.
+ * - `'yes'`       → a usable wallet account exists.
+ * - `'unknown'`   → wallet_status fetch failed (transport/RPC error). We can't
+ *   prove the wallet is absent, so callers should proceed and let the backend
+ *   boundary classifier handle any wallet-locked error (defense-in-depth).
+ *
+ * `agentId` is the resolved Solana address when one exists, else `null`.
+ */
+type WalletConfigured = 'resolving' | 'no' | 'yes' | 'unknown';
+type WalletResolution = { agentId: string | null; configured: WalletConfigured };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -102,19 +122,49 @@ function InitialAvatar({ name }: { name: string }) {
   );
 }
 
-// ── useMyAgentId ──────────────────────────────────────────────────────────────
+// ── useWalletResolution ───────────────────────────────────────────────────────
 
-function useMyAgentId(): string | null {
-  const [agentId, setAgentId] = useState<string | null>(null);
+/**
+ * Resolve the local wallet once on mount.
+ *
+ * Mirrors WalletAddressChip's convention: a wallet is "configured" (usable for
+ * the wallet-gated feed RPCs) when wallet_status resolves with a Solana account.
+ * A successful response with no Solana account means no wallet is set up. A
+ * rejected fetch (transport/RPC error) is treated as "unknown" — we leave
+ * `configured` null so the caller surfaces a transient error rather than
+ * mislabelling a configured wallet as unconfigured.
+ *
+ * Exposing the tri-state lets FeedSection gate the wallet-requiring `homeFeed()`
+ * fetch on wallet status *before* invoking it — so wallet-less users never hit
+ * the RPC and trip the boundary classifier.
+ */
+function useWalletResolution(): WalletResolution {
+  const [resolution, setResolution] = useState<WalletResolution>({
+    agentId: null,
+    configured: 'resolving',
+  });
   useEffect(() => {
+    let cancelled = false;
     void fetchWalletStatus()
       .then(status => {
+        if (cancelled) return;
         const solana = (status.accounts ?? []).find(a => a.chain === 'solana');
-        if (solana?.address) setAgentId(solana.address);
+        const address = solana?.address ?? null;
+        setResolution({ agentId: address, configured: address !== null ? 'yes' : 'no' });
       })
-      .catch(() => {});
+      .catch(() => {
+        // Transport/RPC failure: we can't prove the wallet is absent, so mark
+        // it 'unknown' — the feed proceeds and the backend boundary classifier
+        // handles any wallet-locked error rather than us showing a false
+        // "not configured" state for a wallet that may well exist.
+        if (cancelled) return;
+        setResolution({ agentId: null, configured: 'unknown' });
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
-  return agentId;
+  return resolution;
 }
 
 // ── CommentComposer ───────────────────────────────────────────────────────────
@@ -540,7 +590,7 @@ export default function FeedSection() {
   const [followLoading, setFollowLoading] = useState<Record<string, boolean>>({});
   const [likeState, setLikeState] = useState<Record<string, { liked: boolean; count: number }>>({});
 
-  const myAgentId = useMyAgentId();
+  const { agentId: myAgentId, configured: walletConfigured } = useWalletResolution();
 
   // ── Hydrate follow state from the server ───────────────────────────────────
   // The home feed doesn't carry "am I following this author?", so seed the
@@ -567,7 +617,28 @@ export default function FeedSection() {
   }, [myAgentId]);
 
   // ── Fetch home feed ────────────────────────────────────────────────────────
+  // Gate the wallet-requiring `homeFeed()` RPC on wallet status. While wallet
+  // resolution is still in flight ('resolving') we stay on the loading state
+  // and fire nothing. When no wallet is configured ('no') we render the
+  // configure-wallet state WITHOUT calling the RPC — so wallet-less users never
+  // trip the backend's wallet-not-configured error (prevention at source; the
+  // boundary classifier remains as defense-in-depth). A configured wallet
+  // ('yes') — or an inconclusive wallet_status fetch ('unknown') — fires the
+  // feed fetch as before.
   useEffect(() => {
+    if (walletConfigured === 'resolving') {
+      // Still resolving — stay on the initial loading state, fire nothing yet.
+      return;
+    }
+    if (walletConfigured === 'no') {
+      // Positive "no wallet" signal — skip the wallet-gated RPC entirely.
+      log('skipping homeFeed: no wallet configured');
+      setFeedState({ status: 'wallet_unconfigured' });
+      return;
+    }
+    // 'yes' or 'unknown' → fire the feed fetch ('unknown' falls through so the
+    // backend classifier can handle a wallet-locked error as before).
+
     let cancelled = false;
     setFeedState({ status: 'loading' });
 
@@ -590,7 +661,7 @@ export default function FeedSection() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [walletConfigured]);
 
   // ── Follow / Unfollow ──────────────────────────────────────────────────────
 
@@ -674,6 +745,14 @@ export default function FeedSection() {
       <div className="flex h-64 items-center justify-center text-stone-400 dark:text-neutral-500">
         <span className="animate-pulse text-sm">Loading feed…</span>
       </div>
+    );
+  } else if (feedState.status === 'wallet_unconfigured') {
+    body = (
+      <StatusBlock
+        tone="text-stone-700 dark:text-neutral-200"
+        title="Set up your wallet to view your feed"
+        body="Your personalized feed uses your wallet identity. Set up or import a wallet in Settings to continue."
+      />
     );
   } else if (feedState.status === 'payment_required') {
     body = (


### PR DESCRIPTION
## Summary

- Gate the wallet-requiring `homeFeed()` RPC in `FeedSection` on local wallet status, so a wallet-less user **never calls the RPC** in the first place — prevention at source.
- Frontend follow-up to #3974 (TAURI-RUST-FFB), which classified the wallet-not-configured condition as expected user-state at the Rust JSON-RPC boundary. That stopped the Sentry noise; this stops the doomed call from ever being made, and renders a clear "set up your wallet" state instead.
- Tri-state resolution (`yes` / `no` / `unknown`): only a *positive* "no wallet" signal skips the fetch; an inconclusive `wallet_status` fetch falls through to the RPC so the backend boundary classifier still handles it (defense-in-depth, no false "not configured").

## Problem

`FeedSection` fetched `homeFeed()` unconditionally on mount. For a user with no wallet, that RPC fails with `wallet is not configured` — every feed mount fired a guaranteed-to-fail wallet-gated call. #3974 demoted the resulting Sentry event, but the wasted call and the bare error path remained: the only positive lever to avoid it (the local wallet status) was already available on the client and unused.

## Solution

- Replace `useMyAgentId` with `useWalletResolution`, which resolves `wallet_status` once on mount into a tri-state `WalletResolution { agentId, configured: 'resolving' | 'no' | 'yes' | 'unknown' }` (mirrors `WalletAddressChip`'s "Solana account ⇒ configured" convention). A rejected fetch is `'unknown'`, not `'no'`, so a transient RPC error never mislabels a configured wallet as absent.
- Gate the feed-fetch effect on that state: `'resolving'` fires nothing (stays on loading); `'no'` renders a new `wallet_unconfigured` state and skips the RPC entirely; `'yes'` / `'unknown'` fire the fetch as before. Effect re-runs on `walletConfigured`.
- Add a `wallet_unconfigured` `FeedState` rendering a "Set up your wallet to view your feed" `StatusBlock`.
- The Rust boundary classifier from #3974 stays in place as defense-in-depth for the `'unknown'` fall-through path.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — 3 new `FeedSection.test.tsx` cases: no-wallet ⇒ RPC NOT called + configure prompt; wallet ⇒ RPC called; wallet-status fetch fails ⇒ falls through to RPC.
- [x] **Diff coverage ≥ 80%** — the new branches are each exercised by a dedicated test. CI coverage gate is authoritative.
- [x] N/A: behaviour-only change, no feature row added/removed/renamed — Coverage matrix updated
- [x] N/A: no matrix change — All affected feature IDs from the matrix are listed in `## Related`
- [x] No new external network dependencies introduced — uses the existing `fetchWalletStatus` / `apiClient.graphql.homeFeed`.
- [x] N/A: no release-cut surface change — Manual smoke checklist updated
- [x] N/A: original issue #3964 already closed by #3974 — this is a follow-up hardening; linked in `## Related`

## Impact

- Desktop only; frontend (`app/src/agentworld/pages/FeedSection.tsx`). Wallet-less users get an actionable "set up your wallet" state and the client stops issuing a guaranteed-to-fail wallet-gated RPC on every feed mount.
- No API, schema, or migration impact. Security-neutral.

## Related

- Follow-up to: #3974 (TAURI-RUST-FFB) — Rust boundary classify; this adds the client-side prevention layer.
- Related issue: #3964
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/3964-feed-wallet-gate`
- Commit SHA: `d9ba12cc3`

### Validation Run

- [x] Focused tests: `npx vitest run -c test/vitest.config.ts src/agentworld/pages/FeedSection.test.tsx` — 38/38 pass (incl 3 new wallet-gate cases)
- [x] `pnpm --filter openhuman-app format:check` — "All matched files use Prettier code style!"
- [x] `pnpm typecheck` — clean (tsc --noEmit)
- [x] Lint: `eslint` 0 errors (3 setState-in-effect warnings, consistent with the 6 pre-existing in this file; `lint` script has no `--max-warnings 0`)
- [x] N/A: no Rust change — Tauri fmt/check

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a wallet-less user's feed no longer issues the wallet-gated `homeFeed()` RPC; it renders a configure-wallet prompt instead.
- User-visible effect: clearer "set up your wallet" state; no functional change for users with a wallet.

### Parity Contract

- Legacy behavior preserved: configured wallets fetch the feed exactly as before; an inconclusive `wallet_status` fetch falls through to the RPC so the existing backend wallet-locked handling still applies.
- Guard/fallback/dispatch parity checks: skip-RPC only on a positive "no wallet" signal; `'unknown'` never suppresses the call.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer wallet-status handling before loading the feed.
  * Users without a configured wallet now see a dedicated setup message instead of a failed feed load.

* **Bug Fixes**
  * Improved feed loading behavior when wallet status is unclear or temporarily unavailable.
  * Feed content now continues to load for configured wallets, with wallet-gated requests handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->