### PR TITLE
feat(cost): LLM pricing + context-window catalog, pre-fills model registry

### DIFF
--- a/app/src/components/settings/panels/ModelHealthPanel.tsx
+++ b/app/src/components/settings/panels/ModelHealthPanel.tsx
@@ -12,12 +12,27 @@ const log = debug('openhuman:model-health');
 interface ModelEntry {
   id: string;
   provider: string;
+  /** USD per 1M input tokens (0/absent ⇒ unknown). */
+  cost_per_1m_input?: number;
   cost_per_1m_output: number;
+  /** Max context window in tokens (0/absent ⇒ unknown). */
+  context_window?: number;
   vision: boolean;
   quality_score: number | null;
   hallucination_rate: number | null;
   agents_using: number;
   tasks_evaluated: number;
+}
+
+/** Compact token-count label, e.g. 1_000_000 → "1M", 128_000 → "128K". */
+function formatContextWindow(tokens: number | undefined): string {
+  if (!tokens) return '—';
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+  return String(tokens);
 }
 
 interface HealthConfig {
@@ -244,7 +259,14 @@ const ModelHealthPanel = () => {
                         <div className="font-semibold text-stone-900 dark:text-neutral-100">
                           {m.id}
                         </div>
-                        <div className="text-[10px] text-stone-400">{m.provider}</div>
+                        <div className="text-[10px] text-stone-400">
+                          {m.provider}
+                          {m.context_window ? (
+                            <span className="ml-1 font-mono text-stone-400/80">
+                              · {formatContextWindow(m.context_window)} ctx
+                            </span>
+                          ) : null}
+                        </div>
                       </td>
                       <td className="py-2 px-2 text-amber-400">{qualityStars(m.quality_score)}</td>
                       <td className="py-2 px-2 font-mono">
@@ -261,7 +283,11 @@ const ModelHealthPanel = () => {
                           '—'
                         )}
                       </td>
-                      <td className="py-2 px-2 font-mono">${m.cost_per_1m_output.toFixed(2)}</td>
+                      <td className="py-2 px-2 font-mono whitespace-nowrap">
+                        {m.cost_per_1m_input
+                          ? `$${m.cost_per_1m_input.toFixed(2)} / $${m.cost_per_1m_output.toFixed(2)}`
+                          : `$${m.cost_per_1m_output.toFixed(2)}`}
+                      </td>
                       <td className="py-2 px-2">{m.agents_using}</td>
                       <td className="py-2 px-2">
                         <span

--- a/app/src/components/settings/panels/__tests__/ModelHealthPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ModelHealthPanel.test.tsx
@@ -15,7 +15,10 @@ const MOCK_RESPONSE = {
     {
       id: 'deepseek-v3',
       provider: 'SiliconFlow',
+      cost_per_1m_input: 0.14,
+      cost_per_1m_cached_input: 0.014,
       cost_per_1m_output: 0.33,
+      context_window: 128_000,
       vision: false,
       quality_score: 4,
       hallucination_rate: 0.03,
@@ -69,6 +72,18 @@ describe('ModelHealthPanel', () => {
     });
     expect(screen.getByText('qwen-2.5-8b')).toBeTruthy();
     expect(screen.getByText('bad-model')).toBeTruthy();
+  });
+
+  it('shows context window and input/output pricing', async () => {
+    await mockRpc(MOCK_RESPONSE);
+    renderWithProviders(<ModelHealthPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('deepseek-v3')).toBeTruthy();
+    });
+    // Context window rendered as a compact token-count label next to provider.
+    expect(screen.getByText(/128K ctx/)).toBeTruthy();
+    // Cost cell shows "input / output" when input pricing is present.
+    expect(screen.getByText(/\$0\.14 \/ \$0\.33/)).toBeTruthy();
   });
 
   it('shows correct status badges', async () => {

--- a/app/src/services/api/__tests__/aiSettingsApi.test.ts
+++ b/app/src/services/api/__tests__/aiSettingsApi.test.ts
@@ -746,6 +746,7 @@ describe('saveAISettings', () => {
         cost_per_1m_input: 0,
         cost_per_1m_cached_input: 0,
         cost_per_1m_output: 0,
+        context_window: 0,
         vision: true,
       },
     ]);
@@ -1012,6 +1013,7 @@ describe('model registry vision helpers', () => {
         cost_per_1m_input: 0,
         cost_per_1m_cached_input: 0,
         cost_per_1m_output: 0,
+        context_window: 0,
         vision: true,
       },
     ]);

--- a/app/src/services/api/__tests__/aiSettingsApi.test.ts
+++ b/app/src/services/api/__tests__/aiSettingsApi.test.ts
@@ -740,7 +740,14 @@ describe('saveAISettings', () => {
     await saveAISettings(prev, next);
     const patch = mockOpenhumanUpdateModelSettings.mock.calls[0][0];
     expect(patch.model_registry).toEqual([
-      { id: 'my-llava', provider: 'openai', cost_per_1m_output: 0, vision: true },
+      {
+        id: 'my-llava',
+        provider: 'openai',
+        cost_per_1m_input: 0,
+        cost_per_1m_cached_input: 0,
+        cost_per_1m_output: 0,
+        vision: true,
+      },
     ]);
   });
 
@@ -999,7 +1006,14 @@ describe('model registry vision helpers', () => {
   it('upsertModelRegistryVision adds, flips, and removes entries', () => {
     const added = upsertModelRegistryVision([], 'openai', 'my-llava', true);
     expect(added).toEqual([
-      { id: 'my-llava', provider: 'openai', cost_per_1m_output: 0, vision: true },
+      {
+        id: 'my-llava',
+        provider: 'openai',
+        cost_per_1m_input: 0,
+        cost_per_1m_cached_input: 0,
+        cost_per_1m_output: 0,
+        vision: true,
+      },
     ]);
     // vision:false removes the entry (absence ⇒ no vision).
     const removed = upsertModelRegistryVision(reg, 'openai', 'gpt-4o', false);

--- a/app/src/services/api/aiSettingsApi.ts
+++ b/app/src/services/api/aiSettingsApi.ts
@@ -196,7 +196,14 @@ export function upsertModelRegistryVision(
   const existing = base.find(e => e.provider === provider && e.id === id);
   return [
     ...without,
-    { id, provider, cost_per_1m_output: existing?.cost_per_1m_output ?? 0, vision: true },
+    {
+      id,
+      provider,
+      cost_per_1m_input: existing?.cost_per_1m_input ?? 0,
+      cost_per_1m_cached_input: existing?.cost_per_1m_cached_input ?? 0,
+      cost_per_1m_output: existing?.cost_per_1m_output ?? 0,
+      vision: true,
+    },
   ];
 }
 
@@ -391,9 +398,20 @@ export async function saveAISettings(prev: AISettings, next: AISettings): Promis
   // Per-model registry (vision flags): any change → send the full list.
   if (!modelRegistriesEqual(prev.modelRegistry, next.modelRegistry)) {
     patch.model_registry = next.modelRegistry.map(
-      ({ id, provider, cost_per_1m_output, vision }) => ({
+      ({
         id,
         provider,
+        cost_per_1m_input,
+        cost_per_1m_cached_input,
+        cost_per_1m_output,
+        vision,
+      }) => ({
+        id,
+        provider,
+        // Preserve catalog-prefilled prices through the round-trip; omitting
+        // them would let the Rust serde defaults zero them out.
+        cost_per_1m_input: cost_per_1m_input ?? 0,
+        cost_per_1m_cached_input: cost_per_1m_cached_input ?? 0,
         cost_per_1m_output,
         vision,
       })
@@ -415,7 +433,13 @@ function modelRegistriesEqual(a: ModelRegistryEntry[], b: ModelRegistryEntry[]):
   const bByKey = new Map(b.map(e => [key(e), e]));
   return a.every(e => {
     const m = bByKey.get(key(e));
-    return !!m && m.vision === e.vision && m.cost_per_1m_output === e.cost_per_1m_output;
+    return (
+      !!m &&
+      m.vision === e.vision &&
+      m.cost_per_1m_output === e.cost_per_1m_output &&
+      (m.cost_per_1m_input ?? 0) === (e.cost_per_1m_input ?? 0) &&
+      (m.cost_per_1m_cached_input ?? 0) === (e.cost_per_1m_cached_input ?? 0)
+    );
   });
 }
 

--- a/app/src/services/api/aiSettingsApi.ts
+++ b/app/src/services/api/aiSettingsApi.ts
@@ -202,6 +202,7 @@ export function upsertModelRegistryVision(
       cost_per_1m_input: existing?.cost_per_1m_input ?? 0,
       cost_per_1m_cached_input: existing?.cost_per_1m_cached_input ?? 0,
       cost_per_1m_output: existing?.cost_per_1m_output ?? 0,
+      context_window: existing?.context_window ?? 0,
       vision: true,
     },
   ];
@@ -404,15 +405,18 @@ export async function saveAISettings(prev: AISettings, next: AISettings): Promis
         cost_per_1m_input,
         cost_per_1m_cached_input,
         cost_per_1m_output,
+        context_window,
         vision,
       }) => ({
         id,
         provider,
-        // Preserve catalog-prefilled prices through the round-trip; omitting
-        // them would let the Rust serde defaults zero them out.
+        // Preserve catalog-prefilled prices + context window through the
+        // round-trip; omitting them would let the Rust serde defaults zero
+        // them out.
         cost_per_1m_input: cost_per_1m_input ?? 0,
         cost_per_1m_cached_input: cost_per_1m_cached_input ?? 0,
         cost_per_1m_output,
+        context_window: context_window ?? 0,
         vision,
       })
     );
@@ -438,7 +442,8 @@ function modelRegistriesEqual(a: ModelRegistryEntry[], b: ModelRegistryEntry[]):
       m.vision === e.vision &&
       m.cost_per_1m_output === e.cost_per_1m_output &&
       (m.cost_per_1m_input ?? 0) === (e.cost_per_1m_input ?? 0) &&
-      (m.cost_per_1m_cached_input ?? 0) === (e.cost_per_1m_cached_input ?? 0)
+      (m.cost_per_1m_cached_input ?? 0) === (e.cost_per_1m_cached_input ?? 0) &&
+      (m.context_window ?? 0) === (e.context_window ?? 0)
     );
   });
 }

