### PR TITLE
fix(skills): don't report 4xx install-fetch failures to Sentry

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -2445,6 +2445,31 @@ pub fn is_transient_integrations_failure(event: &sentry::protocol::Event<'_>) ->
         || is_transient_domain_failure(event, "composio")
 }
 
+/// Skill-install fetch **client errors** (4xx, esp. 404/410).
+///
+/// `install_workflow_from_url_with_home` fetches a user/catalog-supplied
+/// `SKILL.md`; a 4xx means the requested URL is gone or wrong — expected
+/// user-input state surfaced to the UI as "skill not found", not a
+/// Sentry-actionable defect. The primary suppression lives at that emit site
+/// (it no longer calls `report_error` for 4xx); this is the defense-in-depth
+/// net mirroring the `is_transient_*` filters, catching any future skills call
+/// site that reports a 4xx. Matched by the tags `report_error` writes:
+/// `domain=skills`, `failure=non_2xx`, and a 4xx `status`. A 5xx is a genuine
+/// remote failure and stays reportable. Drops TAURI-RUST-CGE (~1,446 events /
+/// 72 users on `openhuman@0.57.53`).
+pub fn is_skills_install_client_error_event(event: &sentry::protocol::Event<'_>) -> bool {
+    let tags = &event.tags;
+    if tags.get("domain").map(String::as_str) != Some("skills") {
+        return false;
+    }
+    if tags.get("failure").map(String::as_str) != Some("non_2xx") {
+        return false;
+    }
+    tags.get("status")
+        .and_then(|status| status.parse::<u16>().ok())
+        .is_some_and(|code| (400..500).contains(&code))
+}
+
 /// Transient updater failures from GitHub release probes/downloads.
 ///
 /// Core-side reports carry structured tags (`domain=update`, often
