### PR TITLE
fix(provider): remap Codex auto model

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -27,7 +27,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">Doku</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel folgen (Creator)</a>
@@ -80,7 +80,7 @@ OpenHuman ist ein quelloffener, agentenbasierter Assistent, der sich in deinen A
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian-Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: eine lokal-zentrierte Wissensbasis, aufgebaut aus deinen Daten und deinen Aktivitäten. Alles, was du verbindest, wird in Markdown-Chunks von ≤3k Tokens kanonisiert, bewertet und in hierarchische Zusammenfassungs-Bäume gefaltet, gespeichert in **SQLite auf deiner Maschine**. Dieselben Chunks landen als `.md`-Dateien in einem Obsidian-kompatiblen Vault, das du öffnen, durchstöbern und editieren kannst — inspiriert von Karpathys [obsidian-wiki-Workflow](https://x.com/karpathy/status/2039805659525644595).
 
-- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
+- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
 
 - **[Smarte Token-Kompression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: Jeder Tool-Aufruf, jedes Scrape-Ergebnis, jeder E-Mail-Text und jeder Such-Payload läuft durch eine Token-Kompressionsschicht, bevor er ein LLM-Modell erreicht. HTML wird zu Markdown konvertiert, lange URLs werden gekürzt, und ausschweifende Tool-Ausgaben werden über eine konfigurierbare Regel-Ebene dedupliziert und zusammengefasst usw. CJK, Emojis und andere Multi-Byte-Texte bleiben Graphem für Graphem erhalten — niemals abgeschnitten. Du erhältst dieselbe Information bei einem Bruchteil der Tokens. Kosten und Latenz sinken um bis zu 80%.
 
@@ -133,7 +133,7 @@ Du hostest [agentmemory](https://github.com/rohitg00/agentmemory) bereits selbst
 _Baust du auch in Richtung AGI und künstlichem Bewusstsein? Setze einen Stern und hilf anderen, den Weg zu finden._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">ドキュメント</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel（作者）をフォロー</a>
@@ -80,7 +80,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: あなたのデータとアクティビティから構築されるローカルファーストのナレッジベースです。接続したすべての情報は ≤3k トークンの Markdown チャンクへ正規化され、スコアリングされ、階層的なサマリーツリーに畳み込まれて **あなたのマシン上の SQLite** に保存されます。同じチャンクは Obsidian 互換のボルトに `.md` ファイルとして配置され、開いて閲覧・編集できます。Karpathy 氏の [obsidian-wiki ワークフロー](https://x.com/karpathy/status/2039805659525644595)にインスパイアされています。
 
-- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
+- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
 
 - **[スマートトークン圧縮 (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: すべてのツール呼び出し、スクレイプ結果、メール本文、検索ペイロードは、LLM モデルに渡される前にトークン圧縮レイヤーを通過します。HTML は Markdown に変換され、長い URL は短縮され、冗長なツール出力は設定可能なルールレイヤーで重複排除と要約が行われるなど…。CJK、絵文字などのマルチバイト文字は書記素(grapheme)単位で完全に保持され、除去されることはありません。同じ情報をわずかなトークン数で得られます。コストとレイテンシを最大 80% 削減します。
 
@@ -133,7 +133,7 @@ OpenHuman はその待ち時間をスキップします。アカウントを接�
 _AGI と人工意識への道を進んでいますか? リポジトリにスターをつけて、他の人にも道筋を見つけてもらいましょう。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">문서</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel(제작자) 팔로우</a>
@@ -79,7 +79,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 
 - **[메모리 트리(Memory Tree)](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian 위키](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: 당신의 데이터와 활동을 바탕으로 구축된 로컬 우선 지식 베이스입니다. 연결된 모든 것은 3k 토큰 이하의 Markdown 청크로 규격화되고 점수가 매겨지며, **당신의 머신에 있는 SQLite**에 저장되는 계층적 요약 트리로 접힙니다. 동일한 청크는 당신이 열고, 탐색하고, 편집할 수 있는 Obsidian 호환 볼트에 `.md` 파일로 저장됩니다. 이는 Karpathy의 [obsidian-wiki 워크플로우](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다.
 
-- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
+- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
 
 - **[스마트 토큰 압축(TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: 모든 도구 호출, 스크레이핑 결과, 이메일 본문 및 검색 페이로드는 LLM 모델에 전달되기 전에 토큰 압축 레이어를 거칩니다. HTML은 Markdown으로 변환되고, 긴 URL은 단축되며, 장황한 도구 출력은 구성 가능한 규칙 오버레이 등을 통해 중복 제거 및 요약됩니다. CJK, 이모지 및 기타 멀티바이트 텍스트는 자소(grapheme) 단위로 보존되며 절대 삭제되지 않습니다. 동일한 정보를 훨씬 적은 토큰으로 얻을 수 있어 비용과 지연 시간을 최대 80%까지 줄일 수 있습니다.
 
@@ -132,7 +132,7 @@ OpenHuman은 기다림을 생략합니다. 계정을 연결하고, [자동 가�
 _AGI와 인공 의식을 향해 나아가고 계신가요? 저장소에 스타를 눌러 다른 사람들도 이 길을 찾을 수 있도록 도와주세요._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -34,7 +34,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">ڈسکارڈ</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">ریڈٹ</a> •
+ ریڈٹ •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/ٹویٹر</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">دستاویزات</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">فالو کریں @senamakel (مصنف)</a>
@@ -152,7 +152,7 @@ OpenHuman ایک اوپن سورس ایجنٹک اسسٹنٹ ہے جو آپ کی
 
 - **[میموری ٹری](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: ایک مقامی اول علم کا ذخیرہ جو آپ کے ڈیٹا اور سرگرمی سے بنایا گیا ہے۔ آپ جو کچھ بھی جوڑتے ہیں وہ ≤3k-token کے Markdown ٹکڑوں میں معیاری ہو جاتا ہے، اسکور کیا جاتا ہے، اور درجہ بندی کے خلاصے کے درختوں میں جوڑ دیا جاتا ہے جو **آپ کی مشین پر SQLite** میں محفوظ ہوتے ہیں۔ وہی ٹکڑے Obsidian-مطابق والٹ میں `.md` فائلوں کے طور پر اترتے ہیں جسے آپ کھول سکتے ہیں، براؤز اور ایڈٹ کر سکتے ہیں، کارپیتھی کے [obsidian-wiki ورک فلو](https://x.com/karpathy/status/2039805659525644595) سے متاثر۔
 
-- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
+- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
 
 - **[اسمارٹ ٹوکن کمپریشن (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: ہر ٹول کال، سکریپ نتیجہ، ای میل باڈی، اور سرچ پے لوڈ کسی بھی LLM ماڈل کو چھونے سے پہلے ٹوکن کمپریشن پرت سے گزرتا ہے۔ HTML کو Markdown میں تبدیل کیا جاتا ہے، لمبے URLs کو چھوٹا کیا جاتا ہے، اور لمبے ٹول آؤٹ پٹ کو ایک قابل ترتیب اصول اوورلے وغیرہ کے ذریعے ڈیڈپ اور خلاصہ کیا جاتا ہے... CJK، ایموجی، اور دیگر ملٹی بائٹ ٹیکسٹ گرافیم بہ گرافیم محفوظ رہتے ہیں — کبھی نہیں ہٹائے جاتے۔ آپ کو وہی معلومات ملتی ہیں لیکن ٹوکنز کے ایک حصے میں۔ لاگت اور تاخیر کو 80% تک کم کرنا۔
 
@@ -225,7 +225,7 @@ _AGI اور مصنوعی شعور کی طرف بڑھ رہے ہیں؟ ریپو ک
 <div dir="ltr">
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -26,7 +26,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">文档</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">关注 @senamakel（作者）</a>
@@ -78,7 +78,7 @@ OpenHuman 是一个开源智能助手，旨在融入你的日常生活。以下�
 
 - **[记忆树](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**：一个基于你的数据和活动构建的本地优先知识库。你连接的所有内容都被规范化为不超过 3k token 的 Markdown 片段，经过评分后折叠成层级化的摘要树，存储在**你本机的 SQLite** 中。同样的片段以 `.md` 文件形式落地到兼容 Obsidian 的仓库中，你可以打开、浏览和编辑，灵感来源于 Karpathy 的 [obsidian-wiki 工作流](https://x.com/karpathy/status/2039805659525644595)。
 
-- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
+- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
 
 - **[智能 Token 压缩（TokenJuice）](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**：每个工具调用、抓取结果、邮件正文和搜索载荷在触达任何 LLM 模型之前都会经过 token 压缩层处理。HTML 被转换为 Markdown，长 URL 被缩短，冗长的工具输出会通过可配置的规则层去重并摘要等等。中文、emoji 等多字节字符按字形（grapheme）完整保留，绝不丢弃。你获得相同的信息，但 token 消耗仅为原来的几分之一。最多可降低 80% 的成本和延迟。
 
@@ -131,7 +131,7 @@ OpenHuman 跳过了等待期。连接你的账户，让[自动拉取](https://ti
 _致力于 AGI 和人工意识？为仓库加星，帮助更多人找到这条路。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/agent-workflows/cursor-cloud-agents.md
+++ b/docs/agent-workflows/cursor-cloud-agents.md
@@ -1,6 +1,6 @@
 # Cursor Cloud Agents — parallel workflow
 
-Operator playbook for running 15–20 [Cursor Cloud Agents](https://docs.cursor.com/agents/cloud) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
+Operator playbook for running 15–20 [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
 
 This doc closes [`tinyhumansai/openhuman#1480`](https://github.com/tinyhumansai/openhuman/issues/1480).
 

--- a/src/openhuman/inference/provider/compatible_helpers.rs
+++ b/src/openhuman/inference/provider/compatible_helpers.rs
@@ -3,6 +3,7 @@ use crate::openhuman::inference::provider::traits::{
     UsageInfo as ProviderUsageInfo,
 };
 
+use super::super::openai_codex::OPENAI_CODEX_MODEL_HINTS;
 use super::compatible_parse::{
     aggregate_responses_sse_body, build_responses_prompt, extract_responses_text,
     normalize_function_arguments, parse_responses_response_body,
@@ -53,6 +54,24 @@ impl OpenAiCompatibleProvider {
             })
             .unwrap_or(false);
 
+        // TAURI-RUST-AHX: Codex CLI accepts `model=auto`, but the
+        // ChatGPT-account Codex Responses endpoint rejects that sentinel. Resolve
+        // it to the first known Codex model before the request leaves the host.
+        let request_model = if is_codex_oauth_responses && model.trim().eq_ignore_ascii_case("auto")
+        {
+            let resolved = OPENAI_CODEX_MODEL_HINTS
+                .first()
+                .copied()
+                .unwrap_or("gpt-5.5");
+            log::debug!(
+                "[provider] {} remapping Codex OAuth responses model=auto to {resolved}",
+                self.name,
+            );
+            resolved
+        } else {
+            model
+        };
+
         // TAURI-RUST-EWD: the Codex/ChatGPT OAuth Responses endpoint
         // (`chatgpt.com/backend-api/codex/responses`) rejects `max_output_tokens`
         // outright (400 `Unsupported parameter: max_output_tokens`), the same way
@@ -67,7 +86,7 @@ impl OpenAiCompatibleProvider {
             );
         }
         let mut request = ResponsesRequest {
-            model: model.to_string(),
+            model: request_model.to_string(),
             input,
             instructions,
             stream: Some(is_codex_oauth_responses),
@@ -154,7 +173,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_budget_exhausted_http_400(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::is_custom_openai_upstream_bad_request_http_400(
@@ -165,14 +184,14 @@ impl OpenAiCompatibleProvider {
             super::super::log_custom_openai_upstream_bad_request_http_400(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::is_provider_access_policy_denied_http_403(status, &error) {
             super::super::log_provider_access_policy_denied_http_403(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::is_provider_config_rejection_http(
@@ -183,7 +202,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_provider_config_rejection(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::is_byo_provider_auth_failure_http(
@@ -194,7 +213,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_byo_provider_auth_failure(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::is_openai_oauth_session_expired_http(
@@ -205,7 +224,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_openai_oauth_session_expired(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::is_provider_insufficient_credits_402(status, &error) {
@@ -219,7 +238,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_provider_insufficient_credits_402(
                 "responses_api",
                 self.name.as_str(),
-                Some(model),
+                Some(request_model),
                 status,
             );
         } else if super::super::should_report_provider_http_failure(status) {
@@ -229,7 +248,7 @@ impl OpenAiCompatibleProvider {
                 "responses_api",
                 &[
                     ("provider", self.name.as_str()),
-                    ("model", model),
+                    ("model", request_model),
                     ("status", status_str.as_str()),
                     ("failure", "non_2xx"),
                 ],

--- a/src/openhuman/inference/provider/compatible_helpers.rs
+++ b/src/openhuman/inference/provider/compatible_helpers.rs
@@ -173,7 +173,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_budget_exhausted_http_400(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::is_custom_openai_upstream_bad_request_http_400(
@@ -184,14 +184,14 @@ impl OpenAiCompatibleProvider {
             super::super::log_custom_openai_upstream_bad_request_http_400(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::is_provider_access_policy_denied_http_403(status, &error) {
             super::super::log_provider_access_policy_denied_http_403(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::is_provider_config_rejection_http(
@@ -202,7 +202,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_provider_config_rejection(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::is_byo_provider_auth_failure_http(
@@ -213,7 +213,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_byo_provider_auth_failure(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::is_openai_oauth_session_expired_http(
@@ -224,7 +224,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_openai_oauth_session_expired(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::is_provider_insufficient_credits_402(status, &error) {
@@ -238,7 +238,7 @@ impl OpenAiCompatibleProvider {
             super::super::log_provider_insufficient_credits_402(
                 "responses_api",
                 self.name.as_str(),
-                Some(request_model),
+                Some(model),
                 status,
             );
         } else if super::super::should_report_provider_http_failure(status) {
@@ -248,7 +248,7 @@ impl OpenAiCompatibleProvider {
                 "responses_api",
                 &[
                     ("provider", self.name.as_str()),
-                    ("model", request_model),
+                    ("model", model),
                     ("status", status_str.as_str()),
                     ("failure", "non_2xx"),
                 ],

--- a/src/openhuman/inference/provider/compatible_helpers.rs
+++ b/src/openhuman/inference/provider/compatible_helpers.rs
@@ -154,6 +154,9 @@ impl OpenAiCompatibleProvider {
             "{} Responses API error ({status_str}): {sanitized}",
             self.name
         );
+        // Error telemetry below should reflect the concrete model actually
+        // sent on the wire after Codex `auto` remapping.
+        let model = request_model;
         // A 404 from the `/responses` route can mean this endpoint has no
         // Responses API at all — disable the chat-completions-404 →
         // `/responses` fallback for it so we stop issuing a guaranteed second

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1062,6 +1062,47 @@ async fn responses_api_primary_posts_directly_to_responses() {
     assert_eq!(text, "hello from responses");
 }
 
+/// TAURI-RUST-AHX / GH #4206: Codex CLI allows `model=auto`, but the
+/// ChatGPT-account Codex Responses endpoint rejects that sentinel. The provider
+/// must resolve it before the request leaves the process.
+#[tokio::test]
+async fn codex_responses_remaps_auto_model_before_posting() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(body_json(serde_json::json!({
+            "model": "gpt-5.5",
+            "input": [{
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}]
+            }],
+            "stream": true,
+            "store": false
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n\
+             data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\"}}\n\n\
+             data: [DONE]\n\n",
+        ))
+        .mount(&server)
+        .await;
+
+    let provider = OpenAiCompatibleProvider::new(
+        "openai",
+        &format!("{}/backend-api/codex", server.uri()),
+        Some("oauth-access-token"),
+        AuthStyle::Bearer,
+    )
+    .with_responses_api_primary();
+
+    let text = provider
+        .chat_with_history(&[ChatMessage::user("hello")], "auto", 0.0)
+        .await
+        .unwrap();
+
+    assert_eq!(text, "ok");
+}
+
 /// TAURI-RUST-EWD: the Codex/ChatGPT OAuth Responses endpoint rejects
 /// `max_output_tokens` (400 `Unsupported parameter: max_output_tokens`). The
 /// memory-extraction cap (`ChatRequest::max_tokens`) must therefore be dropped

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -1068,10 +1068,14 @@ async fn responses_api_primary_posts_directly_to_responses() {
 #[tokio::test]
 async fn codex_responses_remaps_auto_model_before_posting() {
     let server = MockServer::start().await;
+    let expected_model = super::super::openai_codex::OPENAI_CODEX_MODEL_HINTS
+        .first()
+        .copied()
+        .unwrap_or("gpt-5.5");
     Mock::given(method("POST"))
         .and(path("/backend-api/codex/responses"))
         .and(body_json(serde_json::json!({
-            "model": "gpt-5.5",
+            "model": expected_model,
             "input": [{
                 "role": "user",
                 "content": [{"type": "input_text", "text": "hello"}]
@@ -1101,6 +1105,56 @@ async fn codex_responses_remaps_auto_model_before_posting() {
         .unwrap();
 
     assert_eq!(text, "ok");
+}
+
+#[tokio::test]
+async fn codex_responses_reports_remapped_auto_model_on_error() {
+    let server = MockServer::start().await;
+    let expected_model = super::super::openai_codex::OPENAI_CODEX_MODEL_HINTS
+        .first()
+        .copied()
+        .unwrap_or("gpt-5.5");
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(body_json(serde_json::json!({
+            "model": expected_model,
+            "input": [{
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}]
+            }],
+            "stream": true,
+            "store": false
+        })))
+        .respond_with(ResponseTemplate::new(500).set_body_string("codex unavailable"))
+        .mount(&server)
+        .await;
+
+    let (transport, _sentry_guard) = install_test_sentry_hub();
+    let provider = OpenAiCompatibleProvider::new(
+        "openai",
+        &format!("{}/backend-api/codex", server.uri()),
+        Some("oauth-access-token"),
+        AuthStyle::Bearer,
+    )
+    .with_responses_api_primary();
+
+    let err = provider
+        .chat_with_history(&[ChatMessage::user("hello")], "auto", 0.0)
+        .await
+        .expect_err("reportable responses failure should propagate");
+
+    assert!(
+        err.to_string()
+            .contains("openai Responses API error (500): codex unavailable"),
+        "unexpected responses error: {err}"
+    );
+    let events = transport.fetch_and_clear_events();
+    assert_eq!(events.len(), 1, "reportable 500 should reach Sentry once");
+    assert_eq!(
+        events[0].tags.get("model").map(String::as_str),
+        Some(expected_model),
+        "Sentry model tag should use the concrete wire model"
+    );
 }
 
 /// TAURI-RUST-EWD: the Codex/ChatGPT OAuth Responses endpoint rejects


### PR DESCRIPTION
## Summary

- Remaps Codex OAuth Responses requests from `model=auto` to the first known concrete Codex model before posting.
- Keeps Codex-specific `stream: true` and `max_output_tokens` omission behaviour intact.
- Carries forward two existing Markdown link fixes needed for the repository link checker.

## Problem

- Closes a Sentry-traced OpenAI Codex OAuth failure where `auto` leaked into `chatgpt.com/backend-api/codex/responses`.
- The ChatGPT-account Codex Responses endpoint rejects the Codex CLI `auto` sentinel with HTTP 400.
- Existing Codex Responses handling already strips unsupported fields, but did not resolve the model sentinel.

## Solution

- Detect the Codex OAuth Responses endpoint and `model=auto` in `chat_via_responses`.
- Resolve `auto` to the first `OPENAI_CODEX_MODEL_HINTS` entry before serializing `ResponsesRequest`.
- Add a regression test with an exact JSON body matcher proving the provider never posts `auto`.
- Keep the docs link-fix commits on this branch because current `upstream/main` lacks them and Markdown Link Check fails without them.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. Covered by targeted Rust regression and CI diff coverage.
- [x] N/A: Coverage matrix updated — provider request-shape bugfix, no feature row added/removed/renamed.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix feature IDs changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces — provider bugfix only, covered by mock-backed Rust tests.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime impact is limited to OpenAI ChatGPT-account Codex OAuth Responses requests.
- Prevents a provider-owned 400 loop for users whose config carries the Codex CLI `auto` model alias.
- No migration, storage, or UI impact.

## Related

- Closes #4206
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4206-codex-auto-model`
- Commit SHA: `b49d868d356f559a7edafec51e2dfb294a6cac45`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend changes.
- [x] N/A: `pnpm typecheck` — no TypeScript changes.
- [x] Focused tests:
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib codex_responses_remaps_auto_model_before_posting` (RED before fix, GREEN after fix)
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib codex_responses`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib responses_api_primary_posts_directly_to_responses`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --check`
  - `git diff --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] N/A: Tauri fmt/check — no Tauri crate changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Codex OAuth Responses calls now send a concrete Codex model instead of the `auto` sentinel.
- User-visible effect: Codex-backed OpenAI Responses chat stops failing with `The 'auto' model is not supported when using Codex with a ChatGPT account.`

### Parity Contract

- Legacy behavior preserved: Non-Codex Responses endpoints still receive their caller-provided model unchanged.
- Guard/fallback/dispatch parity checks: Existing Codex `stream: true` and `max_output_tokens` omission tests still pass.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex response handling so when automatic model selection is requested, a supported model is sent instead of `auto`.
  * Error/telemetry reporting now uses the remapped model value actually sent to the service.
* **Tests**
  * Added async integration tests covering Codex response “auto” remapping, including correct SSE aggregation and error reporting.
* **Documentation**
  * Updated localized README social link formatting for Reddit.
  * Corrected native voice documentation links and refreshed the Cursor Cloud Agents URL.
  * Updated Star History chart embed URLs to the current API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
