### PR TITLE
perf(memory): defer vector-search metadata parse past truncation

### DIFF
--- a/src/openhuman/memory_store/vectors/store.rs
+++ b/src/openhuman/memory_store/vectors/store.rs
@@ -326,18 +326,32 @@ impl VectorStore {
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
 
-        let mut scored: Vec<SearchResult> = rows
+        let scanned = rows.len();
+
+        // Score-only intermediate: keep metadata as the raw JSON string instead
+        // of parsing it here. We scan every vector in the namespace but return
+        // only `limit` rows, so parsing the metadata of all N candidates would
+        // throw away all but `limit` parses. Defer the parse until after the
+        // truncation below, where it runs `limit` times instead of N.
+        struct ScoredRow {
+            score: f64,
+            id: String,
+            namespace: String,
+            text: String,
+            meta_str: String,
+        }
+
+        let mut scored: Vec<ScoredRow> = rows
             .into_iter()
-            .map(|(id, ns, text, blob, meta_str)| {
+            .map(|(id, namespace, text, blob, meta_str)| {
                 let stored_vec = bytes_to_vec(&blob);
                 let score = cosine_similarity(query_vec, &stored_vec);
-                let metadata = serde_json::from_str(&meta_str).unwrap_or(serde_json::Value::Null);
-                SearchResult {
-                    id,
-                    namespace: ns,
-                    text,
+                ScoredRow {
                     score,
-                    metadata,
+                    id,
+                    namespace,
+                    text,
+                    meta_str,
                 }
             })
             .collect();
@@ -350,14 +364,25 @@ impl VectorStore {
         });
         scored.truncate(limit);
 
+        // Parse metadata only for the rows that survived truncation.
+        let results: Vec<SearchResult> = scored
+            .into_iter()
+            .map(|row| SearchResult {
+                id: row.id,
+                namespace: row.namespace,
+                text: row.text,
+                score: row.score,
+                metadata: serde_json::from_str(&row.meta_str).unwrap_or(serde_json::Value::Null),
+            })
+            .collect();
+
         tracing::trace!(
             target: "embeddings.store",
-            "[vector-store] search_by_vector: ns={namespace}, scanned={}, returned={}",
-            scored.len() + scored.capacity() - scored.len(), // approximate total before truncate
-            scored.len()
+            "[vector-store] search_by_vector: ns={namespace}, scanned={scanned}, returned={}",
+            results.len()
         );
 
-        Ok(scored)
+        Ok(results)
     }
 
     // ── Delete / management ──────────────────────────────────

--- a/src/openhuman/memory_store/vectors/store.rs
+++ b/src/openhuman/memory_store/vectors/store.rs
@@ -364,15 +364,27 @@ impl VectorStore {
         });
         scored.truncate(limit);
 
-        // Parse metadata only for the rows that survived truncation.
+        // Parse metadata only for the rows that survived truncation. Invalid
+        // JSON falls back to Null, but log it so data issues stay diagnosable.
         let results: Vec<SearchResult> = scored
             .into_iter()
-            .map(|row| SearchResult {
-                id: row.id,
-                namespace: row.namespace,
-                text: row.text,
-                score: row.score,
-                metadata: serde_json::from_str(&row.meta_str).unwrap_or(serde_json::Value::Null),
+            .map(|row| {
+                let metadata = serde_json::from_str(&row.meta_str).unwrap_or_else(|err| {
+                    tracing::debug!(
+                        target: "embeddings.store",
+                        "[vector-store] invalid metadata json: id={}, ns={}, err={err}",
+                        row.id,
+                        row.namespace,
+                    );
+                    serde_json::Value::Null
+                });
+                SearchResult {
+                    id: row.id,
+                    namespace: row.namespace,
+                    text: row.text,
+                    score: row.score,
+                    metadata,
+                }
             })
             .collect();
 

--- a/src/openhuman/memory_store/vectors/store_tests.rs
+++ b/src/openhuman/memory_store/vectors/store_tests.rs
@@ -295,6 +295,43 @@ fn search_by_vector_limit_zero() {
         .is_empty());
 }
 
+/// Metadata is parsed only for rows that survive truncation, so the parse
+/// must align with the post-sort order — each returned row must carry its
+/// own metadata, and dropped rows must not appear. This pins the deferred
+/// parse against an off-by-one or mis-zipped mapping after sort/truncate.
+#[test]
+fn search_by_vector_returns_metadata_of_surviving_rows() {
+    let store = fake_store(3);
+    store
+        .insert_with_vector("near", "ns", "t", &[1.0, 0.0, 0.0], json!({"tag": "near"}))
+        .unwrap();
+    store
+        .insert_with_vector("mid", "ns", "t", &[0.7, 0.7, 0.0], json!({"tag": "mid"}))
+        .unwrap();
+    store
+        .insert_with_vector("far", "ns", "t", &[0.0, 0.0, 1.0], json!({"tag": "far"}))
+        .unwrap();
+
+    let results = store.search_by_vector("ns", &[1.0, 0.0, 0.0], 2).unwrap();
+
+    assert_eq!(results.len(), 2, "limit should drop the least similar row");
+    assert_eq!(results[0].id, "near");
+    assert_eq!(results[1].id, "mid");
+    assert!(
+        results.iter().all(|hit| hit.id != "far"),
+        "the truncated row must not leak into the results"
+    );
+    // The deferred parse must attach each row's own metadata, not a neighbour's.
+    for hit in &results {
+        assert_eq!(
+            hit.metadata.get("tag").and_then(|v| v.as_str()),
+            Some(hit.id.as_str()),
+            "metadata tag should match the row id for {}",
+            hit.id
+        );
+    }
+}
+
 #[test]
 fn search_by_vector_scores_correct() {
     let store = fake_store(3);

--- a/src/openhuman/memory_store/vectors/store_tests.rs
+++ b/src/openhuman/memory_store/vectors/store_tests.rs
@@ -332,6 +332,41 @@ fn search_by_vector_returns_metadata_of_surviving_rows() {
     }
 }
 
+/// A row with corrupt metadata JSON (e.g. a hand-edited or partially written
+/// DB) must not break the search — the deferred parse falls back to `Null`
+/// rather than dropping the row or erroring. Inserted raw because
+/// `insert_with_vector` always serializes valid JSON.
+#[test]
+fn search_by_vector_falls_back_to_null_on_invalid_metadata() {
+    let store = fake_store(3);
+    {
+        let conn = store.conn.lock();
+        conn.execute(
+            "INSERT INTO vectors (id, namespace, text, embedding, metadata, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                "bad",
+                "ns",
+                "t",
+                vec_to_bytes(&[1.0, 0.0, 0.0]),
+                "{not valid json",
+                0.0_f64,
+                0.0_f64
+            ],
+        )
+        .unwrap();
+    }
+
+    let results = store.search_by_vector("ns", &[1.0, 0.0, 0.0], 5).unwrap();
+
+    assert_eq!(results.len(), 1, "the row must still be returned");
+    assert_eq!(results[0].id, "bad");
+    assert!(
+        results[0].metadata.is_null(),
+        "invalid metadata json must fall back to Null"
+    );
+}
+
 #[test]
 fn search_by_vector_scores_correct() {
     let store = fake_store(3);


### PR DESCRIPTION
## Summary

- Defer metadata JSON parsing in `VectorStore::search_by_vector` until after the result set is truncated to `limit`.
- The search scans every vector in a namespace but returns only `limit` rows, so parsing the metadata of all N candidates threw away all but `limit` parses.
- Fix a misleading trace expression that reported `scored.capacity()` instead of the real scanned count, and add a regression test pinning that the deferred parse maps to the correct surviving rows.

## Problem

`search_by_vector` loads every vector row in the namespace, scores each by cosine similarity, then sorts and truncates to `limit` (typically ~10). It parsed each row's metadata blob inside the scoring map:

```rust
let mut scored: Vec<SearchResult> = rows
    .into_iter()
    .map(|(id, ns, text, blob, meta_str)| {
        let stored_vec = bytes_to_vec(&blob);
        let score = cosine_similarity(query_vec, &stored_vec);
        let metadata = serde_json::from_str(&meta_str).unwrap_or(Value::Null); // parsed for ALL N rows
        SearchResult { id, namespace: ns, text, score, metadata }
    })
    .collect();
scored.sort_by(...);
scored.truncate(limit); // ...then all but `limit` are discarded
```

For a namespace with thousands of vectors that is thousands of `serde_json::from_str` calls (each allocating a `serde_json::Value`) to produce ~10 results. This is the local vector-search path backing hybrid retrieval, so the waste is per-query.

The same function also logged a scanned-row count as `scored.len() + scored.capacity() - scored.len()`, which simplifies to `scored.capacity()` — not the intended "rows scanned before truncate", and fragile (truncate doesn't shrink capacity).

## Solution

Score every candidate but carry the metadata as the raw JSON string through an intermediate; sort and truncate first; parse metadata only for the survivors:

```rust
let scanned = rows.len();

struct ScoredRow { score: f64, id: String, namespace: String, text: String, meta_str: String }

let mut scored: Vec<ScoredRow> = rows
    .into_iter()
    .map(|(id, namespace, text, blob, meta_str)| {
        let stored_vec = bytes_to_vec(&blob);
        let score = cosine_similarity(query_vec, &stored_vec);
        ScoredRow { score, id, namespace, text, meta_str }
    })
    .collect();

scored.sort_by(/* desc by score */);
scored.truncate(limit);

let results: Vec<SearchResult> = scored
    .into_iter()
    .map(|row| SearchResult {
        id: row.id, namespace: row.namespace, text: row.text, score: row.score,
        metadata: serde_json::from_str(&row.meta_str).unwrap_or(Value::Null), // parsed `limit` times
    })
    .collect();
```

`serde_json::from_str` now runs `limit` times instead of N. The trace now reports the real `scanned` (`rows.len()` captured before consuming).

**Behaviour is identical** — scoring, ordering, and the returned `SearchResult`s are unchanged; only the number of metadata parses drops. Scoring depends solely on the vector blob, never on metadata, so deferring the parse past sort/truncate cannot change which rows are returned.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — added `search_by_vector_returns_metadata_of_surviving_rows`: inserts three rows with distinct vectors + per-id metadata tags, searches with `limit=2`, and asserts the two survivors carry their own metadata and the truncated row never leaks. This pins that the deferred parse aligns with the post-sort/truncate order. Existing `search_returns_ranked_results`, `search_respects_limit`, `search_namespace_isolation`, `search_by_vector_limit_zero` continue to cover ordering/limit/isolation.
- [x] **Diff coverage ≥ 80%** — the changed production lines (score-only map, deferred parse map, trace) are exercised by the new + existing `memory_store::vectors` tests.
- [x] Coverage matrix updated — `N/A: behaviour-preserving perf change, no feature added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no feature row affected`.
- [x] No new external network dependencies introduced — none added.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal retrieval path, no user-facing surface`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue`.

## Impact

- **Runtime/platform**: desktop/CLI core (`openhuman` crate). No platform-specific behaviour.
- **Performance**: metadata JSON parsing in local vector search drops from O(N) to O(limit) per query, where N is the namespace's vector count and limit is typically ~10. On large namespaces this removes the dominant per-query allocation; pure win, no behavioural change. Also corrects the scanned-row trace.
- **Security/migration/compatibility**: none.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: an adjacent opportunity remains in the same function — `cosine_similarity` recomputes the query vector's norm for every candidate though it is loop-invariant; precomputing it once would need a `cosine_similarity_with_norm` helper and is intentionally left out of this minimal PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `perf/vector-search-defer-metadata-parse`
- Commit SHA: see PR head

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed
- [x] `pnpm typecheck` — N/A: no TS changed
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib memory_store::vectors`
- [x] Rust fmt/check (if changed): `cargo fmt` clean; `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` clean
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none — performance only
- User-visible effect: none

### Parity Contract

- Legacy behavior preserved: yes — scoring/ordering/returned rows unchanged; only the metadata parse is moved past truncation, and scoring never depends on metadata
- Guard/fallback/dispatch parity checks: cosine scoring, descending sort, and `limit` truncation unchanged

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector search performance/accuracy by deferring metadata parsing until after ranking and truncation, ensuring metadata stays correctly matched to the returned top-N results.
  * Invalid or corrupted metadata no longer prevents matches; those hits now safely return with `metadata` set to `Null`.
  * Updated diagnostic search output to show total scanned rows versus final returned results.
* **Tests**
  * Added unit tests to verify top-N ranking preserves the correct `metadata` and that invalid metadata falls back to `Null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->