### PR TITLE
fix(sidebar): make the active nav tab visible in light theme

### DIFF
--- a/app/src/components/layout/shell/SidebarNav.test.tsx
+++ b/app/src/components/layout/shell/SidebarNav.test.tsx
@@ -35,6 +35,18 @@ describe('SidebarNav active matching', () => {
     expect(tabButton('Chat')).toHaveAttribute('aria-current', 'page');
   });
 
+  it('gives the active tab a visible brand-accent fill (not the white sidebar background)', () => {
+    renderWithProviders(<SidebarNav />, { initialEntries: ['/chat'] });
+
+    const active = tabButton('Chat');
+    // Light-theme active state must contrast against the white sidebar.
+    expect(active.className).toContain('bg-primary-50');
+    expect(active.className).not.toContain('bg-white');
+
+    // Inactive tabs carry no active fill.
+    expect(tabButton('Human').className).not.toContain('bg-primary-50');
+  });
+
   it('clears an active provider selection when clicking the already-active nav item', () => {
     const { store } = renderWithProviders(<SidebarNav />, {
       initialEntries: ['/connections'],

--- a/app/src/components/layout/shell/SidebarNav.tsx
+++ b/app/src/components/layout/shell/SidebarNav.tsx
@@ -73,9 +73,14 @@ export default function SidebarNav() {
             onClick={() => handleClick(tab, active)}
             title={tab.label}
             aria-current={active ? 'page' : undefined}
+            // Light theme: the previous `bg-white` active state matched the
+            // white sidebar background, so the selected tab was nearly
+            // invisible. Use the ocean-brand accent (tinted fill + blue text +
+            // subtle ring) so the current tab clearly stands out. Dark theme
+            // already had enough contrast via `neutral-800`, so it's unchanged.
             className={`group flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13px] transition-colors cursor-pointer ${
               active
-                ? 'bg-white dark:bg-neutral-800 text-stone-900 dark:text-neutral-100 font-semibold shadow-sm'
+                ? 'bg-primary-50 text-primary-700 ring-1 ring-primary-200 dark:bg-neutral-800 dark:text-neutral-100 dark:ring-0 font-semibold shadow-sm'
                 : 'text-stone-500 dark:text-neutral-400 hover:bg-stone-200/70 dark:hover:bg-neutral-800/60 hover:text-stone-700 dark:hover:text-neutral-200'
             }`}>
             <span className="relative inline-flex flex-shrink-0">


### PR DESCRIPTION
## Summary

- In **light theme**, the selected sidebar nav tab (Chat / Human / Brain / Tiny.Place / Connections) used `bg-white` — identical to the white sidebar background — so the active tab was nearly invisible, distinguished only by a faint shadow.
- Switch the light-theme active state to the **ocean-brand accent**: `bg-primary-50` fill + `text-primary-700` + a subtle `ring-1 ring-primary-200`, so the current tab clearly stands out.
- Dark theme already had enough contrast (`neutral-800`) and is unchanged (`dark:ring-0` keeps the new ring light-only).

## Problem

Feedback: "In the light theme, need to make proper visible current tab selection — the current tab selector blends with the background so it's hard to identify visually." The active tab's `bg-white` matched the sidebar's own `bg-white` background (`AppSidebar`), leaving no real contrast.

## Solution

- `SidebarNav.tsx`: change the active branch from `bg-white ... text-stone-900` to `bg-primary-50 text-primary-700 ring-1 ring-primary-200 dark:bg-neutral-800 dark:text-neutral-100 dark:ring-0`.
- Tinted fill + blue text + subtle ring read clearly as "selected" against the white sidebar while staying on the ocean brand palette.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — added a `SidebarNav.test.tsx` case asserting the active tab carries `bg-primary-50` (not `bg-white`) and inactive tabs do not.
- [x] **Diff coverage ≥ 80%** — single className branch, covered by the new assertion.
- [x] Coverage matrix updated — `N/A: styling-only change, no feature row`.
- [x] All affected feature IDs from the matrix are listed — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue`.

## Impact

- Desktop UI, light theme only. No runtime, security, or migration impact. Pure visibility/contrast improvement for the active nav tab.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/light-theme-active-tab


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the sidebar navigation to use a clearer primary-accent style for the active tab, making the selected item stand out more consistently.
  * Refined the active-state appearance in dark mode for better visual consistency.
* **Tests**
  * Added coverage to verify the active tab shows the expected highlight styling and inactive tabs remain unhighlighted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->