### PR TITLE
fix(inference): treat null list_models data as empty catalog (#4121)

### DIFF
--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -262,10 +262,14 @@ pub async fn list_configured_models_from_config(
 ///    string, etc. Caught explicitly so the parser doesn't silently
 ///    drop into the missing-data arm with a `<non-object>` keys list.
 ///
-/// A **null** `data`/`models` field is NOT an error — Ollama's
-/// OpenAI-compatible `/v1/models` null-encodes the catalog
+/// A **null** `data`/`models` field on a **success envelope** is NOT an
+/// error — Ollama's OpenAI-compatible `/v1/models` null-encodes the catalog
 /// (`{"object":"list","data":null}`) when no models are pulled, so it is
-/// treated as an empty model list (TAURI-RUST-874 / TAURI-RUST-875).
+/// treated as an empty model list (TAURI-RUST-874 / TAURI-RUST-875). The
+/// null-as-empty short-circuit is gated on `object` being absent or `"list"`:
+/// a null `data` on an error envelope (`{"object":"error","data":null}`)
+/// instead falls through to failure mode 2 so the provider error still
+/// surfaces in the UI and Sentry.
 ///
 /// Per-entry parsing ignores entries that don't have a usable string id/slug
 /// (lax on purpose — many OpenAI-compatible servers include malformed rows for
@@ -290,16 +294,28 @@ pub fn parse_models_response(body: &serde_json::Value) -> Result<Vec<ModelInfo>,
         )
     })?;
 
-    // A null `data`/`models` field is a valid empty catalog, not a malformed
+    // A null `data`/`models` field is a valid empty catalog ONLY on a success
     // envelope: Ollama's OpenAI-compatible `/v1/models` returns
-    // `{"object":"list","data":null}` when no models are pulled. Treat it as an
-    // empty model list so a healthy-but-empty local runtime doesn't manufacture
-    // a hard error (TAURI-RUST-874 / TAURI-RUST-875). Other non-array kinds
-    // (object/string/number/bool) fall through to the descriptive error below —
-    // those still signal a genuinely malformed/error envelope.
-    if data_value.is_null() {
+    // `{"object":"list","data":null}` (object="list", the success marker) when
+    // no models are pulled. Treat that as an empty model list so a healthy-but-
+    // empty local runtime doesn't manufacture a hard error (TAURI-RUST-874 /
+    // TAURI-RUST-875).
+    //
+    // An error body such as `{"object":"error","data":null}` ALSO null-encodes
+    // `data`; swallowing it as an empty catalog would hide provider/endpoint
+    // failures from the UI and Sentry. So gate on a success envelope: short-
+    // circuit only when `object` is absent or "list". Any other `object` value
+    // (e.g. "error") with null `data` falls through to the descriptive error
+    // below, which surfaces the `object` value for triage. Non-array kinds
+    // (object/string/number/bool) likewise fall through.
+    let is_success_envelope = obj
+        .get("object")
+        .and_then(|value| value.as_str())
+        .map_or(true, |object| object.eq_ignore_ascii_case("list"));
+
+    if data_value.is_null() && is_success_envelope {
         log::info!(
-            "[providers][list_models] `{field_name}` is null — provider returned an empty catalog (no models)"
+            "[providers][list_models] `{field_name}` is null on a success envelope — provider returned an empty catalog (no models)"
         );
         return Ok(Vec::new());
     }

--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -256,12 +256,16 @@ pub async fn list_configured_models_from_config(
 /// 1. **Missing `data`/`models` field** — endpoint isn't `/models`-compatible
 ///    (user typo'd the base URL, pointed at a vector-DB host, etc.).
 /// 2. **`data`/`models` field present but wrong type** — provider returned
-///    `{"object":"error","data":{…}}`, `{"data":null}`, or similar
-///    non-array. The error names the actual JSON type so triage knows what
-///    the provider sent.
+///    `{"object":"error","data":{…}}` or similar non-array. The error names
+///    the actual JSON type so triage knows what the provider sent.
 /// 3. **Non-object top-level body** — provider returned a bare array,
 ///    string, etc. Caught explicitly so the parser doesn't silently
 ///    drop into the missing-data arm with a `<non-object>` keys list.
+///
+/// A **null** `data`/`models` field is NOT an error — Ollama's
+/// OpenAI-compatible `/v1/models` null-encodes the catalog
+/// (`{"object":"list","data":null}`) when no models are pulled, so it is
+/// treated as an empty model list (TAURI-RUST-874 / TAURI-RUST-875).
 ///
 /// Per-entry parsing ignores entries that don't have a usable string id/slug
 /// (lax on purpose — many OpenAI-compatible servers include malformed rows for
@@ -285,6 +289,20 @@ pub fn parse_models_response(body: &serde_json::Value) -> Result<Vec<ModelInfo>,
             keys
         )
     })?;
