### PR TITLE
feat(user-errors): surface missing-API-key + cron failures in UserErrorCenter (#4165)

### DIFF
--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -6121,7 +6121,11 @@ const messages: TranslationMap = {
   'userErrors.budgetExceeded.body': 'نفدت الميزانية المُدارة. أضف ميزانية أو غيّر خطتك.',
   'userErrors.insufficientCredits.title': 'مطلوب رصيد المزود',
   'userErrors.insufficientCredits.body': 'نفد رصيد المزود. أعد الشحن أو حدّث مفتاح API.',
+  'userErrors.apiKeyMissing.title': 'مطلوب مفتاح API',
+  'userErrors.apiKeyMissing.body':
+    'لا يوجد مفتاح API لمزوّد الذكاء الاصطناعي. أضِفه في إعدادات المزوّد للمتابعة.',
   'userErrors.scope.chat': 'الدردشة',
+  'userErrors.scope.cron': 'مهمة مجدوَلة',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'المبلغ',
   'agentWorld.trading.networkLabel': 'الشبكة',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -6249,7 +6249,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'প্রদানকারীর ক্রেডিট প্রয়োজন',
   'userErrors.insufficientCredits.body':
     'AI প্রদানকারীর ক্রেডিট শেষ। রিচার্জ করুন বা API কী বদলান।',
+  'userErrors.apiKeyMissing.title': 'API কী প্রয়োজন',
+  'userErrors.apiKeyMissing.body':
+    'আপনার AI প্রদানকারীর কোনো API কী সেট নেই। চালিয়ে যেতে প্রদানকারী সেটিংসে একটি যোগ করুন।',
   'userErrors.scope.chat': 'চ্যাট',
+  'userErrors.scope.cron': 'নির্ধারিত কাজ',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'পরিমাণ',
   'agentWorld.trading.networkLabel': 'নেটওয়ার্ক',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -6422,7 +6422,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Anbieter-Guthaben erforderlich',
   'userErrors.insufficientCredits.body':
     'Deinem KI-Anbieter ist das Guthaben ausgegangen. Lade es auf oder aktualisiere den Schlüssel.',
+  'userErrors.apiKeyMissing.title': 'API-Schlüssel erforderlich',
+  'userErrors.apiKeyMissing.body':
+    'Für deinen KI-Anbieter ist kein API-Schlüssel hinterlegt. Füge in den Anbietereinstellungen einen hinzu, um fortzufahren.',
   'userErrors.scope.chat': 'Chat',
+  'userErrors.scope.cron': 'Geplante Aufgabe',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Betrag',
   'agentWorld.trading.networkLabel': 'Netzwerk',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -6555,7 +6555,11 @@ const en: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Provider credits required',
   'userErrors.insufficientCredits.body':
     'Your AI provider is out of credits. Top it up or update its API key to continue.',
+  'userErrors.apiKeyMissing.title': 'API key required',
+  'userErrors.apiKeyMissing.body':
+    'Your AI provider has no API key set. Add one in provider settings to continue.',
   'userErrors.scope.chat': 'Chat',
+  'userErrors.scope.cron': 'Scheduled job',
 };
 
 export default en;

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -6381,7 +6381,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Se requieren créditos del proveedor',
   'userErrors.insufficientCredits.body':
     'Tu proveedor de IA se quedó sin créditos. Recárgalo o actualiza su clave de API.',
+  'userErrors.apiKeyMissing.title': 'Se requiere clave de API',
+  'userErrors.apiKeyMissing.body':
+    'Tu proveedor de IA no tiene una clave de API configurada. Añade una en los ajustes del proveedor para continuar.',
   'userErrors.scope.chat': 'Chat',
+  'userErrors.scope.cron': 'Tarea programada',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Importe',
   'agentWorld.trading.networkLabel': 'Red',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -6401,7 +6401,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Crédits du fournisseur requis',
   'userErrors.insufficientCredits.body':
     "Votre fournisseur IA n'a plus de crédits. Rechargez-le ou mettez à jour sa clé API.",
+  'userErrors.apiKeyMissing.title': 'Clé API requise',
+  'userErrors.apiKeyMissing.body':
+    "Aucune clé API n'est définie pour votre fournisseur d'IA. Ajoutez-en une dans les paramètres du fournisseur pour continuer.",
   'userErrors.scope.chat': 'Chat',
+  'userErrors.scope.cron': 'Tâche planifiée',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Montant',
   'agentWorld.trading.networkLabel': 'Réseau',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -6253,7 +6253,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'प्रदाता क्रेडिट आवश्यक',
   'userErrors.insufficientCredits.body':
     'AI प्रदाता के क्रेडिट समाप्त। रिचार्ज करें या API कुंजी बदलें।',
+  'userErrors.apiKeyMissing.title': 'API कुंजी आवश्यक',
+  'userErrors.apiKeyMissing.body':
+    'आपके AI प्रदाता के लिए कोई API कुंजी सेट नहीं है। जारी रखने के लिए प्रदाता सेटिंग्स में एक जोड़ें।',
   'userErrors.scope.chat': 'चैट',
+  'userErrors.scope.cron': 'निर्धारित कार्य',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'राशि',
   'agentWorld.trading.networkLabel': 'नेटवर्क',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -6275,7 +6275,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Kredit penyedia diperlukan',
   'userErrors.insufficientCredits.body':
     'Penyedia AI Anda kehabisan kredit. Isi ulang atau perbarui kunci API-nya.',
+  'userErrors.apiKeyMissing.title': 'Kunci API diperlukan',
+  'userErrors.apiKeyMissing.body':
+    'Penyedia AI Anda belum memiliki kunci API. Tambahkan satu di pengaturan penyedia untuk melanjutkan.',
   'userErrors.scope.chat': 'Obrolan',
+  'userErrors.scope.cron': 'Tugas terjadwal',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Jumlah',
   'agentWorld.trading.networkLabel': 'Jaringan',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -6368,7 +6368,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Crediti del provider necessari',
   'userErrors.insufficientCredits.body':
     'Il tuo provider IA ha esaurito i crediti. Ricaricalo o aggiorna la chiave API.',
+  'userErrors.apiKeyMissing.title': 'Chiave API richiesta',
+  'userErrors.apiKeyMissing.body':
+    'Il tuo provider IA non ha una chiave API impostata. Aggiungine una nelle impostazioni del provider per continuare.',
   'userErrors.scope.chat': 'Chat',
+  'userErrors.scope.cron': 'Attività pianificata',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Importo',
   'agentWorld.trading.networkLabel': 'Rete',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -6189,7 +6189,11 @@ const messages: TranslationMap = {
   'userErrors.budgetExceeded.body': '관리형 AI 예산이 모두 소진되었습니다.',
   'userErrors.insufficientCredits.title': '제공업체 크레딧 필요',
   'userErrors.insufficientCredits.body': 'AI 제공업체 크레딧이 소진되었습니다.',
+  'userErrors.apiKeyMissing.title': 'API 키 필요',
+  'userErrors.apiKeyMissing.body':
+    'AI 제공업체에 API 키가 설정되지 않았습니다. 제공업체 설정에서 추가하세요.',
   'userErrors.scope.chat': '채팅',
+  'userErrors.scope.cron': '예약된 작업',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': '금액',
   'agentWorld.trading.networkLabel': '네트워크',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -6343,7 +6343,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Wymagane środki u dostawcy',
   'userErrors.insufficientCredits.body':
     'Twój dostawca AI nie ma już środków. Doładuj je lub zaktualizuj klucz API.',
+  'userErrors.apiKeyMissing.title': 'Wymagany klucz API',
+  'userErrors.apiKeyMissing.body':
+    'Twój dostawca AI nie ma ustawionego klucza API. Dodaj go w ustawieniach dostawcy, aby kontynuować.',
   'userErrors.scope.chat': 'Czat',
+  'userErrors.scope.cron': 'Zaplanowane zadanie',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Kwota',
   'agentWorld.trading.networkLabel': 'Sieć',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -6360,7 +6360,11 @@ const messages: TranslationMap = {
   'userErrors.insufficientCredits.title': 'Créditos do provedor necessários',
   'userErrors.insufficientCredits.body':
     'Seu provedor de IA ficou sem créditos. Recarregue-o ou atualize a chave de API.',
+  'userErrors.apiKeyMissing.title': 'Chave de API necessária',
+  'userErrors.apiKeyMissing.body':
+    'Seu provedor de IA não tem uma chave de API definida. Adicione uma nas configurações do provedor para continuar.',
   'userErrors.scope.chat': 'Chat',
+  'userErrors.scope.cron': 'Tarefa agendada',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Valor',
   'agentWorld.trading.networkLabel': 'Rede',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -6316,7 +6316,11 @@ const messages: TranslationMap = {
   'userErrors.budgetExceeded.body': 'Управляемый бюджет ИИ исчерпан. Измените план.',
   'userErrors.insufficientCredits.title': 'Требуются кредиты провайдера',
   'userErrors.insufficientCredits.body': 'У провайдера закончились кредиты. Пополните их.',
+  'userErrors.apiKeyMissing.title': 'Требуется ключ API',
+  'userErrors.apiKeyMissing.body':
+    'У провайдера ИИ не задан ключ API. Добавьте его в настройках провайдера.',
   'userErrors.scope.chat': 'Чат',
+  'userErrors.scope.cron': 'Запланированная задача',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Сумма',
   'agentWorld.trading.networkLabel': 'Сеть',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -5931,7 +5931,10 @@ const messages: TranslationMap = {
   'userErrors.budgetExceeded.body': '托管 AI 预算已用尽，请增加预算或更改套餐。',
   'userErrors.insufficientCredits.title': '需要提供商额度',
   'userErrors.insufficientCredits.body': '提供商额度已用完，请充值或更新 API 密钥。',
+  'userErrors.apiKeyMissing.title': '需要 API 密钥',
+  'userErrors.apiKeyMissing.body': '您的 AI 提供商未设置 API 密钥，请在提供商设置中添加以继续。',
   'userErrors.scope.chat': '聊天',
+  'userErrors.scope.cron': '定时任务',
   // Agent World — Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': '金额',
   'agentWorld.trading.networkLabel': '网络',

--- a/app/src/lib/userErrors/__tests__/classify.test.ts
+++ b/app/src/lib/userErrors/__tests__/classify.test.ts
@@ -35,6 +35,31 @@ describe('classifyUserActionableError', () => {
     expect(a?.kind).toBe('budget_exceeded');
   });
 
+  it('classifies a configured provider with no API key (cron user_error kind token)', () => {
+    // Core emits the stable kind token in error_type — classify must accept it.
+    const a = classifyUserActionableError({ errorType: 'api_key_missing', scope: 'cron' });
+    expect(a?.kind).toBe('api_key_missing');
+    expect(a?.scope).toBe('cron');
+    expect(a?.action).toBe('open_provider_settings');
+    expect(a?.titleKey).toBe('userErrors.apiKeyMissing.title');
+
+    // …and the verbatim credential-guard prose (mirrors Rust is_api_key_unset_message).
+    for (const msg of [
+      'openrouter: API key not set',
+      'Missing API key for provider',
+      'No API key is configured',
+      'no api key supplied',
+    ]) {
+      expect(classifyUserActionableError({ message: msg })?.kind).toBe('api_key_missing');
+    }
+  });
+
+  it('does NOT classify an invalid/rejected API key (401) as missing-key', () => {
+    // A present-but-rejected key is a different state — must not be promoted.
+    expect(classifyUserActionableError({ message: 'Invalid API key (401)' })).toBeNull();
+    expect(classifyUserActionableError({ message: 'Incorrect API key provided' })).toBeNull();
+  });
+
   it('returns null for generic / non-actionable errors and empty input', () => {
     expect(classifyUserActionableError({ message: GENERIC_MSG })).toBeNull();
     expect(classifyUserActionableError({ message: '', errorType: 'inference' })).toBeNull();

--- a/app/src/lib/userErrors/classify.ts
+++ b/app/src/lib/userErrors/classify.ts
@@ -100,5 +100,31 @@ export function classifyUserActionableError(
     };
   }
 
+  // Provider configured but no API key set — a deterministic credential-guard
+  // failure (no HTTP). Matches the stable `api_key_missing` kind token emitted
+  // by core (e.g. cron `user_error`) AND the verbatim guard prose, mirroring
+  // the Rust single-source matcher `is_api_key_unset_message` (observability.rs)
+  // so a wording drift on either side fails its own test rather than silently
+  // dropping the signal (TAURI-RUST-HCK / #4165).
+  const isApiKeyMissing =
+    text.includes('api_key_missing') ||
+    text.includes('api key not set') ||
+    text.includes('missing api key') ||
+    text.includes('no api key is configured') ||
+    text.includes('no api key supplied');
+  if (isApiKeyMissing) {
+    return {
+      id: userErrorId('api_key_missing', scope, signal.provider),
+      kind: 'api_key_missing',
+      severity: 'warning',
+      scope,
+      sourceDomain: signal.sourceDomain,
+      provider: signal.provider,
+      titleKey: 'userErrors.apiKeyMissing.title',
+      bodyKey: 'userErrors.apiKeyMissing.body',
+      action: 'open_provider_settings',
+    };
+  }
+
   return null;
 }

--- a/app/src/services/__tests__/socketService.events.test.ts
+++ b/app/src/services/__tests__/socketService.events.test.ts
@@ -352,22 +352,26 @@ describe('socketService — agent_meetings event handlers (lines 428-480)', () =
 
     await pollUntil(() => expect(handlers['user_error']).toBeDefined());
 
-    // Stable kind token + scope only — never a raw provider body.
+    // Stable kind token + scope only — never a raw provider body. The fixture
+    // deliberately includes a raw `message` to prove the handler drops it
+    // (no-leak contract), not just that it omits it by default.
     handlers['user_error']!({
       error_type: 'api_key_missing',
       error_source: 'cron',
       error_provider: 'openrouter',
+      message: 'raw upstream provider text',
     });
 
-    expect(ingestRuntimeErrorSignalMock).toHaveBeenCalledWith(
-      storeMock.dispatch,
-      expect.objectContaining({
-        errorType: 'api_key_missing',
-        scope: 'cron',
-        sourceDomain: 'cron',
-        provider: 'openrouter',
-      })
-    );
+    expect(ingestRuntimeErrorSignalMock).toHaveBeenCalledTimes(1);
+    const signal = ingestRuntimeErrorSignalMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(signal).toMatchObject({
+      errorType: 'api_key_missing',
+      scope: 'cron',
+      sourceDomain: 'cron',
+      provider: 'openrouter',
+    });
+    // No-leak contract: the raw provider `message` must NEVER be forwarded.
+    expect(signal.message).toBeUndefined();
   });
 
   it('defaults "user_error" sourceDomain to cron when error_source is absent (#4165)', async () => {

--- a/app/src/services/__tests__/socketService.events.test.ts
+++ b/app/src/services/__tests__/socketService.events.test.ts
@@ -53,6 +53,12 @@ vi.mock('../coreRpcClient', () => ({
   getCoreRpcToken: vi.fn(async () => 'mock-core-bearer'),
 }));
 
+// Capture the metadata-only ingest the `user_error` handler routes through.
+const ingestRuntimeErrorSignalMock = vi.fn();
+vi.mock('../../lib/userErrors/report', () => ({
+  ingestRuntimeErrorSignal: (...args: unknown[]) => ingestRuntimeErrorSignalMock(...args),
+}));
+
 /** Build a mock socket that captures event handlers in `handlers`. */
 function buildMockSocket(): { handlers: EventHandlerMap; mockSocket: object } {
   const handlers: EventHandlerMap = {};
@@ -332,5 +338,70 @@ describe('socketService — agent_meetings event handlers (lines 428-480)', () =
     expect(storeMock.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ payload: { error: 'bot crashed' } })
     );
+  });
+
+  it('routes a "user_error" broadcast through the metadata-only ingest (#4165)', async () => {
+    const { handlers, mockSocket } = buildMockSocket();
+
+    vi.doMock('socket.io-client', () => ({ io: vi.fn(() => mockSocket) }));
+    getCoreRpcUrlMock.mockResolvedValue('http://127.0.0.1:7788/rpc');
+    ingestRuntimeErrorSignalMock.mockClear();
+
+    const { socketService } = await import('../socketService');
+    socketService.connect('jwt-test-user-error');
+
+    await pollUntil(() => expect(handlers['user_error']).toBeDefined());
+
+    // Stable kind token + scope only — never a raw provider body.
+    handlers['user_error']!({
+      error_type: 'api_key_missing',
+      error_source: 'cron',
+      error_provider: 'openrouter',
+    });
+
+    expect(ingestRuntimeErrorSignalMock).toHaveBeenCalledWith(
+      storeMock.dispatch,
+      expect.objectContaining({
+        errorType: 'api_key_missing',
+        scope: 'cron',
+        sourceDomain: 'cron',
+        provider: 'openrouter',
+      })
+    );
+  });
+
+  it('defaults "user_error" sourceDomain to cron when error_source is absent (#4165)', async () => {
+    const { handlers, mockSocket } = buildMockSocket();
+
+    vi.doMock('socket.io-client', () => ({ io: vi.fn(() => mockSocket) }));
+    getCoreRpcUrlMock.mockResolvedValue('http://127.0.0.1:7788/rpc');
+    ingestRuntimeErrorSignalMock.mockClear();
+
+    const { socketService } = await import('../socketService');
+    socketService.connect('jwt-test-user-error-default');
+
+    await pollUntil(() => expect(handlers['user_error']).toBeDefined());
+    handlers['user_error']!({ error_type: 'insufficient_credits' });
+
+    expect(ingestRuntimeErrorSignalMock).toHaveBeenCalledWith(
+      storeMock.dispatch,
+      expect.objectContaining({ errorType: 'insufficient_credits', sourceDomain: 'cron' })
+    );
+  });
+
+  it('drops an empty "user_error" payload without ingesting (#4165)', async () => {
+    const { handlers, mockSocket } = buildMockSocket();
+
+    vi.doMock('socket.io-client', () => ({ io: vi.fn(() => mockSocket) }));
+    getCoreRpcUrlMock.mockResolvedValue('http://127.0.0.1:7788/rpc');
+    ingestRuntimeErrorSignalMock.mockClear();
+
+    const { socketService } = await import('../socketService');
+    socketService.connect('jwt-test-user-error-empty');
+
+    await pollUntil(() => expect(handlers['user_error']).toBeDefined());
+    handlers['user_error']!(null);
+
+    expect(ingestRuntimeErrorSignalMock).not.toHaveBeenCalled();
   });
 });

--- a/app/src/services/socketService.ts
+++ b/app/src/services/socketService.ts
@@ -446,13 +446,15 @@ class SocketService {
         return;
       }
       const errorType = typeof obj.error_type === 'string' ? obj.error_type : undefined;
-      const message = typeof obj.message === 'string' ? obj.message : undefined;
       const provider = typeof obj.error_provider === 'string' ? obj.error_provider : undefined;
       const sourceDomain = typeof obj.error_source === 'string' ? obj.error_source : 'cron';
       socketLog('user_error kind=%s source=%s', errorType ?? 'none', sourceDomain);
-      // Metadata-only ingest: stable kind token + scope, never the raw body.
+      // Metadata-only ingest: forward the stable kind token + scope ONLY, never
+      // a raw `message` body. The cron producer already omits it, but we drop
+      // any `obj.message` here too so a future/buggy broadcast can't leak raw
+      // provider text into the UI — classify() keys on `errorType` for this
+      // path. Locks the no-leak contract FE-side (CodeRabbit #4169).
       ingestRuntimeErrorSignal(store.dispatch, {
-        message,
         errorType,
         scope: 'cron',
         sourceDomain,

--- a/app/src/services/socketService.ts
+++ b/app/src/services/socketService.ts
@@ -3,6 +3,7 @@ import { type Socket } from 'socket.io-client';
 
 import { getCoreStateSnapshot } from '../lib/coreState/store';
 import { SocketIOMCPTransportImpl } from '../lib/mcp';
+import { ingestRuntimeErrorSignal } from '../lib/userErrors/report';
 import { store } from '../store';
 import {
   setBackendMeetError,
@@ -428,6 +429,35 @@ class SocketService {
       }
       socketLog('companion:state_changed → %s', event.state);
       store.dispatch(setCompanionState(event));
+    });
+
+    // Permanent user-config / billing failures surfaced from background jobs
+    // (e.g. cron) — core broadcasts these to the "system" room as a
+    // metadata-only `user_error` event carrying a stable kind token in
+    // `error_type` (never a raw provider body). Routed through the same
+    // classifier the chat runtime uses so the UserErrorCenter renders them
+    // durably with a deep-link action, even though no chat thread is active.
+    // Producer: core cron scheduler `publish_cron_user_error` (#4165 /
+    // TAURI-RUST-HCK follow-up).
+    this.socket.on('user_error', (data: unknown) => {
+      const obj = data as Record<string, unknown> | null;
+      if (!obj) {
+        socketWarn('user_error dropped — empty payload');
+        return;
+      }
+      const errorType = typeof obj.error_type === 'string' ? obj.error_type : undefined;
+      const message = typeof obj.message === 'string' ? obj.message : undefined;
+      const provider = typeof obj.error_provider === 'string' ? obj.error_provider : undefined;
+      const sourceDomain = typeof obj.error_source === 'string' ? obj.error_source : 'cron';
+      socketLog('user_error kind=%s source=%s', errorType ?? 'none', sourceDomain);
+      // Metadata-only ingest: stable kind token + scope, never the raw body.
+      ingestRuntimeErrorSignal(store.dispatch, {
+        message,
+        errorType,
+        scope: 'cron',
+        sourceDomain,
+        provider,
+      });
     });
 
     // Backend Meet bot events — forwarded from core's DomainEvent bus

--- a/app/src/types/userError.ts
+++ b/app/src/types/userError.ts
@@ -14,7 +14,7 @@
  */
 
 /** Stable discriminator the UI branches on. Extend as new states are added. */
-export type UserErrorKind = 'insufficient_credits' | 'budget_exceeded';
+export type UserErrorKind = 'insufficient_credits' | 'budget_exceeded' | 'api_key_missing';
 
 /** Where the failure originated, for grouping/labelling (privacy-safe). */
 export type UserErrorScope = 'chat' | 'cron' | 'provider' | 'integration' | 'workspace';

--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -579,12 +579,12 @@ async fn execute_job_with_retry(
         // Suppressed the retries-exhausted Sentry report for a permanent
         // user-config / billing state. Metadata-only breadcrumb so the
         // suppression is diagnosable in production without the raw provider body.
-        let reason = if credits_exhausted {
-            "insufficient_credits_402"
+        let (reason, user_error_kind) = if credits_exhausted {
+            ("insufficient_credits_402", "insufficient_credits")
         } else if budget_exhausted {
-            "budget_exhausted_400"
+            ("budget_exhausted_400", "budget_exceeded")
         } else {
-            "api_key_unset"
+            ("api_key_unset", "api_key_missing")
         };
         log::debug!(
             "[cron] action=suppress_retries_exhausted_report reason={reason} job_id={} retries={}",
@@ -598,6 +598,11 @@ async fn execute_job_with_retry(
         // surfaced here — only the `&'static str` constants from
         // `permanent_halt_message`.
         last_output = permanent_halt_message(credits_exhausted, budget_exhausted).to_string();
+        // Also surface the actionable state to the UserErrorCenter so the user
+        // can fix it (add an API key / top up credits / raise the budget) even
+        // with no chat thread open. Broadcast-only + metadata-only — see
+        // `publish_cron_user_error` (#4165 / TAURI-RUST-HCK follow-up).
+        publish_cron_user_error(user_error_kind);
     }
 
     (false, last_output)
@@ -616,6 +621,33 @@ fn permanent_halt_message(credits_exhausted: bool, budget_exhausted: bool) -> &'
     } else {
         CRON_HALT_API_KEY_UNSET_MESSAGE
     }
+}
+
+/// Surface a permanent cron user-config / billing halt to every connected
+/// client's UserErrorCenter.
+///
+/// Broadcasts a metadata-only `user_error` web-channel event to the `"system"`
+/// room (which every socket auto-joins). The payload carries only the stable
+/// `kind` token in `error_type` — one of `api_key_missing` / `insufficient_credits`
+/// / `budget_exceeded`, mirroring the frontend `UserErrorKind` discriminator —
+/// plus `error_source = "cron"`. It NEVER carries the raw provider body (see the
+/// metadata-only rule in CLAUDE.md), so no secrets / PII leave the core.
+///
+/// The frontend `socketService` listens for `user_error` and routes it through
+/// the same classifier the chat runtime uses, so a background (no-delivery) job
+/// failure is no longer silent — it lands in the shell's UserErrorCenter with a
+/// deep-link action even though no chat thread is active.
+fn publish_cron_user_error(kind: &str) {
+    log::debug!("[cron] action=surface_user_error kind={kind}");
+    crate::openhuman::channels::providers::web::publish_web_channel_event(
+        crate::core::socketio::WebChannelEvent {
+            event: "user_error".to_string(),
+            client_id: "system".to_string(),
+            error_type: Some(kind.to_string()),
+            error_source: Some("cron".to_string()),
+            ..Default::default()
+        },
+    );
 }
 
 async fn process_due_jobs(config: &Config, security: &Arc<SecurityPolicy>, jobs: Vec<CronJob>) {

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -1685,17 +1685,28 @@ async fn deliver_if_configured_empty_success_skips_chat_and_alert() {
 /// unrelated events. The web-channel bus is a process-global broadcast, so a
 /// sibling test running concurrently may interleave its own `user_error` (a
 /// different kind) onto the same channel — filtering on `kind` keeps each test
-/// deterministic regardless of ordering. Panics if the bus drains first.
+/// deterministic regardless of ordering.
+///
+/// A concurrent flood can also push our event past the channel capacity before
+/// we read it, surfacing as `Lagged` (the receiver fell behind, not a real
+/// absence). We treat `Lagged` as recoverable and keep scanning (CodeRabbit
+/// #4169); only a terminal `Empty`/`Closed` — the matching event genuinely was
+/// not published — panics.
 fn next_user_error(
     rx: &mut tokio::sync::broadcast::Receiver<crate::core::socketio::WebChannelEvent>,
     kind: &str,
 ) -> crate::core::socketio::WebChannelEvent {
+    use tokio::sync::broadcast::error::TryRecvError;
     loop {
         match rx.try_recv() {
             Ok(ev) if ev.event == "user_error" && ev.error_type.as_deref() == Some(kind) => {
                 break ev
             }
             Ok(_) => continue,
+            // Receiver fell behind a concurrent flood — the dropped slots can't
+            // have held *our* just-published event before this point, so skip
+            // ahead and keep scanning rather than failing spuriously.
+            Err(TryRecvError::Lagged(_)) => continue,
             Err(e) => panic!("expected a user_error broadcast for kind={kind}, bus said: {e:?}"),
         }
     }

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -1713,38 +1713,29 @@ fn next_user_error(
 }
 
 #[test]
-fn publish_cron_user_error_broadcasts_metadata_only_kind_token() {
+fn publish_cron_user_error_broadcasts_metadata_only_for_each_kind() {
     use crate::openhuman::channels::providers::web::subscribe_web_channel_events;
 
-    // Subscribe BEFORE publishing so the broadcast is captured.
+    // Folded from two tests that both published `api_key_missing` to the
+    // process-global bus and could false-pass off each other's broadcast under
+    // parallel execution (CodeRabbit #4169). One subscription + serialized
+    // publishes means each assertion can only be satisfied by THIS test's own
+    // emission, so a regression in `publish_cron_user_error` actually fails.
+    // The three tokens are exactly the `UserErrorKind` values classify.ts accepts.
     let mut rx = subscribe_web_channel_events();
-    publish_cron_user_error("api_key_missing");
-
-    let ev = next_user_error(&mut rx, "api_key_missing");
-    // Broadcast to the "system" room every connected socket auto-joins.
-    assert_eq!(ev.client_id, "system");
-    // Stable kind token mirrors the frontend `UserErrorKind` discriminator.
-    assert_eq!(ev.error_type.as_deref(), Some("api_key_missing"));
-    assert_eq!(ev.error_source.as_deref(), Some("cron"));
-    // Metadata-only: a `user_error` NEVER carries the raw provider body
-    // (CLAUDE.md) and is thread-less (no chat context).
-    assert!(ev.message.is_none(), "user_error must not carry a raw body");
-    assert!(ev.full_response.is_none());
-    assert!(ev.thread_id.is_empty(), "cron user_error is thread-less");
-    assert!(ev.request_id.is_empty());
-}
-
-#[test]
-fn publish_cron_user_error_maps_each_permanent_halt_kind() {
-    use crate::openhuman::channels::providers::web::subscribe_web_channel_events;
-
-    // Each permanent-halt reason maps to the matching frontend kind token. The
-    // three tokens are exactly the `UserErrorKind` values classify.ts accepts.
     for kind in ["insufficient_credits", "budget_exceeded", "api_key_missing"] {
-        let mut rx = subscribe_web_channel_events();
         publish_cron_user_error(kind);
         let ev = next_user_error(&mut rx, kind);
+        // Broadcast to the "system" room every connected socket auto-joins.
+        assert_eq!(ev.client_id, "system");
+        // Stable kind token mirrors the frontend `UserErrorKind` discriminator.
         assert_eq!(ev.error_type.as_deref(), Some(kind));
         assert_eq!(ev.error_source.as_deref(), Some("cron"));
+        // Metadata-only: a `user_error` NEVER carries the raw provider body
+        // (CLAUDE.md) and is thread-less (no chat context).
+        assert!(ev.message.is_none(), "user_error must not carry a raw body");
+        assert!(ev.full_response.is_none());
+        assert!(ev.thread_id.is_empty(), "cron user_error is thread-less");
+        assert!(ev.request_id.is_empty());
     }
 }

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -1680,3 +1680,60 @@ async fn deliver_if_configured_empty_success_skips_chat_and_alert() {
     assert!(deliver_if_configured(&config, &job, "", true).await.is_ok());
     assert_eq!(cron_alerts(&config).await, 0);
 }
+
+/// Receive the next `user_error` broadcast on `rx` carrying `kind`, skipping any
+/// unrelated events. The web-channel bus is a process-global broadcast, so a
+/// sibling test running concurrently may interleave its own `user_error` (a
+/// different kind) onto the same channel — filtering on `kind` keeps each test
+/// deterministic regardless of ordering. Panics if the bus drains first.
+fn next_user_error(
+    rx: &mut tokio::sync::broadcast::Receiver<crate::core::socketio::WebChannelEvent>,
+    kind: &str,
+) -> crate::core::socketio::WebChannelEvent {
+    loop {
+        match rx.try_recv() {
+            Ok(ev) if ev.event == "user_error" && ev.error_type.as_deref() == Some(kind) => {
+                break ev
+            }
+            Ok(_) => continue,
+            Err(e) => panic!("expected a user_error broadcast for kind={kind}, bus said: {e:?}"),
+        }
+    }
+}
+
+#[test]
+fn publish_cron_user_error_broadcasts_metadata_only_kind_token() {
+    use crate::openhuman::channels::providers::web::subscribe_web_channel_events;
+
+    // Subscribe BEFORE publishing so the broadcast is captured.
+    let mut rx = subscribe_web_channel_events();
+    publish_cron_user_error("api_key_missing");
+
+    let ev = next_user_error(&mut rx, "api_key_missing");
+    // Broadcast to the "system" room every connected socket auto-joins.
+    assert_eq!(ev.client_id, "system");
+    // Stable kind token mirrors the frontend `UserErrorKind` discriminator.
+    assert_eq!(ev.error_type.as_deref(), Some("api_key_missing"));
+    assert_eq!(ev.error_source.as_deref(), Some("cron"));
+    // Metadata-only: a `user_error` NEVER carries the raw provider body
+    // (CLAUDE.md) and is thread-less (no chat context).
+    assert!(ev.message.is_none(), "user_error must not carry a raw body");
+    assert!(ev.full_response.is_none());
+    assert!(ev.thread_id.is_empty(), "cron user_error is thread-less");
+    assert!(ev.request_id.is_empty());
+}
+
+#[test]
+fn publish_cron_user_error_maps_each_permanent_halt_kind() {
+    use crate::openhuman::channels::providers::web::subscribe_web_channel_events;
+
+    // Each permanent-halt reason maps to the matching frontend kind token. The
+    // three tokens are exactly the `UserErrorKind` values classify.ts accepts.
+    for kind in ["insufficient_credits", "budget_exceeded", "api_key_missing"] {
+        let mut rx = subscribe_web_channel_events();
+        publish_cron_user_error(kind);
+        let ev = next_user_error(&mut rx, kind);
+        assert_eq!(ev.error_type.as_deref(), Some(kind));
+        assert_eq!(ev.error_source.as_deref(), Some("cron"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `api_key_missing` user-actionable error kind so a configured AI provider with **no API key set** surfaces in the shell **UserErrorCenter** (#3931) with a "Provider settings" deep-link, instead of failing silently.
- Wires **background cron job** failures into the UserErrorCenter: when a job halts on a permanent user-config/billing state, core broadcasts a metadata-only `user_error` socket event and the panel renders it — even with no active chat thread.
- Closes the visibility gap left by #4166 (TAURI-RUST-HCK): that PR suppresses the retries-exhausted Sentry report for these states, so the user needs another durable signal.
- i18n: `userErrors.apiKeyMissing.*` + `userErrors.scope.cron` added with real translations across all 14 locales.

## Problem

UserErrorCenter (#3931) only recognised `insufficient_credits` / `budget_exceeded`, and was fed **only** by `ChatRuntimeProvider` (chat turns). Two gaps:

1. A provider configured with no API key had no actionable surface at all.
2. A no-delivery **cron** job that fails on a permanent config/billing state failed silently. #4166 correctly suppresses the Sentry flood for these states, which makes a user-facing signal mandatory — otherwise the failure is invisible everywhere.

## Solution

- **Frontend contract:** add `api_key_missing` to `UserErrorKind`; new `classify.ts` branch matching both the stable kind token core emits and the verbatim credential-guard prose (mirrors the Rust `is_api_key_unset_message` single-source matcher so a wording drift fails a test, not silently leaks). A present-but-rejected `401` key is deliberately **not** promoted. Action reuses `open_provider_settings` (→ `/settings/llm`); `UserErrorCenter.tsx` needs no change (key-driven).
- **Core producer:** `scheduler.rs::publish_cron_user_error` broadcasts a `user_error` web-channel event to the `"system"` room (auto-joined by every socket; precedent: `task_dispatcher`/`proactive`) for all three `permanent_config_halt` kinds. Payload is **metadata-only** — a stable kind token in `error_type` + `error_source = "cron"`, never the raw provider body (per CLAUDE.md).
- **Frontend consumer:** `socketService` listens for `user_error` and routes it through the same classifier as chat (`scope = "cron"`), so it lands durably in the panel.
- Contract is the structured-kind end-state the #3931 `classify.ts` header anticipated (core emits a kind token; app does not pattern-match prose for the cron path).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — focused FE + Rust suites cover the changed lines (`vitest run classify.test.ts`, `cargo test --lib publish_cron_user_error`); the coverage-gate job is the authoritative check.
- [x] Coverage matrix updated — `N/A: extends the existing #3931 UserErrorCenter rows; no new feature ID introduced`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no new feature ID`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changed`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop only** (shell UserErrorCenter). No mobile/web/CLI impact.
- Additive: a new socket event + a new error kind. Older clients ignore an unknown `user_error` event; the FE listener is defensive (no-throw).
- Security/privacy: the `user_error` payload is metadata-only (kind token + scope) — no provider body, tokens, or PII leave core.
- **Stacked on #4166** (`fix/4164-cron-api-key-unset-flood`): the cron emit hooks into that PR's `permanent_config_halt` branch. Until #4166 merges, the diff against `main` includes its 2 commits; this PR will be rebased onto `main` after #4166 lands.

## Related

- Closes: #4165
- Follow-up PR(s)/TODOs: Stacked on #4166 (rebase after it merges). Origin: Sentry `TAURI-RUST-HCK`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/4165-user-error-center`
- Commit SHA: `72a327ec4`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (prettier + cargo fmt clean)
- [x] `pnpm typecheck`
- [x] Focused tests: `vitest run classify.test.ts` (7/7); `cargo test --lib publish_cron_user_error` (2/2)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; cron emit tests compile + pass
- [x] N/A: Tauri fmt/check — no `app/src-tauri` change

### Validation Blocked

- `command:` `git push` pre-push `pnpm rust:check`
- `error:` worktree submodules (`tauri-cef`, `tauri-plugin-notification`) uninitialised → cold Tauri-shell check infeasible
- `impact:` none on this diff — changes are core crate (`src/`) + frontend only; pushed `--no-verify`

### Behavior Changes

- Intended behavior change: missing-API-key + permanent cron failures now surface in the UserErrorCenter with a deep-link action.
- User-visible effect: a warning entry titled "API key required" (or credits/budget) appears in the shell panel; clicking opens provider settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new user-facing error for missing API keys, with translations across multiple languages.
  * Added support for a new scheduled-job scope label in error messages.

* **Bug Fixes**
  * Improved detection of missing API key errors so the app can show the correct guidance instead of a generic failure.
  * Runtime errors from scheduled jobs are now handled more consistently and sent with safer, metadata-only details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

