### PR TITLE
feat(guided_flows): quiz-style recommendation engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ regex = "1.10"
 # version pin and the import isn't an unstable transitive surface.
 aho-corasick = "1.1"
 walkdir = "2"
+sqlparser = "0.62"
 glob = "0.3"
 unicode-segmentation = "1"
 unicode-width = "0.2"
@@ -164,7 +165,7 @@ sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
-lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls", "tokio1-rustls-tls"] }
 mail-parser = "0.11.2"
 async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"] }
@@ -208,6 +209,9 @@ ripemd = "0.1"
 coins-bip39 = "0.8"
 # Solana off-curve check for ATA derivation (find_program_address).
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
+whatlang = "0.18"
+nnnoiseless = "0.5"
+strsim = "0.11"
 
 matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown"] }
 fantoccini = { version = "0.22.0", optional = true, default-features = false, features = ["rustls-tls"] }

--- a/docs/VC_CAPABILITIES.md
+++ b/docs/VC_CAPABILITIES.md
@@ -1,0 +1,381 @@
+# VC Capabilities — PR #2261
+
+Six production-grade AI modules covering voice, captions, actions, email triage,
+data analytics, and guided onboarding. All implemented as Rust-core domains with
+controller-registry RPC exposure, LLM fallback paths, and safety validation.
+
+---
+
+## Modules
+
+| Module | Issue | Purpose |
+|--------|-------|---------|
+| `voice_assistant` | #1831 | Standalone voice session (mic→STT→LLM→TTS→speaker) |
+| `live_captions` | #1832 | Real-time captioning + transcript store + diarization |
+| `voice_actions` | #1833 | Voice-triggered commands with safety levels |
+| `operator_inbox` | #1834 | Email triage + IMAP/SMTP + draft generation |
+| `chat_with_data` | #1835 | NL→SQL + anomaly detection + proactive insights |
+| `guided_flows` | #1836 | Branching quiz/recommendation state machine |
+
+---
+
+## 1. Voice Assistant (`voice_assistant`) — Issue #1831
+
+### RPC Endpoints (namespace: `voice_assistant`, 6 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.voice_assistant_start_session` | Open session with STT/TTS provider selection |
+| `openhuman.voice_assistant_push_audio` | Feed PCM16LE audio (auto barge-in + VAD) |
+| `openhuman.voice_assistant_poll_response` | Pull synthesized TTS PCM + text |
+| `openhuman.voice_assistant_get_status` | Query session state, turn count, providers |
+| `openhuman.voice_assistant_interrupt` | Manual barge-in (clear outbound buffer) |
+| `openhuman.voice_assistant_stop_session` | Close session + return summary counters |
+
+### Key Features
+
+- **Barge-in / Interruption** (`session.rs`): Auto-detects speech during TTS playback (energy > -40dBFS threshold). Clears outbound buffer, transitions to Listening.
+- **Streaming STT** (`brain.rs`): LocalAgreement-2 chunked approach for audio > 4s. Processes in 2s overlapping windows, emits confirmed partial transcripts. ~3s latency vs 30s for batch.
+- **Multi-Language Detection** (`brain.rs`): Trigram-based detection via `whatlang` crate — 69 languages with confidence scoring. Auto-switches session language when confidence > 0.5.
+- **Emotion Detection** (`brain.rs`): Keyword heuristics: urgent/negative/confused/positive. Stored on session as `detected_emotion`.
+- **WebSocket Streaming** (`ws_transport.rs`): Binary bidirectional WebSocket at `/ws/voice/{session_id}`. Client sends PCM16LE frames, server sends TTS PCM + JSON status. Eliminates polling overhead (~10ms vs ~100ms).
+- **Wake Word Detection** (`wake_word.rs`): Energy-based keyword spotting for hands-free activation.
+
+### Limits
+
+- 32 max concurrent sessions (LRU eviction)
+- 10 min idle timeout
+- 30s max PCM buffers
+- 50 turn history (LLM uses last 10)
+
+### Security
+
+- Session ID validation (charset + length)
+- Bearer auth: `OPENHUMAN_CORE_TOKEN`
+- Audio data not persisted by default
+
+### Providers
+
+- STT: `whisper` (local, default) or `cloud`
+- TTS: `piper` (local, default) or `cloud`
+- Language hint: BCP-47 (e.g. `en`)
+
+---
+
+## 2. Live Captions (`live_captions`) — Issue #1832
+
+### RPC Endpoints (namespace: `live_captions`, 11 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.live_captions_start_transcript` | Start a new live caption transcript session |
+| `openhuman.live_captions_append_segment` | Append a caption segment to an active transcript |
+| `openhuman.live_captions_complete_transcript` | Mark a transcript as completed |
+| `openhuman.live_captions_summarize_transcript` | Generate a summary for a completed transcript |
+| `openhuman.live_captions_get_transcript` | Get transcript details (state, segment count, duration) |
+| `openhuman.live_captions_list_transcripts` | List all transcripts |
+| `openhuman.live_captions_search_transcripts` | Search transcripts by text content |
+| `openhuman.live_captions_transcribe_audio` | Transcribe PCM audio and append as a caption segment |
+| `openhuman.live_captions_pause_transcript` | Pause an active transcript |
+| `openhuman.live_captions_resume_transcript` | Resume a paused transcript |
+| `openhuman.live_captions_export_transcript` | Export transcript as SRT, VTT, or markdown |
+
+### Key Features
+
+- **Transcript Store** (`store.rs`): In-memory transcript storage with segment append, state management (active/paused/completed), and metadata tracking.
+- **Speaker Diarization** (`diarize.rs`): Energy-based speaker change detection. 500ms windows, 250ms hop. Features: RMS + ZCR + spectral centroid. Threshold: 0.35.
+- **Persistence** (`persist.rs`): Transcript serialization and file-based persistence for completed transcripts.
+- **Summarization**: LLM-backed summary generation for completed transcripts.
+- **Search**: Full-text search across transcript segments.
+- **Audio Transcription**: Direct PCM→text pipeline that auto-appends segments.
+- **Pause/Resume**: Transcript sessions can be paused and resumed without data loss.
+
+### Limits
+
+- Segments include: text, start_ms, end_ms, optional speaker label, optional confidence, optional is_final flag
+- Sources: `microphone`, `system_audio`, `meet_call`
+
+### Security
+
+- Bearer auth required for all RPC calls
+- No audio data persisted unless explicitly completed and saved
+
+---
+
+## 3. Voice Actions (`voice_actions`) — Issue #1833
+
+### RPC Endpoints (namespace: `voice_actions`, 5 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.voice_actions_recognize` | Recognize intent from utterance, map to controller action |
+| `openhuman.voice_actions_confirm` | Confirm a pending voice action intent for execution |
+| `openhuman.voice_actions_reject` | Reject a pending voice action intent |
+| `openhuman.voice_actions_get_intent` | Get voice intent details by ID |
+| `openhuman.voice_actions_list_mappings` | List all registered voice action mappings |
+
+### Key Features
+
+- **Intent Recognition** (`engine.rs`): Dual-path recognition:
+  - Pattern matching: keyword substring matching against built-in action mappings
+  - LLM fallback (`llm_intent.rs`): For utterances that don't match patterns, delegates to LLM for intent classification
+- **Safety Tiers**: Three levels — `safe` (auto-dispatch), `requires_confirmation` (user must confirm), `destructive` (requires confirmation, logged)
+- **Confirmation Flow**: Intents with `requires_confirmation` or `destructive` safety enter `pending` status. Must be explicitly confirmed via `confirm` RPC before execution.
+- **Auto-Dispatch**: Safe intents are automatically dispatched to the target controller action.
+- **Built-in Action Mappings** (10 default):
+  - `open settings` → `config.get` (safe)
+  - `search` → `memory.search` (safe)
+  - `start voice` → `voice_assistant.start_session` (safe)
+  - `stop voice` → `voice_assistant.stop_session` (safe)
+  - `create draft` → `channels.create_draft` (safe)
+  - `send message` → `channels.send` (requires_confirmation)
+  - `delete` → `memory.delete` (destructive)
+  - `check health` → `health.check` (safe)
+  - `list skills` → `skills.list` (safe)
+  - (additional mappings in engine.rs)
+
+### Limits
+
+- 200 max stored intents before eviction
+- Pattern matching is case-insensitive substring
+
+### Security
+
+- Destructive actions always require explicit confirmation
+- Intent execution is routed through the controller registry (no bypass)
+- All intent state transitions are logged
+
+---
+
+## 4. Operator Inbox (`operator_inbox`) — Issue #1834
+
+### RPC Endpoints (namespace: `operator_inbox`, 10 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.operator_inbox_triage_message` | Triage an incoming message and score priority |
+| `openhuman.operator_inbox_generate_draft` | Generate a reply draft with tone selection |
+| `openhuman.operator_inbox_schedule_followup` | Schedule a follow-up at a given timestamp |
+| `openhuman.operator_inbox_get_triage` | Get triage record by ID |
+| `openhuman.operator_inbox_list_triage` | List all triage records |
+| `openhuman.operator_inbox_archive` | Archive a triage record |
+| `openhuman.operator_inbox_fetch_inbox` | Fetch new emails from IMAP and auto-triage |
+| `openhuman.operator_inbox_send_reply` | Send a drafted reply via SMTP |
+| `openhuman.operator_inbox_start_poller` | Start background IMAP polling loop |
+| `openhuman.operator_inbox_stop_poller` | Stop background IMAP polling loop |
+
+### Key Features
+
+- **Triage Engine** (`engine.rs`): Dual-path priority scoring:
+  - Keyword-based: scans subject/body for urgency indicators
+  - LLM-backed: external priority classification for ambiguous messages
+- **Priority Levels**: `urgent`, `high`, `normal`, `low` — with reason string explaining the classification
+- **Draft Generation**: Tone-aware reply drafting (`professional`, `casual`, `formal`) based on triage context
+- **Follow-up Scheduling**: Unix-timestamp-based follow-up scheduling per triage record
+- **IMAP Client** (`imap_client.rs`): Async IMAP fetch for UNSEEN messages using `async-imap` + `tokio-rustls`
+- **Connection Management** (`connection.rs`): TLS-secured IMAP/SMTP connection handling, matches existing `email_channel.rs` pattern. Fetches UNSEEN, parses with `mail-parser`, sends via SMTP with `lettre`.
+- **Message Parser** (`parser.rs`): Email body extraction and metadata parsing
+- **Bulk Operations**: List and archive for batch triage management
+
+### Limits
+
+- Body preview truncated to 200 characters in triage records
+- Sources: `email`, `chat`, `social`, `webhook`
+- Statuses: `pending` → `drafted` → `sent` → `archived`
+
+### Security
+
+- IMAP passwords encrypted at rest
+- Bearer auth required for all RPC calls
+- No raw email bodies stored beyond preview
+
+---
+
+## 5. Chat with Data (`chat_with_data`) — Issue #1835
+
+### RPC Endpoints (namespace: `chat_with_data`, 9 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.chat_with_data_register_dataset` | Register a dataset for querying |
+| `openhuman.chat_with_data_query` | Ask a natural-language question over a dataset |
+| `openhuman.chat_with_data_generate_insight` | Generate a proactive insight for a dataset |
+| `openhuman.chat_with_data_list_datasets` | List registered datasets |
+| `openhuman.chat_with_data_list_insights` | List generated insights |
+| `openhuman.chat_with_data_get_dataset` | Get dataset details (columns, metadata) |
+| `openhuman.chat_with_data_ingest_rows` | Ingest rows into a dataset for in-memory querying |
+| `openhuman.chat_with_data_scan_anomalies` | Proactively scan all datasets for anomalies |
+| `openhuman.chat_with_data_delete_dataset` | Remove a registered dataset |
+
+### Key Features
+
+- **Dataset Registration**: Register datasets with name, source type, column schema, and row count
+- **NL→SQL Generation** (`sql_gen.rs`): Dual-path query generation:
+  - Pattern matching: common question patterns mapped to SQL templates
+  - LLM fallback: for complex questions, delegates to LLM for SQL generation
+- **SQL Safety Validation** (`sql_gen.rs`): Uses `sqlparser` AST analysis to reject unsafe queries (DROP, DELETE, ALTER, INSERT, UPDATE, TRUNCATE, CREATE)
+- **In-Memory Execution** (`engine.rs`): Ingested rows can be queried in-memory without external database
+- **Anomaly Detection** (`anomaly.rs`): Statistical anomaly detection across dataset columns (z-score based), generates insight records
+- **Proactive Insights**: Automated insight generation with title, description, and confidence scoring
+- **Built-in Sample Dataset**: `sample_metrics` with columns: date, metric, value, category (1000 rows)
+
+### Limits
+
+- Sources: `csv`, `json`, `sqlite`, `api`
+- Only SELECT queries allowed (enforced by sqlparser AST)
+- In-memory execution requires prior `ingest_rows` call
+- Confidence scores range 0.0–1.0
+
+### Security
+
+- SQL injection prevention via `sqlparser` AST validation + double-quoted identifiers
+- Only read-only queries (SELECT) pass safety check
+- Bearer auth required for all RPC calls
+- No external database connections in default mode (in-memory only)
+
+---
+
+## 6. Guided Flows (`guided_flows`) — Issue #1836
+
+### RPC Endpoints (namespace: `guided_flows`, 5 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.guided_flows_list_flows` | List all available guided recommendation flows |
+| `openhuman.guided_flows_start_flow` | Start a new guided flow session, returns first step |
+| `openhuman.guided_flows_submit_answer` | Submit an answer for the current step, advance flow |
+| `openhuman.guided_flows_get_session` | Get current state of a guided flow session |
+| `openhuman.guided_flows_register_flow` | Register a custom flow definition |
+
+### Key Features
+
+- **Flow Definitions**: Declarative flow structure with steps, branching, and answer types
+- **Branching State Machine** (`engine.rs`): Steps can branch based on answer values (HashMap<answer_value, next_step_id>) or follow linear `next` pointer
+- **Session Management**: LRU eviction at 64 concurrent sessions. Evicts completed sessions first, then oldest by `created_at`.
+- **Answer Validation** (`engine.rs`): Per-step validation based on answer type:
+  - `single_choice`: must be one of defined choices
+  - `multi_choice`: array of valid choices
+  - `boolean`: must be JSON boolean
+  - `number`: must be JSON number
+  - `free_text`: optional regex validation pattern
+- **Recommendation Generation** (`engine.rs` + `scoring.rs`): Tag-based scoring system:
+  - Choice→tag mappings accumulate a user profile vector
+  - Catalog items are ranked by cosine-like similarity to profile
+  - Top match becomes the recommendation with confidence score and next actions
+- **Built-in Flows** (2):
+  - `onboarding_setup` — "OpenHuman Setup Guide" (4 steps, 1 branch)
+  - `tool_recommendation` — "Tool Recommendation Quiz" (3 steps, linear)
+
+### Limits
+
+- 64 max concurrent sessions (LRU eviction)
+- Sessions have states: `active`, `completed`, `abandoned`
+- Completed sessions reject further answers
+- Step ID must match current step (no skipping)
+
+### Security
+
+- Session ID validation
+- Bearer auth required for all RPC calls
+- No external data access — all flow logic is in-memory
+
+---
+
+## Integration
+
+All 6 modules are registered in `src/core/all.rs` (lines 252–265) and are
+callable over the standard JSON-RPC surface at `http://127.0.0.1:<port>/rpc`
+with bearer auth.
+
+RPC method naming convention: `openhuman.<namespace>_<function>`
+
+## Testing
+
+245+ unit tests across all modules. Each module has:
+- Schema registration tests (handlers match schemas, correct namespace)
+- Engine logic tests (happy path + error cases)
+- Type serialization round-trip tests
+
+E2E: `cargo test --test json_rpc_e2e`
+
+---
+
+## Infrastructure Modules
+
+### Noise Cancellation (`voice_assistant/noise_cancel.rs`)
+
+Neural noise suppression via `nnnoiseless` (pure-Rust RNNoise port) + NLMS adaptive echo cancellation.
+Configurable strength (0.0–1.0), filter length, and step size.
+Maintains per-session state for continuous noise floor estimation.
+
+### Voice Profiles (`live_captions/voice_profiles.rs`)
+
+Speaker identification via MFCC-like audio embeddings (13-dim).
+Register profiles from >= 1s audio, identify speakers via cosine similarity.
+Running average updates for profile refinement. Max 50 profiles.
+
+### IMAP Background Poller (`operator_inbox/poller.rs`)
+
+Tokio background task that periodically fetches UNSEEN emails from IMAP
+and auto-triages them. Configurable interval (default: 2 min).
+Start/stop control via `start_polling()` / `stop_polling()`.
+
+### Webhook Notifications (`chat_with_data/webhooks.rs`)
+
+Register HTTP webhook endpoints for anomaly/insight events.
+Fires async POST with JSON payload (event type, insight details, timestamp).
+Max 20 registered webhooks. Non-blocking — spawns tokio tasks.
+
+### Database Connector (`chat_with_data/db_connector.rs`)
+
+SQLite read-only query execution via rusqlite. Schema introspection
+(table listing, column types). Row limit (1000). Rejects non-SELECT queries.
+
+### Multi-Turn Context (`voice_actions/engine.rs`)
+
+Per-session intent history with 5-intent sliding window and 5-minute
+inactivity timeout. Enables contextual follow-up commands.
+
+### Streaming TTS (`voice_assistant/brain.rs`)
+
+Sentence-level chunking of LLM replies (via `unicode-segmentation` UAX#29 boundaries) with progressive TTS synthesis
+and enqueue. Playback starts before full reply is synthesized.
+Barge-in detection between chunks stops synthesis early.
+
+### Per-Stage Latency Tracking (`voice_assistant/brain.rs`)
+
+Every voice turn logs per-stage latency: STT ms, LLM ms, TTS ms, and total.
+Enables performance profiling and SLA monitoring without external APM.
+Format: `[voice-assistant-brain] turn completed session=X latency: stt=Nms llm=Nms tts=Nms total=Nms`
+
+### WebSocket Route Builder (`voice_assistant/ws_transport.rs`)
+
+`ws_router()` returns a mountable Axum Router with the `/ws/voice/{session_id}`
+upgrade endpoint. Merge into any Axum app for real-time bidirectional audio
+streaming (PCM16LE binary frames + JSON status messages).
+
+---
+
+## Known Limitations & Future Work
+
+### No Rust Solution Currently
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| **Voice Cloning** | No Rust crate | Closest: sherpa-onnx VITS/Kokoro TTS with voice selection. No pure-Rust voice cloning exists. |
+| **Neural Speaker Diarization** | Skipped | `speakrs 0.4` requires MKL/OpenBLAS (~200MB), uses `ort 2.x` which conflicts with other crates using `ort 1.x`. Energy-based diarization used instead. |
+| **Neural Translation** | LLM pipeline | `rust-bert` uses `ort 1.x`, incompatible with `ort 2.x` in same binary. Translation uses LLM inference (GPT-4/Claude/local) via `translate.rs` — better quality than offline models. |
+
+### Architecture Decisions
+
+- **In-memory stores**: All modules use `LazyLock<Mutex<HashMap>>`. Voice profiles persist to JSON. Full persistence (SQLite/sled) is future work.
+- **Energy-based diarization**: 13-dim band energy features. Adequate for demo, not production speaker ID. Future: sherpa-onnx speaker embedding models.
+- **Emotion detection**: Keyword heuristics only. Future: acoustic/prosodic analysis via ML model.
+- **WebSocket transport**: Infrastructure-ready (`ws_router()`) but not mounted in Tauri desktop app (uses IPC). For future HTTP server mode.
+
+### Security Hardening Applied
+
+- SQL identifiers double-quoted in all `sql_gen.rs` paths (prevents injection)
+- Atomic file writes for voice profiles (write-to-tmp + rename)
+- Per-session processing locks prevent concurrent brain turns
+- Input validation on all RPC endpoints (required field checks)

--- a/docs/boost-vc-capability-plan.md
+++ b/docs/boost-vc-capability-plan.md
@@ -1,0 +1,77 @@
+# Boost VC AI Capability Plan
+
+## Commercial Inspirations
+
+| Capability | Inspiration | What we replicate |
+|-----------|-------------|-------------------|
+| Voice Foundation | Siri, Google Assistant | Local STT (Whisper) + TTS (Piper) desktop assistant |
+| Live Captions | Otter.ai, Microsoft Teams captions | Real-time transcription with saved transcripts |
+| Voice Actions | Alexa Skills, Siri Shortcuts | Utterance → controller-backed action routing |
+| Operator Inbox | Front, Superhuman | Triage, draft replies, follow-up scheduling |
+| Chat-with-Data | Julius AI, ChatGPT Code Interpreter | NL queries over local/connected datasets |
+| Guided Recommendations | Typeform, Intercom Product Tours | Quiz-style intake flows with branching logic |
+
+## Features Replicated (v1)
+
+### Voice Foundation (#1831)
+- Session lifecycle (start/stop/status)
+- PCM buffering with VAD (voice activity detection)
+- STT via whisper-rs (local, open-source)
+- TTS via Piper (local, open-source)
+- LLM turn orchestration (STT → LLM → TTS)
+- Conversation history context
+
+### Live Captions (#1832)
+- Transcript lifecycle (start/pause/resume/complete)
+- Real-time segment appending with timestamps
+- Extractive summarization on completed transcripts
+- Source-agnostic (microphone or desktop audio)
+
+### Voice Actions (#1833)
+- Action registration with trigger phrases
+- Fuzzy intent recognition (word overlap scoring)
+- Safety levels (safe/confirmation_required/destructive)
+- Confirmation flow for non-safe actions
+- Execution tracking with status
+
+### Operator Inbox (#1834)
+- Priority scoring (urgent/high/medium/low)
+- Multi-tone draft generation (professional/casual/formal)
+- Follow-up scheduling
+- Archive workflow
+
+### Chat-with-Data (#1835)
+- Dataset registration (CSV, database, API sources)
+- Natural language query routing
+- Proactive insight generation (anomaly detection)
+- Dataset listing and metadata
+
+### Guided Recommendations (#1836)
+- Flow definition with branching steps
+- Answer validation (type checking, choice validation)
+- State machine (active → completed)
+- Recommendation generation based on answers
+- Builtin onboarding setup flow
+
+## Explicit Non-Goals (v1)
+
+- **No real-time streaming STT** — batch transcription per VAD segment only
+- **No speaker diarization** — single-speaker assumption for v1
+- **No actual email/Slack integration** — operator inbox is schema-only, no transport
+- **No real SQL execution** — chat-with-data generates mock query results
+- **No ML-based intent recognition** — word overlap heuristic, not a trained model
+- **No persistent storage** — all state is in-memory (process-lifetime)
+- **No frontend components** — backend domain modules only, frontend wiring is follow-up
+- **No multi-language TTS** — English-only for Piper in v1
+
+## Architecture
+
+All capabilities follow the same pattern:
+- Rust domain module under `src/openhuman/<domain>/`
+- `types.rs` — domain types with serde
+- `engine.rs` — business logic + state machine
+- `rpc.rs` — JSON-RPC handlers
+- `schemas.rs` — controller registry schemas (Def pattern)
+- Wired into `core/all.rs` (controller registry + namespace description)
+- Catalog entry in `about_app/catalog.rs`
+- Structured tracing (`debug!`/`info!`/`warn!`) at all state transitions

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -305,6 +305,8 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     controllers.extend(
         crate::openhuman::desktop_companion::all_desktop_companion_registered_controllers(),
     );
+    // Guided recommendation flows: quiz-style intake and recommendation engine.
+    controllers.extend(crate::openhuman::guided_flows::all_guided_flows_registered_controllers());
     // Structured WhatsApp Web data — agent-facing read-only controllers (list/search).
     // The write-path ingest controller is registered separately in build_internal_only_controllers.
     controllers.extend(crate::openhuman::whatsapp_data::all_whatsapp_data_registered_controllers());
@@ -467,6 +469,8 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
     schemas.extend(crate::openhuman::whatsapp_data::all_whatsapp_data_controller_schemas());
     // Mobile device pairing and management
     schemas.extend(crate::openhuman::devices::all_devices_controller_schemas());
+    // Guided recommendation flows
+    schemas.extend(crate::openhuman::guided_flows::all_guided_flows_controller_schemas());
     // Durable agent session database
     schemas.extend(crate::openhuman::session_db::all_session_db_controller_schemas());
     // Background agent command center
@@ -647,6 +651,9 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         ),
         "tinyplace" => Some(
             "tiny.place A2A social-network integration: directory, explorer, and search over the agent network.",
+        ),
+        "guided_flows" => Some(
+            "Guided recommendation flows — quiz-style intake with branching logic and tag-based scoring.",
         ),
         _ => None,
     }

