### PR TITLE
fix(inference): classify Anthropic BYO credit-balance-too-low 400 as budget-exhausted (#4159)

### DIFF
--- a/src/openhuman/inference/provider/billing_error.rs
+++ b/src/openhuman/inference/provider/billing_error.rs
@@ -18,6 +18,16 @@ pub fn is_budget_exhausted_message(body: &str) -> bool {
         // credits", which a positive "you have N remaining credits" balance
         // message could trip) to keep the list tight per the rule above.
         "no remaining credits",
+        // Anthropic's BYO-key out-of-credits 400 wording (TAURI-RUST-4MM):
+        // the full body is `"Your credit balance is too low to access the
+        // Anthropic API. Please go to Plans & Billing to upgrade or purchase
+        // credits."` (direct provider, "anthropic API error", not the managed
+        // "OpenHuman API error"). Anchored on the "credit balance is too low"
+        // fragment — the "too low" qualifier keeps a positive-balance message
+        // (e.g. "your credit balance is $50") from tripping, per the tight-list
+        // rule above. OpenHuman has no lever over a third-party Anthropic
+        // account's balance; budget toast already surfaced in the UI.
+        "credit balance is too low",
     ];
 
     let lower = body.to_ascii_lowercase();
@@ -70,6 +80,29 @@ mod tests {
         ));
     }
 
+    /// Verbatim Anthropic BYO out-of-credits 400 body (Sentry TAURI-RUST-4MM).
+    /// Direct provider — "anthropic API error", not the managed "OpenHuman API
+    /// error". The classifier feeds the emit-site `classify_expected_error`
+    /// demotion, the agent `tool_loop` gate, the `web_errors` net, the
+    /// `is_budget_event` before_send filter, AND the cron billing-halt, so
+    /// pinning the exact wire body makes an Anthropic phrasing drift fail CI
+    /// rather than silently re-flood Sentry (3793 events leaked before this).
+    #[test]
+    fn detects_anthropic_credit_balance_too_low_400_body() {
+        let body = "anthropic API error (400 Bad Request): \
+            {\"error\":{\"code\":\"invalid_request_error\",\"message\":\"Your credit \
+            balance is too low to access the Anthropic API. Please go to Plans & \
+            Billing to upgrade or purchase credits.\",\"type\":\"invalid_request_error\"}}";
+        assert!(
+            is_budget_exhausted_message(body),
+            "anthropic credit-balance-too-low 400 must classify as budget-exhausted user-state"
+        );
+        // Case-insensitive on the same phrase.
+        assert!(is_budget_exhausted_message(
+            "Your CREDIT BALANCE IS TOO LOW to access the Anthropic API"
+        ));
+    }
+
     #[test]
     fn ignores_non_budget_messages() {
         for body in [
@@ -79,6 +112,9 @@ mod tests {
             // A positive-balance message must NOT be demoted: we anchor on the
             // "no remaining credits" fragment precisely so this doesn't trip.
             "You have 100 remaining credits this month",
+            // Likewise the Anthropic matcher anchors on "too low", so a healthy
+            // balance readout stays visible.
+            "Your credit balance is $50.00",
             "",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

- Anthropic's direct-provider (BYO key) out-of-credits 400 is now classified as a budget-exhausted user-state and demoted from Sentry, matching the existing abacus/OpenRouter handling.
- Adds the wording `"credit balance is too low"` to the single-source budget classifier `is_budget_exhausted_message`, anchored on `too low` so a healthy-balance readout stays visible.
- Adds a verbatim-body regression test pinning the exact Anthropic 400 wire body (+ positive-balance negative case).

## Problem

Sentry **TAURI-RUST-4MM** — 3793 events / 3 users (last seen 2026-06-26, 0.57.53). A user's BYO Anthropic key whose account is out of credits returns `anthropic API error (400 Bad Request): {"error":{...,"message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",...}}` (direct provider — `anthropic API error`, not the managed `OpenHuman API error`).

The single-source classifier `is_budget_exhausted_message` (`src/openhuman/inference/provider/billing_error.rs`) matched `insufficient balance` / `add credits` / `no remaining credits` but **not** Anthropic's `credit balance is too low` / `purchase credits` wording. So `classify_expected_error` (`src/core/observability.rs`) never returned `ExpectedErrorKind::BudgetExhausted` and the 400 reached Sentry as an error, flooding the queue on every retry.

**Bucket (sentry-workflow S3.5): genuinely unpreventable user-state.** OpenHuman has zero lever over a third-party Anthropic account's balance; the budget toast is already surfaced in the UI. Same family as #3976 (BYO 402 insufficient-credits), #4071 (abacus 400 no-remaining-credits), #4032 — classifier-demotion is the complete fix, not a band-aid over a real defect.

## Solution

- Extend the `PHRASES` list with `"credit balance is too low"`. The `too low` qualifier keeps a positive readout (e.g. `"your credit balance is \$50"`) from tripping, per the deliberately-tight-list rule.
- One add covers every consumer of the single-source classifier: emit-site `classify_expected_error` demote, agent `tool_loop` gate, `web_errors` net, the `is_budget_event` before_send filter, and the cron billing-halt.
- Regression test `detects_anthropic_credit_balance_too_low_400_body` pins the verbatim Sentry wire body so an Anthropic phrasing drift fails CI rather than silently re-flooding; `ignores_non_budget_messages` gains a positive-balance Anthropic negative case.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — both changed lines (the phrase + its consumers) are exercised by the new verbatim-body test and the negative-case test
- [x] N/A: Coverage matrix updated — behaviour-only classifier widening, no feature row change
- [x] N/A: All affected feature IDs listed — no matrix feature touched
- [x] No new external network dependencies introduced
- [x] N/A: Manual smoke checklist — no release-cut surface touched (pure string classifier)
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop/CLI: Anthropic BYO out-of-credits 400 no longer reports to Sentry as an error; user still sees the existing budget toast. No behaviour change for any other 400.
- Security/perf/migration: none. Pure classification widening, scoped to a tight phrase anchored on `too low`.

## Related

- Closes: #4159
- Sentry-Issue: TAURI-RUST-4MM
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/4159-anthropic-credit-balance-classifier
- Commit SHA: 4e16586182f2729ed67ecb862775b2b1cf5fe361

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend change
- [x] N/A: `pnpm typecheck` — no frontend change
- [x] Focused tests: `cargo test -p openhuman --lib openhuman::inference::provider::billing_error` — 5 passed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean on billing_error.rs
- [x] N/A: Tauri fmt/check — `app/src-tauri` not touched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Anthropic BYO credit-balance-too-low 400 demoted from Sentry to expected budget user-state.
- User-visible effect: none beyond the already-shown budget toast; removes Sentry noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of out-of-credits billing errors for Anthropic responses, reducing false negatives in budget-exhausted handling.
  * Kept matching case-insensitive while avoiding misclassification of valid credit balance messages.

* **Tests**
  * Added coverage for the new out-of-credits message pattern.
  * Expanded negative checks to confirm related but non-exhausted billing messages are not flagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
