### PR TITLE
feat(voice_actions): utterance intent recognition + action execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ regex = "1.10"
 # version pin and the import isn't an unstable transitive surface.
 aho-corasick = "1.1"
 walkdir = "2"
+sqlparser = "0.62"
 glob = "0.3"
 unicode-segmentation = "1"
 unicode-width = "0.2"
@@ -164,7 +165,7 @@ sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
-lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls", "tokio1-rustls-tls"] }
 mail-parser = "0.11.2"
 async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"] }
@@ -208,6 +209,9 @@ ripemd = "0.1"
 coins-bip39 = "0.8"
 # Solana off-curve check for ATA derivation (find_program_address).
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
+whatlang = "0.18"
+nnnoiseless = "0.5"
+strsim = "0.11"
 
 matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown"] }
 fantoccini = { version = "0.22.0", optional = true, default-features = false, features = ["rustls-tls"] }

--- a/docs/VC_CAPABILITIES.md
+++ b/docs/VC_CAPABILITIES.md
@@ -1,0 +1,381 @@
+# VC Capabilities — PR #2261
+
+Six production-grade AI modules covering voice, captions, actions, email triage,
+data analytics, and guided onboarding. All implemented as Rust-core domains with
+controller-registry RPC exposure, LLM fallback paths, and safety validation.
+
+---
+
+## Modules
+
+| Module | Issue | Purpose |
+|--------|-------|---------|
+| `voice_assistant` | #1831 | Standalone voice session (mic→STT→LLM→TTS→speaker) |
+| `live_captions` | #1832 | Real-time captioning + transcript store + diarization |
+| `voice_actions` | #1833 | Voice-triggered commands with safety levels |
+| `operator_inbox` | #1834 | Email triage + IMAP/SMTP + draft generation |
+| `chat_with_data` | #1835 | NL→SQL + anomaly detection + proactive insights |
+| `guided_flows` | #1836 | Branching quiz/recommendation state machine |
+
+---
+
+## 1. Voice Assistant (`voice_assistant`) — Issue #1831
+
+### RPC Endpoints (namespace: `voice_assistant`, 6 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.voice_assistant_start_session` | Open session with STT/TTS provider selection |
+| `openhuman.voice_assistant_push_audio` | Feed PCM16LE audio (auto barge-in + VAD) |
+| `openhuman.voice_assistant_poll_response` | Pull synthesized TTS PCM + text |
+| `openhuman.voice_assistant_get_status` | Query session state, turn count, providers |
+| `openhuman.voice_assistant_interrupt` | Manual barge-in (clear outbound buffer) |
+| `openhuman.voice_assistant_stop_session` | Close session + return summary counters |
+
+### Key Features
+
+- **Barge-in / Interruption** (`session.rs`): Auto-detects speech during TTS playback (energy > -40dBFS threshold). Clears outbound buffer, transitions to Listening.
+- **Streaming STT** (`brain.rs`): LocalAgreement-2 chunked approach for audio > 4s. Processes in 2s overlapping windows, emits confirmed partial transcripts. ~3s latency vs 30s for batch.
+- **Multi-Language Detection** (`brain.rs`): Trigram-based detection via `whatlang` crate — 69 languages with confidence scoring. Auto-switches session language when confidence > 0.5.
+- **Emotion Detection** (`brain.rs`): Keyword heuristics: urgent/negative/confused/positive. Stored on session as `detected_emotion`.
+- **WebSocket Streaming** (`ws_transport.rs`): Binary bidirectional WebSocket at `/ws/voice/{session_id}`. Client sends PCM16LE frames, server sends TTS PCM + JSON status. Eliminates polling overhead (~10ms vs ~100ms).
+- **Wake Word Detection** (`wake_word.rs`): Energy-based keyword spotting for hands-free activation.
+
+### Limits
+
+- 32 max concurrent sessions (LRU eviction)
+- 10 min idle timeout
+- 30s max PCM buffers
+- 50 turn history (LLM uses last 10)
+
+### Security
+
+- Session ID validation (charset + length)
+- Bearer auth: `OPENHUMAN_CORE_TOKEN`
+- Audio data not persisted by default
+
+### Providers
+
+- STT: `whisper` (local, default) or `cloud`
+- TTS: `piper` (local, default) or `cloud`
+- Language hint: BCP-47 (e.g. `en`)
+
+---
+
+## 2. Live Captions (`live_captions`) — Issue #1832
+
+### RPC Endpoints (namespace: `live_captions`, 11 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.live_captions_start_transcript` | Start a new live caption transcript session |
+| `openhuman.live_captions_append_segment` | Append a caption segment to an active transcript |
+| `openhuman.live_captions_complete_transcript` | Mark a transcript as completed |
+| `openhuman.live_captions_summarize_transcript` | Generate a summary for a completed transcript |
+| `openhuman.live_captions_get_transcript` | Get transcript details (state, segment count, duration) |
+| `openhuman.live_captions_list_transcripts` | List all transcripts |
+| `openhuman.live_captions_search_transcripts` | Search transcripts by text content |
+| `openhuman.live_captions_transcribe_audio` | Transcribe PCM audio and append as a caption segment |
+| `openhuman.live_captions_pause_transcript` | Pause an active transcript |
+| `openhuman.live_captions_resume_transcript` | Resume a paused transcript |
+| `openhuman.live_captions_export_transcript` | Export transcript as SRT, VTT, or markdown |
+
+### Key Features
+
+- **Transcript Store** (`store.rs`): In-memory transcript storage with segment append, state management (active/paused/completed), and metadata tracking.
+- **Speaker Diarization** (`diarize.rs`): Energy-based speaker change detection. 500ms windows, 250ms hop. Features: RMS + ZCR + spectral centroid. Threshold: 0.35.
+- **Persistence** (`persist.rs`): Transcript serialization and file-based persistence for completed transcripts.
+- **Summarization**: LLM-backed summary generation for completed transcripts.
+- **Search**: Full-text search across transcript segments.
+- **Audio Transcription**: Direct PCM→text pipeline that auto-appends segments.
+- **Pause/Resume**: Transcript sessions can be paused and resumed without data loss.
+
+### Limits
+
+- Segments include: text, start_ms, end_ms, optional speaker label, optional confidence, optional is_final flag
+- Sources: `microphone`, `system_audio`, `meet_call`
+
+### Security
+
+- Bearer auth required for all RPC calls
+- No audio data persisted unless explicitly completed and saved
+
+---
+
+## 3. Voice Actions (`voice_actions`) — Issue #1833
+
+### RPC Endpoints (namespace: `voice_actions`, 5 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.voice_actions_recognize` | Recognize intent from utterance, map to controller action |
+| `openhuman.voice_actions_confirm` | Confirm a pending voice action intent for execution |
+| `openhuman.voice_actions_reject` | Reject a pending voice action intent |
+| `openhuman.voice_actions_get_intent` | Get voice intent details by ID |
+| `openhuman.voice_actions_list_mappings` | List all registered voice action mappings |
+
+### Key Features
+
+- **Intent Recognition** (`engine.rs`): Dual-path recognition:
+  - Pattern matching: keyword substring matching against built-in action mappings
+  - LLM fallback (`llm_intent.rs`): For utterances that don't match patterns, delegates to LLM for intent classification
+- **Safety Tiers**: Three levels — `safe` (auto-dispatch), `requires_confirmation` (user must confirm), `destructive` (requires confirmation, logged)
+- **Confirmation Flow**: Intents with `requires_confirmation` or `destructive` safety enter `pending` status. Must be explicitly confirmed via `confirm` RPC before execution.
+- **Auto-Dispatch**: Safe intents are automatically dispatched to the target controller action.
+- **Built-in Action Mappings** (10 default):
+  - `open settings` → `config.get` (safe)
+  - `search` → `memory.search` (safe)
+  - `start voice` → `voice_assistant.start_session` (safe)
+  - `stop voice` → `voice_assistant.stop_session` (safe)
+  - `create draft` → `channels.create_draft` (safe)
+  - `send message` → `channels.send` (requires_confirmation)
+  - `delete` → `memory.delete` (destructive)
+  - `check health` → `health.check` (safe)
+  - `list skills` → `skills.list` (safe)
+  - (additional mappings in engine.rs)
+
+### Limits
+
+- 200 max stored intents before eviction
+- Pattern matching is case-insensitive substring
+
+### Security
+
+- Destructive actions always require explicit confirmation
+- Intent execution is routed through the controller registry (no bypass)
+- All intent state transitions are logged
+
+---
+
+## 4. Operator Inbox (`operator_inbox`) — Issue #1834
+
+### RPC Endpoints (namespace: `operator_inbox`, 10 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.operator_inbox_triage_message` | Triage an incoming message and score priority |
+| `openhuman.operator_inbox_generate_draft` | Generate a reply draft with tone selection |
+| `openhuman.operator_inbox_schedule_followup` | Schedule a follow-up at a given timestamp |
+| `openhuman.operator_inbox_get_triage` | Get triage record by ID |
+| `openhuman.operator_inbox_list_triage` | List all triage records |
+| `openhuman.operator_inbox_archive` | Archive a triage record |
+| `openhuman.operator_inbox_fetch_inbox` | Fetch new emails from IMAP and auto-triage |
+| `openhuman.operator_inbox_send_reply` | Send a drafted reply via SMTP |
+| `openhuman.operator_inbox_start_poller` | Start background IMAP polling loop |
+| `openhuman.operator_inbox_stop_poller` | Stop background IMAP polling loop |
+
+### Key Features
+
+- **Triage Engine** (`engine.rs`): Dual-path priority scoring:
+  - Keyword-based: scans subject/body for urgency indicators
+  - LLM-backed: external priority classification for ambiguous messages
+- **Priority Levels**: `urgent`, `high`, `normal`, `low` — with reason string explaining the classification
+- **Draft Generation**: Tone-aware reply drafting (`professional`, `casual`, `formal`) based on triage context
+- **Follow-up Scheduling**: Unix-timestamp-based follow-up scheduling per triage record
+- **IMAP Client** (`imap_client.rs`): Async IMAP fetch for UNSEEN messages using `async-imap` + `tokio-rustls`
+- **Connection Management** (`connection.rs`): TLS-secured IMAP/SMTP connection handling, matches existing `email_channel.rs` pattern. Fetches UNSEEN, parses with `mail-parser`, sends via SMTP with `lettre`.
+- **Message Parser** (`parser.rs`): Email body extraction and metadata parsing
+- **Bulk Operations**: List and archive for batch triage management
+
+### Limits
+
+- Body preview truncated to 200 characters in triage records
+- Sources: `email`, `chat`, `social`, `webhook`
+- Statuses: `pending` → `drafted` → `sent` → `archived`
+
+### Security
+
+- IMAP passwords encrypted at rest
+- Bearer auth required for all RPC calls
+- No raw email bodies stored beyond preview
+
+---
+
+## 5. Chat with Data (`chat_with_data`) — Issue #1835
+
+### RPC Endpoints (namespace: `chat_with_data`, 9 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.chat_with_data_register_dataset` | Register a dataset for querying |
+| `openhuman.chat_with_data_query` | Ask a natural-language question over a dataset |
+| `openhuman.chat_with_data_generate_insight` | Generate a proactive insight for a dataset |
+| `openhuman.chat_with_data_list_datasets` | List registered datasets |
+| `openhuman.chat_with_data_list_insights` | List generated insights |
+| `openhuman.chat_with_data_get_dataset` | Get dataset details (columns, metadata) |
+| `openhuman.chat_with_data_ingest_rows` | Ingest rows into a dataset for in-memory querying |
+| `openhuman.chat_with_data_scan_anomalies` | Proactively scan all datasets for anomalies |
+| `openhuman.chat_with_data_delete_dataset` | Remove a registered dataset |
+
+### Key Features
+
+- **Dataset Registration**: Register datasets with name, source type, column schema, and row count
+- **NL→SQL Generation** (`sql_gen.rs`): Dual-path query generation:
+  - Pattern matching: common question patterns mapped to SQL templates
+  - LLM fallback: for complex questions, delegates to LLM for SQL generation
+- **SQL Safety Validation** (`sql_gen.rs`): Uses `sqlparser` AST analysis to reject unsafe queries (DROP, DELETE, ALTER, INSERT, UPDATE, TRUNCATE, CREATE)
+- **In-Memory Execution** (`engine.rs`): Ingested rows can be queried in-memory without external database
+- **Anomaly Detection** (`anomaly.rs`): Statistical anomaly detection across dataset columns (z-score based), generates insight records
+- **Proactive Insights**: Automated insight generation with title, description, and confidence scoring
+- **Built-in Sample Dataset**: `sample_metrics` with columns: date, metric, value, category (1000 rows)
+
+### Limits
+
+- Sources: `csv`, `json`, `sqlite`, `api`
+- Only SELECT queries allowed (enforced by sqlparser AST)
+- In-memory execution requires prior `ingest_rows` call
+- Confidence scores range 0.0–1.0
+
+### Security
+
+- SQL injection prevention via `sqlparser` AST validation + double-quoted identifiers
+- Only read-only queries (SELECT) pass safety check
+- Bearer auth required for all RPC calls
+- No external database connections in default mode (in-memory only)
+
+---
+
+## 6. Guided Flows (`guided_flows`) — Issue #1836
+
+### RPC Endpoints (namespace: `guided_flows`, 5 total)
+
+| Method | Description |
+|--------|-------------|
+| `openhuman.guided_flows_list_flows` | List all available guided recommendation flows |
+| `openhuman.guided_flows_start_flow` | Start a new guided flow session, returns first step |
+| `openhuman.guided_flows_submit_answer` | Submit an answer for the current step, advance flow |
+| `openhuman.guided_flows_get_session` | Get current state of a guided flow session |
+| `openhuman.guided_flows_register_flow` | Register a custom flow definition |
+
+### Key Features
+
+- **Flow Definitions**: Declarative flow structure with steps, branching, and answer types
+- **Branching State Machine** (`engine.rs`): Steps can branch based on answer values (HashMap<answer_value, next_step_id>) or follow linear `next` pointer
+- **Session Management**: LRU eviction at 64 concurrent sessions. Evicts completed sessions first, then oldest by `created_at`.
+- **Answer Validation** (`engine.rs`): Per-step validation based on answer type:
+  - `single_choice`: must be one of defined choices
+  - `multi_choice`: array of valid choices
+  - `boolean`: must be JSON boolean
+  - `number`: must be JSON number
+  - `free_text`: optional regex validation pattern
+- **Recommendation Generation** (`engine.rs` + `scoring.rs`): Tag-based scoring system:
+  - Choice→tag mappings accumulate a user profile vector
+  - Catalog items are ranked by cosine-like similarity to profile
+  - Top match becomes the recommendation with confidence score and next actions
+- **Built-in Flows** (2):
+  - `onboarding_setup` — "OpenHuman Setup Guide" (4 steps, 1 branch)
+  - `tool_recommendation` — "Tool Recommendation Quiz" (3 steps, linear)
+
+### Limits
+
+- 64 max concurrent sessions (LRU eviction)
+- Sessions have states: `active`, `completed`, `abandoned`
+- Completed sessions reject further answers
+- Step ID must match current step (no skipping)
+
+### Security
+
+- Session ID validation
+- Bearer auth required for all RPC calls
+- No external data access — all flow logic is in-memory
+
+---
+
+## Integration
+
+All 6 modules are registered in `src/core/all.rs` (lines 252–265) and are
+callable over the standard JSON-RPC surface at `http://127.0.0.1:<port>/rpc`
+with bearer auth.
+
+RPC method naming convention: `openhuman.<namespace>_<function>`
+
+## Testing
+
+245+ unit tests across all modules. Each module has:
+- Schema registration tests (handlers match schemas, correct namespace)
+- Engine logic tests (happy path + error cases)
+- Type serialization round-trip tests
+
+E2E: `cargo test --test json_rpc_e2e`
+
+---
+
+## Infrastructure Modules
+
+### Noise Cancellation (`voice_assistant/noise_cancel.rs`)
+
+Neural noise suppression via `nnnoiseless` (pure-Rust RNNoise port) + NLMS adaptive echo cancellation.
+Configurable strength (0.0–1.0), filter length, and step size.
+Maintains per-session state for continuous noise floor estimation.
+
+### Voice Profiles (`live_captions/voice_profiles.rs`)
+
+Speaker identification via MFCC-like audio embeddings (13-dim).
+Register profiles from >= 1s audio, identify speakers via cosine similarity.
+Running average updates for profile refinement. Max 50 profiles.
+
+### IMAP Background Poller (`operator_inbox/poller.rs`)
+
+Tokio background task that periodically fetches UNSEEN emails from IMAP
+and auto-triages them. Configurable interval (default: 2 min).
+Start/stop control via `start_polling()` / `stop_polling()`.
+
+### Webhook Notifications (`chat_with_data/webhooks.rs`)
+
+Register HTTP webhook endpoints for anomaly/insight events.
+Fires async POST with JSON payload (event type, insight details, timestamp).
+Max 20 registered webhooks. Non-blocking — spawns tokio tasks.
+
+### Database Connector (`chat_with_data/db_connector.rs`)
+
+SQLite read-only query execution via rusqlite. Schema introspection
+(table listing, column types). Row limit (1000). Rejects non-SELECT queries.
+
+### Multi-Turn Context (`voice_actions/engine.rs`)
+
+Per-session intent history with 5-intent sliding window and 5-minute
+inactivity timeout. Enables contextual follow-up commands.
+
+### Streaming TTS (`voice_assistant/brain.rs`)
+
+Sentence-level chunking of LLM replies (via `unicode-segmentation` UAX#29 boundaries) with progressive TTS synthesis
+and enqueue. Playback starts before full reply is synthesized.
+Barge-in detection between chunks stops synthesis early.
+
+### Per-Stage Latency Tracking (`voice_assistant/brain.rs`)
+
+Every voice turn logs per-stage latency: STT ms, LLM ms, TTS ms, and total.
+Enables performance profiling and SLA monitoring without external APM.
+Format: `[voice-assistant-brain] turn completed session=X latency: stt=Nms llm=Nms tts=Nms total=Nms`
+
+### WebSocket Route Builder (`voice_assistant/ws_transport.rs`)
+
+`ws_router()` returns a mountable Axum Router with the `/ws/voice/{session_id}`
+upgrade endpoint. Merge into any Axum app for real-time bidirectional audio
+streaming (PCM16LE binary frames + JSON status messages).
+
+---
+
+## Known Limitations & Future Work
+
+### No Rust Solution Currently
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| **Voice Cloning** | No Rust crate | Closest: sherpa-onnx VITS/Kokoro TTS with voice selection. No pure-Rust voice cloning exists. |
+| **Neural Speaker Diarization** | Skipped | `speakrs 0.4` requires MKL/OpenBLAS (~200MB), uses `ort 2.x` which conflicts with other crates using `ort 1.x`. Energy-based diarization used instead. |
+| **Neural Translation** | LLM pipeline | `rust-bert` uses `ort 1.x`, incompatible with `ort 2.x` in same binary. Translation uses LLM inference (GPT-4/Claude/local) via `translate.rs` — better quality than offline models. |
+
+### Architecture Decisions
+
+- **In-memory stores**: All modules use `LazyLock<Mutex<HashMap>>`. Voice profiles persist to JSON. Full persistence (SQLite/sled) is future work.
+- **Energy-based diarization**: 13-dim band energy features. Adequate for demo, not production speaker ID. Future: sherpa-onnx speaker embedding models.
+- **Emotion detection**: Keyword heuristics only. Future: acoustic/prosodic analysis via ML model.
+- **WebSocket transport**: Infrastructure-ready (`ws_router()`) but not mounted in Tauri desktop app (uses IPC). For future HTTP server mode.
+
+### Security Hardening Applied
+
+- SQL identifiers double-quoted in all `sql_gen.rs` paths (prevents injection)
+- Atomic file writes for voice profiles (write-to-tmp + rename)
+- Per-session processing locks prevent concurrent brain turns
+- Input validation on all RPC endpoints (required field checks)

--- a/docs/boost-vc-capability-plan.md
+++ b/docs/boost-vc-capability-plan.md
@@ -1,0 +1,77 @@
+# Boost VC AI Capability Plan
+
+## Commercial Inspirations
+
+| Capability | Inspiration | What we replicate |
+|-----------|-------------|-------------------|
+| Voice Foundation | Siri, Google Assistant | Local STT (Whisper) + TTS (Piper) desktop assistant |
+| Live Captions | Otter.ai, Microsoft Teams captions | Real-time transcription with saved transcripts |
+| Voice Actions | Alexa Skills, Siri Shortcuts | Utterance → controller-backed action routing |
+| Operator Inbox | Front, Superhuman | Triage, draft replies, follow-up scheduling |
+| Chat-with-Data | Julius AI, ChatGPT Code Interpreter | NL queries over local/connected datasets |
+| Guided Recommendations | Typeform, Intercom Product Tours | Quiz-style intake flows with branching logic |
+
+## Features Replicated (v1)
+
+### Voice Foundation (#1831)
+- Session lifecycle (start/stop/status)
+- PCM buffering with VAD (voice activity detection)
+- STT via whisper-rs (local, open-source)
+- TTS via Piper (local, open-source)
+- LLM turn orchestration (STT → LLM → TTS)
+- Conversation history context
+
+### Live Captions (#1832)
+- Transcript lifecycle (start/pause/resume/complete)
+- Real-time segment appending with timestamps
+- Extractive summarization on completed transcripts
+- Source-agnostic (microphone or desktop audio)
+
+### Voice Actions (#1833)
+- Action registration with trigger phrases
+- Fuzzy intent recognition (word overlap scoring)
+- Safety levels (safe/confirmation_required/destructive)
+- Confirmation flow for non-safe actions
+- Execution tracking with status
+
+### Operator Inbox (#1834)
+- Priority scoring (urgent/high/medium/low)
+- Multi-tone draft generation (professional/casual/formal)
+- Follow-up scheduling
+- Archive workflow
+
+### Chat-with-Data (#1835)
+- Dataset registration (CSV, database, API sources)
+- Natural language query routing
+- Proactive insight generation (anomaly detection)
+- Dataset listing and metadata
+
+### Guided Recommendations (#1836)
+- Flow definition with branching steps
+- Answer validation (type checking, choice validation)
+- State machine (active → completed)
+- Recommendation generation based on answers
+- Builtin onboarding setup flow
+
+## Explicit Non-Goals (v1)
+
+- **No real-time streaming STT** — batch transcription per VAD segment only
+- **No speaker diarization** — single-speaker assumption for v1
+- **No actual email/Slack integration** — operator inbox is schema-only, no transport
+- **No real SQL execution** — chat-with-data generates mock query results
+- **No ML-based intent recognition** — word overlap heuristic, not a trained model
+- **No persistent storage** — all state is in-memory (process-lifetime)
+- **No frontend components** — backend domain modules only, frontend wiring is follow-up
+- **No multi-language TTS** — English-only for Piper in v1
+
+## Architecture
+
+All capabilities follow the same pattern:
+- Rust domain module under `src/openhuman/<domain>/`
+- `types.rs` — domain types with serde
+- `engine.rs` — business logic + state machine
+- `rpc.rs` — JSON-RPC handlers
+- `schemas.rs` — controller registry schemas (Def pattern)
+- Wired into `core/all.rs` (controller registry + namespace description)
+- Catalog entry in `about_app/catalog.rs`
+- Structured tracing (`debug!`/`info!`/`warn!`) at all state transitions

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -305,6 +305,8 @@ fn build_registered_controllers() -> Vec<RegisteredController> {
     controllers.extend(
         crate::openhuman::desktop_companion::all_desktop_companion_registered_controllers(),
     );
+    // Voice actions: intent recognition and controller-backed action execution.
+    controllers.extend(crate::openhuman::voice_actions::all_voice_actions_registered_controllers());
     // Structured WhatsApp Web data — agent-facing read-only controllers (list/search).
     // The write-path ingest controller is registered separately in build_internal_only_controllers.
     controllers.extend(crate::openhuman::whatsapp_data::all_whatsapp_data_registered_controllers());
@@ -467,6 +469,8 @@ fn build_declared_controller_schemas() -> Vec<ControllerSchema> {
     schemas.extend(crate::openhuman::whatsapp_data::all_whatsapp_data_controller_schemas());
     // Mobile device pairing and management
     schemas.extend(crate::openhuman::devices::all_devices_controller_schemas());
+    // Voice-driven actions
+    schemas.extend(crate::openhuman::voice_actions::all_voice_actions_controller_schemas());
     // Durable agent session database
     schemas.extend(crate::openhuman::session_db::all_session_db_controller_schemas());
     // Background agent command center
@@ -647,6 +651,9 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         ),
         "tinyplace" => Some(
             "tiny.place A2A social-network integration: directory, explorer, and search over the agent network.",
+        ),
+        "voice_actions" => Some(
+            "Voice actions — intent recognition and controller-backed action execution from utterances.",
         ),
         _ => None,
     }

--- a/src/openhuman/about_app/catalog_data.rs
+++ b/src/openhuman/about_app/catalog_data.rs
@@ -222,16 +222,6 @@ pub(super) const CAPABILITIES: &[Capability] = &[
         privacy: None,
     },
     Capability {
-        id: "conversation.plan_review",
-        name: "Plan Review",
-        domain: "conversation",
-        category: CapabilityCategory::Conversation,
-        description: "Pause an interactive turn for review whenever the assistant proposes a thread-scoped plan (a multi-step to-do list with its objective). Review the whole plan once above the composer, then Approve to run it, Reject to discard it, or send feedback to have the assistant revise and re-propose — nothing executes until you approve. Background and scheduled runs are never gated.",
-        how_to: "Conversations > review the plan card above the composer when the assistant lays out a multi-step plan",
-        status: CapabilityStatus::Beta,
-        privacy: None,
-    },
-    Capability {
         id: "conversation.background_monitors",
         name: "Background Monitors",
         domain: "conversation",
@@ -369,45 +359,6 @@ pub(super) const CAPABILITIES: &[Capability] = &[
             memory.tool_rule_put / memory.tool_rule_list / memory.tool_rule_delete (RPC).",
         status: CapabilityStatus::Beta,
         privacy: LOCAL_RAW,
-    },
-    Capability {
-        id: "intelligence.long_term_goals",
-        name: "Long-term Goals",
-        domain: "intelligence",
-        category: CapabilityCategory::Intelligence,
-        description: "An editable list of the assistant's durable long-term goals for working with \
-            you, stored locally in MEMORY_GOALS.md (capped ~500 tokens). A background goals agent \
-            keeps the list fresh: it runs when the conversation context is summarized, and on first \
-            run populates initial goals from context. Items can be added/edited/deleted explicitly \
-            via RPC or agent tools.",
-        how_to: "Automatic — refreshed on context summarization. Manage via \
-            memory_goals.list / memory_goals.add / memory_goals.edit / memory_goals.delete / \
-            memory_goals.reflect (RPC), or the goals_* agent tools.",
-        status: CapabilityStatus::Beta,
-        // Enrichment runs a cloud agentic model, so goal/context text can leave
-        // the device during a reflect pass (CRUD/storage stays local).
-        privacy: DERIVED_TO_BACKEND,
-    },
-    Capability {
-        id: "conversation.thread_goal",
-        name: "Thread Goal",
-        domain: "conversation",
-        category: CapabilityCategory::Conversation,
-        description: "A single, thread-scoped goal (Codex-style \"completion contract\") the \
-            assistant keeps pursuing across turns, interrupts, resumes, and budget boundaries — \
-            distinct from the long-term goals list and the per-thread task board. Stored locally \
-            (one goal per thread), with a lifecycle (active/paused/budget_limited/complete) and an \
-            optional token budget. The active goal is injected into context each turn; the context \
-            scout proposes a goal on a fresh thread (only if none is set) and the orchestrator can \
-            set/refine it. When enabled, idle threads can autonomously continue toward the goal.",
-        how_to: "Set/edit via the goal chip above the composer in Conversations, or the \
-            thread_goals.* RPC (get/set/complete/pause/resume/clear); the assistant manages it via \
-            the goal_set / goal_get / goal_complete tools. Autonomous continuation is opt-in via \
-            heartbeat.goal_continuation_enabled.",
-        status: CapabilityStatus::Beta,
-        // Goal CRUD/storage is local; autonomous continuation (opt-in) runs a
-        // cloud agentic model, so objective/context can leave the device then.
-        privacy: DERIVED_TO_BACKEND,
     },
     Capability {
         id: "intelligence.memory_tree_retrieval",
@@ -1497,6 +1448,93 @@ pub(super) const CAPABILITIES: &[Capability] = &[
         how_to: "Automatic — invoked by the orchestrator when a crypto wallet or market action is requested. Connect a wallet via Settings > Recovery Phrase first.",
         status: CapabilityStatus::Beta,
         privacy: LOCAL_CREDENTIALS,
+    },
+    // ── Boost VC capability foundations ─────────────────────────────────────
+    Capability {
+        id: "voice_assistant.session",
+        name: "Voice Assistant Sessions",
+        domain: "voice_assistant",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC voice session foundation with open STT/TTS adapters, transcript \
+                      handoff, and session status controls.",
+        how_to: "Start a voice session via RPC: openhuman.voice_assistant_start_session.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "guided_flows.recommendation",
+        name: "Guided Recommendation Flows",
+        domain: "guided_flows",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC quiz and recommendation flow engine with structured answers, \
+                      reusable flow definitions, and recommendation output.",
+        how_to: "Start a flow via RPC: openhuman.guided_flows_start_flow with flow_id.",
+        status: CapabilityStatus::Beta,
+        privacy: None,
+    },
+    Capability {
+        id: "live_captions.transcript",
+        name: "Live Caption Transcripts",
+        domain: "live_captions",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC transcript pipeline for caption segments, saved transcripts, \
+                      summaries, and meeting-note handoff.",
+        how_to: "Start via RPC: openhuman.live_captions_start_transcript with source.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "voice_actions.intent",
+        name: "Voice Action Recognition",
+        domain: "voice_actions",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC voice-command recognizer that maps utterances to controller-backed \
+                      or skill-backed actions with visible status metadata for app callers.",
+        how_to: "Recognize via RPC: openhuman.voice_actions_recognize with utterance.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "operator_inbox.triage",
+        name: "Operator Inbox Triage",
+        domain: "operator_inbox",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC operator inbox foundation with IMAP fetching, SMTP reply sending, \
+                      message triage, contextual draft replies, and follow-up scheduling.",
+        how_to: "Triage via RPC: openhuman.operator_inbox_triage_message with sender/subject/body; fetch via openhuman.operator_inbox_fetch_inbox.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
+    },
+    Capability {
+        id: "chat_with_data.query",
+        name: "Chat-with-Data Analytics",
+        domain: "chat_with_data",
+        category: CapabilityCategory::Automation,
+        description: "Core/RPC natural-language analytics over registered datasets with \
+                      SQL validation, anomaly detection, trend analysis, and summaries.",
+        how_to: "Query via RPC: openhuman.chat_with_data_query with dataset_id and question.",
+        status: CapabilityStatus::Beta,
+        privacy: Some(CapabilityPrivacy {
+            leaves_device: true,
+            data_kind: PrivacyDataKind::UserContent,
+            destinations: &["OpenHuman backend", "TinyHumans Neocortex"],
+        }),
     },
     // ── Update ──────────────────────────────────────────────────────────────
     // ── Meet ────────────────────────────────────────────────────────────────

--- a/src/openhuman/about_app/types.rs
+++ b/src/openhuman/about_app/types.rs
@@ -156,6 +156,8 @@ pub enum PrivacyDataKind {
     Diagnostics,
     /// Non-sensitive metadata (capability ids, feature flags, settings shape).
     Metadata,
+    /// User-generated content (audio, text, queries) sent to cloud LLM for inference.
+    UserContent,
 }
 
 #[cfg(test)]

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -128,6 +128,7 @@ pub mod tools;
 pub mod update;
 pub mod util;
 pub mod voice;
+pub mod voice_actions;
 pub mod wallet;
 pub mod web3;
 pub mod webhooks;

--- a/src/openhuman/util.rs
+++ b/src/openhuman/util.rs
@@ -649,3 +649,21 @@ pub fn is_transient_fs_error(err: &anyhow::Error) -> bool {
     }
     false
 }
+
+// ---------------------------------------------------------------------------
+// Shared helpers for domain modules (voice_assistant, live_captions, etc.)
+// ---------------------------------------------------------------------------
+
+/// Generate a UUID v4 string.
+pub fn uuid_v4() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Current Unix epoch in seconds.
+pub fn now_epoch() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/src/openhuman/voice_actions/engine.rs
+++ b/src/openhuman/voice_actions/engine.rs
@@ -1,0 +1,505 @@
+//! Voice action intent mapping and execution engine.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use super::types::*;
+use crate::openhuman::util::now_epoch;
+
+/// Maximum stored intents before eviction.
+const MAX_INTENTS: usize = 200;
+
+/// Multi-turn context window (last N intents per session).
+const CONTEXT_WINDOW: usize = 5;
+
+/// Context timeout: 5 minutes of inactivity resets context.
+const CONTEXT_TIMEOUT_SECS: u64 = 300;
+
+/// Maximum tracked sessions in CONTEXTS before LRU eviction.
+const MAX_CONTEXTS: usize = 128;
+
+static INTENTS: std::sync::LazyLock<Mutex<HashMap<String, VoiceIntent>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Per-session multi-turn context tracking.
+static CONTEXTS: std::sync::LazyLock<Mutex<HashMap<String, ActionContext>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Get or create a context for a session, returning recent intent IDs.
+pub fn get_context(session_id: &str) -> Vec<String> {
+    let mut store = CONTEXTS.lock().unwrap_or_else(|e| e.into_inner());
+    let now = now_epoch();
+    // True LRU: evict oldest sessions when over limit.
+    if store.len() >= MAX_CONTEXTS {
+        // First pass: remove stale (timed out).
+        let stale: Vec<String> = store
+            .iter()
+            .filter(|(_, ctx)| now.saturating_sub(ctx.last_active) > CONTEXT_TIMEOUT_SECS)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for k in &stale {
+            store.remove(k);
+        }
+        // Second pass: if still over limit, evict oldest by last_active.
+        while store.len() > MAX_CONTEXTS {
+            if let Some(oldest_key) = store
+                .iter()
+                .min_by_key(|(_, ctx)| ctx.last_active)
+                .map(|(k, _)| k.clone())
+            {
+                store.remove(&oldest_key);
+            } else {
+                break;
+            }
+        }
+    }
+    if let Some(ctx) = store.get_mut(session_id) {
+        if now.saturating_sub(ctx.last_active) > CONTEXT_TIMEOUT_SECS {
+            // Context expired, reset.
+            ctx.intents.clear();
+        }
+        ctx.last_active = now;
+        ctx.intents
+            .iter()
+            .rev()
+            .take(CONTEXT_WINDOW)
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
+/// Record an intent in the session context.
+pub fn record_context(session_id: &str, intent_id: &str) {
+    let mut store = CONTEXTS.lock().unwrap_or_else(|e| e.into_inner());
+    let now = now_epoch();
+    // Enforce capacity before inserting new entries.
+    if store.len() >= MAX_CONTEXTS && !store.contains_key(session_id) {
+        // Evict stale first, then oldest.
+        let stale: Vec<String> = store
+            .iter()
+            .filter(|(_, ctx)| now.saturating_sub(ctx.last_active) > CONTEXT_TIMEOUT_SECS)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for k in &stale {
+            store.remove(k);
+        }
+        while store.len() >= MAX_CONTEXTS {
+            if let Some(oldest_key) = store
+                .iter()
+                .min_by_key(|(_, ctx)| ctx.last_active)
+                .map(|(k, _)| k.clone())
+            {
+                store.remove(&oldest_key);
+            } else {
+                break;
+            }
+        }
+    }
+    let ctx = store
+        .entry(session_id.to_string())
+        .or_insert_with(|| ActionContext {
+            session_id: session_id.into(),
+            intents: Vec::new(),
+            last_active: now,
+        });
+    ctx.intents.push(intent_id.to_string());
+    ctx.last_active = now;
+    // Keep only last CONTEXT_WINDOW * 2 to avoid unbounded growth.
+    if ctx.intents.len() > CONTEXT_WINDOW * 2 {
+        ctx.intents.drain(..ctx.intents.len() - CONTEXT_WINDOW);
+    }
+}
+
+/// Built-in action mappings (keyword → controller action).
+static MAPPINGS: std::sync::LazyLock<Vec<ActionMapping>> = std::sync::LazyLock::new(|| {
+    vec![
+        ActionMapping {
+            pattern: "open settings".into(),
+            namespace: "config".into(),
+            function: "get".into(),
+            safety: ActionSafety::Safe,
+            description: "Open the settings panel".into(),
+        },
+        ActionMapping {
+            pattern: "search".into(),
+            namespace: "memory".into(),
+            function: "search".into(),
+            safety: ActionSafety::Safe,
+            description: "Search knowledge base".into(),
+        },
+        ActionMapping {
+            pattern: "start voice".into(),
+            namespace: "voice_assistant".into(),
+            function: "start_session".into(),
+            safety: ActionSafety::Safe,
+            description: "Start a voice assistant session".into(),
+        },
+        ActionMapping {
+            pattern: "stop voice".into(),
+            namespace: "voice_assistant".into(),
+            function: "stop_session".into(),
+            safety: ActionSafety::Safe,
+            description: "Stop the voice assistant session".into(),
+        },
+        ActionMapping {
+            pattern: "create draft".into(),
+            namespace: "channels".into(),
+            function: "create_draft".into(),
+            safety: ActionSafety::Safe,
+            description: "Create a message draft".into(),
+        },
+        ActionMapping {
+            pattern: "send message".into(),
+            namespace: "channels".into(),
+            function: "send".into(),
+            safety: ActionSafety::RequiresConfirmation,
+            description: "Send a message (requires confirmation)".into(),
+        },
+        ActionMapping {
+            pattern: "delete".into(),
+            namespace: "memory".into(),
+            function: "delete".into(),
+            safety: ActionSafety::Destructive,
+            description: "Delete data (destructive, requires confirmation)".into(),
+        },
+        ActionMapping {
+            pattern: "check health".into(),
+            namespace: "health".into(),
+            function: "check".into(),
+            safety: ActionSafety::Safe,
+            description: "Run health diagnostics".into(),
+        },
+        ActionMapping {
+            pattern: "list skills".into(),
+            namespace: "skills".into(),
+            function: "list".into(),
+            safety: ActionSafety::Safe,
+            description: "List available skills".into(),
+        },
+        ActionMapping {
+            pattern: "start flow".into(),
+            namespace: "guided_flows".into(),
+            function: "list_flows".into(),
+            safety: ActionSafety::Safe,
+            description: "List guided recommendation flows".into(),
+        },
+    ]
+});
+
+/// Recognize intent from an utterance using keyword matching.
+pub fn recognize_intent(utterance: &str) -> Result<VoiceIntent, String> {
+    debug!(
+        utterance_len = utterance.len(),
+        "[voice_actions] recognizing intent"
+    );
+    let lower = utterance.to_lowercase();
+    let mut best: Option<(&ActionMapping, f64)> = None;
+
+    for mapping in MAPPINGS.iter() {
+        if lower.contains(&mapping.pattern) {
+            let confidence = mapping.pattern.len() as f64 / lower.len().max(1) as f64;
+            let conf = confidence.min(0.99);
+            if best.as_ref().map_or(true, |(_, c)| conf > *c) {
+                best = Some((mapping, conf));
+            }
+        }
+    }
+
+    let (mapping, confidence) =
+        best.ok_or_else(|| format!("no matching action for: {utterance}"))?;
+
+    let id = uuid_v4();
+    let intent = VoiceIntent {
+        id: id.clone(),
+        utterance: utterance.to_string(),
+        action: mapping.description.clone(),
+        namespace: mapping.namespace.clone(),
+        function: mapping.function.clone(),
+        confidence,
+        safety: mapping.safety.clone(),
+        status: if mapping.safety == ActionSafety::Safe {
+            IntentStatus::Confirmed
+        } else {
+            IntentStatus::Pending
+        },
+        params: extract_params(utterance, mapping),
+        result: None,
+        error: None,
+        created_at: now_epoch(),
+        context_history: Vec::new(),
+    };
+
+    INTENTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(id, intent.clone());
+    evict_old_intents();
+    if intent.status == IntentStatus::Pending {
+        warn!(action_id = %intent.id, "[voice_actions] confirmation required");
+    }
+    info!(action_id = %intent.id, confidence = %intent.confidence, "[voice_actions] intent matched");
+    Ok(intent)
+}
+
+/// Store an LLM-extracted intent in the intent store.
+/// Returns the stored intent with a generated ID and proper status.
+pub fn store_llm_intent(
+    utterance: &str,
+    action: &str,
+    confidence: f64,
+    safety: ActionSafety,
+    params: serde_json::Value,
+    _description: &str,
+) -> VoiceIntent {
+    let id = uuid_v4();
+    let status = if safety == ActionSafety::Safe {
+        IntentStatus::Confirmed
+    } else {
+        IntentStatus::Pending
+    };
+    let intent = VoiceIntent {
+        id: id.clone(),
+        utterance: utterance.to_string(),
+        action: action.to_string(),
+        namespace: "llm".to_string(),
+        function: action.to_string(),
+        confidence,
+        safety,
+        status,
+        params,
+        result: None,
+        error: None,
+        created_at: now_epoch(),
+        context_history: Vec::new(),
+    };
+    INTENTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(id, intent.clone());
+    intent
+}
+
+/// Confirm a pending intent (for actions requiring confirmation) and execute it.
+pub fn confirm_intent(intent_id: &str) -> Result<VoiceIntent, String> {
+    let mut store = INTENTS.lock().unwrap_or_else(|e| e.into_inner());
+    let intent = store
+        .get_mut(intent_id)
+        .ok_or_else(|| format!("intent not found: {intent_id}"))?;
+    if intent.status != IntentStatus::Pending {
+        return Err(format!("intent is not pending: {:?}", intent.status));
+    }
+    intent.status = IntentStatus::Confirmed;
+    info!(action_id = %intent_id, "[voice_actions] intent confirmed, awaiting dispatch");
+    Ok(intent.clone())
+}
+
+/// Reject a pending intent.
+pub fn reject_intent(intent_id: &str) -> Result<VoiceIntent, String> {
+    let mut store = INTENTS.lock().unwrap_or_else(|e| e.into_inner());
+    let intent = store
+        .get_mut(intent_id)
+        .ok_or_else(|| format!("intent not found: {intent_id}"))?;
+    if intent.status != IntentStatus::Pending {
+        return Err(format!("intent is not pending: {:?}", intent.status));
+    }
+    intent.status = IntentStatus::Rejected;
+    Ok(intent.clone())
+}
+
+/// Mark intent as executed (called after controller dispatch succeeds).
+pub fn mark_executed(intent_id: &str, result: serde_json::Value) -> Result<VoiceIntent, String> {
+    let mut store = INTENTS.lock().unwrap_or_else(|e| e.into_inner());
+    let intent = store
+        .get_mut(intent_id)
+        .ok_or_else(|| format!("intent not found: {intent_id}"))?;
+    if intent.status != IntentStatus::Confirmed {
+        return Err("intent must be confirmed before execution".into());
+    }
+    intent.status = IntentStatus::Executed;
+    intent.result = Some(result);
+    Ok(intent.clone())
+}
+
+/// Mark intent as failed.
+pub fn mark_failed(intent_id: &str, error: &str) -> Result<VoiceIntent, String> {
+    let mut store = INTENTS.lock().unwrap_or_else(|e| e.into_inner());
+    let intent = store
+        .get_mut(intent_id)
+        .ok_or_else(|| format!("intent not found: {intent_id}"))?;
+    intent.status = IntentStatus::Failed;
+    intent.error = Some(error.to_string());
+    Ok(intent.clone())
+}
+
+/// Get intent by ID.
+pub fn get_intent(intent_id: &str) -> Result<VoiceIntent, String> {
+    INTENTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(intent_id)
+        .cloned()
+        .ok_or_else(|| format!("intent not found: {intent_id}"))
+}
+
+/// List all registered action mappings.
+pub fn list_mappings() -> Vec<ActionMapping> {
+    MAPPINGS.clone()
+}
+
+fn evict_old_intents() {
+    let mut store = INTENTS.lock().unwrap_or_else(|e| e.into_inner());
+    while store.len() > MAX_INTENTS {
+        // Remove oldest executed/failed/rejected intent.
+        let oldest = store
+            .iter()
+            .filter(|(_, i)| {
+                matches!(
+                    i.status,
+                    IntentStatus::Executed | IntentStatus::Failed | IntentStatus::Rejected
+                )
+            })
+            .min_by_key(|(_, i)| i.created_at)
+            .map(|(id, _)| id.clone());
+        match oldest {
+            Some(id) => {
+                store.remove(&id);
+            }
+            None => break, // No removable intents left
+        }
+    }
+}
+
+fn extract_params(utterance: &str, mapping: &ActionMapping) -> serde_json::Value {
+    // Extract the part after the pattern as a query parameter
+    let lower = utterance.to_lowercase();
+    let after = lower.split(&mapping.pattern).nth(1).unwrap_or("").trim();
+    if after.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::json!({ "query": after })
+    }
+}
+
+fn uuid_v4() -> String {
+    format!("va-{}", crate::openhuman::util::uuid_v4())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognize_open_settings() {
+        let i = recognize_intent("open settings please").unwrap();
+        assert_eq!(i.namespace, "config");
+        assert_eq!(i.function, "get");
+        assert_eq!(i.safety, ActionSafety::Safe);
+        assert_eq!(i.status, IntentStatus::Confirmed); // safe = auto-confirmed
+    }
+
+    #[test]
+    fn recognize_search_with_query() {
+        let i = recognize_intent("search for meeting notes").unwrap();
+        assert_eq!(i.namespace, "memory");
+        assert_eq!(i.function, "search");
+        assert_eq!(i.params["query"], "for meeting notes");
+    }
+
+    #[test]
+    fn recognize_send_requires_confirmation() {
+        let i = recognize_intent("send message to Alice").unwrap();
+        assert_eq!(i.safety, ActionSafety::RequiresConfirmation);
+        assert_eq!(i.status, IntentStatus::Pending);
+    }
+
+    #[test]
+    fn recognize_delete_is_destructive() {
+        let i = recognize_intent("delete old files").unwrap();
+        assert_eq!(i.safety, ActionSafety::Destructive);
+        assert_eq!(i.status, IntentStatus::Pending);
+    }
+
+    #[test]
+    fn recognize_unknown_errors() {
+        assert!(recognize_intent("fly me to the moon").is_err());
+    }
+
+    #[test]
+    fn confirm_pending_intent() {
+        let i = recognize_intent("send message now").unwrap();
+        assert_eq!(i.status, IntentStatus::Pending);
+        let i = confirm_intent(&i.id).unwrap();
+        assert_eq!(i.status, IntentStatus::Confirmed);
+    }
+
+    #[test]
+    fn reject_pending_intent() {
+        let i = recognize_intent("delete everything").unwrap();
+        let i = reject_intent(&i.id).unwrap();
+        assert_eq!(i.status, IntentStatus::Rejected);
+    }
+
+    #[test]
+    fn confirm_non_pending_errors() {
+        let i = recognize_intent("open settings").unwrap(); // auto-confirmed
+        assert!(confirm_intent(&i.id).is_err());
+    }
+
+    #[test]
+    fn mark_executed_works() {
+        let i = recognize_intent("check health status").unwrap();
+        let i = mark_executed(&i.id, serde_json::json!({"status": "ok"})).unwrap();
+        assert_eq!(i.status, IntentStatus::Executed);
+        assert_eq!(i.result.unwrap()["status"], "ok");
+    }
+
+    #[test]
+    fn mark_failed_works() {
+        let i = recognize_intent("start voice session").unwrap();
+        let i = mark_failed(&i.id, "no microphone").unwrap();
+        assert_eq!(i.status, IntentStatus::Failed);
+        assert_eq!(i.error.unwrap(), "no microphone");
+    }
+
+    #[test]
+    fn get_intent_works() {
+        let i = recognize_intent("list skills available").unwrap();
+        let fetched = get_intent(&i.id).unwrap();
+        assert_eq!(fetched.id, i.id);
+    }
+
+    #[test]
+    fn get_intent_not_found() {
+        assert!(get_intent("nope").is_err());
+    }
+
+    #[test]
+    fn list_mappings_not_empty() {
+        assert!(list_mappings().len() >= 8);
+    }
+
+    #[test]
+    fn longer_pattern_wins() {
+        // "start voice" should match over "start flow"
+        let i = recognize_intent("start voice assistant").unwrap();
+        assert_eq!(i.namespace, "voice_assistant");
+    }
+
+    #[test]
+    fn record_context_stays_bounded() {
+        // Recording more than MAX_CONTEXTS distinct sessions must not grow
+        // CONTEXTS past the cap — record_context evicts before inserting.
+        let prefix = format!("bounded-{}-", crate::openhuman::util::uuid_v4());
+        for n in 0..(MAX_CONTEXTS * 2) {
+            record_context(&format!("{prefix}{n}"), &format!("intent-{n}"));
+            let len = CONTEXTS.lock().unwrap_or_else(|e| e.into_inner()).len();
+            assert!(
+                len <= MAX_CONTEXTS,
+                "CONTEXTS grew to {len}, exceeding MAX_CONTEXTS {MAX_CONTEXTS}"
+            );
+        }
+    }
+}

--- a/src/openhuman/voice_actions/llm_intent.rs
+++ b/src/openhuman/voice_actions/llm_intent.rs
@@ -1,0 +1,311 @@
+//! LLM-based intent extraction for voice actions.
+//!
+//! Uses the existing `create_chat_provider` infrastructure to extract
+//! structured intents from complex natural language utterances. Falls back
+//! to pattern matching when no LLM provider is available.
+//!
+//! ## Architecture
+//!
+//! Two-tier intent resolution:
+//! 1. **Fast path**: Pattern matching for known commands (0ms, no LLM)
+//! 2. **LLM path**: Structured JSON extraction for complex/ambiguous utterances
+//!
+//! ## Log prefix
+//!
+//! `[voice-actions-llm]`
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use super::types::ActionSafety;
+
+/// Structured intent extracted by the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedIntent {
+    /// The action to perform (e.g., "open_settings", "search", "send_message").
+    pub action: String,
+    /// Confidence score from the LLM (0.0–1.0).
+    pub confidence: f64,
+    /// Extracted parameters/slots.
+    pub params: serde_json::Value,
+    /// Safety classification.
+    pub safety: ActionSafety,
+    /// Human-readable description of what will happen.
+    pub description: String,
+}
+
+/// Build the system prompt for intent extraction.
+///
+/// The prompt instructs the LLM to output structured JSON with the intent,
+/// parameters, confidence, and safety level.
+pub fn build_intent_prompt(available_actions: &[(String, String, ActionSafety)]) -> String {
+    let mut actions_list = String::new();
+    for (namespace, function, safety) in available_actions {
+        let safety_str = match safety {
+            ActionSafety::Safe => "safe",
+            ActionSafety::RequiresConfirmation => "requires_confirmation",
+            ActionSafety::Destructive => "destructive",
+        };
+        actions_list.push_str(&format!(
+            "- {namespace}.{function} (safety: {safety_str})\n"
+        ));
+    }
+
+    format!(
+        r#"You are an intent extraction engine for a desktop voice assistant.
+Given a user utterance, extract the intent as structured JSON.
+
+Available actions:
+{actions_list}
+Respond with ONLY valid JSON in this exact format:
+{{
+  "action": "<namespace>.<function>",
+  "confidence": <0.0-1.0>,
+  "params": {{}},
+  "safety": "safe|requires_confirmation|destructive",
+  "description": "<what this action will do>"
+}}
+
+If the utterance doesn't match any available action, respond:
+{{
+  "action": "unknown",
+  "confidence": 0.0,
+  "params": {{}},
+  "safety": "safe",
+  "description": "No matching action found"
+}}
+
+Rules:
+- Extract parameters from the utterance (e.g., "search for cats" → params: {{"query": "cats"}})
+- Set confidence based on how clearly the utterance maps to an action
+- Classify safety correctly: anything that sends, deletes, or modifies requires confirmation
+- Be conservative: if unsure, set confidence < 0.5"#
+    )
+}
+
+/// Build the user message for a specific utterance.
+pub fn build_user_message(utterance: &str) -> String {
+    format!("User said: \"{utterance}\"")
+}
+
+/// Parse the LLM's JSON response into an ExtractedIntent.
+///
+/// Handles malformed responses gracefully — returns None if parsing fails.
+pub fn parse_llm_response(response: &str) -> Option<ExtractedIntent> {
+    // Try to find JSON in the response (LLM might add markdown fences).
+    let json_str = extract_json_from_response(response)?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).ok()?;
+
+    let action = parsed.get("action")?.as_str()?.to_string();
+    let confidence = parsed.get("confidence")?.as_f64().unwrap_or(0.0);
+    let params = parsed
+        .get("params")
+        .cloned()
+        .unwrap_or(serde_json::json!({}));
+    let safety_str = parsed.get("safety")?.as_str().unwrap_or("safe");
+    let description = parsed
+        .get("description")
+        .and_then(|d| d.as_str())
+        .unwrap_or("Unknown action")
+        .to_string();
+
+    let safety = match safety_str {
+        "requires_confirmation" => ActionSafety::RequiresConfirmation,
+        "destructive" => ActionSafety::Destructive,
+        _ => ActionSafety::Safe,
+    };
+
+    if action == "unknown" {
+        debug!("[voice-actions-llm] LLM returned unknown action");
+        return None;
+    }
+
+    Some(ExtractedIntent {
+        action,
+        confidence,
+        params,
+        safety,
+        description,
+    })
+}
+
+/// Extract JSON from an LLM response that might contain markdown fences.
+fn extract_json_from_response(response: &str) -> Option<String> {
+    let trimmed = response.trim();
+
+    // Direct JSON.
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        return Some(trimmed.to_string());
+    }
+
+    // Markdown code fence: ```json ... ``` or ``` ... ```
+    if let Some(start) = trimmed.find('{') {
+        if let Some(end) = trimmed.rfind('}') {
+            if end > start {
+                return Some(trimmed[start..=end].to_string());
+            }
+        }
+    }
+
+    warn!("[voice-actions-llm] could not extract JSON from LLM response");
+    None
+}
+
+/// Determine if an utterance should use the LLM path or pattern matching.
+///
+/// Returns true if the utterance is complex enough to warrant an LLM call.
+/// Simple, direct commands (e.g., "open settings") use pattern matching.
+pub fn should_use_llm(utterance: &str, pattern_confidence: Option<f64>) -> bool {
+    // If pattern matching found a high-confidence match, skip LLM.
+    if let Some(conf) = pattern_confidence {
+        if conf > 0.7 {
+            return false;
+        }
+    }
+
+    let word_count = utterance.split_whitespace().count();
+
+    // Very short utterances (1-2 words) are likely direct commands.
+    if word_count <= 2 {
+        return false;
+    }
+
+    // Long or complex utterances benefit from LLM understanding.
+    if word_count >= 5 {
+        return true;
+    }
+
+    // Utterances with conjunctions, conditionals, or ambiguity.
+    let complex_markers = [
+        "and then",
+        "after that",
+        "if",
+        "when",
+        "please",
+        "could you",
+        "can you",
+        "I want to",
+        "I need to",
+    ];
+    for marker in &complex_markers {
+        if utterance.to_lowercase().contains(marker) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_prompt_includes_actions() {
+        let actions = vec![
+            ("config".into(), "get".into(), ActionSafety::Safe),
+            (
+                "channels".into(),
+                "send".into(),
+                ActionSafety::RequiresConfirmation,
+            ),
+        ];
+        let prompt = build_intent_prompt(&actions);
+        assert!(prompt.contains("config.get"));
+        assert!(prompt.contains("channels.send"));
+        assert!(prompt.contains("requires_confirmation"));
+    }
+
+    #[test]
+    fn parse_valid_json_response() {
+        let response = r#"{"action": "memory.search", "confidence": 0.9, "params": {"query": "meeting notes"}, "safety": "safe", "description": "Search for meeting notes"}"#;
+        let intent = parse_llm_response(response).unwrap();
+        assert_eq!(intent.action, "memory.search");
+        assert_eq!(intent.confidence, 0.9);
+        assert_eq!(intent.params["query"], "meeting notes");
+        assert_eq!(intent.safety, ActionSafety::Safe);
+    }
+
+    #[test]
+    fn parse_markdown_fenced_response() {
+        let response = "```json\n{\"action\": \"config.get\", \"confidence\": 0.8, \"params\": {}, \"safety\": \"safe\", \"description\": \"Open settings\"}\n```";
+        let intent = parse_llm_response(response).unwrap();
+        assert_eq!(intent.action, "config.get");
+    }
+
+    #[test]
+    fn parse_unknown_action_returns_none() {
+        let response = r#"{"action": "unknown", "confidence": 0.0, "params": {}, "safety": "safe", "description": "No match"}"#;
+        assert!(parse_llm_response(response).is_none());
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_none() {
+        assert!(parse_llm_response("not json at all").is_none());
+        assert!(parse_llm_response("").is_none());
+        assert!(parse_llm_response("{incomplete").is_none());
+    }
+
+    #[test]
+    fn parse_destructive_safety() {
+        let response = r#"{"action": "memory.delete", "confidence": 0.95, "params": {"target": "all"}, "safety": "destructive", "description": "Delete all data"}"#;
+        let intent = parse_llm_response(response).unwrap();
+        assert_eq!(intent.safety, ActionSafety::Destructive);
+    }
+
+    #[test]
+    fn should_use_llm_short_utterance() {
+        assert!(!should_use_llm("open settings", None));
+        assert!(!should_use_llm("search", None));
+    }
+
+    #[test]
+    fn should_use_llm_complex_utterance() {
+        assert!(should_use_llm(
+            "can you search for the meeting notes from last Tuesday",
+            None
+        ));
+        assert!(should_use_llm(
+            "I want to send a message to Alice about the project",
+            None
+        ));
+    }
+
+    #[test]
+    fn should_use_llm_high_pattern_confidence_skips() {
+        // Even complex utterance skips LLM if pattern matching is confident.
+        assert!(!should_use_llm(
+            "can you open settings for me please",
+            Some(0.85)
+        ));
+    }
+
+    #[test]
+    fn should_use_llm_low_pattern_confidence_uses_llm() {
+        assert!(should_use_llm(
+            "I need to find something about the project deadline",
+            Some(0.3)
+        ));
+    }
+
+    #[test]
+    fn extract_json_direct() {
+        let json = r#"{"key": "value"}"#;
+        assert_eq!(extract_json_from_response(json).unwrap(), json);
+    }
+
+    #[test]
+    fn extract_json_with_surrounding_text() {
+        let response = "Here's the result:\n{\"action\": \"test\"}\nDone.";
+        let extracted = extract_json_from_response(response).unwrap();
+        assert_eq!(extracted, "{\"action\": \"test\"}");
+    }
+
+    #[test]
+    fn build_user_message_formats_correctly() {
+        let msg = build_user_message("open the settings panel");
+        assert!(msg.contains("open the settings panel"));
+        assert!(msg.starts_with("User said:"));
+    }
+}

--- a/src/openhuman/voice_actions/mod.rs
+++ b/src/openhuman/voice_actions/mod.rs
@@ -1,0 +1,19 @@
+//! Voice-driven desktop actions domain.
+//!
+//! Maps recognized utterances to controller-backed actions with safety levels,
+//! confirmation flows, and execution tracking.
+//!
+//! Log prefix: `[voice_actions]`
+
+pub mod engine;
+pub mod llm_intent;
+mod rpc;
+mod schemas;
+pub mod types;
+
+pub use schemas::{
+    all_controller_schemas as all_voice_actions_controller_schemas,
+    all_registered_controllers as all_voice_actions_registered_controllers,
+    schemas as voice_actions_schemas,
+};
+pub use types::{ActionSafety, IntentStatus, VoiceIntent};

--- a/src/openhuman/voice_actions/rpc.rs
+++ b/src/openhuman/voice_actions/rpc.rs
@@ -1,0 +1,195 @@
+//! RPC handlers for voice_actions domain.
+
+use super::engine;
+use serde_json::{json, Map, Value};
+
+pub async fn handle_recognize(p: Map<String, Value>) -> Result<Value, String> {
+    let utterance = p.get("utterance").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Fast path: high-confidence pattern match for simple, direct commands.
+    if let Ok(ref i) = engine::recognize_intent(utterance) {
+        if i.confidence >= 0.7 {
+            // Auto-dispatch Safe intents immediately.
+            if i.safety == super::types::ActionSafety::Safe {
+                let method = format!("openhuman.{}_{}", i.namespace, i.function);
+                let params = i.params.as_object().cloned().unwrap_or_default();
+                let dispatch_result =
+                    crate::core::all::try_invoke_registered_rpc(&method, params).await;
+                if let Some(Ok(result)) = dispatch_result {
+                    engine::mark_executed(&i.id, result.clone()).ok();
+                    return Ok(json!({
+                        "ok": true, "intent_id": i.id, "action": i.action,
+                        "namespace": i.namespace, "function": i.function,
+                        "confidence": i.confidence, "safety": i.safety,
+                        "status": "Executed", "result": result, "source": "pattern",
+                    }));
+                }
+            }
+            return Ok(json!({
+                "ok": true, "intent_id": i.id, "action": i.action,
+                "namespace": i.namespace, "function": i.function,
+                "confidence": i.confidence, "safety": i.safety, "status": i.status,
+                "source": "pattern",
+            }));
+        }
+    }
+
+    // Primary path: LLM-based intent extraction for all other utterances.
+    if let Some(extracted) = try_llm_recognize(utterance).await {
+        let intent = engine::store_llm_intent(
+            utterance,
+            &extracted.action,
+            extracted.confidence,
+            extracted.safety,
+            extracted.params,
+            &extracted.description,
+        );
+        return Ok(json!({
+            "ok": true, "intent_id": intent.id, "action": intent.action,
+            "confidence": intent.confidence, "safety": intent.safety,
+            "status": intent.status, "description": extracted.description,
+            "params": intent.params, "source": "llm",
+        }));
+    }
+
+    // Fallback: use whatever pattern matching found (even low confidence).
+    match engine::recognize_intent(utterance) {
+        Ok(i) => Ok(json!({
+            "ok": true, "intent_id": i.id, "action": i.action,
+            "namespace": i.namespace, "function": i.function,
+            "confidence": i.confidence, "safety": i.safety, "status": i.status,
+            "source": "pattern_fallback",
+        })),
+        Err(_) => {
+            Ok(json!({ "ok": false, "error": format!("no matching action for: {utterance}") }))
+        }
+    }
+}
+
+/// LLM-based intent extraction — the primary intelligence path.
+/// Pattern matching serves as a fast-path optimization for simple commands.
+async fn try_llm_recognize(utterance: &str) -> Option<super::llm_intent::ExtractedIntent> {
+    use super::llm_intent;
+    use crate::openhuman::config::ops::load_config_with_timeout;
+    use crate::openhuman::inference::provider::create_chat_provider;
+    use tracing::debug;
+
+    let actions: Vec<(String, String, super::types::ActionSafety)> = engine::list_mappings()
+        .iter()
+        .map(|m| (m.namespace.clone(), m.function.clone(), m.safety.clone()))
+        .collect();
+
+    let system = llm_intent::build_intent_prompt(&actions);
+    let user_msg = llm_intent::build_user_message(utterance);
+
+    let config = load_config_with_timeout().await.ok()?;
+    let (provider, model) = create_chat_provider("agentic", &config).ok()?;
+
+    let response = provider
+        .chat_with_system(Some(&system), &user_msg, &model, 0.2)
+        .await
+        .ok()?;
+
+    debug!(
+        response_len = response.len(),
+        "[voice_actions] LLM intent response received"
+    );
+    llm_intent::parse_llm_response(&response)
+}
+
+pub async fn handle_confirm(p: Map<String, Value>) -> Result<Value, String> {
+    let id = p.get("intent_id").and_then(|v| v.as_str()).unwrap_or("");
+    match engine::confirm_intent(id) {
+        Ok(i) => {
+            // Actually dispatch the action through the controller registry.
+            let method = format!("openhuman.{}_{}", i.namespace, i.function);
+            let params = match i.params.as_object() {
+                Some(obj) => obj.clone(),
+                None => Map::new(),
+            };
+            let dispatch_result =
+                crate::core::all::try_invoke_registered_rpc(&method, params).await;
+            match dispatch_result {
+                Some(Ok(result)) => {
+                    engine::mark_executed(id, result.clone()).ok();
+                    Ok(
+                        json!({ "ok": true, "intent_id": i.id, "status": "Executed", "result": result }),
+                    )
+                }
+                Some(Err(e)) => {
+                    engine::mark_failed(id, &e).ok();
+                    Ok(json!({ "ok": true, "intent_id": i.id, "status": "Failed", "error": e }))
+                }
+                None => {
+                    // Method not found in registry — mark executed with dispatch info.
+                    Ok(
+                        json!({ "ok": true, "intent_id": i.id, "status": i.status, "dispatched_to": method }),
+                    )
+                }
+            }
+        }
+        Err(e) => Ok(json!({ "ok": false, "error": e })),
+    }
+}
+
+pub async fn handle_reject(p: Map<String, Value>) -> Result<Value, String> {
+    let id = p.get("intent_id").and_then(|v| v.as_str()).unwrap_or("");
+    match engine::reject_intent(id) {
+        Ok(i) => Ok(json!({ "ok": true, "intent_id": i.id, "status": i.status })),
+        Err(e) => Ok(json!({ "ok": false, "error": e })),
+    }
+}
+
+pub async fn handle_get_intent(p: Map<String, Value>) -> Result<Value, String> {
+    let id = p.get("intent_id").and_then(|v| v.as_str()).unwrap_or("");
+    match engine::get_intent(id) {
+        Ok(i) => Ok(json!({
+            "ok": true, "intent_id": i.id, "utterance": i.utterance,
+            "action": i.action, "status": i.status, "safety": i.safety,
+            "result": i.result, "error": i.error,
+        })),
+        Err(e) => Ok(json!({ "ok": false, "error": e })),
+    }
+}
+
+pub async fn handle_list_mappings(_p: Map<String, Value>) -> Result<Value, String> {
+    let mappings: Vec<Value> = engine::list_mappings()
+        .iter()
+        .map(|m| {
+            json!({
+                "pattern": m.pattern, "namespace": m.namespace,
+                "function": m.function, "safety": m.safety, "description": m.description,
+            })
+        })
+        .collect();
+    Ok(json!({ "ok": true, "mappings": mappings }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn recognize_rpc() {
+        let mut p = Map::new();
+        p.insert("utterance".into(), Value::String("open settings".into()));
+        let r = handle_recognize(p).await.unwrap();
+        assert_eq!(r["ok"], true);
+        assert_eq!(r["namespace"], "config");
+    }
+
+    #[tokio::test]
+    async fn recognize_unknown_rpc() {
+        let mut p = Map::new();
+        p.insert("utterance".into(), Value::String("xyz abc".into()));
+        let r = handle_recognize(p).await.unwrap();
+        assert_eq!(r["ok"], false);
+    }
+
+    #[tokio::test]
+    async fn list_mappings_rpc() {
+        let r = handle_list_mappings(Map::new()).await.unwrap();
+        assert_eq!(r["ok"], true);
+        assert!(r["mappings"].as_array().unwrap().len() >= 8);
+    }
+}

--- a/src/openhuman/voice_actions/schemas.rs
+++ b/src/openhuman/voice_actions/schemas.rs
@@ -1,0 +1,300 @@
+//! Controller schemas for the `voice_actions` domain.
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use serde_json::{Map, Value};
+
+type SchemaBuilder = fn() -> ControllerSchema;
+type ControllerHandler = fn(Map<String, Value>) -> ControllerFuture;
+struct Def {
+    function: &'static str,
+    schema: SchemaBuilder,
+    handler: ControllerHandler,
+}
+
+const DEFS: &[Def] = &[
+    Def {
+        function: "recognize",
+        schema: s_recognize,
+        handler: h_recognize,
+    },
+    Def {
+        function: "confirm",
+        schema: s_confirm,
+        handler: h_confirm,
+    },
+    Def {
+        function: "reject",
+        schema: s_reject,
+        handler: h_reject,
+    },
+    Def {
+        function: "get_intent",
+        schema: s_get,
+        handler: h_get,
+    },
+    Def {
+        function: "list_mappings",
+        schema: s_list,
+        handler: h_list,
+    },
+];
+
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    DEFS.iter().map(|d| (d.schema)()).collect()
+}
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    DEFS.iter()
+        .map(|d| RegisteredController {
+            schema: (d.schema)(),
+            handler: d.handler,
+        })
+        .collect()
+}
+pub fn schemas(function: &str) -> ControllerSchema {
+    DEFS.iter()
+        .find(|d| d.function == function)
+        .map(|d| (d.schema)())
+        .unwrap_or_else(s_unknown)
+}
+
+fn s_recognize() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "voice_actions",
+        function: "recognize",
+        description: "Recognize a voice intent from an utterance and map to a controller action.",
+        inputs: vec![FieldSchema {
+            name: "utterance",
+            ty: TypeSchema::String,
+            comment: "Spoken text.",
+            required: true,
+        }],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success.",
+                required: true,
+            },
+            FieldSchema {
+                name: "intent_id",
+                ty: TypeSchema::String,
+                comment: "Intent ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "action",
+                ty: TypeSchema::String,
+                comment: "Matched action.",
+                required: true,
+            },
+            FieldSchema {
+                name: "safety",
+                ty: TypeSchema::String,
+                comment: "safe|requires_confirmation|destructive.",
+                required: true,
+            },
+            FieldSchema {
+                name: "status",
+                ty: TypeSchema::String,
+                comment: "Intent status.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn s_confirm() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "voice_actions",
+        function: "confirm",
+        description: "Confirm a pending voice action intent for execution.",
+        inputs: vec![FieldSchema {
+            name: "intent_id",
+            ty: TypeSchema::String,
+            comment: "Intent ID.",
+            required: true,
+        }],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success.",
+                required: true,
+            },
+            FieldSchema {
+                name: "intent_id",
+                ty: TypeSchema::String,
+                comment: "Intent ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "status",
+                ty: TypeSchema::String,
+                comment: "New status.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn s_reject() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "voice_actions",
+        function: "reject",
+        description: "Reject a pending voice action intent.",
+        inputs: vec![FieldSchema {
+            name: "intent_id",
+            ty: TypeSchema::String,
+            comment: "Intent ID.",
+            required: true,
+        }],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success.",
+                required: true,
+            },
+            FieldSchema {
+                name: "intent_id",
+                ty: TypeSchema::String,
+                comment: "Intent ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "status",
+                ty: TypeSchema::String,
+                comment: "New status.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn s_get() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "voice_actions",
+        function: "get_intent",
+        description: "Get voice intent details by ID.",
+        inputs: vec![FieldSchema {
+            name: "intent_id",
+            ty: TypeSchema::String,
+            comment: "Intent ID.",
+            required: true,
+        }],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success.",
+                required: true,
+            },
+            FieldSchema {
+                name: "intent_id",
+                ty: TypeSchema::String,
+                comment: "ID.",
+                required: true,
+            },
+            FieldSchema {
+                name: "status",
+                ty: TypeSchema::String,
+                comment: "Status.",
+                required: true,
+            },
+            FieldSchema {
+                name: "action",
+                ty: TypeSchema::String,
+                comment: "Action.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn s_list() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "voice_actions",
+        function: "list_mappings",
+        description: "List all registered voice action mappings.",
+        inputs: vec![],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "Success.",
+                required: true,
+            },
+            FieldSchema {
+                name: "mappings",
+                ty: TypeSchema::Array(Box::new(TypeSchema::Json)),
+                comment: "Action mappings.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn s_unknown() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "voice_actions",
+        function: "unknown",
+        description: "Unknown voice_actions function.",
+        inputs: vec![FieldSchema {
+            name: "function",
+            ty: TypeSchema::String,
+            comment: "Requested.",
+            required: true,
+        }],
+        outputs: vec![FieldSchema {
+            name: "error",
+            ty: TypeSchema::String,
+            comment: "Error.",
+            required: true,
+        }],
+    }
+}
+
+fn h_recognize(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::rpc::handle_recognize(p).await })
+}
+fn h_confirm(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::rpc::handle_confirm(p).await })
+}
+fn h_reject(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::rpc::handle_reject(p).await })
+}
+fn h_get(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::rpc::handle_get_intent(p).await })
+}
+fn h_list(p: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::rpc::handle_list_mappings(p).await })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn handlers_match() {
+        let s: Vec<_> = all_controller_schemas()
+            .into_iter()
+            .map(|s| s.function)
+            .collect();
+        let h: Vec<_> = all_registered_controllers()
+            .into_iter()
+            .map(|c| c.schema.function)
+            .collect();
+        assert_eq!(s, h);
+        assert_eq!(s.len(), 5);
+    }
+    #[test]
+    fn namespace_correct() {
+        for s in all_controller_schemas() {
+            assert_eq!(s.namespace, "voice_actions");
+        }
+    }
+    #[test]
+    fn unknown_lookup() {
+        assert_eq!(schemas("nope").function, "unknown");
+    }
+}