--- a/app/src/utils/tauriCommands/config.ts
+++ b/app/src/utils/tauriCommands/config.ts
@@ -63,6 +63,10 @@ export interface ModelRegistryEntry {
   /** USD per 1M cached-prefix input tokens. `0`/absent ⇒ unknown. */
   cost_per_1m_cached_input?: number;
   cost_per_1m_output: number;
+  /** Max context window in tokens. `0`/absent ⇒ unknown. Pre-filled for known
+   *  vendor models from the Rust pricing catalog. Used to budget prompts and
+   *  trigger compaction — providers differ widely (128K–1M+). */
+  context_window?: number;
   vision: boolean;
 }
 

--- a/app/src/utils/tauriCommands/config.ts
+++ b/app/src/utils/tauriCommands/config.ts
@@ -57,6 +57,11 @@ export interface CloudProviderCreds {
 export interface ModelRegistryEntry {
   id: string;
   provider: string;
+  /** USD per 1M input tokens. `0`/absent ⇒ unknown. Pre-filled for known
+   *  vendor models from the Rust pricing catalog (`cost/catalog.rs`). */
+  cost_per_1m_input?: number;
+  /** USD per 1M cached-prefix input tokens. `0`/absent ⇒ unknown. */
+  cost_per_1m_cached_input?: number;
   cost_per_1m_output: number;
   vision: boolean;
 }

--- a/src/openhuman/agent/cost.rs
+++ b/src/openhuman/agent/cost.rs
@@ -111,12 +111,26 @@ pub const PRICING_TABLE: &[ModelPricing] = &[
 
 /// Look up pricing for a model name, falling back to [`FALLBACK_PRICING`].
 ///
-/// Matching is exact on the canonical tier name and case-insensitive on
-/// concrete vendor names (so `"claude-opus"` still hits the
-/// reasoning-tier row when callers pass an underlying model string).
+/// Resolution order:
+/// 1. Exact match on a canonical OpenHuman tier name (`agentic-v1`, …).
+/// 2. The concrete-vendor-model pricing catalog
+///    ([`crate::openhuman::cost::catalog`]) — accurate per-model rates for
+///    `claude-*`, `gpt-*`, `gemini-*`, `deepseek-*`, `kimi-*`, `qwen-*`,
+///    `mistral-*`, including OpenRouter-style `vendor/model` ids.
+/// 3. Coarse case-insensitive vendor-name heuristics (so an unrecognised
+///    `"…opus…"` string still maps to the reasoning tier).
+/// 4. [`FALLBACK_PRICING`].
 pub fn lookup_pricing(model: &str) -> ModelPricing {
     if let Some(row) = PRICING_TABLE.iter().find(|row| row.model == model) {
         return *row;
+    }
+    if let Some(price) = crate::openhuman::cost::catalog::lookup(model) {
+        return ModelPricing {
+            model: price.model_id,
+            input_per_mtok_usd: price.input_per_mtok_usd,
+            cached_input_per_mtok_usd: price.cached_input_per_mtok_usd,
+            output_per_mtok_usd: price.output_per_mtok_usd,
+        };
     }
     let lower = model.to_ascii_lowercase();
     let by_tier = |tier: &str| {

--- a/src/openhuman/config/ops/loader.rs
+++ b/src/openhuman/config/ops/loader.rs
@@ -294,6 +294,8 @@ pub fn client_config_json(config: &Config) -> serde_json::Value {
             serde_json::json!({
                 "id": m.id,
                 "provider": m.provider,
+                "cost_per_1m_input": m.cost_per_1m_input,
+                "cost_per_1m_cached_input": m.cost_per_1m_cached_input,
                 "cost_per_1m_output": m.cost_per_1m_output,
                 "vision": m.vision,
             })

--- a/src/openhuman/config/ops/loader.rs
+++ b/src/openhuman/config/ops/loader.rs
@@ -81,12 +81,52 @@ pub async fn reload_config_snapshot_with_timeout(snapshot: &Config) -> Result<Co
     }
 }
 
-async fn normalize_loaded_config(_config: &mut Config) {
-    // No-op: welcome-agent routing normalization removed. The welcome agent
-    // has been deleted; all chat turns route directly to the orchestrator.
-    // The `chat_onboarding_completed` field in Config is retained for
-    // backward-compatible deserialization of existing config.toml files
-    // but is no longer read by routing logic.
+async fn normalize_loaded_config(config: &mut Config) {
+    // Welcome-agent routing normalization removed (the welcome agent has been
+    // deleted; all chat turns route directly to the orchestrator). The
+    // `chat_onboarding_completed` field is retained only for backward-compatible
+    // deserialization.
+
+    seed_and_enrich_model_registry(config);
+}
+
+/// Populate per-token pricing on the model registry from the static catalog.
+///
+/// Runs on every load and is **in-memory only** — it does not rewrite
+/// `config.toml`. This keeps the user's persisted config clean (the catalog
+/// stays the single source of truth, so price refreshes apply automatically)
+/// while ensuring the Model Health dashboard, cost estimates, and the client
+/// config snapshot see real numbers out of the box.
+///
+/// - Empty registry → seed it with one entry per catalogued model
+///   ([`catalog::default_registry_entries`]).
+/// - Otherwise → backfill any missing (zero) price on each existing entry,
+///   preserving user-supplied prices and the `vision` flag
+///   ([`catalog::enrich_entry`]).
+///
+/// Idempotent: re-running over an already-priced registry is a no-op.
+fn seed_and_enrich_model_registry(config: &mut Config) {
+    use crate::openhuman::cost::catalog;
+
+    if config.model_registry.is_empty() {
+        config.model_registry = catalog::default_registry_entries();
+        log::debug!(
+            "[config] seeded empty model_registry with {} catalogued models (as_of {})",
+            config.model_registry.len(),
+            catalog::PRICING_AS_OF
+        );
+        return;
+    }
+
+    let mut filled = 0usize;
+    for entry in &mut config.model_registry {
+        if catalog::enrich_entry(entry) {
+            filled += 1;
+        }
+    }
+    if filled > 0 {
+        log::debug!("[config] backfilled pricing on {filled} model_registry entries from catalog");
+    }
 }
 
 /// Returns the default workspace directory fallback (~/.openhuman/workspace).
@@ -297,6 +337,7 @@ pub fn client_config_json(config: &Config) -> serde_json::Value {
                 "cost_per_1m_input": m.cost_per_1m_input,
                 "cost_per_1m_cached_input": m.cost_per_1m_cached_input,
                 "cost_per_1m_output": m.cost_per_1m_output,
+                "context_window": m.context_window,
                 "vision": m.vision,
             })
         })
@@ -591,6 +632,67 @@ pub async fn get_data_paths() -> Result<RpcOutcome<serde_json::Value>, String> {
             default_openhuman_dir.display()
         )],
     ))
