### PR TITLE
fix(tinyplace): show own posts in Tiny Place feed so composed posts appear (#4059)

### DIFF
--- a/app/src/agentworld/pages/FeedSection.test.tsx
+++ b/app/src/agentworld/pages/FeedSection.test.tsx
@@ -547,6 +547,49 @@ describe('post composer', () => {
     });
   });
 
+  test('#4059: home feed requests includeSelf so the viewer sees their own posts', async () => {
+    const user = userEvent.setup();
+    const myPostItem = {
+      post: {
+        ...samplePost,
+        postId: 'post-new',
+        body: 'My new post',
+        author: { ...sampleAuthor, cryptoId: MY_AGENT_ID, handle: MY_HANDLE },
+      },
+      score: 1,
+      reason: 'own',
+    };
+    // First load: only a followed-agent post (no own posts). After the user
+    // composes, the refetch returns the followed post *and* their own one.
+    vi.mocked(apiClient.graphql.homeFeed)
+      .mockResolvedValueOnce({ items: [sampleFeedItem], count: 1 })
+      .mockResolvedValue({ items: [sampleFeedItem, myPostItem], count: 2 });
+
+    render(<FeedSection />);
+    const textarea = await screen.findByPlaceholderText(/what's on your mind/i);
+
+    // Initial fetch must opt into own posts — otherwise a freshly composed post
+    // can never appear (the feed is followed-agents-only).
+    expect(vi.mocked(apiClient.graphql.homeFeed)).toHaveBeenCalledWith(
+      expect.objectContaining({ includeSelf: true })
+    );
+
+    await user.type(textarea, 'My new post');
+    await user.click(screen.getByRole('button', { name: /^post$/i }));
+
+    // The created post now shows in the feed after the refetch.
+    await waitFor(() => {
+      expect(screen.getByText('My new post')).toBeInTheDocument();
+    });
+
+    // Every home-feed request (mount + refetch) carries includeSelf:true.
+    const calls = vi.mocked(apiClient.graphql.homeFeed).mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of calls) {
+      expect(call[0]).toMatchObject({ includeSelf: true });
+    }
+  });
+
   test('Post button is disabled until a draft is entered', async () => {
     const user = userEvent.setup();
     vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({ items: [sampleFeedItem], count: 1 });

--- a/app/src/agentworld/pages/FeedSection.tsx
+++ b/app/src/agentworld/pages/FeedSection.tsx
@@ -2,9 +2,11 @@
  * FeedSection — Agent World "Feed" section.
  *
  * Renders the personalized home feed for the authenticated agent via
- * `apiClient.graphql.homeFeed()` (GraphQL, requires unlocked wallet).
- * Supports drill-down into individual posts (comments + likers) via
- * `apiClient.graphql.post()`.
+ * `apiClient.graphql.homeFeed({ includeSelf: true })` (GraphQL, requires
+ * unlocked wallet). `includeSelf` is required so the viewer sees their own
+ * posts — without it the feed is followed-agents-only and a freshly composed
+ * post never shows up (#4059). Supports drill-down into individual posts
+ * (comments + likers) via `apiClient.graphql.post()`.
  *
  * Phase A interactive features (wallet-gated):
  * - Like / unlike toggle with optimistic update and server reconcile
@@ -571,8 +573,13 @@ export default function FeedSection() {
     let cancelled = false;
     setFeedState({ status: 'loading' });
 
+    // `includeSelf: true` — the personalized home feed otherwise returns only
+    // scored posts from *followed* agents, so the viewer's own posts (including
+    // one they just created via the composer) never appear. Without this the
+    // composer looks broken: Post succeeds server-side but the refetch can't
+    // show it (#4059).
     void apiClient.graphql
-      .homeFeed({ limit: 50 })
+      .homeFeed({ limit: 50, includeSelf: true })
       .then(result => {
         if (cancelled) return;
         const items = sortedHomeFeedItems(result);
@@ -648,7 +655,7 @@ export default function FeedSection() {
     void apiClient.feeds
       .deletePost(post.postId)
       .then(() => {
-        void apiClient.graphql.homeFeed({ limit: 50 }).then(result => {
+        void apiClient.graphql.homeFeed({ limit: 50, includeSelf: true }).then(result => {
           const items = sortedHomeFeedItems(result);
           setFeedState({ status: 'ok', items });
         });
@@ -659,7 +666,7 @@ export default function FeedSection() {
   // ── Refetch feed ───────────────────────────────────────────────────────────
 
   const refetchFeed = () => {
-    void apiClient.graphql.homeFeed({ limit: 50 }).then(result => {
+    void apiClient.graphql.homeFeed({ limit: 50, includeSelf: true }).then(result => {
       const items = sortedHomeFeedItems(result);
       setFeedState({ status: 'ok', items });
     });


### PR DESCRIPTION
## Summary

- Tiny Place Feed: a composed post never appeared after **Post**, with no error — fixed by including the viewer's own posts in the home-feed fetch.
- `FeedSection` now passes `includeSelf: true` at all three `homeFeed` call sites (initial load, post/like refetch, delete refetch).
- Frontend-only; the `includeSelf` param is already plumbed end-to-end to the GraphQL home-feed query.

## Problem

The personalized home feed (`tinyplace_graphql_home_feed`) returns *scored posts from followed agents only*. `FeedSection` fetched and refetched it without `includeSelf`, so the viewer's own posts were excluded.

After composing a post, the flow is: `feeds.createPost(body)` → on success `refetchFeed()` → `graphql.homeFeed({ limit: 50 })`. `createPost` succeeds server-side (hence **no error shown**), but the refetched followed-agents feed cannot contain the just-created own post — so it silently never appears. This matches every reported symptom in #4059 (input accepted, no error, post absent, reproducible).

## Solution

Pass `includeSelf: true` on every `FeedSection` home-feed request so the viewer always sees their own posts — most importantly the one they just created.

- The param required no backend change: it is plumbed client → `manifest.rs` → GraphQL client, and the **agent** post flow already reads back with `include_self: true` (`flows_write.rs`), confirming the contract.
- The component already re-sorts newest-first client-side, so the fresh post lands at the top.
- Deliberately **not** adding an optimistic insert — `includeSelf` is necessary and sufficient to fix the defect; optimistic prepend is separate UX scope.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — both changed lines are exercised by the new + existing `FeedSection` tests (Vitest)
- [x] N/A: behaviour-only change — no feature row added/removed/renamed in the coverage matrix
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID for this fix
- [x] No new external network dependencies introduced (apiClient is mocked in tests)
- [x] N/A: does not touch release-cut smoke surfaces (no manual-smoke checklist change)
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop only** (Tiny Place / Agent World UI). No Rust/core change, no RPC/schema change.
- No performance, security, migration, or compatibility implications — the feed query already supported `includeSelf`; this just opts in from the UI.

## Related

- Closes: #4059
- Follow-up PR(s)/TODOs: touches `FeedSection.tsx`, same file as open PR #4030 (wallet-fetch gate) — whichever merges second will rebase; the changes are complementary (gate the fetch vs. include own posts).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/4059-feed-include-self
- Commit SHA: 41fa4200c83869d2ba6c1fb9ee77b84124e96438

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `vitest run --config test/vitest.config.ts src/agentworld/pages/FeedSection.test.tsx` → 36/36 pass
- [x] N/A: Rust fmt/check — no Rust changed
- [x] N/A: Tauri fmt/check — no Tauri changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: viewer's own posts now appear in their Tiny Place home feed.
- User-visible effect: a freshly composed post shows up in the feed within a couple seconds; the composer no longer looks broken.

### Parity Contract

- Legacy behavior preserved: followed-agents posts still shown and scored; client-side newest-first sort unchanged.
- Guard/fallback/dispatch parity checks: wallet gating unchanged (composer still only renders when wallet resolved + feed status ok).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A
