### PR TITLE
fix(local_ai): demote ollama_admin list_models non-JSON 200 parse failure to warn (TAURI-RUST-560)

### DIFF
--- a/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
+++ b/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
@@ -296,13 +296,23 @@ impl LocalAiService {
             format!("ollama tags body read failed: {e}")
         })?;
 
+        // Defense-in-depth (TAURI-RUST-560): a 2xx status is not a guarantee of
+        // an Ollama JSON body. A different local server, a proxy, or a captive
+        // portal listening on the configured Ollama port can answer `/api/tags`
+        // with HTTP 200 and an HTML/text page, which fails to parse. The
+        // diagnostics caller already degrades gracefully (empty models +
+        // surfaces this to the UI as `tags_error`), so — mirroring the
+        // non-success branch above (TAURI-RUST-A3T) — log at `warn!`
+        // (breadcrumb) instead of `error!` to avoid flooding Sentry on every
+        // diagnostics poll. `OllamaTagsResponse` defaults `models`, so a parse
+        // only fails when the body isn't a JSON object at all.
         let payload: OllamaTagsResponse = serde_json::from_str(&body).map_err(|e| {
-            tracing::error!(
+            tracing::warn!(
                 target: "local_ai::ollama_admin",
                 %url,
                 body = %body,
                 error = %e,
-                "[local_ai:ollama_admin] list_models: JSON parse failed"
+                "[local_ai:ollama_admin] list_models: JSON parse failed (non-JSON 2xx body)"
             );
             format!("ollama tags parse failed: {e}")
         })?;

--- a/src/openhuman/inference/local/service/ollama_admin_tests.rs
+++ b/src/openhuman/inference/local/service/ollama_admin_tests.rs
@@ -659,6 +659,39 @@ async fn list_models_errors_on_non_success() {
     }
 }
 
+/// Regression for Sentry TAURI-RUST-560: a misconfigured port can answer the
+/// `/api/tags` probe with HTTP **200** and a non-JSON body (a different local
+/// server, a proxy, or a captive portal serving an HTML page). The parse fails,
+/// but the diagnostics caller already degrades gracefully (empty models +
+/// `tags_error`), so this must surface as a recoverable `Err` (now logged at
+/// `warn!`, not an `error!`-level Sentry flood — mirroring the non-success
+/// branch / TAURI-RUST-A3T).
+#[tokio::test]
+async fn list_models_errors_on_2xx_non_json_body() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new().route(
+        "/api/tags",
+        // 200 OK with a non-JSON (HTML) page instead of Ollama's JSON catalog.
+        get(|| async { "<!doctype html><html><body>captive portal</body></html>" }),
+    );
+    let base = spawn_mock(app).await;
+    unsafe {
+        std::env::set_var("OPENHUMAN_OLLAMA_BASE_URL", &base);
+    }
+
+    let config = Config::default();
+    let service = LocalAiService::new(&config);
+    let err = service.list_models_at(&base).await.unwrap_err();
+    assert!(
+        err.contains("parse failed"),
+        "a 2xx non-JSON body must surface as a recoverable parse error, got: {err}"
+    );
+    unsafe {
+        std::env::remove_var("OPENHUMAN_OLLAMA_BASE_URL");
+    }
+}
+
 #[tokio::test]
 async fn lm_studio_list_models_returns_loaded_models() {
     let _guard = crate::openhuman::inference::inference_test_guard();


### PR DESCRIPTION
## Summary
`list_models_at` GETs `{base}/api/tags`. It already guards `!status.is_success()`
(demoted to `warn!` per TAURI-RUST-A3T), but on a **2xx** response it
unconditionally parses the body as Ollama JSON and logs `tracing::error!` on
failure. That fires whenever something other than Ollama answers **HTTP 200 with a
non-JSON body** on the configured port — a different local server, a proxy, or a
captive-portal HTML page — flooding Sentry (TAURI-RUST-560: **5,116 events / 6
users**, still active on 0.57.18).

The diagnostics caller already degrades gracefully (empty models + surfaces
`tags_error` to the UI), and `OllamaTagsResponse` defaults `models`, so a parse
only fails when the body isn't a JSON object at all. The `error!` is pure noise.

## Fix
Demote the 2xx parse-failure `tracing::error!` → `warn!`, mirroring the existing
non-success branch (TAURI-RUST-A3T). Behavior is unchanged — `list_models_at` still
returns the same `Err`, the caller still degrades to empty models + `tags_error` —
only the Sentry-level emit is lowered to a breadcrumb.

## Tests
Adds `list_models_errors_on_2xx_non_json_body` in `ollama_admin_tests.rs`: a 200
response with a non-JSON (HTML) body surfaces as a recoverable parse `Err` (caller
degrades gracefully). Mirrors the existing `list_models_errors_on_non_success` test.

Fixes #4177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model-list responses when a server returns a successful status code but sends invalid content.
  * The app now reports a clear, recoverable error instead of failing silently or logging an overly severe error.
  * Added regression coverage for non-JSON responses to help prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->