+}
+
+#[cfg(test)]
+mod model_registry_seed_tests {
+    use super::*;
+
+    #[test]
+    fn seeds_empty_registry_from_catalog() {
+        let mut config = Config {
+            model_registry: Vec::new(),
+            ..Default::default()
+        };
+        seed_and_enrich_model_registry(&mut config);
+        assert!(
+            !config.model_registry.is_empty(),
+            "empty registry should be seeded from the catalog"
+        );
+        // Every seeded entry carries pricing + a context window.
+        for entry in &config.model_registry {
+            assert!(entry.cost_per_1m_input > 0.0, "{}", entry.id);
+            assert!(entry.cost_per_1m_output > 0.0, "{}", entry.id);
+            assert!(entry.context_window > 0, "{}", entry.id);
+        }
+    }
+
+    #[test]
+    fn backfills_existing_entries_but_preserves_user_values_and_count() {
+        let mut config = Config {
+            model_registry: vec![
+                // Known model, missing prices → backfilled.
+                crate::openhuman::config::schema::ModelRegistryEntry {
+                    id: "claude-opus-4-8".to_string(),
+                    provider: "anthropic".to_string(),
+                    cost_per_1m_output: 99.0, // user override — must survive
+                    vision: true,
+                    ..Default::default()
+                },
+                // Unknown model → left untouched.
+                crate::openhuman::config::schema::ModelRegistryEntry {
+                    id: "my-byok-model".to_string(),
+                    provider: "custom".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        seed_and_enrich_model_registry(&mut config);
+
+        assert_eq!(
+            config.model_registry.len(),
+            2,
+            "must not seed when non-empty"
+        );
+        let opus = &config.model_registry[0];
+        assert_eq!(opus.cost_per_1m_input, 5.00, "backfilled");
+        assert_eq!(opus.context_window, 1_000_000, "backfilled");
+        assert_eq!(opus.cost_per_1m_output, 99.0, "user value preserved");
+        let byok = &config.model_registry[1];
+        assert_eq!(byok.cost_per_1m_input, 0.0, "unknown model untouched");
+        assert_eq!(byok.context_window, 0);
+    }
 }
 
 #[cfg(test)]

--- a/src/openhuman/config/ops_tests.rs
+++ b/src/openhuman/config/ops_tests.rs
@@ -658,6 +658,7 @@ async fn apply_model_settings_replaces_model_registry_when_some_and_keeps_when_n
             provider: "openai".into(),
             cost_per_1m_output: 0.0,
             vision: true,
+            ..Default::default()
         }]),
         ..Default::default()
     };
