### PR TITLE
fix(ollama): demote list_models 200-with-non-JSON parse failure

### DIFF
--- a/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
+++ b/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
@@ -297,12 +297,23 @@ impl LocalAiService {
         })?;
 
         let payload: OllamaTagsResponse = serde_json::from_str(&body).map_err(|e| {
-            tracing::error!(
+            // Defense-in-depth (TAURI-RUST-560, mirrors the A3T non-success
+            // branch above): a 2xx response whose body is not a JSON object at
+            // all (`OllamaTagsResponse` uses `#[serde(default)]` on `models`, so
+            // parse only fails when the body isn't a JSON object) means the
+            // configured Ollama port is answering with something else entirely
+            // — a different local server/proxy, a captive portal, an HTML page.
+            // That is an external/user-environment condition, not an openhuman
+            // code defect. The diagnostics caller already degrades gracefully
+            // (empty models + surfaces the failure to the UI as `tags_error`),
+            // so log at `warn!` (breadcrumb) instead of `error!` to avoid
+            // flooding Sentry on every diagnostics poll.
+            tracing::warn!(
                 target: "local_ai::ollama_admin",
                 %url,
                 body = %body,
                 error = %e,
-                "[local_ai:ollama_admin] list_models: JSON parse failed"
+                "[local_ai:ollama_admin] list_models: response body is not Ollama tags JSON"
             );
             format!("ollama tags parse failed: {e}")
         })?;

--- a/src/openhuman/inference/local/service/ollama_admin_tests.rs
+++ b/src/openhuman/inference/local/service/ollama_admin_tests.rs
@@ -660,6 +660,45 @@ async fn list_models_errors_on_non_success() {
 }
 
 #[tokio::test]
+async fn list_models_degrades_on_200_with_non_json_body() {
+    // TAURI-RUST-560: a 2xx response whose body is not an Ollama tags JSON
+    // object (a different local server/proxy, a captive portal, an HTML page
+    // bound to the configured Ollama port) must degrade gracefully — return
+    // `Err` so the diagnostics caller surfaces `tags_error` and an empty model
+    // list — rather than emit an `error!`-level event that floods Sentry on
+    // every diagnostics poll. The parse-failure log is now demoted to `warn!`
+    // (a breadcrumb) to match the A3T non-success treatment.
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new().route(
+        "/api/tags",
+        // 200 OK, but the body is an HTML page, not Ollama tags JSON.
+        get(|| async {
+            (
+                axum::http::StatusCode::OK,
+                "<!doctype html><html><head><title>Sign in</title></head>\
+                 <body>Captive portal</body></html>",
+            )
+        }),
+    );
+    let base = spawn_mock(app).await;
+    unsafe {
+        std::env::set_var("OPENHUMAN_OLLAMA_BASE_URL", &base);
+    }
+
+    let config = Config::default();
+    let service = LocalAiService::new(&config);
+    let err = service.list_models_at(&base).await.unwrap_err();
+    assert!(
+        err.contains("parse failed"),
+        "200 non-JSON body must yield a graceful parse-failed Err, got: {err}"
+    );
+    unsafe {
+        std::env::remove_var("OPENHUMAN_OLLAMA_BASE_URL");
+    }
+}
+
+#[tokio::test]
 async fn lm_studio_list_models_returns_loaded_models() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 


### PR DESCRIPTION
## Summary

`list_models_at` (`src/openhuman/inference/local/service/ollama_admin/diagnostics.rs`) GETs `{base}/api/tags`. It already guards `!status.is_success()` (demoted to `warn!` per `TAURI-RUST-A3T`), but on a **2xx response it unconditionally parses the body as Ollama tags JSON** and logged `tracing::error!` on failure. Because `OllamaTagsResponse` uses `#[serde(default)]` on `models`, that parse only fails when the body **isn't a JSON object at all** — i.e. something other than Ollama is answering the configured port (a different local server/proxy, a captive portal, an HTML page).

That's an external / user-environment condition, not an openhuman code defect. The diagnostics caller already degrades gracefully (empty models + surfaces `tags_error` to the UI), so the `error!` was pure Sentry noise — `TAURI-RUST-560`, ~5.1k events / 6 users.

## Change

- Demote the 2xx parse-failure `tracing::error!` to `warn!` (a breadcrumb), mirroring the A3T treatment of the non-success branch.
- Regression test in `ollama_admin_tests.rs`: a `200 OK` response with an HTML body yields a graceful parse-failed `Err` (caller degrades to empty + `tags_error`) instead of an `error!`-level emit.

## Verification

Relying on PR CI for the full Rust test matrix (local multi-compile was paused to avoid CPU thrash).

Closes #4177
Sentry-Issue: TAURI-RUST-560
Bucket: real-defect — RCA: guard/demote non-JSON 200 at the ollama_admin tags parse; caller already degrades gracefully.