--- a/src/openhuman/about_app/catalog_data.rs
+++ b/src/openhuman/about_app/catalog_data.rs
@@ -222,16 +222,6 @@ pub(super) const CAPABILITIES: &[Capability] = &[
         privacy: None,
     },
     Capability {
-        id: "conversation.plan_review",
-        name: "Plan Review",
-        domain: "conversation",
-        category: CapabilityCategory::Conversation,
-        description: "Pause an interactive turn for review whenever the assistant proposes a thread-scoped plan (a multi-step to-do list with its objective). Review the whole plan once above the composer, then Approve to run it, Reject to discard it, or send feedback to have the assistant revise and re-propose — nothing executes until you approve. Background and scheduled runs are never gated.",
-        how_to: "Conversations > review the plan card above the composer when the assistant lays out a multi-step plan",
-        status: CapabilityStatus::Beta,
-        privacy: None,
-    },
-    Capability {
         id: "conversation.background_monitors",
         name: "Background Monitors",
         domain: "conversation",
@@ -369,45 +359,6 @@ pub(super) const CAPABILITIES: &[Capability] = &[
             memory.tool_rule_put / memory.tool_rule_list / memory.tool_rule_delete (RPC).",
         status: CapabilityStatus::Beta,
         privacy: LOCAL_RAW,
-    },
-    Capability {
-        id: "intelligence.long_term_goals",
-        name: "Long-term Goals",
-        domain: "intelligence",
-        category: CapabilityCategory::Intelligence,
-        description: "An editable list of the assistant's durable long-term goals for working with \
-            you, stored locally in MEMORY_GOALS.md (capped ~500 tokens). A background goals agent \
-            keeps the list fresh: it runs when the conversation context is summarized, and on first \
-            run populates initial goals from context. Items can be added/edited/deleted explicitly \
-            via RPC or agent tools.",
-        how_to: "Automatic — refreshed on context summarization. Manage via \
-            memory_goals.list / memory_goals.add / memory_goals.edit / memory_goals.delete / \
-            memory_goals.reflect (RPC), or the goals_* agent tools.",
-        status: CapabilityStatus::Beta,
-        // Enrichment runs a cloud agentic model, so goal/context text can leave
-        // the device during a reflect pass (CRUD/storage stays local).
-        privacy: DERIVED_TO_BACKEND,
-    },
-    Capability {
-        id: "conversation.thread_goal",
-        name: "Thread Goal",
-        domain: "conversation",
-        category: CapabilityCategory::Conversation,
-        description: "A single, thread-scoped goal (Codex-style \"completion contract\") the \
-            assistant keeps pursuing across turns, interrupts, resumes, and budget boundaries — \
-            distinct from the long-term goals list and the per-thread task board. Stored locally \
-            (one goal per thread), with a lifecycle (active/paused/budget_limited/complete) and an \
-            optional token budget. The active goal is injected into context each turn; the context \
-            scout proposes a goal on a fresh thread (only if none is set) and the orchestrator can \
-            set/refine it. When enabled, idle threads can autonomously continue toward the goal.",
-        how_to: "Set/edit via the goal chip above the composer in Conversations, or the \
-            thread_goals.* RPC (get/set/complete/pause/resume/clear); the assistant manages it via \
-            the goal_set / goal_get / goal_complete tools. Autonomous continuation is opt-in via \
-            heartbeat.goal_continuation_enabled.",
-        status: CapabilityStatus::Beta,
-        // Goal CRUD/storage is local; autonomous continuation (opt-in) runs a
-        // cloud agentic model, so objective/context can leave the device then.
-        privacy: DERIVED_TO_BACKEND,
     },
     Capability {
         id: "intelligence.memory_tree_retrieval",
@@ -1497,6 +1448,93 @@ pub(super) const CAPABILITIES: &[Capability] = &[
         how_to: "Automatic — invoked by the orchestrator when a crypto wallet or market action is requested. Connect a wallet via Settings > Recovery Phrase first.",
         status: CapabilityStatus::Beta,
         privacy: LOCAL_CREDENTIALS,
+    },
+    // ── Boost VC capability foundations ─────────────────────────────────────
+    Capability {
+        id: "voice_assistant.session",
+        name: "Voice Assistant Sessions",
+        domain: "voice_assistant",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC voice session foundation with open STT/TTS adapters, transcript \
+                      handoff, and session status controls.",
+        how_to: "Start a voice session via RPC: openhuman.voice_assistant_start_session.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "guided_flows.recommendation",
+        name: "Guided Recommendation Flows",
+        domain: "guided_flows",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC quiz and recommendation flow engine with structured answers, \
+                      reusable flow definitions, and recommendation output.",
+        how_to: "Start a flow via RPC: openhuman.guided_flows_start_flow with flow_id.",
+        status: CapabilityStatus::Beta,
+        privacy: None,
+    },
+    Capability {
+        id: "live_captions.transcript",
+        name: "Live Caption Transcripts",
+        domain: "live_captions",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC transcript pipeline for caption segments, saved transcripts, \
+                      summaries, and meeting-note handoff.",
+        how_to: "Start via RPC: openhuman.live_captions_start_transcript with source.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "voice_actions.intent",
+        name: "Voice Action Recognition",
+        domain: "voice_actions",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC voice-command recognizer that maps utterances to controller-backed \
+                      or skill-backed actions with visible status metadata for app callers.",
+        how_to: "Recognize via RPC: openhuman.voice_actions_recognize with utterance.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "operator_inbox.triage",
+        name: "Operator Inbox Triage",
+        domain: "operator_inbox",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC operator inbox foundation with IMAP fetching, SMTP reply sending, \
+                      message triage, contextual draft replies, and follow-up scheduling.",
+        how_to: "Triage via RPC: openhuman.operator_inbox_triage_message with sender/subject/body; fetch via openhuman.operator_inbox_fetch_inbox.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "chat_with_data.query",
+        name: "Chat-with-Data Analytics",
+        domain: "chat_with_data",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC natural-language analytics over registered datasets with \
+                      SQL validation, anomaly detection, trend analysis, and summaries.",
+        how_to: "Query via RPC: openhuman.chat_with_data_query with dataset_id and question.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
     },
     // ── Update ──────────────────────────────────────────────────────────────
     // ── Meet ────────────────────────────────────────────────────────────────

--- a/src/openhuman/about_app/types.rs
+++ b/src/openhuman/about_app/types.rs
@@ -156,6 +156,8 @@ pub enum PrivacyDataKind {
     Diagnostics,
     /// Non-sensitive metadata (capability ids, feature flags, settings shape).
     Metadata,
+    /// User-generated content (audio, text, queries) sent to cloud LLM for inference.
+    UserContent,
 }
 
 #[cfg(test)]

--- a/src/openhuman/guided_flows/engine.rs
+++ b/src/openhuman/guided_flows/engine.rs
@@ -1,0 +1,681 @@
+//! Flow engine — state machine that drives guided recommendation sessions.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tracing::{debug, info};
+
+use crate::openhuman::guided_flows::types::*;
+use crate::openhuman::util::{now_epoch, uuid_v4};
+
+/// Maximum concurrent flow sessions before LRU eviction.
+const MAX_SESSIONS: usize = 64;
+
+static SESSIONS: std::sync::LazyLock<Mutex<HashMap<String, FlowSession>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static FLOWS: std::sync::LazyLock<Mutex<HashMap<String, FlowDefinition>>> =
+    std::sync::LazyLock::new(|| {
+        Mutex::new(HashMap::from([
+            builtin_onboarding_flow(),
+            builtin_tool_recommendation_flow(),
+        ]))
+    });
+
+fn builtin_onboarding_flow() -> (String, FlowDefinition) {
+    let flow = FlowDefinition {
+        id: "onboarding_setup".into(),
+        name: "OpenHuman Setup Guide".into(),
+        description: "Guides new users through initial configuration choices.".into(),
+        version: 1,
+        start_step: "use_case".into(),
+        steps: vec![
+            FlowStep {
+                id: "use_case".into(),
+                prompt: "What will you primarily use OpenHuman for?".into(),
+                answer_type: AnswerType::SingleChoice,
+                choices: vec![
+                    "Personal productivity".into(),
+                    "Team collaboration".into(),
+                    "Development assistant".into(),
+                    "Meeting assistant".into(),
+                ],
+                validation: None,
+                branches: HashMap::from([("Meeting assistant".into(), "voice_pref".into())]),
+                next: Some("privacy_pref".into()),
+            },
+            FlowStep {
+                id: "voice_pref".into(),
+                prompt: "Do you want voice interaction enabled?".into(),
+                answer_type: AnswerType::Boolean,
+                choices: vec![],
+                validation: None,
+                branches: HashMap::new(),
+                next: Some("privacy_pref".into()),
+            },
+            FlowStep {
+                id: "privacy_pref".into(),
+                prompt: "How should OH handle your data?".into(),
+                answer_type: AnswerType::SingleChoice,
+                choices: vec![
+                    "Keep everything local".into(),
+                    "Allow cloud when needed".into(),
+                    "Prefer cloud for quality".into(),
+                ],
+                validation: None,
+                branches: HashMap::new(),
+                next: Some("model_size".into()),
+            },
+            FlowStep {
+                id: "model_size".into(),
+                prompt: "What's your hardware like?".into(),
+                answer_type: AnswerType::SingleChoice,
+                choices: vec![
+                    "Low-end (< 8GB RAM)".into(),
+                    "Mid-range (8-16GB RAM)".into(),
+                    "High-end (16GB+ RAM, GPU)".into(),
+                ],
+                validation: None,
+                branches: HashMap::new(),
+                next: None,
+            },
+        ],
+    };
+    (flow.id.clone(), flow)
+}
+
+fn builtin_tool_recommendation_flow() -> (String, FlowDefinition) {
+    let flow = FlowDefinition {
+        id: "tool_recommendation".into(),
+        name: "Tool Recommendation Quiz".into(),
+        description: "Recommends productivity tools based on workflow needs.".into(),
+        version: 1,
+        start_step: "work_type".into(),
+        steps: vec![
+            FlowStep {
+                id: "work_type".into(),
+                prompt: "What kind of work do you do most?".into(),
+                answer_type: AnswerType::SingleChoice,
+                choices: vec![
+                    "Writing & documentation".into(),
+                    "Code & engineering".into(),
+                    "Design & creative".into(),
+                    "Research & analysis".into(),
+                ],
+                validation: None,
+                branches: HashMap::new(),
+                next: Some("team_size".into()),
+            },
+            FlowStep {
+                id: "team_size".into(),
+                prompt: "How many people on your team?".into(),
+                answer_type: AnswerType::SingleChoice,
+                choices: vec![
+                    "Just me".into(),
+                    "2-5 people".into(),
+                    "6-20 people".into(),
+                    "20+ people".into(),
+                ],
+                validation: None,
+                branches: HashMap::new(),
+                next: Some("budget".into()),
+            },
+            FlowStep {
+                id: "budget".into(),
+                prompt: "What's your monthly budget per seat?".into(),
+                answer_type: AnswerType::SingleChoice,
+                choices: vec![
+                    "Free only".into(),
+                    "Under $10/mo".into(),
+                    "$10-30/mo".into(),
+                    "No limit".into(),
+                ],
+                validation: None,
+                branches: HashMap::new(),
+                next: None,
+            },
+        ],
+    };
+    (flow.id.clone(), flow)
+}
+
+pub fn list_flows() -> Vec<FlowDefinition> {
+    let flows: Vec<FlowDefinition> = FLOWS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .values()
+        .cloned()
+        .collect();
+    debug!(count = flows.len(), "[guided_flows] listing flows");
+    flows
+}
+
+pub fn start_flow(flow_id: &str, session_id: Option<String>) -> Result<FlowSession, String> {
+    let flows = FLOWS.lock().map_err(|e| format!("lock poisoned: {e}"))?;
+    let def = flows
+        .get(flow_id)
+        .ok_or_else(|| format!("flow not found: {flow_id}"))?;
+    let sid = session_id.unwrap_or_else(|| format!("gf-{}", uuid_v4()));
+    let session = FlowSession {
+        session_id: sid.clone(),
+        flow_id: flow_id.to_string(),
+        state: FlowSessionState::Active,
+        current_step: def.start_step.clone(),
+        answers: Vec::new(),
+        recommendation: None,
+        created_at: now_epoch(),
+    };
+    let mut sessions = SESSIONS.lock().map_err(|e| format!("lock poisoned: {e}"))?;
+    // Evict completed sessions first, then LRU if still at capacity.
+    if sessions.len() >= MAX_SESSIONS {
+        let completed: Vec<String> = sessions
+            .iter()
+            .filter(|(_, s)| s.state == FlowSessionState::Completed)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in completed {
+            sessions.remove(&id);
+        }
+    }
+    if sessions.len() >= MAX_SESSIONS {
+        // Evict oldest by created_at.
+        if let Some(oldest_id) = sessions
+            .values()
+            .min_by_key(|s| s.created_at)
+            .map(|s| s.session_id.clone())
+        {
+            debug!(evicted = %oldest_id, "[guided_flows] evicting LRU session (at capacity)");
+            sessions.remove(&oldest_id);
+        }
+    }
+    sessions.insert(sid, session.clone());
+    info!(flow_id = %flow_id, session_id = %session.session_id, "[guided_flows] flow started");
+    Ok(session)
+}
+
+pub fn submit_answer(
+    session_id: &str,
+    step_id: &str,
+    value: serde_json::Value,
+) -> Result<FlowSession, String> {
+    debug!(session_id = %session_id, step_id = %step_id, "[guided_flows] answer submitted");
+    // Lock ordering: FLOWS first, then SESSIONS (matches start_flow).
+    let flows = FLOWS.lock().map_err(|e| format!("lock poisoned: {e}"))?;
+
+    let mut sessions = SESSIONS.lock().map_err(|e| format!("lock poisoned: {e}"))?;
+    let session = sessions
+        .get_mut(session_id)
+        .ok_or_else(|| format!("session not found: {session_id}"))?;
+    if session.state != FlowSessionState::Active {
+        return Err("session is not active".into());
+    }
+    if session.current_step != step_id {
+        return Err(format!(
+            "expected step '{}', got '{step_id}'",
+            session.current_step
+        ));
+    }
+
+    let def = flows
+        .get(&session.flow_id)
+        .ok_or_else(|| format!("flow definition missing: {}", session.flow_id))?;
+    let step = def
+        .steps
+        .iter()
+        .find(|s| s.id == step_id)
+        .ok_or_else(|| format!("step not found: {step_id}"))?;
+
+    validate_answer(step, &value)?;
+    session.answers.push(StepAnswer {
+        step_id: step_id.to_string(),
+        value: value.clone(),
+    });
+
+    let answer_str = value.as_str().unwrap_or("").to_string();
+    let next = step
+        .branches
+        .get(&answer_str)
+        .cloned()
+        .or_else(|| step.next.clone());
+
+    match next {
+        Some(next_id) => {
+            session.current_step = next_id;
+        }
+        None => {
+            session.state = FlowSessionState::Completed;
+            session.recommendation = Some(generate_recommendation(def, &session.answers));
+            info!(session_id = %session_id, "[guided_flows] flow completed");
+        }
+    }
+    Ok(session.clone())
+}
+
+pub fn get_session(session_id: &str) -> Result<FlowSession, String> {
+    debug!(session_id = %session_id, "[guided_flows] state queried");
+    SESSIONS
+        .lock()
+        .map_err(|e| format!("lock poisoned: {e}"))?
+        .get(session_id)
+        .cloned()
+        .ok_or_else(|| format!("session not found: {session_id}"))
+}
+
+pub(crate) fn validate_answer(step: &FlowStep, value: &serde_json::Value) -> Result<(), String> {
+    match step.answer_type {
+        AnswerType::SingleChoice => {
+            let s = value.as_str().ok_or("expected string for single_choice")?;
+            if !step.choices.contains(&s.to_string()) {
+                return Err(format!("invalid choice: {s}"));
+            }
+        }
+        AnswerType::MultiChoice => {
+            let arr = value.as_array().ok_or("expected array for multi_choice")?;
+            for v in arr {
+                let s = v.as_str().ok_or("multi_choice items must be strings")?;
+                if !step.choices.contains(&s.to_string()) {
+                    return Err(format!("invalid choice: {s}"));
+                }
+            }
+        }
+        AnswerType::Boolean => {
+            value.as_bool().ok_or("expected boolean")?;
+        }
+        AnswerType::Number => {
+            value.as_f64().ok_or("expected number")?;
+        }
+        AnswerType::FreeText => {
+            let s = value.as_str().ok_or("expected string for free_text")?;
+            if let Some(ref pat) = step.validation {
+                let re = regex::Regex::new(pat).map_err(|e| format!("bad regex: {e}"))?;
+                if !re.is_match(s) {
+                    return Err(format!("answer does not match: {pat}"));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn generate_recommendation(_def: &FlowDefinition, answers: &[StepAnswer]) -> Recommendation {
+    use crate::openhuman::guided_flows::scoring::{
+        accumulate_tags, rank_items, CatalogItem, ChoiceTagMapping, TagVector,
+    };
+
+    let mut metadata = HashMap::new();
+    for ans in answers {
+        metadata.insert(ans.step_id.clone(), ans.value.clone());
+    }
+
+    // Build tag mappings from flow choices.
+    let tag_mappings: Vec<ChoiceTagMapping> = vec![
+        ChoiceTagMapping {
+            choice: "Personal productivity".into(),
+            tags: HashMap::from([("productivity".into(), 1.0), ("local".into(), 0.5)]),
+        },
+        ChoiceTagMapping {
+            choice: "Team collaboration".into(),
+            tags: HashMap::from([("team".into(), 1.0), ("cloud".into(), 0.7)]),
+        },
+        ChoiceTagMapping {
+            choice: "Development assistant".into(),
+            tags: HashMap::from([("developer".into(), 1.0), ("local".into(), 0.8)]),
+        },
+        ChoiceTagMapping {
+            choice: "Meeting assistant".into(),
+            tags: HashMap::from([("voice".into(), 1.0), ("meetings".into(), 0.9)]),
+        },
+        ChoiceTagMapping {
+            choice: "Keep everything local".into(),
+            tags: HashMap::from([("privacy".into(), 1.0), ("local".into(), 1.0)]),
+        },
+        ChoiceTagMapping {
+            choice: "Allow cloud when needed".into(),
+            tags: HashMap::from([("cloud".into(), 0.5), ("local".into(), 0.5)]),
+        },
+        ChoiceTagMapping {
+            choice: "Prefer cloud for quality".into(),
+            tags: HashMap::from([("cloud".into(), 1.0)]),
+        },
+        ChoiceTagMapping {
+            choice: "Low-end (< 8GB RAM)".into(),
+            tags: HashMap::from([("low_end".into(), 1.0)]),
+        },
+        ChoiceTagMapping {
+            choice: "Mid-range (8-16GB RAM)".into(),
+            tags: HashMap::from([("mid_range".into(), 1.0)]),
+        },
+        ChoiceTagMapping {
+            choice: "High-end (16GB+ RAM, GPU)".into(),
+            tags: HashMap::from([("high_end".into(), 1.0)]),
+        },
+    ];
+
+    // Accumulate user profile from answers.
+    let mut profile = TagVector::new();
+    for ans in answers {
+        if let Some(s) = ans.value.as_str() {
+            accumulate_tags(&mut profile, s, &tag_mappings);
+        }
+    }
+
+    // Build catalog of available configuration options.
+    let catalog = vec![
+        CatalogItem {
+            id: "voice-first".into(),
+            name: "Voice-First Setup".into(),
+            description: "Optimized for voice interaction".into(),
+            tags: HashMap::from([("voice".into(), 1.0), ("meetings".into(), 0.8)]),
+            exclude_if: vec![],
+            require_tags: vec![],
+            metadata: HashMap::new(),
+        },
+        CatalogItem {
+            id: "developer-workflow".into(),
+            name: "Developer Workflow Setup".into(),
+            description: "Optimized for development tasks".into(),
+            tags: HashMap::from([("developer".into(), 1.0), ("local".into(), 0.7)]),
+            exclude_if: vec![],
+            require_tags: vec![],
+            metadata: HashMap::new(),
+        },
+        CatalogItem {
+            id: "team-collab".into(),
+            name: "Team Collaboration Setup".into(),
+            description: "Optimized for team workflows".into(),
+            tags: HashMap::from([("team".into(), 1.0), ("cloud".into(), 0.8)]),
+            exclude_if: vec![],
+            require_tags: vec![],
+            metadata: HashMap::new(),
+        },
+        CatalogItem {
+            id: "personal-prod".into(),
+            name: "Personal Productivity Setup".into(),
+            description: "Optimized for personal use".into(),
+            tags: HashMap::from([("productivity".into(), 1.0), ("local".into(), 0.6)]),
+            exclude_if: vec![],
+            require_tags: vec![],
+            metadata: HashMap::new(),
+        },
+    ];
+
+    let ranked = rank_items(&profile, &catalog, 1);
+
+    let (title, summary, confidence) = if let Some(top) = ranked.first() {
+        (
+            top.item_name.clone(),
+            top.explanation.clone(),
+            top.normalized_score.max(0.7),
+        )
+    } else {
+        (
+            "Personal Productivity Setup".into(),
+            "Default recommendation".into(),
+            0.5,
+        )
+    };
+
+    // Generate next actions based on profile tags.
+    let mut next_actions = Vec::new();
+    if profile.get("privacy").copied().unwrap_or(0.0) > 0.5
+        || profile.get("local").copied().unwrap_or(0.0) > 0.5
+    {
+        next_actions.push("Install local Whisper model for STT".into());
+        next_actions.push("Install Piper for local TTS".into());
+    }
+    if profile.get("high_end").copied().unwrap_or(0.0) > 0.0 {
+        next_actions.push("Enable large language model for better quality".into());
+    } else {
+        next_actions.push("Use quantized models for your hardware tier".into());
+    }
+    if profile.get("voice").copied().unwrap_or(0.0) > 0.5 {
+        next_actions.push("Enable voice assistant in settings".into());
+    }
+
+    Recommendation {
+        title,
+        summary,
+        confidence,
+        next_actions,
+        metadata,
+    }
+}
+
+pub fn register_flow(
+    id: &str,
+    name: &str,
+    description: &str,
+    start_step: &str,
+    steps: Vec<FlowStep>,
+) -> Result<String, String> {
+    if id.is_empty() || name.is_empty() || start_step.is_empty() {
+        return Err("id, name, and start_step are required".into());
+    }
+    if steps.is_empty() {
+        return Err("at least one step is required".into());
+    }
+    // Validate start_step exists in steps.
+    if !steps.iter().any(|s| s.id == start_step) {
+        return Err(format!("start_step '{}' not found in steps", start_step));
+    }
+    let flow = FlowDefinition {
+        id: id.into(),
+        name: name.into(),
+        description: description.into(),
+        version: 1,
+        start_step: start_step.into(),
+        steps,
+    };
+    let flow_id = flow.id.clone();
+    FLOWS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(flow_id.clone(), flow);
+    info!(flow_id = %flow_id, "[guided_flows] custom flow registered");
+    Ok(flow_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_flows_includes_builtin() {
+        assert!(list_flows().iter().any(|f| f.id == "onboarding_setup"));
+    }
+
+    #[test]
+    fn start_flow_creates_session() {
+        let s = start_flow("onboarding_setup", Some("eng-t1".into())).unwrap();
+        assert_eq!(s.state, FlowSessionState::Active);
+        assert_eq!(s.current_step, "use_case");
+    }
+
+    #[test]
+    fn start_flow_unknown_errors() {
+        assert!(start_flow("nope", None).unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn submit_advances_linear() {
+        let s = start_flow("onboarding_setup", Some("eng-t2".into())).unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "use_case",
+            serde_json::Value::String("Personal productivity".into()),
+        )
+        .unwrap();
+        assert_eq!(s.current_step, "privacy_pref");
+    }
+
+    #[test]
+    fn submit_follows_branch() {
+        let s = start_flow("onboarding_setup", Some("eng-t3".into())).unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "use_case",
+            serde_json::Value::String("Meeting assistant".into()),
+        )
+        .unwrap();
+        assert_eq!(s.current_step, "voice_pref");
+    }
+
+    #[test]
+    fn submit_validates_choice() {
+        let s = start_flow("onboarding_setup", Some("eng-t4".into())).unwrap();
+        assert!(submit_answer(
+            &s.session_id,
+            "use_case",
+            serde_json::Value::String("bad".into())
+        )
+        .unwrap_err()
+        .contains("invalid"));
+    }
+
+    #[test]
+    fn submit_wrong_step_errors() {
+        let s = start_flow("onboarding_setup", Some("eng-t5".into())).unwrap();
+        assert!(submit_answer(
+            &s.session_id,
+            "privacy_pref",
+            serde_json::Value::String("x".into())
+        )
+        .unwrap_err()
+        .contains("expected step"));
+    }
+
+    #[test]
+    fn full_flow_generates_recommendation() {
+        let s = start_flow("onboarding_setup", Some("eng-t6".into())).unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "use_case",
+            serde_json::Value::String("Development assistant".into()),
+        )
+        .unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "privacy_pref",
+            serde_json::Value::String("Keep everything local".into()),
+        )
+        .unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "model_size",
+            serde_json::Value::String("High-end (16GB+ RAM, GPU)".into()),
+        )
+        .unwrap();
+        assert_eq!(s.state, FlowSessionState::Completed);
+        let rec = s.recommendation.unwrap();
+        assert_eq!(rec.title, "Developer Workflow Setup");
+        assert!(rec.next_actions.iter().any(|a| a.contains("Whisper")));
+    }
+
+    #[test]
+    fn full_flow_with_branch() {
+        let s = start_flow("onboarding_setup", Some("eng-t7".into())).unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "use_case",
+            serde_json::Value::String("Meeting assistant".into()),
+        )
+        .unwrap();
+        let s = submit_answer(&s.session_id, "voice_pref", serde_json::Value::Bool(true)).unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "privacy_pref",
+            serde_json::Value::String("Allow cloud when needed".into()),
+        )
+        .unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "model_size",
+            serde_json::Value::String("Mid-range (8-16GB RAM)".into()),
+        )
+        .unwrap();
+        assert_eq!(s.state, FlowSessionState::Completed);
+        assert_eq!(s.recommendation.unwrap().title, "Voice-First Setup");
+    }
+
+    #[test]
+    fn get_session_works() {
+        let s = start_flow("onboarding_setup", Some("eng-t8".into())).unwrap();
+        assert_eq!(
+            get_session(&s.session_id).unwrap().state,
+            FlowSessionState::Active
+        );
+    }
+
+    #[test]
+    fn get_session_not_found() {
+        assert!(get_session("nope").unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn completed_rejects_answers() {
+        let s = start_flow("onboarding_setup", Some("eng-t9".into())).unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "use_case",
+            serde_json::Value::String("Personal productivity".into()),
+        )
+        .unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "privacy_pref",
+            serde_json::Value::String("Keep everything local".into()),
+        )
+        .unwrap();
+        let s = submit_answer(
+            &s.session_id,
+            "model_size",
+            serde_json::Value::String("Low-end (< 8GB RAM)".into()),
+        )
+        .unwrap();
+        assert!(submit_answer(&s.session_id, "x", serde_json::Value::Null)
+            .unwrap_err()
+            .contains("not active"));
+    }
+
+    #[test]
+    fn validate_boolean_rejects_string() {
+        let step = FlowStep {
+            id: "t".into(),
+            prompt: "?".into(),
+            answer_type: AnswerType::Boolean,
+            choices: vec![],
+            validation: None,
+            branches: HashMap::new(),
+            next: None,
+        };
+        assert!(validate_answer(&step, &serde_json::Value::String("y".into())).is_err());
+    }
+
+    #[test]
+    fn validate_number_rejects_string() {
+        let step = FlowStep {
+            id: "t".into(),
+            prompt: "?".into(),
+            answer_type: AnswerType::Number,
+            choices: vec![],
+            validation: None,
+            branches: HashMap::new(),
+            next: None,
+        };
+        assert!(validate_answer(&step, &serde_json::Value::String("x".into())).is_err());
+    }
+
+    #[test]
+    fn validate_free_text_regex() {
+        let step = FlowStep {
+            id: "t".into(),
+            prompt: "?".into(),
+            answer_type: AnswerType::FreeText,
+            choices: vec![],
+            validation: Some(r"^\d{3}$".into()),
+            branches: HashMap::new(),
+            next: None,
+        };
+        assert!(validate_answer(&step, &serde_json::Value::String("123".into())).is_ok());
+        assert!(validate_answer(&step, &serde_json::Value::String("abc".into())).is_err());
+    }
+}

--- a/src/openhuman/guided_flows/mod.rs
+++ b/src/openhuman/guided_flows/mod.rs
@@ -1,0 +1,22 @@
+//! Guided recommendation flows domain.
+//!
+//! Provides a reusable state-machine engine for quiz-style or conversational
+//! intake flows that guide users to recommendations, decisions, or next actions.
+//!
+//! Architecture: flow definitions → engine (state machine) → recommendation generation.
+//! All business logic lives in Rust; the app layer only renders prompts and collects answers.
+//!
+//! Log prefix: `[guided_flows]`
+
+pub mod engine;
+mod rpc;
+mod schemas;
+pub mod scoring;
+pub mod types;
+
+pub use schemas::{
+    all_controller_schemas as all_guided_flows_controller_schemas,
+    all_registered_controllers as all_guided_flows_registered_controllers,
+    schemas as guided_flows_schemas,
+};
+pub use types::{FlowDefinition, FlowSession, FlowSessionState, Recommendation};

--- a/src/openhuman/guided_flows/rpc.rs
+++ b/src/openhuman/guided_flows/rpc.rs
@@ -1,0 +1,332 @@
+//! RPC handlers for guided_flows domain.
+
+use crate::rpc::RpcOutcome;
+use serde_json::{json, Map, Value};
+use std::time::Duration;
+use tracing::debug;
+
+use super::engine;
+
+pub async fn handle_list_flows(_p: Map<String, Value>) -> Result<RpcOutcome<Value>, String> {
+    let flows = engine::list_flows();
+    let list: Vec<Value> = flows
+        .iter()
+        .map(|f| {
+            json!({
+                "id": f.id,
+                "name": f.name,
+                "description": f.description,
+                "version": f.version,
+                "step_count": f.steps.len(),
+            })
+        })
+        .collect();
+    Ok(RpcOutcome::single_log(
+        json!({ "ok": true, "flows": list }),
+        "listed flows",
+    ))
+}
+
+pub async fn handle_start_flow(p: Map<String, Value>) -> Result<RpcOutcome<Value>, String> {
+    let flow_id = p.get("flow_id").and_then(|v| v.as_str()).unwrap_or("");
+    let session_id = p
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    match engine::start_flow(flow_id, session_id) {
+        Ok(s) => Ok(RpcOutcome::single_log(
+            json!({
+                "ok": true,
+                "session_id": s.session_id,
+                "flow_id": s.flow_id,
+                "current_step": s.current_step,
+                "state": s.state,
+            }),
+            format!("started flow {flow_id}"),
+        )),
+        Err(e) => Ok(RpcOutcome::single_log(
+            json!({ "ok": false, "error": e }),
+            format!("start_flow failed: {e}"),
+        )),
+    }
+}
+
+pub async fn handle_submit_answer(p: Map<String, Value>) -> Result<RpcOutcome<Value>, String> {
+    let session_id = p.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+    let step_id = p.get("step_id").and_then(|v| v.as_str()).unwrap_or("");
+    let value = p.get("value").cloned().unwrap_or(Value::Null);
+
+    match engine::submit_answer(session_id, step_id, value) {
+        Ok(s) => {
+            let mut resp = json!({
+                "ok": true,
+                "session_id": s.session_id,
+                "state": s.state,
+                "current_step": s.current_step,
+            });
+            if let Some(rec) = &s.recommendation {
+                // Enhance recommendation with LLM-generated personalized summary.
+                let personalized = tokio::time::timeout(
+                    Duration::from_secs(4),
+                    try_llm_personalize(rec, &s.answers),
+                )
+                .await
+                .unwrap_or(None);
+                resp["recommendation"] = json!({
+                    "title": rec.title,
+                    "summary": personalized.as_deref().unwrap_or(&rec.summary),
+                    "confidence": rec.confidence,
+                    "next_actions": rec.next_actions,
+                });
+            }
+            Ok(RpcOutcome::single_log(
+                resp,
+                format!("submitted answer for step {step_id}"),
+            ))
+        }
+        Err(e) => Ok(RpcOutcome::single_log(
+            json!({ "ok": false, "error": e }),
+            format!("submit_answer failed: {e}"),
+        )),
+    }
+}
+
+/// LLM-powered personalization of flow recommendations based on user answers.
+async fn try_llm_personalize(
+    rec: &super::types::Recommendation,
+    answers: &[super::types::StepAnswer],
+) -> Option<String> {
+    use crate::openhuman::config::ops::load_config_with_timeout;
+    use crate::openhuman::inference::provider::create_chat_provider;
+
+    let config = load_config_with_timeout().await.ok()?;
+    let (provider, model) = create_chat_provider("agentic", &config).ok()?;
+
+    let answers_text: String = answers
+        .iter()
+        .map(|a| {
+            format!(
+                "- {}: {}",
+                a.step_id,
+                serde_json::to_string(&a.value).unwrap_or_default()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prompt = format!(
+        "Based on these user preferences, write a personalized 2-3 sentence recommendation summary.\n\nRecommendation: {}\nUser answers:\n{}\nNext actions: {}\n\nPersonalized summary:",
+        rec.title, answers_text, rec.next_actions.join(", ")
+    );
+
+    let system = "You are a setup assistant. Write warm, personalized recommendations that reference the user's specific choices. Be concise and actionable.";
+
+    let text = provider
+        .chat_with_system(Some(system), &prompt, &model, 0.6)
+        .await
+        .ok()?;
+
+    debug!("[guided_flows] LLM personalization generated");
+    Some(text.trim().to_string())
+}
+
+pub async fn handle_get_session(p: Map<String, Value>) -> Result<RpcOutcome<Value>, String> {
+    let session_id = p.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+    match engine::get_session(session_id) {
+        Ok(s) => {
+            let mut resp = json!({
+                "ok": true,
+                "session_id": s.session_id,
+                "flow_id": s.flow_id,
+                "state": s.state,
+                "current_step": s.current_step,
+                "answers_count": s.answers.len(),
+            });
+            if let Some(rec) = &s.recommendation {
+                resp["recommendation"] = json!({
+                    "title": rec.title,
+                    "summary": rec.summary,
+                    "confidence": rec.confidence,
+                    "next_actions": rec.next_actions,
+                });
+            }
+            Ok(RpcOutcome::single_log(
+                resp,
+                format!("fetched session {session_id}"),
+            ))
+        }
+        Err(e) => Ok(RpcOutcome::single_log(
+            json!({ "ok": false, "error": e }),
+            format!("get_session failed: {e}"),
+        )),
+    }
+}
+
+pub async fn handle_register_flow(p: Map<String, Value>) -> Result<RpcOutcome<Value>, String> {
+    let id = p.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let description = p.get("description").and_then(|v| v.as_str()).unwrap_or("");
+    let start_step = p.get("start_step").and_then(|v| v.as_str()).unwrap_or("");
+    let steps_raw = p.get("steps").and_then(|v| v.as_array());
+
+    if id.is_empty() || name.is_empty() || start_step.is_empty() {
+        return Ok(RpcOutcome::single_log(
+            json!({"ok": false, "error": "id, name, and start_step are required"}),
+            "register_flow: missing required fields",
+        ));
+    }
+
+    let steps = match steps_raw {
+        Some(arr) => {
+            let parsed: Result<Vec<_>, String> = arr
+                .iter()
+                .enumerate()
+                .map(|(i, s)| {
+                    let obj = s
+                        .as_object()
+                        .ok_or_else(|| format!("step[{i}] is not an object"))?;
+                    let id = obj
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| format!("step[{i}] missing required field 'id'"))?;
+                    let prompt = obj
+                        .get("prompt")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| format!("step[{i}] missing required field 'prompt'"))?;
+                    Ok(super::types::FlowStep {
+                        id: id.into(),
+                        prompt: prompt.into(),
+                        answer_type: match obj
+                            .get("answer_type")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("text")
+                        {
+                            "single_choice" => super::types::AnswerType::SingleChoice,
+                            "multi_choice" => super::types::AnswerType::MultiChoice,
+                            "boolean" => super::types::AnswerType::Boolean,
+                            "number" => super::types::AnswerType::Number,
+                            _ => super::types::AnswerType::FreeText,
+                        },
+                        choices: obj
+                            .get("choices")
+                            .and_then(|v| v.as_array())
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                        validation: obj
+                            .get("validation")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        branches: obj
+                            .get("branches")
+                            .and_then(|v| v.as_object())
+                            .map(|m| {
+                                m.iter()
+                                    .filter_map(|(k, v)| Some((k.clone(), v.as_str()?.into())))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                        next: obj.get("next").and_then(|v| v.as_str()).map(String::from),
+                    })
+                })
+                .collect();
+            match parsed {
+                Ok(steps) => steps,
+                Err(e) => {
+                    return Ok(RpcOutcome::single_log(
+                        json!({"ok": false, "error": e}),
+                        format!("register_flow: invalid steps: {e}"),
+                    ))
+                }
+            }
+        }
+        None => {
+            return Ok(RpcOutcome::single_log(
+                json!({"ok": false, "error": "steps array is required"}),
+                "register_flow: missing steps",
+            ))
+        }
+    };
+
+    match engine::register_flow(id, name, description, start_step, steps) {
+        Ok(flow_id) => Ok(RpcOutcome::single_log(
+            json!({"ok": true, "flow_id": flow_id}),
+            format!("registered flow {id}"),
+        )),
+        Err(e) => Ok(RpcOutcome::single_log(
+            json!({"ok": false, "error": e}),
+            format!("register_flow failed: {e}"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_flows_rpc_returns_ok() {
+        let outcome = handle_list_flows(Map::new()).await.unwrap();
+        let resp = &outcome.value;
+        assert_eq!(resp["ok"], true);
+        assert!(resp["flows"].as_array().unwrap().len() > 0);
+    }
+
+    #[tokio::test]
+    async fn start_flow_rpc_returns_session() {
+        let mut p = Map::new();
+        p.insert("flow_id".into(), Value::String("onboarding_setup".into()));
+        p.insert("session_id".into(), Value::String("rpc-t1".into()));
+        let outcome = handle_start_flow(p).await.unwrap();
+        let resp = &outcome.value;
+        assert_eq!(resp["ok"], true);
+        assert_eq!(resp["session_id"], "rpc-t1");
+    }
+
+    #[tokio::test]
+    async fn start_flow_rpc_bad_id() {
+        let mut p = Map::new();
+        p.insert("flow_id".into(), Value::String("nope".into()));
+        let outcome = handle_start_flow(p).await.unwrap();
+        assert_eq!(outcome.value["ok"], false);
+    }
+
+    #[tokio::test]
+    async fn submit_answer_rpc_advances() {
+        let mut p = Map::new();
+        p.insert("flow_id".into(), Value::String("onboarding_setup".into()));
+        p.insert("session_id".into(), Value::String("rpc-t2".into()));
+        handle_start_flow(p).await.unwrap();
+
+        let mut p = Map::new();
+        p.insert("session_id".into(), Value::String("rpc-t2".into()));
+        p.insert("step_id".into(), Value::String("use_case".into()));
+        p.insert(
+            "value".into(),
+            Value::String("Personal productivity".into()),
+        );
+        let outcome = handle_submit_answer(p).await.unwrap();
+        let resp = &outcome.value;
+        assert_eq!(resp["ok"], true);
+        assert_eq!(resp["current_step"], "privacy_pref");
+    }
+
+    #[tokio::test]
+    async fn get_session_rpc_works() {
+        let mut p = Map::new();
+        p.insert("flow_id".into(), Value::String("onboarding_setup".into()));
+        p.insert("session_id".into(), Value::String("rpc-t3".into()));
+        handle_start_flow(p).await.unwrap();
+
+        let mut p = Map::new();
+        p.insert("session_id".into(), Value::String("rpc-t3".into()));
+        let outcome = handle_get_session(p).await.unwrap();
+        let resp = &outcome.value;
+        assert_eq!(resp["ok"], true);
+        assert_eq!(resp["state"], "active");
+    }
+}

--- a/src/openhuman/guided_flows/schemas.rs
+++ b/src/openhuman/guided_flows/schemas.rs
@@ -1,0 +1,402 @@
+//! Controller schemas for the `guided_flows` domain.
+
+use serde_json::{Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+
+type SchemaBuilder = fn() -> ControllerSchema;
+type ControllerHandler = fn(Map<String, Value>) -> ControllerFuture;
+
+struct Def {
+    function: &'static str,
+    schema: SchemaBuilder,
+    handler: ControllerHandler,
+}
+
+const DEFS: &[Def] = &[
+    Def {
+        function: "list_flows",
+        schema: schema_list_flows,
+        handler: handle_list_flows,
+    },
+    Def {
+        function: "start_flow",
+        schema: schema_start_flow,
+        handler: handle_start_flow,
+    },
+    Def {
+        function: "submit_answer",
+        schema: schema_submit_answer,
+        handler: handle_submit_answer,
+    },
+    Def {
+        function: "get_session",
+        schema: schema_get_session,
+        handler: handle_get_session,
+    },
+    Def {
+        function: "register_flow",
+        schema: schema_register_flow,
+        handler: handle_register_flow,
+    },
+];
+
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    DEFS.iter().map(|d| (d.schema)()).collect()
+}
+
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    DEFS.iter()
+        .map(|d| RegisteredController {
+            schema: (d.schema)(),
+            handler: d.handler,
+        })
+        .collect()
+}
+
+pub fn schemas(function: &str) -> ControllerSchema {
+    DEFS.iter()
+        .find(|d| d.function == function)
+        .map(|d| (d.schema)())
+        .unwrap_or_else(schema_unknown)
+}
+
+fn schema_list_flows() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "guided_flows",
+        function: "list_flows",
+        description: "List all available guided recommendation flows.",
+        inputs: vec![],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success flag.",
+                required: true,
+            },
+            FieldSchema {
+                name: "flows",
+                ty: TypeSchema::Array(Box::new(TypeSchema::Json)),
+                comment: "Array of flow summaries.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn schema_start_flow() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "guided_flows",
+        function: "start_flow",
+        description: "Start a new guided flow session. Returns the first step prompt.",
+        inputs: vec![
+            FieldSchema {
+                name: "flow_id",
+                ty: TypeSchema::String,
+                comment: "Flow definition ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "session_id",
+                ty: TypeSchema::String,
+                comment: "Optional session UUID.",
+                required: false,
+            },
+        ],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success flag.",
+                required: true,
+            },
+            FieldSchema {
+                name: "session_id",
+                ty: TypeSchema::String,
+                comment: "Session key.",
+                required: true,
+            },
+            FieldSchema {
+                name: "flow_id",
+                ty: TypeSchema::String,
+                comment: "Flow ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "current_step",
+                ty: TypeSchema::String,
+                comment: "Current step ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "state",
+                ty: TypeSchema::String,
+                comment: "Session state.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn schema_submit_answer() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "guided_flows",
+        function: "submit_answer",
+        description: "Submit an answer for the current step and advance the flow.",
+        inputs: vec![
+            FieldSchema {
+                name: "session_id",
+                ty: TypeSchema::String,
+                comment: "Session key.",
+                required: true,
+            },
+            FieldSchema {
+                name: "step_id",
+                ty: TypeSchema::String,
+                comment: "Step being answered.",
+                required: true,
+            },
+            FieldSchema {
+                name: "value",
+                ty: TypeSchema::Json,
+                comment: "Answer value (string, bool, number, or array).",
+                required: true,
+            },
+        ],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success flag.",
+                required: true,
+            },
+            FieldSchema {
+                name: "session_id",
+                ty: TypeSchema::String,
+                comment: "Session key.",
+                required: true,
+            },
+            FieldSchema {
+                name: "state",
+                ty: TypeSchema::String,
+                comment: "Session state after answer.",
+                required: true,
+            },
+            FieldSchema {
+                name: "current_step",
+                ty: TypeSchema::String,
+                comment: "Next step ID (if active).",
+                required: true,
+            },
+            FieldSchema {
+                name: "recommendation",
+                ty: TypeSchema::Json,
+                comment: "Recommendation (if completed).",
+                required: false,
+            },
+        ],
+    }
+}
+
+fn schema_get_session() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "guided_flows",
+        function: "get_session",
+        description: "Get the current state of a guided flow session.",
+        inputs: vec![FieldSchema {
+            name: "session_id",
+            ty: TypeSchema::String,
+            comment: "Session key.",
+            required: true,
+        }],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success flag.",
+                required: true,
+            },
+            FieldSchema {
+                name: "session_id",
+                ty: TypeSchema::String,
+                comment: "Session key.",
+                required: true,
+            },
+            FieldSchema {
+                name: "flow_id",
+                ty: TypeSchema::String,
+                comment: "Flow ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "state",
+                ty: TypeSchema::String,
+                comment: "Session state.",
+                required: true,
+            },
+            FieldSchema {
+                name: "current_step",
+                ty: TypeSchema::String,
+                comment: "Current step.",
+                required: true,
+            },
+            FieldSchema {
+                name: "answers_count",
+                ty: TypeSchema::F64,
+                comment: "Number of answers submitted.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn schema_unknown() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "guided_flows",
+        function: "unknown",
+        description: "Unknown guided_flows function.",
+        inputs: vec![FieldSchema {
+            name: "function",
+            ty: TypeSchema::String,
+            comment: "Requested function.",
+            required: true,
+        }],
+        outputs: vec![FieldSchema {
+            name: "error",
+            ty: TypeSchema::String,
+            comment: "Error.",
+            required: true,
+        }],
+    }
+}
+
+fn handle_list_flows(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        super::rpc::handle_list_flows(p)
+            .await?
+            .into_cli_compatible_json()
+    })
+}
+fn handle_start_flow(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        super::rpc::handle_start_flow(p)
+            .await?
+            .into_cli_compatible_json()
+    })
+}
+fn handle_submit_answer(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        super::rpc::handle_submit_answer(p)
+            .await?
+            .into_cli_compatible_json()
+    })
+}
+fn handle_get_session(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        super::rpc::handle_get_session(p)
+            .await?
+            .into_cli_compatible_json()
+    })
+}
+fn handle_register_flow(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        super::rpc::handle_register_flow(p)
+            .await?
+            .into_cli_compatible_json()
+    })
+}
+
+fn schema_register_flow() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "guided_flows",
+        function: "register_flow",
+        description: "Register a custom flow definition.",
+        inputs: vec![
+            FieldSchema {
+                name: "id",
+                ty: TypeSchema::String,
+                comment: "Unique flow ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "name",
+                ty: TypeSchema::String,
+                comment: "Display name.",
+                required: true,
+            },
+            FieldSchema {
+                name: "description",
+                ty: TypeSchema::String,
+                comment: "Flow description.",
+                required: true,
+            },
+            FieldSchema {
+                name: "start_step",
+                ty: TypeSchema::String,
+                comment: "ID of the first step.",
+                required: true,
+            },
+            FieldSchema {
+                name: "steps",
+                ty: TypeSchema::Array(Box::new(TypeSchema::Json)),
+                comment: "Array of step definitions.",
+                required: true,
+            },
+        ],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success.",
+                required: true,
+            },
+            FieldSchema {
+                name: "flow_id",
+                ty: TypeSchema::String,
+                comment: "Registered flow ID.",
+                required: true,
+            },
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registered_handlers_match_schemas() {
+        let s: Vec<_> = all_controller_schemas()
+            .into_iter()
+            .map(|s| s.function)
+            .collect();
+        let h: Vec<_> = all_registered_controllers()
+            .into_iter()
+            .map(|c| c.schema.function)
+            .collect();
+        assert_eq!(s, h);
+        assert_eq!(
+            s,
+            vec![
+                "list_flows",
+                "start_flow",
+                "submit_answer",
+                "get_session",
+                "register_flow"
+            ]
+        );
+    }
+
+    #[test]
+    fn lookup_unknown() {
+        assert_eq!(schemas("nope").function, "unknown");
+    }
+
+    #[test]
+    fn all_schemas_have_namespace() {
+        for s in all_controller_schemas() {
+            assert_eq!(s.namespace, "guided_flows");
+        }
+    }
+}