@@ -707,6 +708,7 @@ async fn apply_model_settings_trims_model_registry_ids() {
             provider: "openai".into(),
             cost_per_1m_output: 0.0,
             vision: true,
+            ..Default::default()
         }]),
         ..Default::default()
     };

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -54,6 +54,12 @@ pub struct ModelRegistryEntry {
     /// Completion rate, USD per **million output tokens**.
     #[serde(default)]
     pub cost_per_1m_output: f64,
+    /// Maximum context window in tokens (published max input). `0` means
+    /// "unknown". Providers differ widely (128K–1M+); callers use this to
+    /// budget prompts, trigger compaction, and route work. Pre-filled for known
+    /// vendor models from [`crate::openhuman::cost::catalog`].
+    #[serde(default)]
+    pub context_window: u32,
     #[serde(default)]
     pub vision: bool,
 }

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -36,10 +36,22 @@ pub const DEFAULT_MEMORY_SYNC_INTERVAL_SECS: u64 = 86_400;
 /// "Manual only" is represented separately by `Some(0)`. See issue #3302.
 pub const MEMORY_SYNC_INTERVAL_PRESETS_SECS: [u64; 3] = [14_400, 43_200, 86_400];
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ModelRegistryEntry {
     pub id: String,
     pub provider: String,
+    /// Standard prompt rate, USD per **million input tokens**. Used (together
+    /// with [`Self::cost_per_1m_output`]) to estimate request cost when the
+    /// provider doesn't echo an authoritative `charged_amount_usd`. `0.0` means
+    /// "unknown" — callers fall back to the tier/catalog estimate. Pre-filled
+    /// for known vendor models from [`crate::openhuman::cost::catalog`].
+    #[serde(default)]
+    pub cost_per_1m_input: f64,
+    /// Cached-prefix prompt rate, USD per million cached input tokens (KV-cache
+    /// read hits on supporting backends). `0.0` means "unknown".
+    #[serde(default)]
+    pub cost_per_1m_cached_input: f64,
+    /// Completion rate, USD per **million output tokens**.
     #[serde(default)]
     pub cost_per_1m_output: f64,
     #[serde(default)]

--- a/src/openhuman/cost/catalog.rs
+++ b/src/openhuman/cost/catalog.rs
@@ -1,0 +1,482 @@
+//! Static pricing catalog for known LLM models across providers.
+//!
+//! This is the single source of truth for **pre-filled** per-token pricing of
+//! the default models the product can route to. It exists so the client can
+//! estimate request cost (input + cached-input + output, USD per million
+//! tokens) for any provider — used to:
+//!
+//! - pre-fill [`crate::openhuman::config::schema::ModelRegistryEntry`] rows so
+//!   the Model Health dashboard shows real numbers instead of zeros, and
+//! - power the fallback estimate in
+//!   [`crate::openhuman::agent::cost::lookup_pricing`] when a backend doesn't
+//!   echo an authoritative `charged_amount_usd`.
+//!
+//! ## Authority & freshness
+//!
+//! These are **best-effort published list prices** captured at
+//! [`PRICING_AS_OF`]. The provider-reported `charged_amount_usd` always wins
+//! when present; the catalog is only a floor estimate. Prices drift — when a
+//! provider changes rates or a new default model ships, update the matching
+//! row here (and bump [`PRICING_AS_OF`]). The table is intentionally a plain
+//! `const` slice with no I/O so it's cheap to consult on every lookup.
+//!
+//! ## Matching
+//!
+//! [`lookup`] resolves a concrete model string to a row. It normalises case,
+//! strips a leading `vendor/` segment (OpenRouter-style ids like
+//! `anthropic/claude-opus-4-8`) and trailing decorations (`:tag`, `@date`,
+//! `[1m]`), and finally does a longest-substring match so dated/suffixed ids
+//! (`claude-opus-4-8[1m]`, `gpt-5.4-2026-05-01`) still resolve.
+
+use crate::openhuman::config::schema::ModelRegistryEntry;
+
+/// Month the published prices below were last verified. Bump when refreshing.
+pub const PRICING_AS_OF: &str = "2026-06";
+
+/// A single model's published per-million-token rates (USD).
+#[derive(Debug, Clone, Copy)]
+pub struct ModelPrice {
+    /// Canonical provider slug, matching the `cloud_providers` type strings
+    /// (`anthropic`, `openai`, `google`, `deepseek`, `moonshot`, `qwen`,
+    /// `mistral`). Used as the `provider` field when pre-filling registry rows.
+    pub provider: &'static str,
+    /// Canonical, lower-case model id used for matching. Keep these distinctive
+    /// (no bare `gpt-5`) so substring matching stays unambiguous.
+    pub model_id: &'static str,
+    /// USD per million standard (cache-miss) input tokens.
+    pub input_per_mtok_usd: f64,
+    /// USD per million cached-prefix input tokens. Best-effort: exact where the
+    /// provider publishes it, otherwise the provider's typical cache discount.
+    pub cached_input_per_mtok_usd: f64,
+    /// USD per million output tokens.
+    pub output_per_mtok_usd: f64,
+}
+
+/// Published list prices for the default models the product can route to.
+///
+/// Sources (captured [`PRICING_AS_OF`]): vendor pricing pages. Anthropic rows
+/// are authoritative (cached = 0.1× input, the documented cache-read rate);
+/// other providers' cached rates use the published discount where known and a
+/// conservative provider-typical fraction otherwise.
+pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
+    // ── Anthropic (authoritative; cache read = 0.1× input) ──────────────────
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-fable-5",
+        input_per_mtok_usd: 10.00,
+        cached_input_per_mtok_usd: 1.00,
+        output_per_mtok_usd: 50.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-opus-4-8",
+        input_per_mtok_usd: 5.00,
+        cached_input_per_mtok_usd: 0.50,
+        output_per_mtok_usd: 25.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-opus-4-7",
+        input_per_mtok_usd: 5.00,
+        cached_input_per_mtok_usd: 0.50,
+        output_per_mtok_usd: 25.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-opus-4-6",
+        input_per_mtok_usd: 5.00,
+        cached_input_per_mtok_usd: 0.50,
+        output_per_mtok_usd: 25.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-opus-4-5",
+        input_per_mtok_usd: 5.00,
+        cached_input_per_mtok_usd: 0.50,
+        output_per_mtok_usd: 25.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-6",
+        input_per_mtok_usd: 3.00,
+        cached_input_per_mtok_usd: 0.30,
+        output_per_mtok_usd: 15.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-5",
+        input_per_mtok_usd: 3.00,
+        cached_input_per_mtok_usd: 0.30,
+        output_per_mtok_usd: 15.00,
+    },
+    ModelPrice {
+        provider: "anthropic",
+        model_id: "claude-haiku-4-5",
+        input_per_mtok_usd: 1.00,
+        cached_input_per_mtok_usd: 0.10,
+        output_per_mtok_usd: 5.00,
+    },
+    // ── OpenAI (cache read ≈ 0.25× input — published 75% off) ────────────────
+    ModelPrice {
+        provider: "openai",
+        model_id: "gpt-5.5",
+        input_per_mtok_usd: 5.00,
+        cached_input_per_mtok_usd: 1.25,
+        output_per_mtok_usd: 30.00,
+    },
+    ModelPrice {
+        provider: "openai",
+        model_id: "gpt-5.4",
+        input_per_mtok_usd: 2.50,
+        cached_input_per_mtok_usd: 0.625,
+        output_per_mtok_usd: 15.00,
+    },
+    ModelPrice {
+        provider: "openai",
+        model_id: "gpt-5.4-mini",
+        input_per_mtok_usd: 0.75,
+        cached_input_per_mtok_usd: 0.1875,
+        output_per_mtok_usd: 4.50,
+    },
+    ModelPrice {
+        provider: "openai",
+        model_id: "gpt-5.4-nano",
+        input_per_mtok_usd: 0.20,
+        cached_input_per_mtok_usd: 0.05,
+        output_per_mtok_usd: 1.25,
+    },
+    ModelPrice {
+        provider: "openai",
+        model_id: "gpt-4.1",
+        input_per_mtok_usd: 2.00,
+        cached_input_per_mtok_usd: 0.50,
+        output_per_mtok_usd: 8.00,
+    },
+    ModelPrice {
+        provider: "openai",
+        model_id: "gpt-4.1-mini",
+        input_per_mtok_usd: 0.40,
+        cached_input_per_mtok_usd: 0.10,
+        output_per_mtok_usd: 1.60,
+    },
+    ModelPrice {
+        provider: "openai",
+        model_id: "o3",
+        input_per_mtok_usd: 2.00,
+        cached_input_per_mtok_usd: 0.50,
+        output_per_mtok_usd: 8.00,
+    },
+    // ── Google Gemini (cache read ≈ 0.25× input) ─────────────────────────────
+    ModelPrice {
+        provider: "google",
+        model_id: "gemini-2.5-pro",
+        input_per_mtok_usd: 1.25,
+        cached_input_per_mtok_usd: 0.3125,
+        output_per_mtok_usd: 10.00,
+    },
+    ModelPrice {
+        provider: "google",
+        model_id: "gemini-2.5-flash",
+        input_per_mtok_usd: 0.30,
+        cached_input_per_mtok_usd: 0.075,
+        output_per_mtok_usd: 2.50,
+    },
+    ModelPrice {
+        provider: "google",
+        model_id: "gemini-2.5-flash-lite",
+        input_per_mtok_usd: 0.10,
+        cached_input_per_mtok_usd: 0.025,
+        output_per_mtok_usd: 0.40,
+    },
+    // ── DeepSeek (cache hit = 0.1× input, published) ─────────────────────────
+    ModelPrice {
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        input_per_mtok_usd: 0.14,
+        cached_input_per_mtok_usd: 0.014,
+        output_per_mtok_usd: 0.28,
+    },
+    ModelPrice {
+        provider: "deepseek",
+        model_id: "deepseek-reasoner",
+        input_per_mtok_usd: 0.55,
+        cached_input_per_mtok_usd: 0.055,
+        output_per_mtok_usd: 2.19,
+    },
+    // ── Moonshot Kimi (cache hit published) ──────────────────────────────────
+    ModelPrice {
+        provider: "moonshot",
+        model_id: "kimi-k2.6",
+        input_per_mtok_usd: 0.95,
+        cached_input_per_mtok_usd: 0.16,
+        output_per_mtok_usd: 4.00,
+    },
+    ModelPrice {
+        provider: "moonshot",
+        model_id: "kimi-k2.5",
+        input_per_mtok_usd: 0.60,
+        cached_input_per_mtok_usd: 0.10,
+        output_per_mtok_usd: 3.00,
+    },
+    // ── Qwen / Alibaba (cache read ≈ 0.1× input) ─────────────────────────────
+    ModelPrice {
+        provider: "qwen",
+        model_id: "qwen3-max",
+        input_per_mtok_usd: 1.20,
+        cached_input_per_mtok_usd: 0.12,
+        output_per_mtok_usd: 6.00,
+    },
+    ModelPrice {
+        provider: "qwen",
+        model_id: "qwen-max",
+        input_per_mtok_usd: 1.20,
+        cached_input_per_mtok_usd: 0.12,
+        output_per_mtok_usd: 6.00,
+    },
+    ModelPrice {
+        provider: "qwen",
+        model_id: "qwen-plus",
+        input_per_mtok_usd: 0.40,
+        cached_input_per_mtok_usd: 0.04,
+        output_per_mtok_usd: 1.20,
+    },
+    ModelPrice {
+        provider: "qwen",
+        model_id: "qwen-flash",
+        input_per_mtok_usd: 0.05,
+        cached_input_per_mtok_usd: 0.005,
+        output_per_mtok_usd: 0.40,
+    },
+    // ── Mistral (cache read ≈ 0.1× input) ────────────────────────────────────
+    ModelPrice {
+        provider: "mistral",
+        model_id: "mistral-large",
+        input_per_mtok_usd: 2.00,
+        cached_input_per_mtok_usd: 0.20,
+        output_per_mtok_usd: 6.00,
+    },
+    ModelPrice {
+        provider: "mistral",
+        model_id: "mistral-medium",
+        input_per_mtok_usd: 0.40,
+        cached_input_per_mtok_usd: 0.04,
+        output_per_mtok_usd: 2.00,
+    },
+    ModelPrice {
+        provider: "mistral",
+        model_id: "mistral-small",
+        input_per_mtok_usd: 0.20,
+        cached_input_per_mtok_usd: 0.02,
+        output_per_mtok_usd: 0.60,
+    },
+    ModelPrice {
+        provider: "mistral",
+        model_id: "codestral",
+        input_per_mtok_usd: 0.30,
+        cached_input_per_mtok_usd: 0.03,
+        output_per_mtok_usd: 0.90,
+    },
+    ModelPrice {
+        provider: "mistral",
+        model_id: "ministral-8b",
+        input_per_mtok_usd: 0.10,
+        cached_input_per_mtok_usd: 0.01,
+        output_per_mtok_usd: 0.10,
+    },
+];
+
+/// Normalise a model string for matching: lower-case, trim, drop a trailing
+/// `:tag` / `@date` decoration and a `[...]` suffix.
+fn normalize(model: &str) -> String {
+    let mut s = model.trim().to_ascii_lowercase();
+    // Strip a `[1m]`-style context-window suffix.
+    if let Some(idx) = s.find('[') {
+        s.truncate(idx);
+    }
+    // Strip `:tag` (e.g. ollama-style) and `@date` (Vertex-style) decorations.
+    for sep in [':', '@'] {
+        if let Some(idx) = s.find(sep) {
+            s.truncate(idx);
+        }
+    }
+    s.trim().to_string()
+}
+
+/// Resolve a concrete model string to its published pricing row, if known.
+///
+/// Match order: exact canonical id → id with a leading `vendor/` segment
+/// stripped → longest canonical id that is a substring of the normalised
+/// request (handles dated/suffixed ids). Returns `None` for unknown models —
+/// callers should fall back to a tier estimate.
+pub fn lookup(model: &str) -> Option<&'static ModelPrice> {
+    let norm = normalize(model);
+    if norm.is_empty() {
+        return None;
+    }
+    if let Some(p) = KNOWN_MODEL_PRICING.iter().find(|p| p.model_id == norm) {
+        return Some(p);
+    }
+    let bare = norm.rsplit('/').next().unwrap_or(norm.as_str());
+    if let Some(p) = KNOWN_MODEL_PRICING.iter().find(|p| p.model_id == bare) {
+        return Some(p);
+    }
+    KNOWN_MODEL_PRICING
+        .iter()
+        .filter(|p| norm.contains(p.model_id) || bare.contains(p.model_id))
+        .max_by_key(|p| p.model_id.len())
+}
+
+/// Build a default registry, one [`ModelRegistryEntry`] per catalogued model
+/// with input/cached/output prices pre-filled. Used to seed an empty
+/// `config.model_registry`.
+pub fn default_registry_entries() -> Vec<ModelRegistryEntry> {
+    KNOWN_MODEL_PRICING
+        .iter()
+        .map(|p| ModelRegistryEntry {
+            id: p.model_id.to_string(),
+            provider: p.provider.to_string(),
+            cost_per_1m_input: p.input_per_mtok_usd,
+            cost_per_1m_cached_input: p.cached_input_per_mtok_usd,
+            cost_per_1m_output: p.output_per_mtok_usd,
+            vision: false,
+        })
+        .collect()
+}
+
+/// Pre-fill any **missing** (zero) price field on a registry entry from the
+/// catalog, matching on its `id`. Leaves user-supplied non-zero prices and the
+/// `vision` flag untouched. Returns `true` when a price was filled in.
+pub fn enrich_entry(entry: &mut ModelRegistryEntry) -> bool {
+    let Some(price) = lookup(&entry.id) else {
+        return false;
+    };
+    let mut changed = false;
+    if entry.cost_per_1m_input == 0.0 {
+        entry.cost_per_1m_input = price.input_per_mtok_usd;
+        changed = true;
+    }
+    if entry.cost_per_1m_cached_input == 0.0 {
+        entry.cost_per_1m_cached_input = price.cached_input_per_mtok_usd;
+        changed = true;
+    }
+    if entry.cost_per_1m_output == 0.0 {
+        entry.cost_per_1m_output = price.output_per_mtok_usd;
+        changed = true;
+    }
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_lookup_resolves_canonical_ids() {
+        let p = lookup("claude-opus-4-8").expect("anthropic row");
+        assert_eq!(p.provider, "anthropic");
+        assert_eq!(p.input_per_mtok_usd, 5.00);
+        assert_eq!(p.output_per_mtok_usd, 25.00);
+        assert_eq!(p.cached_input_per_mtok_usd, 0.50);
+    }
+
+    #[test]
+    fn lookup_is_case_insensitive() {
+        assert_eq!(lookup("GPT-4.1").unwrap().model_id, "gpt-4.1");
+    }
+
+    #[test]
+    fn lookup_strips_vendor_prefix_openrouter_style() {
+        assert_eq!(
+            lookup("anthropic/claude-sonnet-4-6").unwrap().model_id,
+            "claude-sonnet-4-6"
+        );
+        assert_eq!(
+            lookup("deepseek/deepseek-chat").unwrap().model_id,
+            "deepseek-chat"
+        );
+        assert_eq!(lookup("qwen/qwen3-max").unwrap().model_id, "qwen3-max");
+    }
+
+    #[test]
+    fn lookup_strips_context_and_tag_decorations() {
+        assert_eq!(
+            lookup("claude-opus-4-8[1m]").unwrap().model_id,
+            "claude-opus-4-8"
+        );
+        assert_eq!(lookup("kimi-k2.6:turbo").unwrap().model_id, "kimi-k2.6");
+        assert_eq!(
+            lookup("claude-opus-4-5@20251101").unwrap().model_id,
+            "claude-opus-4-5"
+        );
+    }
+
+    #[test]
+    fn lookup_longest_substring_wins_for_suffixed_ids() {
+        // A dated/suffixed id should resolve to the most specific row.
+        assert_eq!(
+            lookup("gpt-5.4-mini-2026-05-01").unwrap().model_id,
+            "gpt-5.4-mini"
+        );
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown() {
+        assert!(lookup("totally-made-up-model").is_none());
+        assert!(lookup("").is_none());
+        assert!(
+            lookup("agentic-v1").is_none(),
+            "abstract tiers aren't vendor models"
+        );
+    }
+
+    #[test]
+    fn default_registry_entries_are_fully_priced() {
+        let entries = default_registry_entries();
+        assert_eq!(entries.len(), KNOWN_MODEL_PRICING.len());
+        for e in &entries {
+            assert!(e.cost_per_1m_input > 0.0, "{} missing input price", e.id);
+            assert!(e.cost_per_1m_output > 0.0, "{} missing output price", e.id);
+            assert!(!e.provider.is_empty());
+        }
+    }
+
+    #[test]
+    fn enrich_fills_zeros_but_preserves_user_values() {
+        let mut e = ModelRegistryEntry {
+            id: "claude-opus-4-8".to_string(),
+            provider: "anthropic".to_string(),
+            cost_per_1m_input: 0.0,
+            cost_per_1m_cached_input: 0.0,
+            cost_per_1m_output: 99.0, // user override — must survive
+            vision: true,
+        };
+        assert!(enrich_entry(&mut e));
+        assert_eq!(e.cost_per_1m_input, 5.00);
+        assert_eq!(e.cost_per_1m_cached_input, 0.50);
+        assert_eq!(e.cost_per_1m_output, 99.0, "user value preserved");
+        assert!(e.vision, "vision flag untouched");
+    }
+
+    #[test]
+    fn enrich_unknown_model_is_noop() {
+        let mut e = ModelRegistryEntry {
+            id: "unknown-model".to_string(),
+            ..Default::default()
+        };
+        assert!(!enrich_entry(&mut e));
+        assert_eq!(e.cost_per_1m_input, 0.0);
+    }
+
+    #[test]
+    fn every_row_has_sane_prices() {
+        for p in KNOWN_MODEL_PRICING {
+            assert!(p.input_per_mtok_usd > 0.0, "{}", p.model_id);
+            assert!(p.output_per_mtok_usd > 0.0, "{}", p.model_id);
+            assert!(
+                p.cached_input_per_mtok_usd <= p.input_per_mtok_usd,
+                "{} cached should not exceed input",
+                p.model_id
+            );
+        }
+    }
+}

--- a/src/openhuman/cost/catalog.rs
+++ b/src/openhuman/cost/catalog.rs
@@ -1,9 +1,15 @@
-//! Static pricing catalog for known LLM models across providers.
+//! Static pricing + context-window catalog for known LLM models.
 //!
-//! This is the single source of truth for **pre-filled** per-token pricing of
-//! the default models the product can route to. It exists so the client can
-//! estimate request cost (input + cached-input + output, USD per million
-//! tokens) for any provider — used to:
+//! This is the single source of truth for **pre-filled** per-model metadata of
+//! the default models the product can route to:
+//!
+//! - per-token pricing (input + cached-input + output, USD per million tokens),
+//! - the model's **context window** (max input tokens) — different providers
+//!   ship very different windows, and callers need it to budget prompts,
+//!   trigger compaction, and route work.
+//!
+//! It exists so the client can estimate request cost and reason about context
+//! limits for any provider, used to:
 //!
 //! - pre-fill [`crate::openhuman::config::schema::ModelRegistryEntry`] rows so
 //!   the Model Health dashboard shows real numbers instead of zeros, and
@@ -13,12 +19,14 @@
 //!
 //! ## Authority & freshness
 //!
-//! These are **best-effort published list prices** captured at
-//! [`PRICING_AS_OF`]. The provider-reported `charged_amount_usd` always wins
-//! when present; the catalog is only a floor estimate. Prices drift — when a
-//! provider changes rates or a new default model ships, update the matching
-//! row here (and bump [`PRICING_AS_OF`]). The table is intentionally a plain
-//! `const` slice with no I/O so it's cheap to consult on every lookup.
+//! These are **best-effort published values** captured at [`PRICING_AS_OF`].
+//! The provider-reported `charged_amount_usd` always wins for cost when
+//! present; the catalog is only a floor estimate. Context windows are the
+//! published maximums and may differ from what a given deployment/tier exposes.
+//! Prices and windows drift — when a provider changes them or a new default
+//! model ships, update the matching row here (and bump [`PRICING_AS_OF`]). The
+//! table is intentionally a plain `const` slice with no I/O so it's cheap to
+//! consult on every lookup.
 //!
 //! ## Matching
 //!
@@ -30,10 +38,10 @@
 
 use crate::openhuman::config::schema::ModelRegistryEntry;
 
-/// Month the published prices below were last verified. Bump when refreshing.
+/// Month the published values below were last verified. Bump when refreshing.
 pub const PRICING_AS_OF: &str = "2026-06";
 
-/// A single model's published per-million-token rates (USD).
+/// A single model's published per-million-token rates (USD) and context window.
 #[derive(Debug, Clone, Copy)]
 pub struct ModelPrice {
     /// Canonical provider slug, matching the `cloud_providers` type strings
@@ -50,22 +58,28 @@ pub struct ModelPrice {
     pub cached_input_per_mtok_usd: f64,
     /// USD per million output tokens.
     pub output_per_mtok_usd: f64,
+    /// Maximum context window in tokens (published max input). Providers differ
+    /// widely (128K–1M+); callers budget prompts / trigger compaction off this.
+    pub context_window: u32,
 }
 
-/// Published list prices for the default models the product can route to.
+/// Published list prices and context windows for the default models the product
+/// can route to.
 ///
-/// Sources (captured [`PRICING_AS_OF`]): vendor pricing pages. Anthropic rows
-/// are authoritative (cached = 0.1× input, the documented cache-read rate);
-/// other providers' cached rates use the published discount where known and a
-/// conservative provider-typical fraction otherwise.
+/// Sources (captured [`PRICING_AS_OF`]): vendor pricing/model pages. Anthropic
+/// price rows are authoritative (cached = 0.1× input, the documented cache-read
+/// rate); other providers' cached rates use the published discount where known
+/// and a conservative provider-typical fraction otherwise. Context windows are
+/// the published maximums.
 pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
-    // ── Anthropic (authoritative; cache read = 0.1× input) ──────────────────
+    // ── Anthropic (authoritative prices; cache read = 0.1× input) ────────────
     ModelPrice {
         provider: "anthropic",
         model_id: "claude-fable-5",
         input_per_mtok_usd: 10.00,
         cached_input_per_mtok_usd: 1.00,
         output_per_mtok_usd: 50.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -73,6 +87,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 5.00,
         cached_input_per_mtok_usd: 0.50,
         output_per_mtok_usd: 25.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -80,6 +95,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 5.00,
         cached_input_per_mtok_usd: 0.50,
         output_per_mtok_usd: 25.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -87,6 +103,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 5.00,
         cached_input_per_mtok_usd: 0.50,
         output_per_mtok_usd: 25.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -94,6 +111,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 5.00,
         cached_input_per_mtok_usd: 0.50,
         output_per_mtok_usd: 25.00,
+        context_window: 200_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -101,6 +119,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 3.00,
         cached_input_per_mtok_usd: 0.30,
         output_per_mtok_usd: 15.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -108,6 +127,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 3.00,
         cached_input_per_mtok_usd: 0.30,
         output_per_mtok_usd: 15.00,
+        context_window: 200_000,
     },
     ModelPrice {
         provider: "anthropic",
@@ -115,6 +135,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 1.00,
         cached_input_per_mtok_usd: 0.10,
         output_per_mtok_usd: 5.00,
+        context_window: 200_000,
     },
     // ── OpenAI (cache read ≈ 0.25× input — published 75% off) ────────────────
     ModelPrice {
@@ -123,6 +144,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 5.00,
         cached_input_per_mtok_usd: 1.25,
         output_per_mtok_usd: 30.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "openai",
@@ -130,6 +152,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 2.50,
         cached_input_per_mtok_usd: 0.625,
         output_per_mtok_usd: 15.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "openai",
@@ -137,6 +160,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.75,
         cached_input_per_mtok_usd: 0.1875,
         output_per_mtok_usd: 4.50,
+        context_window: 400_000,
     },
     ModelPrice {
         provider: "openai",
@@ -144,6 +168,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.20,
         cached_input_per_mtok_usd: 0.05,
         output_per_mtok_usd: 1.25,
+        context_window: 400_000,
     },
     ModelPrice {
         provider: "openai",
@@ -151,6 +176,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 2.00,
         cached_input_per_mtok_usd: 0.50,
         output_per_mtok_usd: 8.00,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "openai",
@@ -158,6 +184,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.40,
         cached_input_per_mtok_usd: 0.10,
         output_per_mtok_usd: 1.60,
+        context_window: 1_000_000,
     },
     ModelPrice {
         provider: "openai",
@@ -165,14 +192,16 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 2.00,
         cached_input_per_mtok_usd: 0.50,
         output_per_mtok_usd: 8.00,
+        context_window: 200_000,
     },
-    // ── Google Gemini (cache read ≈ 0.25× input) ─────────────────────────────
+    // ── Google Gemini (cache read ≈ 0.25× input; 1M-token windows) ───────────
     ModelPrice {
         provider: "google",
         model_id: "gemini-2.5-pro",
         input_per_mtok_usd: 1.25,
         cached_input_per_mtok_usd: 0.3125,
         output_per_mtok_usd: 10.00,
+        context_window: 1_048_576,
     },
     ModelPrice {
         provider: "google",
@@ -180,6 +209,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.30,
         cached_input_per_mtok_usd: 0.075,
         output_per_mtok_usd: 2.50,
+        context_window: 1_048_576,
     },
     ModelPrice {
         provider: "google",
@@ -187,6 +217,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.10,
         cached_input_per_mtok_usd: 0.025,
         output_per_mtok_usd: 0.40,
+        context_window: 1_048_576,
     },
     // ── DeepSeek (cache hit = 0.1× input, published) ─────────────────────────
     ModelPrice {
@@ -195,6 +226,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.14,
         cached_input_per_mtok_usd: 0.014,
         output_per_mtok_usd: 0.28,
+        context_window: 128_000,
     },
     ModelPrice {
         provider: "deepseek",
@@ -202,6 +234,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.55,
         cached_input_per_mtok_usd: 0.055,
         output_per_mtok_usd: 2.19,
+        context_window: 128_000,
     },
     // ── Moonshot Kimi (cache hit published) ──────────────────────────────────
     ModelPrice {
@@ -210,6 +243,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.95,
         cached_input_per_mtok_usd: 0.16,
         output_per_mtok_usd: 4.00,
+        context_window: 256_000,
     },
     ModelPrice {
         provider: "moonshot",
@@ -217,6 +251,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.60,
         cached_input_per_mtok_usd: 0.10,
         output_per_mtok_usd: 3.00,
+        context_window: 256_000,
     },
     // ── Qwen / Alibaba (cache read ≈ 0.1× input) ─────────────────────────────
     ModelPrice {
@@ -225,6 +260,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 1.20,
         cached_input_per_mtok_usd: 0.12,
         output_per_mtok_usd: 6.00,
+        context_window: 256_000,
     },
     ModelPrice {
         provider: "qwen",
@@ -232,6 +268,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 1.20,
         cached_input_per_mtok_usd: 0.12,
         output_per_mtok_usd: 6.00,
+        context_window: 256_000,
     },
     ModelPrice {
         provider: "qwen",
@@ -239,6 +276,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.40,
         cached_input_per_mtok_usd: 0.04,
         output_per_mtok_usd: 1.20,
+        context_window: 256_000,
     },
     ModelPrice {
         provider: "qwen",
@@ -246,6 +284,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.05,
         cached_input_per_mtok_usd: 0.005,
         output_per_mtok_usd: 0.40,
+        context_window: 256_000,
     },
     // ── Mistral (cache read ≈ 0.1× input) ────────────────────────────────────
     ModelPrice {
@@ -254,6 +293,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 2.00,
         cached_input_per_mtok_usd: 0.20,
         output_per_mtok_usd: 6.00,
+        context_window: 128_000,
     },
     ModelPrice {
         provider: "mistral",
@@ -261,6 +301,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.40,
         cached_input_per_mtok_usd: 0.04,
         output_per_mtok_usd: 2.00,
+        context_window: 128_000,
     },
     ModelPrice {
         provider: "mistral",
@@ -268,6 +309,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.20,
         cached_input_per_mtok_usd: 0.02,
         output_per_mtok_usd: 0.60,
+        context_window: 128_000,
     },
     ModelPrice {
         provider: "mistral",
@@ -275,6 +317,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.30,
         cached_input_per_mtok_usd: 0.03,
         output_per_mtok_usd: 0.90,
+        context_window: 256_000,
     },
     ModelPrice {
         provider: "mistral",
@@ -282,6 +325,7 @@ pub const KNOWN_MODEL_PRICING: &[ModelPrice] = &[
         input_per_mtok_usd: 0.10,
         cached_input_per_mtok_usd: 0.01,
         output_per_mtok_usd: 0.10,
+        context_window: 128_000,
     },
 ];
 
@@ -302,7 +346,7 @@ fn normalize(model: &str) -> String {
     s.trim().to_string()
 }
 
-/// Resolve a concrete model string to its published pricing row, if known.
+/// Resolve a concrete model string to its catalogued row, if known.
 ///
 /// Match order: exact canonical id → id with a leading `vendor/` segment
 /// stripped → longest canonical id that is a substring of the normalised
@@ -326,8 +370,16 @@ pub fn lookup(model: &str) -> Option<&'static ModelPrice> {
         .max_by_key(|p| p.model_id.len())
 }
 
+/// Published maximum context window (tokens) for a model, if catalogued.
+///
+/// Convenience wrapper over [`lookup`] for callers that only need the window
+/// to budget prompts / trigger compaction / pick a route. `None` ⇒ unknown.
+pub fn context_window(model: &str) -> Option<u32> {
+    lookup(model).map(|p| p.context_window)
+}
+
 /// Build a default registry, one [`ModelRegistryEntry`] per catalogued model
-/// with input/cached/output prices pre-filled. Used to seed an empty
+/// with prices and context window pre-filled. Used to seed an empty
 /// `config.model_registry`.
 pub fn default_registry_entries() -> Vec<ModelRegistryEntry> {
     KNOWN_MODEL_PRICING
@@ -338,14 +390,16 @@ pub fn default_registry_entries() -> Vec<ModelRegistryEntry> {
             cost_per_1m_input: p.input_per_mtok_usd,
             cost_per_1m_cached_input: p.cached_input_per_mtok_usd,
             cost_per_1m_output: p.output_per_mtok_usd,
+            context_window: p.context_window,
             vision: false,
         })
         .collect()
 }
 