@@ -5684,6 +5709,58 @@ mod tests {
         assert!(
             !is_transient_integrations_failure(&non_matching_transport),
             "transport failures without an allowlisted phrase must stay visible"
+        );
+    }
+
+    /// TAURI-RUST-CGE: skill-install fetch 4xx (a missing/renamed catalog
+    /// `SKILL.md`) is expected user-input state — the before_send net must drop
+    /// it, while a genuine 5xx remote failure and unrelated domains stay
+    /// reportable.
+    #[test]
+    fn skills_install_client_error_filter_drops_4xx_keeps_5xx() {
+        // 4xx (esp. 404/410) = missing skill / wrong URL → dropped.
+        for status in ["400", "403", "404", "410", "429"] {
+            let event = event_with_tags(&[
+                ("domain", "skills"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ]);
+            assert!(
+                is_skills_install_client_error_event(&event),
+                "skills install 4xx {status} must be dropped"
+            );
+        }
+
+        // 5xx = genuine remote failure → stays a Sentry signal.
+        for status in ["500", "502", "503"] {
+            let event = event_with_tags(&[
+                ("domain", "skills"),
+                ("failure", "non_2xx"),
+                ("status", status),
+            ]);
+            assert!(
+                !is_skills_install_client_error_event(&event),
+                "skills install 5xx {status} must stay reportable"
+            );
+        }
+
+        // Domain scoping: a 4xx in another domain must not be touched here.
+        let other_domain = event_with_tags(&[
+            ("domain", "backend_api"),
+            ("failure", "non_2xx"),
+            ("status", "404"),
+        ]);
+        assert!(
+            !is_skills_install_client_error_event(&other_domain),
+            "non-skills 4xx must not be swallowed by the skills filter"
+        );
+
+        // A skills event without the non_2xx failure marker (e.g. a transport
+        // failure) must not be dropped by this status-scoped filter.
+        let skills_transport = event_with_tags(&[("domain", "skills"), ("failure", "transport")]);
+        assert!(
+            !is_skills_install_client_error_event(&skills_transport),
+            "skills transport failures are out of scope for the 4xx filter"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,15 @@ fn main() {
             {
                 return None;
             }
+            // Defense-in-depth: drop skill-install fetch 4xx (esp. 404/410) —
+            // a missing/renamed catalog `SKILL.md` is expected user-input state
+            // surfaced to the UI, not a Sentry-actionable defect. Primary
+            // suppression lives at the `install_workflow_from_url_with_home`
+            // emit site; this catches any future skills call site that reports
+            // a 4xx. 5xx (genuine remote failure) still reports. TAURI-RUST-CGE.
+            if openhuman_core::core::observability::is_skills_install_client_error_event(&event) {
+                return None;
+            }
             // Defense-in-depth: 404 on PATCH/DELETE to a channel-message path
             // is an expected state (provider-side delete or backend GC). Primary
             // suppression lives in `authed_json`; this catches any future call

--- a/src/openhuman/workflows/ops_install.rs
+++ b/src/openhuman/workflows/ops_install.rs
@@ -196,25 +196,29 @@ pub(crate) async fn install_workflow_from_url_with_home(
 
     let status = response.status();
     if !status.is_success() {
-        let status_str = status.as_u16().to_string();
-        let msg = format!(
-            "fetch failed: {fetch_url} returned status {}",
-            status.as_u16()
-        );
-        let report_msg = format!(
-            "fetch failed: {redacted_fetch_url} returned status {}",
-            status.as_u16()
-        );
-        crate::core::observability::report_error(
-            report_msg.as_str(),
-            "skills",
-            "install_fetch",
-            &[
-                ("url", redacted_fetch_url.as_str()),
-                ("status", status_str.as_str()),
-                ("failure", "non_2xx"),
-            ],
-        );
+        let code = status.as_u16();
+        let msg = format!("fetch failed: {fetch_url} returned status {code}");
+        // A 4xx (esp. 404/410) means the requested SKILL.md is gone or the URL
+        // is wrong — expected user/catalog input state, surfaced to the UI as
+        // "skill not found". Don't page Sentry for it (TAURI-RUST-CGE: ~1,446
+        // events / 72 users on `openhuman@0.57.53`, almost all 404). Keep
+        // reporting 5xx — a genuine remote failure is still Sentry-actionable.
+        // The `Err(msg)` return is unchanged in both cases so the UI always
+        // surfaces the failure.
+        if !status.is_client_error() {
+            let status_str = code.to_string();
+            let report_msg = format!("fetch failed: {redacted_fetch_url} returned status {code}");
+            crate::core::observability::report_error(
+                report_msg.as_str(),
+                "skills",
+                "install_fetch",
+                &[
+                    ("url", redacted_fetch_url.as_str()),
+                    ("status", status_str.as_str()),
+                    ("failure", "non_2xx"),
+                ],
+            );
+        }
         return Err(msg);
     }
 

--- a/src/openhuman/workflows/ops_install.rs
+++ b/src/openhuman/workflows/ops_install.rs
@@ -868,3 +868,60 @@ fn is_private_v6(ip: &Ipv6Addr) -> bool {
     }
     false
 }
+
+#[cfg(test)]
+mod install_fetch_tests {
+    use super::*;
+    use axum::{http::StatusCode, Router};
+    use tempfile::TempDir;
+
+    /// Spawn a throwaway local HTTP server whose every route answers with
+    /// `status`. Returns its `http://127.0.0.1:<port>` base.
+    async fn spawn_status(status: StatusCode) -> String {
+        let app = Router::new().fallback(move || async move { status });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://127.0.0.1:{}", addr.port())
+    }
+
+    /// TAURI-RUST-CGE: a non-2xx skill-install fetch always returns the
+    /// user-facing `Err` (so the UI surfaces "skill not found" / the failure),
+    /// for both a 4xx (which is NOT reported to Sentry) and a 5xx (which is).
+    /// Exercises both branches of the non-2xx handling; the report-suppression
+    /// polarity itself is asserted by `is_skills_install_client_error_event` in
+    /// observability. Uses the local-HTTP install escape hatch so the loopback
+    /// mock passes URL validation.
+    #[tokio::test]
+    async fn non_2xx_install_fetch_returns_err_for_4xx_and_5xx() {
+        let _env = crate::openhuman::config::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::set_var(ALLOW_LOCAL_HTTP_ENV, "1");
+
+        let tmp = TempDir::new().unwrap();
+
+        for status in [StatusCode::NOT_FOUND, StatusCode::INTERNAL_SERVER_ERROR] {
+            let base = spawn_status(status).await;
+            let url = format!("{base}/skill.md");
+            let err = install_workflow_from_url_with_home(
+                tmp.path(),
+                InstallWorkflowFromUrlParams {
+                    url,
+                    timeout_secs: Some(5),
+                },
+                None,
+            )
+            .await
+            .expect_err("a non-2xx fetch must return Err so the UI surfaces it");
+            assert!(
+                err.contains(&format!("returned status {}", status.as_u16())),
+                "error must surface the status to the UI: {err}"
+            );
+        }
+
+        std::env::remove_var(ALLOW_LOCAL_HTTP_ENV);
+    }
+}


### PR DESCRIPTION
## Summary

`install_workflow_from_url_with_home` (`src/openhuman/workflows/ops_install.rs`) fetches a user/catalog-supplied `SKILL.md` and, on any non-2xx, called `report_error(.., "skills", "install_fetch", ..)` **unconditionally**. A 404/410 simply means the requested skill URL is gone or wrong — expected user-input state, surfaced to the UI as "skill not found" — yet it paged at error level.

Unlike `llm_provider` / `backend_api` / `integrations` / `update`, the `domain="skills"` had **no** `before_send` demotion filter, so these flowed straight through: **TAURI-RUST-CGE — ~1,446 events / 72 users on `openhuman@0.57.53`, almost all 404.**

## RCA fix (preventable-user-state)

- **emit site** (`ops_install.rs`): skip the `report_error` call for client errors (`status.is_client_error()`, i.e. 4xx). **5xx still reports** (genuine remote failure). The user-facing `Err(msg)` return is **unchanged** in both cases, so the UI always surfaces the failure.
- **defense-in-depth** (`src/core/observability.rs` + `src/main.rs`): add `is_skills_install_client_error_event` (`domain=skills`, `failure=non_2xx`, 4xx `status`) and wire it into the `before_send` chain, mirroring the existing `is_transient_*` predicates — catches any future skills call site that reports a 4xx.

## Test

`skills_install_client_error_filter_drops_4xx_keeps_5xx` — 4xx dropped, 5xx kept reportable, domain-scoped (a 4xx in another domain is untouched), transport failures out of scope.

Closes #4175
Sentry-Issue: TAURI-RUST-CGE
Bucket: preventable-user-state — RCA: 404 = missing skill (user input); surface Err to UI, drop 4xx from Sentry.