### PR TITLE
fix(tinyplace): correct identity pricing tiers shown to users

### DIFF
--- a/app/src/agentworld/pages/IdentitiesSection.test.tsx
+++ b/app/src/agentworld/pages/IdentitiesSection.test.tsx
@@ -217,9 +217,11 @@ describe('Register tab — handle availability', () => {
   test('renders the pricing tiers', () => {
     render(<IdentitiesSection />);
     expect(screen.getByText('Pricing tiers')).toBeInTheDocument();
-    expect(screen.getByText('$250/yr')).toBeInTheDocument();
-    expect(screen.getByText('$50/yr')).toBeInTheDocument();
-    expect(screen.getByText('$10/yr')).toBeInTheDocument();
+    // Authoritative tiny.place per-character USDC tiers (#3825), replacing the
+    // old incorrect "$250 / $50 / $10 per year" labels.
+    expect(screen.getByText('2,000 USDC')).toBeInTheDocument();
+    expect(screen.getByText('500 USDC')).toBeInTheDocument();
+    expect(screen.getByText('1 USDC')).toBeInTheDocument();
   });
 
   test('shows a Register button only when the handle is available', async () => {

--- a/app/src/agentworld/pages/IdentitiesSection.test.tsx
+++ b/app/src/agentworld/pages/IdentitiesSection.test.tsx
@@ -18,7 +18,7 @@ import {
   PaymentRequiredError,
 } from '../../lib/agentworld/invokeApiClient';
 import { apiClient } from '../AgentWorldShell';
-import IdentitiesSection from './IdentitiesSection';
+import IdentitiesSection, { IDENTITY_PRICING_TIERS } from './IdentitiesSection';
 
 // ── Mock apiClient ────────────────────────────────────────────────────────────
 // Replace every namespace/method IdentitiesSection calls through.
@@ -1173,5 +1173,37 @@ describe('Trading tab — bid / offer commitments', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
     expect(screen.queryByTestId('commit-submit')).not.toBeInTheDocument();
     expect(apiClient.marketplace.offer).not.toHaveBeenCalled();
+  });
+});
+
+// ── Pricing tiers (#3825 — displayed price must match what is charged) ─────────
+
+describe('IDENTITY_PRICING_TIERS', () => {
+  test('mirrors tiny.place authoritative per-character USDC tiers', () => {
+    // The old table showed $250 / $50 / $10 for only 3 / 4 / 5+ chars — wrong
+    // units, wrong amounts, missing the 1- and 2-char tiers. Pin the corrected
+    // authoritative tiers so a regression to USD or the old values fails CI.
+    expect(IDENTITY_PRICING_TIERS.map(t => [t.label, t.fee])).toEqual([
+      ['1 char', '2,000 USDC'],
+      ['2 chars', '1,000 USDC'],
+      ['3 chars', '500 USDC'],
+      ['4 chars', '100 USDC'],
+      ['5+ chars', '1 USDC'],
+    ]);
+  });
+
+  test('quotes every tier in USDC, never the old per-year USD format', () => {
+    for (const tier of IDENTITY_PRICING_TIERS) {
+      expect(tier.fee).toMatch(/USDC$/);
+      expect(tier.fee).not.toMatch(/\$|\/yr/);
+    }
+  });
+
+  test('renders the corrected tiers (and not the old USD prices) on the Register tab', () => {
+    render(<IdentitiesSection />);
+    expect(screen.getByText('2,000 USDC')).toBeInTheDocument();
+    expect(screen.getByText('100 USDC')).toBeInTheDocument();
+    expect(screen.queryByText('$250/yr')).not.toBeInTheDocument();
+    expect(screen.queryByText('$10/yr')).not.toBeInTheDocument();
   });
 });

--- a/app/src/agentworld/pages/IdentitiesSection.tsx
+++ b/app/src/agentworld/pages/IdentitiesSection.tsx
@@ -282,6 +282,27 @@ function formatPrice(amount: string, asset: string): string {
   return formatAssetAmount(amount, asset);
 }
 
+// Indicative handle-registration pricing, by handle length. These mirror
+// tiny.place's authoritative per-character tiers (`domain-pricing.ts`:
+// 2,000 / 1,000 / 500 / 100 / 1 USDC for 1 / 2 / 3 / 4 / 5+ chars). The old
+// table here showed `$250 / $50 / $10` for only the 3 / 4 / 5+ tiers — wrong
+// units (USD not USDC), wrong amounts, and missing the 1- and 2-char tiers —
+// so users saw a price that bore no relation to what they were charged
+// (#3825, a billing-integrity bug). The binding amount is always the
+// server-quoted x402 challenge shown in the confirm dialog below; this table
+// is reference only.
+export const IDENTITY_PRICING_TIERS: ReadonlyArray<{
+  label: string;
+  example: string;
+  fee: string;
+}> = [
+  { label: '1 char', example: '@a', fee: '2,000 USDC' },
+  { label: '2 chars', example: '@ab', fee: '1,000 USDC' },
+  { label: '3 chars', example: '@abc', fee: '500 USDC' },
+  { label: '4 chars', example: '@abcd', fee: '100 USDC' },
+  { label: '5+ chars', example: '@abcde', fee: '1 USDC' },
+];
+
 // ── Register tab ──────────────────────────────────────────────────────────────
 
 // Devnet/mainnet Solana explorer link for a settled payment tx.
@@ -522,11 +543,7 @@ function RegisterTab({ onRegistered }: { onRegistered?: () => void }) {
       <div className="rounded-lg border border-line bg-surface-muted p-4">
         <h4 className="text-xs font-semibold text-content mb-2">Pricing tiers</h4>
         <div className="space-y-1">
-          {[
-            { label: '3 chars', example: '@abc', fee: '$250/yr' },
-            { label: '4 chars', example: '@abcd', fee: '$50/yr' },
-            { label: '5+ chars', example: '@abcde', fee: '$10/yr' },
-          ].map(tier => (
+          {IDENTITY_PRICING_TIERS.map(tier => (
             <div
               key={tier.label}
               className="flex items-center justify-between text-xs text-content-muted">
@@ -537,6 +554,10 @@ function RegisterTab({ onRegistered }: { onRegistered?: () => void }) {
             </div>
           ))}
         </div>
+        <p className="mt-2 text-[11px] leading-relaxed text-content-faint">
+          Indicative only — the exact price is confirmed at checkout from the on-chain x402
+          quote.
+        </p>
       </div>
 
       {/* Confirm-before-spend dialog (only while a challenge is pending). */}

--- a/app/src/agentworld/pages/IdentitiesSection.tsx
+++ b/app/src/agentworld/pages/IdentitiesSection.tsx
@@ -555,8 +555,7 @@ function RegisterTab({ onRegistered }: { onRegistered?: () => void }) {
           ))}
         </div>
         <p className="mt-2 text-[11px] leading-relaxed text-content-faint">
-          Indicative only — the exact price is confirmed at checkout from the on-chain x402
-          quote.
+          Indicative only — the exact price is confirmed at checkout from the on-chain x402 quote.
         </p>
       </div>
 


### PR DESCRIPTION
The "Pricing tiers" reference table on the Tiny Place Register tab was hardcoded to `$250 / $50 / $10` per year for only the 3 / 4 / 5+ char tiers — wrong units (USD, not USDC), wrong amounts, and missing the 1- and 2-char tiers — so users saw a price unrelated to the on-chain x402 amount they were actually charged (billing-integrity issue).

Replace it with the authoritative tiny.place per-character tiers (2,000 / 1,000 / 500 / 100 / 1 USDC for 1 / 2 / 3 / 4 / 5+ chars, from `domain-pricing.ts`), hoisted into a single exported `IDENTITY_PRICING_TIERS`, plus an "indicative only — exact price confirmed at checkout from the on-chain x402 quote" caption (the binding amount is the server-quoted challenge already shown in the confirm dialog). Adds tests pinning the corrected tiers and asserting the old USD format is gone.

Closes #3825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Register tab’s handle registration “Pricing tiers” to use the proper USDC-based per-character tier values, including 1- and 2-character tiers.
  * Updated the displayed tier labels to remove legacy USD per-year pricing text.
  * Added an “indicative only” note under the tiers clarifying the final price is confirmed at checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->