### PR TITLE
fix(shell): clear macOS traffic lights in collapsed sidebar rail

### DIFF
--- a/app/src/components/layout/shell/RootShellLayout.tsx
+++ b/app/src/components/layout/shell/RootShellLayout.tsx
@@ -180,7 +180,13 @@ export default function RootShellLayout({ sidebar, children }: RootShellLayoutPr
           native CEF webview glued to the content's bounds, which composites
           above the HTML layer — starts to its right and never covers it. */}
       {!isOpen && (
-        <div className="flex w-14 flex-none flex-col items-center gap-0.5 border-r border-line bg-surface pt-2">
+        <div className="flex w-14 flex-none flex-col items-center gap-0.5 border-r border-line bg-surface">
+          {/* macOS overlay title bar (titleBarStyle: Overlay) floats the traffic
+              lights over the top-left. The expanded SidebarHeader dodges them by
+              right-aligning, but this narrow rail can't — so reserve a draggable
+              strip the height of the window controls and start the rail below it,
+              clear of the lights. */}
+          <div className="h-7 w-full flex-none" data-tauri-drag-region />
           <Tooltip label={t('layout.showSidebar')}>
             <button
               type="button"


### PR DESCRIPTION
## Summary

- Fix the collapsed root-shell sidebar rail overlapping the macOS window controls: the reopen `>` chevron sat directly under the traffic lights.
- Reserve a draggable strip the height of the window controls at the top of the collapsed rail so its contents start clear of the lights.
- Layout-only change to `RootShellLayout.tsx`; expanded sidebar and all other platforms are visually unaffected.

## Problem

On macOS the window uses `titleBarStyle: "Overlay"` (`app/src-tauri/tauri.conf.json`), which floats the traffic-light controls over the top-left of the content. The expanded `SidebarHeader` accounts for this by right-aligning its icons into the empty space left of the controls. The **collapsed** rail, however, is a narrow 56px (`w-14`) centered column whose first item — the reopen chevron — had only `pt-2` (8px) of top padding, placing it right under the traffic lights. Result: the chevron and the red/yellow/green controls overlapped.

## Solution

- Remove the rail container's `pt-2` and instead render a dedicated top spacer (`h-7 w-full`) as the first flex child, so the chevron and the rest of the icon rail begin below the control band.
- Mark that spacer `data-tauri-drag-region` so the reserved area is draggable while collapsed — matching the expanded `SidebarHeader`, whose top row is already a drag region.
- The narrow rail can't dodge horizontally the way the expanded header does, so a vertical inset is the correct mirror of the existing approach.

Before: chevron overlaps traffic lights. After: chevron sits cleanly below them (verified visually in the running desktop app).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `N/A`: presentational layout-only change (Tailwind spacing + a drag-region strip); no behavior or logic to assert. `RootShellLayout` has no existing test harness for control-overlay geometry.
- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. — `N/A`: the changed lines are JSX markup/comments with no executable branches; please confirm the gate treatment for presentational diffs.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — `N/A`: presentational change, no feature added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A`: no feature IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A`: no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A`: no tracking issue.

## Impact

- Desktop (macOS) only in practice: corrects the collapsed-rail vs. traffic-light overlap. On Windows/Linux/web the reserved top strip is inert empty space, consistent with how the app already reserves the overlay area elsewhere.
- No performance, security, migration, or data-compatibility implications.

## Related

- Closes: `N/A` — no tracking issue.
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: `N/A`
- URL: `N/A`

### Commit & Branch

- Branch: `fix/collapsed-rail-traffic-light-overlap`
- Commit SHA: `db9120082`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on the changed file.
- [x] `pnpm typecheck` — `tsc --noEmit` passed.
- [ ] Focused tests: `N/A` — no test for this presentational change.
- [x] Rust fmt/check (if changed): `N/A` — no Rust changed.
- [x] Tauri fmt/check (if changed): `N/A` — no Rust changed.

### Validation Blocked

- `command:` `N/A`
- `error:` `N/A`
- `impact:` `N/A`

### Behavior Changes

- Intended behavior change: collapsed sidebar rail no longer overlaps the macOS traffic lights.
- User-visible effect: reopen chevron and icon rail render below the window controls; top strip is draggable.

### Parity Contract

- Legacy behavior preserved: expanded sidebar, navigation, and non-macOS layouts unchanged.
- Guard/fallback/dispatch parity checks: `N/A` — no logic/dispatch changed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this PR.
- Resolution: `N/A`.