-/// Pre-fill any **missing** (zero) price field on a registry entry from the
-/// catalog, matching on its `id`. Leaves user-supplied non-zero prices and the
-/// `vision` flag untouched. Returns `true` when a price was filled in.
+/// Pre-fill any **missing** (zero) price or context-window field on a registry
+/// entry from the catalog, matching on its `id`. Leaves user-supplied non-zero
+/// values and the `vision` flag untouched. Returns `true` when a field was
+/// filled in.
 pub fn enrich_entry(entry: &mut ModelRegistryEntry) -> bool {
     let Some(price) = lookup(&entry.id) else {
         return false;
@@ -363,6 +417,10 @@ pub fn enrich_entry(entry: &mut ModelRegistryEntry) -> bool {
         entry.cost_per_1m_output = price.output_per_mtok_usd;
         changed = true;
     }
+    if entry.context_window == 0 {
+        entry.context_window = price.context_window;
+        changed = true;
+    }
     changed
 }
 
@@ -377,6 +435,7 @@ mod tests {
         assert_eq!(p.input_per_mtok_usd, 5.00);
         assert_eq!(p.output_per_mtok_usd, 25.00);
         assert_eq!(p.cached_input_per_mtok_usd, 0.50);
+        assert_eq!(p.context_window, 1_000_000);
     }
 
     #[test]
@@ -430,12 +489,21 @@ mod tests {
     }
 
     #[test]
-    fn default_registry_entries_are_fully_priced() {
+    fn context_window_helper_resolves_known_models() {
+        assert_eq!(context_window("claude-opus-4-8"), Some(1_000_000));
+        assert_eq!(context_window("openai/gpt-4.1-mini"), Some(1_000_000));
+        assert_eq!(context_window("deepseek-chat"), Some(128_000));
+        assert_eq!(context_window("totally-made-up"), None);
+    }
+
+    #[test]
+    fn default_registry_entries_are_fully_populated() {
         let entries = default_registry_entries();
         assert_eq!(entries.len(), KNOWN_MODEL_PRICING.len());
         for e in &entries {
             assert!(e.cost_per_1m_input > 0.0, "{} missing input price", e.id);
             assert!(e.cost_per_1m_output > 0.0, "{} missing output price", e.id);
+            assert!(e.context_window > 0, "{} missing context window", e.id);
             assert!(!e.provider.is_empty());
         }
     }
@@ -448,12 +516,14 @@ mod tests {
             cost_per_1m_input: 0.0,
             cost_per_1m_cached_input: 0.0,
             cost_per_1m_output: 99.0, // user override — must survive
+            context_window: 0,
             vision: true,
         };
         assert!(enrich_entry(&mut e));
         assert_eq!(e.cost_per_1m_input, 5.00);
         assert_eq!(e.cost_per_1m_cached_input, 0.50);
         assert_eq!(e.cost_per_1m_output, 99.0, "user value preserved");
+        assert_eq!(e.context_window, 1_000_000);
         assert!(e.vision, "vision flag untouched");
     }
 
@@ -465,13 +535,15 @@ mod tests {
         };
         assert!(!enrich_entry(&mut e));
         assert_eq!(e.cost_per_1m_input, 0.0);
+        assert_eq!(e.context_window, 0);
     }
 
     #[test]
