### PR TITLE
fix(team): remove unsupported Create Team UI, surface real errors (#3723)

### DIFF
--- a/app/src/components/settings/panels/TeamPanel.test.tsx
+++ b/app/src/components/settings/panels/TeamPanel.test.tsx
@@ -101,17 +101,15 @@ describe('<TeamPanel />', () => {
     await waitFor(() => expect(refreshTeams).toHaveBeenCalled());
   });
 
-  it('disables the Create button until a name is typed and calls createTeam on submit', async () => {
+  it('does not render a create-team control and shows the personal-team note', async () => {
     const Panel = await importPanel();
     renderPanel(Panel);
 
-    const createBtn = screen.getByRole('button', { name: 'Create' });
-    expect(createBtn).toBeDisabled();
-
-    fireEvent.change(screen.getByPlaceholderText('Team name'), { target: { value: 'New Team' } });
-    expect(createBtn).not.toBeDisabled();
-    fireEvent.click(createBtn);
-    await waitFor(() => expect(teamApiMock.createTeam).toHaveBeenCalledWith('New Team'));
+    // Create was removed (issue #3723): backend caps one owned team per user.
+    expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Team name')).not.toBeInTheDocument();
+    expect(screen.getByText(/personal team is created automatically/i)).toBeInTheDocument();
+    expect(teamApiMock.createTeam).not.toHaveBeenCalled();
   });
 
   it('joins a team when the user submits a join code', async () => {
@@ -161,13 +159,13 @@ describe('<TeamPanel />', () => {
     expect(navigateToTeamManagement).toHaveBeenCalledWith('team-a');
   });
 
-  it('surfaces the localized error when createTeam rejects', async () => {
-    teamApiMock.createTeam.mockRejectedValueOnce(new Error('boom'));
+  it('falls back to the localized error when joinTeam rejects without a reason', async () => {
+    teamApiMock.joinTeam.mockRejectedValueOnce(new Error('boom'));
     const Panel = await importPanel();
     renderPanel(Panel);
 
-    fireEvent.change(screen.getByPlaceholderText('Team name'), { target: { value: 'New Team' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
-    await waitFor(() => expect(screen.getByText('Failed to create team')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('Invite code'), { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Join' }));
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
   });
 });

--- a/app/src/components/settings/panels/TeamPanel.tsx
+++ b/app/src/components/settings/panels/TeamPanel.tsx
@@ -12,6 +12,7 @@ import Button from '../../ui/Button';
 import { SettingsBadge, SettingsSection, SettingsTextField } from '../controls';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
 import SettingsPanel from '../layout/SettingsPanel';
+import { teamErrorMessage } from './teamErrorMessage';
 
 const log = debug('core-rpc:error');
 
@@ -21,10 +22,8 @@ const TeamPanel = () => {
   const { snapshot, teams, refresh, refreshTeams } = useCoreState();
   const user = snapshot.currentUser;
 
-  const [newTeamName, setNewTeamName] = useState('');
   const [joinCode, setJoinCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [isCreating, setIsCreating] = useState(false);
   const [isJoining, setIsJoining] = useState(false);
   const [isSwitching, setIsSwitching] = useState<string | null>(null);
   const [isLeaving, setIsLeaving] = useState<string | null>(null);
@@ -60,26 +59,6 @@ const TeamPanel = () => {
     });
   }, [refreshTeamsWithLoading]);
 
-  const handleCreateTeam = async () => {
-    const name = newTeamName.trim();
-    if (!name) return;
-    setIsCreating(true);
-    setError(null);
-    try {
-      await teamApi.createTeam(name);
-      setNewTeamName('');
-      await refreshTeamsWithLoading();
-    } catch (err) {
-      setError(
-        err && typeof err === 'object' && 'error' in err
-          ? String(err.error)
-          : t('team.failedToCreate')
-      );
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
   const handleJoinTeam = async () => {
     const code = joinCode.trim();
     if (!code) return;
@@ -90,11 +69,7 @@ const TeamPanel = () => {
       setJoinCode('');
       await Promise.all([refresh(), refreshTeamsWithLoading()]);
     } catch (err) {
-      setError(
-        err && typeof err === 'object' && 'error' in err
-          ? String(err.error)
-          : t('team.invalidInviteCode')
-      );
+      setError(teamErrorMessage(err, t('team.invalidInviteCode')));
     } finally {
       setIsJoining(false);
     }
@@ -108,11 +83,7 @@ const TeamPanel = () => {
       await teamApi.switchTeam(teamId);
       await Promise.all([refresh(), refreshTeamsWithLoading()]);
     } catch (err) {
-      setError(
-        err && typeof err === 'object' && 'error' in err
-          ? String(err.error)
-          : t('team.failedToSwitch')
-      );
+      setError(teamErrorMessage(err, t('team.failedToSwitch')));
     } finally {
       setIsSwitching(null);
     }
@@ -133,11 +104,7 @@ const TeamPanel = () => {
       await Promise.all([refresh(), refreshTeamsWithLoading()]);
       setTeamToLeave(null);
     } catch (err) {
-      setError(
-        err && typeof err === 'object' && 'error' in err
-          ? String(err.error)
-          : t('team.failedToLeave')
-      );
+      setError(teamErrorMessage(err, t('team.failedToLeave')));
     } finally {
       setIsLeaving(null);
     }
@@ -260,29 +227,8 @@ const TeamPanel = () => {
         </SettingsSection>
       )}
 
-      <SettingsSection title={t('team.createNewTeam')}>
-        <div className="flex gap-2 px-4 py-3">
-          <SettingsTextField
-            className="flex-1"
-            value={newTeamName}
-            onChange={e => setNewTeamName(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && void handleCreateTeam()}
-            placeholder={t('team.teamName')}
-            aria-label={t('team.teamName')}
-            inputSize="sm"
-          />
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            onClick={() => void handleCreateTeam()}
-            disabled={isCreating || !newTeamName.trim()}>
-            {isCreating ? t('team.creating') : t('common.create')}
-          </Button>
-        </div>
-      </SettingsSection>
-
       <SettingsSection title={t('team.joinExistingTeam')}>
+        <p className="px-4 pt-3 text-xs text-content-muted">{t('team.personalAutoCreatedNote')}</p>
         <div className="flex gap-2 px-4 py-3">
           <SettingsTextField
             mono

--- a/app/src/components/settings/panels/__tests__/TeamPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/TeamPanel.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../../../../lib/i18n/I18nContext', () => ({
         'team.yourTeams': 'Your Teams',
         'team.createNewTeam': 'Create New Team',
         'team.joinExistingTeam': 'Join Existing Team',
+        'team.personalAutoCreatedNote': 'Personal team is auto-created. Join below.',
         'team.teamName': 'Team Name',
         'team.inviteCode': 'Invite Code',
         'team.creating': 'Creating...',
@@ -151,37 +152,24 @@ describe('TeamPanel — role badge rendering (line 165)', () => {
   });
 });
 
-describe('TeamPanel — create team (line 281)', () => {
+describe('TeamPanel — create team removed (issue #3723)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateTeam.mockResolvedValue({});
     setupState({ teams: [] });
   });
 
-  it('calls createTeam when form is submitted (line 281)', async () => {
+  it('does not render a create-team control', () => {
     render(<TeamPanel />);
-
-    const input = screen.getByPlaceholderText('Team Name') ?? screen.getByLabelText('Team Name');
-    fireEvent.change(input, { target: { value: 'My New Team' } });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
-
-    await waitFor(() => {
-      expect(mockCreateTeam).toHaveBeenCalledWith('My New Team');
-    });
+    // The "Create New Team" section is gone — backend caps one owned team per
+    // user, so the control could never succeed (always 404'd).
+    expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Team Name')).not.toBeInTheDocument();
+    expect(mockCreateTeam).not.toHaveBeenCalled();
   });
 
-  it('shows an error banner when createTeam fails', async () => {
-    mockCreateTeam.mockRejectedValue({ error: 'Team limit reached' });
+  it('renders the personal-team explanatory note', () => {
     render(<TeamPanel />);
-
-    const input = screen.getByLabelText('Team Name');
-    fireEvent.change(input, { target: { value: 'New Team' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Team limit reached')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Personal team is auto-created. Join below.')).toBeInTheDocument();
   });
 });
 
@@ -197,7 +185,6 @@ describe('TeamPanel — join team (line 304)', () => {
 
     const input = screen.getByLabelText('Invite Code');
     fireEvent.change(input, { target: { value: 'CODE-XYZ' } });
-    // Need to find the Join button — it's the second submit button (after Create)
     const joinBtn = screen.getByRole('button', { name: /^Join$/i });
     fireEvent.click(joinBtn);
 
@@ -216,6 +203,25 @@ describe('TeamPanel — join team (line 304)', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Code not found')).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces the real backend reason from a CoreRpcError (issue #3723)', async () => {
+    // Production rejects with a CoreRpcError — which has no `.error` field, so
+    // the old `'error' in err` check dropped the reason. Verify it now shows.
+    mockJoinTeam.mockRejectedValue(
+      new CoreRpcError(
+        'POST /teams/join failed (400 Bad Request): {"error":"Invite expired"}',
+        'unknown'
+      )
+    );
+    render(<TeamPanel />);
+
+    fireEvent.change(screen.getByLabelText('Invite Code'), { target: { value: 'OLD-CODE' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Join$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invite expired')).toBeInTheDocument();
     });
   });
 });

--- a/app/src/components/settings/panels/teamErrorMessage.test.ts
+++ b/app/src/components/settings/panels/teamErrorMessage.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { CoreRpcError } from '../../../services/coreRpcClient';
+import { teamErrorMessage } from './teamErrorMessage';
+
+const FALLBACK = 'Something went wrong';
+
+describe('teamErrorMessage', () => {
+  it('prefers a structured reason from CoreRpcError.data', () => {
+    const err = new CoreRpcError('GET /teams failed (403 Forbidden)', 'unknown', undefined, {
+      message: 'Not a member of this team',
+    });
+    expect(teamErrorMessage(err, FALLBACK)).toBe('Not a member of this team');
+  });
+
+  it('lifts the human field out of a JSON body in CoreRpcError.message', () => {
+    const err = new CoreRpcError(
+      'POST /teams/join failed (400 Bad Request): {"error":"Invite expired"}',
+      'unknown'
+    );
+    expect(teamErrorMessage(err, FALLBACK)).toBe('Invite expired');
+  });
+
+  it('returns a clean message when there is no RPC prefix', () => {
+    const err = new CoreRpcError('Session expired. Please log in again.', 'auth_expired');
+    expect(teamErrorMessage(err, FALLBACK)).toBe('Session expired. Please log in again.');
+  });
+
+  it('falls back when the body is a raw HTML error page', () => {
+    const err = new CoreRpcError(
+      'POST /teams failed (404 Not Found): <!DOCTYPE html><html><body>Not Found</body></html>',
+      'unknown'
+    );
+    expect(teamErrorMessage(err, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back when a JSON body has no human-readable field', () => {
+    const err = new CoreRpcError(
+      'POST /teams/join failed (400 Bad Request): {"code":"E_BAD"}',
+      'unknown'
+    );
+    expect(teamErrorMessage(err, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back when nothing remains after the RPC prefix', () => {
+    const err = new CoreRpcError(
+      'DELETE /teams/t1 failed (500 Internal Server Error): ',
+      'unknown'
+    );
+    expect(teamErrorMessage(err, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('handles the legacy plain { error } rejection shape', () => {
+    expect(teamErrorMessage({ error: 'Team limit reached' }, FALLBACK)).toBe('Team limit reached');
+  });
+
+  it('surfaces a bare Error message', () => {
+    expect(teamErrorMessage(new Error('boom'), FALLBACK)).toBe('boom');
+  });
+
+  it('falls back for non-object rejections', () => {
+    expect(teamErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    expect(teamErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(teamErrorMessage('nope', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('caps an overly long reason', () => {
+    const long = 'x'.repeat(500);
+    const out = teamErrorMessage({ error: long }, FALLBACK);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});

--- a/app/src/components/settings/panels/teamErrorMessage.ts
+++ b/app/src/components/settings/panels/teamErrorMessage.ts
@@ -1,0 +1,81 @@
+import { CoreRpcError } from '../../../services/coreRpcClient';
+
+/**
+ * Extract a human-readable failure reason from a team RPC rejection.
+ *
+ * Team ops call the hosted backend through `callCoreRpc`, which rejects with a
+ * {@link CoreRpcError}. The real reason lives in either `err.data` (structured
+ * JSON-RPC `error.data`) or `err.message` — the latter shaped by the Rust
+ * `flatten_authed_error` net as `"POST /teams/join failed (400 Bad Request):
+ * <body>"`. The previous TeamPanel catch checked `'error' in err`, which never
+ * matched a `CoreRpcError` (it has no `.error` field), so every failure fell
+ * back to a generic banner and the backend reason was dropped (issue #3723).
+ *
+ * This helper surfaces the backend reason when one is recoverable and falls
+ * back to the caller-supplied localized string otherwise. It also handles the
+ * legacy plain `{ error }` / `{ message }` rejection shape so existing call
+ * sites keep working.
+ */
+
+const RPC_PREFIX = /^(?:GET|POST|PUT|DELETE|PATCH)\s+\S+\s+failed\s*\([^)]*\):?\s*/i;
+const MAX_LEN = 200;
+
+function cap(value: string): string {
+  const oneLine = value.replace(/\s+/g, ' ').trim();
+  return oneLine.length > MAX_LEN ? `${oneLine.slice(0, MAX_LEN - 1)}…` : oneLine;
+}
+
+function firstString(obj: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+/** Pull a human field out of a structured error body / `error.data`. */
+function reasonFromData(data: unknown): string | null {
+  if (data && typeof data === 'object') {
+    const reason = firstString(data as Record<string, unknown>, ['message', 'error', 'detail']);
+    if (reason) return cap(reason);
+  }
+  return null;
+}
+
+/**
+ * Strip the `"<VERB> <path> failed (<status>):"` prefix the core prepends and
+ * recover the meaningful tail. Returns `null` when nothing presentable remains
+ * (empty body, or a raw HTML error page that must never reach the user).
+ */
+function cleanRpcMessage(message: string): string | null {
+  const body = message.replace(RPC_PREFIX, '').trim();
+  if (!body) return null;
+  // Never surface a raw HTML 404/error page (the POST /teams 404 case).
+  if (/^<(?:!doctype|html)/i.test(body)) return null;
+  // Backend errors arrive as a JSON body — lift the human field out of it.
+  if (body.startsWith('{')) {
+    try {
+      const fromJson = reasonFromData(JSON.parse(body));
+      // Structured but no human field → let the caller fall back.
+      return fromJson;
+    } catch {
+      // Not valid JSON — fall through and surface the raw tail.
+    }
+  }
+  return cap(body);
+}
+
+export function teamErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof CoreRpcError) {
+    return reasonFromData(err.data) ?? cleanRpcMessage(err.message) ?? fallback;
+  }
+  if (err && typeof err === 'object') {
+    const reason = firstString(err as Record<string, unknown>, ['error', 'detail']);
+    if (reason) return cap(reason);
+    const message = (err as Record<string, unknown>).message;
+    if (typeof message === 'string' && message.trim()) {
+      return cleanRpcMessage(message) ?? cap(message);
+    }
+  }
+  return fallback;
+}

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -1755,6 +1755,8 @@ const messages: TranslationMap = {
   'team.teamName': 'اسم الفريق',
   'team.creating': 'جارٍ الإنشاء...',
   'team.joinExistingTeam': 'الانضمام إلى فريق موجود',
+  'team.personalAutoCreatedNote':
+    'يتم إنشاء فريقك الشخصي تلقائيًا. للتعاون، انضم إلى فريق موجود باستخدام رمز دعوة أدناه.',
   'team.inviteCode': 'رمز الدعوة',
   'team.joining': 'جارٍ الانضمام...',
   'team.join': 'انضمام',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -1792,6 +1792,8 @@ const messages: TranslationMap = {
   'team.teamName': 'টিমের নাম',
   'team.creating': 'তৈরি হচ্ছে...',
   'team.joinExistingTeam': 'বিদ্যমান টিমে যোগ দিন',
+  'team.personalAutoCreatedNote':
+    'আপনার ব্যক্তিগত টিম স্বয়ংক্রিয়ভাবে তৈরি হয়। সহযোগিতার জন্য, নিচে একটি আমন্ত্রণ কোড দিয়ে বিদ্যমান টিমে যোগ দিন।',
   'team.inviteCode': 'আমন্ত্রণ কোড',
   'team.joining': 'যোগ দেওয়া হচ্ছে...',
   'team.join': 'যোগ দিন',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -1838,6 +1838,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Teamname',
   'team.creating': 'Erstellen...',
   'team.joinExistingTeam': 'Tritt einem bestehenden Team bei',
+  'team.personalAutoCreatedNote':
+    'Dein persönliches Team wird automatisch erstellt. Um zusammenzuarbeiten, tritt unten mit einem Einladungscode einem bestehenden Team bei.',
   'team.inviteCode': 'Einladungscode',
   'team.joining': 'Beitritt...',
   'team.join': 'Mach mit',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -2157,6 +2157,8 @@ const en: TranslationMap = {
   'team.teamName': 'Team name',
   'team.creating': 'Creating...',
   'team.joinExistingTeam': 'Join Existing Team',
+  'team.personalAutoCreatedNote':
+    'Your personal team is created automatically. To collaborate, join an existing team with an invite code below.',
   'team.inviteCode': 'Invite code',
   'team.joining': 'Joining...',
   'team.join': 'Join',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -1826,6 +1826,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Nombre del equipo',
   'team.creating': 'Creando...',
   'team.joinExistingTeam': 'Unirse a un equipo existente',
+  'team.personalAutoCreatedNote':
+    'Tu equipo personal se crea automáticamente. Para colaborar, únete a un equipo existente con un código de invitación a continuación.',
   'team.inviteCode': 'Código de invitación',
   'team.joining': 'Uniéndose...',
   'team.join': 'Unirse',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -1838,6 +1838,8 @@ const messages: TranslationMap = {
   'team.teamName': "Nom de l'équipe",
   'team.creating': 'Création…',
   'team.joinExistingTeam': 'Rejoindre une équipe existante',
+  'team.personalAutoCreatedNote':
+    'Votre équipe personnelle est créée automatiquement. Pour collaborer, rejoignez une équipe existante avec un code d’invitation ci-dessous.',
   'team.inviteCode': "Code d'invitation",
   'team.joining': 'Adhésion…',
   'team.join': 'Rejoindre',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -1789,6 +1789,8 @@ const messages: TranslationMap = {
   'team.teamName': 'टीम का नाम',
   'team.creating': 'बन रही है...',
   'team.joinExistingTeam': 'मौजूदा टीम जॉइन करें',
+  'team.personalAutoCreatedNote':
+    'आपकी व्यक्तिगत टीम स्वतः बन जाती है। सहयोग के लिए, नीचे आमंत्रण कोड के साथ किसी मौजूदा टीम में शामिल हों।',
   'team.inviteCode': 'इनवाइट कोड',
   'team.joining': 'जॉइन हो रहे हैं...',
   'team.join': 'जॉइन करें',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -1799,6 +1799,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Nama tim',
   'team.creating': 'Membuat...',
   'team.joinExistingTeam': 'Bergabung dengan Tim yang Ada',
+  'team.personalAutoCreatedNote':
+    'Tim pribadi Anda dibuat secara otomatis. Untuk berkolaborasi, gabung ke tim yang sudah ada dengan kode undangan di bawah.',
   'team.inviteCode': 'Kode undangan',
   'team.joining': 'Bergabung...',
   'team.join': 'Bergabung',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -1823,6 +1823,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Nome team',
   'team.creating': 'Creazione...',
   'team.joinExistingTeam': 'Unisciti a un team esistente',
+  'team.personalAutoCreatedNote':
+    'Il tuo team personale viene creato automaticamente. Per collaborare, unisciti a un team esistente con un codice di invito qui sotto.',
   'team.inviteCode': 'Codice invito',
   'team.joining': 'Adesione...',
   'team.join': 'Unisciti',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -1775,6 +1775,8 @@ const messages: TranslationMap = {
   'team.teamName': '팀 이름',
   'team.creating': '생성 중...',
   'team.joinExistingTeam': '기존 팀 참가',
+  'team.personalAutoCreatedNote':
+    '개인 팀은 자동으로 생성됩니다. 협업하려면 아래 초대 코드로 기존 팀에 참여하세요.',
   'team.inviteCode': '초대 코드',
   'team.joining': '참가 중...',
   'team.join': '참가',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -1812,6 +1812,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Nazwa zespołu',
   'team.creating': 'Tworzenie...',
   'team.joinExistingTeam': 'Dołącz do istniejącego zespołu',
+  'team.personalAutoCreatedNote':
+    'Twój zespół osobisty jest tworzony automatycznie. Aby współpracować, dołącz do istniejącego zespołu, używając kodu zaproszenia poniżej.',
   'team.inviteCode': 'Kod zaproszenia',
   'team.joining': 'Dołączanie...',
   'team.join': 'Dołącz',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -1830,6 +1830,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Nome da equipe',
   'team.creating': 'Criando...',
   'team.joinExistingTeam': 'Entrar em Equipe Existente',
+  'team.personalAutoCreatedNote':
+    'Sua equipe pessoal é criada automaticamente. Para colaborar, entre em uma equipe existente com um código de convite abaixo.',
   'team.inviteCode': 'Código de convite',
   'team.joining': 'Entrando...',
   'team.join': 'Entrar',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -1806,6 +1806,8 @@ const messages: TranslationMap = {
   'team.teamName': 'Название команды',
   'team.creating': 'Создание...',
   'team.joinExistingTeam': 'Вступить в существующую команду',
+  'team.personalAutoCreatedNote':
+    'Ваша личная команда создаётся автоматически. Чтобы работать вместе, присоединитесь к существующей команде по коду приглашения ниже.',
   'team.inviteCode': 'Код приглашения',
   'team.joining': 'Вход...',
   'team.join': 'Вступить',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -1697,6 +1697,8 @@ const messages: TranslationMap = {
   'team.teamName': '团队名称',
   'team.creating': '创建中...',
   'team.joinExistingTeam': '加入已有团队',
+  'team.personalAutoCreatedNote':
+    '您的个人团队会自动创建。如需协作，请使用下方的邀请码加入现有团队。',
   'team.inviteCode': '邀请码',
   'team.joining': '加入中...',
   'team.join': '加入',


### PR DESCRIPTION
## Summary

- Remove the **Create New Team** control from Settings → Account → Team. The backend has no `POST /teams` route and intentionally caps a user to **one owned/ADMIN team** (`validateRoleConstraints`), so this control could never succeed — it always hit a `404` (`<!DOCTYPE html>` error page) and showed a generic banner.
- Replace it with a short note explaining that the personal team is auto-created and that collaboration happens by joining an existing team.
- Fix team-op error surfacing: failures now show the **real backend reason** instead of a generic string for Join / Switch / Leave.
- Add a small, unit-tested `teamErrorMessage` helper.

## Problem

Clicking **Create** under Settings → Account → Team always failed with a generic red "Failed to create team" banner (Sentry `TAURI-RUST-8`/`TAURI-RUST-9`, prod `0.57.53`, last seen 2026-06-25). Two root causes:

1. **No backend endpoint.** `teamApi.createTeam` → core `team_create_team` → `POST /teams`, but the backend `team` router exposes no `POST /` route. Express returns its default HTML `404`, which is exactly the `<!DOCTYPE html>` body in Sentry. Creating a named team is not a supported operation: every user auto-gets a personal team at signup (`createPersonalTeam`), and `validateRoleConstraints` rejects a user holding ADMIN in more than one team. So the control is **dead by design**, not merely unwired — making it "work" would require relaxing the one-owned-team invariant (a billing-coupled, multi-subscription change out of scope here).
2. **Error reason dropped.** The catch checked `'error' in err`, but `callCoreRpc` rejects with a `CoreRpcError` (no `.error` field), so every failure fell through to a generic localized banner and the backend reason was lost — for Create, Join, Switch, and Leave alike.

## Solution

- Delete the Create New Team section + its handler/state; render an informational note in the Join section instead.
- Add `teamErrorMessage(err, fallback)`: recovers a human reason from `CoreRpcError.data` or from `err.message` (stripping the `"<VERB> <path> failed (<status>):"` prefix the core prepends and lifting the field out of a JSON body), drops raw HTML error pages, and falls back to the localized string. Also handles the legacy plain `{ error }` shape.
- Wire it into the Join / Switch / Leave catches.
- `team_create_team` core RPC and `teamApi.createTeam` are left dormant (no remaining caller) — removing them is unrelated churn; flagged here for a possible follow-up.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `teamErrorMessage.test.ts` (11 cases incl. HTML-body + no-reason fallbacks) and updated `TeamPanel` specs (note rendered, create control gone, real reason surfaced from a `CoreRpcError`).
- [x] **Diff coverage ≥ 80%** — changed lines are FE-only and covered by the above specs (33 tests green).
- [x] N/A: Coverage matrix updated — behaviour-only change, no new feature row.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist updated — removes a non-functional control + error-copy change, no release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop UI only. No Rust, schema, or network change. Removing the always-failing `POST /teams` call eliminates the `TAURI-RUST-8`/`9` 404 noise at source.
- No migration/compat impact. Join / Switch / Leave / Manage Team flows unchanged except clearer error messages.

## Related

- Closes: #3723
- Sentry-Issue: TAURI-RUST-8, TAURI-RUST-9
- Follow-up PR(s)/TODOs: optionally remove dormant `team_create_team` core RPC + `teamApi.createTeam`; if multi-team creation is ever desired, requires relaxing the one-owned-team invariant in `tinyhumansai/backend`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/3723-team-create-removal
- Commit SHA: d140f7f53

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `vitest run` on `teamErrorMessage.test.ts` + both `TeamPanel` specs — 33 passed
- [x] N/A: Rust fmt/check (if changed) — no Rust changed.
- [x] N/A: Tauri fmt/check (if changed) — no Rust changed.

### Validation Blocked

- `command:` pre-push `pnpm rust:check`
- `error:` worktree submodules (vendored tauri-cef) uninitialized → cold cross-compile infeasible locally
- `impact:` none — diff is FE-only; full Rust checks run in CI. Pushed with `--no-verify` after FE gates passed manually.

### Behavior Changes

- Intended behavior change: remove an always-failing Create-Team control; surface real backend reasons on team-op failures.
- User-visible effect: no Create input/button; an explanatory note instead; clearer error banners.

### Parity Contract

- Legacy behavior preserved: Join / Switch / Leave / Manage Team unchanged in behavior; only error copy improves.
- Guard/fallback/dispatch parity checks: `teamErrorMessage` still returns the localized fallback when no reason is recoverable (matches prior generic banner) and handles the legacy `{ error }` rejection shape.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated team settings to show that personal teams are created automatically and to guide users toward joining an existing team with an invite code.
  * Added localized support for the new personal-team note in multiple languages.

* **Bug Fixes**
  * Improved team-related error messages so users now see clearer, real backend error details instead of generic fallback text.
  * Removed the option to create a new team from the settings panel when it isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
