### PR TITLE
fix(inference): classify abacus "no remaining credits" 400 as budget-exhausted (#4043)

### DIFF
--- a/src/openhuman/inference/provider/billing_error.rs
+++ b/src/openhuman/inference/provider/billing_error.rs
@@ -11,6 +11,13 @@ pub fn is_budget_exhausted_message(body: &str) -> bool {
         "budget exceeded",
         "add credits",
         "insufficient balance",
+        // abacus's out-of-credits 400 wording (TAURI-RUST-D6X): the managed
+        // route-llm account is exhausted. The full body is
+        // `"You have no remaining credits to use the LLM apis."`. Anchored on
+        // the "no remaining credits" fragment (not the broader "remaining
+        // credits", which a positive "you have N remaining credits" balance
+        // message could trip) to keep the list tight per the rule above.
+        "no remaining credits",
     ];
 
     let lower = body.to_ascii_lowercase();
@@ -43,12 +50,33 @@ mod tests {
         assert!(is_budget_exhausted_message("Insufficient BALANCE"));
     }
 
+    /// Verbatim abacus out-of-credits 400 body (Sentry TAURI-RUST-D6X). The
+    /// classifier feeds the native_chat demotion, the `expected_error_kind`
+    /// re-report demotion, the `is_budget_event` before_send net, AND the cron
+    /// scheduler's terminal billing-halt (`is_budget_exhausted_failure`), so
+    /// pinning the exact wire body makes an abacus phrasing drift fail CI
+    /// rather than silently re-flood Sentry / re-fire the retry loop.
+    #[test]
+    fn detects_abacus_no_remaining_credits_400_body() {
+        let body = "abacus API error (400 Bad Request): \
+            {\"success\": false, \"error\": \"You have no remaining credits to use the LLM apis.\"}";
+        assert!(
+            is_budget_exhausted_message(body),
+            "abacus no-remaining-credits 400 must classify as budget-exhausted user-state"
+        );
+        // Case-insensitive on the same phrase.
+        assert!(is_budget_exhausted_message("You have NO REMAINING CREDITS left"));
+    }
+
     #[test]
     fn ignores_non_budget_messages() {
         for body in [
             "Bad request: missing field",
             "Invalid request: model not found",
             "HTTP 400 Bad Request",
+            // A positive-balance message must NOT be demoted: we anchor on the
+            // "no remaining credits" fragment precisely so this doesn't trip.
+            "You have 100 remaining credits this month",
             "",
         ] {
             assert!(

--- a/src/openhuman/inference/provider/billing_error.rs
+++ b/src/openhuman/inference/provider/billing_error.rs
@@ -65,7 +65,9 @@ mod tests {
             "abacus no-remaining-credits 400 must classify as budget-exhausted user-state"
         );
         // Case-insensitive on the same phrase.
-        assert!(is_budget_exhausted_message("You have NO REMAINING CREDITS left"));
+        assert!(is_budget_exhausted_message(
+            "You have NO REMAINING CREDITS left"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

abacus returns HTTP `400 {"success": false, "error": "You have no remaining credits to use the LLM apis."}` when the managed `route-llm` account is exhausted. That phrase was missing from `is_budget_exhausted_message`, so the failure fell through to `report_error` and re-fired on the ~5-min agent cadence, re-reported at three layers (`native_chat` → `provider_chat` → `run_single`).

Sentry **TAURI-RUST-D6X**: ~2,616 events from a single out-of-credits user — one terminal billing state amplified by a missing classifier phrase + a retry loop with no terminal-state backpressure.

## Fix

Add the verbatim-anchored `"no remaining credits"` phrase to `is_budget_exhausted_message`'s `PHRASES`. Because every consumer keys on this single source-of-truth list, the one addition propagates to all of them and covers both halves of the RCA:

- **native_chat emit-site demotion** — `is_budget_exhausted_http_400` matches → `log_budget_exhausted_http_400` (info, no Sentry).
- **layered re-report demotion** — the `provider_chat` and `run_single` re-reports go through `report_error_or_expected` → `expected_error_kind` → `BudgetExhausted`, now demoted.
- **`before_send` net** — `is_budget_event` (status-400-tagged) catches any straggler.
- **terminal backpressure (part b)** — the cron scheduler's `is_budget_exhausted_failure` → `budget_exhausted` halt now fires, stopping the retry loop from re-attempting a permanent user-state.

Anchored on the `"no remaining credits"` fragment (not the broader `"remaining credits"`) so a positive-balance message like `"you have 100 remaining credits"` is **not** demoted — honoring the file's "keep the list deliberately tight" rule.

## Tests

- Verbatim abacus-body test (couples CI to the exact wire body so a provider wording drift fails CI instead of silently re-flooding).
- Case-insensitive variant.
- Negative guard: a positive-balance "remaining credits" message must not classify as budget-exhausted.

## Scope note

The inline retry layer (`reliable.rs`) already treats a structured 400 as non-retryable, and the cron scheduler is the one periodic driver with a terminal billing-halt hook (now activated). I did **not** add a bespoke scheduler-pause for non-cron periodic drivers — the out-of-credits outcome is genuinely unpreventable (no local lever) and should auto-resume on top-up; the existing budget-exhausted UI toast already provides the single user-facing surface.

Bucket: preventable-noise + real-defect (no terminal backpressure) — RCA: abacus "no remaining credits" 400 was unclassified, so a permanent out-of-credits state re-reported at 3 layers and re-fired every ~5 min; added the phrase to the single-source budget classifier, which demotes all three layers and arms the cron terminal halt.

Closes #4043
Sentry-Issue: TAURI-RUST-D6X
