### PR TITLE
perf(memory): hoist loop-invariant relation clone out of recall loop

### DIFF
--- a/src/openhuman/memory_store/unified/query.rs
+++ b/src/openhuman/memory_store/unified/query.rs
@@ -395,6 +395,14 @@ impl UnifiedMemory {
         let now = Self::now_ts();
         let mut hits = Vec::new();
 
+        // Loop-invariant: every document sees the same graph relations, so build
+        // the RelationMatch view once instead of cloning all rows per document.
+        let relation_matches = graph_relations
+            .iter()
+            .cloned()
+            .map(|relation| RelationMatch { relation, hop: 1 })
+            .collect::<Vec<_>>();
+
         for doc in docs {
             let freshness = Self::recency_score(doc.updated_at, now);
             let priority = Self::document_priority_signal(
@@ -432,11 +440,7 @@ impl UnifiedMemory {
                 supporting_relations: self.supporting_relations_for_document(
                     &doc.document_id,
                     &doc.content,
-                    &graph_relations
-                        .iter()
-                        .cloned()
-                        .map(|relation| RelationMatch { relation, hop: 1 })
-                        .collect::<Vec<_>>(),
+                    &relation_matches,
                 ),
                 taint: doc.taint,
             });

--- a/src/openhuman/memory_store/unified/query_tests.rs
+++ b/src/openhuman/memory_store/unified/query_tests.rs
@@ -428,6 +428,114 @@ async fn query_supporting_relations_contain_entity_types() {
     }
 }
 
+/// `recall_namespace_memories` builds one shared `RelationMatch` view for all
+/// documents (hoisted out of the per-document loop). This pins that the shared
+/// input is still filtered per-document: with two documents each carrying their
+/// own graph relation, neither hit may surface the other's relation. A naive
+/// hoist that leaked the wrong relations across documents would fail here, where
+/// the single-document recall tests above cannot.
+#[tokio::test]
+async fn recall_supporting_relations_stay_scoped_per_document() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    let alpha_id = memory
+        .upsert_document(NamespaceDocumentInput {
+            namespace: "team".to_string(),
+            key: "alpha-doc".to_string(),
+            title: "Alpha".to_string(),
+            content: "Alice leads the Atlas project.".to_string(),
+            source_type: "doc".to_string(),
+            priority: "high".to_string(),
+            tags: vec!["project".to_string()],
+            metadata: json!({}),
+            category: "core".to_string(),
+            session_id: None,
+            document_id: None,
+            taint: crate::openhuman::memory::MemoryTaint::Internal,
+        })
+        .await
+        .unwrap();
+    let beta_id = memory
+        .upsert_document(NamespaceDocumentInput {
+            namespace: "team".to_string(),
+            key: "beta-doc".to_string(),
+            title: "Beta".to_string(),
+            content: "Bob manages the Borealis launch.".to_string(),
+            source_type: "doc".to_string(),
+            priority: "high".to_string(),
+            tags: vec!["project".to_string()],
+            metadata: json!({}),
+            category: "core".to_string(),
+            session_id: None,
+            document_id: None,
+            taint: crate::openhuman::memory::MemoryTaint::Internal,
+        })
+        .await
+        .unwrap();
+
+    memory
+        .graph_upsert_namespace(
+            "team",
+            "Alice",
+            "OWNS",
+            "Atlas",
+            &json!({ "document_id": alpha_id }),
+        )
+        .await
+        .unwrap();
+    memory
+        .graph_upsert_namespace(
+            "team",
+            "Bob",
+            "OWNS",
+            "Borealis",
+            &json!({ "document_id": beta_id }),
+        )
+        .await
+        .unwrap();
+
+    let hits = memory.recall_namespace_memories("team", 10).await.unwrap();
+    let alpha = hits
+        .iter()
+        .find(|hit| hit.key == "alpha-doc")
+        .expect("recall should return alpha-doc");
+    let beta = hits
+        .iter()
+        .find(|hit| hit.key == "beta-doc")
+        .expect("recall should return beta-doc");
+
+    let objects = |hit: &crate::openhuman::memory_store::NamespaceMemoryHit| {
+        hit.supporting_relations
+            .iter()
+            .map(|relation| relation.object.to_uppercase())
+            .collect::<Vec<_>>()
+    };
+    let alpha_objects = objects(alpha);
+    let beta_objects = objects(beta);
+
+    assert!(
+        alpha_objects.iter().any(|object| object.contains("ATLAS")),
+        "alpha-doc should keep its own relation, got {alpha_objects:?}"
+    );
+    assert!(
+        !alpha_objects
+            .iter()
+            .any(|object| object.contains("BOREALIS")),
+        "alpha-doc must not surface beta-doc's relation, got {alpha_objects:?}"
+    );
+    assert!(
+        beta_objects
+            .iter()
+            .any(|object| object.contains("BOREALIS")),
+        "beta-doc should keep its own relation, got {beta_objects:?}"
+    );
+    assert!(
+        !beta_objects.iter().any(|object| object.contains("ATLAS")),
+        "beta-doc must not surface alpha-doc's relation, got {beta_objects:?}"
+    );
+}
+
 #[tokio::test]
 async fn format_context_text_includes_entity_types() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Hoist a loop-invariant allocation out of the per-document loop in `UnifiedMemory::recall_namespace_memories` (query-less recall hot path).
