### PR TITLE
fix(inference): gate Responses fallback by endpoint host

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -27,7 +27,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">Doku</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel folgen (Creator)</a>
@@ -80,7 +80,7 @@ OpenHuman ist ein quelloffener, agentenbasierter Assistent, der sich in deinen A
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian-Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: eine lokal-zentrierte Wissensbasis, aufgebaut aus deinen Daten und deinen Aktivitäten. Alles, was du verbindest, wird in Markdown-Chunks von ≤3k Tokens kanonisiert, bewertet und in hierarchische Zusammenfassungs-Bäume gefaltet, gespeichert in **SQLite auf deiner Maschine**. Dieselben Chunks landen als `.md`-Dateien in einem Obsidian-kompatiblen Vault, das du öffnen, durchstöbern und editieren kannst — inspiriert von Karpathys [obsidian-wiki-Workflow](https://x.com/karpathy/status/2039805659525644595).
 
-- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
+- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
 
 - **[Smarte Token-Kompression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: Jeder Tool-Aufruf, jedes Scrape-Ergebnis, jeder E-Mail-Text und jeder Such-Payload läuft durch eine Token-Kompressionsschicht, bevor er ein LLM-Modell erreicht. HTML wird zu Markdown konvertiert, lange URLs werden gekürzt, und ausschweifende Tool-Ausgaben werden über eine konfigurierbare Regel-Ebene dedupliziert und zusammengefasst usw. CJK, Emojis und andere Multi-Byte-Texte bleiben Graphem für Graphem erhalten — niemals abgeschnitten. Du erhältst dieselbe Information bei einem Bruchteil der Tokens. Kosten und Latenz sinken um bis zu 80%.
 
@@ -133,7 +133,7 @@ Du hostest [agentmemory](https://github.com/rohitg00/agentmemory) bereits selbst
 _Baust du auch in Richtung AGI und künstlichem Bewusstsein? Setze einen Stern und hilf anderen, den Weg zu finden._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">ドキュメント</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel（作者）をフォロー</a>
@@ -80,7 +80,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: あなたのデータとアクティビティから構築されるローカルファーストのナレッジベースです。接続したすべての情報は ≤3k トークンの Markdown チャンクへ正規化され、スコアリングされ、階層的なサマリーツリーに畳み込まれて **あなたのマシン上の SQLite** に保存されます。同じチャンクは Obsidian 互換のボルトに `.md` ファイルとして配置され、開いて閲覧・編集できます。Karpathy 氏の [obsidian-wiki ワークフロー](https://x.com/karpathy/status/2039805659525644595)にインスパイアされています。
 
-- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
+- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
 
 - **[スマートトークン圧縮 (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: すべてのツール呼び出し、スクレイプ結果、メール本文、検索ペイロードは、LLM モデルに渡される前にトークン圧縮レイヤーを通過します。HTML は Markdown に変換され、長い URL は短縮され、冗長なツール出力は設定可能なルールレイヤーで重複排除と要約が行われるなど…。CJK、絵文字などのマルチバイト文字は書記素(grapheme)単位で完全に保持され、除去されることはありません。同じ情報をわずかなトークン数で得られます。コストとレイテンシを最大 80% 削減します。
 
@@ -133,7 +133,7 @@ OpenHuman はその待ち時間をスキップします。アカウントを接�
 _AGI と人工意識への道を進んでいますか? リポジトリにスターをつけて、他の人にも道筋を見つけてもらいましょう。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">문서</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel(제작자) 팔로우</a>
@@ -79,7 +79,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 
 - **[메모리 트리(Memory Tree)](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian 위키](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: 당신의 데이터와 활동을 바탕으로 구축된 로컬 우선 지식 베이스입니다. 연결된 모든 것은 3k 토큰 이하의 Markdown 청크로 규격화되고 점수가 매겨지며, **당신의 머신에 있는 SQLite**에 저장되는 계층적 요약 트리로 접힙니다. 동일한 청크는 당신이 열고, 탐색하고, 편집할 수 있는 Obsidian 호환 볼트에 `.md` 파일로 저장됩니다. 이는 Karpathy의 [obsidian-wiki 워크플로우](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다.
 
-- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
+- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
 
 - **[스마트 토큰 압축(TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: 모든 도구 호출, 스크레이핑 결과, 이메일 본문 및 검색 페이로드는 LLM 모델에 전달되기 전에 토큰 압축 레이어를 거칩니다. HTML은 Markdown으로 변환되고, 긴 URL은 단축되며, 장황한 도구 출력은 구성 가능한 규칙 오버레이 등을 통해 중복 제거 및 요약됩니다. CJK, 이모지 및 기타 멀티바이트 텍스트는 자소(grapheme) 단위로 보존되며 절대 삭제되지 않습니다. 동일한 정보를 훨씬 적은 토큰으로 얻을 수 있어 비용과 지연 시간을 최대 80%까지 줄일 수 있습니다.
 
@@ -132,7 +132,7 @@ OpenHuman은 기다림을 생략합니다. 계정을 연결하고, [자동 가�
 _AGI와 인공 의식을 향해 나아가고 계신가요? 저장소에 스타를 눌러 다른 사람들도 이 길을 찾을 수 있도록 도와주세요._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -34,7 +34,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">ڈسکارڈ</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">ریڈٹ</a> •
+ ریڈٹ •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/ٹویٹر</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">دستاویزات</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">فالو کریں @senamakel (مصنف)</a>
@@ -152,7 +152,7 @@ OpenHuman ایک اوپن سورس ایجنٹک اسسٹنٹ ہے جو آپ کی
 
 - **[میموری ٹری](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: ایک مقامی اول علم کا ذخیرہ جو آپ کے ڈیٹا اور سرگرمی سے بنایا گیا ہے۔ آپ جو کچھ بھی جوڑتے ہیں وہ ≤3k-token کے Markdown ٹکڑوں میں معیاری ہو جاتا ہے، اسکور کیا جاتا ہے، اور درجہ بندی کے خلاصے کے درختوں میں جوڑ دیا جاتا ہے جو **آپ کی مشین پر SQLite** میں محفوظ ہوتے ہیں۔ وہی ٹکڑے Obsidian-مطابق والٹ میں `.md` فائلوں کے طور پر اترتے ہیں جسے آپ کھول سکتے ہیں، براؤز اور ایڈٹ کر سکتے ہیں، کارپیتھی کے [obsidian-wiki ورک فلو](https://x.com/karpathy/status/2039805659525644595) سے متاثر۔
 
-- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
+- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
 
 - **[اسمارٹ ٹوکن کمپریشن (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: ہر ٹول کال، سکریپ نتیجہ، ای میل باڈی، اور سرچ پے لوڈ کسی بھی LLM ماڈل کو چھونے سے پہلے ٹوکن کمپریشن پرت سے گزرتا ہے۔ HTML کو Markdown میں تبدیل کیا جاتا ہے، لمبے URLs کو چھوٹا کیا جاتا ہے، اور لمبے ٹول آؤٹ پٹ کو ایک قابل ترتیب اصول اوورلے وغیرہ کے ذریعے ڈیڈپ اور خلاصہ کیا جاتا ہے... CJK، ایموجی، اور دیگر ملٹی بائٹ ٹیکسٹ گرافیم بہ گرافیم محفوظ رہتے ہیں — کبھی نہیں ہٹائے جاتے۔ آپ کو وہی معلومات ملتی ہیں لیکن ٹوکنز کے ایک حصے میں۔ لاگت اور تاخیر کو 80% تک کم کرنا۔
 
@@ -225,7 +225,7 @@ _AGI اور مصنوعی شعور کی طرف بڑھ رہے ہیں؟ ریپو ک
 <div dir="ltr">
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -26,7 +26,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">文档</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">关注 @senamakel（作者）</a>
@@ -78,7 +78,7 @@ OpenHuman 是一个开源智能助手，旨在融入你的日常生活。以下�
 
 - **[记忆树](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**：一个基于你的数据和活动构建的本地优先知识库。你连接的所有内容都被规范化为不超过 3k token 的 Markdown 片段，经过评分后折叠成层级化的摘要树，存储在**你本机的 SQLite** 中。同样的片段以 `.md` 文件形式落地到兼容 Obsidian 的仓库中，你可以打开、浏览和编辑，灵感来源于 Karpathy 的 [obsidian-wiki 工作流](https://x.com/karpathy/status/2039805659525644595)。
 
-- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
+- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
 
 - **[智能 Token 压缩（TokenJuice）](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**：每个工具调用、抓取结果、邮件正文和搜索载荷在触达任何 LLM 模型之前都会经过 token 压缩层处理。HTML 被转换为 Markdown，长 URL 被缩短，冗长的工具输出会通过可配置的规则层去重并摘要等等。中文、emoji 等多字节字符按字形（grapheme）完整保留，绝不丢弃。你获得相同的信息，但 token 消耗仅为原来的几分之一。最多可降低 80% 的成本和延迟。
 
@@ -131,7 +131,7 @@ OpenHuman 跳过了等待期。连接你的账户，让[自动拉取](https://ti
 _致力于 AGI 和人工意识？为仓库加星，帮助更多人找到这条路。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/src/openhuman/config/schema/cloud_providers.rs
+++ b/src/openhuman/config/schema/cloud_providers.rs
@@ -239,18 +239,37 @@ pub fn builtin_cloud_supports_responses_api(slug: &str) -> bool {
 /// `/responses` guarantees a second 404 on every fresh process.
 pub fn cloud_endpoint_supports_responses_api(slug: &str, endpoint: &str) -> bool {
     if is_builtin_cloud_slug(slug) {
-        return builtin_cloud_supports_responses_api(slug);
+        let supports = builtin_cloud_supports_responses_api(slug);
+        log::debug!(
+            "[config][cloud_providers] responses capability builtin slug={} supports={}",
+            slug,
+            supports
+        );
+        return supports;
     }
 
     let Some(host) = endpoint_host(endpoint) else {
+        log::debug!(
+            "[config][cloud_providers] responses capability custom slug={} endpoint_host_parse=false supports=true",
+            slug
+        );
         return true;
     };
 
-    !BUILTIN_CLOUD_PROVIDERS
+    let matched_builtin_chat_only_host = BUILTIN_CLOUD_PROVIDERS
         .iter()
         .filter(|provider| !builtin_cloud_supports_responses_api(provider.slug))
         .filter_map(|provider| endpoint_host(provider.endpoint))
-        .any(|builtin_chat_only_host| builtin_chat_only_host == host)
+        .any(|builtin_chat_only_host| builtin_chat_only_host == host);
+    let supports = !matched_builtin_chat_only_host;
+    log::debug!(
+        "[config][cloud_providers] responses capability custom slug={} endpoint_host={} matched_builtin_chat_only_host={} supports={}",
+        slug,
+        host,
+        matched_builtin_chat_only_host,
+        supports
+    );
+    supports
 }
 
 fn endpoint_host(endpoint: &str) -> Option<String> {

--- a/src/openhuman/config/schema/cloud_providers.rs
+++ b/src/openhuman/config/schema/cloud_providers.rs
@@ -229,6 +229,40 @@ pub fn builtin_cloud_supports_responses_api(slug: &str) -> bool {
     matches!(slug, "openai")
 }
 
+/// Whether a cloud provider endpoint should use the OpenAI **Responses API**
+/// fallback.
+///
+/// Built-in slugs keep the explicit built-in capability table. Custom slugs stay
+/// permissive unless their endpoint host matches one of our known built-in
+/// chat-completions-only hosts. This catches user-defined aliases such as
+/// `nvidia-nim` pointed at `integrate.api.nvidia.com`, where falling back to
+/// `/responses` guarantees a second 404 on every fresh process.
+pub fn cloud_endpoint_supports_responses_api(slug: &str, endpoint: &str) -> bool {
+    if is_builtin_cloud_slug(slug) {
+        return builtin_cloud_supports_responses_api(slug);
+    }
+
+    let Some(host) = endpoint_host(endpoint) else {
+        return true;
+    };
+
+    !BUILTIN_CLOUD_PROVIDERS
+        .iter()
+        .filter(|provider| !builtin_cloud_supports_responses_api(provider.slug))
+        .filter_map(|provider| endpoint_host(provider.endpoint))
+        .any(|builtin_chat_only_host| builtin_chat_only_host == host)
+}
+
+fn endpoint_host(endpoint: &str) -> Option<String> {
+    url::Url::parse(endpoint.trim())
+        .ok()
+        .and_then(|url| url.host_str().map(normalize_host))
+}
+
+fn normalize_host(host: &str) -> String {
+    host.trim_end_matches('.').to_ascii_lowercase()
+}
+
 /// Authentication header style for a cloud provider.
 ///
 /// Wire format is lowercase (e.g. `"bearer"`). Determines which HTTP headers
@@ -504,8 +538,9 @@ impl CloudProviderType {
 #[cfg(test)]
 mod tests {
     use super::{
-        builtin_cloud_supports_responses_api, is_builtin_cloud_slug, is_slug_reserved,
-        migrate_legacy_fields, AuthStyle, CloudProviderCreds, BUILTIN_CLOUD_PROVIDERS,
+        builtin_cloud_supports_responses_api, cloud_endpoint_supports_responses_api,
+        is_builtin_cloud_slug, is_slug_reserved, migrate_legacy_fields, AuthStyle,
+        CloudProviderCreds, BUILTIN_CLOUD_PROVIDERS,
     };
 
     #[test]
@@ -615,6 +650,32 @@ mod tests {
                 "{slug} is chat-completions-only and must not advertise the Responses API"
             );
         }
+    }
+
+    #[test]
+    fn custom_slug_on_builtin_chat_only_host_does_not_expose_responses_api() {
+        for endpoint in [
+            "https://integrate.api.nvidia.com/v1",
+            "https://api.deepseek.com/v1",
+            "https://api.groq.com/openai/v1",
+        ] {
+            assert!(
+                !cloud_endpoint_supports_responses_api("my-custom-slug", endpoint),
+                "custom slug at known chat-only endpoint {endpoint} must not advertise Responses API"
+            );
+        }
+
+        assert!(
+            cloud_endpoint_supports_responses_api(
+                "my-openai-proxy",
+                "https://proxy.example.com/v1"
+            ),
+            "unknown custom proxy remains permissive because it may serve /responses"
+        );
+        assert!(
+            cloud_endpoint_supports_responses_api("my-openai", "https://api.openai.com/v1"),
+            "custom slug pointed at OpenAI's first-party host keeps Responses API support"
+        );
     }
 
     /// Drift guard (TAURI-RUST-5EN): couple the capability helper to the

--- a/src/openhuman/inference/provider/compatible_helpers.rs
+++ b/src/openhuman/inference/provider/compatible_helpers.rs
@@ -144,10 +144,10 @@ impl OpenAiCompatibleProvider {
         // model on a Responses-capable endpoint. Skip when Responses is the
         // primary path (Codex OAuth): the fallback flag is never consulted
         // and a 404 there is not evidence the route is missing.
-        if status == reqwest::StatusCode::NOT_FOUND
+        let responses_route_missing_404 = status == reqwest::StatusCode::NOT_FOUND
             && !self.responses_api_primary
-            && Self::responses_404_indicates_missing_route(&error)
-        {
+            && Self::responses_404_indicates_missing_route(&error);
+        if responses_route_missing_404 {
             super::mark_responses_api_unsupported(&self.base_url);
         }
         if super::super::is_budget_exhausted_http_400(status, &error) {
@@ -221,6 +221,14 @@ impl OpenAiCompatibleProvider {
                 self.name.as_str(),
                 Some(model),
                 status,
+            );
+        } else if responses_route_missing_404 {
+            log::info!(
+                "[provider] {} /responses route missing for endpoint {} model={} status={} - disabling fallback and skipping Sentry report",
+                self.name,
+                super::super::factory::redact_endpoint(&self.base_url),
+                model,
+                status_str,
             );
         } else if super::super::should_report_provider_http_failure(status) {
             crate::core::observability::report_error(

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -4302,6 +4302,50 @@ async fn responses_api_insufficient_balance_402_not_reported_to_sentry() {
 }
 
 #[tokio::test]
+async fn missing_responses_route_404_marks_unsupported_without_sentry_event() {
+    // TAURI-RUST-5A1 residual: a custom slug can still point at a
+    // chat-completions-only endpoint. The first `/responses` 404 should teach
+    // the process that the endpoint is unsupported, but it must not page
+    // Sentry because this is deterministic endpoint capability, not an app bug.
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("model route absent"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("404 page not found"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _guard) = install_test_sentry_hub();
+    let base_url = format!("{}/v1", mock_server.uri());
+    let provider = make_provider("nvidia", &base_url, Some("byo-key"));
+
+    let err = provider
+        .chat_with_history(&[ChatMessage::user("hello")], "nvidia/test-model", 0.0)
+        .await
+        .expect_err("chat-only endpoint must still propagate the terminal 404");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("responses fallback failed") && msg.contains("Responses API error (404)"),
+        "err: {msg}"
+    );
+    assert!(
+        super::responses_api_known_unsupported(&base_url),
+        "route-missing /responses 404 must cache the endpoint as unsupported"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "route-missing /responses 404 must be demoted instead of reported to Sentry"
+    );
+}
+
+#[tokio::test]
 async fn stream_chat_with_system_insufficient_balance_402_propagates_error() {
     // Exercises the `stream_chat_with_system` (operation=stream_chat) 402
     // insufficient-balance demote arm. The streaming work runs in a detached

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -25,7 +25,7 @@
 //! Unknown slugs and missing-creds configurations produce actionable errors.
 
 use crate::openhuman::config::schema::cloud_providers::{
-    builtin_cloud_supports_responses_api, is_builtin_cloud_slug, AuthStyle,
+    cloud_endpoint_supports_responses_api, AuthStyle,
 };
 use crate::openhuman::config::Config;
 use crate::openhuman::credentials::AuthService;
@@ -1637,10 +1637,11 @@ fn make_cloud_provider_by_slug(
             // 404 and floods Sentry with an empty-body "<provider> Responses
             // API error:" event (TAURI-RUST-5EN, same class as the
             // local-provider TAURI-RUST-59Y fix). OpenAI keeps the fallback
-            // (genuine `/responses`), and so do custom / unknown slugs, whose
-            // endpoint may be a real OpenAI proxy.
+            // (genuine `/responses`). Custom / unknown slugs stay permissive
+            // unless their endpoint host matches a known built-in
+            // chat-completions-only provider such as NVIDIA.
             let responses_fallback =
-                !is_builtin_cloud_slug(slug) || builtin_cloud_supports_responses_api(slug);
+                cloud_endpoint_supports_responses_api(slug, &openai_codex_routing.endpoint);
             let credential = (!key.trim().is_empty()).then_some(key.as_str());
             let base_provider = if responses_fallback {
                 OpenAiCompatibleProvider::new(


### PR DESCRIPTION
## Summary

- Add an endpoint-host Responses API capability gate for cloud providers.
- Keep custom / unknown slugs permissive unless their endpoint host matches a known built-in chat-completions-only provider.
- Demote deterministic `/responses` route-missing 404s: cache the endpoint as unsupported, log at info, skip Sentry, and still propagate the terminal error.
- Add regression coverage for NVIDIA-style custom slugs and the first `/responses` 404 demotion path.
- Repair stale localized README links that block the required Markdown Link Check.

## Problem

- Issue #4203 reports repeated Sentry noise when a custom or renamed provider slug points at a chat-only OpenAI-compatible host such as NVIDIA.
- The previous slug-only gate allowed those custom slugs to attempt `/responses`, guaranteeing an extra 404 on fresh processes and a false-positive Sentry event.
- The repository-wide Markdown Link Check currently fails on unrelated stale localized README links; those links must be fixed for this PR to become mergeable.

## Solution

- Introduce `cloud_endpoint_supports_responses_api(slug, endpoint)` so built-in slugs keep the explicit capability table while custom slugs are also checked against known built-in chat-only hosts.
- Use that endpoint-aware gate when building bearer-auth cloud providers.
- Treat route-missing `/responses` 404s on fallback paths as endpoint capability discovery instead of reportable provider failures.
- Replace stale localized README links for Reddit, GitBook voice, and star-history so the docs link gate can pass.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Local full coverage was not run; required CI coverage gate will enforce this before merge.
- [x] Coverage matrix updated — N/A: behaviour-only provider fallback fix; no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature ID.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: provider fallback internals only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime impact is limited to cloud inference provider selection and fallback error handling.
- Custom OpenAI-compatible providers on unknown hosts remain allowed to use `/responses` fallback.
- Known chat-only provider hosts avoid deterministic `/responses` retries and Sentry noise.
- Docs impact is limited to stale link cleanup in localized README files.
- No migration, security, or new network dependency impact.

## Related

- Closes #4203
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: TAURI-RUST-5A1
- URL: N/A

### Commit & Branch

- Branch: fix/GH-4203-responses-host-gate
- Commit SHA: 5b537f458894fcacc3c634194687d7be4c882dbc

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only app path; docs/Rust change.
- [x] `pnpm typecheck` — N/A: no frontend/TypeScript changes.
- [x] Focused tests:
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib custom_slug_on_builtin_chat_only_host_does_not_expose_responses_api`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib missing_responses_route_404_marks_unsupported_without_sentry_event`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib openhuman::inference::provider::factory::factory_tests`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib openhuman::inference::provider::compatible::tests`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib responses`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --check`
  - `git diff --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): N/A: no Tauri changes.

### Validation Blocked

- `command:` `lychee --version`
- `error:` local `lychee` binary is not installed.
- `impact:` local link-check replication unavailable; GitHub Markdown Link Check validates the docs change.

### Behavior Changes

- Intended behavior change: custom slugs pointed at known chat-only provider hosts no longer advertise Responses API fallback.
- User-visible effect: fewer duplicate failed provider calls and fewer false-positive Sentry reports for unsupported `/responses` routes.

### Parity Contract

- Legacy behavior preserved: OpenAI still uses `/responses`; unknown custom proxies remain permissive.
- Guard/fallback/dispatch parity checks: built-in capability table remains authoritative for built-in slugs; endpoint-host guard only narrows custom slugs on known chat-only hosts.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic detection of whether a provider endpoint supports the Responses API, making retries/fallbacks more reliable.

* **Bug Fixes**
  * Tightened fallback gating for known “chat-completions-only” host endpoints, while keeping unknown/custom endpoints permissive.
  * When the `/responses` route returns 404, fallback handling proceeds without generating Sentry events.

* **Tests**
  * Added regression coverage for 404 “missing `/responses`” fallback behavior and Sentry suppression.

* **Documentation**
  * Updated README navigation/link details and refreshed Star History embeds across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->