### PR TITLE
feat(api): capture host + body snippet on backend_api non-2xx (#4055)

### DIFF
--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -107,11 +107,15 @@ const BACKEND_API_BODY_SHAPE_MAX_BYTES: usize = 120;
 /// Sentry `before_send` scrubbing, and that scrubber only catches a few
 /// secret-shaped patterns — so the raw body must never be echoed (a non-2xx body
 /// can carry emails / profile JSON / OAuth errors / nonstandard token fields).
-/// We emit only the SHAPE: for a JSON object, its sorted top-level key NAMES
-/// (schema, never values); otherwise a coarse label. Key names are enough to
-/// identify which backend/gateway produced a response — the `TAURI-RUST-8C` case
-/// (a 91-byte body matching no route this backend emits), where our canonical
-/// envelope is `{success,error,errorCode}` and a foreign gateway/proxy is not.
+/// We emit only the SHAPE: for a JSON object, the count of top-level keys plus
+/// the sorted subset that look like schema field names; otherwise a coarse
+/// label. Even key NAMES are response-controlled (a foreign backend could return
+/// `{"jo@example.com": 1}`), so only keys matching a conservative ASCII-identifier
+/// shape are echoed — everything else is counted as `redacted` and never logged.
+/// The surviving names are enough to identify which backend/gateway produced a
+/// response — the `TAURI-RUST-8C` case (a 91-byte body matching no route this
+/// backend emits), where our canonical envelope is `{success,error,errorCode}`
+/// and a foreign gateway/proxy is not.
 fn backend_api_body_shape(body: &str) -> String {
     let trimmed = body.trim();
     if trimmed.is_empty() {
@@ -119,21 +123,40 @@ fn backend_api_body_shape(body: &str) -> String {
     }
     match serde_json::from_str::<Value>(trimmed) {
         Ok(Value::Object(map)) => {
-            let mut keys: Vec<&str> = map.keys().map(String::as_str).collect();
-            keys.sort_unstable();
-            let joined = keys.join(",");
-            format!(
-                "object{{{}}}",
-                crate::openhuman::util::truncate_at_byte_boundary(
-                    &joined,
-                    BACKEND_API_BODY_SHAPE_MAX_BYTES,
-                )
-            )
+            let total = map.len();
+            let mut safe: Vec<&str> = map
+                .keys()
+                .map(String::as_str)
+                .filter(|k| is_schema_like_key(k))
+                .collect();
+            safe.sort_unstable();
+            let redacted = total - safe.len();
+            // `safe` keys are ASCII identifiers, so the join is ASCII and the
+            // truncation can only ever land on a byte boundary — but route it
+            // through the UTF-8-safe truncator regardless (defence-in-depth).
+            let keys = crate::openhuman::util::truncate_at_byte_boundary(
+                &safe.join(","),
+                BACKEND_API_BODY_SHAPE_MAX_BYTES,
+            );
+            format!("object(keys={total},safe=[{keys}],redacted={redacted})")
         }
         Ok(Value::Array(_)) => "array".to_string(),
         Ok(_) => "scalar".to_string(),
         Err(_) => "non_json".to_string(),
     }
+}
+
+/// A JSON key safe to echo into telemetry: a short ASCII identifier (the shape
+/// of a schema field name). Anything else — non-ASCII, punctuation like `@`,
+/// whitespace, or overlong — is treated as response-controlled data and excluded
+/// so `body_shape` can never leak an email/UUID/free-text used as a key.
+fn is_schema_like_key(key: &str) -> bool {
+    const MAX_KEY_LEN: usize = 40;
+    !key.is_empty()
+        && key.len() <= MAX_KEY_LEN
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
 }
 
 fn sanitize_client_version(raw: &str) -> Option<String> {

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -96,10 +96,45 @@ fn parse_message_path(path: &str) -> Option<(&str, &str)> {
 
 const CLIENT_VERSION_HEADER_MAX_LEN: usize = 64;
 
-/// Max bytes of a non-2xx response body echoed into the `authed_json` Sentry
-/// report (`body_preview=…`). Bounded so a large/hostile error page can't bloat
-/// the event or the Sentry tag indexes; the truncation is UTF-8-safe.
-const BACKEND_API_BODY_PREVIEW_MAX_BYTES: usize = 120;
+/// Max bytes of the `body_shape` key-name list echoed into the `authed_json`
+/// report. Bounded so a body with pathologically many keys can't bloat the
+/// event; truncation is UTF-8-safe.
+const BACKEND_API_BODY_SHAPE_MAX_BYTES: usize = 120;
+
+/// PII-safe classification of a non-2xx response body for telemetry.
+///
+/// `report_error`'s message is written to the core/Tauri daily logs BEFORE any
+/// Sentry `before_send` scrubbing, and that scrubber only catches a few
+/// secret-shaped patterns — so the raw body must never be echoed (a non-2xx body
+/// can carry emails / profile JSON / OAuth errors / nonstandard token fields).
+/// We emit only the SHAPE: for a JSON object, its sorted top-level key NAMES
+/// (schema, never values); otherwise a coarse label. Key names are enough to
+/// identify which backend/gateway produced a response — the `TAURI-RUST-8C` case
+/// (a 91-byte body matching no route this backend emits), where our canonical
+/// envelope is `{success,error,errorCode}` and a foreign gateway/proxy is not.
+fn backend_api_body_shape(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "empty".to_string();
+    }
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(Value::Object(map)) => {
+            let mut keys: Vec<&str> = map.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            let joined = keys.join(",");
+            format!(
+                "object{{{}}}",
+                crate::openhuman::util::truncate_at_byte_boundary(
+                    &joined,
+                    BACKEND_API_BODY_SHAPE_MAX_BYTES,
+                )
+            )
+        }
+        Ok(Value::Array(_)) => "array".to_string(),
+        Ok(_) => "scalar".to_string(),
+        Err(_) => "non_json".to_string(),
+    }
+}
 
 fn sanitize_client_version(raw: &str) -> Option<String> {
     let sanitized: String = raw
@@ -678,30 +713,25 @@ impl BackendOAuthClient {
                 );
             } else {
                 // Enrich the report with the two fields triage needs to pin a
-                // non-2xx's origin: the outbound `host` and a bounded snippet of
-                // the response body. `report_error` previously logged only
+                // non-2xx's origin: the outbound `host` and a PII-safe `body_shape`
+                // (top-level JSON key names only — never values; see
+                // `backend_api_body_shape`). `report_error` previously logged only
                 // `response_body_len`, leaving us blind when a client hits a
                 // non-canonical backend (custom BACKEND_URL / proxy / foreign
                 // host) — TAURI-RUST-8C: 12k `GET /teams/me/usage` 404s from one
                 // user whose 91-byte body matched no route this backend emits,
-                // un-diagnosable because neither host nor body was captured.
-                // The snippet is UTF-8-safe truncated (never slices mid-codepoint
-                // — feedback_http_body_byte_slice_utf8_panic) and rides the
-                // Sentry `before_send` PII scrub; `host_str()` carries no
-                // scheme/path/query/token. Telemetry only — the error still
-                // propagates below (no suppression).
+                // un-diagnosable because neither host nor shape was captured.
+                // `host_str()` carries no scheme/path/query/token. Telemetry only
+                // — the error still propagates below (no suppression).
                 let host = url.host_str().unwrap_or("");
-                let body_preview = crate::openhuman::util::truncate_at_byte_boundary(
-                    text.trim(),
-                    BACKEND_API_BODY_PREVIEW_MAX_BYTES,
-                );
+                let body_shape = backend_api_body_shape(&text);
                 crate::core::observability::report_error(
                     format!(
-                        "{} {} failed ({status}); response_body_len={}; body_preview={}",
+                        "{} {} failed ({status}); response_body_len={}; body_shape={}",
                         method.as_str(),
                         url.path(),
                         text.len(),
-                        body_preview,
+                        body_shape,
                     )
                     .as_str(),
                     "backend_api",

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -96,6 +96,11 @@ fn parse_message_path(path: &str) -> Option<(&str, &str)> {
 
 const CLIENT_VERSION_HEADER_MAX_LEN: usize = 64;
 
+/// Max bytes of a non-2xx response body echoed into the `authed_json` Sentry
+/// report (`body_preview=…`). Bounded so a large/hostile error page can't bloat
+/// the event or the Sentry tag indexes; the truncation is UTF-8-safe.
+const BACKEND_API_BODY_PREVIEW_MAX_BYTES: usize = 120;
+
 fn sanitize_client_version(raw: &str) -> Option<String> {
     let sanitized: String = raw
         .trim()
@@ -672,12 +677,31 @@ impl BackendOAuthClient {
                     url.path(),
                 );
             } else {
+                // Enrich the report with the two fields triage needs to pin a
+                // non-2xx's origin: the outbound `host` and a bounded snippet of
+                // the response body. `report_error` previously logged only
+                // `response_body_len`, leaving us blind when a client hits a
+                // non-canonical backend (custom BACKEND_URL / proxy / foreign
+                // host) — TAURI-RUST-8C: 12k `GET /teams/me/usage` 404s from one
+                // user whose 91-byte body matched no route this backend emits,
+                // un-diagnosable because neither host nor body was captured.
+                // The snippet is UTF-8-safe truncated (never slices mid-codepoint
+                // — feedback_http_body_byte_slice_utf8_panic) and rides the
+                // Sentry `before_send` PII scrub; `host_str()` carries no
+                // scheme/path/query/token. Telemetry only — the error still
+                // propagates below (no suppression).
+                let host = url.host_str().unwrap_or("");
+                let body_preview = crate::openhuman::util::truncate_at_byte_boundary(
+                    text.trim(),
+                    BACKEND_API_BODY_PREVIEW_MAX_BYTES,
+                );
                 crate::core::observability::report_error(
                     format!(
-                        "{} {} failed ({status}); response_body_len={}",
+                        "{} {} failed ({status}); response_body_len={}; body_preview={}",
                         method.as_str(),
                         url.path(),
-                        text.len()
+                        text.len(),
+                        body_preview,
                     )
                     .as_str(),
                     "backend_api",
@@ -685,6 +709,7 @@ impl BackendOAuthClient {
                     &[
                         ("method", method.as_str()),
                         ("path", url.path()),
+                        ("host", host),
                         ("status", status_str.as_str()),
                         ("failure", "non_2xx"),
                     ],

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -416,16 +416,30 @@ async fn authed_json_surfaces_unauthorized_on_401() {
 }
 
 #[test]
-fn backend_api_body_shape_emits_keys_not_values() {
-    // PII guard (Codex P1 on #4058): the body SHAPE must expose top-level JSON
-    // key NAMES (schema) and NEVER the values — a non-2xx body can carry emails /
+fn backend_api_body_shape_emits_safe_keys_not_values() {
+    // PII guard (Codex P1 on #4058): the body SHAPE must expose only schema-like
+    // top-level key NAMES and NEVER the values — a non-2xx body can carry emails /
     // tokens / profile JSON that would otherwise leak to unscrubbed daily logs.
     let body = r#"{"error":"not found","email":"jo@example.com","token":"sk-secret"}"#;
     let shape = backend_api_body_shape(body);
-    assert_eq!(shape, "object{email,error,token}"); // sorted key names only
+    assert_eq!(shape, "object(keys=3,safe=[email,error,token],redacted=0)");
     assert!(!shape.contains("jo@example.com"), "value leaked: {shape}");
     assert!(!shape.contains("sk-secret"), "value leaked: {shape}");
     assert!(!shape.contains("not found"), "value leaked: {shape}");
+}
+
+#[test]
+fn backend_api_body_shape_redacts_pii_and_nonidentifier_keys() {
+    // CodeRabbit Major on #4058: key NAMES are response-controlled too. A foreign
+    // backend can put an email / free text / unicode in the KEY position; those
+    // must be counted as `redacted`, never echoed.
+    let body = r#"{"jo@example.com":1,"a b":2,"naïve":3,"error":4}"#;
+    let shape = backend_api_body_shape(body);
+    // Only the schema-like `error` survives; the other three are redacted.
+    assert_eq!(shape, "object(keys=4,safe=[error],redacted=3)");
+    assert!(!shape.contains("jo@example.com"), "PII key leaked: {shape}");
+    assert!(!shape.contains("naïve"), "non-ascii key leaked: {shape}");
+    assert!(!shape.contains("a b"), "free-text key leaked: {shape}");
 }
 
 #[test]
@@ -442,30 +456,32 @@ fn backend_api_body_shape_classifies_non_object_bodies() {
 }
 
 #[test]
-fn backend_api_body_shape_truncates_multibyte_keys_without_panicking() {
-    // mid-codepoint guard (feedback_http_body_byte_slice_utf8_panic): the joined
-    // key list is truncated at BACKEND_API_BODY_SHAPE_MAX_BYTES = 120. A 1-byte
-    // ASCII prefix + 3-byte unicode chars forces the cap INSIDE a codepoint
-    // (byte 120 = 1 + 119, and 119 % 3 != 0), so a naive byte slice would panic.
-    let long_key = format!("a{}", "あ".repeat(60)); // 1 + 180 = 181 bytes
-    let body = format!("{{{:?}:1}}", long_key); // {"aあああ…":1}
-    let shape = backend_api_body_shape(&body); // must not panic
-    assert!(shape.starts_with("object{"), "unexpected shape: {shape}");
+fn backend_api_body_shape_bounds_long_safe_key_list() {
+    // The `safe=[…]` list is truncated at BACKEND_API_BODY_SHAPE_MAX_BYTES = 120.
+    // Surviving keys are ASCII identifiers (non-ASCII keys are redacted upstream),
+    // so build many ASCII keys to overflow the cap and assert the truncation
+    // CONTRACT: bounded, ellipsis-terminated, and not carrying the last key.
+    let mut obj = serde_json::Map::new();
+    for i in 0..30 {
+        obj.insert(format!("field{i:02}"), json!(1)); // 30 × "fieldNN" (7 bytes) ≫ 120
+    }
+    let body = serde_json::to_string(&Value::Object(obj)).unwrap();
+    let shape = backend_api_body_shape(&body);
 
-    // Assert the truncation CONTRACT, not just absence of panic: the key list
-    // must actually be clipped — bounded by the cap, ellipsis-terminated, and
-    // never carrying the full 181-byte key.
     let keys = shape
-        .strip_prefix("object{")
-        .and_then(|s| s.strip_suffix('}'))
-        .expect("framed shape");
+        .strip_prefix("object(keys=30,safe=[")
+        .and_then(|s| s.strip_suffix("],redacted=0)"))
+        .unwrap_or_else(|| panic!("unexpected shape: {shape}"));
     assert!(
         keys.len() <= BACKEND_API_BODY_SHAPE_MAX_BYTES,
-        "key list exceeds cap ({} > {BACKEND_API_BODY_SHAPE_MAX_BYTES}): {keys}",
+        "safe list exceeds cap ({} > {BACKEND_API_BODY_SHAPE_MAX_BYTES}): {keys}",
         keys.len()
     );
     assert!(keys.ends_with('…'), "expected ellipsis-terminated: {keys}");
-    assert!(!shape.contains(&long_key), "full key leaked: {shape}");
+    assert!(
+        !keys.contains("field29"),
+        "last key should be truncated away: {keys}"
+    );
 }
 
 #[tokio::test]

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,6 +1,6 @@
 use super::{
     backend_api_body_shape, flatten_authed_error, key_bytes_from_string, parse_message_path,
-    sanitize_client_version, BackendApiError, BackendOAuthClient,
+    sanitize_client_version, BackendApiError, BackendOAuthClient, BACKEND_API_BODY_SHAPE_MAX_BYTES,
 };
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -451,6 +451,21 @@ fn backend_api_body_shape_truncates_multibyte_keys_without_panicking() {
     let body = format!("{{{:?}:1}}", long_key); // {"aあああ…":1}
     let shape = backend_api_body_shape(&body); // must not panic
     assert!(shape.starts_with("object{"), "unexpected shape: {shape}");
+
+    // Assert the truncation CONTRACT, not just absence of panic: the key list
+    // must actually be clipped — bounded by the cap, ellipsis-terminated, and
+    // never carrying the full 181-byte key.
+    let keys = shape
+        .strip_prefix("object{")
+        .and_then(|s| s.strip_suffix('}'))
+        .expect("framed shape");
+    assert!(
+        keys.len() <= BACKEND_API_BODY_SHAPE_MAX_BYTES,
+        "key list exceeds cap ({} > {BACKEND_API_BODY_SHAPE_MAX_BYTES}): {keys}",
+        keys.len()
+    );
+    assert!(keys.ends_with('…'), "expected ellipsis-terminated: {keys}");
+    assert!(!shape.contains(&long_key), "full key leaked: {shape}");
 }
 
 #[tokio::test]

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -415,6 +415,50 @@ async fn authed_json_surfaces_unauthorized_on_401() {
     assert_eq!(path, "/referral/stats");
 }
 
+#[tokio::test]
+async fn authed_json_reports_non_channel_404_with_multibyte_body_without_panicking() {
+    // TAURI-RUST-8C: a GET 404 on a non-channel path (e.g. `/teams/me/usage`)
+    // falls through to `report_error` (not a typed/suppressed state). That report
+    // now embeds a UTF-8-safe truncated `body_preview` + the outbound `host`.
+    // Guard: a multibyte body larger than the preview cap must NOT panic from a
+    // mid-codepoint byte slice (feedback_http_body_byte_slice_utf8_panic), and
+    // the error must still propagate verbatim (telemetry-only — no suppression).
+    //
+    // Body = 40×"🤖" = 160 bytes (> BACKEND_API_BODY_PREVIEW_MAX_BYTES = 120),
+    // so truncation lands inside a 4-byte codepoint region.
+    let body = "🤖".repeat(40);
+    let body_for_route = body.clone();
+    let app = Router::new().route(
+        "/teams/me/usage",
+        get(move || {
+            let b = body_for_route.clone();
+            async move { (axum::http::StatusCode::NOT_FOUND, b) }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base_url = format!("http://{addr}");
+    let client = BackendOAuthClient::new(&base_url).unwrap();
+
+    // Must return an Err (404 still propagates), not panic, and not a typed
+    // `BackendApiError` (this path is neither 401 nor a channel-message 404).
+    let err = client
+        .authed_json("mock-jwt", Method::GET, "/teams/me/usage", None)
+        .await
+        .unwrap_err();
+    assert!(err.downcast_ref::<BackendApiError>().is_none());
+    let msg = format!("{err:#}");
+    assert!(msg.contains("404"), "error should carry the status: {msg}");
+    assert!(
+        msg.contains("/teams/me/usage"),
+        "error should carry the path: {msg}"
+    );
+}
+
 #[test]
 fn flatten_authed_error_maps_unauthorized_to_session_expired_sentinel() {
     // #3297: the typed `Unauthorized` (expected session-lapse 401) must flatten

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    flatten_authed_error, key_bytes_from_string, parse_message_path, sanitize_client_version,
-    BackendApiError, BackendOAuthClient,
+    backend_api_body_shape, flatten_authed_error, key_bytes_from_string, parse_message_path,
+    sanitize_client_version, BackendApiError, BackendOAuthClient,
 };
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -415,24 +415,56 @@ async fn authed_json_surfaces_unauthorized_on_401() {
     assert_eq!(path, "/referral/stats");
 }
 
+#[test]
+fn backend_api_body_shape_emits_keys_not_values() {
+    // PII guard (Codex P1 on #4058): the body SHAPE must expose top-level JSON
+    // key NAMES (schema) and NEVER the values — a non-2xx body can carry emails /
+    // tokens / profile JSON that would otherwise leak to unscrubbed daily logs.
+    let body = r#"{"error":"not found","email":"jo@example.com","token":"sk-secret"}"#;
+    let shape = backend_api_body_shape(body);
+    assert_eq!(shape, "object{email,error,token}"); // sorted key names only
+    assert!(!shape.contains("jo@example.com"), "value leaked: {shape}");
+    assert!(!shape.contains("sk-secret"), "value leaked: {shape}");
+    assert!(!shape.contains("not found"), "value leaked: {shape}");
+}
+
+#[test]
+fn backend_api_body_shape_classifies_non_object_bodies() {
+    assert_eq!(backend_api_body_shape(""), "empty");
+    assert_eq!(backend_api_body_shape("   "), "empty");
+    assert_eq!(
+        backend_api_body_shape("Cannot GET /teams/me/usage"),
+        "non_json"
+    );
+    assert_eq!(backend_api_body_shape("<html>404</html>"), "non_json");
+    assert_eq!(backend_api_body_shape("[1,2,3]"), "array");
+    assert_eq!(backend_api_body_shape("42"), "scalar");
+}
+
+#[test]
+fn backend_api_body_shape_truncates_multibyte_keys_without_panicking() {
+    // mid-codepoint guard (feedback_http_body_byte_slice_utf8_panic): the joined
+    // key list is truncated at BACKEND_API_BODY_SHAPE_MAX_BYTES = 120. A 1-byte
+    // ASCII prefix + 3-byte unicode chars forces the cap INSIDE a codepoint
+    // (byte 120 = 1 + 119, and 119 % 3 != 0), so a naive byte slice would panic.
+    let long_key = format!("a{}", "あ".repeat(60)); // 1 + 180 = 181 bytes
+    let body = format!("{{{:?}:1}}", long_key); // {"aあああ…":1}
+    let shape = backend_api_body_shape(&body); // must not panic
+    assert!(shape.starts_with("object{"), "unexpected shape: {shape}");
+}
+
 #[tokio::test]
-async fn authed_json_reports_non_channel_404_with_multibyte_body_without_panicking() {
+async fn authed_json_reports_non_channel_404_still_propagates() {
     // TAURI-RUST-8C: a GET 404 on a non-channel path (e.g. `/teams/me/usage`)
-    // falls through to `report_error` (not a typed/suppressed state). That report
-    // now embeds a UTF-8-safe truncated `body_preview` + the outbound `host`.
-    // Guard: a multibyte body larger than the preview cap must NOT panic from a
-    // mid-codepoint byte slice (feedback_http_body_byte_slice_utf8_panic), and
-    // the error must still propagate verbatim (telemetry-only — no suppression).
-    //
-    // Body = 40×"🤖" = 160 bytes (> BACKEND_API_BODY_PREVIEW_MAX_BYTES = 120),
-    // so truncation lands inside a 4-byte codepoint region.
-    let body = "🤖".repeat(40);
-    let body_for_route = body.clone();
+    // falls through to `report_error` (not a typed/suppressed state) — it must
+    // still return an Err (no suppression) and not a typed `BackendApiError`.
     let app = Router::new().route(
         "/teams/me/usage",
-        get(move || {
-            let b = body_for_route.clone();
-            async move { (axum::http::StatusCode::NOT_FOUND, b) }
+        get(|| async {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                r#"{"message":"Not Found"}"#,
+            )
         }),
     );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -444,8 +476,6 @@ async fn authed_json_reports_non_channel_404_with_multibyte_body_without_panicki
     let base_url = format!("http://{addr}");
     let client = BackendOAuthClient::new(&base_url).unwrap();
 
-    // Must return an Err (404 still propagates), not panic, and not a typed
-    // `BackendApiError` (this path is neither 401 nor a channel-message 404).
     let err = client
         .authed_json("mock-jwt", Method::GET, "/teams/me/usage", None)
         .await


### PR DESCRIPTION
## Summary

- Enrich the `authed_json` non-2xx `report_error` with the outbound **`host`** tag and a UTF-8-safe, byte-bounded **`body_preview`** snippet.
- Previously only `response_body_len` was logged — neither the backend host nor the body — leaving non-2xx origins un-diagnosable.
- Telemetry-only: the error still propagates; no suppression, no control-flow change.

## Problem

Sentry **TAURI-RUST-8C**: 12,409 `GET /teams/me/usage failed (404); response_body_len=91` events from a single user. Triage stalled because the report captured neither the outbound host nor the body. The 91-byte body matches **no** 404 this backend emits (canonical `getTeamTokenUsage` "User not found" = 42B legacy / 66B current), so the client is reaching a **non-canonical backend** (custom `BACKEND_URL` / proxy / foreign host) — but the existing telemetry can't confirm which. The end-user is external/unreachable, so confirming origin requires adding the missing fields first.

## Solution

- `src/api/rest.rs` (`authed_json` non-2xx arm): add `("host", url.host_str())` to the report tags and append `body_preview={…}` to the report message, truncated via the existing UTF-8-safe `crate::openhuman::util::truncate_at_byte_boundary` (cap `BACKEND_API_BODY_PREVIEW_MAX_BYTES = 120`).
- `host_str()` carries no scheme/path/query/token; the snippet rides the existing Sentry `before_send` PII scrub. Body cap bounds event size + tag-index growth.
- The 404 keeps firing intentionally — the next event from this user names the host + body and closes the RCA.
- **Scope guard**: flood-prevention (typed 404 + usage poll-backoff) and the backend-contract question are deferred to a follow-up gated on the confirmed host (see Related) — not bundled here, so this can't be read as a band-aid suppression.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — the new `authed_json_reports_non_channel_404_with_multibyte_body_without_panicking` exercises the changed non-2xx arm (host + body_preview + format) end-to-end.
- [x] N/A: behaviour-only change — no coverage-matrix feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix feature touched.
- [x] No new external network dependencies introduced (test uses an in-process axum mock).
- [x] N/A: does not touch release-cut smoke surfaces (internal telemetry only).
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop/CLI Rust core only. No UI, no schema, no migration.
- Adds a low-cardinality `host` tag + a ≤120-byte scrubbed body snippet to existing non-2xx Sentry events; no new events, no behaviour change.
- Security: hostname only (no token/path/query); body snippet bounded + scrubbed.

## Related

- Closes: #4055
- Follow-up PR(s)/TODOs: flood-prevention (typed 404 + usage poll-backoff) + backend `/teams/me/usage` 200-empty-vs-401 contract — opened once this PR's telemetry confirms the foreign host.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub issue #4055)
- URL: https://github.com/tinyhumansai/openhuman/issues/4055

### Commit & Branch

- Branch: fix/4055-backend-api-non2xx-host-body
- Commit SHA: f8e31c95ca0552c6af6286023549f3c9b1851dd1

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no `app/` changes
- [x] N/A: `pnpm typecheck` — no frontend changes
- [x] Focused tests: `cargo test --lib authed_json` → 6 passed (incl. new multibyte-404 guard)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo clippy --lib` clean on changed files
- [x] Tauri fmt/check (if changed): `pnpm rust:check` ran green via pre-push hook

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none (additive telemetry on an already-firing report)
- User-visible effect: none

### Parity Contract

- Legacy behavior preserved: yes — control flow (`anyhow::bail!`) unchanged; 401 + channel-message-404 typed arms untouched
- Guard/fallback/dispatch parity checks: non-channel non-2xx still reports + propagates; only the report payload is enriched

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 45d-merged; rest.rs last touched by #3794, unrelated)
- Canonical PR: this
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend non-success error reporting with a bounded, PII-safe “body shape” preview and added the outbound backend host to observability details.
  * The preview labels responses as `empty`, `non_json`, `array`, `scalar`, or `object{…}` using only top-level JSON key names, with UTF-8-safe truncation and redaction of unsafe key names.
  * Preserved existing special-case handling and suppression behavior.

* **Tests**
  * Added coverage for body-shape classification, truncation/ellipsis, and safe-key redaction, plus a regression ensuring certain 404s remain untyped while including status and request path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->