### PR TITLE
fix(tokenjuice): avoid char-boundary panic in HTML content detection

### DIFF
--- a/src/openhuman/tokenjuice/detect/kind.rs
+++ b/src/openhuman/tokenjuice/detect/kind.rs
@@ -143,7 +143,9 @@ pub fn looks_like_diff(content: &str) -> bool {
 /// True if `content` looks like an HTML document: a doctype / `<html`/`<body`
 /// marker, or a high density of angle-bracket tags over the first lines.
 pub fn looks_like_html(content: &str) -> bool {
-    let head = &content[..content.len().min(8192)];
+    // Snap to a UTF-8 char boundary: a raw `&content[..8192]` panics when byte
+    // 8192 lands inside a multi-byte codepoint (CJK/emoji in large tool output).
+    let head = crate::openhuman::util::utf8_safe_prefix_at_byte_boundary(content, 8192);
     let lower = head.to_ascii_lowercase();
     if lower.contains("<!doctype html")
         || lower.contains("<html")
@@ -398,6 +400,24 @@ mod tests {
     fn detect_html() {
         let c = "<!DOCTYPE html>\n<html><head><title>x</title></head><body><p>hi</p></body></html>";
         assert_eq!(detect_content_kind(c, &hint()), ContentKind::Html);
+    }
+
+    #[test]
+    fn looks_like_html_handles_multibyte_at_byte_cutoff() {
+        // Build content longer than the 8192-byte head window with a multi-byte
+        // char (4-byte emoji) straddling byte index 8192, so a raw byte slice
+        // would panic on the non-char-boundary cut. Detection must not panic.
+        let mut content = "a".repeat(8190);
+        content.push('🦀'); // 4 bytes spanning indices 8190..8194 — crosses 8192
+        content.push_str(&"b".repeat(2000));
+        assert!(content.len() > 8192);
+        // Plain text with no tags: just assert it returns without panicking.
+        assert!(!looks_like_html(&content));
+        // And the full detector stays reachable on the same input.
+        assert_eq!(
+            detect_content_kind(&content, &hint()),
+            ContentKind::PlainText
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix a UTF-8 char-boundary panic in `looks_like_html` (content-kind detection): the head window was sliced with a raw byte index, which panics when byte 8192 lands inside a multi-byte codepoint.
- Slice via the existing `util::utf8_safe_prefix_at_byte_boundary` helper, which snaps the cut down to a char boundary.
- Add a regression test that crosses a 4-byte emoji over byte 8192.

## Problem

`detect::kind::looks_like_html` took `let head = &content[..content.len().min(8192)];`. Slicing a `&str` at a byte index requires that index to fall on a UTF-8 char boundary; when `content` is longer than 8192 bytes and a multi-byte character (CJK, emoji, accented Latin) straddles byte 8192, the slice panics with `byte index 8192 is not a char boundary`.

This is reachable on real input via two paths:

- Compression: `tokenjuice::compress` → `detect_content_kind` → `detect` → `looks_like_html`, run on the full untruncated content. The compression floor is ~2048 bytes, so content of 8 KB+ reaches detection routinely.
- RPC: `tokenjuice.detect` (`schemas.rs::handle_detect`) classifies caller-supplied content directly.

JSON and diff are checked first and early-return, but ordinary large text/logs/non-ASCII tool output falls through to the HTML check. The result is an intermittent panic tied to specific large outputs containing non-ASCII text near the 8 KB mark.

## Solution

Replace the raw byte slice with the crate's `utf8_safe_prefix_at_byte_boundary(content, 8192)`, the same helper already used for UTF-8-safe truncation in `web_fetch`, `shell`, `install_tool`, and `node_exec`. It returns a prefix of at most 8192 bytes, backing up to the nearest char boundary. Behavior is otherwise unchanged (the head window is still capped at 8192 bytes).

Regression test `looks_like_html_handles_multibyte_at_byte_cutoff` builds content longer than the window with a 4-byte emoji spanning bytes 8190..8194 (so byte 8192 is mid-codepoint) and asserts both `looks_like_html` and the full `detect_content_kind` path return without panicking.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — the two changed lines (the slice + comment) are exercised by the new regression test through `looks_like_html`/`detect_content_kind`.
- [x] Coverage matrix updated — `N/A: bug fix, no feature row added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature touched`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal detection helper, no release-cut surface`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; defect found by code inspection`

## Impact

- Removes a panic on the content-compression hot path and the `tokenjuice.detect` RPC handler. Affects all desktop platforms (CLI/desktop core). No API, schema, or migration impact. Pure robustness fix; no performance change (same 8192-byte cap).

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/html-detect-char-boundary-panic
- Commit SHA: e2b28a425

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib tokenjuice::detect::kind::tests`
- [x] Rust fmt/check (if changed): `cargo fmt` + `pnpm rust:check`
- [x] Tauri fmt/check (if changed): N/A — no Tauri shell code changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: content-kind detection no longer panics on large non-ASCII input
- User-visible effect: no more intermittent crashes when compacting/detecting large tool output containing CJK/emoji/accented text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML detection to handle text safely at byte-cutoff boundaries, preventing crashes with multi-byte characters.
  * Detection now correctly falls back to plain text when content is not HTML.
  * Added a regression test covering long input with an emoji at the cutoff point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->