-    fn every_row_has_sane_prices() {
+    fn every_row_has_sane_values() {
         for p in KNOWN_MODEL_PRICING {
             assert!(p.input_per_mtok_usd > 0.0, "{}", p.model_id);
             assert!(p.output_per_mtok_usd > 0.0, "{}", p.model_id);
+            assert!(p.context_window > 0, "{}", p.model_id);
             assert!(
                 p.cached_input_per_mtok_usd <= p.input_per_mtok_usd,
                 "{} cached should not exceed input",

--- a/src/openhuman/cost/mod.rs
+++ b/src/openhuman/cost/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalog;
 mod global;
 mod rpc;
 mod schemas;
@@ -5,6 +6,9 @@ pub mod tools;
 pub mod tracker;
 pub mod types;
 
+pub use catalog::{
+    default_registry_entries, enrich_entry, lookup as lookup_model_price, ModelPrice,
+};
 pub use global::{init_global, record_provider_usage, try_global};
 pub use schemas::{
     all_controller_schemas as all_cost_controller_schemas,

--- a/src/openhuman/cost/mod.rs
+++ b/src/openhuman/cost/mod.rs
@@ -7,7 +7,8 @@ pub mod tracker;
 pub mod types;
 
 pub use catalog::{
-    default_registry_entries, enrich_entry, lookup as lookup_model_price, ModelPrice,
+    context_window as model_context_window, default_registry_entries, enrich_entry,
+    lookup as lookup_model_price, ModelPrice,
 };
 pub use global::{init_global, record_provider_usage, try_global};
 pub use schemas::{

--- a/src/openhuman/dashboard/ops.rs
+++ b/src/openhuman/dashboard/ops.rs
@@ -28,7 +28,10 @@ pub fn model_health(config: &Config) -> Result<RpcOutcome<ModelHealthResponse>, 
         .map(|entry| ModelHealthEntry {
             id: entry.id.clone(),
             provider: entry.provider.clone(),
+            cost_per_1m_input: entry.cost_per_1m_input,
+            cost_per_1m_cached_input: entry.cost_per_1m_cached_input,
             cost_per_1m_output: entry.cost_per_1m_output,
+            context_window: entry.context_window,
             vision: entry.vision,
             // Placeholder metrics — see module-level docs.
             quality_score: None,

--- a/src/openhuman/dashboard/ops.rs
+++ b/src/openhuman/dashboard/ops.rs
@@ -70,12 +70,14 @@ mod tests {
                 provider: "SiliconFlow".to_string(),
                 cost_per_1m_output: 0.33,
                 vision: false,
+                ..Default::default()
             },
             crate::openhuman::config::schema::ModelRegistryEntry {
                 id: "qwen-2.5-8b".to_string(),
                 provider: "OpenRouter".to_string(),
                 cost_per_1m_output: 0.09,
                 vision: true,
+                ..Default::default()
             },
         ];
         cfg

--- a/src/openhuman/dashboard/schemas.rs
+++ b/src/openhuman/dashboard/schemas.rs
@@ -81,9 +81,29 @@ fn model_health_entry_fields() -> Vec<FieldSchema> {
             required: true,
         },
         FieldSchema {
+            name: "cost_per_1m_input",
+            ty: TypeSchema::F64,
+            comment: "USD cost per 1M input tokens (0 when unknown). Pre-filled \
+                      from the pricing catalog for known vendor models.",
+            required: true,
+        },
+        FieldSchema {
+            name: "cost_per_1m_cached_input",
+            ty: TypeSchema::F64,
+            comment: "USD cost per 1M cached-prefix input tokens (0 when unknown).",
+            required: true,
+        },
+        FieldSchema {
             name: "cost_per_1m_output",
             ty: TypeSchema::F64,
             comment: "USD cost per 1M output tokens from local config.",
+            required: true,
+        },
+        FieldSchema {
+            name: "context_window",
+            ty: TypeSchema::U64,
+            comment: "Maximum context window in tokens (0 when unknown). \
+                      Pre-filled from the pricing catalog for known vendor models.",
             required: true,
         },
         FieldSchema {

--- a/src/openhuman/dashboard/types.rs
+++ b/src/openhuman/dashboard/types.rs
@@ -5,15 +5,22 @@ use serde::{Deserialize, Serialize};
 /// One row in the model health comparison table.
 ///
 /// Mirrors the JSON shape consumed by the frontend
-/// `ModelHealthPanel` — `id`/`provider`/`cost_per_1m_output`/`vision`
-/// come from `Config::model_registry`; the four metric fields are
-/// emitted as placeholder (`null` / `0`) values until a local telemetry
-/// pipeline is wired in.
+/// `ModelHealthPanel` — `id`/`provider`/`cost_per_1m_input`/
+/// `cost_per_1m_cached_input`/`cost_per_1m_output`/`vision` come from
+/// `Config::model_registry` (pricing pre-filled from the cost catalog);
+/// the four metric fields are emitted as placeholder (`null` / `0`)
+/// values until a local telemetry pipeline is wired in.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ModelHealthEntry {
     pub id: String,
     pub provider: String,
+    /// USD per 1M input tokens (`0.0` when unknown).
+    pub cost_per_1m_input: f64,
+    /// USD per 1M cached-prefix input tokens (`0.0` when unknown).
+    pub cost_per_1m_cached_input: f64,
     pub cost_per_1m_output: f64,
+    /// Maximum context window in tokens (`0` when unknown).
+    pub context_window: u32,
     pub vision: bool,
     pub quality_score: Option<f64>,
     pub hallucination_rate: Option<f64>,

--- a/src/openhuman/inference/model_context.rs
+++ b/src/openhuman/inference/model_context.rs
@@ -314,12 +314,14 @@ mod tests {
                 provider: "openai".into(),
                 cost_per_1m_output: 0.0,
                 vision: true,
+                ..Default::default()
             },
             ModelRegistryEntry {
                 id: "text-only".into(),
                 provider: "openai".into(),
                 cost_per_1m_output: 0.0,
                 vision: false,
+                ..Default::default()
             },
         ];
         assert!(model_vision_enabled("my-llava", &config));
@@ -337,6 +339,7 @@ mod tests {
             provider: "openai".into(),
             cost_per_1m_output: 0.0,
             vision: true,
+            ..Default::default()
         }];
         // `reasoning-v1` is the one vision-capable managed tier; the rest are not.
         assert!(model_supports_vision("reasoning-v1", &config));

--- a/tests/config_auth_app_state_connectivity_e2e.rs
+++ b/tests/config_auth_app_state_connectivity_e2e.rs
@@ -2968,6 +2968,64 @@ async fn config_controller_mutations_round_trip_over_json_rpc() {
         "client config must not echo local API keys: {client_payload}"
     );
 
+    // The model registry is seeded + price/context-window-enriched from the
+    // static pricing catalog on load (in-memory), so a fresh workspace surfaces
+    // real numbers over RPC. Validates the full path: catalog → seed-on-load →
+    // client_config_json → JSON-RPC. (The earlier update_model_settings call did
+    // not include `model_registry`, so the seeded registry is left intact.)
+    let registry = client_payload
+        .get("model_registry")
+        .and_then(Value::as_array)
+        .expect("client config should expose model_registry");
+    assert!(
+        !registry.is_empty(),
+        "model_registry should be auto-seeded from the pricing catalog: {client_payload}"
+    );
+    let opus = registry
+        .iter()
+        .find(|m| m.get("id").and_then(Value::as_str) == Some("claude-opus-4-8"))
+        .unwrap_or_else(|| panic!("seeded registry should contain claude-opus-4-8: {registry:?}"));
+    assert_eq!(
+        opus.get("provider").and_then(Value::as_str),
+        Some("anthropic")
+    );
+    assert_eq!(
+        opus.get("cost_per_1m_input").and_then(Value::as_f64),
+        Some(5.0),
+        "input price should be pre-filled from the catalog: {opus:?}"
+    );
+    assert_eq!(
+        opus.get("cost_per_1m_output").and_then(Value::as_f64),
+        Some(25.0),
+        "output price should be pre-filled from the catalog: {opus:?}"
+    );
+    assert_eq!(
+        opus.get("context_window").and_then(Value::as_u64),
+        Some(1_000_000),
+        "context window should be pre-filled from the catalog: {opus:?}"
+    );
+    // Every seeded entry carries non-zero pricing + context window — the whole
+    // point of the catalog pre-fill.
+    for entry in registry {
+        let id = entry.get("id").and_then(Value::as_str).unwrap_or("<none>");
+        assert!(
+            entry
+                .get("cost_per_1m_output")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0)
+                > 0.0,
+            "{id} missing output price: {entry:?}"
+        );
+        assert!(
+            entry
+                .get("context_window")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+                > 0,
+            "{id} missing context window: {entry:?}"
+        );
+    }
+
     let memory = rpc(
         &harness.rpc_base,
         10_004,


### PR DESCRIPTION
## Summary

- Add a static **LLM pricing + context-window catalog** (`src/openhuman/cost/catalog.rs`): published input/cached/output rates (USD per 1M tokens) and max context window for the default models the product routes to — Anthropic, OpenAI, Google, DeepSeek, Moonshot Kimi, Qwen, Mistral (verified 2026-06 via `PRICING_AS_OF`).
- Extend `ModelRegistryEntry` with `cost_per_1m_input`, `cost_per_1m_cached_input`, and `context_window` (serde-default, backward-compatible).
- Auto-seed/enrich `config.model_registry` from the catalog on load (in-memory, idempotent) so the dashboard, cost estimates, and client-config snapshot show real numbers out of the box without rewriting `config.toml`.
- `agent::cost::lookup_pricing` now consults the catalog for concrete vendor model ids, so client-side cost estimates are accurate per-model when a backend omits `charged_amount_usd`.
- Surface input/output pricing **and** the per-model context window in the Model Health dashboard (RPC `ModelHealthEntry` + panel). Expose `cost::model_context_window(model)` for prompt-budgeting / compaction / routing callers.

## Problem

The model registry only stored an output-only price that was display-only and never pre-filled, so the Model Health dashboard showed zeros and the client-side cost fallback had no per-model rates. There was also no captured notion of each model's context window, which the system needs to budget prompts and react to provider-specific limits.

## Solution

A single pure `const` catalog keyed by canonical model id is the source of truth. `lookup()` normalises case, strips OpenRouter-style `vendor/` prefixes and `:tag`/`@date`/`[1m]` decorations, then longest-substring-matches dated/suffixed ids. `default_registry_entries()` seeds an empty registry; `enrich_entry()` backfills only missing (zero) fields and preserves user-set values + the `vision` flag. Seeding runs in the post-load normalize hook **in memory** — the catalog stays authoritative, so price/window refreshes apply automatically and we never clobber user config. Provider-reported `charged_amount_usd` still wins for billing; the catalog is a best-effort floor.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: behaviour-only / additive enrichment to existing model-registry & model-health surfaces — no new top-level feature row in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md).
- [x] N/A: no matrix feature IDs affected (additive fields on existing surfaces).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: does not touch release-cut surfaces in [`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md).
- [x] N/A: no tracking issue — exploratory feature work.

## Impact

- Desktop/CLI/web: model registry is now seeded with priced, context-window-annotated entries on first load; the Model Health dashboard renders input/output cost and context window per model. No migration — new `ModelRegistryEntry` fields are serde-default and seeding is in-memory only (no `config.toml` rewrite). No new deps; no security/PII surface.

## Related

- Closes: N/A — no tracking issue.
- Follow-up PR(s)/TODOs: wire `cost::model_context_window` into an actual prompt-budgeting / compaction call site; surface input/cached pricing columns more richly in the dashboard if desired.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: feat/llm-pricing-catalog
- Commit SHA: 0847208a51a522752a1c5c41527c613dcf6d59ca

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib cost dashboard`, loader/config seed tests, Vitest `aiSettingsApi`/`ModelHealthPanel`, and `config_controller_mutations_round_trip_over_json_rpc` E2E (mock backend) — all green.
- [x] Rust fmt/check (if changed): `cargo fmt` + pre-push `pnpm rust:check` passed.
- [x] N/A: Tauri shell crate not changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: model registry is pre-filled with per-model pricing + context window from a static catalog; dashboard surfaces them; cost fallback uses them.
- User-visible effect: Model Health dashboard shows real input/output cost and context window per model on a fresh install.

### Parity Contract

- Legacy behavior preserved: existing `cost_per_1m_output` field retained; new fields are serde-default; provider-reported `charged_amount_usd` remains authoritative; enrichment never overwrites user-supplied non-zero values.
- Guard/fallback/dispatch parity checks: `lookup_pricing` consults the catalog only after the tier table and before the legacy name heuristics + `FALLBACK_PRICING`, so unknown models behave exactly as before.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A