### PR TITLE
fix(app-update): retry transient updater download failures (#4111)

### DIFF
--- a/app/src-tauri/src/app_update.rs
+++ b/app/src-tauri/src/app_update.rs
@@ -1,0 +1,134 @@
+//! Bounded-retry policy for the Tauri auto-updater download.
+//!
+//! The updater fetches a large (~100MB) bundle from the GitHub release CDN.
+//! A single transient mid-stream HTTP failure (`reqwest` "error decoding
+//! response body", connection reset, incomplete body) otherwise aborts the
+//! entire update with no retry — the root cause of Sentry TAURI-RUST-4JR
+//! (2.8k events / 68 users): users could not update and re-triggered the
+//! failing download repeatedly.
+//!
+//! We retry only on the transient network class (`Error::Reqwest`). Integrity
+//! and config errors (`Minisign`, `SignatureUtf8`, `Io`, `TargetNotFound`, …)
+//! are NOT retried — re-downloading cannot fix a bad signature or a missing
+//! target, and looping on a verification failure could mask tampering.
+//!
+//! The download call sites live in `lib.rs` (`download_app_update` /
+//! `apply_app_update`); they wrap the updater call in a loop driven by
+//! [`classify`]. The decision logic is factored out here so it can be unit
+//! tested without constructing a real `tauri_plugin_updater::Update` (which
+//! needs a live endpoint) or a `reqwest::Error` (no public constructor).
+
+use std::time::Duration;
+
+/// Total download attempts before giving up (1 initial + 2 retries).
+pub const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+
+/// Outcome of evaluating a failed download attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDecision {
+    /// Transient failure with attempts left — sleep [`backoff_for`] and retry.
+    Retry,
+    /// Fatal (non-transient) failure, or retry budget exhausted — surface the error.
+    GiveUp,
+}
+
+/// Decide whether a failed attempt should be retried.
+///
+/// * `attempt` — 1-based index of the attempt that just failed.
+/// * `max` — total attempt budget (see [`MAX_DOWNLOAD_ATTEMPTS`]).
+/// * `transient` — whether the error is a retryable network error
+///   (computed at the call site via [`is_transient_updater_err`]).
+///
+/// Pure function: no I/O, no error construction — fully unit-testable.
+pub fn classify(attempt: u32, max: u32, transient: bool) -> RetryDecision {
+    if transient && attempt < max {
+        RetryDecision::Retry
+    } else {
+        RetryDecision::GiveUp
+    }
+}
+
+/// Backoff before the next attempt: linear 2s · `attempt` (2s, 4s, …).
+///
+/// Kept short because the foreground (`apply_app_update`) path holds the core
+/// shut down while it waits, and the user is actively waiting on the update.
+pub fn backoff_for(attempt: u32) -> Duration {
+    Duration::from_secs(2 * attempt as u64)
+}
+
+/// Whether an updater error is a transient network failure worth retrying.
+///
+/// Only [`tauri_plugin_updater::Error::Reqwest`] qualifies — that variant wraps
+/// the `reqwest` transport/decode layer where "error decoding response body"
+/// originates. Signature (`Minisign`/`SignatureUtf8`), filesystem (`Io`),
+/// extract, and config (`TargetNotFound`/`ReleaseNotFound`) errors are
+/// deliberately excluded.
+pub fn is_transient_updater_err(err: &tauri_plugin_updater::Error) -> bool {
+    matches!(err, tauri_plugin_updater::Error::Reqwest(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_with_attempts_left_retries() {
+        assert_eq!(
+            classify(1, MAX_DOWNLOAD_ATTEMPTS, true),
+            RetryDecision::Retry
+        );
+        assert_eq!(
+            classify(2, MAX_DOWNLOAD_ATTEMPTS, true),
+            RetryDecision::Retry
+        );
+    }
+
+    #[test]
+    fn transient_on_last_attempt_gives_up() {
+        assert_eq!(
+            classify(MAX_DOWNLOAD_ATTEMPTS, MAX_DOWNLOAD_ATTEMPTS, true),
+            RetryDecision::GiveUp
+        );
+    }
+
+    #[test]
+    fn transient_past_budget_gives_up() {
+        assert_eq!(
+            classify(MAX_DOWNLOAD_ATTEMPTS + 1, MAX_DOWNLOAD_ATTEMPTS, true),
+            RetryDecision::GiveUp
+        );
+    }
+
+    #[test]
+    fn non_transient_never_retries() {
+        // Fatal on the very first attempt, regardless of remaining budget.
+        assert_eq!(
+            classify(1, MAX_DOWNLOAD_ATTEMPTS, false),
+            RetryDecision::GiveUp
+        );
+        assert_eq!(
+            classify(2, MAX_DOWNLOAD_ATTEMPTS, false),
+            RetryDecision::GiveUp
+        );
+    }
+
+    #[test]
+    fn single_attempt_budget_never_retries() {
+        // max == 1 means no retries even for a transient error.
+        assert_eq!(classify(1, 1, true), RetryDecision::GiveUp);
+    }
+
+    #[test]
+    fn backoff_is_monotonic_and_bounded() {
+        let b1 = backoff_for(1);
+        let b2 = backoff_for(2);
+        assert!(b2 > b1, "backoff must grow with attempt");
+        assert_eq!(b1, Duration::from_secs(2));
+        // Worst-case wait across the full budget stays small (2s + 4s = 6s).
+        let total: Duration = (1..MAX_DOWNLOAD_ATTEMPTS).map(backoff_for).sum();
+        assert!(
+            total <= Duration::from_secs(10),
+            "total backoff stays bounded"
+        );
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 compile_error!("src-tauri host supports desktop (Windows/macOS/Linux) only. Mobile lives in app/src-tauri-mobile.");
 
+mod app_update;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod artifact_commands;
 mod cdp;
@@ -535,33 +536,65 @@ async fn apply_app_update(
     log::debug!("[app-update] acquired core restart lock");
     state.inner().shutdown().await;
 
-    let progress_app = app.clone();
-    let install_app = app.clone();
-    let download_result = update
-        .download_and_install(
-            move |chunk_length, content_length| {
-                let payload = serde_json::json!({
-                    "chunk": chunk_length,
-                    "total": content_length,
-                });
-                let _ = progress_app.emit("app-update:progress", payload);
-            },
-            move || {
-                log::info!("[app-update] download complete — installing");
-                let _ = install_app.emit("app-update:status", "installing");
-            },
-        )
-        .await;
+    // Bounded retry on transient download failures (Sentry TAURI-RUST-4JR). The
+    // core stays shut down across attempts (the restart lock is held above); we
+    // only revive it on the terminal give-up. A `Reqwest` error is always
+    // download-phase — `download_and_install` verifies + installs strictly after
+    // a complete download — so retrying never re-runs a partial install.
+    let mut attempt: u32 = 1;
+    loop {
+        let progress_app = app.clone();
+        let install_app = app.clone();
+        let download_result = update
+            .download_and_install(
+                move |chunk_length, content_length| {
+                    let payload = serde_json::json!({
+                        "chunk": chunk_length,
+                        "total": content_length,
+                    });
+                    let _ = progress_app.emit("app-update:progress", payload);
+                },
+                move || {
+                    log::info!("[app-update] download complete — installing");
+                    let _ = install_app.emit("app-update:status", "installing");
+                },
+            )
+            .await;
 
-    if let Err(e) = download_result {
-        log::error!("[app-update] download/install failed: {e}");
-        // Same recovery as `install_app_update`: the .app wasn't swapped,
-        // so revive the in-process core we shut down above.
-        if let Err(start_err) = state.inner().ensure_running().await {
-            log::error!("[app-update] failed to restart core after apply error: {start_err}");
+        match download_result {
+            Ok(()) => break,
+            Err(e) => {
+                let transient = app_update::is_transient_updater_err(&e);
+                match app_update::classify(attempt, app_update::MAX_DOWNLOAD_ATTEMPTS, transient) {
+                    app_update::RetryDecision::Retry => {
+                        log::warn!(
+                            "[app-update] download/install attempt {}/{} failed (transient): {e} — retrying",
+                            attempt,
+                            app_update::MAX_DOWNLOAD_ATTEMPTS
+                        );
+                        tokio::time::sleep(app_update::backoff_for(attempt)).await;
+                        attempt += 1;
+                        // Keep core down; re-assert downloading status for the next pass.
+                        let _ = app.emit("app-update:status", "downloading");
+                    }
+                    app_update::RetryDecision::GiveUp => {
+                        log::error!(
+                            "[app-update] download/install failed after {} attempt(s): {e}",
+                            attempt
+                        );
+                        // Same recovery as `install_app_update`: the .app wasn't
+                        // swapped, so revive the in-process core we shut down above.
+                        if let Err(start_err) = state.inner().ensure_running().await {
+                            log::error!(
+                                "[app-update] failed to restart core after apply error: {start_err}"
+                            );
+                        }
+                        let _ = app.emit("app-update:status", "error");
+                        return Err(format!("download_and_install failed: {e}"));
+                    }
+                }
+            }
         }
-        let _ = app.emit("app-update:status", "error");
-        return Err(format!("download_and_install failed: {e}"));
     }
 
     log::info!("[app-update] install complete — relaunching");
@@ -649,28 +682,60 @@ async fn download_app_update(
     log::info!("[app-update] downloading {} (background)", new_version);
     let _ = app.emit("app-update:status", "downloading");
 
-    let progress_app = app.clone();
-    let download_result = update
-        .download(
-            move |chunk_length, content_length| {
-                let payload = serde_json::json!({
-                    "chunk": chunk_length,
-                    "total": content_length,
-                });
-                let _ = progress_app.emit("app-update:progress", payload);
-            },
-            || {
-                log::info!("[app-update] download complete — staging for install");
-            },
-        )
-        .await;
+    // Bounded retry: a single transient mid-stream HTTP failure on the large
+    // bundle download otherwise aborts the whole update (Sentry TAURI-RUST-4JR).
+    // Retry only the network class; surface fatal/exhausted errors as before.
+    let bytes = {
+        let mut attempt: u32 = 1;
+        loop {
+            let progress_app = app.clone();
+            let download_result = update
+                .download(
+                    move |chunk_length, content_length| {
+                        let payload = serde_json::json!({
+                            "chunk": chunk_length,
+                            "total": content_length,
+                        });
+                        let _ = progress_app.emit("app-update:progress", payload);
+                    },
+                    || {
+                        log::info!("[app-update] download complete — staging for install");
+                    },
+                )
+                .await;
 
-    let bytes = match download_result {
-        Ok(b) => b,
-        Err(e) => {
-            log::error!("[app-update] download failed: {e}");
-            let _ = app.emit("app-update:status", "error");
-            return Err(format!("download failed: {e}"));
+            match download_result {
+                Ok(b) => break b,
+                Err(e) => {
+                    let transient = app_update::is_transient_updater_err(&e);
+                    match app_update::classify(
+                        attempt,
+                        app_update::MAX_DOWNLOAD_ATTEMPTS,
+                        transient,
+                    ) {
+                        app_update::RetryDecision::Retry => {
+                            log::warn!(
+                                "[app-update] download attempt {}/{} failed (transient): {e} — retrying",
+                                attempt,
+                                app_update::MAX_DOWNLOAD_ATTEMPTS
+                            );
+                            tokio::time::sleep(app_update::backoff_for(attempt)).await;
+                            attempt += 1;
+                            // Re-assert status so a stale "error" never lingers; the
+                            // next attempt's progress callback resets the bar.
+                            let _ = app.emit("app-update:status", "downloading");
+                        }
+                        app_update::RetryDecision::GiveUp => {
+                            log::error!(
+                                "[app-update] download failed after {} attempt(s): {e}",
+                                attempt
+                            );
+                            let _ = app.emit("app-update:status", "error");
+                            return Err(format!("download failed: {e}"));
+                        }
+                    }
+                }
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

- Auto-updater now retries the bundle download on transient network failures instead of aborting the whole update on the first hiccup.
- Both update paths fixed: `download_app_update` (background staging) and `apply_app_update` (foreground download+install+restart).
- New `app/src-tauri/src/app_update.rs` holds a pure, unit-tested retry policy (`classify` / `is_transient_updater_err` / bounded backoff).
- Terminal `log::error!` (the Sentry signal) now fires only on genuine give-ups, cutting TAURI-RUST-4JR noise to real failures.

## Problem

Sentry **TAURI-RUST-4JR** — `[app-update] download failed: error decoding response body` — 2,791 events / 68 users (firstSeen 2026-05-27, still live). The ~100MB app bundle is fetched from the GitHub release CDN with **zero retry**, so a single transient mid-stream HTTP failure (`reqwest` connection reset / incomplete body) aborts the entire update. Affected users cannot update and re-trigger the failing download repeatedly (~41 events/user).

## Solution

- Extract the retry decision into `app_update::classify(attempt, max, transient) -> RetryDecision` — pure, so it is unit-testable without a live updater endpoint or an un-constructable `reqwest::Error`.
- `is_transient_updater_err` gates on `Error::Reqwest` **only**; signature (`Minisign`/`SignatureUtf8`), filesystem (`Io`), extract, and config (`TargetNotFound`/`ReleaseNotFound`) errors are never retried — re-downloading cannot fix a bad signature, and looping on a verification failure could mask tampering.
- Both call sites loop up to `MAX_DOWNLOAD_ATTEMPTS = 3` with 2s/4s linear backoff, re-asserting `app-update:status = downloading` between tries and emitting `error` + `log::error!` only on terminal give-up.
- Foreground path keeps the in-process core shut down across retries (restart lock held) and revives it via `ensure_running()` only on final failure. A `Reqwest` error is always download-phase (`download_and_install` installs strictly after a complete download), so retrying never re-runs a partial install.
- **RCA, not suppression**: the local lever for a transient CDN drop is retry; the reduced Sentry volume is a side effect of fixing the failure, not a demotion.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — `app_update::tests` covers Retry / GiveUp-on-last / GiveUp-past-budget / non-transient-never-retries / single-attempt-budget / backoff bounds
- [x] **Diff coverage ≥ 80%** — pure policy (`classify`/`backoff_for`/`is_transient_updater_err`) carries the new logic and is fully unit-tested; the rust coverage-gate job enforces the number on changed lines
- [x] N/A: Coverage matrix updated — bug-fix hardening of the existing app-update download path; no new/removed/renamed feature row
- [x] All affected feature IDs from the matrix are listed under `## Related` — Sentry TAURI-RUST-4JR
- [x] No new external network dependencies introduced — reuses the existing updater endpoint; no new deps
- [x] N/A: Manual smoke checklist updated — retry is transparent to the existing update smoke; no new manual step (a live CDN mid-stream drop is not summonable on demand, so the branch proof is the policy unit tests)
- [x] Linked issue closed via `Closes #4111` in the `## Related` section

## Impact

- **Platform**: desktop (Windows/macOS/Linux) auto-updater. No mobile/web/CLI impact.
- **Behavior**: transient download hiccups now self-heal within 3 attempts; users on flaky networks can update again.
- **Latency**: foreground path may wait ≤6s (2s+4s) with the core down before a *final* failure — acceptable since the user has initiated an update and expects a restart.
- **Known limitation**: `tauri-plugin-updater` has no HTTP resume, so each retry re-downloads the full bundle (bounded at 3). Range/resume = potential follow-up.
- **Security**: signature/integrity errors are explicitly excluded from retry.

## Related

- Closes: #4111
- Sentry: TAURI-RUST-4JR
- Follow-up PR(s)/TODOs: resumable download (HTTP range) to avoid full re-download on retry

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/4111-app-update-retry
- Commit SHA: 0ee12b697

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust-only change, no frontend files touched
- [x] N/A: `pnpm typecheck` — Rust-only change, no TypeScript files touched
- [x] Focused tests: `cargo test --manifest-path app/src-tauri/Cargo.toml app_update` — 7 passed
- [x] N/A: Rust fmt/check (if changed) — root core crate (`src/`) not touched
- [x] Tauri fmt/check: `cargo fmt` applied + `cargo check --manifest-path app/src-tauri/Cargo.toml` clean

### Validation Blocked

- `command:` live CDN mid-stream drop
- `error:` cannot be summoned on demand
- `impact:` transient repro covered by `classify` unit tests instead

### Behavior Changes

- Intended behavior change: retry transient updater download failures (3 attempts, backoff)
- User-visible effect: updates succeed through brief network hiccups instead of failing

### Parity Contract

- Legacy behavior preserved: non-transient errors fail exactly as before; happy path unchanged
- Guard/fallback/dispatch parity checks: foreground core-revive-on-failure semantics preserved

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (dedup vs open + 30d-merged PRs clean)
- Canonical PR: this
- Resolution: N/A
