### PR TITLE
fix(inference): demote provider monthly-quota exhaustion from Sentry (#4075)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2313,6 +2313,21 @@ pub fn run() {
                 );
                 return None;
             }
+            // Drop provider monthly-quota exhausted events — the user's
+            // third-party plan has spent its allotment (e.g. Kiro
+            // `MONTHLY_REQUEST_COUNT`, sometimes wrapped in a 500 envelope so
+            // the 402-gated credits filter above misses it). No local lever;
+            // mirrors the core binary's main.rs before_send chain
+            // (TAURI-RUST-C9A: 9k events from a single quota-capped user).
+            if openhuman_core::core::observability::is_quota_exhausted_event(&event) {
+                // Metadata-only log shape — `event.message` carries the raw
+                // provider body which CLAUDE.md forbids from local logs.
+                log::debug!(
+                    "[sentry-quota-exhausted-filter] dropping monthly-quota event_id={:?}",
+                    event.event_id
+                );
+                return None;
+            }
             // Strip server_name (hostname) to avoid leaking machine identity.
             event.server_name = None;
             // Attach the cached account uid so Sentry can count unique users

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -2547,6 +2547,46 @@ pub fn is_insufficient_credits_event(event: &sentry::protocol::Event<'_>) -> boo
     })
 }
 
+/// Message-level matcher for a provider **monthly-quota / usage-limit
+/// exhausted** failure. Status-agnostic by design — unlike
+/// [`is_insufficient_credits_message`] it does NOT anchor on a 402 status,
+/// because the Kiro IDE proxy wraps its 402 inside a 500 envelope
+/// (TAURI-RUST-C9A). Delegates to the single-source quota-phrase set in
+/// [`crate::openhuman::inference::provider::body_indicates_quota_exhausted`], so
+/// the emit-site guard and this `before_send` net can't drift. Shared with the
+/// event-level filter [`is_quota_exhausted_event`].
+pub fn is_quota_exhausted_message(text: &str) -> bool {
+    crate::openhuman::inference::provider::body_indicates_quota_exhausted(text)
+}
+
+/// Defense-in-depth `before_send` filter for provider **monthly-quota
+/// exhausted** events (TAURI-RUST-C9A): the user's third-party plan has spent
+/// its allotment for the period — a billing/plan state OpenHuman has no lever
+/// over.
+///
+/// The primary emit-site demotion lives in the `Provider::chat()` native_chat
+/// cascade and the shared `api_error` helper (`is_provider_quota_exhausted`),
+/// but the compatible provider reports the same failure from several other
+/// paths that don't run those guards. This filter is the single outermost net
+/// that catches all of them, keyed on the formatted message rather than tags so
+/// it matches regardless of which path emitted it (and regardless of whether
+/// the upstream wrapped the 402 in a 500 envelope).
+pub fn is_quota_exhausted_event(event: &sentry::protocol::Event<'_>) -> bool {
+    if event
+        .message
+        .as_deref()
+        .is_some_and(is_quota_exhausted_message)
+    {
+        return true;
+    }
+    event.exception.values.iter().any(|exception| {
+        exception
+            .value
+            .as_deref()
+            .is_some_and(is_quota_exhausted_message)
+    })
+}
+
 /// 404 on PATCH/DELETE to a channel-message path is an expected backend state
 /// (user deleted the message provider-side, backend GC'd the relay row). The
 /// primary suppression lives in `authed_json` via `parse_message_path` +
@@ -5840,6 +5880,32 @@ mod tests {
         }]
         .into();
         event
