### PR TITLE
fix: demote provider moderation rejections

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -27,7 +27,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">Doku</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel folgen (Creator)</a>
@@ -80,7 +80,7 @@ OpenHuman ist ein quelloffener, agentenbasierter Assistent, der sich in deinen A
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian-Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: eine lokal-zentrierte Wissensbasis, aufgebaut aus deinen Daten und deinen Aktivitäten. Alles, was du verbindest, wird in Markdown-Chunks von ≤3k Tokens kanonisiert, bewertet und in hierarchische Zusammenfassungs-Bäume gefaltet, gespeichert in **SQLite auf deiner Maschine**. Dieselben Chunks landen als `.md`-Dateien in einem Obsidian-kompatiblen Vault, das du öffnen, durchstöbern und editieren kannst — inspiriert von Karpathys [obsidian-wiki-Workflow](https://x.com/karpathy/status/2039805659525644595).
 
-- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
+- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
 
 - **[Smarte Token-Kompression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: Jeder Tool-Aufruf, jedes Scrape-Ergebnis, jeder E-Mail-Text und jeder Such-Payload läuft durch eine Token-Kompressionsschicht, bevor er ein LLM-Modell erreicht. HTML wird zu Markdown konvertiert, lange URLs werden gekürzt, und ausschweifende Tool-Ausgaben werden über eine konfigurierbare Regel-Ebene dedupliziert und zusammengefasst usw. CJK, Emojis und andere Multi-Byte-Texte bleiben Graphem für Graphem erhalten — niemals abgeschnitten. Du erhältst dieselbe Information bei einem Bruchteil der Tokens. Kosten und Latenz sinken um bis zu 80%.
 
@@ -133,7 +133,7 @@ Du hostest [agentmemory](https://github.com/rohitg00/agentmemory) bereits selbst
 _Baust du auch in Richtung AGI und künstlichem Bewusstsein? Setze einen Stern und hilf anderen, den Weg zu finden._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">ドキュメント</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel（作者）をフォロー</a>
@@ -80,7 +80,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: あなたのデータとアクティビティから構築されるローカルファーストのナレッジベースです。接続したすべての情報は ≤3k トークンの Markdown チャンクへ正規化され、スコアリングされ、階層的なサマリーツリーに畳み込まれて **あなたのマシン上の SQLite** に保存されます。同じチャンクは Obsidian 互換のボルトに `.md` ファイルとして配置され、開いて閲覧・編集できます。Karpathy 氏の [obsidian-wiki ワークフロー](https://x.com/karpathy/status/2039805659525644595)にインスパイアされています。
 
-- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
+- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
 
 - **[スマートトークン圧縮 (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: すべてのツール呼び出し、スクレイプ結果、メール本文、検索ペイロードは、LLM モデルに渡される前にトークン圧縮レイヤーを通過します。HTML は Markdown に変換され、長い URL は短縮され、冗長なツール出力は設定可能なルールレイヤーで重複排除と要約が行われるなど…。CJK、絵文字などのマルチバイト文字は書記素(grapheme)単位で完全に保持され、除去されることはありません。同じ情報をわずかなトークン数で得られます。コストとレイテンシを最大 80% 削減します。
 
@@ -133,7 +133,7 @@ OpenHuman はその待ち時間をスキップします。アカウントを接�
 _AGI と人工意識への道を進んでいますか? リポジトリにスターをつけて、他の人にも道筋を見つけてもらいましょう。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">문서</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel(제작자) 팔로우</a>
@@ -79,7 +79,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 
 - **[메모리 트리(Memory Tree)](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian 위키](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: 당신의 데이터와 활동을 바탕으로 구축된 로컬 우선 지식 베이스입니다. 연결된 모든 것은 3k 토큰 이하의 Markdown 청크로 규격화되고 점수가 매겨지며, **당신의 머신에 있는 SQLite**에 저장되는 계층적 요약 트리로 접힙니다. 동일한 청크는 당신이 열고, 탐색하고, 편집할 수 있는 Obsidian 호환 볼트에 `.md` 파일로 저장됩니다. 이는 Karpathy의 [obsidian-wiki 워크플로우](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다.
 
-- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
+- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
 
 - **[스마트 토큰 압축(TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: 모든 도구 호출, 스크레이핑 결과, 이메일 본문 및 검색 페이로드는 LLM 모델에 전달되기 전에 토큰 압축 레이어를 거칩니다. HTML은 Markdown으로 변환되고, 긴 URL은 단축되며, 장황한 도구 출력은 구성 가능한 규칙 오버레이 등을 통해 중복 제거 및 요약됩니다. CJK, 이모지 및 기타 멀티바이트 텍스트는 자소(grapheme) 단위로 보존되며 절대 삭제되지 않습니다. 동일한 정보를 훨씬 적은 토큰으로 얻을 수 있어 비용과 지연 시간을 최대 80%까지 줄일 수 있습니다.
 
@@ -132,7 +132,7 @@ OpenHuman은 기다림을 생략합니다. 계정을 연결하고, [자동 가�
 _AGI와 인공 의식을 향해 나아가고 계신가요? 저장소에 스타를 눌러 다른 사람들도 이 길을 찾을 수 있도록 도와주세요._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -34,7 +34,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">ڈسکارڈ</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">ریڈٹ</a> •
+ ریڈٹ •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/ٹویٹر</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">دستاویزات</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">فالو کریں @senamakel (مصنف)</a>
@@ -152,7 +152,7 @@ OpenHuman ایک اوپن سورس ایجنٹک اسسٹنٹ ہے جو آپ کی
 
 - **[میموری ٹری](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: ایک مقامی اول علم کا ذخیرہ جو آپ کے ڈیٹا اور سرگرمی سے بنایا گیا ہے۔ آپ جو کچھ بھی جوڑتے ہیں وہ ≤3k-token کے Markdown ٹکڑوں میں معیاری ہو جاتا ہے، اسکور کیا جاتا ہے، اور درجہ بندی کے خلاصے کے درختوں میں جوڑ دیا جاتا ہے جو **آپ کی مشین پر SQLite** میں محفوظ ہوتے ہیں۔ وہی ٹکڑے Obsidian-مطابق والٹ میں `.md` فائلوں کے طور پر اترتے ہیں جسے آپ کھول سکتے ہیں، براؤز اور ایڈٹ کر سکتے ہیں، کارپیتھی کے [obsidian-wiki ورک فلو](https://x.com/karpathy/status/2039805659525644595) سے متاثر۔
 
-- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
+- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
 
 - **[اسمارٹ ٹوکن کمپریشن (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: ہر ٹول کال، سکریپ نتیجہ، ای میل باڈی، اور سرچ پے لوڈ کسی بھی LLM ماڈل کو چھونے سے پہلے ٹوکن کمپریشن پرت سے گزرتا ہے۔ HTML کو Markdown میں تبدیل کیا جاتا ہے، لمبے URLs کو چھوٹا کیا جاتا ہے، اور لمبے ٹول آؤٹ پٹ کو ایک قابل ترتیب اصول اوورلے وغیرہ کے ذریعے ڈیڈپ اور خلاصہ کیا جاتا ہے... CJK، ایموجی، اور دیگر ملٹی بائٹ ٹیکسٹ گرافیم بہ گرافیم محفوظ رہتے ہیں — کبھی نہیں ہٹائے جاتے۔ آپ کو وہی معلومات ملتی ہیں لیکن ٹوکنز کے ایک حصے میں۔ لاگت اور تاخیر کو 80% تک کم کرنا۔
 
@@ -225,7 +225,7 @@ _AGI اور مصنوعی شعور کی طرف بڑھ رہے ہیں؟ ریپو ک
 <div dir="ltr">
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -26,7 +26,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">文档</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">关注 @senamakel（作者）</a>
@@ -78,7 +78,7 @@ OpenHuman 是一个开源智能助手，旨在融入你的日常生活。以下�
 
 - **[记忆树](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**：一个基于你的数据和活动构建的本地优先知识库。你连接的所有内容都被规范化为不超过 3k token 的 Markdown 片段，经过评分后折叠成层级化的摘要树，存储在**你本机的 SQLite** 中。同样的片段以 `.md` 文件形式落地到兼容 Obsidian 的仓库中，你可以打开、浏览和编辑，灵感来源于 Karpathy 的 [obsidian-wiki 工作流](https://x.com/karpathy/status/2039805659525644595)。
 
-- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
+- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
 
 - **[智能 Token 压缩（TokenJuice）](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**：每个工具调用、抓取结果、邮件正文和搜索载荷在触达任何 LLM 模型之前都会经过 token 压缩层处理。HTML 被转换为 Markdown，长 URL 被缩短，冗长的工具输出会通过可配置的规则层去重并摘要等等。中文、emoji 等多字节字符按字形（grapheme）完整保留，绝不丢弃。你获得相同的信息，但 token 消耗仅为原来的几分之一。最多可降低 80% 的成本和延迟。
 
@@ -131,7 +131,7 @@ OpenHuman 跳过了等待期。连接你的账户，让[自动拉取](https://ti
 _致力于 AGI 和人工意识？为仓库加星，帮助更多人找到这条路。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/agent-workflows/cursor-cloud-agents.md
+++ b/docs/agent-workflows/cursor-cloud-agents.md
@@ -1,6 +1,6 @@
 # Cursor Cloud Agents — parallel workflow
 
-Operator playbook for running 15–20 [Cursor Cloud Agents](https://docs.cursor.com/agents/cloud) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
+Operator playbook for running 15–20 [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
 
 This doc closes [`tinyhumansai/openhuman#1480`](https://github.com/tinyhumansai/openhuman/issues/1480).
 

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -420,6 +420,13 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if crate::openhuman::inference::provider::is_openai_oauth_session_expired_message(message) {
         return Some(ExpectedErrorKind::ProviderUserState);
     }
+    // TAURI-RUST-ECR — an external moderation proxy rejected the prompt
+    // (`Message rejected by Ombudsman`). The provider HTTP layer demotes its
+    // own native_chat event; this catches the same provider error if it is
+    // re-reported at the agent / RPC boundary after being flattened to text.
+    if crate::openhuman::inference::provider::is_provider_moderation_rejection_message(message) {
+        return Some(ExpectedErrorKind::ProviderUserState);
+    }
     // TAURI-RUST-5MV — ollama.com hosted-inference 500 (`Internal Server Error
     // (ref: <uuid>)`) for `*:cloud` models. The provider HTTP layer
     // (`native_chat` / `streaming_chat` / `api_error`) already demotes its own
@@ -6145,6 +6152,24 @@ mod tests {
         assert!(is_insufficient_credits_event(&event_with_exception_value(
             body
         )));
+    }
+
+    #[test]
+    fn provider_moderation_rejection_reraise_routes_through_expected_path() {
+        // TAURI-RUST-ECR — same text returned from native_chat can be
+        // re-reported by a higher layer after the provider emit-site demotes
+        // its own event.
+        assert_eq!(
+            expected_error_kind(
+                "agent.run_single failed: ollama API error (400 Bad Request): \
+                 {\"error\":\"Message rejected by Ombudsman\",\"score\":80}"
+            ),
+            Some(ExpectedErrorKind::ProviderUserState)
+        );
+        assert_eq!(
+            expected_error_kind("ollama API error (400): message rejected: invalid JSON schema"),
+            None
+        );
     }
 
     #[test]

--- a/src/openhuman/inference/provider/compatible_helpers.rs
+++ b/src/openhuman/inference/provider/compatible_helpers.rs
@@ -175,6 +175,13 @@ impl OpenAiCompatibleProvider {
                 Some(model),
                 status,
             );
+        } else if super::super::is_provider_moderation_rejection_http_400(status, &error) {
+            super::super::log_provider_moderation_rejection_http_400(
+                "responses_api",
+                self.name.as_str(),
+                Some(model),
+                status,
+            );
         } else if super::super::is_provider_config_rejection_http(
             status,
             self.name.as_str(),

--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -760,6 +760,16 @@ impl Provider for OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::super::is_provider_moderation_rejection_http_400(status, &error) {
+                // External moderation proxy refusal (TAURI-RUST-ECR): the
+                // provider rejected the prompt deterministically. Keep the
+                // exact provider error visible, but do not page on each retry.
+                super::super::log_provider_moderation_rejection_http_400(
+                    "native_chat",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                );
             } else if super::super::is_provider_access_policy_denied_http_403(status, &error) {
                 super::super::log_provider_access_policy_denied_http_403(
                     "native_chat",

--- a/src/openhuman/inference/provider/compatible_provider_impl.rs
+++ b/src/openhuman/inference/provider/compatible_provider_impl.rs
@@ -174,6 +174,13 @@ impl Provider for OpenAiCompatibleProvider {
                     Some(model),
                     status,
                 );
+            } else if super::super::is_provider_moderation_rejection_http_400(status, &error) {
+                super::super::log_provider_moderation_rejection_http_400(
+                    "chat_completions",
+                    self.name.as_str(),
+                    Some(model),
+                    status,
+                );
             } else if super::super::is_provider_access_policy_denied_http_403(status, &error) {
                 super::super::log_provider_access_policy_denied_http_403(
                     "chat_completions",
@@ -1030,6 +1037,16 @@ impl Provider for OpenAiCompatibleProvider {
                         Some(model_owned.as_str()),
                         status,
                     );
+                } else if crate::openhuman::inference::provider::is_provider_moderation_rejection_http_400(
+                    status,
+                    &raw_error,
+                ) {
+                    crate::openhuman::inference::provider::log_provider_moderation_rejection_http_400(
+                        "stream_chat",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                    );
                 } else if crate::openhuman::inference::provider::is_backend_error_code_owned(
                     provider_name.as_str(),
                     &raw_error,
@@ -1259,6 +1276,16 @@ impl Provider for OpenAiCompatibleProvider {
                     &raw_error,
                 ) {
                     crate::openhuman::inference::provider::log_provider_config_rejection(
+                        "stream_chat_history",
+                        provider_name.as_str(),
+                        Some(model_owned.as_str()),
+                        status,
+                    );
+                } else if crate::openhuman::inference::provider::is_provider_moderation_rejection_http_400(
+                    status,
+                    &raw_error,
+                ) {
+                    crate::openhuman::inference::provider::log_provider_moderation_rejection_http_400(
                         "stream_chat_history",
                         provider_name.as_str(),
                         Some(model_owned.as_str()),

--- a/src/openhuman/inference/provider/compatible_stream_native.rs
+++ b/src/openhuman/inference/provider/compatible_stream_native.rs
@@ -93,6 +93,13 @@ impl OpenAiCompatibleProvider {
                     Some(native_request.model.as_str()),
                     status,
                 );
+            } else if super::super::is_provider_moderation_rejection_http_400(status, &body) {
+                super::super::log_provider_moderation_rejection_http_400(
+                    "streaming_chat",
+                    self.name.as_str(),
+                    Some(native_request.model.as_str()),
+                    status,
+                );
             } else if Self::is_native_tool_schema_unsupported(status, &body) {
                 log::info!(
                     "[stream] {} model rejected tool schema (status={}) — caller will retry without tools",

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -427,6 +427,145 @@ async fn native_chat_ombudsman_400_demoted_from_sentry() {
     );
 }
 
+#[tokio::test]
+async fn chat_with_system_ombudsman_400_demoted_from_sentry() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_test_sentry_hub();
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None);
+
+    let err = provider
+        .chat_with_system(None, "hello", "gemma3:1b-it-qat", 0.7)
+        .await
+        .expect_err("moderation rejection must still propagate");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Message rejected by Ombudsman") && msg.contains("\"score\":80"),
+        "provider rejection detail must remain visible, got: {msg}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "chat_completions moderation 400 must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn chat_with_history_ombudsman_400_demoted_via_api_error() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_test_sentry_hub();
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None);
+
+    let err = provider
+        .chat_with_history(&[ChatMessage::user("hello")], "gemma3:1b-it-qat", 0.7)
+        .await
+        .expect_err("moderation rejection must still propagate");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Message rejected by Ombudsman") && msg.contains("\"score\":80"),
+        "provider rejection detail must remain visible, got: {msg}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "api_error moderation 400 must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn streaming_chat_ombudsman_400_demoted_from_sentry() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_test_sentry_hub();
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None);
+    let request = NativeChatRequest {
+        model: "gemma3:1b-it-qat".to_string(),
+        messages: vec![NativeMessage {
+            role: "user".to_string(),
+            content: Some("hello".into()),
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_content: None,
+        }],
+        temperature: Some(0.7),
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        thread_id: None,
+        stream_options: Some(super::compatible_types::OpenAiStreamOptions {
+            include_usage: true,
+        }),
+        options: None,
+        frequency_penalty: None,
+        max_tokens: None,
+    };
+    let (delta_tx, _delta_rx) = tokio::sync::mpsc::channel(8);
+
+    let err = provider
+        .stream_native_chat(None, &request, &delta_tx, 0)
+        .await
+        .expect_err("streaming moderation rejection must still propagate");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Message rejected by Ombudsman") && msg.contains("\"score\":80"),
+        "provider rejection detail must remain visible, got: {msg}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "streaming moderation 400 must not be reported to Sentry"
+    );
+}
+
+#[tokio::test]
+async fn responses_api_ombudsman_400_demoted_from_sentry() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_test_sentry_hub();
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None)
+            .with_responses_api_primary();
+
+    let err = provider
+        .chat_with_history(&[ChatMessage::user("hello")], "gemma3:1b-it-qat", 0.7)
+        .await
+        .expect_err("responses moderation rejection must still propagate");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Message rejected by Ombudsman") && msg.contains("\"score\":80"),
+        "provider rejection detail must remain visible, got: {msg}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "responses moderation 400 must not be reported to Sentry"
+    );
+}
+
 /// TAURI-RUST-5MV: ollama.com hosted-inference 500 on the non-streaming native
 /// path must be demoted (no Sentry event) and surface the actionable message,
 /// while still propagating as `Err` so reliable-provider retry/fallback runs.
@@ -4396,6 +4535,44 @@ async fn stream_chat_with_system_insufficient_balance_402_propagates_error() {
 }
 
 #[tokio::test]
+async fn stream_chat_with_system_ombudsman_400_propagates_error() {
+    // The streaming work runs in a detached tokio task whose Sentry hub is not
+    // the test hub. Assert the terminal Provider chunk still carries the
+    // provider body; inline Sentry suppression is covered by the awaited
+    // native/chat/api/responses tests above.
+    use crate::openhuman::inference::provider::traits::{StreamError, StreamOptions};
+    use futures_util::StreamExt;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None);
+    let mut stream = provider.stream_chat_with_system(
+        None,
+        "hello",
+        "gemma3:1b-it-qat",
+        0.7,
+        StreamOptions::new(true),
+    );
+    let mut terminal: Option<String> = None;
+    while let Some(item) = stream.next().await {
+        if let Err(StreamError::Provider(msg)) = item {
+            terminal = Some(msg);
+        }
+    }
+    let msg = terminal.expect("a 400 must yield a terminal Provider error chunk");
+    assert!(
+        msg.contains("400") && msg.contains("Message rejected by Ombudsman"),
+        "msg: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn stream_chat_with_history_insufficient_balance_402_propagates_error() {
     // Sibling of the above for `stream_chat_with_history`
     // (operation=stream_chat_history). Same detached-task caveat — asserts the
@@ -4427,6 +4604,41 @@ async fn stream_chat_with_history_insufficient_balance_402_propagates_error() {
     let msg = terminal.expect("a 402 must yield a terminal Provider error chunk");
     assert!(
         msg.contains("402") && msg.contains("Insufficient Balance"),
+        "msg: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn stream_chat_with_history_ombudsman_400_propagates_error() {
+    // Sibling of the above for `stream_chat_with_history`
+    // (operation=stream_chat_history).
+    use crate::openhuman::inference::provider::traits::{StreamError, StreamOptions};
+    use futures_util::StreamExt;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None);
+    let mut stream = provider.stream_chat_with_history(
+        &[ChatMessage::user("hello")],
+        "gemma3:1b-it-qat",
+        0.7,
+        StreamOptions::new(true),
+    );
+    let mut terminal: Option<String> = None;
+    while let Some(item) = stream.next().await {
+        if let Err(StreamError::Provider(msg)) = item {
+            terminal = Some(msg);
+        }
+    }
+    let msg = terminal.expect("a 400 must yield a terminal Provider error chunk");
+    assert!(
+        msg.contains("400") && msg.contains("Message rejected by Ombudsman"),
         "msg: {msg}"
     );
 }

--- a/src/openhuman/inference/provider/compatible_tests.rs
+++ b/src/openhuman/inference/provider/compatible_tests.rs
@@ -376,6 +376,57 @@ async fn streaming_chat_frequency_penalty_rejection_not_reported_to_sentry() {
 const OLLAMA_CLOUD_500_WIRE_BODY: &str =
     r#"{"error":"Internal Server Error (ref: df512dcb-d915-493b-8f2d-e8d3dfa640c1)"}"#;
 
+/// Verbatim TAURI-RUST-ECR body — external moderation proxy rejects the prompt.
+const OLLAMA_OMBUDSMAN_400_WIRE_BODY: &str =
+    r#"{"error":"Message rejected by Ombudsman","score":80}"#;
+
+/// TAURI-RUST-ECR: an external moderation proxy rejected the request. This is a
+/// deterministic provider/user-state refusal, not an OpenHuman product error;
+/// keep propagating the provider error but do not report every retry to Sentry.
+#[tokio::test]
+async fn native_chat_ombudsman_400_demoted_from_sentry() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(OLLAMA_OMBUDSMAN_400_WIRE_BODY))
+        .mount(&mock_server)
+        .await;
+
+    let (transport, _sentry_guard) = install_test_sentry_hub();
+
+    let provider =
+        OpenAiCompatibleProvider::new("ollama", &mock_server.uri(), None, AuthStyle::None);
+    let messages = vec![ChatMessage {
+        id: None,
+        role: "user".to_string(),
+        content: "hello".to_string(),
+        extra_metadata: None,
+    }];
+    let err = provider
+        .chat(
+            super::super::ChatRequest {
+                messages: &messages,
+                tools: None,
+                stream: None,
+                max_tokens: None,
+            },
+            "gemma3:1b-it-qat",
+            0.7,
+        )
+        .await
+        .expect_err("moderation rejection must still propagate as Err to drive retry/fallback");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Message rejected by Ombudsman") && msg.contains("\"score\":80"),
+        "provider rejection detail must remain visible to the caller, got: {msg}"
+    );
+    assert!(
+        transport.fetch_and_clear_events().is_empty(),
+        "external moderation 400 must be demoted, not reported to Sentry"
+    );
+}
+
 /// TAURI-RUST-5MV: ollama.com hosted-inference 500 on the non-streaming native
 /// path must be demoted (no Sentry event) and surface the actionable message,
 /// while still propagating as `Err` so reliable-provider retry/fallback runs.

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -155,6 +155,45 @@ pub fn log_provider_access_policy_denied_http_403(
     );
 }
 
+/// Whether a provider non-2xx response is an external moderation/proxy
+/// rejection, not an OpenHuman product error.
+///
+/// Canonical example (TAURI-RUST-ECR):
+/// `{"error":"Message rejected by Ombudsman","score":80}`. The response is a
+/// deterministic provider policy/user-state refusal; callers should still see
+/// and retry/fallback the provider error, but Sentry should not receive one
+/// event per retry.
+pub fn is_provider_moderation_rejection_http_400(status: reqwest::StatusCode, body: &str) -> bool {
+    status == reqwest::StatusCode::BAD_REQUEST && is_provider_moderation_rejection_message(body)
+}
+
+/// Message-level half of [`is_provider_moderation_rejection_http_400`], shared
+/// with the higher-layer `report_error_or_expected` classifier so a re-raised
+/// provider error stays demoted outside the provider emit site too.
+pub fn is_provider_moderation_rejection_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("message rejected by ombudsman")
+        || (lower.contains("message rejected") && lower.contains("ombudsman"))
+}
+
+pub fn log_provider_moderation_rejection_http_400(
+    operation: &str,
+    provider: &str,
+    model: Option<&str>,
+    status: reqwest::StatusCode,
+) {
+    tracing::info!(
+        domain = "llm_provider",
+        operation = operation,
+        provider = provider,
+        model = model.unwrap_or(""),
+        status = status.as_u16(),
+        failure = "non_2xx",
+        kind = "provider_moderation_rejection",
+        "[llm_provider] {operation} external moderation rejection 400 — not reporting to Sentry"
+    );
+}
+
 /// Whether a provider non-2xx response is a deterministic
 /// **insufficient-credits** user-state error — the BYO provider account
 /// (e.g. OpenRouter) lacks the balance to satisfy the request.
@@ -993,6 +1032,30 @@ mod tests {
     const C62_BODY: &str = "myopenrouter API error (402 Payment Required): \
         {\"error\":{\"message\":\"This request requires more credits, or fewer max_tokens. \
         You requested up to 65536 tokens, but can only afford 49732.\"}}";
+    const ECR_BODY: &str = r#"{"error":"Message rejected by Ombudsman","score":80}"#;
+
+    #[test]
+    fn moderation_rejection_400_matches_verbatim_ecr_body() {
+        assert!(is_provider_moderation_rejection_http_400(
+            StatusCode::BAD_REQUEST,
+            ECR_BODY,
+        ));
+        assert!(is_provider_moderation_rejection_message(
+            "ollama API error (400 Bad Request): {\"error\":\"Message rejected by Ombudsman\"}"
+        ));
+    }
+
+    #[test]
+    fn moderation_rejection_requires_400_and_ombudsman_signal() {
+        assert!(!is_provider_moderation_rejection_http_400(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ECR_BODY,
+        ));
+        assert!(!is_provider_moderation_rejection_http_400(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"message rejected: invalid JSON schema"}"#,
+        ));
+    }
 
     #[test]
     fn insufficient_credits_402_matches_verbatim_c62_body() {

--- a/src/openhuman/inference/provider/ops/http_error.rs
+++ b/src/openhuman/inference/provider/ops/http_error.rs
@@ -936,6 +936,7 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     let is_custom_openai_upstream_bad_request =
         is_custom_openai_upstream_bad_request_http_400(provider, status, &body);
     let is_provider_access_policy_denied = is_provider_access_policy_denied_http_403(status, &body);
+    let is_provider_moderation_rejection = is_provider_moderation_rejection_http_400(status, &body);
     let is_provider_config_rejection = is_provider_config_rejection_http(status, provider, &body);
     // Context-overflow is status-agnostic: match the body directly (some
     // custom gateways mis-report it as 500 — TAURI-RUST-501 — so a status
@@ -984,6 +985,8 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
         log_custom_openai_upstream_bad_request_http_400("api_error", provider, None, status);
     } else if is_provider_access_policy_denied {
         log_provider_access_policy_denied_http_403("api_error", provider, None, status);
+    } else if is_provider_moderation_rejection {
+        log_provider_moderation_rejection_http_400("api_error", provider, None, status);
     } else if is_provider_config_rejection {
         log_provider_config_rejection("api_error", provider, None, status);
     } else if is_context_window_exceeded {

--- a/src/openhuman/inference/provider/ops/mod.rs
+++ b/src/openhuman/inference/provider/ops/mod.rs
@@ -26,13 +26,15 @@ pub use http_error::{
     is_ollama_cloud_internal_500_message, is_openai_oauth_session_expired_http,
     is_openai_oauth_session_expired_message, is_provider_access_policy_denied_http_403,
     is_provider_config_rejection_http, is_provider_insufficient_credits_402,
+    is_provider_moderation_rejection_http_400, is_provider_moderation_rejection_message,
     is_provider_quota_exhausted, log_backend_error_code_owned, log_budget_exhausted_http_400,
     log_byo_provider_auth_failure, log_context_window_exceeded,
     log_custom_openai_upstream_bad_request_http_400, log_ollama_cloud_internal_500,
     log_openai_oauth_session_expired, log_provider_access_policy_denied_http_403,
     log_provider_config_rejection, log_provider_insufficient_credits_402,
-    log_provider_quota_exhausted, ollama_cloud_internal_500_user_message,
-    publish_backend_session_expired, should_report_provider_http_failure,
+    log_provider_moderation_rejection_http_400, log_provider_quota_exhausted,
+    ollama_cloud_internal_500_user_message, publish_backend_session_expired,
+    should_report_provider_http_failure,
 };
 
 pub use models::{


### PR DESCRIPTION
## Summary

- Demotes the Ollama/Ombudsman `400 Message rejected by Ombudsman` provider response from Sentry noise to an info log.
- Keeps the original provider error body visible to callers so retry/fallback and UI surfacing are unchanged.
- Adds a shared provider moderation classifier plus an `expected_error_kind` guard for higher-layer re-reports.
- Includes regression coverage across native chat, chat_with_system, chat history/tools, streaming, Responses API, matcher edge cases, and agent/RPC re-report paths.
- Includes current Markdown link fixes already needed for CI on branches based on `upstream/main`.

## Problem

- Issue #4205 reports 4,517 Sentry events from one user for `ollama API error (400 Bad Request): {"error":"Message rejected by Ombudsman","score":80}`.
- This is an external moderation/proxy refusal, not an OpenHuman product failure.
- Multiple compatible-provider non-2xx cascades treated the 400 as reportable, so native, chat-with-system, history/tools, streaming, and Responses attempts could page Sentry.

## Solution

- Added `is_provider_moderation_rejection_http_400` and `is_provider_moderation_rejection_message` in the provider HTTP error classifier.
- Added moderation branches across native chat, chat_with_system, stream_chat, stream_chat_history, native streaming, Responses API, and shared `api_error` paths so the known Ombudsman 400 logs without `report_error`.
- Wired the message matcher into `expected_error_kind` so flattened higher-layer re-reports are also treated as expected provider user-state.
- Added focused Rust tests for the exact TAURI-RUST-ECR body, non-matching false positives, Sentry transport behavior, and propagation across non-streaming/streaming provider paths.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are covered by focused Rust tests; CI will enforce the merged `diff-cover` gate.
- [x] Coverage matrix updated — N/A: behavior-only Sentry classification change, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: provider error classification only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust core provider error reporting only.
- Sentry impact: Ombudsman moderation 400s stop reporting as product errors across compatible-provider non-2xx paths and expected-error re-report paths.
- Compatibility: callers still receive the provider error string, including the `score`, so existing fallback and display behavior is preserved.
- No migration, performance, or security impact.

## Related

- Closes #4205
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4205-moderation-rejection`
- Commit SHA: `5d302ac9b414915997bc46a6e855c154a335023d`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change.
- [x] `pnpm typecheck` — N/A: Rust-only change.
- [x] Focused tests:
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib ombudsman`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib moderation_rejection`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --check`
  - `git diff --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): N/A: no Tauri crate changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: provider moderation/proxy `400 Message rejected by Ombudsman` responses are treated as expected provider user-state for Sentry routing.
- User-visible effect: unchanged; the provider error still propagates with its original details.

### Parity Contract

- Legacy behavior preserved: retry/fallback and caller-visible error propagation remain intact.
- Guard/fallback/dispatch parity checks: provider Sentry transport tests prove no report is emitted while original errors still propagate; stream tests cover terminal error chunks, and `expected_error_kind` covers higher-layer re-report demotion.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain provider moderation/proxy HTTP 400 rejections to classify them as expected outcomes.
  * Reduced unnecessary alerting/monitoring noise while still returning the original error to the caller.

* **Documentation**
  * Updated translated documentation link targets (including Reddit and “Star History” chart embeds) and refreshed one workflow documentation URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