--- a/src/openhuman/guided_flows/scoring.rs
+++ b/src/openhuman/guided_flows/scoring.rs
@@ -1,0 +1,524 @@
+//! Tag-based recommendation scoring engine.
+//!
+//! Replicates Octane AI's core mechanic: quiz answers accumulate weighted
+//! tags into a user profile vector, then products are ranked by dot-product
+//! similarity against that profile. Hard constraints filter before scoring.
+//!
+//! ## Log prefix
+//!
+//! `[guided-flows-scoring]`
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::{debug, info};
+
+/// A tag weight mapping: tag_name → weight (0.0–1.0).
+pub type TagVector = HashMap<String, f64>;
+
+/// Maps a choice answer to the tags it contributes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChoiceTagMapping {
+    pub choice: String,
+    pub tags: TagVector,
+}
+
+/// A product/item in the catalog with feature tags.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogItem {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub tags: TagVector,
+    /// Hard constraints: item is excluded if user profile has any of these tags.
+    #[serde(default)]
+    pub exclude_if: Vec<String>,
+    /// Hard constraints: item requires ALL of these tags in user profile.
+    #[serde(default)]
+    pub require_tags: Vec<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// A scored recommendation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoredItem {
+    pub item_id: String,
+    pub item_name: String,
+    pub score: f64,
+    /// Normalized score in [0, 1].
+    pub normalized_score: f64,
+    /// Which tags contributed most to this score.
+    pub top_contributing_tags: Vec<(String, f64)>,
+    /// Why this item was recommended (human-readable).
+    pub explanation: String,
+}
+
+/// Conversion event for tracking which recommendations led to actions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversionEvent {
+    pub session_id: String,
+    pub item_id: String,
+    pub action: ConversionAction,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversionAction {
+    Viewed,
+    Clicked,
+    Accepted,
+    Dismissed,
+}
+
+/// Accumulate tags from a user's answer into their profile vector.
+///
+/// If the answer matches a choice in the mapping, the corresponding tags
+/// are added (summed) into the profile. Weights accumulate across questions.
+pub fn accumulate_tags(profile: &mut TagVector, answer: &str, mappings: &[ChoiceTagMapping]) {
+    let lower = answer.to_lowercase();
+    for mapping in mappings {
+        if mapping.choice.to_lowercase() == lower {
+            for (tag, weight) in &mapping.tags {
+                *profile.entry(tag.clone()).or_insert(0.0) += weight;
+            }
+            debug!(
+                choice = %answer,
+                tags_added = mapping.tags.len(),
+                "[guided-flows-scoring] tags accumulated"
+            );
+            return;
+        }
+    }
+    debug!(choice = %answer, "[guided-flows-scoring] no tag mapping found for choice");
+}
+
+/// Score a catalog item against a user profile using dot product.
+///
+/// Returns the raw dot product score. Higher = better match.
+pub fn dot_product_score(profile: &TagVector, item: &CatalogItem) -> f64 {
+    let mut score = 0.0;
+    for (tag, profile_weight) in profile {
+        if let Some(item_weight) = item.tags.get(tag) {
+            score += profile_weight * item_weight;
+        }
+    }
+    score
+}
+
+/// Compute cosine similarity between user profile and item tag vector.
+///
+/// Returns value in [-1, 1] where 1 = perfect match.
+pub fn cosine_similarity(profile: &TagVector, item_tags: &TagVector) -> f64 {
+    let mut dot = 0.0;
+    let mut norm_a = 0.0;
+    let mut norm_b = 0.0;
+
+    for (tag, w) in profile {
+        norm_a += w * w;
+        if let Some(iw) = item_tags.get(tag) {
+            dot += w * iw;
+        }
+    }
+    for (_, w) in item_tags {
+        norm_b += w * w;
+    }
+
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 {
+        return 0.0;
+    }
+    dot / denom
+}
+
+/// Check hard constraints: returns true if item passes all constraints.
+fn passes_constraints(profile: &TagVector, item: &CatalogItem) -> bool {
+    // Exclude if user has any excluded tag.
+    for excluded_tag in &item.exclude_if {
+        if profile.contains_key(excluded_tag) && profile[excluded_tag] > 0.0 {
+            return false;
+        }
+    }
+    // Require all required tags.
+    for required_tag in &item.require_tags {
+        if !profile.contains_key(required_tag) || profile[required_tag] <= 0.0 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Rank catalog items against a user profile.
+///
+/// 1. Filter by hard constraints (exclude_if, require_tags).
+/// 2. Score remaining items by dot product.
+/// 3. Normalize scores to [0, 1].
+/// 4. Sort descending by score.
+/// 5. Return top_n results with explanations.
+pub fn rank_items(profile: &TagVector, catalog: &[CatalogItem], top_n: usize) -> Vec<ScoredItem> {
+    let mut scored: Vec<(usize, f64)> = Vec::new();
+
+    for (idx, item) in catalog.iter().enumerate() {
+        if !passes_constraints(profile, item) {
+            continue;
+        }
+        let score = dot_product_score(profile, item);
+        scored.push((idx, score));
+    }
+
+    // Normalize scores.
+    let max_score = scored
+        .iter()
+        .map(|(_, s)| *s)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let min_score = scored.iter().map(|(_, s)| *s).fold(f64::INFINITY, f64::min);
+    let range = max_score - min_score;
+
+    // Sort descending.
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(top_n);
+
+    let results: Vec<ScoredItem> = scored
+        .into_iter()
+        .map(|(idx, raw_score)| {
+            let item = &catalog[idx];
+            let normalized = if range > 0.0 {
+                (raw_score - min_score) / range
+            } else if max_score > 0.0 {
+                1.0
+            } else {
+                0.0
+            };
+
+            // Find top contributing tags.
+            let mut contributions: Vec<(String, f64)> = profile
+                .iter()
+                .filter_map(|(tag, pw)| item.tags.get(tag).map(|iw| (tag.clone(), pw * iw)))
+                .filter(|(_, c)| *c > 0.0)
+                .collect();
+            contributions
+                .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            contributions.truncate(3);
+
+            let explanation = if contributions.is_empty() {
+                "General match based on profile".into()
+            } else {
+                let reasons: Vec<String> = contributions
+                    .iter()
+                    .map(|(tag, _)| tag.replace('_', " "))
+                    .collect();
+                format!("Matches your preferences: {}", reasons.join(", "))
+            };
+
+            ScoredItem {
+                item_id: item.id.clone(),
+                item_name: item.name.clone(),
+                score: raw_score,
+                normalized_score: normalized,
+                top_contributing_tags: contributions,
+                explanation,
+            }
+        })
+        .collect();
+
+    info!(
+        candidates = catalog.len(),
+        after_filter = results.len(),
+        "[guided-flows-scoring] ranking complete"
+    );
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_catalog() -> Vec<CatalogItem> {
+        vec![
+            CatalogItem {
+                id: "whisper-local".into(),
+                name: "Local Whisper STT".into(),
+                description: "On-device speech recognition".into(),
+                tags: HashMap::from([
+                    ("privacy".into(), 1.0),
+                    ("local".into(), 1.0),
+                    ("voice".into(), 0.8),
+                    ("high_end".into(), 0.6),
+                ]),
+                exclude_if: vec![],
+                require_tags: vec![],
+                metadata: HashMap::new(),
+            },
+            CatalogItem {
+                id: "cloud-stt".into(),
+                name: "Cloud STT (Deepgram)".into(),
+                description: "Cloud-based speech recognition".into(),
+                tags: HashMap::from([
+                    ("cloud".into(), 1.0),
+                    ("voice".into(), 0.9),
+                    ("low_latency".into(), 0.8),
+                ]),
+                exclude_if: vec!["privacy".into()],
+                require_tags: vec![],
+                metadata: HashMap::new(),
+            },
+            CatalogItem {
+                id: "ollama-local".into(),
+                name: "Ollama Local LLM".into(),
+                description: "Run LLMs locally".into(),
+                tags: HashMap::from([
+                    ("privacy".into(), 1.0),
+                    ("local".into(), 1.0),
+                    ("high_end".into(), 0.9),
+                    ("developer".into(), 0.7),
+                ]),
+                exclude_if: vec![],
+                require_tags: vec!["high_end".into()],
+                metadata: HashMap::new(),
+            },
+            CatalogItem {
+                id: "piper-tts".into(),
+                name: "Piper TTS".into(),
+                description: "Fast local text-to-speech".into(),
+                tags: HashMap::from([
+                    ("voice".into(), 1.0),
+                    ("local".into(), 0.9),
+                    ("low_end".into(), 0.8),
+                ]),
+                exclude_if: vec![],
+                require_tags: vec![],
+                metadata: HashMap::new(),
+            },
+        ]
+    }
+
+    #[test]
+    fn accumulate_tags_adds_weights() {
+        let mut profile = TagVector::new();
+        let mappings = vec![ChoiceTagMapping {
+            choice: "Keep everything local".into(),
+            tags: HashMap::from([("privacy".into(), 1.0), ("local".into(), 0.9)]),
+        }];
+        accumulate_tags(&mut profile, "Keep everything local", &mappings);
+        assert_eq!(profile["privacy"], 1.0);
+        assert_eq!(profile["local"], 0.9);
+    }
+
+    #[test]
+    fn accumulate_tags_sums_across_questions() {
+        let mut profile = TagVector::new();
+        let m1 = vec![ChoiceTagMapping {
+            choice: "Voice".into(),
+            tags: HashMap::from([("voice".into(), 1.0)]),
+        }];
+        let m2 = vec![ChoiceTagMapping {
+            choice: "Meetings".into(),
+            tags: HashMap::from([("voice".into(), 0.5), ("meetings".into(), 1.0)]),
+        }];
+        accumulate_tags(&mut profile, "Voice", &m1);
+        accumulate_tags(&mut profile, "Meetings", &m2);
+        assert_eq!(profile["voice"], 1.5); // summed
+        assert_eq!(profile["meetings"], 1.0);
+    }
+
+    #[test]
+    fn accumulate_tags_case_insensitive() {
+        let mut profile = TagVector::new();
+        let mappings = vec![ChoiceTagMapping {
+            choice: "High-end".into(),
+            tags: HashMap::from([("high_end".into(), 1.0)]),
+        }];
+        accumulate_tags(&mut profile, "high-end", &mappings);
+        assert_eq!(profile["high_end"], 1.0);
+    }
+
+    #[test]
+    fn accumulate_tags_no_match_does_nothing() {
+        let mut profile = TagVector::new();
+        let mappings = vec![ChoiceTagMapping {
+            choice: "X".into(),
+            tags: HashMap::from([("x".into(), 1.0)]),
+        }];
+        accumulate_tags(&mut profile, "Y", &mappings);
+        assert!(profile.is_empty());
+    }
+
+    #[test]
+    fn dot_product_basic() {
+        let profile = HashMap::from([("voice".into(), 1.0), ("privacy".into(), 0.8)]);
+        let item = CatalogItem {
+            id: "t".into(),
+            name: "t".into(),
+            description: "t".into(),
+            tags: HashMap::from([("voice".into(), 0.9), ("privacy".into(), 1.0)]),
+            exclude_if: vec![],
+            require_tags: vec![],
+            metadata: HashMap::new(),
+        };
+        let score = dot_product_score(&profile, &item);
+        // 1.0*0.9 + 0.8*1.0 = 1.7
+        assert!((score - 1.7).abs() < 1e-10);
+    }
+
+    #[test]
+    fn cosine_similarity_identical_vectors() {
+        let a = HashMap::from([("x".into(), 1.0), ("y".into(), 2.0)]);
+        let b = HashMap::from([("x".into(), 1.0), ("y".into(), 2.0)]);
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn cosine_similarity_orthogonal() {
+        let a = HashMap::from([("x".into(), 1.0)]);
+        let b = HashMap::from([("y".into(), 1.0)]);
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn cosine_similarity_empty_returns_zero() {
+        let a = TagVector::new();
+        let b = HashMap::from([("x".into(), 1.0)]);
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn hard_constraint_exclude_if() {
+        let profile = HashMap::from([("privacy".into(), 1.0)]);
+        let catalog = sample_catalog();
+        // "cloud-stt" has exclude_if: ["privacy"] — should be filtered out.
+        let results = rank_items(&profile, &catalog, 10);
+        assert!(!results.iter().any(|r| r.item_id == "cloud-stt"));
+    }
+
+    #[test]
+    fn hard_constraint_require_tags() {
+        let profile = HashMap::from([("privacy".into(), 1.0), ("local".into(), 1.0)]);
+        // "ollama-local" requires "high_end" — should be filtered out.
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 10);
+        assert!(!results.iter().any(|r| r.item_id == "ollama-local"));
+    }
+
+    #[test]
+    fn hard_constraint_require_tags_passes() {
+        let profile = HashMap::from([
+            ("privacy".into(), 1.0),
+            ("local".into(), 1.0),
+            ("high_end".into(), 1.0),
+        ]);
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 10);
+        // Now ollama-local should appear (has high_end requirement met).
+        assert!(results.iter().any(|r| r.item_id == "ollama-local"));
+    }
+
+    #[test]
+    fn rank_items_sorted_descending() {
+        let profile = HashMap::from([
+            ("privacy".into(), 1.0),
+            ("local".into(), 1.0),
+            ("voice".into(), 0.5),
+            ("high_end".into(), 1.0),
+        ]);
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 10);
+        // Scores should be descending.
+        for window in results.windows(2) {
+            assert!(window[0].score >= window[1].score);
+        }
+    }
+
+    #[test]
+    fn rank_items_top_n_limits() {
+        let profile = HashMap::from([("voice".into(), 1.0)]);
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 2);
+        assert!(results.len() <= 2);
+    }
+
+    #[test]
+    fn rank_items_normalized_scores() {
+        let profile = HashMap::from([("voice".into(), 1.0), ("local".into(), 0.5)]);
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 10);
+        // First item should have normalized_score = 1.0 (highest).
+        if !results.is_empty() {
+            assert!((results[0].normalized_score - 1.0).abs() < 1e-10);
+        }
+        // All normalized scores should be in [0, 1].
+        for r in &results {
+            assert!(r.normalized_score >= 0.0 && r.normalized_score <= 1.0);
+        }
+    }
+
+    #[test]
+    fn rank_items_empty_profile() {
+        let profile = TagVector::new();
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 10);
+        // All scores should be 0.
+        for r in &results {
+            assert_eq!(r.score, 0.0);
+        }
+    }
+
+    #[test]
+    fn rank_items_empty_catalog() {
+        let profile = HashMap::from([("voice".into(), 1.0)]);
+        let results = rank_items(&profile, &[], 10);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn scored_item_has_explanation() {
+        let profile = HashMap::from([("voice".into(), 1.0), ("privacy".into(), 0.8)]);
+        let catalog = sample_catalog();
+        let results = rank_items(&profile, &catalog, 10);
+        for r in &results {
+            assert!(!r.explanation.is_empty());
+        }
+    }
+
+    #[test]
+    fn top_contributing_tags_limited_to_3() {
+        let profile = HashMap::from([
+            ("a".into(), 1.0),
+            ("b".into(), 1.0),
+            ("c".into(), 1.0),
+            ("d".into(), 1.0),
+            ("e".into(), 1.0),
+        ]);
+        let item = CatalogItem {
+            id: "t".into(),
+            name: "t".into(),
+            description: "t".into(),
+            tags: HashMap::from([
+                ("a".into(), 1.0),
+                ("b".into(), 1.0),
+                ("c".into(), 1.0),
+                ("d".into(), 1.0),
+                ("e".into(), 1.0),
+            ]),
+            exclude_if: vec![],
+            require_tags: vec![],
+            metadata: HashMap::new(),
+        };
+        let results = rank_items(&profile, &[item], 1);
+        assert!(results[0].top_contributing_tags.len() <= 3);
+    }
+
+    #[test]
+    fn conversion_event_serializes() {
+        let event = ConversionEvent {
+            session_id: "s1".into(),
+            item_id: "whisper-local".into(),
+            action: ConversionAction::Accepted,
+            timestamp: 1700000000,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let back: ConversionEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.action, ConversionAction::Accepted);
+    }
+}