- Each iteration rebuilt the *same* `Vec<RelationMatch>` by cloning every graph relation for the scope; build it once before the loop instead.
- Add a two-document regression test pinning that the shared relation view is still filtered per-document (no cross-document leakage).

## Problem

`recall_namespace_memories` ranks every document in a namespace scope by priority + graph + freshness. Inside the per-document loop it constructed the supporting-relations input like this:

```rust
for doc in docs {
    ...
    supporting_relations: self.supporting_relations_for_document(
        &doc.document_id,
        &doc.content,
        &graph_relations
            .iter()
            .cloned()                                  // clone ALL relations for the scope...
            .map(|relation| RelationMatch { relation, hop: 1 })
            .collect::<Vec<_>>(),                      // ...into a fresh Vec, once per document
    ),
    ...
}
```

`graph_relations` is loaded once before the loop and never mutated, so this rebuilds an identical vector on every iteration. `graph_relations_for_scope` returns up to ~600 `GraphRelationRecord` rows (namespace `LIMIT 300` + global `LIMIT 300`), each holding several `String`s and two `Vec`s. With `D` documents in scope that is `D × clone(~600 records)` of redundant allocation per recall call — pure O(D·R) churn where O(R) suffices.

## Solution

Build the `RelationMatch` view once, before the loop, and pass a borrow into each call:

```rust
let relation_matches = graph_relations
    .iter()
    .cloned()
    .map(|relation| RelationMatch { relation, hop: 1 })
    .collect::<Vec<_>>();

for doc in docs {
    ...
    supporting_relations: self.supporting_relations_for_document(
        &doc.document_id,
        &doc.content,
        &relation_matches,
    ),
    ...
}
```

**Behaviour is identical.** `supporting_relations_for_document` only reads from the slice and already filters per document (by `document_id`, `chunk_id` prefix, or normalized-content substring), so sharing one immutable input across documents yields the same per-document output. This also aligns the recall path with the sibling `compute_graph_document_scores`, which already hoists its per-relation normalization out of the document loop.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — added `recall_supporting_relations_stay_scoped_per_document`: two documents each carry their own graph relation; the test asserts each recall hit surfaces only its own relation and never the other document's, which a leaky hoist would fail. Existing single-document recall tests (`query_supporting_relations_contain_entity_types`, `recall_namespace_memories_includes_namespace_kv`) cover the happy path.
- [x] **Diff coverage ≥ 80%** — the changed production lines (the hoisted `let` + the borrow at the call site) are exercised by the new + existing recall tests; the remainder of the diff is the test itself.
- [x] Coverage matrix updated — `N/A: behaviour-preserving perf change, no feature added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no feature row affected`.
- [x] No new external network dependencies introduced — none added.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal recall scoring, no user-facing surface`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue`.

## Impact

- **Runtime/platform**: desktop/CLI core (`openhuman` crate). No platform-specific behaviour.
- **Performance**: query-less recall drops from cloning all graph relations per document (O(D·R)) to a single clone (O(R)) per call. On scopes with many documents and a populated relation graph this removes the dominant per-document allocation; pure win, no behavioural change.
- **Security/migration/compatibility**: none.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: a smaller adjacent opportunity remains — `supporting_relations_for_document` re-normalizes each relation's subject/object per call; precomputing those once would need a signature change across both call sites and is intentionally left out of this minimal PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `perf/recall-relations-hoist`
- Commit SHA: see PR head

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed
- [x] `pnpm typecheck` — N/A: no TS changed
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib memory_store::unified::query`
- [x] Rust fmt/check (if changed): `cargo fmt` clean; `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` clean
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none — performance only
- User-visible effect: none

### Parity Contract

- Legacy behavior preserved: yes — `supporting_relations_for_document` reads the slice immutably and filters per document, so a single shared input produces the same per-document output the per-iteration clone did
- Guard/fallback/dispatch parity checks: recall scoring weights, ordering, and supporting-relation selection unchanged

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory recall so relation context stays correctly scoped to each document, preventing unrelated relation details from appearing in results.
  * Made recall handling more efficient by reusing shared relation matching data instead of rebuilding it for every document.

* **Tests**
  * Added coverage to verify that supporting relations remain isolated per document during recall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->