--- a/src/openhuman/voice_actions/types.rs
+++ b/src/openhuman/voice_actions/types.rs
@@ -1,0 +1,108 @@
+//! Domain types for voice-driven desktop actions.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionSafety {
+    Safe,
+    RequiresConfirmation,
+    Destructive,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IntentStatus {
+    Pending,
+    Confirmed,
+    Executed,
+    Rejected,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoiceIntent {
+    pub id: String,
+    pub utterance: String,
+    pub action: String,
+    pub namespace: String,
+    pub function: String,
+    pub confidence: f64,
+    pub safety: ActionSafety,
+    pub status: IntentStatus,
+    pub params: serde_json::Value,
+    pub result: Option<serde_json::Value>,
+    pub error: Option<String>,
+    pub created_at: u64,
+    /// Previous intents in this conversation for multi-turn context.
+    #[serde(default)]
+    pub context_history: Vec<String>,
+}
+
+/// Multi-turn conversation context for voice actions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionContext {
+    pub session_id: String,
+    pub intents: Vec<String>,
+    pub last_active: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionMapping {
+    pub pattern: String,
+    pub namespace: String,
+    pub function: String,
+    pub safety: ActionSafety,
+    pub description: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safety_serializes() {
+        assert_eq!(
+            serde_json::to_string(&ActionSafety::Safe).unwrap(),
+            "\"safe\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ActionSafety::RequiresConfirmation).unwrap(),
+            "\"requires_confirmation\""
+        );
+    }
+
+    #[test]
+    fn intent_status_serializes() {
+        assert_eq!(
+            serde_json::to_string(&IntentStatus::Pending).unwrap(),
+            "\"pending\""
+        );
+        assert_eq!(
+            serde_json::to_string(&IntentStatus::Executed).unwrap(),
+            "\"executed\""
+        );
+    }
+
+    #[test]
+    fn voice_intent_round_trips() {
+        let vi = VoiceIntent {
+            id: "vi-1".into(),
+            utterance: "open settings".into(),
+            action: "Open Settings".into(),
+            namespace: "config".into(),
+            function: "get".into(),
+            confidence: 0.9,
+            safety: ActionSafety::Safe,
+            status: IntentStatus::Pending,
+            params: serde_json::json!({}),
+            result: None,
+            error: None,
+            created_at: 0,
+            context_history: vec![],
+        };
+        let json = serde_json::to_string(&vi).unwrap();
+        let back: VoiceIntent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.utterance, "open settings");
+    }
+}

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -13388,3 +13388,55 @@ async fn json_rpc_threads_token_usage_reads_persisted_thread_totals() {
 
     rpc_join.abort();
 }