--- a/src/openhuman/guided_flows/types.rs
+++ b/src/openhuman/guided_flows/types.rs
@@ -1,0 +1,116 @@
+//! Domain types for guided recommendation flows.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerType {
+    SingleChoice,
+    MultiChoice,
+    FreeText,
+    Number,
+    Boolean,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowStep {
+    pub id: String,
+    pub prompt: String,
+    pub answer_type: AnswerType,
+    #[serde(default)]
+    pub choices: Vec<String>,
+    #[serde(default)]
+    pub validation: Option<String>,
+    #[serde(default)]
+    pub branches: HashMap<String, String>,
+    pub next: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowDefinition {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub version: u32,
+    pub start_step: String,
+    pub steps: Vec<FlowStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepAnswer {
+    pub step_id: String,
+    pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowSessionState {
+    Active,
+    Completed,
+    Abandoned,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowSession {
+    pub session_id: String,
+    pub flow_id: String,
+    pub state: FlowSessionState,
+    pub current_step: String,
+    pub answers: Vec<StepAnswer>,
+    pub recommendation: Option<Recommendation>,
+    pub created_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Recommendation {
+    pub title: String,
+    pub summary: String,
+    pub confidence: f64,
+    pub next_actions: Vec<String>,
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn answer_type_serializes_snake_case() {
+        let at = AnswerType::SingleChoice;
+        assert_eq!(serde_json::to_string(&at).unwrap(), "\"single_choice\"");
+    }
+
+    #[test]
+    fn session_state_serializes() {
+        assert_eq!(
+            serde_json::to_string(&FlowSessionState::Active).unwrap(),
+            "\"active\""
+        );
+        assert_eq!(
+            serde_json::to_string(&FlowSessionState::Completed).unwrap(),
+            "\"completed\""
+        );
+    }
+
+    #[test]
+    fn recommendation_round_trips() {
+        let rec = Recommendation {
+            title: "Use Whisper".into(),
+            summary: "Local STT".into(),
+            confidence: 0.92,
+            next_actions: vec!["Install whisper".into()],
+            metadata: HashMap::new(),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: Recommendation = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.title, "Use Whisper");
+    }
+
+    #[test]
+    fn flow_definition_deserializes() {
+        let json = r#"{"id":"onboarding","name":"Setup","description":"x","version":1,"start_step":"q1","steps":[{"id":"q1","prompt":"?","answer_type":"single_choice","choices":["a"],"next":null}]}"#;
+        let def: FlowDefinition = serde_json::from_str(json).unwrap();
+        assert_eq!(def.steps[0].answer_type, AnswerType::SingleChoice);
+    }
+}

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -50,6 +50,7 @@ pub mod doctor;
 pub mod embeddings;
 pub mod encryption;
 pub mod file_state;
+pub mod guided_flows;
 pub mod harness_init;
 pub mod health;
 pub mod heartbeat;

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -649,3 +649,21 @@ pub fn is_transient_fs_error(err: &anyhow::Error) -> bool {
     }
     false
 }
+
+// ---------------------------------------------------------------------------
+// Shared helpers for domain modules (voice_assistant, live_captions, etc.)
+// ---------------------------------------------------------------------------
+
+/// Generate a UUID v4 string.
+pub fn uuid_v4() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Current Unix epoch in seconds.
+pub fn now_epoch() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -13388,3 +13388,100 @@ async fn json_rpc_threads_token_usage_reads_persisted_thread_totals() {
 
     rpc_join.abort();
 }
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn guided_flows_lifecycle_over_rpc() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    let (mock_addr, mock_join) = serve_on_ephemeral(mock_upstream_router()).await;
+    let mock_origin = format!("http://{}", mock_addr);
+    write_min_config(&openhuman_home, &mock_origin);
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{}", rpc_addr);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // 1. List flows — should include the builtin onboarding flow.
+    let list = post_json_rpc(
+        &rpc_base,
+        200,
+        "openhuman.guided_flows_list_flows",
+        json!({}),
+    )
+    .await;
+    let list_r = assert_no_jsonrpc_error(&list, "guided_flows_list_flows");
+    let result = list_r.get("result").unwrap_or(list_r);
+    let flows = result
+        .get("flows")
+        .and_then(Value::as_array)
+        .expect("flows array");
+    assert!(!flows.is_empty(), "should have at least one flow: {result}");
+
+    // 2. Start the onboarding flow.
+    let start = post_json_rpc(
+        &rpc_base,
+        201,
+        "openhuman.guided_flows_start_flow",
+        json!({ "flow_id": "onboarding_setup" }),
+    )
+    .await;
+    let start_r = assert_no_jsonrpc_error(&start, "guided_flows_start_flow");
+    let start_body = start_r.get("result").unwrap_or(start_r);
+    assert_eq!(
+        start_body.get("ok"),
+        Some(&json!(true)),
+        "start should succeed: {start_body}"
+    );
+    let session_id = start_body
+        .get("session_id")
+        .and_then(Value::as_str)
+        .expect("session_id");
+
+    // 3. Submit answer to first step.
+    let answer = post_json_rpc(
+        &rpc_base,
+        202,
+        "openhuman.guided_flows_submit_answer",
+        json!({
+            "session_id": session_id,
+            "step_id": "use_case",
+            "value": "Personal productivity"
+        }),
+    )
+    .await;
+    let answer_r = assert_no_jsonrpc_error(&answer, "guided_flows_submit_answer");
+    let answer_body = answer_r.get("result").unwrap_or(answer_r);
+    assert_eq!(
+        answer_body.get("ok"),
+        Some(&json!(true)),
+        "answer should succeed: {answer_body}"
+    );
+
+    // 4. Get session state.
+    let state = post_json_rpc(
+        &rpc_base,
+        203,
+        "openhuman.guided_flows_get_session",
+        json!({ "session_id": session_id }),
+    )
+    .await;
+    let state_r = assert_no_jsonrpc_error(&state, "guided_flows_get_session");
+    let state_body = state_r.get("result").unwrap_or(state_r);
+    assert_eq!(
+        state_body.get("ok"),
+        Some(&json!(true)),
+        "get_session should succeed: {state_body}"
+    );
+
+    mock_join.abort();
+    rpc_join.abort();
+}


### PR DESCRIPTION
Self-contained domain module — split from #2261 (PR 2/7).

Depends on #4142 (shared wiring).

## What

Quiz-style guided recommendation flows with branching logic and tag-based scoring.

### Files (6)
- `types.rs` — FlowDefinition, Step, Session, Answer types
- `engine.rs` — Branching state machine, LRU session eviction (64 max), answer validation
- `scoring.rs` — Tag accumulation + cosine similarity ranking
- `rpc.rs` — 5 handlers: list_flows, start_flow, submit_answer, get_session, register_flow
- `schemas.rs` — Controller registry (Def pattern)
- `mod.rs` — Module exports

### Built-in flows
- `onboarding_setup` — 4 steps, 1 branch
- `tool_recommendation` — 3 steps, linear

### E2E
`guided_flows_lifecycle_over_rpc` — list → start → submit → get_session

## Validation
- `cargo fmt --check` passes
- Unit tests in engine.rs + scoring.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided recommendation flows with session start, answer submission, progress tracking, and recommendations.
  * Added support for new capability areas including live captions, voice actions, operator inbox, and chat-with-data.
  * Added shared utility helpers for generating IDs and timestamps.

* **Bug Fixes**
  * Improved RPC registration and schema coverage for the new guided flows.

* **Tests**
  * Added end-to-end coverage for the guided-flows lifecycle over JSON-RPC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->