### PR TITLE
fix(tinyplace): raise RPC timeout for x402 bounty creation

### DIFF
--- a/app/src/lib/agentworld/invokeApiClient.test.ts
+++ b/app/src/lib/agentworld/invokeApiClient.test.ts
@@ -418,6 +418,48 @@ describe('PaymentRequiredError propagation', () => {
   });
 });
 
+describe('bounties.create', () => {
+  const bountyParams = {
+    title: 'Build a widget',
+    description: 'Need a widget',
+    amount: '5',
+    asset: 'USDC',
+  };
+
+  test('marshals params and passes the x402 spend timeout (#4201)', async () => {
+    mockCallCoreRpc.mockResolvedValueOnce({ bounty: { id: 'b1' } });
+    const client = createInvokeApiClient();
+    await client.bounties.create(bountyParams, { confirmed: true });
+
+    expect(mockCallCoreRpc).toHaveBeenCalledWith({
+      method: 'openhuman.tinyplace_bounties_create',
+      params: {
+        title: 'Build a widget',
+        description: 'Need a widget',
+        amount: '5',
+        asset: 'USDC',
+        deadline: null,
+        durationDays: null,
+        confirmed: true,
+      },
+      // On-chain escrow funding + settle polling exceeds the 30s default, so
+      // the renderer must grant a longer per-call budget or the call aborts at
+      // 30s with a spurious timeout even while settlement is in flight.
+      timeoutMs: 120_000,
+    });
+  });
+
+  test('the unconfirmed probe also gets the longer timeout', async () => {
+    mockCallCoreRpc.mockResolvedValueOnce({ challenge: {} });
+    const client = createInvokeApiClient();
+    await client.bounties.create(bountyParams);
+
+    const callArgs = mockCallCoreRpc.mock.calls[0][0];
+    expect(callArgs.params.confirmed).toBe(false);
+    expect(callArgs.timeoutMs).toBe(120_000);
+  });
+});
+
 describe('registry.export', () => {
   test('calls openhuman.tinyplace_registry_export with name', async () => {
     mockCallCoreRpc.mockResolvedValueOnce({

--- a/app/src/lib/agentworld/invokeApiClient.ts
+++ b/app/src/lib/agentworld/invokeApiClient.ts
@@ -47,9 +47,33 @@ function safeParseJson(s: string): unknown {
  * function throws a {@link PaymentRequiredError} with the decoded challenge.
  * All other errors propagate as-is.
  */
-async function call<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+/**
+ * Per-call timeout (ms) for x402 confirm-before-spend RPCs (bounty creation,
+ * registration, marketplace buys).
+ *
+ * These fund a reward / registration into escrow on-chain at the moment of the
+ * call: the core probes for the 402 challenge, signs and submits the payment,
+ * then polls `settle_retry` until the backend confirms settlement. That whole
+ * round-trip routinely exceeds the global 30s `CORE_RPC_TIMEOUT_MS`, so the
+ * renderer aborted `tinyplace_bounties_create` at 30s and surfaced a spurious
+ * `timed out after 30000ms` even though the chain settlement was still in
+ * flight — bounty creation appeared completely broken (#4201). Give the spend
+ * path a longer-but-still-bounded budget; the core clamps it to the
+ * `[1s, 10min]` per-call window.
+ */
+const X402_SPEND_TIMEOUT_MS = 120_000;
+
+async function call<T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number
+): Promise<T> {
   try {
-    return await callCoreRpc<T>({ method, params });
+    return await callCoreRpc<T>({
+      method,
+      params,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
   } catch (err) {
     // Core serialises 402 errors as a plain string "PAYMENT_REQUIRED:<json>".
     const msg = String(err);
@@ -1911,15 +1935,22 @@ export function createInvokeApiClient() {
        *  escrow at creation). confirmed:false returns the challenge (no spend);
        *  confirmed:true pays and creates. */
       create: (params: BountyCreateParams, opts?: { confirmed?: boolean }) =>
-        call<X402BuyResult>('openhuman.tinyplace_bounties_create', {
-          title: params.title,
-          description: params.description,
-          amount: params.amount,
-          asset: params.asset ?? null,
-          deadline: params.deadline ?? null,
-          durationDays: params.durationDays ?? null,
-          confirmed: opts?.confirmed ?? false,
-        }),
+        call<X402BuyResult>(
+          'openhuman.tinyplace_bounties_create',
+          {
+            title: params.title,
+            description: params.description,
+            amount: params.amount,
+            asset: params.asset ?? null,
+            deadline: params.deadline ?? null,
+            durationDays: params.durationDays ?? null,
+            confirmed: opts?.confirmed ?? false,
+          },
+          // On-chain escrow funding + settle polling exceeds the 30s default
+          // (#4201). Both legs need the longer budget: the unconfirmed probe
+          // also waits on a network round-trip + wallet-balance lookup.
+          X402_SPEND_TIMEOUT_MS
+        ),
       cancel: (bountyId: string) =>
         call<Bounty>('openhuman.tinyplace_bounties_cancel', { bountyId }),
       submit: (bountyId: string, url: string, title?: string, note?: string) =>


### PR DESCRIPTION
## Summary

`tinyplace_bounties_create` runs an x402 confirm-before-spend flow: the core probes the 402 challenge, funds the reward into escrow **on-chain**, then polls `settle_retry` until the backend confirms settlement. That round-trip routinely exceeds the global 30s `CORE_RPC_TIMEOUT_MS`, so the renderer aborted the call at 30s with `Core RPC openhuman.tinyplace_bounties_create timed out after 30000ms` even while settlement was still in flight — bounty creation appeared completely broken (#4201).

## Fix

Thread an optional per-call `timeoutMs` through the invoke-API `call()` helper (`app/src/lib/agentworld/invokeApiClient.ts`) and give `bounties.create` a 120s budget (the core clamps per-call timeouts to the `[1s, 10min]` window). Both legs need it: the unconfirmed probe also waits on a network round-trip plus a wallet-balance lookup. Non-spend RPCs are unaffected — the timeout is only attached when explicitly passed.

Test: `invokeApiClient.test.ts` asserts both the confirmed spend and the unconfirmed probe forward `timeoutMs: 120_000`.

Closes #4201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for bounty creation by allowing longer processing time for confirm-before-spend flows.
  * Prevents premature timeouts when submitting a bounty, and ensures confirmation is handled consistently whether explicitly provided or not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->