+
+    // A null `data`/`models` field is a valid empty catalog, not a malformed
+    // envelope: Ollama's OpenAI-compatible `/v1/models` returns
+    // `{"object":"list","data":null}` when no models are pulled. Treat it as an
+    // empty model list so a healthy-but-empty local runtime doesn't manufacture
+    // a hard error (TAURI-RUST-874 / TAURI-RUST-875). Other non-array kinds
+    // (object/string/number/bool) fall through to the descriptive error below —
+    // those still signal a genuinely malformed/error envelope.
+    if data_value.is_null() {
+        log::info!(
+            "[providers][list_models] `{field_name}` is null — provider returned an empty catalog (no models)"
+        );
+        return Ok(Vec::new());
+    }
 
     let data = data_value.as_array().ok_or_else(|| {
         // Include the sibling `object` field if present — OpenAI-shaped

--- a/src/openhuman/inference/provider/ops_tests.rs
+++ b/src/openhuman/inference/provider/ops_tests.rs
@@ -1017,15 +1017,22 @@ fn parse_models_response_rejects_null_data_on_error_envelope() {
     // descriptive malformed/error-envelope error, which surfaces `object`.
     for field in ["data", "models"] {
         let body = serde_json::json!({ "object": "error", field: serde_json::Value::Null });
-        let err = parse_models_response(&body)
-            .expect_err("null `{field}` on an error envelope must fail, not return empty");
+        let err = match parse_models_response(&body) {
+            Ok(models) => panic!(
+                "null `{field}` on an error envelope must fail, not return empty (got {models:?})"
+            ),
+            Err(err) => err,
+        };
         assert!(
             !err.contains("missing"),
             "error-envelope null `{field}` must not say `missing`: {err}"
         );
+        // Tighten on the surfaced `object` value, not the literal "error
+        // envelope" prose, so the assertion proves the provider error is
+        // actually carried through to triage.
         assert!(
-            err.contains("error"),
-            "error-envelope null `{field}` must surface `object` = error: {err}"
+            err.contains(r#""object" = "error""#),
+            "error-envelope null `{field}` must surface `\"object\" = \"error\"`: {err}"
         );
     }
 }

--- a/src/openhuman/inference/provider/ops_tests.rs
+++ b/src/openhuman/inference/provider/ops_tests.rs
@@ -948,13 +948,14 @@ fn parse_models_response_distinguishes_missing_data_field_from_wrong_type() {
     // shape (`object` + `data` keys both present, but `data` isn't an
     // array). The error MUST NOT say "missing" — it must surface the
     // actual JSON type so triage knows what shape the provider sent.
+    // `null` is deliberately excluded here — it is a valid empty catalog,
+    // not a wrong type (see `parse_models_response_treats_null_data_as_empty_list`).
     for (label, value) in [
         (
             "object",
             serde_json::json!({"object":"error","message":"boom"}),
         ),
         ("string", serde_json::json!("models go here")),
-        ("null", serde_json::Value::Null),
         ("bool", serde_json::json!(true)),
         ("number", serde_json::json!(42)),
     ] {
@@ -969,6 +970,31 @@ fn parse_models_response_distinguishes_missing_data_field_from_wrong_type() {
             "wrong-type error must name the actual JSON kind ({label}): {err}"
         );
     }
+}
+
+#[test]
+fn parse_models_response_treats_null_data_as_empty_list() {
+    // TAURI-RUST-874 / TAURI-RUST-875: Ollama's OpenAI-compatible
+    // `/v1/models` null-encodes the catalog (`{"object":"list","data":null}`)
+    // when no models are pulled. A null `data`/`models` field is a valid empty
+    // model list, not a malformed envelope — it MUST parse to an empty Vec
+    // instead of manufacturing a hard error that floods Sentry.
+    let data_null = serde_json::json!({ "object": "list", "data": serde_json::Value::Null });
+    let models = parse_models_response(&data_null)
+        .expect("null `data` must parse as an empty catalog, not an error");
+    assert!(
+        models.is_empty(),
+        "null `data` must yield an empty model list, got {models:?}"
+    );
+
+    // The sibling `models` key (Codex-shaped envelope) gets the same treatment.
+    let models_null = serde_json::json!({ "object": "list", "models": serde_json::Value::Null });
+    let models = parse_models_response(&models_null)
+        .expect("null `models` must parse as an empty catalog, not an error");
+    assert!(
+        models.is_empty(),
+        "null `models` must yield an empty model list, got {models:?}"
+    );
 }
 
 #[test]

--- a/src/openhuman/inference/provider/ops_tests.rs
+++ b/src/openhuman/inference/provider/ops_tests.rs
@@ -995,6 +995,39 @@ fn parse_models_response_treats_null_data_as_empty_list() {
         models.is_empty(),
         "null `models` must yield an empty model list, got {models:?}"
     );
+
+    // A bare success envelope with no `object` field still null-encodes an
+    // empty catalog (treated as success — `object` absent ⇒ not an error).
+    let object_absent = serde_json::json!({ "data": serde_json::Value::Null });
+    let models = parse_models_response(&object_absent)
+        .expect("null `data` with no `object` field must parse as an empty catalog");
+    assert!(
+        models.is_empty(),
+        "null `data` (object absent) must yield an empty model list, got {models:?}"
+    );
+}
+
+#[test]
+fn parse_models_response_rejects_null_data_on_error_envelope() {
+    // Codex P2 (PR #4157): an HTTP-200 error body such as
+    // `{"object":"error","data":null}` ALSO null-encodes `data`. The
+    // null-as-empty short-circuit MUST NOT swallow it as a successful empty
+    // catalog — that would hide provider/endpoint failures from the UI and
+    // Sentry. A non-"list" `object` with null `data` falls through to the
+    // descriptive malformed/error-envelope error, which surfaces `object`.
+    for field in ["data", "models"] {
+        let body = serde_json::json!({ "object": "error", field: serde_json::Value::Null });
+        let err = parse_models_response(&body)
+            .expect_err("null `{field}` on an error envelope must fail, not return empty");
+        assert!(
+            !err.contains("missing"),
+            "error-envelope null `{field}` must not say `missing`: {err}"
+        );
+        assert!(
+            err.contains("error"),
+            "error-envelope null `{field}` must surface `object` = error: {err}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `parse_models_response` now treats a **null** `data`/`models` field as an empty model list instead of a hard error.
- Stops a Sentry flood from Ollama: its OpenAI-compatible `/v1/models` null-encodes the catalog (`{"object":"list","data":null}`) when no models are pulled.
- Resolves **TAURI-RUST-874** (tracing logger) + **TAURI-RUST-875** (RPC boundary) — same defect, two fingerprints, 355 events / 28 users.
- Other non-array kinds (object/string/number/bool) still surface the descriptive malformed-envelope error.

## Problem

`inference_list_models` reported `provider response has \`data\` field but it is null, expected array …` at `level=error`. Confirmed source: `provider_id: "ollama"` on the 874 latest **and** oldest events across the 24-day span. A healthy Ollama instance with zero models pulled returns a 200 with `data: null` — a valid empty catalog — but `parse_models_response` (`models.rs`) ran it through `as_array().ok_or_else(...)`, manufacturing an `Err`. That `Err` hit the `ops.rs` arm-3 `error!` (874) and, because the central `expected_error_kind` classifier didn't match it, the RPC boundary captured it too (875).

## Solution

- Short-circuit a null `data`/`data_value` to `Ok(Vec::new())` **before** the wrong-type error, with an `info!` breadcrumb for local visibility. No `Err` is produced → both fingerprints stop at source (no classifier-demote / suppression).
- **Bucket: real defect** — the parser was over-strict, not a noise-suppression case. Empty dropdown is the truthful state for an empty Ollama.
- Updated the rustdoc to document null = empty (Ollama no-models), and removed `null` from the wrong-type-must-fail test loop.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `parse_models_response_treats_null_data_as_empty_list` (null `data` + null `models`); wrong-type loop still covers object/string/number/bool failures
- [x] **Diff coverage ≥ 80%** — the new `parse_models_response_treats_null_data_as_empty_list` test exercises both added branches (null `data` + null `models`); Rust Core Coverage `diff-cover` gate confirms at CI
- [x] Coverage matrix updated — `N/A: behaviour-only edge-case fix to an existing parser, no feature row`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows affected`
- [x] No new external network dependencies introduced — pure JSON parsing, no network
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal parser branch, no release-cut surface`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop core (Rust). No API/schema change. Users running a local Ollama with no models pulled stop emitting a spurious `error` and see an empty model list (correct) instead. No migration, no perf/security impact.

## Related

- Closes: #4121
- Sentry-Issue: TAURI-RUST-874
- Sentry-Issue: TAURI-RUST-875
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/4121-list-models-null-data
- Commit SHA: b6e1baa520916b59536295462aca50617820a7ea

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend change
- [x] N/A: `pnpm typecheck` — no frontend change
- [x] Focused tests: `cargo test --lib openhuman::inference::provider::ops` — parse_models suite 5/5 pass (incl. new null test); openrouter probe passes in isolation
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check` exit 0
- [x] N/A: Tauri fmt/check — `app/src-tauri` untouched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: null `data`/`models` from `/models` parses as an empty catalog instead of erroring.
- User-visible effect: empty Ollama (no models pulled) no longer raises an error; model dropdown is simply empty.

### Parity Contract

- Legacy behavior preserved: non-null wrong-type bodies (object/string/number/bool) still error with the same descriptive message.
- Guard/fallback/dispatch parity checks: missing-field and non-object-body arms unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model catalog responses so successful envelopes with `data`/`models` set to `null` are treated as an empty list instead of failing validation.
  * Ensured failure/error envelopes still reject `null` `data`/`models` and return a clear validation error (without incorrectly treating it as empty).
  * Expanded automated test coverage across multiple response formats to verify both empty-catalog success cases and null-in-error rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->