+    let complete_r = assert_no_jsonrpc_error(&complete, "live_captions_complete_transcript");
+    let complete_body = complete_r.get("result").unwrap_or(complete_r);
+    assert_eq!(
+        complete_body.get("ok"),
+        Some(&json!(true)),
+        "complete should succeed: {complete_body}"
+    );
+
+    mock_join.abort();
+    rpc_join.abort();
+}
+
+// ---------------------------------------------------------------------------
+// Voice actions — register + recognize over RPC
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn voice_actions_lifecycle_over_rpc() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    let (mock_addr, mock_join) = serve_on_ephemeral(mock_upstream_router()).await;
+    let mock_origin = format!("http://{}", mock_addr);
+    write_min_config(&openhuman_home, &mock_origin);
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{}", rpc_addr);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // 1. Recognize intent (returns match or no-match — both are valid responses).
+    let rec = post_json_rpc(
+        &rpc_base,
+        500,
+        "openhuman.voice_actions_recognize",
+        json!({ "utterance": "open settings please" }),
+    )
+    .await;
+    let rec_r = assert_no_jsonrpc_error(&rec, "voice_actions_recognize");
+    let rec_body = rec_r.get("result").unwrap_or(rec_r);
+    assert!(
+        rec_body.get("ok").is_some(),
+        "recognize should return ok field: {rec_body}"
+    );
+
+    // 2. List action mappings.


### PR DESCRIPTION
Self-contained domain module — split from #2261 (PR 5/7). Depends on #4142.

6 files: types, engine, llm_intent, rpc, schemas, mod.
E2E: recognize → list_mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new voice actions capability, including intent recognition, confirmation, rejection, and action mapping support.
  * Introduced support for multi-turn voice action context and LLM-assisted intent extraction.
  * Expanded the app’s capabilities catalog with additional voice, captions, inbox, and data-query foundations.

* **Bug Fixes**
  * Improved handling of voice action routing and discovery so supported actions are registered consistently.
  * Added broader support for email-related TLS connections.

* **Documentation**
  * Added detailed capability and implementation planning docs for the new voice-focused features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->