### PR TITLE
fix(observability): demote responses usage-limit caps

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -27,7 +27,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">Doku</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel folgen (Creator)</a>
@@ -80,7 +80,7 @@ OpenHuman ist ein quelloffener, agentenbasierter Assistent, der sich in deinen A
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian-Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: eine lokal-zentrierte Wissensbasis, aufgebaut aus deinen Daten und deinen Aktivitäten. Alles, was du verbindest, wird in Markdown-Chunks von ≤3k Tokens kanonisiert, bewertet und in hierarchische Zusammenfassungs-Bäume gefaltet, gespeichert in **SQLite auf deiner Maschine**. Dieselben Chunks landen als `.md`-Dateien in einem Obsidian-kompatiblen Vault, das du öffnen, durchstöbern und editieren kannst — inspiriert von Karpathys [obsidian-wiki-Workflow](https://x.com/karpathy/status/2039805659525644595).
 
-- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
+- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
 
 - **[Smarte Token-Kompression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: Jeder Tool-Aufruf, jedes Scrape-Ergebnis, jeder E-Mail-Text und jeder Such-Payload läuft durch eine Token-Kompressionsschicht, bevor er ein LLM-Modell erreicht. HTML wird zu Markdown konvertiert, lange URLs werden gekürzt, und ausschweifende Tool-Ausgaben werden über eine konfigurierbare Regel-Ebene dedupliziert und zusammengefasst usw. CJK, Emojis und andere Multi-Byte-Texte bleiben Graphem für Graphem erhalten — niemals abgeschnitten. Du erhältst dieselbe Information bei einem Bruchteil der Tokens. Kosten und Latenz sinken um bis zu 80%.
 
@@ -133,7 +133,7 @@ Du hostest [agentmemory](https://github.com/rohitg00/agentmemory) bereits selbst
 _Baust du auch in Richtung AGI und künstlichem Bewusstsein? Setze einen Stern und hilf anderen, den Weg zu finden._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">ドキュメント</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel（作者）をフォロー</a>
@@ -80,7 +80,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: あなたのデータとアクティビティから構築されるローカルファーストのナレッジベースです。接続したすべての情報は ≤3k トークンの Markdown チャンクへ正規化され、スコアリングされ、階層的なサマリーツリーに畳み込まれて **あなたのマシン上の SQLite** に保存されます。同じチャンクは Obsidian 互換のボルトに `.md` ファイルとして配置され、開いて閲覧・編集できます。Karpathy 氏の [obsidian-wiki ワークフロー](https://x.com/karpathy/status/2039805659525644595)にインスパイアされています。
 
-- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
+- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
 
 - **[スマートトークン圧縮 (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: すべてのツール呼び出し、スクレイプ結果、メール本文、検索ペイロードは、LLM モデルに渡される前にトークン圧縮レイヤーを通過します。HTML は Markdown に変換され、長い URL は短縮され、冗長なツール出力は設定可能なルールレイヤーで重複排除と要約が行われるなど…。CJK、絵文字などのマルチバイト文字は書記素(grapheme)単位で完全に保持され、除去されることはありません。同じ情報をわずかなトークン数で得られます。コストとレイテンシを最大 80% 削減します。
 
@@ -133,7 +133,7 @@ OpenHuman はその待ち時間をスキップします。アカウントを接�
 _AGI と人工意識への道を進んでいますか? リポジトリにスターをつけて、他の人にも道筋を見つけてもらいましょう。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">문서</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel(제작자) 팔로우</a>
@@ -79,7 +79,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 
 - **[메모리 트리(Memory Tree)](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian 위키](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: 당신의 데이터와 활동을 바탕으로 구축된 로컬 우선 지식 베이스입니다. 연결된 모든 것은 3k 토큰 이하의 Markdown 청크로 규격화되고 점수가 매겨지며, **당신의 머신에 있는 SQLite**에 저장되는 계층적 요약 트리로 접힙니다. 동일한 청크는 당신이 열고, 탐색하고, 편집할 수 있는 Obsidian 호환 볼트에 `.md` 파일로 저장됩니다. 이는 Karpathy의 [obsidian-wiki 워크플로우](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다.
 
-- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
+- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
 
 - **[스마트 토큰 압축(TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: 모든 도구 호출, 스크레이핑 결과, 이메일 본문 및 검색 페이로드는 LLM 모델에 전달되기 전에 토큰 압축 레이어를 거칩니다. HTML은 Markdown으로 변환되고, 긴 URL은 단축되며, 장황한 도구 출력은 구성 가능한 규칙 오버레이 등을 통해 중복 제거 및 요약됩니다. CJK, 이모지 및 기타 멀티바이트 텍스트는 자소(grapheme) 단위로 보존되며 절대 삭제되지 않습니다. 동일한 정보를 훨씬 적은 토큰으로 얻을 수 있어 비용과 지연 시간을 최대 80%까지 줄일 수 있습니다.
 
@@ -132,7 +132,7 @@ OpenHuman은 기다림을 생략합니다. 계정을 연결하고, [자동 가�
 _AGI와 인공 의식을 향해 나아가고 계신가요? 저장소에 스타를 눌러 다른 사람들도 이 길을 찾을 수 있도록 도와주세요._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -34,7 +34,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">ڈسکارڈ</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">ریڈٹ</a> •
+ ریڈٹ •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/ٹویٹر</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">دستاویزات</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">فالو کریں @senamakel (مصنف)</a>
@@ -152,7 +152,7 @@ OpenHuman ایک اوپن سورس ایجنٹک اسسٹنٹ ہے جو آپ کی
 
 - **[میموری ٹری](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: ایک مقامی اول علم کا ذخیرہ جو آپ کے ڈیٹا اور سرگرمی سے بنایا گیا ہے۔ آپ جو کچھ بھی جوڑتے ہیں وہ ≤3k-token کے Markdown ٹکڑوں میں معیاری ہو جاتا ہے، اسکور کیا جاتا ہے، اور درجہ بندی کے خلاصے کے درختوں میں جوڑ دیا جاتا ہے جو **آپ کی مشین پر SQLite** میں محفوظ ہوتے ہیں۔ وہی ٹکڑے Obsidian-مطابق والٹ میں `.md` فائلوں کے طور پر اترتے ہیں جسے آپ کھول سکتے ہیں، براؤز اور ایڈٹ کر سکتے ہیں، کارپیتھی کے [obsidian-wiki ورک فلو](https://x.com/karpathy/status/2039805659525644595) سے متاثر۔
 
-- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
+- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
 
 - **[اسمارٹ ٹوکن کمپریشن (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: ہر ٹول کال، سکریپ نتیجہ، ای میل باڈی، اور سرچ پے لوڈ کسی بھی LLM ماڈل کو چھونے سے پہلے ٹوکن کمپریشن پرت سے گزرتا ہے۔ HTML کو Markdown میں تبدیل کیا جاتا ہے، لمبے URLs کو چھوٹا کیا جاتا ہے، اور لمبے ٹول آؤٹ پٹ کو ایک قابل ترتیب اصول اوورلے وغیرہ کے ذریعے ڈیڈپ اور خلاصہ کیا جاتا ہے... CJK، ایموجی، اور دیگر ملٹی بائٹ ٹیکسٹ گرافیم بہ گرافیم محفوظ رہتے ہیں — کبھی نہیں ہٹائے جاتے۔ آپ کو وہی معلومات ملتی ہیں لیکن ٹوکنز کے ایک حصے میں۔ لاگت اور تاخیر کو 80% تک کم کرنا۔
 
@@ -225,7 +225,7 @@ _AGI اور مصنوعی شعور کی طرف بڑھ رہے ہیں؟ ریپو ک
 <div dir="ltr">
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -26,7 +26,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">文档</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">关注 @senamakel（作者）</a>
@@ -78,7 +78,7 @@ OpenHuman 是一个开源智能助手，旨在融入你的日常生活。以下�
 
 - **[记忆树](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**：一个基于你的数据和活动构建的本地优先知识库。你连接的所有内容都被规范化为不超过 3k token 的 Markdown 片段，经过评分后折叠成层级化的摘要树，存储在**你本机的 SQLite** 中。同样的片段以 `.md` 文件形式落地到兼容 Obsidian 的仓库中，你可以打开、浏览和编辑，灵感来源于 Karpathy 的 [obsidian-wiki 工作流](https://x.com/karpathy/status/2039805659525644595)。
 
-- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
+- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
 
 - **[智能 Token 压缩（TokenJuice）](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**：每个工具调用、抓取结果、邮件正文和搜索载荷在触达任何 LLM 模型之前都会经过 token 压缩层处理。HTML 被转换为 Markdown，长 URL 被缩短，冗长的工具输出会通过可配置的规则层去重并摘要等等。中文、emoji 等多字节字符按字形（grapheme）完整保留，绝不丢弃。你获得相同的信息，但 token 消耗仅为原来的几分之一。最多可降低 80% 的成本和延迟。
 
@@ -131,7 +131,7 @@ OpenHuman 跳过了等待期。连接你的账户，让[自动拉取](https://ti
 _致力于 AGI 和人工意识？为仓库加星，帮助更多人找到这条路。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/agent-workflows/cursor-cloud-agents.md
+++ b/docs/agent-workflows/cursor-cloud-agents.md
@@ -1,6 +1,6 @@
 # Cursor Cloud Agents — parallel workflow
 
-Operator playbook for running 15–20 [Cursor Cloud Agents](https://docs.cursor.com/agents/cloud) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
+Operator playbook for running 15–20 [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
 
 This doc closes [`tinyhumansai/openhuman#1480`](https://github.com/tinyhumansai/openhuman/issues/1480).
 

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -6036,6 +6036,19 @@ mod tests {
     }
 
     #[test]
+    fn quota_exhausted_filter_matches_openai_responses_usage_limit_reached() {
+        // TAURI-RUST-AFE: ChatGPT/Codex OAuth Responses returns a 400 body with
+        // a machine-readable usage-limit type and "has been reached" wording.
+        // This is the same user plan-cap state as C9A, just through /responses.
+        let body = "openai Responses API error: {\"error\":{\"type\":\
+            \"usage_limit_reached\",\"message\":\"The usage limit has been reached\",\
+            \"plan_type\":\"plus\"}}";
+        assert!(is_quota_exhausted_event(&event_with_message(body)));
+        assert!(is_quota_exhausted_event(&event_with_exception_value(body)));
+        assert!(is_quota_exhausted_message(body));
+    }
+
+    #[test]
     fn quota_exhausted_filter_ignores_generic_500_and_rate_limit() {
         // A generic 500 outage and a 429 rate-limit are not plan-quota
         // exhaustion — they must keep reaching Sentry / their own handling.

--- a/src/openhuman/inference/provider/compatible_helpers.rs
+++ b/src/openhuman/inference/provider/compatible_helpers.rs
@@ -222,6 +222,13 @@ impl OpenAiCompatibleProvider {
                 Some(model),
                 status,
             );
+        } else if super::super::is_provider_quota_exhausted(&error) {
+            super::super::log_provider_quota_exhausted(
+                "responses_api",
+                self.name.as_str(),
+                Some(model),
+                status,
+            );
         } else if super::super::should_report_provider_http_failure(status) {
             crate::core::observability::report_error(
                 message.as_str(),

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -4137,6 +4137,7 @@ async fn effective_context_window_lmstudio_falls_back_when_native_unavailable() 
 /// pinning the exact wire shape makes a provider wording drift fail CI rather
 /// than silently re-flood Sentry (23,970 events from 17 BYO users).
 const DEEPSEEK_4QF_402_BODY: &str = r#"{"error":{"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}}"#;
+const OPENAI_AFE_USAGE_LIMIT_BODY: &str = r#"{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"plus","resets_at":1919452800}}"#;
 
 /// Build a Sentry hub backed by a `TestTransport` and install it for the
 /// current scope, returning the transport so the test can assert no events
@@ -4298,6 +4299,40 @@ async fn responses_api_insufficient_balance_402_not_reported_to_sentry() {
     assert!(
         transport.fetch_and_clear_events().is_empty(),
         "an exhausted BYO balance 402 (responses_api path) must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn responses_api_usage_limit_reached_400_not_reported_to_sentry() {
+    // TAURI-RUST-AFE: OpenAI/ChatGPT OAuth Responses returns a deterministic
+    // user plan-cap 400 (`usage_limit_reached`). The call must still return an
+    // error, but Sentry should not receive one event per background retry.
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OPENAI_AFE_USAGE_LIMIT_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _guard) = install_test_sentry_hub();
+
+    let provider = OpenAiCompatibleProvider::new(
+        "openai",
+        &mock_server.uri(),
+        Some("chatgpt-oauth-token"),
+        AuthStyle::Bearer,
+    )
+    .with_responses_api_primary();
+    let err = provider
+        .chat_with_history(&[ChatMessage::user("hello")], "gpt-5-codex", 0.0)
+        .await
+        .expect_err("a Responses API usage cap must still propagate as Err");
+    assert!(
+        err.to_string().contains("usage_limit_reached"),
+        "err: {err}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "a usage_limit_reached Responses 400 must not be reported to Sentry"
     );
 }
 

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -254,6 +254,8 @@ pub fn body_indicates_quota_exhausted(body: &str) -> bool {
         || lower.contains("monthly limit")
         || lower.contains("monthly quota")
         || lower.contains("quota exceeded")
+        || lower.contains("usage_limit_reached")
+        || lower.contains("usage limit has been reached")
         || lower.contains("usage limit exceeded")
         // "reached the limit" alone is ambiguous (rate-limit, token-limit), so
         // require a quota/plan/request/monthly co-marker to keep the blast
@@ -1050,6 +1052,9 @@ mod tests {
         {\"error\":{\"message\":\"HTTP 402 from Kiro IDE: {\\\"message\\\":\\\"You have \
         reached the limit.\\\",\\\"reason\\\":\\\"MONTHLY_REQUEST_COUNT\\\"}\",\
         \"type\":\"server_error\"}}";
+    const AFE_BODY: &str = "openai Responses API error: \
+        {\"error\":{\"type\":\"usage_limit_reached\",\"message\":\"The usage limit \
+        has been reached\",\"plan_type\":\"plus\",\"resets_at\":1919452800}}";
 
     #[test]
     fn quota_exhausted_matches_verbatim_c9a_body() {
@@ -1057,6 +1062,12 @@ mod tests {
         // the transport status is 500, not 402.
         assert!(is_provider_quota_exhausted(C9A_BODY));
         assert!(body_indicates_quota_exhausted(C9A_BODY));
+    }
+
+    #[test]
+    fn quota_exhausted_matches_openai_responses_usage_limit_reached() {
+        assert!(is_provider_quota_exhausted(AFE_BODY));
+        assert!(body_indicates_quota_exhausted(AFE_BODY));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extends the shared provider quota matcher to cover OpenAI/ChatGPT OAuth Responses `usage_limit_reached` bodies.
- Adds a `responses_api` emit-site demotion so 400 usage-cap responses still return errors without reporting to Sentry.
- Adds regression coverage for matcher, before_send filter, and the actual Responses API Sentry leak path.
- Carries the current docs link-check fixes from #4237 so this PR can pass CI while that PR is still pending.

## Problem

- The existing quota-exhaustion classifier covers C9A-style monthly quota wording but misses OpenAI Responses bodies with `usage_limit_reached` and “The usage limit has been reached”.
- The Responses API path therefore falls through to `should_report_provider_http_failure(400)` and reports every background retry to Sentry.
- This creates the active #4180 Sentry flood even though the underlying condition is user/account plan state, not an actionable OpenHuman error.
- The repo link-check gate currently also sees stale localized README links on base; those fixes are included here as CI hygiene until #4237 merges.

## Solution

- Adds `usage_limit_reached` and `usage limit has been reached` to `body_indicates_quota_exhausted`, preserving the existing shared single source of truth.
- Adds a `chat_via_responses` quota arm before the report fallthrough, reusing `log_provider_quota_exhausted` with `operation=responses_api`.
- Keeps the caller-facing error unchanged so the agent/runtime can still surface the cap state.
- Updates stale localized README links and the Cursor cloud-agent docs link to their current targets.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — focused Rust tests cover the changed branches; CI remains the source of truth for the enforced diff-cover gate.
- [x] Coverage matrix updated — N/A: behavior-only observability/classification change, no user-facing feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: observability filtering only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform: Rust core compatible-provider error classification only.
- User-visible effect: OpenAI Responses usage-cap failures still propagate as errors; only Sentry reporting changes.
- Observability effect: `usage_limit_reached` plan-cap retries are demoted from Sentry errors; generic 400/500/provider failures stay reportable.
- Docs: localized README links are updated to the same current targets used by #4237.

## Related

- Closes #4180
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4180-responses-usage-limit`
- Commit SHA: `9c3d7931840eb9a55e692fd4e527b56b3a221960`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no app TS/CSS changes.
- [x] `pnpm typecheck` — N/A: no frontend TypeScript changes.
- [x] Focused tests:
  - RED: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib quota_exhausted_matches_openai_responses_usage_limit_reached` failed before implementation.
  - RED: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib responses_api_usage_limit_reached_400_not_reported_to_sentry` failed before implementation.
  - GREEN: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib usage_limit`
  - GREEN: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib quota_exhausted`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --check`
  - `git diff --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): N/A: no Tauri shell changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: OpenAI Responses usage-cap 400s are treated as quota/user plan state for Sentry reporting.
- User-visible effect: request still returns the provider error; repeated Sentry events are suppressed.

### Parity Contract

- Legacy behavior preserved: existing C9A quota, insufficient-credit, transient, and unrelated error handling remain unchanged.
- Guard/fallback/dispatch parity checks: shared matcher drives both emit-site classification and before_send filtering.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several translated README pages with refreshed links and embeds.
  * Improved the Star History display link and corrected a few feature reference URLs.

* **Bug Fixes**
  * Expanded quota-exhaustion detection for OpenAI Responses-style errors.
  * Reduced false error reporting for “usage limit reached” responses, helping avoid unnecessary alerts while preserving the original error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

