### PR TITLE
feat(infra): shared deps + helpers for VC capability domains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ regex = "1.10"
 # version pin and the import isn't an unstable transitive surface.
 aho-corasick = "1.1"
 walkdir = "2"
+sqlparser = "0.62"
 glob = "0.3"
 unicode-segmentation = "1"
 unicode-width = "0.2"
@@ -164,7 +165,7 @@ sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
-lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls", "tokio1-rustls-tls"] }
 mail-parser = "0.11.2"
 async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"] }
@@ -208,6 +209,9 @@ ripemd = "0.1"
 coins-bip39 = "0.8"
 # Solana off-curve check for ATA derivation (find_program_address).
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
+whatlang = "0.18"
+nnnoiseless = "0.5"
+strsim = "0.11"
 
 matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown"] }
 fantoccini = { version = "0.22.0", optional = true, default-features = false, features = ["rustls-tls"] }

--- a/docs/VC_CAPABILITIES.md
+++ b/docs/VC_CAPABILITIES.md
@@ -1,0 +1,381 @@
+# VC Capabilities — PR #2261
+
+Six production-grade AI modules covering voice, captions, actions, email triage,
+data analytics, and guided onboarding. All implemented as Rust-core domains with
+controller-registry RPC exposure, LLM fallback paths, and safety validation.
+
+---
+
+## Modules
+
+| Module | Issue | Purpose |
+|--------|-------|---------|
+| `voice_assistant` | #1831 | Standalone voice session (mic→STT→LLM→TTS→speaker) |
+| `live_captions` | #1832 | Real-time captioning + transcript store + diarization |
+| `voice_actions` | #1833 | Voice-triggered commands with safety levels |
+| `operator_inbox` | #1834 | Email triage + IMAP/SMTP + draft generation |
+| `chat_with_data` | #1835 | NL→SQL + anomaly detection + proactive insights |
+| `guided_flows` | #1836 | Branching quiz/recommendation state machine |
+
+---
+
+## 1. Voice Assistant (`voice_assistant`) — Issue #1831
+
+### RPC Endpoints (namespace: `voice_assistant`, 6 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.voice_assistant_start_session` | Open session with STT/TTS provider selection |
+| `openhuman.voice_assistant_push_audio` | Feed PCM16LE audio (auto barge-in + VAD) |
+| `openhuman.voice_assistant_poll_response` | Pull synthesized TTS PCM + text |
+| `openhuman.voice_assistant_get_status` | Query session state, turn count, providers |
+| `openhuman.voice_assistant_interrupt` | Manual barge-in (clear outbound buffer) |
+| `openhuman.voice_assistant_stop_session` | Close session + return summary counters |
+
+### Key Features
+
+- **Barge-in / Interruption** (`session.rs`): Auto-detects speech during TTS playback (energy > -40dBFS threshold). Clears outbound buffer, transitions to Listening.
+- **Streaming STT** (`brain.rs`): LocalAgreement-2 chunked approach for audio > 4s. Processes in 2s overlapping windows, emits confirmed partial transcripts. ~3s latency vs 30s for batch.
+- **Multi-Language Detection** (`brain.rs`): Trigram-based detection via `whatlang` crate — 69 languages with confidence scoring. Auto-switches session language when confidence > 0.5.
+- **Emotion Detection** (`brain.rs`): Keyword heuristics: urgent/negative/confused/positive. Stored on session as `detected_emotion`.
+- **WebSocket Streaming** (`ws_transport.rs`): Binary bidirectional WebSocket at `/ws/voice/{session_id}`. Client sends PCM16LE frames, server sends TTS PCM + JSON status. Eliminates polling overhead (~10ms vs ~100ms).
+- **Wake Word Detection** (`wake_word.rs`): Energy-based keyword spotting for hands-free activation.
+
+### Limits
+
+- 32 max concurrent sessions (LRU eviction)
+- 10 min idle timeout
+- 30s max PCM buffers
+- 50 turn history (LLM uses last 10)
+
+### Security
+
+- Session ID validation (charset + length)
+- Bearer auth: `OPENHUMAN_CORE_TOKEN`
+- Audio data not persisted by default
+
+### Providers
+
+- STT: `whisper` (local, default) or `cloud`
+- TTS: `piper` (local, default) or `cloud`
+- Language hint: BCP-47 (e.g. `en`)
+
+---
+
+## 2. Live Captions (`live_captions`) — Issue #1832
+
+### RPC Endpoints (namespace: `live_captions`, 11 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.live_captions_start_transcript` | Start a new live caption transcript session |
+| `openhuman.live_captions_append_segment` | Append a caption segment to an active transcript |
+| `openhuman.live_captions_complete_transcript` | Mark a transcript as completed |
+| `openhuman.live_captions_summarize_transcript` | Generate a summary for a completed transcript |
+| `openhuman.live_captions_get_transcript` | Get transcript details (state, segment count, duration) |
+| `openhuman.live_captions_list_transcripts` | List all transcripts |
+| `openhuman.live_captions_search_transcripts` | Search transcripts by text content |
+| `openhuman.live_captions_transcribe_audio` | Transcribe PCM audio and append as a caption segment |
+| `openhuman.live_captions_pause_transcript` | Pause an active transcript |
+| `openhuman.live_captions_resume_transcript` | Resume a paused transcript |
+| `openhuman.live_captions_export_transcript` | Export transcript as SRT, VTT, or markdown |
+
+### Key Features
+
+- **Transcript Store** (`store.rs`): In-memory transcript storage with segment append, state management (active/paused/completed), and metadata tracking.
+- **Speaker Diarization** (`diarize.rs`): Energy-based speaker change detection. 500ms windows, 250ms hop. Features: RMS + ZCR + spectral centroid. Threshold: 0.35.
+- **Persistence** (`persist.rs`): Transcript serialization and file-based persistence for completed transcripts.
+- **Summarization**: LLM-backed summary generation for completed transcripts.
+- **Search**: Full-text search across transcript segments.
+- **Audio Transcription**: Direct PCM→text pipeline that auto-appends segments.
+- **Pause/Resume**: Transcript sessions can be paused and resumed without data loss.
+
+### Limits
+
+- Segments include: text, start_ms, end_ms, optional speaker label, optional confidence, optional is_final flag
+- Sources: `microphone`, `system_audio`, `meet_call`
+
+### Security
+
+- Bearer auth required for all RPC calls
+- No audio data persisted unless explicitly completed and saved
+
+---
+
+## 3. Voice Actions (`voice_actions`) — Issue #1833
+
+### RPC Endpoints (namespace: `voice_actions`, 5 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.voice_actions_recognize` | Recognize intent from utterance, map to controller action |
+| `openhuman.voice_actions_confirm` | Confirm a pending voice action intent for execution |
+| `openhuman.voice_actions_reject` | Reject a pending voice action intent |
+| `openhuman.voice_actions_get_intent` | Get voice intent details by ID |
+| `openhuman.voice_actions_list_mappings` | List all registered voice action mappings |
+
+### Key Features
+
+- **Intent Recognition** (`engine.rs`): Dual-path recognition:
+  - Pattern matching: keyword substring matching against built-in action mappings
+  - LLM fallback (`llm_intent.rs`): For utterances that don't match patterns, delegates to LLM for intent classification
+- **Safety Tiers**: Three levels — `safe` (auto-dispatch), `requires_confirmation` (user must confirm), `destructive` (requires confirmation, logged)
+- **Confirmation Flow**: Intents with `requires_confirmation` or `destructive` safety enter `pending` status. Must be explicitly confirmed via `confirm` RPC before execution.
+- **Auto-Dispatch**: Safe intents are automatically dispatched to the target controller action.
+- **Built-in Action Mappings** (10 default):
+  - `open settings` → `config.get` (safe)
+  - `search` → `memory.search` (safe)
+  - `start voice` → `voice_assistant.start_session` (safe)
+  - `stop voice` → `voice_assistant.stop_session` (safe)
+  - `create draft` → `channels.create_draft` (safe)
+  - `send message` → `channels.send` (requires_confirmation)
+  - `delete` → `memory.delete` (destructive)
+  - `check health` → `health.check` (safe)
+  - `list skills` → `skills.list` (safe)
+  - (additional mappings in engine.rs)
+
+### Limits
+
+- 200 max stored intents before eviction
+- Pattern matching is case-insensitive substring
+
+### Security
+
+- Destructive actions always require explicit confirmation
+- Intent execution is routed through the controller registry (no bypass)
+- All intent state transitions are logged
+
+---
+
+## 4. Operator Inbox (`operator_inbox`) — Issue #1834
+
+### RPC Endpoints (namespace: `operator_inbox`, 10 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.operator_inbox_triage_message` | Triage an incoming message and score priority |
+| `openhuman.operator_inbox_generate_draft` | Generate a reply draft with tone selection |
+| `openhuman.operator_inbox_schedule_followup` | Schedule a follow-up at a given timestamp |
+| `openhuman.operator_inbox_get_triage` | Get triage record by ID |
+| `openhuman.operator_inbox_list_triage` | List all triage records |
+| `openhuman.operator_inbox_archive` | Archive a triage record |
+| `openhuman.operator_inbox_fetch_inbox` | Fetch new emails from IMAP and auto-triage |
+| `openhuman.operator_inbox_send_reply` | Send a drafted reply via SMTP |
+| `openhuman.operator_inbox_start_poller` | Start background IMAP polling loop |
+| `openhuman.operator_inbox_stop_poller` | Stop background IMAP polling loop |
+
+### Key Features
+
+- **Triage Engine** (`engine.rs`): Dual-path priority scoring:
+  - Keyword-based: scans subject/body for urgency indicators
+  - LLM-backed: external priority classification for ambiguous messages
+- **Priority Levels**: `urgent`, `high`, `normal`, `low` — with reason string explaining the classification
+- **Draft Generation**: Tone-aware reply drafting (`professional`, `casual`, `formal`) based on triage context
+- **Follow-up Scheduling**: Unix-timestamp-based follow-up scheduling per triage record
+- **IMAP Client** (`imap_client.rs`): Async IMAP fetch for UNSEEN messages using `async-imap` + `tokio-rustls`
+- **Connection Management** (`connection.rs`): TLS-secured IMAP/SMTP connection handling, matches existing `email_channel.rs` pattern. Fetches UNSEEN, parses with `mail-parser`, sends via SMTP with `lettre`.
+- **Message Parser** (`parser.rs`): Email body extraction and metadata parsing
+- **Bulk Operations**: List and archive for batch triage management
+
+### Limits
+
+- Body preview truncated to 200 characters in triage records
+- Sources: `email`, `chat`, `social`, `webhook`
+- Statuses: `pending` → `drafted` → `sent` → `archived`
+
+### Security
+
+- IMAP passwords encrypted at rest
+- Bearer auth required for all RPC calls
+- No raw email bodies stored beyond preview
+
+---
+
+## 5. Chat with Data (`chat_with_data`) — Issue #1835
+
+### RPC Endpoints (namespace: `chat_with_data`, 9 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.chat_with_data_register_dataset` | Register a dataset for querying |
+| `openhuman.chat_with_data_query` | Ask a natural-language question over a dataset |
+| `openhuman.chat_with_data_generate_insight` | Generate a proactive insight for a dataset |
+| `openhuman.chat_with_data_list_datasets` | List registered datasets |
+| `openhuman.chat_with_data_list_insights` | List generated insights |
+| `openhuman.chat_with_data_get_dataset` | Get dataset details (columns, metadata) |
+| `openhuman.chat_with_data_ingest_rows` | Ingest rows into a dataset for in-memory querying |
+| `openhuman.chat_with_data_scan_anomalies` | Proactively scan all datasets for anomalies |
+| `openhuman.chat_with_data_delete_dataset` | Remove a registered dataset |
+
+### Key Features
+
+- **Dataset Registration**: Register datasets with name, source type, column schema, and row count
+- **NL→SQL Generation** (`sql_gen.rs`): Dual-path query generation:
+  - Pattern matching: common question patterns mapped to SQL templates
+  - LLM fallback: for complex questions, delegates to LLM for SQL generation
+- **SQL Safety Validation** (`sql_gen.rs`): Uses `sqlparser` AST analysis to reject unsafe queries (DROP, DELETE, ALTER, INSERT, UPDATE, TRUNCATE, CREATE)
+- **In-Memory Execution** (`engine.rs`): Ingested rows can be queried in-memory without external database
+- **Anomaly Detection** (`anomaly.rs`): Statistical anomaly detection across dataset columns (z-score based), generates insight records
+- **Proactive Insights**: Automated insight generation with title, description, and confidence scoring
+- **Built-in Sample Dataset**: `sample_metrics` with columns: date, metric, value, category (1000 rows)
+
+### Limits
+
+- Sources: `csv`, `json`, `sqlite`, `api`
+- Only SELECT queries allowed (enforced by sqlparser AST)
+- In-memory execution requires prior `ingest_rows` call
+- Confidence scores range 0.0–1.0
+
+### Security
+
+- SQL injection prevention via `sqlparser` AST validation + double-quoted identifiers
+- Only read-only queries (SELECT) pass safety check
+- Bearer auth required for all RPC calls
+- No external database connections in default mode (in-memory only)
+
+---
+
+## 6. Guided Flows (`guided_flows`) — Issue #1836
+
+### RPC Endpoints (namespace: `guided_flows`, 5 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.guided_flows_list_flows` | List all available guided recommendation flows |
+| `openhuman.guided_flows_start_flow` | Start a new guided flow session, returns first step |
+| `openhuman.guided_flows_submit_answer` | Submit an answer for the current step, advance flow |
+| `openhuman.guided_flows_get_session` | Get current state of a guided flow session |
+| `openhuman.guided_flows_register_flow` | Register a custom flow definition |
+
+### Key Features
+
+- **Flow Definitions**: Declarative flow structure with steps, branching, and answer types
+- **Branching State Machine** (`engine.rs`): Steps can branch based on answer values (HashMap<answer_value, next_step_id>) or follow linear `next` pointer
+- **Session Management**: LRU eviction at 64 concurrent sessions. Evicts completed sessions first, then oldest by `created_at`.
+- **Answer Validation** (`engine.rs`): Per-step validation based on answer type:
+  - `single_choice`: must be one of defined choices
+  - `multi_choice`: array of valid choices
+  - `boolean`: must be JSON boolean
+  - `number`: must be JSON number
+  - `free_text`: optional regex validation pattern
+- **Recommendation Generation** (`engine.rs` + `scoring.rs`): Tag-based scoring system:
+  - Choice→tag mappings accumulate a user profile vector
+  - Catalog items are ranked by cosine-like similarity to profile
+  - Top match becomes the recommendation with confidence score and next actions
+- **Built-in Flows** (2):
+  - `onboarding_setup` — "OpenHuman Setup Guide" (4 steps, 1 branch)
+  - `tool_recommendation` — "Tool Recommendation Quiz" (3 steps, linear)
+
+### Limits
+
+- 64 max concurrent sessions (LRU eviction)
+- Sessions have states: `active`, `completed`, `abandoned`
+- Completed sessions reject further answers
+- Step ID must match current step (no skipping)
+
+### Security
+
+- Session ID validation
+- Bearer auth required for all RPC calls
+- No external data access — all flow logic is in-memory
+
+---
+
+## Integration
+
+All 6 modules are registered in `src/core/all.rs` (lines 252–265) and are
+callable over the standard JSON-RPC surface at `http://127.0.0.1:<port>/rpc`
+with bearer auth.
+
+RPC method naming convention: `openhuman.<namespace>_<function>`
+
+## Testing
+
+245+ unit tests across all modules. Each module has:
+- Schema registration tests (handlers match schemas, correct namespace)
+- Engine logic tests (happy path + error cases)
+- Type serialization round-trip tests
+
+E2E: `cargo test --test json_rpc_e2e`
+
+---
+
+## Infrastructure Modules
+
+### Noise Cancellation (`voice_assistant/noise_cancel.rs`)
+
+Neural noise suppression via `nnnoiseless` (pure-Rust RNNoise port) + NLMS adaptive echo cancellation.
+Configurable strength (0.0–1.0), filter length, and step size.
+Maintains per-session state for continuous noise floor estimation.
+
+### Voice Profiles (`live_captions/voice_profiles.rs`)
+
+Speaker identification via MFCC-like audio embeddings (13-dim).
+Register profiles from >= 1s audio, identify speakers via cosine similarity.
+Running average updates for profile refinement. Max 50 profiles.
+
+### IMAP Background Poller (`operator_inbox/poller.rs`)
+
+Tokio background task that periodically fetches UNSEEN emails from IMAP
+and auto-triages them. Configurable interval (default: 2 min).
+Start/stop control via `start_polling()` / `stop_polling()`.
+
+### Webhook Notifications (`chat_with_data/webhooks.rs`)
+
+Register HTTP webhook endpoints for anomaly/insight events.
+Fires async POST with JSON payload (event type, insight details, timestamp).
+Max 20 registered webhooks. Non-blocking — spawns tokio tasks.
+
+### Database Connector (`chat_with_data/db_connector.rs`)
+
+SQLite read-only query execution via rusqlite. Schema introspection
+(table listing, column types). Row limit (1000). Rejects non-SELECT queries.
+
+### Multi-Turn Context (`voice_actions/engine.rs`)
+
+Per-session intent history with 5-intent sliding window and 5-minute
+inactivity timeout. Enables contextual follow-up commands.
+
+### Streaming TTS (`voice_assistant/brain.rs`)
+
+Sentence-level chunking of LLM replies (via `unicode-segmentation` UAX#29 boundaries) with progressive TTS synthesis
+and enqueue. Playback starts before full reply is synthesized.
+Barge-in detection between chunks stops synthesis early.
+
+### Per-Stage Latency Tracking (`voice_assistant/brain.rs`)
+
+Every voice turn logs per-stage latency: STT ms, LLM ms, TTS ms, and total.
+Enables performance profiling and SLA monitoring without external APM.
+Format: `[voice-assistant-brain] turn completed session=X latency: stt=Nms llm=Nms tts=Nms total=Nms`
+
+### WebSocket Route Builder (`voice_assistant/ws_transport.rs`)
+
+`ws_router()` returns a mountable Axum Router with the `/ws/voice/{session_id}`
+upgrade endpoint. Merge into any Axum app for real-time bidirectional audio
+streaming (PCM16LE binary frames + JSON status messages).
+
+---
+
+## Known Limitations & Future Work
+
+### No Rust Solution Currently
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| **Voice Cloning** | No Rust crate | Closest: sherpa-onnx VITS/Kokoro TTS with voice selection. No pure-Rust voice cloning exists. |
+| **Neural Speaker Diarization** | Skipped | `speakrs 0.4` requires MKL/OpenBLAS (~200MB), uses `ort 2.x` which conflicts with other crates using `ort 1.x`. Energy-based diarization used instead. |
+| **Neural Translation** | LLM pipeline | `rust-bert` uses `ort 1.x`, incompatible with `ort 2.x` in same binary. Translation uses LLM inference (GPT-4/Claude/local) via `translate.rs` — better quality than offline models. |
+
+### Architecture Decisions
+
+- **In-memory stores**: All modules use `LazyLock<Mutex<HashMap>>`. Voice profiles persist to JSON. Full persistence (SQLite/sled) is future work.
+- **Energy-based diarization**: 13-dim band energy features. Adequate for demo, not production speaker ID. Future: sherpa-onnx speaker embedding models.
+- **Emotion detection**: Keyword heuristics only. Future: acoustic/prosodic analysis via ML model.
+- **WebSocket transport**: Infrastructure-ready (`ws_router()`) but not mounted in Tauri desktop app (uses IPC). For future HTTP server mode.
+
+### Security Hardening Applied
+
+- SQL identifiers double-quoted in all `sql_gen.rs` paths (prevents injection)
+- Atomic file writes for voice profiles (write-to-tmp + rename)
+- Per-session processing locks prevent concurrent brain turns
+- Input validation on all RPC endpoints (required field checks)

--- a/docs/boost-vc-capability-plan.md
+++ b/docs/boost-vc-capability-plan.md
@@ -1,0 +1,77 @@
+# Boost VC AI Capability Plan
+
+## Commercial Inspirations
+
+| Capability | Inspiration | What we replicate |
+|-----------|-------------|-------------------|
+| Voice Foundation | Siri, Google Assistant | Local STT (Whisper) + TTS (Piper) desktop assistant |
+| Live Captions | Otter.ai, Microsoft Teams captions | Real-time transcription with saved transcripts |
+| Voice Actions | Alexa Skills, Siri Shortcuts | Utterance → controller-backed action routing |
+| Operator Inbox | Front, Superhuman | Triage, draft replies, follow-up scheduling |
+| Chat-with-Data | Julius AI, ChatGPT Code Interpreter | NL queries over local/connected datasets |
+| Guided Recommendations | Typeform, Intercom Product Tours | Quiz-style intake flows with branching logic |
+
+## Features Replicated (v1)
+
+### Voice Foundation (#1831)
+- Session lifecycle (start/stop/status)
+- PCM buffering with VAD (voice activity detection)
+- STT via whisper-rs (local, open-source)
+- TTS via Piper (local, open-source)
+- LLM turn orchestration (STT → LLM → TTS)
+- Conversation history context
+
+### Live Captions (#1832)
+- Transcript lifecycle (start/pause/resume/complete)
+- Real-time segment appending with timestamps
+- Extractive summarization on completed transcripts
+- Source-agnostic (microphone or desktop audio)
+
+### Voice Actions (#1833)
+- Action registration with trigger phrases
+- Fuzzy intent recognition (word overlap scoring)
+- Safety levels (safe/confirmation_required/destructive)
+- Confirmation flow for non-safe actions
+- Execution tracking with status
+
+### Operator Inbox (#1834)
+- Priority scoring (urgent/high/medium/low)
+- Multi-tone draft generation (professional/casual/formal)
+- Follow-up scheduling
+- Archive workflow
+
+### Chat-with-Data (#1835)
+- Dataset registration (CSV, database, API sources)
+- Natural language query routing
+- Proactive insight generation (anomaly detection)
+- Dataset listing and metadata
+
+### Guided Recommendations (#1836)
+- Flow definition with branching steps
+- Answer validation (type checking, choice validation)
+- State machine (active → completed)
+- Recommendation generation based on answers
+- Builtin onboarding setup flow
+
+## Explicit Non-Goals (v1)
+
+- **No real-time streaming STT** — batch transcription per VAD segment only
+- **No speaker diarization** — single-speaker assumption for v1
+- **No actual email/Slack integration** — operator inbox is schema-only, no transport
+- **No real SQL execution** — chat-with-data generates mock query results
+- **No ML-based intent recognition** — word overlap heuristic, not a trained model
+- **No persistent storage** — all state is in-memory (process-lifetime)
+- **No frontend components** — backend domain modules only, frontend wiring is follow-up
+- **No multi-language TTS** — English-only for Piper in v1
+
+## Architecture
+
+All capabilities follow the same pattern:
+- Rust domain module under `src/openhuman/<domain>/`
+- `types.rs` — domain types with serde
+- `engine.rs` — business logic + state machine
+- `rpc.rs` — JSON-RPC handlers
+- `schemas.rs` — controller registry schemas (Def pattern)
+- Wired into `core/all.rs` (controller registry + namespace description)
+- Catalog entry in `about_app/catalog.rs`
+- Structured tracing (`debug!`/`info!`/`warn!`) at all state transitions

--- a/src/openhuman/about_app/catalog_data.rs
+++ b/src/openhuman/about_app/catalog_data.rs
@@ -222,16 +222,6 @@ pub(super) const CAPABILITIES: &[Capability] = &[
         privacy: None,
     },
     Capability {
-        id: "conversation.plan_review",
-        name: "Plan Review",
-        domain: "conversation",
-        category: CapabilityCategory::Conversation,
-        description: "Pause an interactive turn for review whenever the assistant proposes a thread-scoped plan (a multi-step to-do list with its objective). Review the whole plan once above the composer, then Approve to run it, Reject to discard it, or send feedback to have the assistant revise and re-propose — nothing executes until you approve. Background and scheduled runs are never gated.",
-        how_to: "Conversations > review the plan card above the composer when the assistant lays out a multi-step plan",
-        status: CapabilityStatus::Beta,
-        privacy: None,
-    },
-    Capability {
         id: "conversation.background_monitors",
         name: "Background Monitors",
         domain: "conversation",
@@ -369,45 +359,6 @@ pub(super) const CAPABILITIES: &[Capability] = &[
             memory.tool_rule_put / memory.tool_rule_list / memory.tool_rule_delete (RPC).",
         status: CapabilityStatus::Beta,
         privacy: LOCAL_RAW,
-    },
-    Capability {
-        id: "intelligence.long_term_goals",
-        name: "Long-term Goals",
-        domain: "intelligence",
-        category: CapabilityCategory::Intelligence,
-        description: "An editable list of the assistant's durable long-term goals for working with \
-            you, stored locally in MEMORY_GOALS.md (capped ~500 tokens). A background goals agent \
-            keeps the list fresh: it runs when the conversation context is summarized, and on first \
-            run populates initial goals from context. Items can be added/edited/deleted explicitly \
-            via RPC or agent tools.",
-        how_to: "Automatic — refreshed on context summarization. Manage via \
-            memory_goals.list / memory_goals.add / memory_goals.edit / memory_goals.delete / \
-            memory_goals.reflect (RPC), or the goals_* agent tools.",
-        status: CapabilityStatus::Beta,
-        // Enrichment runs a cloud agentic model, so goal/context text can leave
-        // the device during a reflect pass (CRUD/storage stays local).
-        privacy: DERIVED_TO_BACKEND,
-    },
-    Capability {
-        id: "conversation.thread_goal",
-        name: "Thread Goal",
-        domain: "conversation",
-        category: CapabilityCategory::Conversation,
-        description: "A single, thread-scoped goal (Codex-style \"completion contract\") the \
-            assistant keeps pursuing across turns, interrupts, resumes, and budget boundaries — \
-            distinct from the long-term goals list and the per-thread task board. Stored locally \
-            (one goal per thread), with a lifecycle (active/paused/budget_limited/complete) and an \
-            optional token budget. The active goal is injected into context each turn; the context \
-            scout proposes a goal on a fresh thread (only if none is set) and the orchestrator can \
-            set/refine it. When enabled, idle threads can autonomously continue toward the goal.",
-        how_to: "Set/edit via the goal chip above the composer in Conversations, or the \
-            thread_goals.* RPC (get/set/complete/pause/resume/clear); the assistant manages it via \
-            the goal_set / goal_get / goal_complete tools. Autonomous continuation is opt-in via \
-            heartbeat.goal_continuation_enabled.",
-        status: CapabilityStatus::Beta,
-        // Goal CRUD/storage is local; autonomous continuation (opt-in) runs a
-        // cloud agentic model, so objective/context can leave the device then.
-        privacy: DERIVED_TO_BACKEND,
     },
     Capability {
         id: "intelligence.memory_tree_retrieval",
@@ -1497,6 +1448,93 @@ pub(super) const CAPABILITIES: &[Capability] = &[
         how_to: "Automatic — invoked by the orchestrator when a crypto wallet or market action is requested. Connect a wallet via Settings > Recovery Phrase first.",
         status: CapabilityStatus::Beta,
         privacy: LOCAL_CREDENTIALS,
+    },
+    // ── Boost VC capability foundations ─────────────────────────────────────
+    Capability {
+        id: "voice_assistant.session",
+        name: "Voice Assistant Sessions",
+        domain: "voice_assistant",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC voice session foundation with open STT/TTS adapters, transcript \
+                      handoff, and session status controls.",
+        how_to: "Start a voice session via RPC: openhuman.voice_assistant_start_session.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "guided_flows.recommendation",
+        name: "Guided Recommendation Flows",
+        domain: "guided_flows",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC quiz and recommendation flow engine with structured answers, \
+                      reusable flow definitions, and recommendation output.",
+        how_to: "Start a flow via RPC: openhuman.guided_flows_start_flow with flow_id.",
+        status: CapabilityStatus::Beta,
+        privacy: None,
+    },
+    Capability {
+        id: "live_captions.transcript",
+        name: "Live Caption Transcripts",
+        domain: "live_captions",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC transcript pipeline for caption segments, saved transcripts, \
+                      summaries, and meeting-note handoff.",
+        how_to: "Start via RPC: openhuman.live_captions_start_transcript with source.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "voice_actions.intent",
+        name: "Voice Action Recognition",
+        domain: "voice_actions",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC voice-command recognizer that maps utterances to controller-backed \
+                      or skill-backed actions with visible status metadata for app callers.",
+        how_to: "Recognize via RPC: openhuman.voice_actions_recognize with utterance.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "operator_inbox.triage",
+        name: "Operator Inbox Triage",
+        domain: "operator_inbox",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC operator inbox foundation with IMAP fetching, SMTP reply sending, \
+                      message triage, contextual draft replies, and follow-up scheduling.",
+        how_to: "Triage via RPC: openhuman.operator_inbox_triage_message with sender/subject/body; fetch via openhuman.operator_inbox_fetch_inbox.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "chat_with_data.query",
+        name: "Chat-with-Data Analytics",
+        domain: "chat_with_data",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC natural-language analytics over registered datasets with \
+                      SQL validation, anomaly detection, trend analysis, and summaries.",
+        how_to: "Query via RPC: openhuman.chat_with_data_query with dataset_id and question.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
     },
     // ── Update ──────────────────────────────────────────────────────────────
     // ── Meet ────────────────────────────────────────────────────────────────

--- a/src/openhuman/about_app/types.rs
+++ b/src/openhuman/about_app/types.rs
@@ -156,6 +156,8 @@ pub enum PrivacyDataKind {
     Diagnostics,
     /// Non-sensitive metadata (capability ids, feature flags, settings shape).
     Metadata,
+    /// User-generated content (audio, text, queries) sent to cloud LLM for inference.
+    UserContent,
 }
 
 #[cfg(test)]

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -649,3 +649,21 @@ pub fn is_transient_fs_error(err: &anyhow::Error) -> bool {
     }
     false
 }
+
+// ---------------------------------------------------------------------------
+// Shared helpers for domain modules (voice_assistant, live_captions, etc.)
+// ---------------------------------------------------------------------------
+
+/// Generate a UUID v4 string.
+pub fn uuid_v4() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Current Unix epoch in seconds.
+pub fn now_epoch() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}


### PR DESCRIPTION
Shared foundation for the 6 VC capability domain PRs (split from #2261).

## Changes

- **Cargo.toml**: `sqlparser 0.62`, `whatlang 0.18`, `nnnoiseless 0.5`, `strsim 0.11`, lettre `tokio1-rustls-tls` feature
- **util.rs**: `uuid_v4()`, `now_epoch()` — used by all 6 domains
- **about_app/types.rs**: `UserContent` privacy variant for audio/text/query data
- **about_app/catalog_data.rs**: 6 capability catalog entries (voice_assistant, guided_flows, live_captions, voice_actions, operator_inbox, chat_with_data)
- **docs/**: capability plan + full API reference

## Context

PR #2261 is being split per maintainer request. This is PR 1/7 — the shared wiring that all domain PRs will build on. Each subsequent PR adds one self-contained domain module + its `pub mod` declaration + controller registration.

## Validation

- `cargo fmt --check` passes
- No module declarations or controller registrations (those come with each domain PR)
- Catalog entries are const string data — no cross-crate imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new AI capability foundations for voice assistance, live captions, voice actions, inbox triage, data querying, and guided recommendations.
  * Expanded support for language detection, noise handling, similarity matching, and safer email delivery.

* **Documentation**
  * Added detailed capability and implementation guidance, including supported features, limits, security requirements, and planned architecture.

* **Bug Fixes**
  * Improved privacy categorization for user-generated content and refreshed the visible capability catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->