### PR TITLE
feat(harness): reduce agent & sub-agent output verbosity (#4099)

### DIFF
--- a/src/openhuman/agent/prompts/builder.rs
+++ b/src/openhuman/agent/prompts/builder.rs
@@ -11,7 +11,14 @@ use anyhow::Result;
 pub const GLOBAL_STYLE_SUFFIX: &str = "## Output style\n\n\
     - Do **not** use em-dashes (`—`). Replace them with commas, colons, \
     parentheses, or two short sentences. This applies to every output \
-    you produce: chat replies, summaries, tool args, and file contents.\n";
+    you produce: chat replies, summaries, tool args, and file contents.\n\
+    - **Be concise.** Lead with the answer, then only the detail the task \
+    needs. No preamble, no recap of the request, no filler. Make the \
+    response as long as the task requires and no longer: a one-line answer \
+    for a simple ask, fuller treatment only when the task genuinely needs it.\n\
+    - **Do not repeat yourself.** Don't restate facts, context, or results \
+    already shown earlier in this conversation; reference them instead of \
+    pasting them again.\n";
 
 #[derive(Default)]
 pub struct SystemPromptBuilder {

--- a/src/openhuman/agent_registry/agents/archivist/agent.toml
+++ b/src/openhuman/agent_registry/agents/archivist/agent.toml
@@ -4,6 +4,11 @@ delegate_name = "archive_session"
 when_to_use = "Background librarian — extracts lessons from a completed session, updates MEMORY.md, and indexes to FTS5. Runs cheap and slow."
 temperature = 0.4
 max_iterations = 3
+# Bound the archiving summary that flows up to the orchestrator verbatim
+# (delegate_archivist). 8000 chars (~2000 tokens) matches the normal
+# sub-agent cap and stops a verbose memory-write confirmation from
+# bloating the orchestrator's context (#4099).
+max_result_chars = 8000
 sandbox_mode = "none"
 background = true
 omit_identity = true

--- a/src/openhuman/agent_registry/agents/critic/agent.toml
+++ b/src/openhuman/agent_registry/agents/critic/agent.toml
@@ -4,6 +4,11 @@ delegate_name = "review_code"
 when_to_use = "Adversarial reviewer — reviews diffs and code against project rules, flags vulnerabilities, regressions, and missing tests. Read-only."
 temperature = 0.4
 max_iterations = 5
+# Bound the review verdict that flows up to the orchestrator verbatim
+# (delegate_critic). 8000 chars (~2000 tokens) matches the normal
+# sub-agent cap (planner/researcher) and keeps long diffs from leaking
+# an unbounded critique into the orchestrator's context (#4099).
+max_result_chars = 8000
 sandbox_mode = "read_only"
 omit_identity = true
 omit_memory_context = true

--- a/src/openhuman/agent_registry/agents/loader.rs
+++ b/src/openhuman/agent_registry/agents/loader.rs
@@ -1021,6 +1021,25 @@ mod tests {
     }
 
     #[test]
+    fn chatty_sub_agents_have_bounded_output() {
+        // critic + archivist results flow up to the orchestrator verbatim
+        // (delegate_critic / delegate_archivist). Without a cap their output
+        // is unbounded and bloats the orchestrator's context (#4099). Both
+        // must carry the normal sub-agent cap so a long diff review or a
+        // verbose memory-write confirmation can't leak unbounded text.
+        assert_eq!(
+            find("critic").max_result_chars,
+            Some(8000),
+            "critic output must be bounded so reviews don't leak unbounded text up"
+        );
+        assert_eq!(
+            find("archivist").max_result_chars,
+            Some(8000),
+            "archivist output must be bounded so memory summaries stay concise"
+        );
+    }
+
+    #[test]
     fn researcher_has_curl_for_artifact_downloads() {
         let def = find("researcher");
         match &def.tools {

--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.md
@@ -47,7 +47,7 @@ Follow this sequence for every user message:
    - If complex multi-step decomposition is required, use `delegate_plan`.
    - If code review is requested, use `delegate_critic`.
    - If memory archiving or distillation is required, use `delegate_archivist`.
-5. **After delegation**, summarise results clearly and concisely.
+5. **After delegation, distill — never forward verbatim.** A sub-agent's reply is raw material, not your answer. Extract only the parts that answer the user's question and present them in as few words as carry the meaning. Drop the sub-agent's working notes, restated context, and any detail the user already has. If the useful answer is two sentences, send two sentences, even when the sub-agent returned eight paragraphs. Never paste a sub-agent's full response back to the user.
 
 Default bias: **do not spawn a sub-agent when a direct response or direct tool call is sufficient** — but live external-service, scheduling, desktop-control, presentation, product-docs, code-repo, market, and crypto requests belong to their specialists.
 


### PR DESCRIPTION
## Summary

- Add a global **concision + no-repeat** rule to `GLOBAL_STYLE_SUFFIX`, the single style block every agent receives, so all agents lead with the answer, drop preamble/filler, and stop restating context already shown.
- Strengthen the orchestrator's post-delegation rule from a soft "summarise concisely" into an explicit **distill-not-forward** instruction: extract only the parts that answer the user, never paste a sub-agent's full response back.
- Bound the two chatty leaf sub-agents whose results flow up verbatim (`critic` via `delegate_critic`, `archivist` via `delegate_archivist`) with `max_result_chars = 8000`, matching the existing planner/researcher cap.
- Pin the new caps with a loader regression test.

## Problem

Surfaced by the internal agent-simulation harness (#4099): agent and sub-agent outputs are frequently more verbose than necessary. Sub-agent results are forwarded up the chain without distillation, final messages are long, and information is repeated across turns.

Root cause in the harness:
- A sub-agent's final text becomes the orchestrator's tool result **verbatim** (`agent_orchestration/tools/dispatch.rs` → `ToolResult::success(outcome.output)`). The only size control is a blind char-cut in `subagent_runner/ops/runner.rs`, gated on `max_result_chars`.
- Two chatty leaf agents (`critic`, `archivist`) leave `max_result_chars = None`, so their output is unbounded.
- The sole shared style preamble (`agent/prompts/builder.rs::GLOBAL_STYLE_SUFFIX`) only bans em-dashes: no concision or no-repetition guidance.
- The orchestrator's distill instruction (`orchestrator/prompt.md:50`) was too weak to stop verbatim forwarding.

## Solution

Deterministic prompt + config, no new runtime machinery:

- **`agent/prompts/builder.rs`** — extend `GLOBAL_STYLE_SUFFIX`'s "## Output style" section with two rules: be concise (lead with the answer, length proportional to the task, no preamble/recap/filler) and do-not-repeat (reference earlier context instead of re-pasting it). One edit reaches every agent (orchestrator + all sub-agents) and keeps the header byte-stable, so existing `contains("## Output style")` assertions still hold.
- **`orchestrator/prompt.md`** — rewrite the after-delegation step to an explicit anti-pattern: a sub-agent reply is raw material, extract only what answers the user, drop working notes and restated context, never forward the full response (directly targets the issue's 8-paragraphs-forwarded example).
- **`critic/agent.toml`, `archivist/agent.toml`** — add `max_result_chars = 8000` so a long diff review or a verbose memory-write confirmation can't leak unbounded text into the orchestrator's context. 8000 chars (~2000 tokens) matches the established normal-sub-agent cap.
- **`loader.rs`** — `chatty_sub_agents_have_bounded_output` asserts both caps load.

Design notes / rejected alternatives:
- **No automatic LLM distillation pass** at the dispatch seam: it adds an inference call per delegation (latency + cost on the hot path), is lossy, and is large review surface. The existing `payload_summarizer` already handles the genuinely-oversized case.
- **No blanket default cap** (`None` → `Some(N)`): too blunt, would silently truncate output a parent genuinely needs across all uncapped agents, including builtins.
- **`summarizer` left uncapped**: it is runtime-dispatched (not verbatim-forwarded via `delegate_*`) and already self-bounds in its own prompt; capping risks cutting its legitimate compression output.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `chatty_sub_agents_have_bounded_output` pins the new caps; existing `subagent_runner/ops_truncation_tests` already cover the cap-enforcement (truncation) path including the multibyte edge case.
- [x] **Diff coverage ≥ 80%** — the only instrumented Rust change is the `GLOBAL_STYLE_SUFFIX` constant, exercised by existing prompt-render tests asserting `"## Output style"`; remaining changes are TOML config, prompt markdown, and a new test. CI coverage gate is the authority.
- [x] Coverage matrix updated — `N/A: behaviour/config-only change, no feature row added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no network code touched.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: prompt text + output caps only, no release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Runtime/platform impact: desktop/CLI agent harness only. No UI, no migration, no schema change.
- Behavior: agent outputs become more concise; critic/archivist results are bounded at 8000 chars (previously unbounded). No change to control flow, no added inference calls, no hot-path latency.
- Security: none.

## Related

- Closes: #4099
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub-issue-driven, not Linear)
- URL: N/A

### Commit & Branch

- Branch: `fix/4099-output-concision`
- Commit SHA: `4171fb3b1f2072b4b22297ee7d1d43c1f1780567`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no app/ frontend files changed`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed`
- [x] Focused tests: `cargo test --lib chatty_sub_agents_have_bounded_output` — passed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check` exit 0
- [x] Tauri fmt/check (if changed): pre-push hook `pnpm rust:check` green on push

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: agents produce more concise, non-repetitive output; orchestrator distills sub-agent results instead of forwarding verbatim; critic/archivist outputs are length-bounded.
- User-visible effect: shorter, more scannable agent replies.

### Parity Contract

- Legacy behavior preserved: all control flow unchanged; uncapped agents other than critic/archivist keep `None` semantics; `GLOBAL_STYLE_SUFFIX` header unchanged.
- Guard/fallback/dispatch parity checks: existing `max_result_chars` truncation path (incl. `None` = no cap, multibyte-safe cut) unchanged and still tested.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 30d-merged for verbosity/concision/#4099)
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved prompt guidance so responses stay concise and avoid repeating earlier conversation details.
  * Added output-length limits for selected built-in agents to keep delegated results shorter and more manageable.
  * Updated delegation handling so sub-agent results are distilled instead of passed through verbatim.

* **Tests**
  * Added coverage to verify output-size limits are enforced for chatty sub-agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->