+    }
+
+    #[test]
+    fn quota_exhausted_filter_matches_500_wrapped_kiro_event() {
+        // TAURI-RUST-C9A: verbatim message as formatted by the provider emit
+        // site — a 500 envelope around an inner 402 / MONTHLY_REQUEST_COUNT.
+        // The status-agnostic quota filter must catch it on the message path
+        // and the exception path.
+        let body = "kiro API error (500 Internal Server Error): {\"error\":{\"message\":\
+            \"HTTP 402 from Kiro IDE: {\\\"reason\\\":\\\"MONTHLY_REQUEST_COUNT\\\"}\",\
+            \"type\":\"server_error\"}}";
+        assert!(is_quota_exhausted_event(&event_with_message(body)));
+        assert!(is_quota_exhausted_event(&event_with_exception_value(body)));
+        assert!(is_quota_exhausted_message(body));
+    }
+
+    #[test]
+    fn quota_exhausted_filter_ignores_generic_500_and_rate_limit() {
+        // A generic 500 outage and a 429 rate-limit are not plan-quota
+        // exhaustion — they must keep reaching Sentry / their own handling.
+        assert!(!is_quota_exhausted_event(&event_with_message(
+            "kiro API error (500 Internal Server Error): upstream connection reset"
+        )));
+        assert!(!is_quota_exhausted_event(&event_with_message(
+            "provider API error (429 Too Many Requests): rate_limit_exceeded"
+        )));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,13 @@ fn main() {
             if openhuman_core::core::observability::is_insufficient_credits_event(&event) {
                 return None;
             }
+            // Drop provider monthly-quota exhausted events — third-party plan
+            // allotment spent (e.g. Kiro `MONTHLY_REQUEST_COUNT`, sometimes
+            // wrapped in a 500 envelope so the 402-gated credits filter above
+            // misses it). No local lever (TAURI-RUST-C9A).
+            if openhuman_core::core::observability::is_quota_exhausted_event(&event) {
+                return None;
+            }
             // Defense-in-depth: drop max-tool-iterations cap events that
             // slipped past the call-site filters in
             // `agent::harness::session::runtime::run_single`,

--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -786,6 +786,17 @@ impl Provider for OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::super::is_provider_quota_exhausted(&error) {
+                // Upstream plan quota spent (e.g. Kiro `MONTHLY_REQUEST_COUNT`),
+                // sometimes wrapped in a 500 envelope so the credits matcher
+                // above (402-gated) misses it — no local lever, demote instead
+                // of paging once per memory-extraction retry (TAURI-RUST-C9A).
+                super::super::log_provider_quota_exhausted(
+                    "native_chat",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                );
             } else if super::super::should_report_provider_http_failure(status) {
                 crate::core::observability::report_error(
                     message.as_str(),

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -214,6 +214,76 @@ pub fn log_provider_insufficient_credits_402(
     );
 }
 
+/// Whether a provider non-2xx response is a deterministic **monthly-quota /
+/// usage-limit exhausted** user-state error — the user's third-party plan has
+/// spent its allotment for the period and no request will succeed until it
+/// resets (a billing/plan state OpenHuman has no lever over).
+///
+/// Distinct from [`is_provider_insufficient_credits_402`] in two ways:
+/// 1. The signal is a *usage-quota cap* ("you have reached the limit",
+///    `MONTHLY_REQUEST_COUNT`), not an account balance.
+/// 2. The upstream proxy may wrap its own 402 inside a **500** envelope, e.g.
+///    Kiro IDE: `kiro API error (500 Internal Server Error): {"error":\
+///    {"message":"HTTP 402 from Kiro IDE: {\"reason\":\"MONTHLY_REQUEST_COUNT\"}"…}}`.
+///    So this is **status-agnostic** — matched against the body like
+///    [`is_context_window_exceeded_message`] — because gating on a 402
+///    transport status (as the credits matcher does) would let the 500-wrapped
+///    flood straight through to [`should_report_provider_http_failure`]
+///    (TAURI-RUST-C9A: 9k events from a single quota-capped user, retried per
+///    memory-extraction attempt).
+///
+/// Keyed on quota-specific wording only, so a generic 500 outage (or a 429
+/// rate-limit, which has its own transient handling) is not swallowed. Covered
+/// by a verbatim-body test so a provider wording drift fails CI.
+pub fn is_provider_quota_exhausted(body: &str) -> bool {
+    body_indicates_quota_exhausted(body)
+}
+
+/// Phrase-level matcher for a provider monthly-quota / usage-limit exhausted
+/// body. Single source of truth for the quota-phrase set, shared by the
+/// emit-site guard [`is_provider_quota_exhausted`] and the `before_send`
+/// defense-in-depth filter
+/// [`crate::core::observability::is_quota_exhausted_event`] (which matches the
+/// formatted `<provider> API error (…): <body>` message so the demotion reaches
+/// every compatible-provider HTTP path, not just `Provider::chat()`'s
+/// `native_chat` cascade). TAURI-RUST-C9A.
+pub fn body_indicates_quota_exhausted(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("monthly_request_count")
+        || lower.contains("monthly request")
+        || lower.contains("monthly limit")
+        || lower.contains("monthly quota")
+        || lower.contains("quota exceeded")
+        || lower.contains("usage limit exceeded")
+        // "reached the limit" alone is ambiguous (rate-limit, token-limit), so
+        // require a quota/plan/request/monthly co-marker to keep the blast
+        // radius on plan-quota exhaustion only.
+        || (lower.contains("reached the limit")
+            && (lower.contains("request")
+                || lower.contains("quota")
+                || lower.contains("monthly")
+                || lower.contains("plan")))
+}
+
+pub fn log_provider_quota_exhausted(
+    operation: &str,
+    provider: &str,
+    model: Option<&str>,
+    status: reqwest::StatusCode,
+) {
+    tracing::info!(
+        domain = "llm_provider",
+        operation = operation,
+        provider = provider,
+        model = model.unwrap_or(""),
+        status = status.as_u16(),
+        failure = "non_2xx",
+        kind = "quota_exhausted",
+        "[llm_provider] {operation} provider monthly-quota exhausted — third-party plan limit \
+         reached (no local lever), not reporting to Sentry"
+    );
+}
+
 /// Whether a provider non-2xx response is a deterministic
 /// **configuration-rejection** user-state error (unknown model id,
 /// abstract tier leaked to a custom provider, model-specific temperature
@@ -705,6 +775,11 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     // custom gateways mis-report it as 500 — TAURI-RUST-501 — so a status
     // gate would let those through to `should_report_provider_http_failure`).
     let is_context_window_exceeded = is_context_window_exceeded_message(&body);
+    // Monthly-quota exhaustion is likewise status-agnostic: the Kiro IDE proxy
+    // wraps its 402 inside a 500 envelope (TAURI-RUST-C9A), so match the body
+    // directly rather than gating on a 402 status (which the credits matcher
+    // below does). The user's third-party plan quota is spent — no local lever.
+    let is_quota_exhausted = is_provider_quota_exhausted(&body);
     // F4/F2: any managed-backend response carrying a stable `errorCode` is
     // backend-owned — it already paged or is expected user-state — so the FE
     // must not double-report. The one exception (malformed `BAD_REQUEST`) is
@@ -735,6 +810,8 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
         log_provider_config_rejection("api_error", provider, None, status);
     } else if is_context_window_exceeded {
         log_context_window_exceeded("api_error", provider, None, status);
+    } else if is_quota_exhausted {
+        log_provider_quota_exhausted("api_error", provider, None, status);
     } else if is_backend_error_code_owned {
         log_backend_error_code_owned("api_error", provider, None, status, &body);
     } else if is_byo_auth_failure {
@@ -814,6 +891,70 @@ mod tests {
             StatusCode::PAYMENT_REQUIRED,
             "{\"error\":{\"message\":\"some unrelated condition\"}}"
         ));
+    }
+
+    /// Verbatim TAURI-RUST-C9A provider body — the Kiro IDE proxy wraps its own
+    /// 402 monthly-quota refusal inside a 500 envelope. The matcher keys on this
+    /// prose, so coupling the test to the exact string makes a provider wording
+    /// drift fail CI rather than silently leak events back to Sentry.
+    const C9A_BODY: &str = "kiro API error (500 Internal Server Error): \
+        {\"error\":{\"message\":\"HTTP 402 from Kiro IDE: {\\\"message\\\":\\\"You have \
+        reached the limit.\\\",\\\"reason\\\":\\\"MONTHLY_REQUEST_COUNT\\\"}\",\
+        \"type\":\"server_error\"}}";
+
+    #[test]
+    fn quota_exhausted_matches_verbatim_c9a_body() {
+        // Status-agnostic: the verbatim 500-wrapped body must match even though
+        // the transport status is 500, not 402.
+        assert!(is_provider_quota_exhausted(C9A_BODY));
+        assert!(body_indicates_quota_exhausted(C9A_BODY));
+    }
+
+    #[test]
+    fn quota_exhausted_matches_common_phrasings() {
+        for body in [
+            "{\"reason\":\"MONTHLY_REQUEST_COUNT\"}",
+            "You have reached the limit on your monthly requests",
+            "monthly request quota reached",
+            "monthly limit reached",
+            "plan quota exceeded",
+            "usage limit exceeded for this period",
+        ] {
+            assert!(is_provider_quota_exhausted(body), "should match: {body:?}");
+        }
+    }
+
+    #[test]
+    fn quota_exhausted_ignores_unrelated_500_and_rate_limit() {
+        // A generic 500 outage and a 429 rate-limit are NOT plan-quota
+        // exhaustion and must stay reportable / retryable respectively — the
+        // quota guard must not swallow them.
+        for body in [
+            "kiro API error (500 Internal Server Error): {\"error\":\
+             {\"message\":\"upstream connection reset\",\"type\":\"server_error\"}}",
+            "rate_limit_exceeded: too many requests, retry after 12s",
+            "429 Too Many Requests",
+            "context length exceeded: reduce the number of tokens",
+        ] {
+            assert!(
+                !is_provider_quota_exhausted(body),
+                "should NOT match: {body:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn quota_and_credits_matchers_do_not_overlap_on_c9a() {
+        // The 402-gated credits matcher must keep ignoring the 500-wrapped
+        // quota body (it is status-anchored) — the quota matcher is the one
+        // that catches it. Proves the locked-in
+        // `insufficient_credits_402_ignores_non_402_status` invariant holds and
+        // the two classifiers cover distinct shapes.
+        assert!(!is_provider_insufficient_credits_402(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            C9A_BODY
+        ));
+        assert!(is_provider_quota_exhausted(C9A_BODY));
     }
 
     /// Verbatim TAURI-RUST-8FQ Responses-API body. The matcher keys on this

--- a/src/openhuman/inference/provider/ops/mod.rs
+++ b/src/openhuman/inference/provider/ops/mod.rs
@@ -19,17 +19,18 @@ pub use sanitize::{
 };
 
 pub use http_error::{
-    api_error, body_indicates_insufficient_credits, is_backend_auth_failure,
-    is_backend_error_code_owned, is_budget_exhausted_http_400, is_byo_provider_auth_failure_http,
-    is_context_window_exceeded_message, is_custom_openai_upstream_bad_request_http_400,
-    is_openai_oauth_session_expired_http, is_openai_oauth_session_expired_message,
-    is_provider_access_policy_denied_http_403, is_provider_config_rejection_http,
-    is_provider_insufficient_credits_402, log_backend_error_code_owned,
-    log_budget_exhausted_http_400, log_byo_provider_auth_failure, log_context_window_exceeded,
+    api_error, body_indicates_insufficient_credits, body_indicates_quota_exhausted,
+    is_backend_auth_failure, is_backend_error_code_owned, is_budget_exhausted_http_400,
+    is_byo_provider_auth_failure_http, is_context_window_exceeded_message,
+    is_custom_openai_upstream_bad_request_http_400, is_openai_oauth_session_expired_http,
+    is_openai_oauth_session_expired_message, is_provider_access_policy_denied_http_403,
+    is_provider_config_rejection_http, is_provider_insufficient_credits_402,
+    is_provider_quota_exhausted, log_backend_error_code_owned, log_budget_exhausted_http_400,
+    log_byo_provider_auth_failure, log_context_window_exceeded,
     log_custom_openai_upstream_bad_request_http_400, log_openai_oauth_session_expired,
     log_provider_access_policy_denied_http_403, log_provider_config_rejection,
-    log_provider_insufficient_credits_402, publish_backend_session_expired,
-    should_report_provider_http_failure,
+    log_provider_insufficient_credits_402, log_provider_quota_exhausted,
+    publish_backend_session_expired, should_report_provider_http_failure,
 };
 
 pub use models::{

--- a/src/openhuman/inference/provider/ops_tests.rs
+++ b/src/openhuman/inference/provider/ops_tests.rs
@@ -1236,6 +1236,41 @@ async fn api_error_byo_auth_failure_returns_message_via_demoted_branch() {
     );
 }
 
+/// End-to-end through `api_error`: a 500-wrapped monthly-quota refusal (the
+/// Kiro IDE proxy nests its 402 / `MONTHLY_REQUEST_COUNT` inside a 500
+/// envelope, TAURI-RUST-C9A) returns the sanitized provider error to the UI
+/// while routing through the quota-exhausted demote branch — *before* the
+/// `should_report_provider_http_failure(500)` status gate that would otherwise
+/// page once per memory-extraction retry.
+#[tokio::test]
+async fn api_error_monthly_quota_returns_message_via_demoted_branch() {
+    let body = "{\"error\":{\"message\":\"HTTP 402 from Kiro IDE: \
+        {\\\"message\\\":\\\"You have reached the limit.\\\",\
+        \\\"reason\\\":\\\"MONTHLY_REQUEST_COUNT\\\"}\",\"type\":\"server_error\"}}";
+    let http_response = axum::http::Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(body.to_string())
+        .expect("build 500 response");
+    let response = reqwest::Response::from(http_response);
+
+    let err = api_error("kiro", response).await;
+    let msg = err.to_string();
+    assert!(
+        msg.contains("kiro API error (500"),
+        "error must still carry the provider/status prefix for the UI: {msg}"
+    );
+    assert!(
+        msg.contains("MONTHLY_REQUEST_COUNT"),
+        "sanitized upstream quota body must propagate to the caller: {msg}"
+    );
+    // The body must classify as quota-exhausted so the demote branch — not the
+    // 500 status gate — handles it.
+    assert!(is_provider_quota_exhausted(body));
+    assert!(should_report_provider_http_failure(
+        StatusCode::INTERNAL_SERVER_ERROR
+    ));
+}
+
 /// `publish_backend_session_expired` must emit a `SessionExpired` event on
 /// the `auth` domain with the canonical source and a sanitized reason, so
 /// the credentials subscriber can drive reauth.

--- a/src/openhuman/inference/provider/reliable.rs
+++ b/src/openhuman/inference/provider/reliable.rs
@@ -50,6 +50,13 @@ pub(crate) fn is_non_retryable(err: &anyhow::Error) -> bool {
     if crate::core::observability::is_session_expired_message(&msg) {
         return true;
     }
+    // Monthly-quota / usage-limit exhaustion (e.g. Kiro `MONTHLY_REQUEST_COUNT`,
+    // possibly wrapped in a 500 envelope so `structured_http_4xx` can't see the
+    // inner 402) is terminal for the period — retrying a spent plan quota only
+    // multiplies wasted calls and Sentry events (TAURI-RUST-C9A).
+    if crate::openhuman::inference::provider::body_indicates_quota_exhausted(&msg) {
+        return true;
+    }
 
     if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
         if let Some(status) = reqwest_err.status() {

--- a/src/openhuman/inference/provider/reliable_tests.rs
+++ b/src/openhuman/inference/provider/reliable_tests.rs
@@ -221,6 +221,26 @@ fn non_retryable_detects_common_patterns() {
     )));
 }
 
+// TAURI-RUST-C9A: a monthly-quota refusal wrapped in a 500 envelope (so the
+// `structured_http_4xx` regex can't see the inner 402) must still be terminal —
+// retrying a spent plan quota only multiplies wasted calls + Sentry events.
+#[test]
+fn non_retryable_detects_monthly_quota_exhaustion() {
+    assert!(is_non_retryable(&anyhow::anyhow!(
+        "kiro API error (500 Internal Server Error): {{\"error\":{{\"message\":\
+         \"HTTP 402 from Kiro IDE: {{\\\"reason\\\":\\\"MONTHLY_REQUEST_COUNT\\\"}}\",\
+         \"type\":\"server_error\"}}}}"
+    )));
+    assert!(is_non_retryable(&anyhow::anyhow!(
+        "provider returned: you have reached the limit on your monthly requests"
+    )));
+    // A generic 500 outage stays retryable (transient) — the quota arm must not
+    // over-match.
+    assert!(!is_non_retryable(&anyhow::anyhow!(
+        "kiro API error (500 Internal Server Error): upstream connection reset"
+    )));
+}
+
 // C10: a 4xx-looking digit run that appears in *free text* (latency figures,
 // model ids, token counts) must NOT be inferred as a permanent HTTP client
 // error — that wrongly short-circuits retries/fallback for transient failures.

--- a/src/openhuman/memory_tree/score/extract/llm.rs
+++ b/src/openhuman/memory_tree/score/extract/llm.rs
@@ -346,6 +346,13 @@ fn permanent_failure_code(
         || lower.contains("payment required")
         || lower.contains("requires more credits")
         || lower.contains("insufficient")
+        // Monthly-quota exhaustion (e.g. Kiro `MONTHLY_REQUEST_COUNT`) — the
+        // budget-exhausted remediation ("out of budget; top up — retrying won't
+        // help") is the honest signal even when the proxy omits a 402 status
+        // (TAURI-RUST-C9A).
+        || lower.contains("monthly_request_count")
+        || lower.contains("monthly request")
+        || lower.contains("quota")
     {
         FailureCode::BudgetExhausted
     } else if lower.contains("401")

--- a/src/openhuman/memory_tree/score/extract/llm_tests.rs
+++ b/src/openhuman/memory_tree/score/extract/llm_tests.rs
@@ -654,6 +654,66 @@ async fn extract_does_not_retry_on_permanent_402() {
 }
 
 #[tokio::test]
+async fn extract_does_not_retry_on_500_wrapped_monthly_quota() {
+    // TAURI-RUST-C9A: the Kiro IDE proxy wraps a 402 monthly-quota refusal
+    // inside a 500 envelope. Before the quota classifier, `is_non_retryable`
+    // saw only a 500 and treated it as a transient transport failure — so
+    // extract() retried 3× and each attempt fired a provider Sentry event
+    // (9k events from a single quota-capped user). It must now call the
+    // provider exactly once and map to the budget-exhausted cause.
+    let _health_guard = crate::openhuman::memory_tree::health::test_guard();
+    use crate::openhuman::memory::chat::{ChatPrompt, ChatProvider};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct MonthlyQuotaProvider {
+        calls: AtomicUsize,
+    }
+    #[async_trait]
+    impl ChatProvider for MonthlyQuotaProvider {
+        fn name(&self) -> &str {
+            "test:kiro"
+        }
+        async fn chat_for_json(&self, _p: &ChatPrompt) -> anyhow::Result<String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            // Verbatim shape of the TAURI-RUST-C9A provider error (500 envelope
+            // around the inner 402 / MONTHLY_REQUEST_COUNT).
+            Err(anyhow::anyhow!(
+                "kiro API error (500 Internal Server Error): {{\"error\":{{\"message\":\
+                 \"HTTP 402 from Kiro IDE: {{\\\"message\\\":\\\"You have reached the \
+                 limit.\\\",\\\"reason\\\":\\\"MONTHLY_REQUEST_COUNT\\\"}}\",\
+                 \"type\":\"server_error\"}}}}"
+            ))
+        }
+    }
+
+    let mock = Arc::new(MonthlyQuotaProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let ex = LlmEntityExtractor::new(LlmExtractorConfig::default(), mock.clone());
+    let out = ex.extract("some text").await.unwrap();
+
+    assert_eq!(
+        mock.calls.load(Ordering::SeqCst),
+        1,
+        "a 500-wrapped monthly-quota refusal must not be retried"
+    );
+    assert!(out.entities.is_empty());
+
+    let state = crate::openhuman::memory_tree::health::current_degraded_state();
+    assert!(
+        state.structure,
+        "a permanent extraction failure must still mark structure degraded"
+    );
+    assert_eq!(
+        state.cause.expect("degraded cause present").code,
+        crate::openhuman::memory_tree::health::FailureCode::BudgetExhausted,
+        "monthly-quota exhaustion must map to the budget-exhausted cause"
+    );
+}
+
+#[tokio::test]
 async fn extract_retries_transient_provider_error() {
     // The de-amplification fix must only short-circuit *permanent* errors. A
     // transport/transient failure (no 4xx, no auth marker) must still exhaust


### PR DESCRIPTION
## Summary

- Classify a provider **monthly-quota / usage-limit exhausted** failure (e.g. Kiro IDE `MONTHLY_REQUEST_COUNT`, "You have reached the limit") as deterministic user-state and demote it from Sentry.
- The signal is **status-agnostic**: the Kiro proxy wraps its own `402` inside a **`500`** envelope, so the existing 402-gated credit/quota classifiers never see it.
- Stop the **retry storm**: a spent plan quota is now classified non-retryable, so the memory-tree extraction loop no longer retries it 3× (each retry fired a Sentry event).
- Defense-in-depth `before_send` net on both Sentry chains (standalone core + in-process Tauri shell).

## Problem

`Sentry-Issue: TAURI-RUST-C9A` — **9,243 events / 1 user** (release 0.57.40, Windows, prod).

The Kiro IDE proxy returns a user's monthly-quota exhaustion wrapped in a 500 envelope:

```
kiro API error (500 Internal Server Error): {"error":{"message":"HTTP 402 from Kiro IDE:
{\"message\":\"You have reached the limit.\",\"reason\":\"MONTHLY_REQUEST_COUNT\"}","type":"server_error"}}
```

OpenHuman sees transport status **500**, not 402. Every existing credit/quota classifier (`is_provider_insufficient_credits_402`, `is_insufficient_credits_message`'s `(402` anchor) is gated on the transport status being 402, so all of them miss it. Two failures cascade:

1. `reliable::is_non_retryable()` has no quota arm → returns `false` → the memory-tree extraction loop (`extract/llm.rs`, `MAX_ATTEMPTS = 3`) retries the quota error as a transient transport failure.
2. Status 500 ∉ `TRANSIENT_PROVIDER_HTTP_STATUSES` → each retry reports to Sentry. Same user, retry-amplified → flood.

#3617 fixed only the status-402 case. This is a real defect (pointless retry of an unrecoverable error) on top of a genuinely-unpreventable external condition (the user's third-party plan quota is spent — no local lever).

## Solution

- **New status-agnostic matcher** `body_indicates_quota_exhausted` / `is_provider_quota_exhausted` (`ops/http_error.rs`), keyed on quota-specific wording only (`MONTHLY_REQUEST_COUNT`, monthly request/limit/quota, "reached the limit" + a quota/plan/request/monthly co-marker). A generic 500 outage or a 429 rate-limit is **not** swallowed.
- **Retry path** (`reliable::is_non_retryable`): quota → terminal, so the 3× extraction retry storm stops at source. `permanent_failure_code` maps it to `FailureCode::BudgetExhausted` (honest degraded-structure cause).
- **Report path**: demote arm added to both the `Provider::chat()` `native_chat` cascade (the site that stamped the C9A events) and the shared `api_error` helper, mirroring the existing status-agnostic context-window case.
- **`before_send` net** (`is_quota_exhausted_event`) wired into `src/main.rs` and `app/src-tauri/src/lib.rs` as the outermost catch for any path that bypasses the emit-site guards.

**RCA bucket (sentry-workflow S3.5):** `genuinely-unpreventable` (Kiro monthly quota, zero local lever) **+** `real-defect` (quota mis-classified as retryable → retry storm). The demotion is the legit answer for the unpreventable external quota; the non-retryable reclassification is the real correctness fix. Extends the #3617 / TAURI-RUST-C62 family — re-justified per S3.5.e.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — verbatim-C9A drift guard, `api_error` end-to-end demote, `is_non_retryable` terminal + transient-500 negative, memory-extract single-call regression, `before_send` match + generic-500/429 negatives.
- [x] **Diff coverage ≥ 80%** — every new branch is exercised by a dedicated test; CI coverage gate is authoritative.
- [x] N/A: behaviour-only change (Sentry noise classification), no feature row added/removed/renamed — Coverage matrix updated
- [x] All affected feature IDs listed in `## Related` (none — observability change)
- [x] No new external network dependencies introduced — uses existing `reqwest`/`axum`-test harness.
- [x] N/A: no release-cut surface change (no UI/RPC/migration) — Manual smoke checklist
- [x] Linked issue closed via `Closes #4075` in `## Related`

## Impact

- Desktop (all platforms); Rust core + Tauri shell `before_send`. Removes a single-user 9k-event/period Sentry flood and the pointless 3× extraction retries against a spent quota.
- No API, schema, or migration impact. Security-neutral. A genuine provider 500 outage and a 429 rate-limit remain reportable / retryable respectively.

## Related

- Closes: #4075
- Sentry-Issue: TAURI-RUST-C9A
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/4075-kiro-quota-402-in-500-sentry`
- Commit SHA: `ef25cfa17`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no frontend change); `cargo fmt --check` clean
- [x] `pnpm typecheck` — N/A (no TS change)
- [x] Focused tests: `cargo test --lib quota` (10 pass) + `insufficient_credits` (16) + `non_retryable` (24) + `extract_does_not_retry` (3) — all green
- [x] Rust fmt/check (if changed): `cargo check` + `cargo clippy -p openhuman` clean on touched files
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml` clean

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a provider monthly-quota refusal (incl. 500-wrapped) is now non-retryable and demoted from Sentry instead of retried + paged per attempt.
- User-visible effect: none functional — the chat/UI surface still receives the sanitized provider error; only Sentry noise + wasted retries are removed.

### Parity Contract

- Legacy behavior preserved: generic 500 outages stay reportable; 429 rate-limits stay retryable; the 402-gated insufficient-credits path is untouched (its locked-in `ignores_non_402_status` test still passes).
- Guard/fallback/dispatch parity checks: quota demote sits before the status gate in both the native_chat cascade and `api_error`; the `before_send` net mirrors the insufficient-credits filter on both Sentry chains.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monthly quota exhaustion errors are now handled more gracefully across the app.
  * These cases are no longer sent to error monitoring, reducing noise from expected quota limits.
  * Quota-exhausted provider errors are treated as non-retryable, so failed requests stop retrying sooner.
  * Related extraction and scoring flows now recognize quota limits as a permanent budget issue, improving consistency when providers return wrapped error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->