### PR TITLE
ci(build-desktop): stop CEF lib-dir lookup aborting the Linux build under pipefail

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -453,7 +453,13 @@ jobs:
           #      never regress relative to the old double build.
           # macOS / Windows take the single-call path unchanged.
           find_cef_lib_dir() {
-            find "$HOME/.cache/tauri-cef" -name libcef.so -printf '%h\n' 2>/dev/null | head -1
+            # `-quit` stops find after the first match so the `| head -1` can't
+            # close the pipe early and SIGPIPE find. Under this step's
+            # `set -o pipefail` + `-e`, that SIGPIPE (exit 141) aborted the whole
+            # build before `cargo tauri build` ran whenever the warm cache held
+            # more than one libcef.so (multiple version/arch dirs). Trailing
+            # `|| true` also absorbs find's exit 1 when the cache dir is absent.
+            find "$HOME/.cache/tauri-cef" -name libcef.so -printf '%h\n' -quit 2>/dev/null | head -1 || true
           }
           if [ "${RUNNER_OS}" = "Linux" ]; then
             CEF_LIB_DIR="$(find_cef_lib_dir)"


### PR DESCRIPTION
## Problem

The **Release Staging** build (and any Desktop Linux build) fails at the **Build and package Tauri app (CEF, vendored CLI)** step, instantly and with no output, before `cargo tauri build` runs. Seen on [run 28097713509](https://github.com/tinyhumansai/openhuman/actions/runs/28097713509) (`v0.57.54` staging).

The step shell is `bash --noprofile --norc -e -o pipefail`. The first command in the Linux branch is:

```bash
find_cef_lib_dir() {
  find "$HOME/.cache/tauri-cef" -name libcef.so -printf '%h\n' 2>/dev/null | head -1
}
CEF_LIB_DIR="$(find_cef_lib_dir)"
```

On a **warm cache that holds more than one `libcef.so`** (multiple `<version>/<os-arch>/` dirs accumulate on the cached runner), `head -1` closes the pipe after the first line, `find` is killed by **SIGPIPE (exit 141)**, `pipefail` surfaces that as the pipeline status, and `set -e` aborts the whole step. Because line is a bare assignment, nothing is printed — which matches the observed "endgroup → `##[error]Process completed with exit code 1`" with no build output. Single-match caches don't trip it, which is why earlier runs passed.

## Fix

```bash
find "$HOME/.cache/tauri-cef" -name libcef.so -printf '%h\n' -quit 2>/dev/null | head -1 || true
```

- `-quit` makes `find` stop after the first match, so `head -1` can't SIGPIPE it.
- `|| true` makes the lookup non-fatal for any `find` non-zero exit (SIGPIPE, a permission error mid-traversal, or the cache dir not existing yet on a cold cache).

The existing `[ -z "$CEF_LIB_DIR" ]` checks still drive the cold-cache prewarm / `--no-bundle` fallback path unchanged. macOS/Windows skip this block (`RUNNER_OS = Linux` guard).

Verified locally that the new pipeline returns `0` and the correct dir on a warm multi-match cache, and `0` with an empty result on a cold cache, both under `set -e -o pipefail`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux desktop build reliability by making cached library discovery more tolerant of missing directories and search errors.
  * Reduced the chance of build interruptions during AppImage packaging when the required library is already present in cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->